### PR TITLE
Add install-dependencies.ps1, and point the associated vscode Task at it when running on Windows

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -102,8 +102,9 @@
     {
       "label": "install-all-dependencies",
       "type": "shell",
+      "windows": { "command": "./install-dependencies.ps1" },
       "command": "./install-dependencies.sh",
-      "problemMatcher": [] // Empty so users are not promted to select progress reporting
+      "problemMatcher": [] // Empty so users are not prompted to select progress reporting
     },
     //
     // Start the React App for debugging with Vite

--- a/install-dependencies.ps1
+++ b/install-dependencies.ps1
@@ -4,46 +4,91 @@
 # - Debug -> Extension
 
 # Everything needs node and npm
-Write-Output "Checking for node..."
+Write-Host "`nChecking for dependencies that may require manual installation...`n" -ForegroundColor White
 
-if ($null -eq (get-command node -ErrorAction SilentlyContinue)) {
-    Write-Output "No node found, installing node LTS using winget"
-    winget install OpenJS.NodeJS.LTS
-
-    # we still won't find it in this script if we don't also refresh our path
-    $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+$cargo = (get-command cargo -ErrorAction SilentlyContinue)
+if ($null -eq $cargo) {
+    Write-Host "Not Found " -ForegroundColor Red -NoNewLine
+    Write-Host "cargo"
 } else {
-    node --version
+    Write-Host "Found " -ForegroundColor Green -NoNewLine
+    & cargo --version
 }
 
-Write-Output "Installing Core extension dependencies..."
+$node  = (get-command node -ErrorAction SilentlyContinue)
+if ($null -eq $node) {
+    Write-Host "Not Found " -ForegroundColor Red -NoNewLine
+    Write-Host "node"
+} else {
+    Write-Host "Found " -ForegroundColor Green -NoNewLine
+    Write-Host "node "  -NoNewLine
+    & node --version
+}
+
+Push-Location extensions/vscode
+$yarn  = (get-command yarn -ErrorAction SilentlyContinue)
+if ($null -eq $yarn) {
+    Write-Host "Not Found " -ForegroundColor Red -NoNewLine
+    Write-Host "yarn"
+} else {
+    Write-Host "Found " -ForegroundColor Green -NoNewLine
+    Write-Host "yarn " -NoNewLine
+    & yarn --version
+}
+Pop-Location
+
+if ($null -eq $cargo) {
+    Write-Host "`n...`n"
+    Write-Host "Cargo`n" -ForegroundColor  White
+    Write-Host "Doesn't appear to be installed or is not on your Path."
+    Write-Host "For how to install cargo see:" -NoNewline
+    Write-Host "https://doc.rust-lang.org/cargo/getting-started/installation.html" -ForegroundColor Green
+}
+
+if ($null -eq $node) {
+    Write-Host "`n...`n"
+    Write-Host "NodeJS`n" -ForegroundColor White
+    Write-Host "Doesn't appear to be installed or is not on your Path."
+    Write-Host "On most Windows systems you can install node using: " -NoNewLine
+    Write-Host "winget install OpenJS.NodeJS.LTS " -ForegroundColor Green
+    Write-Host "After installing restart your Terminal to update your Path."
+    Write-Host "Alternatively see: " -NoNewLine
+    Write-Host "https://nodejs.org/" -ForegroundColor Yellow
+}
+
+if ($null -eq $yarn) {
+    Write-Host "`n...`n"
+    Write-Host "Yarn`n" -ForegroundColor White
+    Write-Host "Doesn't appear to be installed or is not accessible from .\extensions\vscode"
+    Write-Host "For how to install Yarn 1.x see:"
+    Write-Host "https://classic.yarnpkg.com/lang/en/docs/install/#windows-stable" -ForegroundColor Yellow
+    Write-Host "For how to install Yarn 2.x or 3.x see: "
+    Write-Host "https://yarnpkg.com/getting-started/install" -ForegroundColor Yellow
+}
+
+if (($null -eq $cargo) -or ($null -eq $node) -or ($null -eq $yarn)) {
+    return "`nSome dependencies that may require installation could not be found. Exiting"
+}
+
+Write-Host "`nInstalling Core extension dependencies..." -ForegroundColor White
 Push-Location core
 npm install
 npm link
 Pop-Location
 
-Write-Output "Installing GUI extension dependencies..."
+Write-Output "`nInstalling GUI extension dependencies..." -ForegroundColor White
 Push-Location gui
 npm install
 npm link core
 Pop-Location
 
 # VSCode Extension (will also package GUI)
-Write-Output "Installing VSCode extension dependencies..."
+Write-Output "`nInstalling VSCode extension dependencies..." -ForegroundColor White
 Push-Location extensions/vscode
 
 # This does way too many things inline but is the common denominator between many of the scripts
 npm install
 npm link core
-
-#Yarn is required for the package build apparently
-Write-Output "Checking for yarn..."
-if ($null -eq (get-command yarn -ErrorAction SilentlyContinue)) {
-    Write-Output "No yarn found, installing 1.x"
-    npm install yarn
-} else {
-    yarn --version
-}
 
 npm run package
 

--- a/install-dependencies.ps1
+++ b/install-dependencies.ps1
@@ -1,0 +1,50 @@
+# This is used in a task in .vscode/tasks.json when on windows
+# Start developing with:
+# - Run Task -> Install Dependencies
+# - Debug -> Extension
+
+# Everything needs node and npm
+Write-Output "Checking for node..."
+
+if ($null -eq (get-command node -ErrorAction SilentlyContinue)) {
+    Write-Output "No node found, installing node LTS using winget"
+    winget install OpenJS.NodeJS.LTS
+
+    # we still won't find it in this script if we don't also refresh our path
+    $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+} else {
+    node --version
+}
+
+Write-Output "Installing Core extension dependencies..."
+Push-Location core
+npm install
+npm link
+Pop-Location
+
+Write-Output "Installing GUI extension dependencies..."
+Push-Location gui
+npm install
+npm link core
+Pop-Location
+
+# VSCode Extension (will also package GUI)
+Write-Output "Installing VSCode extension dependencies..."
+Push-Location extensions/vscode
+
+# This does way too many things inline but is the common denominator between many of the scripts
+npm install
+npm link core
+
+#Yarn is required for the package build apparently
+Write-Output "Checking for yarn..."
+if ($null -eq (get-command yarn -ErrorAction SilentlyContinue)) {
+    Write-Output "No yarn found, installing 1.x"
+    npm install yarn
+} else {
+    yarn --version
+}
+
+npm run package
+
+Pop-Location


### PR DESCRIPTION
### Motivation

As a complete madman, who currently does all their stuff with LLMs and AI on Windows (It's the box that has the Graphics Card with the VRAM - but, yes, it's AMD, even madder!) the bash script for the install dependencies task obviously didn't work me out of the box.

There is probably some way of getting it working with either git-bash or WSL, but instead I went and wrote a powershell version and tweaked the task to run that one when on windows. It should still run the bash one if you're not.


### Changes

* Add an install-dependencies.ps1 powershell script for installing the dependencies as the bash version didn't work for me on windows.
* Update the install dependencies task definition to use the powershell script rather than the bash script on windows.
* Installs node on windows if its not already installed.
* Installs yarn 1.x on windows at extensions/vscode level as it seems `npm run package` needs it.


### Possible Problems/Concerns

* ~Installing node if you don't already have is probably a bit aggressive.~ addressed https://github.com/continuedev/continue/pull/773/commits/206b6e686bb4b1548dba9639b838a764c6dffd56
* ~Similarly for yarn, which its something down in the the vsode extension packaging seems to need.~ addressed https://github.com/continuedev/continue/pull/773/commits/206b6e686bb4b1548dba9639b838a764c6dffd56
* ~If those aren't too aggressive it should probably do cargo too (but I already had that).~ addressed https://github.com/continuedev/continue/pull/773/commits/206b6e686bb4b1548dba9639b838a764c6dffd56
