### PR TITLE
Fix issue with /edit not acknowledging highlighted code after retrying

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor.tsx
@@ -29,7 +29,7 @@ import useHistory from "../../hooks/useHistory";
 import useUpdatingRef from "../../hooks/useUpdatingRef";
 import { useWebviewListener } from "../../hooks/useWebviewListener";
 import { defaultModelSelector } from "../../redux/selectors/modelSelectors";
-import { setEditingContextItemAtIndex } from "../../redux/slices/stateSlice";
+import { addHighlightedCode, setEditingContextItemAtIndex } from "../../redux/slices/stateSlice";
 import { RootState } from "../../redux/store";
 import { isMetaEquivalentKeyPressed } from "../../util";
 import { isJetBrains, postToIde } from "../../util/ide";
@@ -497,6 +497,7 @@ function TipTapEditor(props: TipTapEditorProps) {
           editor.commands.blur();
           editor.commands.focus("end");
         }, 20);
+        dispatch(addHighlightedCode({rangeInFileWithContents: rif, edit: true}));
       }
       setIgnoreHighlightedCode(false);
     },

--- a/gui/src/redux/slices/stateSlice.ts
+++ b/gui/src/redux/slices/stateSlice.ts
@@ -239,7 +239,7 @@ export const stateSlice = createSlice({
         contextItems: [],
       });
 
-      state.contextItems = [];
+      state.contextItems = state.contextItems;
       state.active = true;
     },
     initNewActiveMessage: (
@@ -262,7 +262,7 @@ export const stateSlice = createSlice({
         },
         contextItems: [],
       });
-      state.contextItems = [];
+      state.contextItems = state.contextItems;
       state.active = true;
     },
     setMessageAtIndex: (
@@ -402,7 +402,7 @@ export const stateSlice = createSlice({
       const lineNums = `(${
         payload.rangeInFileWithContents.range.start.line + 1
       }-${payload.rangeInFileWithContents.range.end.line + 1})`;
-      contextItems.push({
+      contextItems = [{
         name: `${base} ${lineNums}`,
         description: payload.rangeInFileWithContents.filepath,
         id: {
@@ -412,7 +412,7 @@ export const stateSlice = createSlice({
         content: payload.rangeInFileWithContents.contents,
         editing: true,
         editable: true,
-      });
+      }];
 
       return { ...state, contextItems };
     },


### PR DESCRIPTION
Closes #1013

This PR addresses the issue #1013 where the /edit functionality was not acknowledging highlighted code after retrying.