### PR TITLE
Query 🤗TGI /info endpoint to get model name and context window

### DIFF
--- a/core/llm/llms/HuggingFaceTGI.ts
+++ b/core/llm/llms/HuggingFaceTGI.ts
@@ -23,7 +23,7 @@ class HuggingFaceTGI extends BaseLLM {
       }
       const json = await response.json();
       this.model = json.model_id;
-      this.contextLength = json.max_input_length;
+      this.contextLength = parseInt(json.max_input_length);
     });
   }
 

--- a/core/llm/llms/HuggingFaceTGI.ts
+++ b/core/llm/llms/HuggingFaceTGI.ts
@@ -8,6 +8,26 @@ class HuggingFaceTGI extends BaseLLM {
     apiBase: "http://localhost:8080",
   };
 
+  constructor(options: LLMOptions) {
+    super(options);
+
+    this.fetch(`${this.apiBase}/info`, {
+      method: "GET",
+      // body: JSON.stringify({ name: this._getModel() }),
+    }).then(async (response) => {
+      if (response.status !== 200) {
+        console.warn(
+          "Error calling Hugging Face TGI /info endpoint: ",
+          await response.text()
+        );
+        return;
+      }
+      const json = await response.json();
+      this.model = json.model_id;
+      this.contextLength = json.max_input_length;
+    });
+  }
+
   private _convertArgs(options: CompletionOptions, prompt: string) {
     const finalOptions = {
       max_new_tokens: options.maxTokens,

--- a/core/llm/llms/HuggingFaceTGI.ts
+++ b/core/llm/llms/HuggingFaceTGI.ts
@@ -13,7 +13,6 @@ class HuggingFaceTGI extends BaseLLM {
 
     this.fetch(`${this.apiBase}/info`, {
       method: "GET",
-      // body: JSON.stringify({ name: this._getModel() }),
     }).then(async (response) => {
       if (response.status !== 200) {
         console.warn(


### PR DESCRIPTION
Similar to #609 and #502
The Hugging Face Text Generation Inference Server exposes a `/info` endpoint (see [here](https://huggingface.github.io/text-generation-inference/#/Text%20Generation%20Inference/get_model_info)) which gives us the model name and the context size, allowing for automatic population of these parameters.

code was adapted from the Ollama `/api/show` implementation [here](https://github.com/continuedev/continue/blob/982c0cd15674b415ae24536899b736f471ef9f84/core/llm/llms/Ollama.ts#L20)