### PR TITLE
feat(gui): add flex-grow to TdDiv in history page

### DIFF
--- a/gui/src/pages/history.tsx
+++ b/gui/src/pages/history.tsx
@@ -45,6 +45,7 @@ const SectionHeader = styled.tr`
 
 const TdDiv = styled.div`
   cursor: pointer;
+  flex-grow: 1;
   padding-left: 1rem;
   padding-right: 1rem;
   padding-top: 0.5rem;


### PR DESCRIPTION
### description
The key point here is to ensure that the `TdDiv` is taking up the full width of the parent div so that
clicking anywhere on the history row triggers the click event.

<img src="https://raw.githubusercontent.com/LangLangbart/ImagePool/a493fd5d8f3eeb1231956edd1f8b84279854d1a0/storage/2023-11-13_00-01-04_history_flex-grow.gif" width="500">
