### PR TITLE
Prevent duplicate calls to keyDown events due to IME

### DIFF
--- a/gui/src/components/ComboBox.tsx
+++ b/gui/src/components/ComboBox.tsx
@@ -1081,6 +1081,11 @@ const ComboBox = React.forwardRef((props: ComboBoxProps, ref) => {
                 setInputFocused(false);
               },
               onKeyDown: (event) => {
+                // Prevent duplicate calls to keyDown events due to IME.
+                if (isComposing) {
+                  return;
+                }
+                
                 dispatch(setBottomMessage(undefined));
                 if (event.key === "Enter" && event.shiftKey) {
                   // Prevent Downshift's default 'Enter' behavior.


### PR DESCRIPTION
**Problem**
When typing non-latin characters (such as Korean, Japanese or  Chinese) in the MainInputWindow, the KeyDown event is called duplicately due to IME.  As a result, non-latin character input does not work properly.

- Intellij extention : Korean input is almost impossible.
https://github.com/continuedev/continue/assets/4496185/66b61907-f137-4680-946a-a37ee9f25134
- VS code extention : It is better than IntelliJ, but sometimes letters are entered twice.

**Solution**
Since the moment isComposing is true is the composition phase by the IME, we can use methods to prevent events from occurring at this stage.
```
onKeyDown: (event) => {
    // Prevent duplicate calls to keyDown events due to IME.
    if (isComposing) {
        return;
    }
    // handle event
```

