### PR TITLE
fix: replace null with empty string in getSidebarContent function

### DIFF
--- a/extensions/vscode/src/debugPanel.ts
+++ b/extensions/vscode/src/debugPanel.ts
@@ -745,7 +745,7 @@ export function getSidebarContent(
           window.$RefreshSig$ = () => (type) => type
           window.__vite_plugin_react_preamble_installed__ = true
           </script>`
-            : null
+            : ""
         }
 
         <script type="module" nonce="${nonce}" src="${scriptUri}"></script>


### PR DESCRIPTION
### description
- 'null' becomes a literal string
- similar to #618
