### PR TITLE
Add ability to disable templating

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -289,6 +289,7 @@ type ContextProviderName =
   | "http";
 
 type TemplateType =
+  | "none"
   | "llama2"
   | "alpaca"
   | "zephyr"

--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -84,6 +84,7 @@ function autodetectTemplateFunction(
 
   if (templateType) {
     const mapping: Record<TemplateType, any> = {
+      none: null,
       llama2: llama2TemplateMessages,
       alpaca: templateAlpacaMessages,
       phind: phindTemplateMessages,


### PR DESCRIPTION
This PR adds the ability to disable templating for a model by explicitly setting template to "none" in the config.

This is useful for people using a model server that can handle templating for them (Ollama, LocalAI, etc.). The current default is the chatml template, and to avoid having that set you either have to set your model name to something with "gpt", "chat-bison", etc in it, or drop into config.ts.

Currently, you can actually just set the template to some string that doesn't match anything, like "my nonexistent template" in the config and that will give you the same behavior as "gpt" etc, but I think it's better to be explicit here and have a defined setting that shows up with autocomplete, etc. 


I don't love the name "none" here so hoping someone has a better idea.


My LocalAI Mixtral prompts before PR:
```
12:06PM DBG Prompt (after templating):
 [INST] <|im_start|>user
Is this on?<|im_end|>
<|im_start|>assistant
 Yes, I'm here! How can I assist you today?<|im_end|>
<|im_start|>user
What is 2 + 2?<|im_end|>
<|im_start|>assistant
 [/INST]
```

After PR:
```
1:56AM DBG Prompt (after templating):
 [INST] Is this on? [/INST]
 Yes, I'm here! How can I assist you today?
 [INST] What is 2 + 2? [/INST]
```