### PR TITLE
Improve API support for self hosted OpenAI-like models

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -299,6 +299,7 @@ type TemplateType =
   | "phind"
   | "anthropic"
   | "chatml"
+  | "none"
   | "deepseek";
 
 type ModelProvider =

--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -92,6 +92,7 @@ function autodetectTemplateFunction(
       anthropic: anthropicTemplateMessages,
       chatml: chatmlTemplateMessages,
       deepseek: deepseekTemplateMessages,
+      none: null,
     };
 
     return mapping[templateType];
@@ -262,9 +263,9 @@ export abstract class BaseLLM implements ILLM {
       .join("\n");
     return `Settings:
   ${settings}
-  
+
   ############################################
-  
+
   ${prompt}`;
   }
 


### PR DESCRIPTION
This PR tries to improve how model servers which comply with the OpenAI API work.

I'm happy to raise this as an issue or discuss on discord as well.

### The issue

With the current implementation a "chat" will get formatted twice: once on the client and once on the LLM server. So with a CodeLLama vLLM server my final prompt for the message "Hi" would be:

```
[INST][INST] Hello [/INST][/INST]
```

Note that formatting server side seems to be the intended behaviour of the OpenAI `v1/chat/completions` endpoint

### The solutions in this PR

It fixes this issue in two ways:

- Allow chat templates to be explicitly turned off with a `"template": "none"` flag, this means that the raw conversation is passed to the `v1/chat/completions` endpoint;
- Call the `v1/completions` when `_complete` or `_streamComplete` is called, which happens when a template is being applied.

Possible issues with this PR:
- the `v1/completions` API is being deprecated by OpenAI (but that will not affect vLLM or other OpenAI compliant APIs).
- `/edit` which format a message always call `_complete` and `_streamComplete`, the edits could get formatted as list of messages and then be processed with a similar templating engine?

### Testing

I tested this on my machine, connecting to a vLLM server. Inspecting prompts on the server after they were decoded.

