### PR TITLE
Fix markComplete removal

### DIFF
--- a/core/indexing/refreshIndex.ts
+++ b/core/indexing/refreshIndex.ts
@@ -165,12 +165,14 @@ async function getAddRemoveForTag(
         case AddRemoveResultType.Remove:
           await db.run(
             `DELETE FROM tag_catalog WHERE
-              path IN (?) AND
+              cacheKey = ? AND
+              path = ? AND
               dir = ? AND
               branch = ? AND
               artifactId = ?
           `,
-            remove.map((r) => `'${r.path}'`).join(", "),
+            cacheKey,
+            path,
             tag.directory,
             tag.branch,
             tag.artifactId


### PR DESCRIPTION
Deleted and previously index files were not removed from the tag_catalog database table.

To reproduce just add a file (not ignored by .gitignore or .continueignore) let continue index it and remove it again.

MarkComplete is called for every added, removed or changed item found. Therefore it seems odd (ignoring the performance perspective) that we try to remove all items at once. The other cases also only handle one single item at the time. Nevertheless the "remove" case did not behave as expected and did not remove anything from the tag_catalog.

With the code change we now handle one single item at the time and the item is removed from the tag_catalog as expected.