### PR TITLE
Syntax error fixes

### DIFF
--- a/server/continuedev/core/context.py
+++ b/server/continuedev/core/context.py
@@ -416,9 +416,9 @@ class ContextManager:
 
                 tasks = [
                     safe_load(provider)
-                    for _, provider in (
-                        providers_to_load or self.context_providers
-                    ).items()
+                    for provider in (
+                        providers_to_load or self.context_providers.values()
+                    )
                 ]
                 await asyncio.wait_for(asyncio.gather(*tasks), timeout=20)
 

--- a/server/continuedev/libs/util/paths.py
+++ b/server/continuedev/libs/util/paths.py
@@ -144,5 +144,5 @@ def getSavedContextGroupsPath():
     os.makedirs(os.path.dirname(path), exist_ok=True)
     if not os.path.exists(path):
         with open(path, "w") as f:
-            f.write("\{\}")
+            f.write("{}")
     return path

--- a/server/continuedev/libs/util/paths.py
+++ b/server/continuedev/libs/util/paths.py
@@ -144,5 +144,5 @@ def getSavedContextGroupsPath():
     os.makedirs(os.path.dirname(path), exist_ok=True)
     if not os.path.exists(path):
         with open(path, "w") as f:
-            f.write("{}")
+            f.write("\{\}")
     return path


### PR DESCRIPTION
issue 1: Escaping curly braces are not required when using inside double quotes, leading to invalid json being written

issue 2: Using or between list and dict, throwing syntax error when providers_to_load is not empty
            providers_to_load: List[ContextProvider]
            sef.context_providers: dict[str, ContextProvider]