### PR TITLE
Update message to match revised shortcut

### DIFF
--- a/core/commands/slash/edit.ts
+++ b/core/commands/slash/edit.ts
@@ -225,7 +225,7 @@ const EditSlashCommand: SlashCommand = {
     }
 
     if (!contextItemToEdit) {
-      yield "Select (highlight and press `cmd+shift+M` (MacOS) / `ctrl+shift+M` (Windows)) the code that you want to edit first";
+      yield "Select (highlight and press `cmd+shift+L` (MacOS) / `ctrl+shift+L` (Windows)) the code that you want to edit first";
       return;
     }
 


### PR DESCRIPTION
If user attempts to use /edit without any context selected they get a message prompting them to do so. Selection shortcut was recently changed from ctrl/cmd-M to L; this revises the message to match