### PR TITLE
feat: add GitLab Merge Request context provider

### DIFF
--- a/core/context/providers/GitLabMergeRequestContextProvider.ts
+++ b/core/context/providers/GitLabMergeRequestContextProvider.ts
@@ -1,0 +1,185 @@
+import type { AxiosInstance, AxiosError } from "axios";
+import {BaseContextProvider} from "..";
+import { ContextProviderExtras, ContextItem, ContextProviderDescription } from "../..";
+
+interface RemoteBranchInfo {
+  branch: string | null;
+  project: string | null;
+}
+
+const trimFirstElement = (args: Array<string>): string => {
+  return args[0].trim();
+};
+
+
+class GitLabMergeRequestContextProvider extends BaseContextProvider {
+  static description: ContextProviderDescription = {
+    title: 'gitlab-mr',
+    displayTitle: 'GitLab Merge Request',
+    description: 'Reference comments in a GitLab Merge Request',
+    type: 'normal'
+  };
+
+  private async getApi(): Promise<AxiosInstance> {
+    const { default: Axios } = await import("axios");
+
+    const domain = this.options.domain ?? "gitlab.com";
+    const token = this.options.token;
+
+    if(!token) {
+      throw new Error(`GitLab Private Token is required!`);
+    }
+  
+    return Axios.create({
+      baseURL: `https://${domain ?? "gitlab.com"}/api`,
+      headers: {
+        "PRIVATE-TOKEN": token,
+      },
+    });
+  };
+
+
+  private async getRemoteBranchName(extras: ContextProviderExtras): Promise<RemoteBranchInfo> {
+
+    const workingDir = await extras.ide
+    .getWorkspaceDirs()
+    .then(trimFirstElement);
+
+    const subprocess = (command: string) =>
+    extras.ide
+      .subprocess(`cd ${workingDir}; ${command}`)
+        .then(trimFirstElement);
+    
+    const branchName = await subprocess(`git branch --show-current`);
+  
+    const branchRemote = await subprocess(
+      `git config branch.${branchName}.remote`
+    );
+  
+    const branchInfo = await subprocess(`git branch -vv`);
+  
+    const currentBranchInfo = branchInfo
+      .split("\n")
+      .find((line) => line.startsWith("*"));
+  
+    const remoteMatches = RegExp(
+      `\\[${branchRemote}/(?<remote_branch>[^\\]]+)\\]`
+    ).exec(currentBranchInfo!);
+  
+    console.dir({ remoteMatches });
+  
+    const remoteBranch = remoteMatches?.groups?.["remote_branch"] ?? null;
+  
+    const remoteUrl = await subprocess(`git remote get-url ${branchRemote}`);
+  
+    const urlMatches = RegExp(`:(?<project>.*).git`).exec(remoteUrl);
+  
+    const project = urlMatches?.groups?.["project"] ?? null;
+  
+    return {
+      branch: remoteBranch,
+      project,
+    };
+  };
+
+  async getContextItems(query: string, extras: ContextProviderExtras): Promise<ContextItem[]> {
+
+    const parts = [`# ${this.description.displayTitle}`];  
+
+    const { branch, project } = await this.getRemoteBranchName(extras);
+  
+    const api = await this.getApi();
+  
+    try {
+    const mergeRequests = await api
+      .get<Array<{ iid: number; project_id: number }>>(
+        `/v4/projects/${encodeURIComponent(project!)}/merge_requests`,
+        {
+          params: {
+            source_branch: branch,
+            state: "opened",
+          },
+        }
+      )
+      .then((x) => x.data);
+  
+      if (mergeRequests?.length) {
+        const mergeRequest = mergeRequests[0];
+  
+        parts.push(`Merge Request: ${mergeRequest.iid}`);
+  
+        const comments = await api.get<Array<GitLabComment>>(
+          `/v4/projects/${mergeRequest.project_id}/merge_requests/${mergeRequest.iid}/notes`,
+          {
+            params: {
+              sort: "asc",
+              order_by: "created_at",
+            },
+          }
+        );
+  
+        const locations = {} as Record<string, Array<GitLabComment>>;
+  
+        for (const comment of comments.data.filter(
+          (x) => x.type === "DiffNote"
+        )) {
+          const filename = comment.position?.new_path ?? "general";
+  
+          if (!locations[filename]) {
+            locations[filename] = [];
+          }
+  
+          locations[filename].push(comment);
+        }
+  
+        const commentFormatter = (comment: GitLabComment) => {
+          const commentParts = [
+            `### ${comment.author.name} on ${comment.created_at}${
+              comment.resolved ? " (Resolved)" : ""
+            }`,
+          ];
+  
+          if (comment.position?.new_line) {
+            commentParts.push(
+              `line: ${comment.position.new_line}\ncommit: ${comment.position.head_sha}`
+            );
+          }
+  
+          commentParts.push(comment.body);
+  
+          return commentParts.join("\n\n");
+        };
+  
+        for (const [filename, locationComments] of Object.entries(locations)) {
+          if (filename !== "general") {
+            parts.push(`## File ${filename}`);
+            locationComments.sort(
+              (a, b) => a.position!.new_line - b.position!.new_line
+            );
+          } else {
+            parts.push("## Comments");
+          }
+  
+          parts.push(...locationComments.map(commentFormatter));
+        }
+      }
+  
+      const content = parts.join("\n\n");
+  
+      return [
+        {
+          name: `GitLab MR Comments`,
+          content,
+          description: `Comments from the Merge Request for this branch.`,
+        },
+      ];
+    } catch(ex) {
+      if(ex instanceof AxiosError) {
+
+      }
+    }
+  }
+
+}
+
+export default GitLabMergeRequestContextProvider;

