### PR TITLE
Adds support for Octocoder for autocomplete

### DIFF
--- a/core/autocomplete/templates.ts
+++ b/core/autocomplete/templates.ts
@@ -50,6 +50,7 @@ export function getTemplateForModel(model: string): AutocompleteTemplate {
     lowerCaseModel.includes("starcoder") ||
     lowerCaseModel.includes("star-coder") ||
     lowerCaseModel.includes("starchat") ||
+    lowerCaseModel.includes("octocoder") ||
     lowerCaseModel.includes("stable")
   ) {
     return stableCodeFimTemplate;


### PR DESCRIPTION
This change adds support for Octocoder similar to the change for StarChat made in #847.

## Current Issue

Similar to the issue fixed in #847, the model I'm working with is [TheBloke/Octocoder-GPTQ](https://huggingface.co/TheBloke/Octocoder-GPTQ). The "GPT" in that name is currently causing the extension to use the GPT template.

## The change

By adding `octocoder` as one of the search strings alongside the `starcoder` models, the template code will now return the `stableCodeFirmTemplate` rather than the `gptAutocompleteTemplate`.

## Testing

Prior to the change, the extension output would contain:

```
Your task is to complete the line at the end of this code block:
\```
def add(a, b
\```

The last line is incomplete, and you should provide the rest of that line. If the line is already complete, just return a new line. Otherwise, DO NOT provide explanation, a code block, or extra whitespace, just the code that should be added to the last line to complete it:
```

After the change, the extension output contains:

```
<fim_prefix>def add(a, b)<fim_suffix><fim_middle
```