### PR TITLE
Allow gemini models to use completion options via the palm provider.

### DIFF
--- a/core/llm/llms/GooglePalm.ts
+++ b/core/llm/llms/GooglePalm.ts
@@ -52,6 +52,14 @@ class GooglePalm extends BaseLLM {
           parts: [{ text: msg.content }],
         };
       }),
+      generationConfig: {
+        temperature: options.temperature,
+        topP: options.topP,
+        topK: options.topK,
+        candidateCount: 1,
+        maxOutputTokens: options.maxTokens,
+        stopSequences: options.stop,
+      },
     };
     const response = await this.fetch(apiURL, {
       method: "POST",


### PR DESCRIPTION
Pass the relevant completion options through when using Gemini via the GooglePalmprovider.

Tested this by setting maxTokens to 8:

config.json:

```
    {
      "title": "Google Palm Gemini",
      "provider": "google-palm",
      "apiKey": <key>,
      "model": "gemini-pro",
      "contextLength": 32768,
      "completionOptions": {
        "temperature": 1.0,
        "topP": 0.9,
        "topK": 40,
        "maxTokens": 8
      }
    }
```

<img width="423" alt="image" src="https://github.com/continuedev/continue/assets/1211248/a0d08624-30f2-487b-95e1-810bdb57ff54">

After removing maxTokens:

<img width="425" alt="image" src="https://github.com/continuedev/continue/assets/1211248/c95f5964-fdf8-4fda-b7b6-0076a233cb52">

