### PR TITLE
fix: remove conditional for npm run build

### DIFF
--- a/extensions/vscode/scripts/prepackage.js
+++ b/extensions/vscode/scripts/prepackage.js
@@ -33,9 +33,7 @@ if (args[2] === "--target") {
   execSync("npm install");
   console.log("[info] npm install in gui completed");
 
-  if (ghAction()) {
-    execSync("npm run build");
-  }
+  execSync("npm run build");
 
   // Copy over the dist folder to the Intellij extension //
   const intellijExtensionWebviewPath = path.join(


### PR DESCRIPTION
### description

fix #812

---

The `npm run build` needs to be executed also when the user presses <kbd>F5</kbd> to ensure that the
latest changes are used.
