### PR TITLE
fix: add focus to InputToolbar on click

### DIFF
--- a/gui/src/components/mainInput/ComboBox.tsx
+++ b/gui/src/components/mainInput/ComboBox.tsx
@@ -1367,7 +1367,7 @@ const ComboBox = React.forwardRef((props: ComboBoxProps, ref) => {
           />
 
           {(inputFocused || props.isMainInput) && (
-            <InputToolbar>
+            <InputToolbar onClick={() => inputRef.current?.focus()}>
               <span
                 style={{
                   color: lightGray,


### PR DESCRIPTION
### description

When a user interacts with the `MainTextInput` area, there is a non-responsive space between the
`+ Add Context` and `⏎ Enter` buttons. It would be beneficial if clicking this space also focused the
`MainTextInput`, enabling immediate typing.

See GIF below for more clarity

<img src="https://raw.githubusercontent.com/LangLangbart/ImagePool/98545d96224d02077db17f7427928797fb14584d/storage/2023-12-23_21-47-23_InputToolbar.gif" width="800">
