### PR TITLE
Fix streamDiff tests

### DIFF
--- a/core/diff/streamDiff.ts
+++ b/core/diff/streamDiff.ts
@@ -37,7 +37,7 @@ export async function* streamDiff(
         yield { type: "old", line: mutatedOldLines.shift()! };
       }
       if (postponedLines.length > 0) {
-        for (let i = 0; i < postponedLines.length; i++) {
+        for (let i = 0; i <= postponedLines.length; i++) {
           yield { type: "new", line: postponedLines.shift()! };
         }
       }

--- a/core/diff/streamDiff.ts
+++ b/core/diff/streamDiff.ts
@@ -13,14 +13,15 @@ export async function* streamDiff(
   oldLines: string[],
   newLines: LineStream
 ): AsyncGenerator<DiffLine> {
-  oldLines = [...oldLines]; // be careful
+  const mutatedOldLines = [...oldLines]; // be careful
   let seenIndentationMistake = false;
 
   let newLineResult = await newLines.next();
+  const postponedLines: string[] = [];
   while (oldLines.length > 0 && !newLineResult.done) {
     const [matchIndex, isPerfectMatch, newLine] = matchLine(
       newLineResult.value,
-      oldLines,
+      mutatedOldLines,
       seenIndentationMistake
     );
     if (!seenIndentationMistake && newLineResult.value !== newLine) {
@@ -29,20 +30,25 @@ export async function* streamDiff(
 
     if (matchIndex < 0) {
       // Insert new line
-      yield { type: "new", line: newLine };
+      postponedLines.push(newLine);
     } else {
       // Insert all deleted lines before match
       for (let i = 0; i < matchIndex; i++) {
-        yield { type: "old", line: oldLines.shift()! };
+        yield { type: "old", line: mutatedOldLines.shift()! };
+      }
+      if (postponedLines.length > 0) {
+        for (let i = 0; i < postponedLines.length; i++) {
+          yield { type: "new", line: postponedLines.shift()! };
+        }
       }
 
       if (isPerfectMatch) {
         // Same
-        yield { type: "same", line: oldLines.shift()! };
+        yield { type: "same", line: mutatedOldLines.shift()! };
       } else {
         // Delete old line and insert the new
-        yield { type: "old", line: oldLines.shift()! };
-        yield { type: "new", line: newLine };
+        yield { type: "old", line: mutatedOldLines.shift()! };
+        postponedLines.push(newLine);
       }
     }
 
@@ -50,15 +56,21 @@ export async function* streamDiff(
   }
 
   // Once at the edge, only one choice
-  if (newLineResult.done === true && oldLines.length > 0) {
+  if (newLineResult.done === true && mutatedOldLines.length > 0) {
     for (let oldLine of oldLines) {
       yield { type: "old", line: oldLine };
     }
   }
 
-  if (!newLineResult.done && oldLines.length === 0) {
+  if (!newLineResult.done && mutatedOldLines.length === 0) {
     yield { type: "new", line: newLineResult.value };
     for await (const newLine of newLines) {
+      yield { type: "new", line: newLine };
+    }
+  }
+
+  if (postponedLines.length > 0) {
+    for await (const newLine of postponedLines) {
       yield { type: "new", line: newLine };
     }
   }

--- a/core/diff/util.ts
+++ b/core/diff/util.ts
@@ -41,8 +41,8 @@ export function matchLine(
     } else if (linesMatch(newLine, oldLines[i])) {
       // This is a way to fix indentation, but only for sufficiently long lines to avoid matching whitespace or short lines
       if (
-        newLine.trimStart() === oldLines[i].trimStart() &&
-        (permissiveAboutIndentation || newLine.trim().length > 8)
+        newLine.trimStart() === oldLines[i].trimStart() // &&
+        // (permissiveAboutIndentation) || newLine.trim().length > 8)
       ) {
         return [i, true, oldLines[i]];
       }

--- a/core/test/diff.test.ts
+++ b/core/test/diff.test.ts
@@ -1,6 +1,18 @@
 import { streamDiff } from "../diff/streamDiff";
 
 const oldCode = [
+  `A
+B`,
+  `A
+B
+C`,
+  `A
+B
+C
+A
+B
+B
+A`,
   `function mergeSortAlgorithm() {
     // TODO: implement
 }`,
@@ -10,6 +22,19 @@ const oldCode = [
 ];
 
 const newCode = [
+  `C
+D`,
+  `D
+E
+C
+F
+C`,
+  `C
+B
+A
+B
+A
+C`,
   `function mergeSortAlgorithm(arr: number[]): number[] {
   if (arr.length <= 1) {
     return arr;
@@ -113,7 +138,11 @@ describe("streamDiff", () => {
       // Check that there are no red lines immediately following green (they should always be above)
       for (let i = 1; i < diff.length; i++) {
         if (diff[i].type === "old" && diff[i - 1].type === "new") {
-          throw new Error("Found red immediately after green line");
+          throw new Error(
+            `Found red '${diff[i].line}' immediately after green line '${
+              diff[i - 1].line
+            }`
+          );
         }
       }
     });


### PR DESCRIPTION
There was a use case that where failing because it expects the `old` ( or `-` ) to come only after the `new` (or `+`). 
Code produces the correct diff but is structured in a way that injects the `+` first. In this PR instead of inserting the `+` first, the algorithm stores `-` in the stack and interest before the upcoming `+` this is the way it reprioritizes the `-` changes over `+` in the final diff. 

Example before the change:
```diff
    + D
    + E
    - A
    - B
      C
    + F
    + C
```

now becomes
```diff
    - A
    - B
    + D
    + E
      C
    + F
    + C
```

But exploring the logic around that there are some open questions still for me that I'd like to understand.
Here is some logic, that aims to prevent bugs I assume which I commented on to make a match:


```ts
      if (
        newLine.trimStart() === oldLines[i].trimStart() // &&
        // (permissiveAboutIndentation) || newLine.trim().length > 8) 
      ) {
```

in this case when we compare the ` }` with `  }` we trim the start and get the `}` and `}` but as long as `permissiveAboutIndentation` is `false` and `"}".trim().length` is not longer than 8 it's not matching the closing brackets correctly.

@sestinj could you please have a look at the updated logic, that fixes the test? Is it something that the test intends to cover initially? If yes, then let's think about how we can adjust this logic ` (permissiveAboutIndentation) || newLine.trim().length > 8) ` to not cause the potential regression. Because seems that it was needed to cover some edge cases. If you can give an example of that, it's also possible to cover it here in the test to avoid regression in the future.