### PR TITLE
Make give_user_input async

### DIFF
--- a/server/continuedev/core/autopilot.py
+++ b/server/continuedev/core/autopilot.py
@@ -232,7 +232,7 @@ class Autopilot(ContinueBaseModel):
         for callback in self._on_update_callbacks:
             await callback(full_state)
 
-    def give_user_input(self, input: str, index: int):
+    async def give_user_input(self, input: str, index: int):
         self._user_input_queue.post(str(index), input)
 
     async def wait_for_user_input(self) -> str:


### PR DESCRIPTION
The only callsite in gui.py expects this to be async or return a coroutine.

Without this, uses of `sdk.wait_for_user_confirmation` will always throw in the asyncio library.