### PR TITLE
fix: editor focus handling on click events

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor.tsx
@@ -340,7 +340,12 @@ function TipTapEditor(props: TipTapEditorProps) {
   }, [editor, props.isMainInput, historyLength, ignoreHighlightedCode]);
 
   return (
-    <InputBoxDiv className="cursor-text">
+    <InputBoxDiv
+      className="cursor-text"
+      onClick={() => {
+        editor && editor.commands.focus();
+      }}
+    >
       <EditorContent
         editor={editor}
         onFocus={() => {
@@ -351,6 +356,9 @@ function TipTapEditor(props: TipTapEditorProps) {
           setTimeout(() => {
             setInputFocused(false);
           }, 100);
+        }}
+        onClick={(event) => {
+          event.stopPropagation();
         }}
       />
       <InputToolbar
@@ -363,9 +371,6 @@ function TipTapEditor(props: TipTapEditorProps) {
         }}
         onEnter={() => {
           onEnterRef.current(editor.getJSON());
-        }}
-        onClick={() => {
-          editor.commands.focus("end");
         }}
       />
     </InputBoxDiv>


### PR DESCRIPTION
### issue
When a user attempts to focus on the text input by clicking within the text area, there is a
portion of dead space that remains unresponsive.

In the image below, the `EditorContent` is highlighted in red and the `InputToolbar` in green. These
are the only areas where a user can click to activate the text input, aside from the two special
buttons that retain their unique click functions in the `InputToolbar`. 


<img src="https://github.com/continuedev/continue/assets/92653266/f1bd8b07-293e-4445-8845-295d98ce5c76" width="600">

In version 0.7.58 the user could click anywhere.

<img src="https://github.com/continuedev/continue/assets/92653266/fea85838-8792-41da-9f0c-f1c30fe6350e" width="600">

---

The fix intends to add the click event to the `InputBoxDiv`.
