### PR TITLE
check if attribute choices is present

### DIFF
--- a/continuedev/src/continuedev/libs/llm/openai.py
+++ b/continuedev/src/continuedev/libs/llm/openai.py
@@ -134,7 +134,7 @@ class OpenAI(LLM):
             stream=True,
             **args,
         ):
-            if len(chunk.choices) == 0:
+            if not hasattr(chunk, "choices") or len(chunk.choices) == 0:
                 continue
             yield chunk.choices[0].delta
 


### PR DESCRIPTION
If there is an error upstream in the LLM server for example if a custom LLM server (FastChat) raises an OOM error, there is no attribute `choices` in the chunk variable. This causes error in the UI and removes all the previous generations from the UI. This is a temporary fix to silence the error and make sure that the output history doesn't get affected