### PR TITLE
fix: Promise arrays being returned. Added a new definitions-only context provider. fix: typescript tagging.

### DIFF
--- a/core/context/providers/CodeHighlightsContextProvider.ts
+++ b/core/context/providers/CodeHighlightsContextProvider.ts
@@ -6,7 +6,7 @@ import {
 } from "../..";
 import { getBasename } from "../../util";
 
-const highlighterPromise = import("llm-code-highlighter/dist/index.continue");
+import { getSourceSetHighlights } from "llm-code-highlighter/dist/index.continue";
 
 class CodeHighlightsContextProvider extends BaseContextProvider {
   static description: ContextProviderDescription = {
@@ -33,8 +33,7 @@ class CodeHighlightsContextProvider extends BaseContextProvider {
         })
       );
     const topPercentile = 0.5;
-    const highlighter = await highlighterPromise;
-    const repoMap = await highlighter.getRepoHighlights(
+    const repoMap = await getSourceSetHighlights(
       topPercentile,
       [],
       allFiles

--- a/core/context/providers/CodeOutlineContextProvider.ts
+++ b/core/context/providers/CodeOutlineContextProvider.ts
@@ -1,0 +1,57 @@
+import { BaseContextProvider } from "..";
+import {
+  ContextItem,
+  ContextProviderDescription,
+  ContextProviderExtras,
+} from "../..";
+import { getBasename } from "../../util";
+
+import { getFileOutlineHighlights } from "llm-code-highlighter/dist/index.continue";
+
+class CodeOutlineContextProvider extends BaseContextProvider {
+  static description: ContextProviderDescription = {
+    title: "outlines",
+    displayTitle: "Outlines",
+    description: "Definition lines only (from open files)",
+    type: "normal",
+  };
+
+  async getContextItems(
+    query: string,
+    extras: ContextProviderExtras
+  ): Promise<ContextItem[]> {
+    const ide = extras.ide;
+    const openFiles = await ide.getOpenFiles();
+    const allFiles: { name: string; absPath: string; content: string }[] =
+      await Promise.all(
+        openFiles.map(async (filepath: string) => {
+          return {
+            name: getBasename(filepath),
+            absPath: filepath,
+            content: `${await ide.readFile(filepath)}`,
+          };
+        })
+      );
+    const outlines = await getFileOutlineHighlights(
+      allFiles
+        .filter((file) => file.content.length > 0)
+        .map((file) => {
+          return {
+            relPath: file.name,
+            code: file.content,
+          };
+        })
+    );
+    return [
+      {
+        content: outlines ? outlines : "",
+        name: "Code Outline",
+        description: "Definition lines only (from open files)",
+      },
+    ];
+  }
+
+  async load(): Promise<void> {}
+}
+
+export default CodeOutlineContextProvider;

--- a/core/context/providers/index.ts
+++ b/core/context/providers/index.ts
@@ -2,6 +2,7 @@ import { BaseContextProvider } from "..";
 import { ContextProviderName } from "../..";
 import CodebaseContextProvider from "./CodebaseContextProvider";
 import CodeHighlightsContextProvider from "./CodeHighlightsContextProvider";
+import CodeOutlineContextProvider from "./CodeOutlineContextProvider";
 import DiffContextProvider from "./DiffContextProvider";
 import DocsContextProvider from "./DocsContextProvider";
 import FileTreeContextProvider from "./FileTreeContextProvider";
@@ -30,6 +31,7 @@ const Providers: (typeof BaseContextProvider)[] = [
   FolderContextProvider,
   DocsContextProvider,
   CodeHighlightsContextProvider,
+  CodeOutlineContextProvider,
 ];
 
 export function contextProviderClassFromName(

--- a/core/context/providers/index.ts
+++ b/core/context/providers/index.ts
@@ -1,7 +1,7 @@
 import { BaseContextProvider } from "..";
 import { ContextProviderName } from "../..";
 import CodebaseContextProvider from "./CodebaseContextProvider";
-// import CodeHighlightsContextProvider from "./CodeHighlightsContextProvider";
+import CodeHighlightsContextProvider from "./CodeHighlightsContextProvider";
 import DiffContextProvider from "./DiffContextProvider";
 import DocsContextProvider from "./DocsContextProvider";
 import FileTreeContextProvider from "./FileTreeContextProvider";
@@ -29,7 +29,7 @@ const Providers: (typeof BaseContextProvider)[] = [
   ProblemsContextProvider,
   FolderContextProvider,
   DocsContextProvider,
-  // CodeHighlightsContextProvider,
+  CodeHighlightsContextProvider,
 ];
 
 export function contextProviderClassFromName(

--- a/core/package.json
+++ b/core/package.json
@@ -26,7 +26,7 @@
     "fastest-levenshtein": "^1.0.16",
     "handlebars": "^4.7.8",
     "js-tiktoken": "^1.0.8",
-    "llm-code-highlighter": "^0.0.3",
+    "llm-code-highlighter": "^0.0.5",
     "node-fetch": "^3.3.2",
     "node-html-markdown": "^1.3.0",
     "ollama": "^0.4.6",


### PR DESCRIPTION
There was still an issue with the provider returning an array of Promise objects. This should now be fixed.

There was another issue with typescript files not returning definition tags. This should now also be fixed.

I added a new provider.

The first provider, a tag-ranking highlighter tries to restrict the highlighted symbols to the "most important" nth percentile. I'm still playing around trying to figure out the scenarios in which this is most useful, and what "most important" means.

In the meantime, this new provider shows only the definition line with the name of classes, functions, methods, etc. It very predictably "summarizes" a file. This should be useful in many places where the entire file is too big to send. So, for example

```python
def greet(name):
  return f"Hello, {name}!"

def calculate_area(length, width):
  return length * width

class Point:
  def __init__(self, x, y):
      self.x = x
      self.y = y

  def distance_to(self, other):
      dx = self.x - other.x
      dy = self.y - other.y
      return (dx**2 + dy**2)**0.5

# Example usage
print(greet("Alice"))
print(calculate_area(5, 3))
point1 = Point(2, 3)
point2 = Point(4, 5)
print(point1.distance_to(point2))
```
is 'outlined' to 
```
test_python_code.py
█def greet(name):
⋮...
█def calculate_area(length, width):
⋮...
█class Point:
█  def __init__(self, x, y):
⋮...
█  def distance_to(self, other):
⋮...
```

