### PR TITLE
Add Hugging Face TGI to ModelProvider UI

### DIFF
--- a/gui/src/util/modelData.ts
+++ b/gui/src/util/modelData.ts
@@ -737,6 +737,27 @@ After it's up and running, you can start using Continue.`,
       },
     ],
   },
+  "huggingface-tgi": {
+    title: "Hugging Face Text Generation Inference",
+    provider: "huggingface-tgi",
+    description:
+      "A Rust, Python and gRPC server for text generation inference. Used in production at HuggingFace to power Hugging Chat, the Inference API and Inference Endpoint.",
+    longDescription: `Text Generation Inference (TGI) is an open-source toolkit for deploying and serving LLMs. It is designed for fast inference and high throughput, enabling you to provide a highly concurrent, low latency experience. As of October 2023, TGI has been optimized for Code Llama, Mistral, StarCoder, and Llama 2 on NVIDIA A100, A10G and T4 GPUs. It's possible to use other models and different hardware, it just might be a more difficult setup and the models might not perform as well. The easiest way of getting started is using the [official Docker container](https://huggingface.co/docs/text-generation-inference/quicktour).`,
+    params: {
+      apiBase: "",
+    },
+    collectInputFor: [
+      {
+        ...apiBaseInput,
+        defaultValue: "http://localhost:8000",
+      },
+      ...completionParamsInputs,
+    ],
+    icon: "hf.png",
+    tags: [ModelProviderTag.Local, ModelProviderTag["Open-Source"]],
+    packages: [...osModels, deepseek],
+  },
+
   "openai-aiohttp": {
     title: "Other OpenAI-compatible API",
     provider: "openai",

--- a/server/continuedev/libs/llm/hf_tgi.py
+++ b/server/continuedev/libs/llm/hf_tgi.py
@@ -8,6 +8,23 @@ from .base import LLM, CompletionOptions
 
 
 class HuggingFaceTGI(LLM):
+    """
+    Text Generation Inference (TGI) is an open-source toolkit for deploying and serving LLMs. It is designed for fast inference and high throughput, enabling you to provide a highly concurrent, low latency experience. As of October 2023, TGI has been optimized for Code Llama, Mistral, StarCoder, and Llama 2 on NVIDIA A100, A10G and T4 GPUs. It's possible to use other models and different hardware, it just might be a more difficult setup and the models might not perform as well. The easiest way of getting started is using the [official Docker container](https://huggingface.co/docs/text-generation-inference/quicktour).
+
+    Once the model is running on e.g. localhost:8000, change `~/.continue/config.json` to look like this:
+
+    ```json title="~/.continue/config.json"
+    {
+        "models": [{
+            "title": "Hugging Face TGI",
+            "provider": "huggingface-tgi",
+            "model": "MODEL_NAME",
+            "api_base": "http://localhost:8000"
+        }]
+    }
+    ```
+    """
+
     model: str = "huggingface-tgi"
     api_base: Optional[str] = Field(
         "http://127.0.0.1:8080", description="URL of your TGI server"


### PR DESCRIPTION
Add the 🤗Text Generation Inference Model Provider to the User Interface

For the short description I've used the [tagline of its repo](https://github.com/huggingface/text-generation-inference?tab=readme-ov-file#text-generation-inference), for the longer one, [your own documentation](https://github.com/continuedev/deploy-os-code-llm?tab=readme-ov-file#tgi)