### PR TITLE
fix: ensure code preview uses one more backtick than in the selected code as a fence

### DIFF
--- a/gui/src/components/markdown/CodeSnippetPreview.tsx
+++ b/gui/src/components/markdown/CodeSnippetPreview.tsx
@@ -63,6 +63,9 @@ const StyledHeaderButtonWithText = styled(HeaderButtonWithText)<{
   ${(props) => props.color && `background-color: ${props.color};`}
 `;
 
+// Pre-compile the regular expression outside of the function
+const backticksRegex = /`{3,}/gm
+
 function CodeSnippetPreview(props: CodeSnippetPreviewProps) {
   const dispatch = useDispatch();
 
@@ -70,6 +73,11 @@ function CodeSnippetPreview(props: CodeSnippetPreviewProps) {
   const [hovered, setHovered] = React.useState(false);
 
   const codeBlockRef = React.useRef<HTMLPreElement>(null);
+  const fence = React.useMemo(() => {
+    const backticks = props.item.content.match(backticksRegex);
+    return backticks ? (backticks.sort().at(-1) + "`") : "```";
+  }, [props.item.content]);
+
 
   return (
     <PreviewMarkdownDiv
@@ -138,9 +146,9 @@ function CodeSnippetPreview(props: CodeSnippetPreviewProps) {
       </PreviewMarkdownHeader>
       <pre className="m-0" ref={codeBlockRef}>
         <StyledMarkdownPreview
-          source={`\`\`\`${getMarkdownLanguageTagForFile(
+          source={`${fence}${getMarkdownLanguageTagForFile(
             props.item.description
-          )}\n${props.item.content}\n\`\`\``}
+          )}\n${props.item.content}\n${fence}`}
           maxHeight={MAX_PREVIEW_HEIGHT}
           showCodeBorder={false}
         />


### PR DESCRIPTION
### description
- to ensure all fenced code blocks are displayed correctly during preview, always use one more
  backtick than the maximum number used in the fenced code block


<img src="https://raw.githubusercontent.com/LangLangbart/ImagePool/b798ae52b693c3a19d7b3d462cfe8c2d9fa33ab7/storage/2024-01-10_18-59-35_13.png" width="800">

---

The issue that the code block is being removed by the `/edit` slash command is not addressed by this
PR.
- Ref: #738
