### PR TITLE
fix: fix #709

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor.tsx
@@ -275,6 +275,9 @@ function TipTapEditor(props: TipTapEditorProps) {
     if (!props.isMainInput) {
       return;
     }
+    if (editor && document.hasFocus()) {
+      editor.commands.focus()
+    }
     const handler = async (event: any) => {
       if (!editor) return;
 


### PR DESCRIPTION
### description
Ref: #709

Allows the cursor to stay focused on the next text area. However, do not restore the cursor position
if the user has exited the extension, for instance, if they moved their cursor to the internal
terminal in VSCode. 
