### PR TITLE
Fix local build script

### DIFF
--- a/extensions/vscode/scripts/prepackage.js
+++ b/extensions/vscode/scripts/prepackage.js
@@ -11,7 +11,7 @@ if (args[2] === "--target") {
 }
 
 (async () => {
-  console.log("Packaging extension for target ", target);
+  console.log("[info] Packaging extension for target ", target);
 
   // Copy config_schema.json to config.json in docs
   fs.copyFileSync(
@@ -26,12 +26,12 @@ if (args[2] === "--target") {
 
   // Install node_modules //
   execSync("npm install");
-  console.log("npm install in extensions/vscode completed");
+  console.log("[info] npm install in extensions/vscode completed");
 
   process.chdir("../../gui");
 
   execSync("npm install");
-  console.log("npm install in gui completed");
+  console.log("[info] npm install in gui completed");
 
   if (ghAction()) {
     execSync("npm run build");
@@ -56,8 +56,8 @@ if (args[2] === "--target") {
   await new Promise((resolve, reject) => {
     ncp("dist", intellijExtensionWebviewPath, (error) => {
       if (error) {
-        console.log(
-          "Error copying React app build to Intellij extension: ",
+        console.warn(
+          "[error] Error copying React app build to Intellij extension: ",
           error
         );
         reject(error);
@@ -71,7 +71,7 @@ if (args[2] === "--target") {
   }
   fs.copyFileSync("tmp_index.html", indexHtmlPath);
   fs.unlinkSync("tmp_index.html");
-  console.log("Copied gui build to Intellij extension");
+  console.log("[info] Copied gui build to Intellij extension");
 
   // Then copy over the dist folder to the VSCode extension //
   const vscodeGuiPath = path.join("../extensions/vscode/gui");
@@ -93,9 +93,6 @@ if (args[2] === "--target") {
 
   // Copy over native / wasm modules //
   process.chdir("../extensions/vscode");
-  if (!ghAction() && fs.existsSync("./bin")) {
-    return;
-  }
 
   // If target doesn't exist, but the bin folder also doesn't, we want to download it once, to help set up the dev environment
   if (!target) {
@@ -124,7 +121,7 @@ if (args[2] === "--target") {
     }[process.arch];
 
     target = `${os}-${arch}`;
-    console.log("Detected target: ", target);
+    console.log("[info] Detected target: ", target);
   }
   fs.mkdirSync("bin", { recursive: true });
 
@@ -135,7 +132,7 @@ if (args[2] === "--target") {
       path.join(__dirname, "../bin"),
       (error) => {
         if (error) {
-          console.warn("Error copying onnxruntime-node files", error);
+          console.warn("[info] Error copying onnxruntime-node files", error);
           reject(error);
         }
         resolve();
@@ -160,22 +157,31 @@ if (args[2] === "--target") {
       });
     }
   }
-  console.log("Copied onnxruntime-node");
+  console.log("[info] Copied onnxruntime-node");
 
-  // tree-sitter-wasms
-  ncp(
-    path.join(__dirname, "../../../core/node_modules/tree-sitter-wasms/out"),
-    path.join(__dirname, "../out/tree-sitter-wasms"),
-    (error) => {
-      if (error) console.warn("Error copying tree-sitter-wasms files", error);
-    }
-  );
+  // tree-sitter-wasm
+  fs.mkdirSync("out", { recursive: true });
+
+  await new Promise((resolve, reject) => {
+    ncp(
+      path.join(__dirname, "../../../core/node_modules/tree-sitter-wasms/out"),
+      path.join(__dirname, "../out/tree-sitter-wasms"),
+      (error) => {
+        if (error) {
+          console.warn("[error] Error copying tree-sitter-wasm files", error);
+          reject(error);
+        } else {
+          resolve();
+        }
+      }
+    );
+  });
 
   fs.copyFileSync(
     path.join(__dirname, "../../../core/vendor/tree-sitter.wasm"),
     path.join(__dirname, "../out/tree-sitter.wasm")
   );
-  console.log("Copied tree-sitter wasms");
+  console.log("[info] Copied tree-sitter wasms");
 
   function ghAction() {
     return target !== undefined;
@@ -198,7 +204,7 @@ if (args[2] === "--target") {
     // Neither lancedb nor sqlite3 have pre-built windows arm64 binaries
     if (!isWin()) {
       // lancedb binary
-      console.log("Downloading pre-built lancedb binary");
+      console.log("[info] Downloading pre-built lancedb binary");
       rimrafSync("node_modules/@lancedb");
       const packageToInstall = {
         "darwin-arm64": "@lancedb/vectordb-darwin-arm64",
@@ -208,7 +214,7 @@ if (args[2] === "--target") {
     }
 
     // Download and unzip esbuild
-    console.log("Downloading pre-built esbuild binary");
+    console.log("[info] Downloading pre-built esbuild binary");
     rimrafSync("node_modules/@esbuild");
     fs.mkdirSync("node_modules/@esbuild", { recursive: true });
     execSync(
@@ -222,7 +228,7 @@ if (args[2] === "--target") {
     // sqlite3
     if (isArm() && !isWin()) {
       // Replace the installed with pre-built
-      console.log("Downloading pre-built sqlite3 binary");
+      console.log("[info] Downloading pre-built sqlite3 binary");
       rimrafSync("../../core/node_modules/sqlite3/build");
       const downloadUrl = {
         "darwin-arm64":
@@ -236,24 +242,45 @@ if (args[2] === "--target") {
       execSync("cd ../../core/node_modules/sqlite3 && tar -xvzf build.tar.gz");
       fs.unlinkSync("../../core/node_modules/sqlite3/build.tar.gz");
     }
+  }
 
+  await new Promise((resolve, reject) => {
     ncp(
       path.join(__dirname, "../../../core/node_modules/sqlite3/build"),
       path.join(__dirname, "../out/build"),
       (error) => {
-        if (error) console.warn("Error copying sqlite3 files", error);
+        if (error) {
+          console.warn("[error] Error copying sqlite3 files", error);
+          reject(error);
+        } else {
+          resolve();
+        }
       }
     );
-  }
+  });
 
   // Copy node_modules for pre-built binaries
   const NODE_MODULES_TO_COPY = ["esbuild", "@esbuild", "@lancedb"];
   fs.mkdirSync("out/node_modules", { recursive: true });
-  NODE_MODULES_TO_COPY.forEach((mod) => {
-    ncp.ncp(`node_modules/${mod}`, `out/node_modules/${mod}`, function (err) {
-      if (err) {
-        return console.error(err);
-      }
-    });
-  });
+
+  await Promise.all(
+    NODE_MODULES_TO_COPY.map(
+      (mod) =>
+        new Promise((resolve, reject) =>
+          ncp(
+            `node_modules/${mod}`,
+            `out/node_modules/${mod}`,
+            function (error) {
+              if (error) {
+                console.error(`[error] Error copying ${mod}`, error);
+                reject(error);
+              } else {
+                resolve();
+              }
+            }
+          )
+        )
+    )
+  );
+  console.log(`[info] Copied ${NODE_MODULES_TO_COPY.join(", ")}`);
 })();

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -22,5 +22,4 @@ pushd extensions/vscode
 # This does way too many things inline but is the common denominator between many of the scripts
 npm install
 npm link core
-npm run prepackage
 npm run package


### PR DESCRIPTION
The local installation bash script does not produce the correct extension bundle file - `extensions/vscode/build/continue-patch.vsix` . It is missing the `tree-sitter.wasm` and the rest of the dependencies that are installed manually through the `prepackage` stage

##  How to reproduce:

Do the clean install: 
```bash
git clone git@github.com:pikisoft/continue.git
cd continue 
./install-dependencies.sh
```

There is an error message:
```bash
Copied onnxruntime-node
(node:20683) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)
node:fs:2894
  handleErrorFromBinding(ctx);
  ^

Error: ENOENT: no such file or directory, copyfile '/home/my8bit/github/continue_tmp_3/core/vendor/tree-sitter.wasm' -> '/home/my8bit/github/continue_tmp_3/extensions/vscode/out/tree-sitter.wasm'
    at Object.copyFileSync (node:fs:2894:3)
    at /home/my8bit/github/continue_tmp_3/extensions/vscode/scripts/prepackage.js:172:6
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  errno: -2,
  syscall: 'copyfile',
  code: 'ENOENT',
  path: '/home/my8bit/github/continue_tmp_3/core/vendor/tree-sitter.wasm',
  dest: '/home/my8bit/github/continue_tmp_3/extensions/vscode/out/tree-sitter.wasm'
}

Node.js v18.15.0
FAIL: 1
```

This is because there is there is no `extensions/vscode/out` dir. You can check by:

```bash
ls /home/my8bit/github/continue_tmp_3/extensions/vscode/out
ls: cannot access '/home/my8bit/github/continue_tmp_3/extensions/vscode/out': No such file or directory
FAIL: 2
```

after the second run, for reasons described below it changes to:

```bash
ls /home/my8bit/github/continue_tmp_3/extensions/vscode/out
extension.js  extension.js.map
```

### Main problem

When you rerun this code there will be no error because of these lines from `extensions/vscode/scripts/prepackage.js`

```js
if (!ghAction() && fs.existsSync("./bin")) {
    return;
}
```

Because `bin` dir was created before the exception `extensions/vscode/scripts/prepackage.js`

As a result, the next invocation of the `./install-dependencies.sh` will NOT throw an error and skip the file copying step. So it means that there will be no:

```
out/tree-sitter-wasms
out/tree-sitter.wasm
out/node_modules/esbuild
out/node_modules/@esbuild
out/node_modules/esbuild
out/node_modules/@lancedb
```

### Second issue

After removing that line the new issues become clear. There is no folder yet to copy wasms and wasm files to

```bash
ls /home/my8bit/github/continue_tmp_3/extensions/vscode/out
ls: cannot access '/home/my8bit/github/continue_tmp_3/extensions/vscode/out': No such file or directory
```

after creating such a folder all files copied as expected

```bash
ls /home/my8bit/github/continue_tmp_3/extensions/vscode/out
build  extension.js  extension.js.map  node_modules  tree-sitter-wasms  tree-sitter.wasm
```

### Mix of sync vs async copying

some `ncp` tasks are executed async and some of them are wrapped in a promise. But to avoid potential race conditions between async and sync tasks I refactored them to be wrapped with Promise

### Duplication of the prepackage step
There are naming conventions [npm](https://docs.npmjs.com/cli/v10/using-npm/scripts#life-cycle-scripts) that will execute tasks like `pre<even>` in this case `prepackage` automagically. Meaning there is no need for extra:

```bash
npm run prepackage
```

in 

in `./install-dependencies.sh` as it will duplicate the execution of the `prepackage` twice as you can see from the logs

### Issue with package script
This is something that I noticed but decided to not add to this MR as I do not have a fix for that yet and I went down the rabbit hole already. The problem is that the `package` script is now working as expected as well. However, errors are hidden because of how the Node.js `exec` command works. To see the error such change this change has to be applied to `extensions/vscode/package.json`

```js
exec(command, (error, stdout, stderr) => {
    if (error) {
        console.error(`Error: ${error.message}`);
    }
    if (stderr) {
        console.error(`stderr: ${stderr}`);
    }
    console.log(`stdout: ${stdout}`);
});
```