### PR TITLE
Move OpenAI "v1" to apiBase

### DIFF
--- a/core/llm/llms/Mistral.ts
+++ b/core/llm/llms/Mistral.ts
@@ -4,7 +4,7 @@ import OpenAI from "./OpenAI";
 class Mistral extends OpenAI {
   static providerName: ModelProvider = "mistral";
   static defaultOptions: Partial<LLMOptions> = {
-    apiBase: "https://api.mistral.ai",
+    apiBase: "https://api.mistral.ai/v1",
     model: "mistral-small",
   };
 }

--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -10,7 +10,7 @@ import {
 class OpenAI extends BaseLLM {
   static providerName: ModelProvider = "openai";
   static defaultOptions: Partial<LLMOptions> = {
-    apiBase: "https://api.openai.com",
+    apiBase: "https://api.openai.com/v1",
   };
 
   protected _convertArgs(
@@ -62,7 +62,7 @@ class OpenAI extends BaseLLM {
     if (this.apiType === "azure") {
       return `${this.apiBase}/openai/deployments/${this.engine}/chat/completions?api-version=${this.apiVersion}`;
     } else {
-      return this.apiBase + "/v1/chat/completions";
+      return this.apiBase + "/chat/completions";
     }
   }
 

--- a/core/llm/llms/TextGenWebUI.ts
+++ b/core/llm/llms/TextGenWebUI.ts
@@ -4,7 +4,7 @@ import OpenAI from "./OpenAI";
 class TextGenWebUI extends OpenAI {
   static providerName: ModelProvider = "text-gen-webui";
   static defaultOptions: Partial<LLMOptions> = {
-    apiBase: "http://localhost:5000",
+    apiBase: "http://localhost:5000/v1",
   };
 }
 


### PR DESCRIPTION
Currently, any usage of the openai provider other than azure automatically adds a "v1" into the API URL. This makes using the openai provider with servers that don't use "v1" impossible. This was specifically motivated by wanting to try out the perplexity.ai API which serves at `https://api.perplexity.ai/chat/completions`

I have moved the "v1" to the default apiBase in the provider. This also aligns with how OpenAI themselves construct URLs in their packages:

https://github.com/openai/openai-python/blob/15d3aba42ed40713ef2d2757462d19846049523a/src/openai/_client.py#L301-L304

```
        if base_url is None:
            base_url = os.environ.get("OPENAI_BASE_URL")
        if base_url is None:
            base_url = f"https://api.openai.com/v1"
```