### PR TITLE
check for edge cases

### DIFF
--- a/core/context/providers/CodeHighlightsContextProvider.ts
+++ b/core/context/providers/CodeHighlightsContextProvider.ts
@@ -48,7 +48,7 @@ class CodeHighlightsContextProvider extends BaseContextProvider {
     );
     return [
       {
-        content: repoMap,
+        content: repoMap ? repoMap : "",
         name: "Code Highlights",
         description: "Code highlights from open files",
       },

--- a/core/package.json
+++ b/core/package.json
@@ -26,7 +26,7 @@
     "fastest-levenshtein": "^1.0.16",
     "handlebars": "^4.7.8",
     "js-tiktoken": "^1.0.8",
-    "llm-code-highlighter": "^0.0.1",
+    "llm-code-highlighter": "^0.0.3",
     "node-fetch": "^3.3.2",
     "node-html-markdown": "^1.3.0",
     "openai": "^4.20.1",


### PR DESCRIPTION
The library now checks for cases such as where a source file has no definitions or references (according to the tags query) so there's nothing to rank.

I'm not entirely sure what's the right context to return. For now I've gone with an empty string as the content value.
