### PR TITLE
docs: Clearer instructions on where the .continue directory lives

### DIFF
--- a/docs/docs/telemetry.md
+++ b/docs/docs/telemetry.md
@@ -25,7 +25,7 @@ All data is anonymous and cleaned of PII before being sent to PostHog.
 
 ## How to opt out
 
-There is a `.continue` directory, which contains a `config.py` file that looks like this:
+The `~/.continue` directory contains a `config.py` file that looks like this:
 
 ```python
 config = ContinueConfig(


### PR DESCRIPTION
In the current docs, it's not clear where `.continue` lives. Since most vscode extensions live inside of `~/.vscode`, it's not obvious to look in `~`.