### PR TITLE
set `text-embedding-3-small` as default for openai

### DIFF
--- a/core/indexing/embeddings/OpenAIEmbeddingsProvider.ts
+++ b/core/indexing/embeddings/OpenAIEmbeddingsProvider.ts
@@ -4,7 +4,7 @@ import BaseEmbeddingsProvider from "./BaseEmbeddingsProvider";
 class OpenAIEmbeddingsProvider extends BaseEmbeddingsProvider {
   static defaultOptions: Partial<EmbedOptions> | undefined = {
     apiBase: "https://api.openai.com/v1",
-    model: "text-embedding-3-large",
+    model: "text-embedding-3-small",
   };
 
   get id(): string {

--- a/docs/docs/walkthroughs/codebase-embeddings.md
+++ b/docs/docs/walkthroughs/codebase-embeddings.md
@@ -98,7 +98,7 @@ We also support other methods of generating embeddings, which can be configured 
 
 OpenAI's [embeddings](https://platform.openai.com/docs/guides/embeddings) are high dimensional embeddings that give great performance on both text and code.
 
-Configuration for text-embedding-3-small Model
+Configuration for text-embedding-3-small Model. This is default. 
 The text-embedding-3-small model offers an outstanding balance between performance and efficiency, suitable for a versatile range of applications.
 
 ```json title="~/.continue/config.json"


### PR DESCRIPTION
this is for saving money
![image](https://github.com/continuedev/continue/assets/47577197/4998a725-6448-406c-8ec3-9ed715d9f31d)
 