### PR TITLE
address some of the ruff warnings

### DIFF
--- a/server/continuedev/core/steps.py
+++ b/server/continuedev/core/steps.py
@@ -13,7 +13,6 @@ from ..libs.util.count_tokens import DEFAULT_MAX_TOKENS
 from ..libs.util.devdata import dev_data_logger
 from ..libs.util.strings import (
     dedent_and_get_common_whitespace,
-    remove_quotes_and_escapes,
 )
 from ..libs.util.telemetry import posthog_logger
 from ..libs.util.templating import render_prompt_template
@@ -24,8 +23,6 @@ from .main import (
     ChatMessage,
     ContextItem,
     ContinueCustomException,
-    DeltaStep,
-    SessionUpdate,
     SetStep,
     Step,
 )

--- a/server/continuedev/libs/index/pipelines/main.py
+++ b/server/continuedev/libs/index/pipelines/main.py
@@ -5,7 +5,6 @@ from ..chunkers.chunk import Chunk
 from ..hyde import code_hyde
 from ..indices.chroma_index import ChromaCodebaseIndex
 from ..indices.meilisearch_index import MeilisearchCodebaseIndex
-from ..rerankers.default import default_reranker_parallel
 from ..rerankers.single_token import single_token_reranker_parallel
 
 
@@ -59,7 +58,7 @@ async def main_retrieval_pipeline(
     )
     # Rerank to select top results
     if use_reranking:
-        print(f"Selecting most important files...")
+        print("Selecting most important files...")
         chunks = await single_token_reranker_parallel(
             chunks,
             query,

--- a/server/continuedev/libs/util/copy_codebase.py
+++ b/server/continuedev/libs/util/copy_codebase.py
@@ -6,6 +6,7 @@ from typing import Iterable, List, Union
 from watchdog.events import PatternMatchingEventHandler
 from watchdog.observers import Observer
 
+from ...libs.util import calculate_diff
 from ...core.autopilot import Autopilot
 from ...models.filesystem import FileSystem
 from ...models.main import (

--- a/server/continuedev/plugins/recipes/TemplateRecipe/main.py
+++ b/server/continuedev/plugins/recipes/TemplateRecipe/main.py
@@ -1,6 +1,6 @@
 from typing import Coroutine
 
-from ....core.main import Observation, Step
+from ....core.main import Step
 from ....core.sdk import ContinueSDK, Models
 
 

--- a/server/continuedev/plugins/steps/codebase.py
+++ b/server/continuedev/plugins/steps/codebase.py
@@ -2,7 +2,7 @@ import asyncio
 import os
 from typing import List, Optional, Union
 
-from ...core.config import ModelDescription, RetrievalSettings
+from ...core.config import RetrievalSettings
 from ...core.main import (
     ContextItem,
     ContextItemDescription,

--- a/server/continuedev/plugins/steps/steps_on_startup.py
+++ b/server/continuedev/plugins/steps/steps_on_startup.py
@@ -1,5 +1,3 @@
-from typing import Type
-
 from ...core.main import Step
 from ...core.sdk import ContinueSDK, Models
 


### PR DESCRIPTION
i know the python implementation isn't going to be used in the long-term (i'm assuming that's still the assumption?) but in the meantime, there are errors in `main` that are causing CI to fail.

Consistently failing jobs means CI feedback on PRs is less meaningful.

i've squashed most of the warnings, except for these-

```
continuedev/libs/util/copy_codebase.py:104:18: F821 Undefined name `ManualEditAction`
continuedev/plugins/context_providers/embeddings.py:28:29: F821 Undefined name `ChromaIndexManager`
continuedev/plugins/context_providers/embeddings.py:36:34: F821 Undefined name `ChromaIndexManager`
```

where are these objects defined??