### PR TITLE
Improved 2 click setup experience for new devs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,7 +131,6 @@ dmypy.json
 
 **/node_modules
 **/out
-**/.vscode/settings.json
 notes.txt
 cached_embeddings.pkl
 .ruff_cache

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -34,6 +34,7 @@
       "request": "launch",
       "cwd": "${workspaceFolder}/extension",
       "args": [
+        "${workspaceFolder}/extension/manual-testing-sandbox",
         "--extensionDevelopmentPath=${workspaceFolder}/extension",
       ],
       "outFiles": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,13 +5,34 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Python: Module",
+      "name": "Server",
       "type": "python",
       "request": "launch",
       "module": "continuedev.src.continuedev.server.main",
-      "args": ["--port", "8001"],
+      "args": [
+        "--port",
+        "8001"
+      ],
       "justMyCode": false,
-      "subProcess": false
-    }
+      "subProcess": false,
+      // Does it need a build task?
+      // What about a watch task? - type errors?
+    },
+    {
+      "name": "VSCode Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/extension",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}/extension",
+      ],
+      "outFiles": [
+        "${workspaceFolder}/extension/out/**/*.js"
+      ],
+      "preLaunchTask": "vscode-extension:build-watch",
+      "env": {
+        "CONTINUE_SERVER_URL": "http://localhost:8001"
+      }
+    },
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,6 +3,16 @@
   // Hover to view descriptions of existing attributes.
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
+  "compounds": [
+    {
+      "name": "Server + Extension (VSCode)",
+      "stopAll": true,
+      "configurations": [
+        "Server",
+        "Extension (VSCode)"
+      ]
+    }
+  ],
   "configurations": [
     {
       "name": "Server",
@@ -19,7 +29,7 @@
       // What about a watch task? - type errors?
     },
     {
-      "name": "VSCode Extension",
+      "name": "Extension (VSCode)",
       "type": "extensionHost",
       "request": "launch",
       "cwd": "${workspaceFolder}/extension",
@@ -29,7 +39,7 @@
       "outFiles": [
         "${workspaceFolder}/extension/out/**/*.js"
       ],
-      "preLaunchTask": "vscode-extension:build-watch",
+      "preLaunchTask": "vscode-extension:build",
       "env": {
         "CONTINUE_SERVER_URL": "http://localhost:8001"
       }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.defaultInterpreterPath": "${workspaceFolder}/continuedev/.venv/bin/python",
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -55,6 +55,7 @@
             "label": "install-all-dependencies",
             "type": "shell",
             "command": "./install-dependencies.sh",
+            "problemMatcher": [], // Empty so users are not promted to select progress reporting
         },
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -49,10 +49,12 @@
                 "revealProblems": "onProblem",
                 "clear": true,
             },