--- a/core/context/providers/GitLabMergeRequestContextProvider.ts
+++ b/core/context/providers/GitLabMergeRequestContextProvider.ts
@@ -186,6 +186,13 @@ class GitLabMergeRequestContextProvider extends BaseContextProvider {
   
           locations[filename].push(comment);
         }
+
+        if (extras.selectedCode.length && this.options.filterComments) {
+          const toRemove = Object.keys(locations).filter(filename => !extras.selectedCode.find(selection => selection.filepath.endsWith(filename)) && filename !== "general");
+          for (const filepath of toRemove) {
+            delete locations[filepath];
+          }
+        }
   
         const commentFormatter = async (comment: GitLabComment) => {
           const commentLabel = comment.body.includes("```suggestion") ? 'Code Suggestion' : 'Comment';

--- a/core/context/providers/index.ts
+++ b/core/context/providers/index.ts
@@ -17,6 +17,7 @@ import ProblemsContextProvider from "./ProblemsContextProvider";
 import SearchContextProvider from "./SearchContextProvider";
 import TerminalContextProvider from "./TerminalContextProvider";
 import URLContextProvider from "./URLContextProvider";
+import GitLabMergeRequestContextProvider from "./GitLabMergeRequestContextProvider";
 
 const Providers: (typeof BaseContextProvider)[] = [
   DiffContextProvider,
@@ -32,6 +33,7 @@ const Providers: (typeof BaseContextProvider)[] = [
   ProblemsContextProvider,
   FolderContextProvider,
   DocsContextProvider,
+  GitLabMergeRequestContextProvider,
   // CodeHighlightsContextProvider,
   // CodeOutlineContextProvider,
   JiraIssuesContextProvider,

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -428,7 +428,8 @@ type ContextProviderName =
   | "postgres"
   | "database"
   | "code"
-  | "docs";
+  | "docs"
+  | "gitlab-mr";
 
 type TemplateType =
   | "llama2"

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -55,7 +55,6 @@
         "@types/uuid": "^9.0.7",
         "esbuild": "^0.19.11",
         "jest": "^29.7.0",
-        "tree-sitter-cli": "^0.21.0",
         "ts-jest": "^29.1.1"
       }
     },
@@ -9574,16 +9573,6 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
-    },
-    "node_modules/tree-sitter-cli": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.21.0.tgz",
-      "integrity": "sha512-wA7wT5724fNQW82XDH6zT6ZcYonjrAKLCHHuhLsPcAKULrhp3rNuMvlgBdB5FUBvmjHNhtTZF/qpHenMoRJPBw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "tree-sitter": "cli.js"
-      }
     },
     "node_modules/tree-sitter-wasms": {
       "version": "0.1.6",

--- a/core/yarn.lock
+++ b/core/yarn.lock
@@ -318,11 +318,6 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@esbuild/darwin-arm64@0.19.12":
-  version "0.19.12"
-  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz"
-  integrity sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==
-
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
   dependencies:
@@ -601,9 +596,6 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
-
-"@lancedb/vectordb-darwin-arm64@0.4.11":
-  version "0.4.11"
 
 "@mozilla/readability@^0.5.0":
   version "0.5.0"
@@ -2500,11 +2492,6 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
-
-fsevents@^2.3.2:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
   version "1.1.2"
@@ -5263,11 +5250,6 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
-
-tree-sitter-cli@^0.21.0:
-  version "0.21.0"
-  resolved "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.21.0.tgz"
-  integrity sha512-wA7wT5724fNQW82XDH6zT6ZcYonjrAKLCHHuhLsPcAKULrhp3rNuMvlgBdB5FUBvmjHNhtTZF/qpHenMoRJPBw==
 
 tree-sitter-wasms@^0.1.6:
   version "0.1.6"

--- a/docs/docs/customization/context-providers.md
+++ b/docs/docs/customization/context-providers.md
@@ -151,6 +151,10 @@ You can specify the domain to communicate with by setting the `domain` parameter
 }
 ```
 
+#### Filtering Comments
+
+If you select some code to be edited, you can have the context provider filter out comments for other files. To enable this feature, set `filterComments` to `true`.
+
 ### Jira Issues
 
 Type '@jira' to reference the conversation in a Jira issue. Make sure to include your own [Atlassian API Token](https://id.atlassian.com/manage-profile/security/api-tokens).

--- a/docs/docs/customization/context-providers.md
+++ b/docs/docs/customization/context-providers.md
@@ -120,6 +120,37 @@ Type '@issue' to reference the conversation in a GitHub issue. Make sure to incl
 }
 ```
 
