### PR TITLE
Config: add ui.codeBlockToolbarPosition

### DIFF
--- a/core/config/default.ts
+++ b/core/config/default.ts
@@ -74,6 +74,9 @@ export const defaultConfig: SerializedContinueConfig = {
     provider: "ollama",
     model: "starcoder-3b",
   },
+  ui: {
+    codeBlockToolbarPosition: "top",
+  }
 };
 
 export const defaultConfigJetBrains: SerializedContinueConfig = {
@@ -137,4 +140,7 @@ export const defaultConfigJetBrains: SerializedContinueConfig = {
       params: {},
     },
   ],
+  ui: {
+    codeBlockToolbarPosition: "top",
+  }
 };

--- a/core/config/load.ts
+++ b/core/config/load.ts
@@ -319,6 +319,7 @@ function finalToBrowserConfig(
     disableSessionTitles: final.disableSessionTitles,
     userToken: final.userToken,
     embeddingsProvider: final.embeddingsProvider?.id,
+    ui: final.ui,
   };
 }
 

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -624,6 +624,10 @@ export interface TabAutocompleteOptions {
   useOtherFiles: boolean;
 }
 
+export interface ContinueUIConfig {
+  codeBlockToolbarPosition?: "top" | "bottom";
+}
+
 export interface SerializedContinueConfig {
   env?: string[];
   allowAnonymousTelemetry?: boolean;
@@ -639,6 +643,7 @@ export interface SerializedContinueConfig {
   embeddingsProvider?: EmbeddingsProviderDescription;
   tabAutocompleteModel?: ModelDescription;
   tabAutocompleteOptions?: Partial<TabAutocompleteOptions>;
+  ui?: ContinueUIConfig;
 }
 
 export type ConfigMergeType = "merge" | "overwrite";
@@ -677,6 +682,8 @@ export interface Config {
   tabAutocompleteModel?: CustomLLM | ModelDescription;
   /** Options for tab autocomplete */
   tabAutocompleteOptions?: Partial<TabAutocompleteOptions>;
+  /** UI styles customization */
+  ui?: ContinueUIConfig;
 }
 
 export interface ContinueConfig {
@@ -692,6 +699,7 @@ export interface ContinueConfig {
   embeddingsProvider: EmbeddingsProvider;
   tabAutocompleteModel?: ILLM;
   tabAutocompleteOptions?: Partial<TabAutocompleteOptions>;
+  ui?: ContinueUIConfig;
 }
 
 export interface BrowserSerializedContinueConfig {
@@ -705,4 +713,5 @@ export interface BrowserSerializedContinueConfig {
   disableSessionTitles?: boolean;
   userToken?: string;
   embeddingsProvider?: string;
+  ui?: ContinueUIConfig;
 }

--- a/gui/src/components/markdown/CodeBlockToolbar.tsx
+++ b/gui/src/components/markdown/CodeBlockToolbar.tsx
@@ -19,9 +19,9 @@ const TopDiv = styled.div`
   z-index: 100;
 `;
 
-const SecondDiv = styled.div`
+const SecondDiv = styled.div<{ bottom: boolean; }>`
   position: absolute;
-  top: 4px;
+  ${(props) => props.bottom ? "bottom: 1.2rem;" : "top: 4px;"}
   right: 4px;
   display: flex;
   gap: 4px;
@@ -30,6 +30,7 @@ const SecondDiv = styled.div`
 
 interface CodeBlockToolBarProps {
   text: string;
+  bottom: boolean;
 }
 
 function CodeBlockToolBar(props: CodeBlockToolBarProps) {
@@ -38,7 +39,7 @@ function CodeBlockToolBar(props: CodeBlockToolBarProps) {
 
   return (
     <TopDiv>
-      <SecondDiv>
+      <SecondDiv bottom={props.bottom || false}>
         {isJetBrains() || (
           <HeaderButtonWithText
             text={applying ? "Applying..." : "Apply to current file"}

--- a/gui/src/components/markdown/PreWithToolbar.tsx
+++ b/gui/src/components/markdown/PreWithToolbar.tsx
@@ -1,5 +1,6 @@
 import { debounce } from "lodash";
 import { useEffect, useState } from "react";
+import useUIConfig from "../../hooks/useUIConfig";
 import CodeBlockToolBar from "./CodeBlockToolbar";
 
 function childToText(child: any) {
@@ -19,7 +20,10 @@ function childrenToText(children: any) {
 }
 
 function PreWithToolbar(props: { children: any }) {
-  const [hovering, setHovering] = useState(false);
+  const uiConfig = useUIConfig()
+  const toolbarBottom = uiConfig?.codeBlockToolbarPosition == 'bottom';
+
+  const [hovering, setHovering] = useState(true);
 
   const [copyValue, setCopyValue] = useState("");
 
@@ -42,8 +46,9 @@ function PreWithToolbar(props: { children: any }) {
       onMouseEnter={() => setHovering(true)}
       onMouseLeave={() => setHovering(false)}
     >
-      {hovering && <CodeBlockToolBar text={copyValue}></CodeBlockToolBar>}
+      {!toolbarBottom && hovering && <CodeBlockToolBar text={copyValue} bottom={toolbarBottom}></CodeBlockToolBar>}
       {props.children}
+      {toolbarBottom && hovering && <CodeBlockToolBar text={copyValue} bottom={toolbarBottom}></CodeBlockToolBar>}
     </div>
   );
 }

--- a/gui/src/hooks/useUIConfig.ts
+++ b/gui/src/hooks/useUIConfig.ts
@@ -1,0 +1,8 @@
+import { useSelector } from 'react-redux';
+import { RootState } from '../redux/store';
+
+function useUIConfig() {
+  return useSelector((store: RootState) => store.state.config.ui);
+}
+
+export default useUIConfig;

--- a/gui/src/redux/slices/stateSlice.ts
+++ b/gui/src/redux/slices/stateSlice.ts
@@ -117,6 +117,9 @@ const initialState: State = {
       },
     ],
     contextProviders: [],
+    ui: {
+      codeBlockToolbarPosition: 'top',
+    }
   },
   title: "New Session",
   sessionId: v4(),


### PR DESCRIPTION
- Introduce UI configuration to `~/.continue/config.json`
- Added option to move down the code block toolbar

![ui-config](https://github.com/continuedev/continue/assets/28678580/69d6fa14-a52d-41e3-b7cc-1f4a4cfaa61c)
