### PR TITLE
Fix chat msg formatting in Output for multimodal models

### DIFF
--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -29,6 +29,7 @@ import {
   compileChatMessages,
   countTokens,
   pruneRawPromptFromTop,
+  stripImages,
 } from "./countTokens";
 import CompletionOptionsForModels from "./templates/options";
 
@@ -245,8 +246,13 @@ ${prompt}`;
   }
 
   private _formatChatMessages(messages: ChatMessage[]): string {
+    const msgsCopy = messages ? messages.map((msg) => ({ ...msg })) : [];
     let formatted = "";
-    for (let msg of messages) {
+    for (let msg of msgsCopy) {
+      if ("content" in msg && Array.isArray(msg.content)) {
+        const content = stripImages(msg.content);
+        msg.content = content;
+      }
       formatted += `<${msg.role}>\n${msg.content || ""}\n\n`;
     }
     return formatted;


### PR DESCRIPTION
For models that support images, all chat messages showed up as [object Object] in the Output, rather than message text. The completion text for the model response is unaffected. 
```<user>
[object Object]

<assistant>
[object Object]

<user>
[object Object]```

This fix ensures that the text portion shows up correctly in the output. Though it might be nice to have the output include some token to represent any image pieces of a chat dialog, for now they're just stripped from the formatted message just as if the user included an image for a model that doesn't support them.