+### GitLab Merge Request
+
+Type `@gitlab-mr` to reference an open MR for this branch on GitLab. 
+
+#### Configuration
+
+You will need to create a [personal access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) with the `read_api` scope. then add the following to your configuration:
+
+```json
+{
+  "name": "gitlab-mr",
+  "params": {
+    "token": "..."
+  }
+}
+```
+
+#### Using Self-Hosted GitLab
+
+You can specify the domain to communicate with by setting the `domain` parameter in your configurtion. By default this is set to `gitlab.com`.
+
+```json
+{
+  "name": "gitlab-mr",
+  "params": {
+    "token": "...",
+    "domain": "gitlab.example.com"
+  }
+}
+```
+
 ### Jira Issues
 
 Type '@jira' to reference the conversation in a Jira issue. Make sure to include your own [Atlassian API Token](https://id.atlassian.com/manage-profile/security/api-tokens).

--- a/docs/static/schemas/config.json
+++ b/docs/static/schemas/config.json
@@ -1260,6 +1260,10 @@
                   "token": {
                     "type": "string",
                     "description": "Your private access token."
+                  },
+                  "filterComments": {
+                    "type": "boolean",
+                    "description": "If you have code selected, filters out comments that aren't related to the selection."
                   }
                 },
                 "required": ["token"]

