### PR TITLE
fix: Use `uriFromFilePath` instead of `vscode.Uri.from` for VSCode remote development mode

### DIFF
--- a/extensions/vscode/src/ideProtocol.ts
+++ b/extensions/vscode/src/ideProtocol.ts
@@ -8,7 +8,7 @@ import { ContinueRcJson, IDE, IdeInfo, Problem, Range } from "core";
 import { DiffManager } from "./diff/horizontal";
 import { VsCodeIdeUtils } from "./util/ideUtils";
 import { traverseDirectory } from "./util/traverseDirectory";
-import { getExtensionUri, openEditorAndRevealRange } from "./util/vscode";
+import { getExtensionUri, openEditorAndRevealRange, uriFromFilePath } from "./util/vscode";
 
 class VsCodeIde implements IDE {
   ideUtils: VsCodeIdeUtils;
@@ -40,10 +40,13 @@ class VsCodeIde implements IDE {
     const pathToLastModified: { [path: string]: number } = {};
     await Promise.all(
       files.map(async (file) => {
-        const uri = vscode.Uri.from({
+        let uri = vscode.Uri.from({
           scheme: scheme ? scheme : "file",
           path: file,
         });
+        if (scheme?.includes("vscode-remote")) {
+          uri = uriFromFilePath(file);
+        }
         let stat = await vscode.workspace.fs.stat(uri);
         pathToLastModified[file] = stat.mtime;
       }),


### PR DESCRIPTION
## Please confirm

**I would like to ask reviewers to confirm that it works, because maybe this change will cause problems in another environment**

## Summary of Issue

- Codebase retrieval feature of `continue` does not work when VSCode remote development mode

FIX: https://github.com/continuedev/continue/issues/517
FIX: https://github.com/continuedev/continue/issues/902

## How to reproduce

- On Windows, try to use `continue` in a workspace on WSL2
- On macOS, try to use `continue` in a workspace on some DevContainer
- Open the Developer Tools from the command palette and see the console logs
- You can see that during embedding & indexing step of `continue` there is an error because the file path cannot be resolved

[![Image from Gyazo](https://i.gyazo.com/c3774bb87e2fbe7d74214ccf97741054.png)](https://gyazo.com/c3774bb87e2fbe7d74214ccf97741054)

## Cause of Issue & How to fix Issue

- The function named `VsCodeIde.getStats` in `extensions/vscode/src/ideProtocol.ts` uses `vscode.Uri.from` directly
  - But in VSCode remote development mode, this would cause problems
- In many other places, `uriFromFilePath` is used appropriately
  - `uriFromFilePath` can properly determine whether the current VSCode workspace is local or remote and obtain a value of the appropriate `vscode.Uri` type
- So I changed it to use `uriFromFilePath` instead of `vscode.Uri.from` within `VsCodeIde.getStats`

## What I confirmed

- I confirmed that the Codebase retrieval feature of `continue`, which was not working at first in VSCode remote development mode, now works after adding this modification


## Note

- Interestingly, when I opened the cloned `continue` repository inside WSL2 with VSCode and started debug mode with F5, this problem did not reproduce
- I had to clone `continue` and run it in debug mode on the Windows side, not within WSL2, to reproduce and fix this problem

