### PR TITLE
Fix VS Code status bar flicker when updating it

### DIFF
--- a/extensions/vscode/src/autocomplete/statusBar.ts
+++ b/extensions/vscode/src/autocomplete/statusBar.ts
@@ -6,7 +6,7 @@ const statusBarItemText = (enabled: boolean | undefined) =>
 const statusBarItemTooltip = (enabled: boolean | undefined) =>
   enabled ? "Tab autocomplete is enabled" : "Click to enable tab autocomplete";
 
-let lastStatusBar: vscode.StatusBarItem | undefined = undefined;
+let statusBarItem: vscode.StatusBarItem | undefined = undefined;
 let statusBarFalseTimeout: NodeJS.Timeout | undefined = undefined;
 
 export function stopStatusBarLoading() {
@@ -24,27 +24,25 @@ export function setupStatusBar(
     statusBarFalseTimeout = undefined;
   }
 
-  const statusBarItem = vscode.window.createStatusBarItem(
-    vscode.StatusBarAlignment.Right,
-  );
+  // If statusBarItem hasn't been defined yet, create it
+  if (!statusBarItem) {
+    statusBarItem = vscode.window.createStatusBarItem(
+      vscode.StatusBarAlignment.Right,
+    );
+  }
+
   statusBarItem.text = loading
     ? "$(loading~spin) Continue"
     : statusBarItemText(enabled);
   statusBarItem.tooltip = statusBarItemTooltip(enabled);
   statusBarItem.command = "continue.toggleTabAutocompleteEnabled";
 
-  // Swap out with old status bar
-  if (lastStatusBar) {
-    lastStatusBar.dispose();
-  }
   statusBarItem.show();
-  lastStatusBar = statusBarItem;
 
   vscode.workspace.onDidChangeConfiguration((event) => {
     if (event.affectsConfiguration("continue")) {
       const config = vscode.workspace.getConfiguration("continue");
       const enabled = config.get<boolean>("enableTabAutocomplete");
-      statusBarItem.dispose();
       setupStatusBar(enabled);
     }
   });


### PR DESCRIPTION
The status bar in VS Code flickers when updating the loading icon because it is destroyed by "dispose()" on every update.

To fix, I propose to keep the same statusBar item when updating it to.