### PR TITLE
Add link to llamafile reference page in select-provider.md

### DIFF
--- a/docs/docs/model-setup/select-provider.md
+++ b/docs/docs/model-setup/select-provider.md
@@ -17,6 +17,7 @@ You can run a model on your local computer using:
 - [Ollama](../reference/Model%20Providers/ollama.md)
 - [LM Studio](../reference/Model%20Providers/lmstudio.md)
 - [Llama.cpp](../reference/Model%20Providers/llamacpp.md)
+- [llamafile](../reference/Model%20Providers/llamafile) ((OpenAI compatible server)
 - [LocalAI](../reference/Model%20Providers/openai.md) (OpenAI compatible server)
 - [Text generation web UI](../reference/Model%20Providers/openai.md) (OpenAI compatible server)
 - [FastChat](../reference/Model%20Providers/openai.md) (OpenAI compatible server)


### PR DESCRIPTION
A llamafile reference page [already exists](https://continue.dev/docs/reference/Model%20Providers/llamafile) but was not linked from the "[Select a model provider](https://continue.dev/docs/model-setup/select-provider)" page.