### PR TITLE
Build script fixes

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -13,7 +13,7 @@ popd
 echo "Installing GUI extension dependencies..."
 pushd gui
 npm install
-npm link core
+npm link @continuedev/core
 npm run build
 popd
 # VSCode Extension (will also package GUI)
@@ -22,7 +22,7 @@ pushd extensions/vscode
 
 # This does way too many things inline but is the common denominator between many of the scripts
 npm install
-npm link core
+npm link @continuedev/core
 npm run package
 
 popd

--- a/pkg/build.js
+++ b/pkg/build.js
@@ -114,7 +114,7 @@ const targetToLanceDb = {
     const targetDir = `bin/${target}`;
     console.log(`[info] Building ${target}...`);
     execSync(
-      `npx pkg --no-bytecode --public-packages "*" --public pkgJson/${target} --out-path ${targetDir}`
+      `./node_modules/.bin/pkg --no-bytecode --public-packages "*" --public pkgJson/${target} --out-path ${targetDir}`
     );
 
     // Download and unzip prebuilt sqlite3 binary for the target


### PR DESCRIPTION
- change `npm link` commands to specifically target packages using the `@continuedev` scope to avoid naming-collisions with external packages with the same names
- replace `npx pkg` with an explicit reference to the `pkg` executable script within `node_modules`, again because naming-collisions with the `pkg` dependency were causing issues.