### PR TITLE
Update template configuration docs

### DIFF
--- a/docs/docs/customization/models.md
+++ b/docs/docs/customization/models.md
@@ -120,7 +120,7 @@ It can then be used like this:
 
 ```python title="~/.continue/config.py"
 def modify_config(config: ContinueConfig) -> ContinueConfig:
-    config.models[0].template_messages = template_alpaca_messages
+    config.models.default.template_messages = template_alpaca_messages
     return config
 ```
 
@@ -150,7 +150,7 @@ It can then be used like this in `config.py`:
 
 ```python title="~/.continue/config.py"
 def modify_config(config: ContinueConfig) -> ContinueConfig:
-    config.models[0].prompt_templates["edit"] = "<INSERT_TEMPLATE_HERE>"
+    config.models.edit.prompt_templates["edit"] = "<INSERT_TEMPLATE_HERE>"
     return config
 ```
 


### PR DESCRIPTION
Attempting to add `config.models[0].template_messages = template_alpaca_messages` or
`config.models[0].prompt_templates["edit"] = "<INSERT_TEMPLATE_HERE>"` to config.py results in `[WARNING] Failed to modify config: 'Models' object is not subscriptable` when saving config.py
This PR modifies those lines in documentation to account for the fact that "models" is an instantiated Models object containing LLM objects