### PR TITLE
Introducing an interactive Entra AD based login workflow for Azure OpenAI models

### DIFF
--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -27,9 +27,8 @@ class OpenAI extends BaseLLM {
   static defaultOptions: Partial<LLMOptions> = {
     apiBase: "https://api.openai.com",
   };
-
   private _accessToken: string | undefined;
-  private _tokenExpiry: number | undefined
+  private _tokenExpiry: number | undefined;
 
 
   protected _convertArgs(
@@ -70,16 +69,22 @@ class OpenAI extends BaseLLM {
       return this._accessToken;
     }
   
-    const credential = new InteractiveBrowserCredential({});
+    return new Promise(async (resolve, reject) => {
+      try {
+        const credential = new InteractiveBrowserCredential({});
   
-    const token = await credential.getToken(
-      "https://cognitiveservices.azure.com/.default"
-    );
+        const token = await credential.getToken(
+          "https://cognitiveservices.azure.com/.default"
+        );
   
-    // Save the token and its expiry time for later use
-    this._accessToken = token.token;
-    this._tokenExpiry = token.expiresOnTimestamp!;
-    return this._accessToken;
+        // Save the token and its expiry time for later use
+        this._accessToken = token.token;
+        this._tokenExpiry = token.expiresOnTimestamp!;
+        resolve(this._accessToken);
+      } catch (error) {
+        reject(error);
+      }
+    });
   }
   
   private _isTokenExpired(): boolean {
@@ -140,7 +145,7 @@ class OpenAI extends BaseLLM {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${this.getAuthorizationHeader()}`,
+        Authorization: await this.getAuthorizationHeader(),
         "api-key": this.apiKey || "", // For Azure
       },
       body: JSON.stringify({
@@ -210,7 +215,7 @@ class OpenAI extends BaseLLM {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${this.getAuthorizationHeader()}`,
+        Authorization: await this.getAuthorizationHeader(),
         "api-key": this.apiKey || "",
       },
       body: JSON.stringify({

--- a/core/package.json
+++ b/core/package.json
@@ -29,6 +29,7 @@
     "js-tiktoken": "^1.0.8",
     "openai": "^4.20.1",
     "replicate": "^0.23.0",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "@azure/identity": "^4.0.0"
   }
 }

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -138,7 +138,7 @@
         },
         "apiKey": {
           "title": "Api Key",
-          "description": "OpenAI, Anthropic, Together, or other API key",
+          "description": "OpenAI, Anthropic, Together, or other API key. Leave empty if you're using azuread interactive login",
           "type": "string"
         },
         "apiBase": {
@@ -218,8 +218,8 @@
         },
         "apiType": {
           "title": "Api Type",
-          "description": "OpenAI API type, either `openai` or `azure`",
-          "enum": ["openai", "azure"]
+          "description": "OpenAI API type, either `openai`, `azure`, or `azuread` (Same as azure but with interactivelogin via AAD/Entra)",
+          "enum": ["openai", "azure", "azuread"]
         },
         "apiVersion": {
           "title": "Api Version",


### PR DESCRIPTION
Hey,

## What

This pull request (PR) modifies the `core/llm/openai.ts` file to incorporate an interactive browser-based login prompt using `@azure/identity`. The login prompt is triggered only if the `apiType` is set to `azuread` instead of `azure` or `openai`. Additionally, I have updated the config schema to accommodate this new API type. The logic checks if a token is already saved and not expired; if needed, it triggers the login window.

## Why

Distributing Azure OpenAI API keys directly to developers poses a security risk, even with VNET restrictions. This modification introduces a more secure approach by utilizing Azure Identity and allowing individual users or groups to interactively log in. Users can be granted access to the OpenAI resource using the "Cognitive Services OpenAI User" role.

## How to use
add an Azure OpenAI based model, use azuread for apitype and provide an empty apikey


It might not be perfect but i think it's a good start for implementation.

Kind regards,

Wanis