### PR TITLE
🐛  Bugfix cursor sometimes not shown initially.

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor.tsx
@@ -369,14 +369,21 @@ function TipTapEditor(props: TipTapEditorProps) {
     };
   }, []);
 
+  
+
   // IDE event listeners
   useEffect(() => {
     if (!props.isMainInput) {
       return;
     }
-    if (editor && document.hasFocus()) {
+
+    if (editor) {
       editor.commands.focus();
+      setTimeout(() => {
+        editor.commands.blur();
+      }, 0); 
     }
+
     const handler = async (event: any) => {
       if (!editor) return;
 


### PR DESCRIPTION
There seems to be a bug in tip-tap that the cursor doesn't come up initially and waits for a blur event meaning a user won't have a cursor unless some other screen gets focus. this forces the blur on initialization causing the no curser issue to go away