### PR TITLE
fix: add 'rich' module to requirements.txt

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -28,6 +28,7 @@ huggingface-hub==0.16.4
 chromadb==0.4.12
 tree-sitter==0.20.2
 tree-sitter-languages==1.7.0
+rich==13.6.0
 python-socketio==5.10.0
 pathspec==0.11.2
 tqdm==4.66.1


### PR DESCRIPTION
### description
- 'rich' is included in the `pyproject.toml` but missing in the `requirements.txt`

```bash
python -m venv env
source env/bin/activate
python --version
# Python 3.11.6
cd server
pip install -r requirements.txt >/dev/null
python -m continuedev.__main__ --port 8001 >/dev/null
# Traceback (most recent call last):
#   File "<frozen runpy>", line 198, in _run_module_as_main
#   File "<frozen runpy>", line 88, in _run_code
#   File "/Users/paria/Developer/continue/server/continuedev/__main__.py", line 12, in <module>
#     from rich.console import Console
# ModuleNotFoundError: No module named 'rich'
```
