### PR TITLE
Close Client after use

### DIFF
--- a/continuedev/src/continuedev/server/meilisearch_server.py
+++ b/continuedev/src/continuedev/server/meilisearch_server.py
@@ -3,6 +3,7 @@ import shutil
 import subprocess
 
 from meilisearch_python_async import Client
+
 from ..libs.util.paths import getServerFolderPath
 
 
@@ -53,11 +54,11 @@ async def check_meilisearch_running() -> bool:
     """
 
     try:
-        client = Client('http://localhost:7700')
-        resp = await client.health()
-        if resp["status"] != "available":
-            return False
-        return True
+        async with Client('http://localhost:7700') as client:
+            resp = await client.health()
+            if resp["status"] != "available":
+                return False
+            return True
     except Exception:
         return False
 


### PR DESCRIPTION
This client only gets used once in this function and is not used again. Putting it in a context manager will close the client after use freeing up it's resources.