### PR TITLE
Sap generative ai hub

### DIFF
--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -23,6 +23,10 @@ declare global {
     apiType?: string;
     region?: string;
     projectId?: string;
+    resourceGroup?: string;
+    authURL?: string;
+    clientID?: string;
+    clientSecret?: string;
 
     _fetch?: (input: any, init?: any) => Promise<any>;
 
@@ -198,6 +202,12 @@ declare global {
     // GCP Options
     region?: string;
     projectId?: string;
+
+    // SAP Gen AI Core options
+    resourceGroup?: string;
+    authURL?: string;
+    clientID?: string;
+    clientSecret?: string;
   }
   type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<
     T,
@@ -230,6 +240,7 @@ declare global {
   >;
 
   // IDE
+
 
   export interface DiffLine {
     type: "new" | "old" | "same";
@@ -342,6 +353,7 @@ declare global {
     | "gemini"
     | "mistral"
     | "bedrock"
+    | "sap-gen-ai-hub"
     | "deepinfra";
 
   export type ModelName =
@@ -509,8 +521,8 @@ declare global {
     disableIndexing?: boolean;
     userToken?: string;
   }
-  
-  
+
+
 }
 
 export {};

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -21,6 +21,11 @@ export interface ILLM extends LLMOptions {
   apiType?: string;
   region?: string;
   projectId?: string;
+  // SAP Gen AI Core options
+  resourceGroup?: string;
+  authURL?: string;
+  clientID?: string;
+  clientSecret?: string;
 
   _fetch?: (input: any, init?: any) => Promise<any>;
 
@@ -196,6 +201,12 @@ export interface LLMOptions {
   // GCP Options
   region?: string;
   projectId?: string;
+
+    // SAP Gen AI Core options
+    resourceGroup?: string;
+    authURL?: string;
+    clientID?: string;
+    clientSecret?: string;
 }
 type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<
   T,
@@ -340,6 +351,7 @@ type ModelProvider =
   | "gemini"
   | "mistral"
   | "bedrock"
+  | "sap-gen-ai-hub"
   | "deepinfra";
 
 export type ModelName =

--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -88,7 +88,6 @@ function autodetectTemplateType(model: string): TemplateType | undefined {
   if (lower.includes("mistral")) {
     return "llama2";
   }
-
   if (lower.includes("deepseek")) {
     return "deepseek";
   }
@@ -202,6 +201,12 @@ export abstract class BaseLLM implements ILLM {
   region?: string;
   projectId?: string;
 
+  // SAP Gen AI Core options
+  resourceGroup?: string;
+  authURL?: string;
+  clientID?: string;
+  clientSecret?: string;
+
   private _llmOptions: LLMOptions;
 
   constructor(options: LLMOptions) {
@@ -252,6 +257,14 @@ export abstract class BaseLLM implements ILLM {
     this.apiType = options.apiType;
     this.region = options.region;
     this.projectId = options.projectId;
+
+    // SAP Gen AI Core options
+    this.resourceGroup = options.resourceGroup;
+    this.authURL = options.authURL;
+    this.clientID = options.clientID;
+    this.clientSecret = options.clientSecret;
+
+
   }
 
   private _compileChatMessages(

--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -59,7 +59,7 @@ class OpenAI extends BaseLLM {
 
     return completion;
   }
-  private _getCompletionUrl() {
+  protected _getCompletionUrl() {
     if (this.apiType === "azure") {
       return `${this.apiBase}/openai/deployments/${this.engine}/completions?api-version=${this.apiVersion}`;
     } else {
@@ -79,6 +79,15 @@ class OpenAI extends BaseLLM {
     }
   }
 
+  protected async _getRequestHeaders(): Promise<Record<string, string>>  {
+    return {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${this.apiKey}`,
+      "api-key": this.apiKey || "", // For Azure
+    };
+  }
+
+
   protected async *_streamComplete(
     prompt: string,
     options: CompletionOptions
@@ -95,13 +104,11 @@ class OpenAI extends BaseLLM {
     prompt: string,
     options: CompletionOptions
   ): AsyncGenerator<string> {
-    const response = await this.fetch(this._getCompletionUrl(), {
+    const header = await this._getRequestHeaders();
+    const url = this._getCompletionUrl();
+    const response = await this.fetch(url, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${this.apiKey}`,
-        "api-key": this.apiKey || "", // For Azure
-      },
+      headers: header,
       body: JSON.stringify({
         ...{
           prompt,
@@ -124,7 +131,7 @@ class OpenAI extends BaseLLM {
     }
   }
 
-  private _getChatUrl() {
+  protected _getChatUrl() {
     if (this.apiType === "azure") {
       return `${this.apiBase}/openai/deployments/${this.engine}/chat/completions?api-version=${this.apiVersion}`;
     } else {
@@ -163,13 +170,11 @@ class OpenAI extends BaseLLM {
       return;
     }
 
-    const response = await this.fetch(this._getChatUrl(), {
+    const header = await this._getRequestHeaders();
+    const url = this._getChatUrl();
+    const response = await this.fetch(url, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${this.apiKey}`,
-        "api-key": this.apiKey || "", // For Azure
-      },
+      headers: header,
       body: JSON.stringify({
         ...this._convertArgs(options, messages),
         stream: true,

--- a/core/llm/llms/SAPGenAIHub.ts
+++ b/core/llm/llms/SAPGenAIHub.ts
@@ -1,0 +1,114 @@
+import { ModelProvider } from "../..";
+import OpenAI from "./OpenAI";
+
+class SAPGenAIHub extends OpenAI {
+    private tokenCache: { token: string; expiry: number } | null = null;
+
+    static providerName: ModelProvider = "sap-gen-ai-hub";
+
+    private _getTokenParams(): { authURL: string; clientID: string; clientSecret: string } {
+        if (!this.authURL || !this.clientID || !this.clientSecret) {
+            throw new Error("Authentication parameters (authURL, clientID, clientSecret) are undefined");
+        }
+        return {
+            authURL: this.authURL.endsWith("/oauth/token") ? this.authURL : `${this.authURL}/oauth/token`,
+            clientID: this.clientID,
+            clientSecret: this.clientSecret,
+        };
+    }
+
+    private async fetchWithTimeout(url: string, options: RequestInit, timeout: number): Promise<Response> {
+        return new Promise((resolve, reject) => {
+            const timer = setTimeout(() => reject(new Error('Request timed out')), timeout);
+
+            fetch(url, options)
+                .then(response => {
+                    clearTimeout(timer);
+                    resolve(response);
+                })
+                .catch(err => {
+                    clearTimeout(timer);
+                    reject(err);
+                });
+        });
+    }
+
+    private async fetchOAuthToken(): Promise<string> {
+        const params = this._getTokenParams();
+        const response = await this.fetchWithTimeout(params.authURL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({
+                client_id: params.clientID,
+                client_secret: params.clientSecret,
+                grant_type: 'client_credentials',
+            }).toString(),
+        }, 10000); // 10-second timeout
+
+        const data = await response.json();
+        return data.access_token;
+    }
+
+    private async ensureToken(): Promise<void> {
+        if (!this.tokenCache || Date.now() >= this.tokenCache.expiry) {
+            const token = await this.fetchOAuthToken();
+            const expiry = Date.now() + 3600 * 1000; // Consider making this configurable
+            this.tokenCache = { token, expiry };
+        }
+    }
+
+    protected async _getRequestHeaders(): Promise<Record<string, string>> {
+        await this.ensureToken();
+        const header: Record<string, string> = {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${this.tokenCache?.token}`,
+            "api-key": this.apiKey || "",
+            "AI-Resource-Group": this.resourceGroup || "default",
+        };
+        return header;
+    }
+
+    protected _getChatUrl() {
+        if (this.apiType === "azure") {
+          return `${this.apiBase}/chat/completions?api-version=${this.apiVersion}`;
+        } else {
+          let url = this.apiBase;
+          if (!url) {
+            throw new Error(
+              "No API base URL provided. Please set the 'apiBase' option in config.json"
+            );
+          }
+          if (url.endsWith("/")) {
+            url = url.slice(0, -1);
+          }
+
+          if (!url.endsWith("/v1")) {
+            url += "/v1";
+          }
+          return url + "/chat/completions";
+        }
+      }
+
+      protected _getCompletionUrl() {
+        if (this.apiType === "azure") {
+          return `${this.apiBase}/completions?api-version=${this.apiVersion}`;
+        } else {
+          let url = this.apiBase;
+          if (!url) {
+            throw new Error(
+              "No API base URL provided. Please set the 'apiBase' option in config.json"
+            );
+          }
+          if (url.endsWith("/")) {
+            url = url.slice(0, -1);
+          }
+          if (!url.endsWith("/v1")) {
+            url += "/v1";
+          }
+          return url + "/completions";
+        }
+      }
+
+}
+
+export default SAPGenAIHub;

--- a/core/llm/llms/index.ts
+++ b/core/llm/llms/index.ts
@@ -23,6 +23,7 @@ import OpenAI from "./OpenAI";
 import Replicate from "./Replicate";
 import TextGenWebUI from "./TextGenWebUI";
 import Together from "./Together";
+import SAPGenAIHub from "./SAPGenAIHub";
 
 function convertToLetter(num: number): string {
   let result = "";
@@ -88,6 +89,7 @@ const LLMs = [
   Gemini,
   Mistral,
   Bedrock,
+  SAPGenAIHub,
   DeepInfra,
 ];
 

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -111,6 +111,7 @@
             "lmstudio",
             "llamafile",
             "mistral",
+            "sap-gen-ai-hub",
             "deepinfra"
           ],
           "markdownEnumDescriptions": [
@@ -219,7 +220,7 @@
         "apiType": {
           "title": "Api Type",
           "description": "OpenAI API type, either `openai` or `azure`",
-          "enum": ["openai", "azure"]
+          "enum": ["openai", "azure", "vllm"]
         },
         "apiVersion": {
           "title": "Api Version",
@@ -229,6 +230,26 @@
         "engine": {
           "title": "Engine",
           "description": "Azure OpenAI engine",
+          "type": "string"
+        },
+        "authURL": {
+          "title": "OAuth URL",
+          "description": "URL to fetch OAuth token from",
+          "type": "string"
+        },
+        "clientID": {
+          "title": "OAuth Client ID",
+          "description": "OAuth client ID",
+          "type": "string"
+        },
+        "clientSecret": {
+          "title": "OAuth Client Secret",
+          "description": "OAuth client secret",
+          "type": "string"
+        },
+        "resourceGroup": {
+          "title": "SAP Gen AI Core Resource Group",
+          "description": "SAP Gen AI Core resource group",
           "type": "string"
         }
       },
@@ -305,6 +326,26 @@
               },
               "apiVersion": {
                 "type": "string"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "provider": {
+                "enum": ["openai"]
+              }
+            },
+            "required": ["provider"]
+          },
+          "then": {
+            "properties": {
+              "apiType": {
+                "enum": [
+                  "openai",
+                  "azure"
+                ]
               }
             }
           }
@@ -678,6 +719,54 @@
                 "type": "string"
               }
             }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "provider": {
+                "enum": [
+                  "sap-gen-ai-hub"
+                ]
+              }
+            },
+            "required": ["provider"]
+          },
+          "then": {
+            "required": ["clientID", "clientSecret", "authURL", "resourceGroup", "apiBase"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "provider": {
+                "enum": ["sap-gen-ai-hub"]
+              }
+            },
+            "required": ["provider"]
+          },
+          "then": {
+            "properties": {
+              "apiType": {
+                "enum": [
+                  "azure",
+                  "vllm"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "apiType": {
+                "const": "azure"
+              }
+            },
+            "required": ["apiType"]
+          },
+          "then": {
+            "required": ["apiVersion", "apiBase"]
           }
         }
       ]


### PR DESCRIPTION
This PR is to add the [SAP Generative AI Hub](https://blogs.sap.com/2023/12/21/generative-ai-hub-out-now/) as a model provider (reopened from https://github.com/continuedev/continue/pull/728).

The SAP Generative AI Hub provides a proxy for commercial models such as OpenAI and the ability to provide your own models. OAuth is always used for authentication, i.e. if you use OpenAI models via the Generative AI Hub, you do not need an API key, but the OAuth token.

In this PR, I have slightly modified the OpenAI class and introduced protected methods for determining the URLs and for generating the request headers. Based on the modified class, I added a SAPGenAI class that adapts the two methods for the Gen AI Hub.

ToDos:

- Check how to adjust config validation, because the GenAI Hub's `azure` `openai/apiType` does not require `engine` + `apiKey`and the `openai` type does not require `apiKey`.