-            "group": {
-                "kind": "build",
-                "isDefault": true
-            }
-        }
+        },
+        // Install or update all dependencies for all projects in the monrepo
+        {
+            "label": "install-all-dependencies",
+            "type": "shell",
+            "command": "./install-dependencies.sh",
+        },
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,49 @@
+// See https://go.microsoft.com/fwlink/?LinkId=733558
+// for the documentation about the tasks.json format
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "vscode-extension:build-watch",
+            "type": "npm",
+            "script": "esbuild-watch",
+            "path": "extension",
+            "isBackground": true,
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": [
+                // We rely on tsc to emit type errors in a separate task
+            ],
+            // Depends on prevents the task from running until the other task has completed, not want we want
+            // does not start the extension
+            // "dependsOn": [
+            //     // esbuild does not emit type errors so we need a separate task for that
+            //     // https://esbuild.github.io/content-types/#typescript
+            //     "vscode-extension:tsc-watch"
+            // ]
+        },
+        {
+            "label": "vscode-extension:tsc-watch",
+            "type": "npm",
+            "script": "watch",
+            "path": "extension",
+            "isBackground": true,
+            "problemMatcher": [
+                "$tsc-watch"
+            ],
+            // Problems are currently broken due to path resolution not being relative to the workspace root
+            // The way cursorless does it it by having top level package.json which is not ideal.
+            // Multi root workspaces would help here
+            "presentation": {
+                "revealProblems": "onProblem",
+                "clear": true
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,44 +1,53 @@
-// See https://go.microsoft.com/fwlink/?LinkId=733558
-// for the documentation about the tasks.json format
 {
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "vscode-extension:build-watch",
-            "type": "npm",
-            "script": "esbuild-watch",
-            "path": "extension",
-            "isBackground": true,
+            "label": "vscode-extension:build",
+            "dependsOn": [
+                // To detect compile errors
+                "vscode-extension:tsc",
+                // To bundle the code the same way we do for publishing
+                "vscode-extension:esbuild"
+            ],
             "group": {
                 "kind": "build",
                 "isDefault": true
-            },
-            "problemMatcher": [
-                // We rely on tsc to emit type errors in a separate task
-            ],
-            // Depends on prevents the task from running until the other task has completed, not want we want
-            // does not start the extension
-            // "dependsOn": [
-            //     // esbuild does not emit type errors so we need a separate task for that
-            //     // https://esbuild.github.io/content-types/#typescript
-            //     "vscode-extension:tsc-watch"
-            // ]
+            }
         },
         {
-            "label": "vscode-extension:tsc-watch",
+            "label": "vscode-extension:esbuild",
             "type": "npm",
-            "script": "watch",
+            "script": "esbuild",
             "path": "extension",
-            "isBackground": true,
             "problemMatcher": [
-                "$tsc-watch"
+                {
+                    "pattern": [
+                        {
+                            "regexp": "> (.*?):([0-9]+):([0-9]+): (warning|error): (.+)$",
+                            "file": 1,
+                            "line": 2,
+                            "column": 3,
+                            "severity": 4,
+                            "message": 5
+                        }
+                    ],
+                }
             ],
-            // Problems are currently broken due to path resolution not being relative to the workspace root
-            // The way cursorless does it it by having top level package.json which is not ideal.
-            // Multi root workspaces would help here
+        },
+        // Tsc currently errors out due to testing setup issues, will be resolved in a different PR
+        // This will be useful for preventing debugging if there are compile errors
+        {
+            "label": "vscode-extension:tsc",
+            "type": "shell",
+            "command": "echo lol",
+            // "script": "tsc",
+            // "path": "extension",
+            "problemMatcher": [
+                "$tsc"
+            ],
             "presentation": {
                 "revealProblems": "onProblem",
-                "clear": true
+                "clear": true,
             },
             "group": {
                 "kind": "build",

--- a/continuedev/install-dependencies.sh
+++ b/continuedev/install-dependencies.sh
@@ -1,0 +1,16 @@
+
+#!/bin/bash
+
+# Check if Poetry is installed
+if ! command -v poetry &> /dev/null
+then
+    echo "Poetry not found, installing..."
+    curl -sSL https://install.python-poetry.org | python3 -
+fi
+
+# Install or update dependencies & create .venv if it doesn't exist
+echo "Installing dependencies..."
+poetry install
+
+echo "Running type generation..."
+poetry run typegen

--- a/extension/manual-testing-sandbox/example.ts
+++ b/extension/manual-testing-sandbox/example.ts
@@ -1,0 +1,3 @@
+function mergeSortAlgorithm() {
+    // TODO: implement
+}

--- a/extension/manual-testing-sandbox/readme.md
+++ b/extension/manual-testing-sandbox/readme.md
@@ -1,0 +1,3 @@
+The sole purpose of this folder is to open it when debugging the extension. 
+It is not used by the extension itself.
+You can add more files that can be useful when manually testing the extension.

--- a/extension/package.json
+++ b/extension/package.json
@@ -192,7 +192,7 @@
     "typegen": "node scripts/typegen.js",
     "clientgen": "rm -rf src/client/ && npx @openapitools/openapi-generator-cli generate -i ../schema/openapi.json -g typescript-fetch -o src/client/ --additional-properties=supportsES6=true,npmVersion=8.19.2,typescriptThreePlus=true",
     "rebuild": "electron-rebuild -v 19.1.8 node-pty",
-    "pretest": "npm run build && npm run lint",
+    "pretest": "npm run tsc && npm run lint",
     "lint": "eslint src --ext ts",
     "test": "node ./out/test/runTest.js",
     "jest": "jest --config ./jest.config.js",

--- a/extension/package.json
+++ b/extension/package.json
@@ -183,8 +183,8 @@
     ]
   },
   "scripts": {
+    "esbuild-base": "rm -rf ./out && node esbuild.mjs",
     "vscode:prepublish": "npm run esbuild-base -- --minify",
-    "esbuild-base": "rm -rf ./out && esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node",
     "esbuild": "npm run esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
     "tsc": "tsc -p ./",

--- a/extension/package.json
+++ b/extension/package.json
@@ -185,17 +185,17 @@
   "scripts": {
     "vscode:prepublish": "npm run esbuild-base -- --minify",
     "esbuild-base": "rm -rf ./out && esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node",
-    "esbuild": "rm -rf ./out && node esbuild.mjs",
+    "esbuild": "npm run esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
-    "test-compile": "tsc -p ./",
+    "tsc": "tsc -p ./",
+    "tsc-watch": "tsc -watch -p ./",
+    "typegen": "node scripts/typegen.js",
     "clientgen": "rm -rf src/client/ && npx @openapitools/openapi-generator-cli generate -i ../schema/openapi.json -g typescript-fetch -o src/client/ --additional-properties=supportsES6=true,npmVersion=8.19.2,typescriptThreePlus=true",
     "rebuild": "electron-rebuild -v 19.1.8 node-pty",
-    "watch": "tsc -watch -p ./",
-    "pretest": "npm run compile && npm run lint",
+    "pretest": "npm run build && npm run lint",
     "lint": "eslint src --ext ts",
     "test": "node ./out/test/runTest.js",
     "jest": "jest --config ./jest.config.js",
-    "typegen": "node scripts/typegen.js",
     "package": "npm install && npm run typegen && npm run clientgen && cd react-app && npm install && npm run build && cd .. && mkdir -p ./build && vsce package --out ./build"
   },
   "devDependencies": {

--- a/extension/scripts/install_from_source.py
+++ b/extension/scripts/install_from_source.py
@@ -1,3 +1,5 @@
+# Run from extension/scripts directory
+
 import os
 import subprocess
 
@@ -5,23 +7,22 @@ import subprocess
 def run(cmd: str):
     return subprocess.run(cmd, shell=True, capture_output=False)
 
-
 def get_latest_version() -> str:
-    latest = None
-    latest_major = 0
-    latest_minor = 0
-    latest_patch = 0
-    for file in os.listdir("../build"):
-        if file.endswith(".vsix"):
-            version = file.split("-")[1].split(".vsix")[0]
-            major, minor, patch = list(
-                map(lambda x: int(x), version.split(".")))
-            if latest is None or (major >= latest_major and minor >= latest_minor and patch > latest_patch):
-                latest = file
-                latest_major = major
-                latest_minor = minor
-                latest_patch = patch
+    # Ensure build directory exists
+    if not os.path.exists("../build"):
+        os.mkdir("../build")
+    
+    def version_tuple(filename):
+        version = filename.split("-")[1].split(".vsix")[0]
+        return tuple(map(int, version.split(".")))
 
+    versions = [file for file in os.listdir("../build") if file.endswith(".vsix")]
+    
+    # Ensure we have at least one version
+    if len(versions) == 0:
+        return None
+    
+    return max(versions, key=version_tuple)
 
 def main():
     # Clear out old stuff
@@ -62,7 +63,7 @@ def main():
 
     latest = get_latest_version()
     resp = run(f"cd ..; code --install-extension ./build/{latest}")
-
+    
     print("Continue VS Code extension installed successfully. Please restart VS Code to use it.")
 
 

--- a/extension/src/activation/environmentSetup.ts
+++ b/extension/src/activation/environmentSetup.ts
@@ -10,7 +10,7 @@ import * as vscode from "vscode";
 import * as os from "os";
 import fkill from "fkill";
 import { finished } from "stream/promises";
-import * as request from "request";
+import request = require("request");
 
 const exec = promisify(execCb);
 

--- a/extension/src/activation/environmentSetup.ts
+++ b/extension/src/activation/environmentSetup.ts
@@ -1,7 +1,7 @@
 import { getExtensionUri } from "../util/vscode";
-const util = require("util");
-const exec = util.promisify(require("child_process").exec);
-const { spawn } = require("child_process");
+import { promisify } from "util";
+import { exec as execCb } from "child_process";
+import { spawn } from "child_process";
 import * as path from "path";
 import * as fs from "fs";
 import { getContinueServerUrl } from "../bridge";
@@ -10,11 +10,13 @@ import * as vscode from "vscode";
 import * as os from "os";
 import fkill from "fkill";
 import { finished } from "stream/promises";
-const request = require("request");
+import * as request from "request";
+
+const exec = promisify(execCb);
 
 async function runCommand(cmd: string): Promise<[string, string | undefined]> {
-  var stdout: any = "";
-  var stderr: any = "";
+  var stdout = "";
+  var stderr = "";
   try {
     var { stdout, stderr } = await exec(cmd, {
       shell: process.platform === "win32" ? "powershell.exe" : undefined,
@@ -23,14 +25,9 @@ async function runCommand(cmd: string): Promise<[string, string | undefined]> {
     stderr = e.stderr;
     stdout = e.stdout;
   }
-  if (stderr === "") {
-    stderr = undefined;
-  }
-  if (typeof stdout === "undefined") {
-    stdout = "";
-  }
 
-  return [stdout, stderr];
+  const stderrOrUndefined = stderr === "" ? undefined : stderr;
+  return [stdout, stderrOrUndefined];
 }
 
 async function checkServerRunning(serverUrl: string): Promise<boolean> {

--- a/extension/src/bridge.ts
+++ b/extension/src/bridge.ts
@@ -1,14 +1,11 @@
 import * as vscode from "vscode";
-import { extensionContext } from "./activation/activate";
 
 export function getContinueServerUrl() {
-  // If in debug mode, always use 8001
-  if (
-    extensionContext &&
-    extensionContext.extensionMode === vscode.ExtensionMode.Development
-  ) {
-    return "http://localhost:8001";
+  // Passed in from launch.json
+  if (process.env.CONTINUE_SERVER_URL) {
+    return process.env.CONTINUE_SERVER_URL;
   }
+  
   return (
     vscode.workspace.getConfiguration("continue").get<string>("serverUrl") ||
     "http://localhost:65432"

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -1,0 +1,18 @@
+
+#!/bin/bash
+# This is used in a task in .vscode/tasks.json
+# Start developing with:
+# - Run Task -> Install Dependencies
+# - Debug -> Server + Extension
+
+# Server
+echo "Installing server dependencies..."
+pushd continuedev || exit
+./install-dependencies.sh
+popd || exit
+
+# VSCode Extension (will also package GUI)
+echo "Installing VSCode extension dependencies..."
+pushd extension || exit
+# This does way too many things inline but is the common denominator between many of the scripts
+npm run package


### PR DESCRIPTION
Addresses #346

# Adds
- Adds a top level vscode task to install all dependencies (including poetry & creating .venv) in server, extension GUI, extension itself
- Adds top level launch.json entries to start 2 debugging sessions for both server and extension - no need to have 2 windows opened anymore
- Checks in settings.json that sets default python interpreter to the one created by poetry

# Does not address
There are currently typescript errors related to testing which I am fixing on a different branch, I will uncomment tsc build task once I fix those

# Testing
How experience for new devs will look like now:
https://github.com/continuedev/continue/assets/12608159/9f531edc-f485-4a49-a75c-48aa2f1c8157

Tested basic /edit commands still work

