### PR TITLE
 Remove duplicates in this character class.

### DIFF
--- a/core/indexing/chunk/markdown.ts
+++ b/core/indexing/chunk/markdown.ts
@@ -17,7 +17,7 @@ function cleanFragment(fragment: string | undefined): string | undefined {
   }
 
   // Remove all special characters except alphanumeric, hyphen, space, and underscore
-  fragment = fragment.replace(/[^\w\d-\s]/g, "").trim();
+  fragment = fragment.replace(/[^\w-\s]/g, "").trim();
 
   // Convert to lowercase
   fragment = fragment.toLowerCase();
@@ -43,7 +43,7 @@ function cleanHeader(header: string | undefined): string | undefined {
   }
 
   // Remove all special characters except alphanumeric, hyphen, space, and underscore
-  header = header.replace(/[^\w\d-\s]/g, "").trim();
+  header = header.replace(/[^\w-\s]/g, "").trim();
 
   return header;
 }


### PR DESCRIPTION
To fix the problem in your code snippet, you need to remove the duplicate character class definition. The \w character class already includes \d (digits), so there is no need to explicitly mention \d again. Here's the corrected version of your code:

`fragment = fragment.replace(/[^\w-\s]/g, "").trim();`

In this corrected version, I have removed \d from the character class since it's redundant. Now, this pattern will remove all characters that are not alphanumeric, hyphen, or space characters, exactly as intended. Additionally, it ensures that underscores, which are included in \w, are also retained.