### PR TITLE
fix: hotkey for new session

### DIFF
--- a/extension/react-app/src/components/Layout.tsx
+++ b/extension/react-app/src/components/Layout.tsx
@@ -128,7 +128,7 @@ const Layout = () => {
     const handleKeyDown = (event: any) => {
       if (
         event.metaKey &&
-        event.ctrlKey &&
+        event.altKey &&
         event.code === "KeyN" &&
         timeline.filter((n) => !n.step.hide).length > 0
       ) {

--- a/intellij-extension/src/main/resources/META-INF/plugin.xml
+++ b/intellij-extension/src/main/resources/META-INF/plugin.xml
@@ -84,7 +84,7 @@
             <keyboard-shortcut keymap="$default"
                                first-keystroke="alt ctrl N"/>
             <keyboard-shortcut keymap="Mac OS X"
-                               first-keystroke="meta ctrl N"/>
+                               first-keystroke="alt meta N"/>
         </action>
 
         <action id="continue.focusContinueInput"


### PR DESCRIPTION
#### descriptin
- fix #566

This PR addresses the issue where the <kbd>⌘ Command</kbd> + <kbd>⌥ Option</kbd> + <kbd>N</kbd> key combination no longer creates a
new session in macOS.

The problem was traced back to commit 0752c15 where a one-line change was made in
`Layout.tsx`. The issue seems to be resolved when reverting the line `event.ctrlKey` back to `event.altKey`.

---

The change in `continue/intellij-extension/src/main/resources/META-INF/plugin.xml` was not tested,
needs to judged by the maintainer. It just seem logical.
