### PR TITLE
Fully typed redux store

### DIFF
--- a/gui/src/components/Layout.tsx
+++ b/gui/src/components/Layout.tsx
@@ -19,7 +19,7 @@ import {
   setBottomMessageCloseTimeout,
   setShowDialog,
 } from "../redux/slices/uiStateSlice";
-import { RootStore } from "../redux/store";
+import { RootState } from "../redux/store";
 import { getFontSize, isMetaEquivalentKeyPressed } from "../util";
 import HeaderButtonWithText from "./HeaderButtonWithText";
 import TextDialog from "./dialogs";
@@ -106,23 +106,23 @@ const Layout = () => {
   const location = useLocation();
   const dispatch = useDispatch();
   const dialogMessage = useSelector(
-    (state: RootStore) => state.uiState.dialogMessage
+    (state: RootState) => state.uiState.dialogMessage
   );
   const showDialog = useSelector(
-    (state: RootStore) => state.uiState.showDialog
+    (state: RootState) => state.uiState.showDialog
   );
 
   const defaultModel = useSelector(defaultModelSelector);
   // #region Selectors
 
   const bottomMessage = useSelector(
-    (state: RootStore) => state.uiState.bottomMessage
+    (state: RootState) => state.uiState.bottomMessage
   );
   const displayBottomMessageOnBottom = useSelector(
-    (state: RootStore) => state.uiState.displayBottomMessageOnBottom
+    (state: RootState) => state.uiState.displayBottomMessageOnBottom
   );
 
-  const timeline = useSelector((state: RootStore) => state.state.history);
+  const timeline = useSelector((state: RootState) => state.state.history);
 
   // #endregion
 

--- a/gui/src/components/dialogs/SelectContextGroupDialog.tsx
+++ b/gui/src/components/dialogs/SelectContextGroupDialog.tsx
@@ -12,7 +12,7 @@ import {
   setDialogMessage,
   setShowDialog,
 } from "../../redux/slices/uiStateSlice";
-import { RootStore } from "../../redux/store";
+import { RootState } from "../../redux/store";
 import HeaderButtonWithText from "../HeaderButtonWithText";
 
 const MiniPillSpan = styled.span`
@@ -50,7 +50,7 @@ const ContextGroupSelectDiv = styled.div`
 function SelectContextGroupDialog() {
   const dispatch = useDispatch();
   const savedContextGroups = useSelector(
-    (state: RootStore) => state.serverState.savedContextGroups
+    (state: RootState) => state.serverState.savedContextGroups
   );
 
   return (

--- a/gui/src/components/gui/StepContainer.tsx
+++ b/gui/src/components/gui/StepContainer.tsx
@@ -13,7 +13,7 @@ import {
   vscBackground,
   vscInputBackground,
 } from "..";
-import { RootStore } from "../../redux/store";
+import { RootState } from "../../redux/store";
 import { getFontSize } from "../../util";
 import { logDevData } from "../../util/ide";
 import HeaderButtonWithText from "../HeaderButtonWithText";
@@ -62,7 +62,7 @@ const ContentDiv = styled.div<{ isUserInput: boolean; fontSize?: number }>`
 function StepContainer(props: StepContainerProps) {
   const [isHovered, setIsHovered] = useState(false);
   const isUserInput = props.item.message.role === "user";
-  const active = useSelector((store: RootStore) => store.state.active);
+  const active = useSelector((store: RootState) => store.state.active);
 
   const [feedback, setFeedback] = useState<boolean | undefined>(undefined);
 

--- a/gui/src/components/loaders/Loader.tsx
+++ b/gui/src/components/loaders/Loader.tsx
@@ -1,5 +1,5 @@
 import { useSelector } from "react-redux";
-import { RootStore } from "../../redux/store";
+import { RootState } from "../../redux/store";
 import styled from "styled-components";
 import { PlayIcon } from "@heroicons/react/24/outline";
 

--- a/gui/src/components/mainInput/CodeBlockExtension.tsx
+++ b/gui/src/components/mainInput/CodeBlockExtension.tsx
@@ -4,7 +4,7 @@ import { ContextItemWithId } from "core";
 import { useDispatch, useSelector } from "react-redux";
 import { vscBadgeBackground } from "..";
 import { setEditingContextItemAtIndex } from "../../redux/slices/stateSlice";
-import { RootStore } from "../../redux/store";
+import { RootState } from "../../redux/store";
 import CodeSnippetPreview from "../markdown/CodeSnippetPreview";
 
 const CodeBlockComponent = ({
@@ -18,7 +18,7 @@ const CodeBlockComponent = ({
   const item: ContextItemWithId = node.attrs.item;
 
   const contextItems = useSelector(
-    (state: RootStore) => state.state.contextItems
+    (state: RootState) => state.state.contextItems
   );
   return (
     <NodeViewWrapper className="code-block-with-content" as="pre">

--- a/gui/src/components/mainInput/ContinueInputBox.tsx
+++ b/gui/src/components/mainInput/ContinueInputBox.tsx
@@ -6,7 +6,7 @@ import styled, { keyframes } from "styled-components";
 import { defaultBorderRadius, vscBackground } from "..";
 import { selectSlashCommands } from "../../redux/selectors";
 import { newSession } from "../../redux/slices/stateSlice";
-import { RootStore } from "../../redux/store";
+import { RootState } from "../../redux/store";
 import ContextItemsPeek from "./ContextItemsPeek";
 import TipTapEditor from "./TipTapEditor";
 
@@ -62,10 +62,10 @@ interface ContinueInputBoxProps {
 function ContinueInputBox(props: ContinueInputBoxProps) {
   const dispatch = useDispatch();
 
-  const active = useSelector((store: RootStore) => store.state.active);
+  const active = useSelector((store: RootState) => store.state.active);
   const availableSlashCommands = useSelector(selectSlashCommands);
   const availableContextProviders = useSelector(
-    (store: RootStore) => store.state.config.contextProviders
+    (store: RootState) => store.state.config.contextProviders
   );
 
   const [editorState, setEditorState] = useState(props.editorState);

--- a/gui/src/components/mainInput/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor.tsx
@@ -27,7 +27,7 @@ import { SubmenuContextProvidersContext } from "../../App";
 import useHistory from "../../hooks/useHistory";
 import useUpdatingRef from "../../hooks/useUpdatingRef";
 import { setEditingContextItemAtIndex } from "../../redux/slices/stateSlice";
-import { RootStore } from "../../redux/store";
+import { RootState } from "../../redux/store";
 import { isMetaEquivalentKeyPressed } from "../../util";
 import { errorPopup, isJetBrains, postToIde } from "../../util/ide";
 import CodeBlockExtension from "./CodeBlockExtension";
@@ -130,7 +130,7 @@ function TipTapEditor(props: TipTapEditorProps) {
   const { getSubmenuContextItems } = useContext(SubmenuContextProvidersContext);
 
   const historyLength = useSelector(
-    (store: RootStore) => store.state.history.length
+    (store: RootState) => store.state.history.length
   );
 
   const [inputFocused, setInputFocused] = useState(false);
@@ -171,7 +171,7 @@ function TipTapEditor(props: TipTapEditorProps) {
   };
 
   const contextItems = useSelector(
-    (store: RootStore) => store.state.contextItems
+    (store: RootState) => store.state.contextItems
   );
 
   const getSubmenuContextItemsRef = useUpdatingRef(getSubmenuContextItems);

--- a/gui/src/components/modelSelection/ModelSelect.tsx
+++ b/gui/src/components/modelSelection/ModelSelect.tsx
@@ -20,7 +20,7 @@ import {
 } from "..";
 import { defaultModelSelector } from "../../redux/selectors/modelSelectors";
 import { setDefaultModel } from "../../redux/slices/stateSlice";
-import { RootStore } from "../../redux/store";
+import { RootState } from "../../redux/store";
 import { getMetaKeyLabel, isMetaEquivalentKeyPressed } from "../../util";
 import { deleteModel } from "../../util/ide";
 import HeaderButtonWithText from "../HeaderButtonWithText";
@@ -209,7 +209,7 @@ function ModelSelect(props: {}) {
   const dispatch = useDispatch();
   const defaultModel = useSelector(defaultModelSelector);
   const allModels = useSelector(
-    (state: RootStore) => state.state.config.models
+    (state: RootState) => state.state.config.models
   );
 
   const navigate = useNavigate();

--- a/gui/src/hooks/CustomPostHogProvider.tsx
+++ b/gui/src/hooks/CustomPostHogProvider.tsx
@@ -2,11 +2,11 @@ import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
 import React, { PropsWithChildren, useEffect } from "react";
 import { useSelector } from "react-redux";
-import { RootStore } from "../redux/store";
+import { RootState } from "../redux/store";
 
 const CustomPostHogProvider = ({ children }: PropsWithChildren) => {
   const allowAnonymousTelemetry = useSelector(
-    (store: RootStore) => store?.state?.config.allowAnonymousTelemetry
+    (store: RootState) => store?.state?.config.allowAnonymousTelemetry
   );
 
   const [client, setClient] = React.useState<any>(undefined);

--- a/gui/src/hooks/useChatHandler.ts
+++ b/gui/src/hooks/useChatHandler.ts
@@ -25,7 +25,7 @@ import {
   setMessageAtIndex,
   streamUpdate,
 } from "../redux/slices/stateSlice";
-import { RootStore } from "../redux/store";
+import { RootState } from "../redux/store";
 import { errorPopup } from "../util/ide";
 
 function useChatHandler(dispatch: Dispatch) {
@@ -34,15 +34,15 @@ function useChatHandler(dispatch: Dispatch) {
   const defaultModel = useSelector(defaultModelSelector);
 
   const slashCommands = useSelector(
-    (store: RootStore) => store.state.config.slashCommands || []
+    (store: RootState) => store.state.config.slashCommands || []
   );
 
   const contextItems = useSelector(
-    (state: RootStore) => state.state.contextItems
+    (state: RootState) => state.state.contextItems
   );
 
-  const history = useSelector((store: RootStore) => store.state.history);
-  const active = useSelector((store: RootStore) => store.state.active);
+  const history = useSelector((store: RootState) => store.state.history);
+  const active = useSelector((store: RootState) => store.state.active);
   const activeRef = useRef(active);
   useEffect(() => {
     activeRef.current = active;

--- a/gui/src/hooks/useHistory.tsx
+++ b/gui/src/hooks/useHistory.tsx
@@ -6,7 +6,7 @@ import { stripImages } from "core/llm/countTokens";
 import { useSelector } from "react-redux";
 import { defaultModelSelector } from "../redux/selectors/modelSelectors";
 import { newSession } from "../redux/slices/stateSlice";
-import { RootStore } from "../redux/store";
+import { RootState } from "../redux/store";
 
 function truncateText(text: string, maxLength: number) {
   if (text.length > maxLength) {
@@ -16,10 +16,10 @@ function truncateText(text: string, maxLength: number) {
 }
 
 function useHistory(dispatch: Dispatch) {
-  const state = useSelector((state: RootStore) => state.state);
+  const state = useSelector((state: RootState) => state.state);
   const defaultModel = useSelector(defaultModelSelector);
   const disableSessionTitles = useSelector(
-    (store: RootStore) => store.state.config.disableSessionTitles
+    (store: RootState) => store.state.config.disableSessionTitles
   );
 
   async function getHistory(): Promise<SessionInfo[]> {

--- a/gui/src/hooks/useSetup.ts
+++ b/gui/src/hooks/useSetup.ts
@@ -12,7 +12,7 @@ import {
   setConfig,
   setInactive,
 } from "../redux/slices/stateSlice";
-import { RootStore } from "../redux/store";
+import { RootState } from "../redux/store";
 import useChatHandler from "./useChatHandler";
 
 function useSetup(dispatch: Dispatch<any>) {
@@ -36,7 +36,7 @@ function useSetup(dispatch: Dispatch<any>) {
   const { streamResponse } = useChatHandler(dispatch);
 
   const defaultModelTitle = useSelector(
-    (store: RootStore) => store.state.defaultModelTitle
+    (store: RootState) => store.state.defaultModelTitle
   );
 
   // IDE event listeners

--- a/gui/src/pages/gui.tsx
+++ b/gui/src/pages/gui.tsx
@@ -38,7 +38,7 @@ import {
   setDisplayBottomMessageOnBottom,
   setShowDialog,
 } from "../redux/slices/uiStateSlice";
-import { RootStore } from "../redux/store";
+import { RootState } from "../redux/store";
 import { getMetaKeyLabel, isMetaEquivalentKeyPressed } from "../util";
 import { isJetBrains } from "../util/ide";
 
@@ -141,11 +141,11 @@ function GUI(props: GUIProps) {
   // #endregion
 
   // #region Selectors
-  const sessionState = useSelector((state: RootStore) => state.state);
+  const sessionState = useSelector((state: RootState) => state.state);
 
   const defaultModel = useSelector(defaultModelSelector);
 
-  const active = useSelector((state: RootStore) => state.state.active);
+  const active = useSelector((state: RootState) => state.state.active);
 
   // #endregion
 
@@ -169,7 +169,7 @@ function GUI(props: GUIProps) {
   // Set displayBottomMessageOnBottom
   const aboveComboBoxDivRef = useRef<HTMLDivElement>(null);
   const bottomMessage = useSelector(
-    (state: RootStore) => state.uiState.bottomMessage
+    (state: RootState) => state.uiState.bottomMessage
   );
   useEffect(() => {
     if (!aboveComboBoxDivRef.current) return;
@@ -184,7 +184,7 @@ function GUI(props: GUIProps) {
   const [userScrolledAwayFromBottom, setUserScrolledAwayFromBottom] =
     useState<boolean>(false);
 
-  const state = useSelector((state: RootStore) => state.state);
+  const state = useSelector((state: RootState) => state.state);
 
   useEffect(() => {
     const handleScroll = () => {

--- a/gui/src/pages/settings.tsx
+++ b/gui/src/pages/settings.tsx
@@ -16,7 +16,7 @@ import {
 } from "../components";
 import InfoHover from "../components/InfoHover";
 import Loader from "../components/loaders/Loader";
-import { RootStore } from "../redux/store";
+import { RootState } from "../redux/store";
 import { getFontSize, getPlatform } from "../util";
 import { postToIde } from "../util/ide";
 
@@ -99,7 +99,7 @@ function Settings() {
   const onSubmit = (data: ContinueConfig) => console.log(data);
 
   const navigate = useNavigate();
-  const config = useSelector((state: RootStore) => state.state.config);
+  const config = useSelector((state: RootState) => state.state.config);
   const dispatch = useDispatch();
 
   const submitChanges = () => {

--- a/gui/src/redux/selectors/index.ts
+++ b/gui/src/redux/selectors/index.ts
@@ -1,9 +1,9 @@
 import { createSelector } from "@reduxjs/toolkit";
 import { ComboBoxItemType } from "../../components/mainInput/types";
-import { RootStore } from "../store";
+import { RootState } from "../store";
 
 export const selectSlashCommands = createSelector(
-  [(store: RootStore) => store.state.config.slashCommands],
+  [(store: RootState) => store.state.config.slashCommands],
   (slashCommands) => {
     return (
       slashCommands?.map((cmd) => {
@@ -18,7 +18,7 @@ export const selectSlashCommands = createSelector(
 );
 
 export const selectContextProviderDescriptions = createSelector(
-  [(store: RootStore) => store.state.config.contextProviders],
+  [(store: RootState) => store.state.config.contextProviders],
   (providers) => {
     return providers.filter((desc) => desc.type === "submenu") || [];
   }

--- a/gui/src/redux/selectors/modelSelectors.ts
+++ b/gui/src/redux/selectors/modelSelectors.ts
@@ -1,11 +1,11 @@
 import { DEFAULT_MAX_TOKENS } from "core/llm/constants";
-import { RootStore } from "../store";
+import { RootState } from "../store";
 
-export const defaultModelSelector = (state: RootStore) => {
+export const defaultModelSelector = (state: RootState) => {
   const title = state.state.defaultModelTitle;
   return state.state.config.models.find((model) => model.title === title);
 };
 
-export const contextLengthSelector = (state: RootStore) => {
+export const contextLengthSelector = (state: RootState) => {
   return defaultModelSelector(state)?.contextLength || DEFAULT_MAX_TOKENS;
 };

--- a/gui/src/redux/selectors/uiStateSelectors.ts
+++ b/gui/src/redux/selectors/uiStateSelectors.ts
@@ -1,5 +1,5 @@
-import { RootStore } from "../store";
+import { RootState } from "../store";
 
-const selectBottomMessage = (state: RootStore) => state.uiState.bottomMessage;
+const selectBottomMessage = (state: RootState) => state.uiState.bottomMessage;
 
 export { selectBottomMessage };

--- a/gui/src/redux/slices/configSlice.ts
+++ b/gui/src/redux/slices/configSlice.ts
@@ -1,38 +1,18 @@
-import { createSlice } from "@reduxjs/toolkit";
-import { RootStore } from "../store";
+import { PayloadAction, createSlice } from "@reduxjs/toolkit";
 
 const windowAny: any = window;
 
 export const configSlice = createSlice({
   name: "config",
   initialState: {
-    vscMachineId: windowAny.vscMachineId || undefined,
-  } as RootStore["config"],
+    vscMachineId: window.vscMachineId,
+  },
   reducers: {
-    setVscMachineId: (
-      state: RootStore["config"],
-      action: { type: string; payload: string }
-    ) => ({
-      ...state,
-      vscMachineId: action.payload,
-    }),
-    setSessionId: (
-      state: RootStore["config"],
-      action: { type: string; payload: string }
-    ) => ({
-      ...state,
-      sessionId: action.payload,
-    }),
-    setDataSwitchOn: (
-      state: RootStore["config"],
-      action: { type: string; payload: boolean }
-    ) => ({
-      ...state,
-      dataSwitchOn: action.payload,
-    }),
+    setVscMachineId: (state, action: PayloadAction<string>) => {
+      state.vscMachineId = action.payload;
+    },
   },
 });
 
-export const { setVscMachineId, setSessionId, setDataSwitchOn } =
-  configSlice.actions;
+export const { setVscMachineId } = configSlice.actions;
 export default configSlice.reducer;

--- a/gui/src/redux/slices/miscSlice.ts
+++ b/gui/src/redux/slices/miscSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { PayloadAction, createSlice } from "@reduxjs/toolkit";
 
 export const miscSlice = createSlice({
   name: "misc",
@@ -7,10 +7,10 @@ export const miscSlice = createSlice({
     serverStatusMessage: "Continue Server Starting",
   },
   reducers: {
-    setTakenActionTrue: (state: any, action) => {
+    setTakenActionTrue: (state) => {
       state.takenAction = true;
     },
-    setServerStatusMessage: (state: any, action) => {
+    setServerStatusMessage: (state, action: PayloadAction<string>) => {
       state.serverStatusMessage = action.payload;
     },
   },

--- a/gui/src/redux/slices/serverStateReducer.ts
+++ b/gui/src/redux/slices/serverStateReducer.ts
@@ -1,7 +1,11 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { PayloadAction, createSlice } from "@reduxjs/toolkit";
 import TransformersJsEmbeddingsProvider from "core/indexing/embeddings/TransformersJsEmbeddingsProvider";
 import FreeTrial from "core/llm/llms/FreeTrial";
-import { RootStore } from "../store";
+import {
+  ContextProviderDescription,
+  ContinueConfig,
+  SlashCommandDescription,
+} from "core";
 
 const TEST_SLASH_COMMANDS = [
   {
@@ -18,7 +22,17 @@ const TEST_SLASH_COMMANDS = [
   },
 ];
 
-const initialState: RootStore["serverState"] = {
+type ServerState = {
+  meilisearchUrl: string | undefined;
+  slashCommands: SlashCommandDescription[];
+  selectedContextItems: any[];
+  config: ContinueConfig;
+  contextProviders: ContextProviderDescription[];
+  savedContextGroups: any[]; // TODO: Context groups
+  indexingProgress: number;
+};
+
+const initialState: ServerState = {
   meilisearchUrl: undefined,
   slashCommands: [],
   selectedContextItems: [],
@@ -38,27 +52,27 @@ export const serverStateSlice = createSlice({
   name: "serverState",
   initialState,
   reducers: {
-    setSlashCommands: (state, action) => {
-      return {
-        ...state,
-        slashCommands: [
-          ...action.payload,
-          { name: "codebase", description: "Retrieve codebase context" },
-          { name: "so", description: "Search StackOverflow" },
-        ],
-      };
+    setSlashCommands: (
+      state,
+      action: PayloadAction<ServerState["slashCommands"]>
+    ) => {
+      state.slashCommands = [
+        ...action.payload,
+        { name: "codebase", description: "Retrieve codebase context" },
+        { name: "so", description: "Search StackOverflow" },
+      ];
     },
-    setContextProviders: (state, action) => {
-      return {
-        ...state,
-        contextProviders: action.payload,
-      };
+    setContextProviders: (
+      state,
+      action: PayloadAction<ServerState["contextProviders"]>
+    ) => {
+      state.contextProviders = action.payload;
     },
-    setIndexingProgress: (state, { payload }: { payload: number }) => {
-      return {
-        ...state,
-        indexingProgress: payload,
-      };
+    setIndexingProgress: (
+      state,
+      action: PayloadAction<ServerState["indexingProgress"]>
+    ) => {
+      state.indexingProgress = action.payload;
     },
   },
 });

--- a/gui/src/redux/slices/stateSlice.ts
+++ b/gui/src/redux/slices/stateSlice.ts
@@ -1,7 +1,8 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { PayloadAction, createSlice } from "@reduxjs/toolkit";
 import { JSONContent } from "@tiptap/react";
 import {
   ChatHistory,
+  ChatHistoryItem,
   ChatMessage,
   ContextItemId,
   ContextItemWithId,
@@ -9,7 +10,6 @@ import {
 } from "core";
 import { BrowserSerializedContinueConfig } from "core/config/load";
 import { v4 } from "uuid";
-import { RootStore } from "../store";
 
 const TEST_CONTEXT_ITEMS: ContextItemWithId[] = [
   {
@@ -81,7 +81,17 @@ fn bubble_sort<T: Ord>(values: &mut[T]) {
   },
 ];
 
-const initialState: RootStore["state"] = {
+type State = {
+  history: ChatHistory;
+  contextItems: ContextItemWithId[];
+  active: boolean;
+  config: BrowserSerializedContinueConfig;
+  title: string;
+  sessionId: string;
+  defaultModelTitle: string;
+};
+
+const initialState: State = {
   history: [],
   contextItems: [],
   active: false,
@@ -129,123 +139,95 @@ export const stateSlice = createSlice({
   reducers: {
     setConfig: (
       state,
-      { payload }: { payload: BrowserSerializedContinueConfig }
+      { payload: config }: PayloadAction<BrowserSerializedContinueConfig>
     ) => {
-      const config = payload;
-      const defaultModelTitle = config.models.find(
-        (model) => model.title === state.defaultModelTitle
-      )
-        ? state.defaultModelTitle
-        : config.models[0].title;
-      return {
-        ...state,
-        config,
-        defaultModelTitle,
-      };
+      const defaultModelTitle =
+        config.models.find((model) => model.title === state.defaultModelTitle)
+          ?.title || config.models[0].title;
+      state.config = config;
+      state.defaultModelTitle = defaultModelTitle;
     },
-    addLogs: (state, { payload }: { payload: [string, string][] }) => {
-      if (state.history.length === 0) {
+    addLogs: (state, { payload }: PayloadAction<[string, string][]>) => {
+      if (!state.history.length) {
         return;
       }
+      const lastHistory = state.history[state.history.length - 1];
 
-      if (state.history[state.history.length - 1].promptLogs) {
-        state.history[state.history.length - 1].promptLogs.push(...payload);
-      } else {
-        state.history[state.history.length - 1].promptLogs = payload;
-      }
+      lastHistory.promptLogs = lastHistory.promptLogs
+        ? lastHistory.promptLogs.concat(payload)
+        : payload;
     },
     setActive: (state) => {
-      return {
-        ...state,
-        active: true,
-      };
+      state.active = true;
     },
-    setContextItemsAtIndex: (state, action) => {
-      if (action.payload.index < state.history.length) {
-        return {
-          ...state,
-          history: state.history.map((historyItem, i) => {
-            if (i === action.payload.index) {
-              return {
-                ...historyItem,
-                contextItems: action.payload.contextItems,
-              };
-            }
-            return historyItem;
-          }),
-        };
+    setContextItemsAtIndex: (
+      state,
+      {
+        payload: { index, contextItems },
+      }: PayloadAction<{
+        index: number;
+        contextItems: ChatHistoryItem["contextItems"];
+      }>
+    ) => {
+      if (state.history[index]) {
+        state.history[index].contextItems = contextItems;
       }
     },
     setEditingContextItemAtIndex: (
       state,
       {
         payload: { index, item },
-      }: {
-        payload: { index?: number; item: ContextItemWithId };
-      }
+      }: PayloadAction<{ index?: number; item: ContextItemWithId }>
     ) => {
       if (index === undefined) {
-        if (state.contextItems[0]?.id.itemId === item.id.itemId) {
-          return {
-            ...state,
-            contextItems: [],
-          };
-        } else {
-          return {
-            ...state,
-            contextItems: [{ ...item, editing: true }],
-          };
-        }
-      } else {
-        // TODO
+        const isFirstContextItem =
+          state.contextItems[0]?.id.itemId === item.id.itemId;
+
+        state.contextItems = isFirstContextItem
+          ? []
+          : [{ ...item, editing: true }];
+        return;
       }
+      // TODO
     },
-    addContextItems: (state, action) => {
-      return {
-        ...state,
-        contextItems: [...state.contextItems, ...action.payload],
-      };
+    addContextItems: (state, action: PayloadAction<ContextItemWithId[]>) => {
+      state.contextItems = state.contextItems.concat(action.payload);
     },
     resubmitAtIndex: (
       state,
       {
         payload,
-      }: {
-        payload: {
-          index: number;
-          editorState: JSONContent;
-        };
-      }
+      }: PayloadAction<{
+        index: number;
+        editorState: JSONContent;
+      }>
     ) => {
-      if (payload.index < state.history.length) {
-        state.history[payload.index].message.content = "";
-        state.history[payload.index].editorState = payload.editorState;
-
-        // Cut off history after the resubmitted message
-        state.history = [
-          ...state.history.slice(0, payload.index + 1),
-          {
-            message: {
-              role: "assistant",
-              content: "",
-            },
-            contextItems: [],
-          },
-        ];
-
-        state.contextItems = [];
-        state.active = true;
+      const historyItem = state.history[payload.index];
+      if (!historyItem) {
+        return;
       }
+      historyItem.message.content = "";
+      historyItem.editorState = payload.editorState;
+
+      // Cut off history after the resubmitted message
+      state.history = state.history.slice(0, payload.index + 1).concat({
+        message: {
+          role: "assistant",
+          content: "",
+        },
+        contextItems: [],
+      });
+
+      state.contextItems = [];
+      state.active = true;
     },
     initNewActiveMessage: (
       state,
       {
         payload,
-      }: {
-        payload: {
-          editorState: JSONContent;
-        };
-      }
+      }: PayloadAction<{
+        editorState: JSONContent;
+      }>
     ) => {
       state.history.push({
         message: { role: "user", content: "" },
@@ -266,13 +248,11 @@ export const stateSlice = createSlice({
       state,
       {
         payload,
-      }: {
-        payload: {
-          message: ChatMessage;
-          index: number;
-          contextItems?: ContextItemWithId[];
-        };
-      }
+      }: PayloadAction<{
+        message: ChatMessage;
+        index: number;
+        contextItems?: ContextItemWithId[];
+      }>
     ) => {
       state.history[payload.index].message = payload.message;
       state.history[payload.index].contextItems = payload.contextItems || [];
@@ -281,91 +261,66 @@ export const stateSlice = createSlice({
       state,
       {
         payload,
-      }: {
-        payload: {
-          index: number;
-          contextItems: ContextItemWithId[];
-        };
-      }
+      }: PayloadAction<{
+        index: number;
+        contextItems: ContextItemWithId[];
+      }>
     ) => {
-      if (payload.index < state.history.length) {
-        state.history[payload.index].contextItems.push(...payload.contextItems);
+      const historyItem = state.history[payload.index];
+      if (!historyItem) {
+        return;
       }
+      historyItem.contextItems.push(...payload.contextItems);
     },
     setInactive: (state) => {
-      return {
-        ...state,
-        active: false,
-      };
+      state.active = false;
     },
-    streamUpdate: (state, action) => {
-      if (state.history.length > 0) {
+    streamUpdate: (state, action: PayloadAction<string>) => {
+      if (state.history.length) {
         state.history[state.history.length - 1].message.content +=
           action.payload;
       }
     },
     newSession: (
       state,
-      { payload }: { payload: PersistedSessionInfo | undefined }
+      { payload }: PayloadAction<PersistedSessionInfo | undefined>
     ) => {
       if (payload) {
-        return {
-          ...state,
-          history: payload.history,
-          title: payload.title,
-          sessionId: payload.sessionId,
-        };
+        state.history = payload.history;
+        state.title = payload.title;
+        state.sessionId = payload.sessionId;
+      } else {
+        state.history = [];
+        state.contextItems = [];
+        state.active = false;
+        state.title = "New Session";
+        state.sessionId = v4();
       }
-      return {
-        ...state,
-        history: [],
-        contextItems: [],
-        active: false,
-        title: "New Session",
-        sessionId: v4(),
-      };
     },
     deleteContextWithIds: (
       state,
       {
         payload,
-      }: { payload: { ids: ContextItemId[]; index: number | undefined } }
+      }: PayloadAction<{ ids: ContextItemId[]; index: number | undefined }>
     ) => {
-      const ids = payload.ids.map((id) => `${id.providerTitle}-${id.itemId}`);
-      if (typeof payload.index === "undefined") {
-        return {
-          ...state,
-          contextItems: state.contextItems.filter(
-            (item) =>
-              !ids.includes(`${item.id.providerTitle}-${item.id.itemId}`)
-          ),
-        };
-      } else {
-        return {
-          ...state,
-          history: state.history.map((historyItem, i) => {
-            if (i === payload.index) {
-              return {
-                ...historyItem,
+      const getKey = (id: ContextItemId) => `${id.providerTitle}-${id.itemId}`;
+      const ids = new Set(payload.ids.map(getKey));
 
-                contextItems: historyItem.contextItems.filter(
-                  (item) =>
-                    !ids.includes(`${item.id.providerTitle}-${item.id.itemId}`)
-                ),
-              };
-            }
-            return historyItem;
-          }),
-        };
+      if (payload.index === undefined) {
+        state.contextItems = state.contextItems.filter(
+          (item) => !ids.has(getKey(item.id))
+        );
+      } else {
+        state.history[payload.index].contextItems = state.history[
+          payload.index
+        ].contextItems.filter((item) => !ids.has(getKey(item.id)));
       }
     },
     addHighlightedCode: (
       state,
       {
         payload,
-      }: {
-        payload: { rangeInFileWithContents: any; edit: boolean };
-      }
+      }: PayloadAction<{ rangeInFileWithContents: any; edit: boolean }>
     ) => {
       let contextItems = [...state.contextItems].map((item) => {
         return { ...item, editing: false };
@@ -428,7 +383,7 @@ export const stateSlice = createSlice({
       state,
       {
         payload,
-      }: { payload: { ids: ContextItemId[]; index: number | undefined } }
+      }: PayloadAction<{ ids: ContextItemId[]; index: number | undefined }>
     ) => {
       const ids = payload.ids.map((id) => id.itemId);
 
@@ -462,7 +417,7 @@ export const stateSlice = createSlice({
         };
       }
     },
-    setDefaultModel: (state, { payload }: { payload: string }) => {
+    setDefaultModel: (state, { payload }: PayloadAction<string>) => {
       const model = state.config.models.find(
         (model) => model.title === payload
       );

--- a/gui/src/redux/slices/uiStateSlice.ts
+++ b/gui/src/redux/slices/uiStateSlice.ts
@@ -1,4 +1,12 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { PayloadAction, createSlice } from "@reduxjs/toolkit";
+type UiState = {
+  bottomMessage: JSX.Element | undefined;
+  bottomMessageCloseTimeout: NodeJS.Timeout | undefined;
+  displayBottomMessageOnBottom: boolean;
+  showDialog: boolean;
+  dialogMessage: string | JSX.Element;
+  dialogEntryOn: boolean;
+};
 
 export const uiStateSlice = createSlice({
   name: "uiState",
@@ -9,27 +17,42 @@ export const uiStateSlice = createSlice({
     dialogMessage: "",
     dialogEntryOn: false,
     displayBottomMessageOnBottom: true,
-  },
+  } as UiState,
   reducers: {
-    setBottomMessage: (state, action) => {
+    setBottomMessage: (
+      state,
+      action: PayloadAction<UiState["bottomMessage"]>
+    ) => {
       state.bottomMessage = action.payload;
     },
-    setBottomMessageCloseTimeout: (state, action) => {
+    setBottomMessageCloseTimeout: (
+      state,
+      action: PayloadAction<UiState["bottomMessageCloseTimeout"]>
+    ) => {
       if (state.bottomMessageCloseTimeout) {
         clearTimeout(state.bottomMessageCloseTimeout);
       }
       state.bottomMessageCloseTimeout = action.payload;
     },
-    setDialogMessage: (state, action) => {
+    setDialogMessage: (
+      state,
+      action: PayloadAction<UiState["dialogMessage"]>
+    ) => {
       state.dialogMessage = action.payload;
     },
-    setDialogEntryOn: (state, action) => {
+    setDialogEntryOn: (
+      state,
+      action: PayloadAction<UiState["dialogEntryOn"]>
+    ) => {
       state.dialogEntryOn = action.payload;
     },
-    setShowDialog: (state, action) => {
+    setShowDialog: (state, action: PayloadAction<UiState["showDialog"]>) => {
       state.showDialog = action.payload;
     },
-    setDisplayBottomMessageOnBottom: (state, action) => {
+    setDisplayBottomMessageOnBottom: (
+      state,
+      action: PayloadAction<UiState["displayBottomMessageOnBottom"]>
+    ) => {
       state.displayBottomMessageOnBottom = action.payload;
     },
   },

--- a/gui/src/redux/store.ts
+++ b/gui/src/redux/store.ts
@@ -5,14 +5,6 @@ import serverStateReducer from "./slices/serverStateReducer";
 import stateReducer from "./slices/stateSlice";
 import uiStateReducer from "./slices/uiStateSlice";
 
-import {
-  ChatHistory,
-  ContextItemWithId,
-  ContextProviderDescription,
-  ContinueConfig,
-  SlashCommandDescription,
-} from "core";
-import { BrowserSerializedContinueConfig } from "core/config/load";
 import { createTransform, persistReducer, persistStore } from "redux-persist";
 import { createFilter } from "redux-persist-transform-filter";
 import autoMergeLevel2 from "redux-persist/lib/stateReconciler/autoMergeLevel2";
@@ -23,43 +15,6 @@ export interface ChatMessage {
   content: string;
 }
 
-export interface RootStore {
-  state: {
-    history: ChatHistory;
-    contextItems: ContextItemWithId[];
-    active: boolean;
-    config: BrowserSerializedContinueConfig;
-    title: string;
-    sessionId: string;
-    defaultModelTitle: string;
-  };
-
-  config: {
-    vscMachineId: string | undefined;
-  };
-  misc: {
-    takenAction: boolean;
-    serverStatusMessage: string;
-  };
-  uiState: {
-    bottomMessage: JSX.Element | undefined;
-    bottomMessageCloseTimeout: NodeJS.Timeout | undefined;
-    displayBottomMessageOnBottom: boolean;
-    showDialog: boolean;
-    dialogMessage: string | JSX.Element;
-    dialogEntryOn: boolean;
-  };
-  serverState: {
-    meilisearchUrl: string | undefined;
-    slashCommands: SlashCommandDescription[];
-    selectedContextItems: any[];
-    config: ContinueConfig;
-    contextProviders: ContextProviderDescription[];
-    savedContextGroups: any[]; // TODO: Context groups
-    indexingProgress: number;
-  };
-}
-
 const rootReducer = combineReducers({
   state: stateReducer,
   config: configReducer,
@@ -67,6 +22,8 @@ const rootReducer = combineReducers({
   uiState: uiStateReducer,
   serverState: serverStateReducer,
 });
+
+export type RootState = ReturnType<typeof rootReducer>;
 
 const windowIDTransform = (windowID) =>
   createTransform(


### PR DESCRIPTION
This makes the GUI's redux store be fully typed by:
 - Following Redux Tookits' recommendation of deriving [the root state type from the root reducer](https://redux-toolkit.js.org/usage/usage-with-typescript#getting-the-state-type)
 - Adding `PayloadAction` type to slice payloads (thereby typing their usage)
 - Simplifying some of the reducers in the redux store to be more idiomatic (i.e. using mutation over state spreading)
