### PR TITLE
Adds support for StarChat for autocomplete

### DIFF
--- a/core/autocomplete/templates.ts
+++ b/core/autocomplete/templates.ts
@@ -49,6 +49,7 @@ export function getTemplateForModel(model: string): AutocompleteTemplate {
   if (
     lowerCaseModel.includes("starcoder") ||
     lowerCaseModel.includes("star-coder") ||
+    lowerCaseModel.includes("starchat") ||
     lowerCaseModel.includes("stable")
   ) {
     return stableCodeFimTemplate;


### PR DESCRIPTION
This change updates the handling of template generation to explicitly treat StarChat models the same as StarCoder models.

## The current issue

While the current implementation of template generate does fallback to the `stableCodeFirmTemplate` if there aren't matches, the specific StarChat model I'm using hits an edge case. I'm using the [`starchat-beta-GPTQ`](https://huggingface.co/TheBloke/starchat-beta-GPTQ) model. Since it includes `gpt` in the lowercase name, the current template support ends up using the OpenAI / GPT style prompt.

## The change

By adding `starchat` as one of the search strings alongside the `starcoder` models, the template code will now return the `stableCodeFirmTemplate` rather than the `gptAutocompleteTemplate`.

## Testing

Prior to the change, the extension output would include:

```
Your task is to complete the line at the end of this code block:
\```
def add(a, b)
\```

The last line is incomplete, and you should provide the rest of that line. If the line is already complete, just return a new line. Otherwise, DO NOT provide explanation, a code block, or extra whitespace, just the code that should be added to the last line to complete 
```

After the change, the extension output is:

```
Settings:
contextLength: 4096
model: TheBloke/starchat-beta-GPTQ
maxTokens: 1024
stop: <fim_prefix>,<fim_suffix>,<fim_middle>,<|endoftext|>,

,```,function,class,module,export 
temperature: 0

############################################

<fim_prefix>def add(a, b<fim_suffix>)<fim_middle>
```