### PR TITLE
Specify primary key for Meilisearch

### DIFF
--- a/server/continuedev/libs/index/indices/meilisearch_index.py
+++ b/server/continuedev/libs/index/indices/meilisearch_index.py
@@ -76,7 +76,8 @@ class MeilisearchCodebaseIndex(CodebaseIndex):
                     chunk, int(chunk.digest, 16), [self.tag]
                 )
                 for chunk in chunks
-            ]
+            ],
+            primary_key="id",
         )
 
     async def delete_chunks(self, document_ids: List[str], index: Index):
@@ -98,14 +99,14 @@ class MeilisearchCodebaseIndex(CodebaseIndex):
         for document in documents:
             document["tags"].remove(label)
 
-        await index.update_documents(documents)
+        await index.update_documents(documents, primary_key="id")
 
     async def add_label(self, digest: str, label: str, index: Index):
         documents = (await self.get_docs_for_digest(digest, index)).results
         for document in documents:
             document["tags"].append(label)
 
-        await index.update_documents(documents)
+        await index.update_documents(documents, primary_key="id")
 
     async def build(
         self, chunks: AsyncGenerator[Tuple[IndexAction, Union[str, Chunk]], None]
@@ -113,7 +114,7 @@ class MeilisearchCodebaseIndex(CodebaseIndex):
         """Builds the index, yielding progress as a float between 0 and 1"""
         async with Client(get_meilisearch_url()) as search_client:
             try:
-                await search_client.create_index(self.index_name)
+                await search_client.create_index(self.index_name, primary_key="id")
                 index = await search_client.get_index(self.index_name)
                 # await index.update_ranking_rules(
                 #     ["attribute", "words", "typo", "proximity", "sort", "exactness"]


### PR DESCRIPTION
Closes #658

The issue here is that there are multiple fields with `id` in the name. Because no `primary_key` is specified Meilisearch is trying to guess based off the name, but can't. Specifying the primary key should fix the issue. I'm assuming here that `id` should be the primary key and not `document_id`.

I looked and there aren't any Meilisearch tests, and I don't use (or have installed) VS Code so I'm not sure how to properly test this on my end. If there is something I missed I'm happy to make updates.