### PR TITLE
Add PAT authentication support in JIRA Provider

### DIFF
--- a/core/context/providers/JiraIssuesContextProvider/JiraClient.ts
+++ b/core/context/providers/JiraIssuesContextProvider/JiraClient.ts
@@ -79,10 +79,18 @@ export class JiraClient {
 
       this._api = Axios.create({
         baseURL: `https://${this.options.domain}/rest/api/${this.options.apiVersion}/`,
-        auth: {
-          username: this.options.username,
-          password: this.options.password,
-        },
+        ...(this.options.username
+          ? {
+              auth: {
+                username: this.options.username,
+                password: this.options.password,
+              },
+            }
+          : {
+              headers: {
+                Authorization: `Bearer ${this.options.password}`,
+              },
+            }),
       });
     }
 


### PR DESCRIPTION
Support PAT authentication rather than basic auth for security.
options.token to be used as authorization bearer token if username(email) option is skipped