### PR TITLE
fix: attempt to fix #485

### DIFF
--- a/extension/scripts/install_from_source.py
+++ b/extension/scripts/install_from_source.py
@@ -4,30 +4,35 @@ import os
 import subprocess
 
 
-def run(cmd: str):
-    return subprocess.run(cmd, shell=True, capture_output=False)
+def run(cmd, suppress_errors=False):
+    return subprocess.run(cmd, shell=True, capture_output=suppress_errors)
 
-def get_latest_version() -> str:
+
+def remove_existing_vsix_files(build_directory):
     # Ensure build directory exists
-    if not os.path.exists("../build"):
-        os.mkdir("../build")
-    
-    def version_tuple(filename):
-        version = filename.split("-")[1].split(".vsix")[0]
-        return tuple(map(int, version.split(".")))
+    if not os.path.exists(build_directory):
+        os.mkdir(build_directory)
+    for filename in os.listdir(build_directory):
+        if filename.endswith(".vsix"):
+            file_path = os.path.join(build_directory, filename)
+            os.remove(file_path)
 
-    versions = [file for file in os.listdir("../build") if file.endswith(".vsix")]
-    
-    # Ensure we have at least one version
-    if len(versions) == 0:
-        return None
-    
-    return max(versions, key=version_tuple)
+
+def return_vsix(build_directory):
+    vsix_files = [
+        filename
+        for filename in os.listdir(build_directory)
+        if filename.endswith(".vsix")
+    ]
+    return os.path.join(build_directory, vsix_files[0])
+
 
 def main():
     # Clear out old stuff
-    run(f"rm -rf ../build/{get_latest_version()}")
-    run("rm ../server/continuedev-0.1.2-py3-none-any.whl")
+    build_directory = "../build"
+    remove_existing_vsix_files(build_directory)
+    run("rm ../server/continuedev-0.1.2-py3-none-any.whl", True)
+
 
     # Check for Python and Node - we won't install them, but will warn
     resp1 = run("python --version")
@@ -51,20 +56,31 @@ def main():
         print("Poetry is required for Continue but is not installed on your machine. See https://python-poetry.org/docs/#installation to download the latest version, then try again.")
         return
 
+    editor_cmd = None
+    editor_name = None
+    for cmd, editor in [('code', 'VSCode'), ('codium', 'VSCodium')]:
+        resp = run(f"{cmd} --version", True)
+        if resp.returncode == 0:
+            print(f"{editor} version {resp.stdout.decode()}")
+            editor_cmd = cmd
+            editor_name = editor
+            break
+
+    if not editor_cmd:
+        print("No code editor command is available. Please install a code editor and try again.")
+        return
+
     resp = run("cd ../../continuedev; poetry install; poetry run typegen")
 
-    resp = run(
-        "cd ..; npm i; cd react-app; npm i; cd ..; npm run package")
+    resp = run("cd ..; npm i; cd react-app; npm i; cd ..; npm run package")
 
     if resp.stderr:
         print("Error packaging the extension. Please try again.")
         print("This was the error: ", resp.stderr)
         return
 
-    latest = get_latest_version()
-    resp = run(f"cd ..; code --install-extension ./build/{latest}")
-    
-    print("Continue VS Code extension installed successfully. Please restart VS Code to use it.")
+    run(f"NODE_OPTIONS='--no-warnings' {editor_cmd} --install-extension {return_vsix(build_directory)}")
+    print(f"Continue extension installed successfully in {editor_name}. Please restart your editor to use it.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### description
- try to fix #485
  - check `vscode` first and fall back to `vscodium`
  - remove the `get_latest_version`, instead clear out the `build` directory and return
    the name of the created `vsix` file after building the extension
- `NODE_OPTIONS='--no-warnings'` is not needed, but these warnings seem to unrelated to
  this project, see difference below

```sh
NODE_OPTIONS='--no-warnings' code --install-extension ../build/continue-patch.vsix
# Installing extensions...
# Extension 'continue-patch.vsix' was successfully installed.
```

```sh
code --install-extension ../build/continue-patch.vsix
# Installing extensions...
# (node:12048) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
# (Use `Electron --trace-deprecation ...` to show where the warning was created)
# Extension 'continue-patch.vsix' was successfully installed.
```

```sh
NODE_OPTIONS="--trace-deprecation" code --install-extension ../build/continue-patch.vsix
# Installing extensions...
# (node:12112) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
#     at showFlaggedDeprecation (node:buffer:198:11)
#     at new Buffer (node:buffer:282:3)
#     at /Applications/Visual Studio Code.app/Contents/Resources/app/node_modules.asar/fd-slicer/index.js:109:18
#     at pendGo (/Applications/Visual Studio Code.app/Contents/Resources/app/node_modules.asar/pend/index.js:54:3)
#     at onCb (/Applications/Visual Studio Code.app/Contents/Resources/app/node_modules.asar/pend/index.js:41:7)
#     at /Applications/Visual Studio Code.app/Contents/Resources/app/node_modules.asar/fd-slicer/index.js:31:7
#     at FSReqCallback.wrapper [as oncomplete] (node:fs:684:5)
# Extension 'continue-patch.vsix' was successfully installed.
```
