### PR TITLE
fix(vscode): keybinding full screen toggle shortcut

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -170,7 +170,8 @@
       {
         "command": "continue.toggleFullScreen",
         "mac": "cmd+k cmd+m",
-        "key": "ctrl+k ctrl+m"
+        "key": "ctrl+k ctrl+m",
+        "when": "!terminalFocus"
       }
     ],
     "submenus": [

--- a/gui/src/components/dialogs/KeyboardShortcuts.tsx
+++ b/gui/src/components/dialogs/KeyboardShortcuts.tsx
@@ -110,6 +110,11 @@ const vscodeShortcuts: KeyboardShortcutProps[] = [
     windows: "Tab",
     description: "Toggle between context items",
   },
+  {
+    mac: "⌘ K ⌘ M",
+    windows: "⌃ K ⌃ M",
+    description: "Toggle Full Screen",
+  },
 ];
 
 const jetbrainsShortcuts: KeyboardShortcutProps[] = [

--- a/gui/src/pages/gui.tsx
+++ b/gui/src/pages/gui.tsx
@@ -586,7 +586,7 @@ function GUI(props: GUIProps) {
               onClick={() => {
                 postToIde("toggleFullScreen", {});
               }}
-              text={`Toggle Full Screen (${getMetaKeyLabel()}K M)`}
+              text={`Toggle Full Screen (${getMetaKeyLabel()}K ${getMetaKeyLabel()}M)`}
             >
               {(window as any).isFullScreen ? (
                 <ArrowsPointingInIcon width="1.4em" height="1.4em" />


### PR DESCRIPTION
### description
1. Adjust the hotkey documentation on the help page for `continue.toggleFullScreen`
	- unsure which key combo was intended, opted for the longer version:
		- <kbd>⌘ Command</kbd> + <kbd>K</kbd> <kbd>⌘ Command</kbd> + <kbd>M</kbd> or,
		- <kbd>⌘ Command</kbd> + <kbd>K</kbd> <kbd>M</kbd>

2. The `continue.toggleFullScreen` key should have a `when` requirement. This is because VSCode has
   a default hotkey `cmd+k` to clear the terminal. Pressing `cmd+k` with `Continue` enabled doesn't
   clear the terminal, but instead waits for another key to be pressed.


```json
{
  "key": "cmd+k",
  "command": "workbench.action.terminal.clear",
  "when": "terminalFocus && terminalHasBeenCreated && !accessibilityModeEnabled || terminalFocus && terminalProcessSupported && !accessibilityModeEnabled || accessibilityModeEnabled && accessibleViewIsShown && terminalHasBeenCreated && accessibleViewCurrentProviderId == 'terminal' || accessibilityModeEnabled && accessibleViewIsShown && terminalProcessSupported && accessibleViewCurrentProviderId == 'terminal'"
}
```

---

PS: not tested on jetbrains
