### PR TITLE
make chat font consistent with vscode UI

### DIFF
--- a/gui/src/components/markdown/StyledMarkdownPreview.tsx
+++ b/gui/src/components/markdown/StyledMarkdownPreview.tsx
@@ -55,7 +55,7 @@ const StyledMarkdown = styled.div<{
   }
 
   code:not(pre > code) {
-    font-family: monospace;
+    font-family: var(--vscode-editor-font-family);
   }
 
   background-color: ${vscBackground};

--- a/gui/src/components/markdown/StyledMarkdownPreview.tsx
+++ b/gui/src/components/markdown/StyledMarkdownPreview.tsx
@@ -60,6 +60,7 @@ const StyledMarkdown = styled.div<{
 
   background-color: ${vscBackground};
   font-family:
+    var(--vscode-font-family),
     system-ui,
     -apple-system,
     BlinkMacSystemFont,


### PR DESCRIPTION
For compatibility purposes I didn't remove the original fonts below, seems they are removable. This one is working on my vscode setting, but haven't tested it in a clean install. Please help check, thanks!