--- a/docs/static/schemas/config.json
+++ b/docs/static/schemas/config.json
@@ -1245,6 +1245,33 @@
           "if": {
             "properties": {
               "name": {
+                "enum": ["gitlab-mr"]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "params": {
+                "properties": {
+                  "domain": {
+                    "type": "string",
+                    "description": "Your GitLab domain, will default to gitlab.com"
+                  },
+                  "token": {
+                    "type": "string",
+                    "description": "Your private access token."
+                  }
+                },
+                "required": ["token"]
+              }
+            },
+            "required": ["params"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "name": {
                 "enum": ["jira"]
               }
             }

--- a/extensions/intellij/src/main/resources/config_schema.json
+++ b/extensions/intellij/src/main/resources/config_schema.json
@@ -1260,6 +1260,10 @@
                   "token": {
                     "type": "string",
                     "description": "Your private access token."
+                  },
+                  "filterComments": {
+                    "type": "boolean",
+                    "description": "If you have code selected, filters out comments that aren't related to the selection."
                   }
                 },
                 "required": ["token"]

--- a/extensions/intellij/src/main/resources/config_schema.json
+++ b/extensions/intellij/src/main/resources/config_schema.json
@@ -1245,6 +1245,33 @@
           "if": {
             "properties": {
               "name": {
+                "enum": ["gitlab-mr"]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "params": {
+                "properties": {
+                  "domain": {
+                    "type": "string",
+                    "description": "Your GitLab domain, will default to gitlab.com"
+                  },
+                  "token": {
+                    "type": "string",
+                    "description": "Your private access token."
+                  }
+                },
+                "required": ["token"]
+              }
+            },
+            "required": ["params"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "name": {
                 "enum": ["jira"]
               }
             }

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -1260,6 +1260,10 @@
                   "token": {
                     "type": "string",
                     "description": "Your private access token."
+                  },
+                  "filterComments": {
+                    "type": "boolean",
+                    "description": "If you have code selected, filters out comments that aren't related to the selection."
                   }
                 },
                 "required": ["token"]

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -1245,6 +1245,33 @@
           "if": {
             "properties": {
               "name": {
+                "enum": ["gitlab-mr"]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "params": {
+                "properties": {
+                  "domain": {
+                    "type": "string",
+                    "description": "Your GitLab domain, will default to gitlab.com"
+                  },
+                  "token": {
+                    "type": "string",
+                    "description": "Your private access token."
+                  }
+                },
+                "required": ["token"]
+              }
+            },
+            "required": ["params"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "name": {
                 "enum": ["jira"]
               }
             }

--- a/extensions/vscode/continue_rc_schema.json
+++ b/extensions/vscode/continue_rc_schema.json
@@ -1395,6 +1395,39 @@
             "properties": {
               "name": {
                 "enum": [
+                  "gitlab-mr"
+                ]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "params": {
+                "properties": {
+                  "domain": {
+                    "type": "string",
+                    "description": "Your GitLab domain, will default to gitlab.com"
+                  },
+                  "token": {
+                    "type": "string",
+                    "description": "Your private access token."
+                  }
+                },
+                "required": [
+                  "token"
+                ]
+              }
+            },
+            "required": [
+              "params"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "name": {
+                "enum": [
                   "jira"
                 ]
               }

--- a/extensions/vscode/continue_rc_schema.json
+++ b/extensions/vscode/continue_rc_schema.json
@@ -1411,6 +1411,10 @@
                   "token": {
                     "type": "string",
                     "description": "Your private access token."
+                  },
+                  "filterComments": {
+                    "type": "boolean",
+                    "description": "If you have code selected, filters out comments that aren't related to the selection."
                   }
                 },
                 "required": [

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "0.9.84",
+  "version": "0.9.85",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "0.9.84",
+      "version": "0.9.85",
       "license": "Apache-2.0",
       "dependencies": {
         "@electron/rebuild": "^3.2.10",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "continue",
   "icon": "media/icon.png",
-  "version": "0.9.84",
+  "version": "0.9.85",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"

--- a/extensions/vscode/yarn.lock
+++ b/extensions/vscode/yarn.lock
@@ -368,15 +368,15 @@
     tar "^6.0.5"
     yargs "^17.0.1"
 
-"@esbuild/darwin-arm64@0.17.19":
+"@esbuild/linux-x64@0.17.19":
   version "0.17.19"
-  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz"
-  integrity sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==
+  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz"
+  integrity sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==
 
-"@esbuild/darwin-arm64@0.18.20":
+"@esbuild/linux-x64@0.18.20":
   version "0.18.20"
-  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz"
-  integrity sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==
+  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz"
+  integrity sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==
 
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
@@ -691,10 +691,10 @@
   resolved "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
-"@lancedb/vectordb-darwin-arm64@*", "@lancedb/vectordb-darwin-arm64@0.4.12":
+"@lancedb/vectordb-linux-x64-gnu@0.4.12":
   version "0.4.12"
-  resolved "https://registry.npmjs.org/@lancedb/vectordb-darwin-arm64/-/vectordb-darwin-arm64-0.4.12.tgz"
-  integrity sha512-38/rkJRlWXkPWXuj9onzvbrhnIWcIUQjgEp5G9v5ixPosBowm7A4j8e2Q8CJMsVSNcVX2JLqwWVldiWegZFuYw==
+  resolved "https://registry.npmjs.org/@lancedb/vectordb-linux-x64-gnu/-/vectordb-linux-x64-gnu-0.4.12.tgz"
+  integrity sha512-gJqYR0aymrS+C60xc4EQPzmQ5/69XfeFv2ofBvAj7qW+c6BcnoAcfVl+7s1IrcWeGz251sm5cD5Lx4AzJd89dA==
 
 "@lukeed/csprng@^1.0.0":
   version "1.1.0"
@@ -3443,11 +3443,6 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
-
-fsevents@^2.3.2, fsevents@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Finds open merge requests for the current branch on gitlab and pulls in comments. Here is an example context provided from a sample project:

````markdown
# GitLab Merge Request
title: "feat: production db"
description: "Create a database to be queried for the production API."

## Comments

### File packages/esbuild-path-resolver/src/index.ts

#### Code Suggestion
author: "Ben Force"
date: "2024-02-21T11:46:56.166Z"
resolved: No
line: 40
source: `    console.info(`Error parsing tsconfig`, ex);`

```suggestion:-0+0
    console.info(`Error parsing ${absTsconfigPath}`, ex);
```

### File functions/updates-fn/src/index.ts

#### Comment
author: "Ben Force"
date: "2024-03-15T10:52:27.587Z"
resolved: No
line: 71
source: `export const handler: DynamoDBStreamHandler = async (event) => {`

Need to make some unit tests for this.
````