### PR TITLE
Bump vectordb version

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -43,7 +43,7 @@
         "sqlite3": "^5.1.7",
         "tree-sitter-wasms": "^0.1.6",
         "uuid": "^9.0.1",
-        "vectordb": "^0.4.3",
+        "vectordb": "^0.4.12",
         "web-tree-sitter": "^0.21.0"
       },
       "devDependencies": {
@@ -55,13 +55,13 @@
         "@types/uuid": "^9.0.7",
         "esbuild": "^0.19.11",
         "jest": "^29.7.0",
-        "tree-sitter-cli": "^0.21.0",
         "ts-jest": "^29.1.1"
       }
     },
     "node_modules/@75lb/deep-merge": {
       "version": "1.1.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash.assignwith": "^4.2.0",
         "typical": "^7.1.1"
@@ -73,6 +73,7 @@
     "node_modules/@75lb/deep-merge/node_modules/typical": {
       "version": "7.1.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.17"
       }
@@ -100,6 +101,7 @@
     "node_modules/@apache-arrow/ts": {
       "version": "14.0.2",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/command-line-args": "5.2.0",
         "@types/command-line-usage": "5.0.2",
@@ -115,11 +117,13 @@
     },
     "node_modules/@apache-arrow/ts/node_modules/@types/node": {
       "version": "20.3.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@apache-arrow/ts/node_modules/flatbuffers": {
       "version": "23.5.26",
-      "license": "SEE LICENSE IN LICENSE"
+      "license": "SEE LICENSE IN LICENSE",
+      "peer": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.23.5",
@@ -1422,14 +1426,63 @@
       }
     },
     "node_modules/@lancedb/vectordb-darwin-arm64": {
-      "version": "0.4.11",
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@lancedb/vectordb-darwin-arm64/-/vectordb-darwin-arm64-0.4.12.tgz",
+      "integrity": "sha512-38/rkJRlWXkPWXuj9onzvbrhnIWcIUQjgEp5G9v5ixPosBowm7A4j8e2Q8CJMsVSNcVX2JLqwWVldiWegZFuYw==",
       "cpu": [
         "arm64"
       ],
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@lancedb/vectordb-darwin-x64": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@lancedb/vectordb-darwin-x64/-/vectordb-darwin-x64-0.4.12.tgz",
+      "integrity": "sha512-psE48dztyO450hXWdv9Rl9aayM2HQ1uF9wErfC0gKmDUh1N0NdVq2viDuFpZxnmCis/nvGwKlYiYT9OnYNCJ9g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@lancedb/vectordb-linux-arm64-gnu": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@lancedb/vectordb-linux-arm64-gnu/-/vectordb-linux-arm64-gnu-0.4.12.tgz",
+      "integrity": "sha512-xwkgF6MiF5aAdG9JG8v4ke652YxUJrhs9z4OrsEfrENnvsIQd2C5UyKMepVLdvij4BI/XPFRFWXdjPvP7S9rTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lancedb/vectordb-linux-x64-gnu": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@lancedb/vectordb-linux-x64-gnu/-/vectordb-linux-x64-gnu-0.4.12.tgz",
+      "integrity": "sha512-gJqYR0aymrS+C60xc4EQPzmQ5/69XfeFv2ofBvAj7qW+c6BcnoAcfVl+7s1IrcWeGz251sm5cD5Lx4AzJd89dA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@lancedb/vectordb-win32-x64-msvc": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@lancedb/vectordb-win32-x64-msvc/-/vectordb-win32-x64-msvc-0.4.12.tgz",
+      "integrity": "sha512-LhCzpyEeBUyO6L2fuVqeP3mW8kYDryyU9PNqcM01m88sZB1Do6AlwiM+GjPRQ0SpzD0LK9oxQqSmJrdcNGqjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@mozilla/readability": {
@@ -1842,11 +1895,13 @@
     },
     "node_modules/@types/command-line-args": {
       "version": "5.2.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/command-line-usage": {
       "version": "5.0.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/follow-redirects": {
       "version": "1.14.4",
@@ -1980,7 +2035,8 @@
     },
     "node_modules/@types/pad-left": {
       "version": "2.1.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/sizzle": {
       "version": "2.3.8",
@@ -2220,6 +2276,7 @@
     "node_modules/apache-arrow": {
       "version": "14.0.2",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/command-line-args": "5.2.0",
         "@types/command-line-usage": "5.0.2",
@@ -2238,11 +2295,13 @@
     },
     "node_modules/apache-arrow/node_modules/@types/node": {
       "version": "20.3.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/apache-arrow/node_modules/flatbuffers": {
       "version": "23.5.26",
-      "license": "SEE LICENSE IN LICENSE"
+      "license": "SEE LICENSE IN LICENSE",
+      "peer": true
     },
     "node_modules/aproba": {
       "version": "2.0.0",
@@ -2283,6 +2342,7 @@
     "node_modules/array-back": {
       "version": "3.1.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2959,6 +3019,7 @@
     "node_modules/chalk-template": {
       "version": "0.4.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^4.1.2"
       },
@@ -3167,6 +3228,7 @@
     "node_modules/command-line-args": {
       "version": "5.2.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-back": "^3.1.0",
         "find-replace": "^3.0.0",
@@ -3180,6 +3242,7 @@
     "node_modules/command-line-usage": {
       "version": "7.0.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-back": "^6.2.2",
         "chalk-template": "^0.4.0",
@@ -3193,6 +3256,7 @@
     "node_modules/command-line-usage/node_modules/array-back": {
       "version": "6.2.2",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.17"
       }
@@ -3200,6 +3264,7 @@
     "node_modules/command-line-usage/node_modules/typical": {
       "version": "7.1.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.17"
       }
@@ -4522,6 +4587,7 @@
     "node_modules/find-replace": {
       "version": "3.0.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-back": "^3.0.1"
       },
@@ -6572,6 +6638,7 @@
     },
     "node_modules/json-bignum": {
       "version": "0.0.3",
+      "peer": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -6713,11 +6780,13 @@
     },
     "node_modules/lodash.assignwith": {
       "version": "4.2.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -7783,6 +7852,7 @@
     "node_modules/pad-left": {
       "version": "2.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "repeat-string": "^1.5.4"
       },
@@ -8483,6 +8553,7 @@
     "node_modules/repeat-string": {
       "version": "1.6.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -9240,6 +9311,7 @@
     "node_modules/stream-read-all": {
       "version": "3.0.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9417,6 +9489,7 @@
     "node_modules/table-layout": {
       "version": "3.0.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@75lb/deep-merge": "^1.1.1",
         "array-back": "^6.2.2",
@@ -9436,6 +9509,7 @@
     "node_modules/table-layout/node_modules/array-back": {
       "version": "6.2.2",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.17"
       }
@@ -9443,6 +9517,7 @@
     "node_modules/table-layout/node_modules/typical": {
       "version": "7.1.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.17"
       }
@@ -9575,16 +9650,6 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
-    "node_modules/tree-sitter-cli": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.21.0.tgz",
-      "integrity": "sha512-wA7wT5724fNQW82XDH6zT6ZcYonjrAKLCHHuhLsPcAKULrhp3rNuMvlgBdB5FUBvmjHNhtTZF/qpHenMoRJPBw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "tree-sitter": "cli.js"
-      }
-    },
     "node_modules/tree-sitter-wasms": {
       "version": "0.1.6",
       "license": "Unlicense"
@@ -9701,7 +9766,8 @@
     },
     "node_modules/tslib": {
       "version": "2.6.2",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -9831,6 +9897,7 @@
     "node_modules/typical": {
       "version": "4.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9989,29 +10056,32 @@
       }
     },
     "node_modules/vectordb": {
-      "version": "0.4.11",
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/vectordb/-/vectordb-0.4.12.tgz",
+      "integrity": "sha512-H2mFwZ87d3BcuX4yGx5RoW06amRZQ3W5u/FRTNc86rwVINuEEa+Ivsqng1i8hURHXoTDbF/0Y9qwCshySkeznQ==",
       "cpu": [
         "x64",
         "arm64"
       ],
-      "license": "Apache-2.0",
       "os": [
         "darwin",
         "linux",
         "win32"
       ],
       "dependencies": {
-        "@apache-arrow/ts": "^14.0.2",
         "@neon-rs/load": "^0.0.74",
-        "apache-arrow": "^14.0.2",
         "axios": "^1.4.0"
       },
       "optionalDependencies": {
-        "@lancedb/vectordb-darwin-arm64": "0.4.11",
-        "@lancedb/vectordb-darwin-x64": "0.4.11",
-        "@lancedb/vectordb-linux-arm64-gnu": "0.4.11",
-        "@lancedb/vectordb-linux-x64-gnu": "0.4.11",
-        "@lancedb/vectordb-win32-x64-msvc": "0.4.11"
+        "@lancedb/vectordb-darwin-arm64": "0.4.12",
+        "@lancedb/vectordb-darwin-x64": "0.4.12",
+        "@lancedb/vectordb-linux-arm64-gnu": "0.4.12",
+        "@lancedb/vectordb-linux-x64-gnu": "0.4.12",
+        "@lancedb/vectordb-win32-x64-msvc": "0.4.12"
+      },
+      "peerDependencies": {
+        "@apache-arrow/ts": "^14.0.2",
+        "apache-arrow": "^14.0.2"
       }
     },
     "node_modules/verror": {
@@ -10177,6 +10247,7 @@
     "node_modules/wordwrapjs": {
       "version": "5.1.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.17"
       }

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     "sqlite3": "^5.1.7",
     "tree-sitter-wasms": "^0.1.6",
     "uuid": "^9.0.1",
-    "vectordb": "^0.4.3",
+    "vectordb": "^0.4.12",
     "web-tree-sitter": "^0.21.0"
   },
   "puppeteer": {

--- a/core/yarn.lock
+++ b/core/yarn.lock
@@ -602,8 +602,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@lancedb/vectordb-darwin-arm64@0.4.11":
-  version "0.4.11"
+"@lancedb/vectordb-darwin-arm64@0.4.12":
+  version "0.4.12"
+  resolved "https://registry.npmjs.org/@lancedb/vectordb-darwin-arm64/-/vectordb-darwin-arm64-0.4.12.tgz"
+  integrity sha512-38/rkJRlWXkPWXuj9onzvbrhnIWcIUQjgEp5G9v5ixPosBowm7A4j8e2Q8CJMsVSNcVX2JLqwWVldiWegZFuYw==
 
 "@mozilla/readability@^0.5.0":
   version "0.5.0"
@@ -5264,11 +5266,6 @@ tr46@~0.0.3:
   resolved "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
-tree-sitter-cli@^0.21.0:
-  version "0.21.0"
-  resolved "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.21.0.tgz"
-  integrity sha512-wA7wT5724fNQW82XDH6zT6ZcYonjrAKLCHHuhLsPcAKULrhp3rNuMvlgBdB5FUBvmjHNhtTZF/qpHenMoRJPBw==
-
 tree-sitter-wasms@^0.1.6:
   version "0.1.6"
 
@@ -5471,19 +5468,19 @@ v8-to-istanbul@^9.0.1:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^2.0.0"
 
-vectordb@^0.4.3:
-  version "0.4.11"
+vectordb@^0.4.12:
+  version "0.4.12"
+  resolved "https://registry.npmjs.org/vectordb/-/vectordb-0.4.12.tgz"
+  integrity sha512-H2mFwZ87d3BcuX4yGx5RoW06amRZQ3W5u/FRTNc86rwVINuEEa+Ivsqng1i8hURHXoTDbF/0Y9qwCshySkeznQ==
   dependencies:
-    "@apache-arrow/ts" "^14.0.2"
     "@neon-rs/load" "^0.0.74"
-    apache-arrow "^14.0.2"
     axios "^1.4.0"
   optionalDependencies:
-    "@lancedb/vectordb-darwin-arm64" "0.4.11"
-    "@lancedb/vectordb-darwin-x64" "0.4.11"
-    "@lancedb/vectordb-linux-arm64-gnu" "0.4.11"
-    "@lancedb/vectordb-linux-x64-gnu" "0.4.11"
-    "@lancedb/vectordb-win32-x64-msvc" "0.4.11"
+    "@lancedb/vectordb-darwin-arm64" "0.4.12"
+    "@lancedb/vectordb-darwin-x64" "0.4.12"
+    "@lancedb/vectordb-linux-arm64-gnu" "0.4.12"
+    "@lancedb/vectordb-linux-x64-gnu" "0.4.12"
+    "@lancedb/vectordb-win32-x64-msvc" "0.4.12"
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
I had some problems with the `@Docs` feature, couldn't add docs nor use preindexed. It was giving an `ERR Table 'docs' was not found: Error: Table 'docs' was not found`. Seems like this was caused by a bug in lance, so I just bumped `vectordb` version. Please add this to the nightly release.
