### PR TITLE
fix: add document focus check before input focus

### DIFF
--- a/gui/src/components/mainInput/ComboBox.tsx
+++ b/gui/src/components/mainInput/ComboBox.tsx
@@ -715,7 +715,7 @@ const ComboBox = React.forwardRef((props: ComboBoxProps, ref) => {
     if (!inputRef.current || !props.isMainInput) {
       return;
     }
-    if (props.isMainInput) {
+    if (props.isMainInput && document.hasFocus()) {
       inputRef.current.focus();
     }
     const handler = (event: any) => {


### PR DESCRIPTION
### description

- Fix #704
- If the user input has shifted away from the extension by the time the response has been generated,
  don't return the cursor to the new `ComboBox`.
- See GIF below for more clarity

<img src="https://raw.githubusercontent.com/LangLangbart/ImagePool/67dcaec6fd0ed92f5d3130f4be207db2346a4885/storage/2023-12-27_19-09-55_focus.gif" width="800">
