### PR TITLE
Fix full-text search containing special characters

### DIFF
--- a/core/context/retrieval.ts
+++ b/core/context/retrieval.ts
@@ -137,7 +137,7 @@ export async function retrieveContextItemsFromEmbeddings(
     if (extras.fullInput.trim() !== "") {
       ftsResults = await ftsIndex.retrieve(
         tags,
-        extras.fullInput.trim().split(" ").join(" OR "),
+        extras.fullInput.trim().split(" ").map(element => `"${element}"`).join(" OR "),
         nRetrieve / 2,
         filterDirectory,
         undefined


### PR DESCRIPTION
Previously the `ftsIndex.retrieve` would fail if any of the search terms contain characters like dots. This would be the case where you use the `folder` context provider searching using a folder containing dots.

Now we wrap each search term in double-quotes before joining them with `OR`.  This forces dots to be considered as part of the literal search term.