### PR TITLE
feat: hide empty code lines in markdown preview

### DIFF
--- a/gui/src/components/markdown/StyledMarkdownPreview.tsx
+++ b/gui/src/components/markdown/StyledMarkdownPreview.tsx
@@ -46,6 +46,9 @@ const StyledMarkdown = styled.div<{
   }
 
   code {
+    span.line:empty {
+      display: none;
+    }
     color: #f78383;
     word-wrap: break-word;
     border-radius: ${defaultBorderRadius};


### PR DESCRIPTION
### description

An empty span element is being added when some code is highlighted. The issue seems to originate
from the `rehypeShikiji` plugin. A related issue[^1] was previously filed but without any
actions taken.

---

The idea is to not display these empty `span` elements.

<img src="https://raw.githubusercontent.com/LangLangbart/ImagePool/b33448e47f6dac3ce4e3628e47428769bab6ed1f/storage/2024-02-03_10-39-34_empty.png" width="400">

[^1]: [Extra <span class="line"></span> added to code blocks?· Issue #101 · antfu/shikiji](https://github.com/antfu/shikiji/issues/101)
