### PR TITLE
Bug Fix: Add ternary operator to prevent nonexistant value error

### DIFF
--- a/extensions/vscode/src/webviewProtocol.ts
+++ b/extensions/vscode/src/webviewProtocol.ts
@@ -71,18 +71,13 @@ export class VsCodeWebviewProtocol {
             response &&
             typeof response[Symbol.asyncIterator] === "function"
           ) {
-            console.log("assigning next")
             let next = await response.next();
-            console.log("next assigned: ", next)
             while (!next.done) {
-              console.log("begin loop next: ", next)
               respond(next.value);
               next = await response.next();
-              console.log("end loop next: ", next)
             }
             respond({ done: true, 
               content: next.value && next.value.content ? next.value.content : "" }); //if content exists, return it, otherwise return ""
-            console.log("response error-free")
           } else {
             respond(response || {});
           }

--- a/extensions/vscode/src/webviewProtocol.ts
+++ b/extensions/vscode/src/webviewProtocol.ts
@@ -71,18 +71,24 @@ export class VsCodeWebviewProtocol {
             response &&
             typeof response[Symbol.asyncIterator] === "function"
           ) {
+            console.log("assigning next")
             let next = await response.next();
+            console.log("next assigned: ", next)
             while (!next.done) {
+              console.log("begin loop next: ", next)
               respond(next.value);
               next = await response.next();
+              console.log("end loop next: ", next)
             }
-            respond({ done: true, content: next.value.content });
+            respond({ done: true, 
+              content: next.value && next.value.content ? next.value.content : "" }); //if content exists, return it, otherwise return ""
+            console.log("response error-free")
           } else {
             respond(response || {});
           }
         } catch (e: any) {
           console.error(
-            "Error handling webview message: " +
+            "Error handling webview message: " + //should expect to see this message
               JSON.stringify({ msg }, null, 2),
           );
 

--- a/extensions/vscode/src/webviewProtocol.ts
+++ b/extensions/vscode/src/webviewProtocol.ts
@@ -83,7 +83,7 @@ export class VsCodeWebviewProtocol {
           }
         } catch (e: any) {
           console.error(
-            "Error handling webview message: " + //should expect to see this message
+            "Error handling webview message: " + 
               JSON.stringify({ msg }, null, 2),
           );
 


### PR DESCRIPTION
![Screenshot from 2024-03-31 16-17-29](https://github.com/continuedev/continue/assets/42585006/97bb89e4-d8f4-47de-96ea-2705e8f531eb)

[This commit](https://github.com/continuedev/continue/commit/4053f1ad60a61a32bbd3a5543e373f4be4e36508) created a bug where a nonexistant value (next.value.content) is attempted to be read. 

I'm guessing it was added for cases where next.value.content will exist, so adding a ternary operator enables either case.