### PR TITLE
fix: dropdown with the height of the sticky div

### DIFF
--- a/gui/src/components/ComboBox.tsx
+++ b/gui/src/components/ComboBox.tsx
@@ -707,6 +707,7 @@ const ComboBox = React.forwardRef((props: ComboBoxProps, ref) => {
   }, [inputRef.current, props.isMainInput, persistSession]);
 
   const deleteButtonDivRef = React.useRef<HTMLDivElement>(null);
+  const stickyDropdownHeaderDiv = React.useRef<HTMLDivElement>(null);
 
   const selectContextItemFromDropdown = useCallback(
     (event: any) => {
@@ -1408,6 +1409,7 @@ const ComboBox = React.forwardRef((props: ComboBoxProps, ref) => {
         >
           {nestedContextProvider && (
             <div
+              ref={stickyDropdownHeaderDiv}
               style={{
                 backgroundColor: secondaryDark,
                 borderBottom: `0.5px solid ${lightGray}`,
@@ -1431,7 +1433,15 @@ const ComboBox = React.forwardRef((props: ComboBoxProps, ref) => {
               {nestedContextProvider.description}
             </div>
           )}
-          <div style={{ maxHeight: `${UlMaxHeight - 50}px`, overflow: "auto" }}>
+          <div
+            style={{
+              maxHeight: `${
+                UlMaxHeight -
+                (stickyDropdownHeaderDiv.current?.clientHeight || 50)
+              }px`,
+              overflow: "auto",
+            }}
+          >
             {downshiftProps.isOpen &&
               items.map((item, index) => (
                 <Li


### PR DESCRIPTION
### description
- use the height of the sticky div, rather than the `50px`
	- this PR is based on the commit written by `sestinj` that was lost in some merge
- Ref: #576


- if you increase the font size the `50px` aren't enough
	- the GIF below uses `Font Size: 25`

<img src="https://github.com/continuedev/continue/assets/92653266/bd7427f3-7949-43c3-b5a3-d2340bda2951" width="600">
