### PR TITLE
fix(vscode): handle null values for edits and page in getSidebarContent

### DIFF
--- a/extensions/vscode/src/debugPanel.ts
+++ b/extensions/vscode/src/debugPanel.ts
@@ -241,7 +241,7 @@ export function getSidebarContent(
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
         <link href="https://fonts.googleapis.com/css2?family=Lexend:wght@300&display=swap" rel="stylesheet">
         <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
-        
+
         <title>Continue</title>
       </head>
       <body>
@@ -260,8 +260,8 @@ export function getSidebarContent(
         )}</script>
         <script>window.isFullScreen = ${isFullScreen}</script>
 
-        ${edits && `<script>window.edits = ${JSON.stringify(edits)}</script>`}
-        ${page && `<script>window.location.pathname = "${page}"</script>`}
+        ${edits ? `<script>window.edits = ${JSON.stringify(edits)}</script>` : ''}
+        ${page ? `<script>window.location.pathname = "${page}"</script>` : ''}
       </body>
     </html>`;
 }


### PR DESCRIPTION
### description
- when `edits` or `page` is undefined, the expressions `${edits && }` and `${page && }` will
  evaluate to `undefined` and that gets converted to the string "undefined" in the template literal

- to reproduce the issue, open 'Continue' and scroll down below the LLM selector, optionally open
  the 'Developer Tools'

<img src="https://raw.githubusercontent.com/LangLangbart/ImagePool/b2a4e7c7e217240e84a7fe0c726a0fec6a701dbb/storage/2023-11-12_21-50-21_html_un.png" width="500">


- issue was introduced with commmit: 4763da10c99b6eda490cdfd510b73e199dc2be42
	- released in **0.5.2 Pre-Release  2023-11-10T20:02:30.66Z ✹ 10/Nov/23**
