### PR TITLE
Correct import for Llama.cpp

### DIFF
--- a/docs/docs/customization.md
+++ b/docs/docs/customization.md
@@ -155,7 +155,7 @@ Run the llama.cpp server binary to start the API server. If running on a remote 
 After it's up and running, change `~/.continue/config.py` to look like this:
 
 ```python
-from continuedev.src.continuedev.libs.llm.ggml import GGML
+from continuedev.src.continuedev.libs.llm.llamacpp import LlamaCpp
 
 config = ContinueConfig(
     ...


### PR DESCRIPTION
In the documentation, the python import in config.py for running Llama.cpp is wrong (looks like a copy paste error from running with GGML).