### PR TITLE
refactor: Simplify focus command in TipTapEditor

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor.tsx
@@ -328,10 +328,10 @@ function TipTapEditor(props: TipTapEditorProps) {
                 item,
               },
             })
-            .focus("end")
             .run();
-          await new Promise((resolve) => setTimeout(resolve, 100));
-          editor.commands.focus("end");
+          setTimeout(() => {
+            editor.commands.focus("end");
+          }, 100);
         }
         setIgnoreHighlightedCode(false);
       }


### PR DESCRIPTION
### description
I frequently encounter an issue where, when pressing

- <kbd>⌘ Command</kbd> + <kbd>M</kbd> or
- <kbd>⌘ Command</kbd> + <kbd>⇧ Shift</kbd> + <kbd>M</kbd>

with some code as input, the cursor inexplicably lands in the title of the preview code.

This issue occurs consistently when a user clicks on the `History` icon in the top right of the
extension.

Refer to the GIF below for clarity.

<img
src="https://raw.githubusercontent.com/LangLangbart/ImagePool/573f8ad66babd537cfd3c3b772b676b81498c386/storage/2023-12-30_08-27-15_ed_focus.gif"
width="800">

---

Interestingly, simply removing one `focus()` method and running the focus again after a brief
timeout seems to resolve the issue. Is there a specific reason the `focus()` was added twice?
