### PR TITLE
let ggml server url be customized by config

### DIFF
--- a/continuedev/src/continuedev/core/config.py
+++ b/continuedev/src/continuedev/core/config.py
@@ -50,6 +50,7 @@ class ContinueConfig(BaseModel):
     on_traceback: Optional[List[OnTracebackSteps]] = []
     system_message: Optional[str] = None
     azure_openai_info: Optional[AzureInfo] = None
+    ggml_server_url: Optional[str] = None
 
     context_providers: List[ContextProvider] = []
 

--- a/continuedev/src/continuedev/core/sdk.py
+++ b/continuedev/src/continuedev/core/sdk.py
@@ -116,7 +116,10 @@ class Models:
 
     @cached_property
     def ggml(self):
-        return GGML(system_message=self.system_message)
+        return GGML(
+            system_message=self.system_message,
+            server_url=self.sdk.config.ggml_server_url
+        )
 
     def __model_from_name(self, model_name: str):
         if model_name == "starcoder":


### PR DESCRIPTION
there may be ggml servers that live outside of the main machine (e.g colab, or some cloud gpu somewhere with a llama-70b + cuBLAS build of llama.cpp). it'd be easier for someone to only have to get `llama-cpp-python[server]` running on that external machine and point their pre-existing continuerun install to that, instead of spinning up a separate continuerun installation on that server.

this pr may be denied, i'm fine with that.

my argument for configurable ggml rather than *just* configurable continuerun endpoint is that the server running ggml is (as i understand) stateless (it only provides model inference). in the case of colab free tier *or* some cloud gpu provider that you ran out of credits for, that server may go down, and your data with it (in my opinion, especially important for future usage of [the suggestions.json file](https://continue.dev/docs/collecting-data))!

inspired by [this reddit comment](https://www.reddit.com/r/LocalLLaMA/comments/15b565t/best_oss_coding_assistant_for_vs_code/jtphvo9/). ;)