### PR TITLE
Set CWD when running ui build prelaunch task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -60,6 +60,9 @@
       "presentation": {
         "revealProblems": "onProblem",
         "clear": true
+      },
+      "options": {
+        "cwd": "${workspaceFolder}/extensions/vscode"
       }
     },
     //


### PR DESCRIPTION
Fixes Server + Extension vscode launch configuration.

Then previous "npm" type task respected the cwd setting from launch.json. However, the new "shell" type task seems to require it be explicitly set in the task.