### PR TITLE
Allow the usage of apiKey for llama.cpp

### DIFF
--- a/core/llm/llms/LlamaCpp.ts
+++ b/core/llm/llms/LlamaCpp.ts
@@ -25,6 +25,7 @@ class LlamaCpp extends BaseLLM {
   ): AsyncGenerator<string> {
     const headers = {
       "Content-Type": "application/json",
+      "Authorization": `Bearer ${this.apiKey}`,
       ...this.requestOptions?.headers,
     };
 


### PR DESCRIPTION
Since the llama.cpp server got support for an optional api key in commit https://github.com/ggerganov/llama.cpp/pull/4441, Continue should pass the apiKey set in config to the llama.cpp server. Currently the apiKey property is ignored, so the server always returns 403 Unauthorized if it has an api-key set.