### PR TITLE
✨Add copy to workspace button for history items

### DIFF
--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -22,35 +22,35 @@ declare global {
       ) => void;
     }
   }
-  
+
   export interface ChunkWithoutID {
     content: string;
     startLine: number;
     endLine: number;
     otherMetadata?: { [key: string]: any };
   }
-  
+
   export interface Chunk extends ChunkWithoutID {
     digest: string;
     filepath: string;
     index: number; // Index of the chunk in the document at filepath
   }
-  
+
   export interface IndexingProgressUpdate {
     progress: number;
     desc: string;
   }
-  
+
   export interface LLMReturnValue {
     prompt: string;
     completion: string;
   }
   export interface ILLM extends LLMOptions {
     get providerName(): ModelProvider;
-  
+
     uniqueId: string;
     model: string;
-  
+
     title?: string;
     systemMessage?: string;
     contextLength: number;
@@ -62,41 +62,41 @@ declare global {
     llmRequestHook?: (model: string, prompt: string) => any;
     apiKey?: string;
     apiBase?: string;
-  
+
     engine?: string;
     apiVersion?: string;
     apiType?: string;
     region?: string;
     projectId?: string;
-  
+
     _fetch?: (input: any, init?: any) => Promise<any>;
-  
+
     complete(prompt: string, options?: LLMFullCompletionOptions): Promise<string>;
-  
+
     streamComplete(
       prompt: string,
       options?: LLMFullCompletionOptions
     ): AsyncGenerator<string, LLMReturnValue>;
-  
+
     streamChat(
       messages: ChatMessage[],
       options?: LLMFullCompletionOptions
     ): AsyncGenerator<ChatMessage, LLMReturnValue>;
-  
+
     chat(
       messages: ChatMessage[],
       options?: LLMFullCompletionOptions
     ): Promise<ChatMessage>;
-  
+
     countTokens(text: string): number;
-  
+
     supportsImages(): boolean;
-  
+
     listModels(): Promise<string[]>;
   }
-  
+
   export type ContextProviderType = "normal" | "query" | "submenu";
-  
+
   export interface ContextProviderDescription {
     title: string;
     displayTitle: string;
@@ -104,7 +104,7 @@ declare global {
     renderInlineAs?: string;
     type: ContextProviderType;
   }
-  
+
   export interface ContextProviderExtras {
     fullInput: string;
     embeddingsProvider: EmbeddingsProvider;
@@ -112,11 +112,11 @@ declare global {
     ide: IDE;
     selectedCode: RangeInFile[];
   }
-  
+
   export interface LoadSubmenuItemsArgs {
     ide: IDE;
   }
-  
+
   export interface CustomContextProvider {
     title: string;
     displayTitle?: string;
@@ -131,43 +131,43 @@ declare global {
       args: LoadSubmenuItemsArgs
     ) => Promise<ContextSubmenuItem[]>;
   }
-  
+
   export interface ContextSubmenuItem {
     id: string;
     title: string;
     description: string;
   }
-  
+
   export interface IContextProvider {
     get description(): ContextProviderDescription;
-  
+
     getContextItems(
       query: string,
       extras: ContextProviderExtras
     ): Promise<ContextItem[]>;
-  
+
     loadSubmenuItems(args: LoadSubmenuItemsArgs): Promise<ContextSubmenuItem[]>;
   }
-  
+
   export interface PersistedSessionInfo {
     history: ChatHistory;
     title: string;
     workspaceDirectory: string;
     sessionId: string;
   }
-  
+
   export interface SessionInfo {
     sessionId: string;
     title: string;
     dateCreated: string;
     workspaceDirectory: string;
   }
-  
+
   export interface RangeInFile {
     filepath: string;
     range: Range;
   }
-  
+
   export interface Range {
     start: Position;
     end: Position;
@@ -181,36 +181,36 @@ declare global {
     range: Range;
     replacement: string;
   }
-  
+
   export interface ContinueError {
     title: string;
     message: string;
   }
-  
+
   export interface CompletionOptions extends BaseCompletionOptions {
     model: string;
   }
-  
+
   export type ChatMessageRole = "user" | "assistant" | "system";
-  
+
   export interface MessagePart {
     type: "text" | "imageUrl";
     text?: string;
     imageUrl?: { url: string };
   }
-  
+
   export type MessageContent = string | MessagePart[];
-  
+
   export interface ChatMessage {
     role: ChatMessageRole;
     content: MessageContent;
   }
-  
+
   export interface ContextItemId {
     providerTitle: string;
     itemId: string;
   }
-  
+
   export interface ContextItem {
     content: string;
     name: string;
@@ -218,7 +218,7 @@ declare global {
     editing?: boolean;
     editable?: boolean;
   }
-  
+
   export interface ContextItemWithId {
     content: string;
     name: string;
@@ -227,27 +227,27 @@ declare global {
     editing?: boolean;
     editable?: boolean;
   }
-  
+
   export interface ChatHistoryItem {
     message: ChatMessage;
     editorState?: any;
     contextItems: ContextItemWithId[];
     promptLogs?: [string, string][]; // [prompt, completion]
   }
-  
+
   export type ChatHistory = ChatHistoryItem[];
-  
+
   // LLM
-  
+
   export interface LLMFullCompletionOptions extends BaseCompletionOptions {
     raw?: boolean;
     log?: boolean;
-  
+
     model?: string;
   }
   export interface LLMOptions {
     model: string;
-  
+
     title?: string;
     uniqueId?: string;
     systemMessage?: string;
@@ -261,12 +261,12 @@ declare global {
     llmRequestHook?: (model: string, prompt: string) => any;
     apiKey?: string;
     apiBase?: string;
-  
+
     // Azure options
     engine?: string;
     apiVersion?: string;
     apiType?: string;
-  
+
     // GCP Options
     region?: string;
     projectId?: string;
@@ -278,7 +278,7 @@ declare global {
     {
       [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>;
     }[Keys];
-  
+
   export interface CustomLLMWithOptionals {
     options?: LLMOptions;
     streamCompletion?: (
@@ -295,7 +295,7 @@ declare global {
       fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
     ) => Promise<string[]>;
   }
-  
+
   /**
    * The LLM interface requires you to specify either \`streamCompletion\` or \`streamChat\` (or both).
    */
@@ -303,20 +303,20 @@ declare global {
     CustomLLMWithOptionals,
     "streamCompletion" | "streamChat"
   >;
-  
+
   // IDE
-  
+
   export interface DiffLine {
     type: "new" | "old" | "same";
     line: string;
   }
-  
+
   export class Problem {
     filepath: string;
     range: Range;
     message: string;
   }
-  
+
   export type IdeType = "vscode" | "jetbrains";
   export interface IdeInfo {
     ideType: IdeType;
@@ -324,11 +324,12 @@ declare global {
     version: string;
     remoteName: string;
   }
-  
+
   export interface IDE {
     getIdeInfo(): Promise<IdeInfo>;
     getDiff(): Promise<string>;
     isTelemetryEnabled(): Promise<boolean>;
+    isHistoryMirroringEnabled(): Promise<boolean>;
     getUniqueId(): Promise<string>;
     getTerminalContents(): Promise<string>;
     listWorkspaceContents(directory?: string): Promise<string[]>;
@@ -361,9 +362,9 @@ declare global {
     getBranch(dir: string): Promise<string>;
     getStats(directory: string): Promise<{ [path: string]: number }>;
   }
-  
+
   // Slash Commands
-  
+
   export interface ContinueSDK {
     ide: IDE;
     llm: ILLM;
@@ -375,20 +376,20 @@ declare global {
     selectedCode: RangeInFile[];
     config: ContinueConfig;
   }
-  
+
   export interface SlashCommand {
     name: string;
     description: string;
     params?: { [key: string]: any };
     run: (sdk: ContinueSDK) => AsyncGenerator<string | undefined>;
-  
+
     // If true, this command will be run in NodeJs and have access to the filesystem and other Node-only APIs
     // You must make sure to dynamically import any Node-only dependencies in your command so that it doesn't break in the browser
     runInNodeJs?: boolean;
   }
-  
+
   // Config
-  
+
   type StepName =
     | "AnswerQuestionChroma"
     | "GenerateShellCommandStep"
@@ -400,7 +401,7 @@ declare global {
     | "OpenConfigStep"
     | "GenerateShellCommandStep"
     | "DraftIssueStep";
-  
+
   type ContextProviderName =
     | "diff"
     | "github"
@@ -413,7 +414,7 @@ declare global {
     | "codebase"
     | "problems"
     | "folder";
-  
+
   type TemplateType =
     | "llama2"
     | "alpaca"
@@ -429,7 +430,7 @@ declare global {
     | "neural-chat"
     | "codellama-70b"
     | "llava";
-  
+
   type ModelProvider =
     | "openai"
     | "free-trial"
@@ -449,7 +450,7 @@ declare global {
     | "bedrock"
     | "deepinfra"
     | "flowise";
-  
+
   export type ModelName =
     | "AUTODETECT"
     // OpenAI
@@ -494,7 +495,7 @@ declare global {
     | "starcoder-1b"
     | "starcoder-3b"
     | "stable-code-3b";
-  
+
   export interface RequestOptions {
     timeout?: number;
     verifySsl?: boolean;
@@ -503,29 +504,29 @@ declare global {
     headers?: { [key: string]: string };
     extraBodyProperties?: { [key: string]: any };
   }
-  
+
   export interface StepWithParams {
     name: StepName;
     params: { [key: string]: any };
   }
-  
+
   export interface ContextProviderWithParams {
     name: ContextProviderName;
     params: { [key: string]: any };
   }
-  
+
   export interface SlashCommandDescription {
     name: string;
     description: string;
     params?: { [key: string]: any };
   }
-  
+
   export interface CustomCommand {
     name: string;
     prompt: string;
     description: string;
   }
-  
+
   interface BaseCompletionOptions {
     temperature?: number;
     topP?: number;
@@ -537,7 +538,7 @@ declare global {
     stop?: string[];
     maxTokens?: number;
   }
-  
+
   export interface ModelDescription {
     title: string;
     provider: ModelProvider;
@@ -551,24 +552,24 @@ declare global {
     requestOptions?: RequestOptions;
     promptTemplates?: { [key: string]: string };
   }
-  
+
   export type EmbeddingsProviderName = "transformers.js" | "ollama" | "openai";
-  
+
   export interface EmbedOptions {
     apiBase?: string;
     apiKey?: string;
     model?: string;
   }
-  
+
   export interface EmbeddingsProviderDescription extends EmbedOptions {
     provider: EmbeddingsProviderName;
   }
-  
+
   export interface EmbeddingsProvider {
     id: string;
     embed(chunks: string[]): Promise<number[][]>;
   }
-  
+
   export interface TabAutocompleteOptions {
     useCopyBuffer: boolean;
     useSuffix: boolean;
@@ -579,7 +580,7 @@ declare global {
     template?: string;
     disableMultiLineCompletions?: boolean;
   }
-  
+
   export interface SerializedContinueConfig {
     allowAnonymousTelemetry?: boolean;
     models: ModelDescription[];
@@ -595,13 +596,13 @@ declare global {
     tabAutocompleteModel?: ModelDescription;
     tabAutocompleteOptions?: Partial<TabAutocompleteOptions>;
   }
-  
+
   export type ConfigMergeType = "merge" | "overwrite";
-  
+
   export type ContinueRcJson = Partial<SerializedContinueConfig> & {
     mergeBehavior: ConfigMergeType;
   };
-  
+
   export interface Config {
     /** If set to true, Continue will collect anonymous usage data to improve the product. If set to false, we will collect nothing. Read here to learn more: https://continue.dev/docs/telemetry */
     allowAnonymousTelemetry?: boolean;
@@ -633,7 +634,7 @@ declare global {
     /** Options for tab autocomplete */
     tabAutocompleteOptions?: Partial<TabAutocompleteOptions>;
   }
-  
+
   export interface ContinueConfig {
     allowAnonymousTelemetry?: boolean;
     models: ILLM[];
@@ -648,7 +649,7 @@ declare global {
     tabAutocompleteModel?: ILLM;
     tabAutocompleteOptions?: Partial<TabAutocompleteOptions>;
   }
-  
+
   export interface BrowserSerializedContinueConfig {
     allowAnonymousTelemetry?: boolean;
     models: ModelDescription[];
@@ -660,7 +661,7 @@ declare global {
     disableSessionTitles?: boolean;
     userToken?: string;
     embeddingsProvider?: string;
-  }  
+  }
 }
 
 export {};

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -361,6 +361,7 @@ export interface IDE {
   getIdeInfo(): Promise<IdeInfo>;
   getDiff(): Promise<string>;
   isTelemetryEnabled(): Promise<boolean>;
+  isHistoryMirroringEnabled(): Promise<boolean>;
   getUniqueId(): Promise<string>;
   getTerminalContents(): Promise<string>;
   getDebugLocals(threadIndex: number): Promise<string>;

--- a/core/protocol.ts
+++ b/core/protocol.ts
@@ -27,6 +27,7 @@ export type Protocol = {
 
   // History
   "history/list": [undefined, SessionInfo[]];
+  "history/copy": [{ id: string; workspaceDirectory: string }, void];
   "history/delete": [{ id: string }, void];
   "history/load": [{ id: string }, PersistedSessionInfo];
   "history/save": [PersistedSessionInfo, void];

--- a/core/protocol.ts
+++ b/core/protocol.ts
@@ -30,7 +30,10 @@ export type Protocol = {
   "history/copy": [{ id: string; workspaceDirectory: string }, void];
   "history/delete": [{ id: string }, void];
   "history/load": [{ id: string }, PersistedSessionInfo];
-  "history/save": [PersistedSessionInfo, void];
+  "history/save": [
+    { sessionInfo: PersistedSessionInfo; mirrorHistoryToWorkspace: boolean },
+    void,
+  ];
   "devdata/log": [{ tableName: string; data: any }, void];
   "config/addOpenAiKey": [string, void];
   "config/addModel": [

--- a/core/util/filesystem.ts
+++ b/core/util/filesystem.ts
@@ -41,6 +41,10 @@ class FileSystemIde implements IDE {
     return Promise.resolve(false);
   }
 
+  isHistoryMirroringEnabled(): Promise<boolean> {
+    return Promise.resolve(false);
+  }
+
   getUniqueId(): Promise<string> {
     return Promise.resolve("NOT_UNIQUE");
   }

--- a/core/util/history.ts
+++ b/core/util/history.ts
@@ -5,6 +5,7 @@ import {
   getSessionFilePath,
   getSessionsListPath,
 } from "./paths";
+import { IDE } from "..";
 
 class HistoryManager {
   list(): SessionInfo[] {
@@ -69,12 +70,23 @@ class HistoryManager {
     }
   }
 
-  save(session: PersistedSessionInfo) {
+  save(session: PersistedSessionInfo, mirrorToWorkspace: boolean = false) {
     // Save the main session json file
     fs.writeFileSync(
       getSessionFilePath(session.sessionId),
       JSON.stringify(session),
     );
+
+    if () {
+      fs.writeFileSync(
+        getWorkspaceSessionFilePath(
+          session.workspaceDirectory,
+          session.sessionId,
+        ),
+        // getSessionFilePath(session.sessionId),
+        JSON.stringify(session),
+      );
+    }
 
     // Read and update the sessions list
     const sessionsListFilePath = getSessionsListPath();
@@ -129,13 +141,10 @@ class HistoryManager {
   }
 
   copy(sessionId: string, workspaceDirectory: string) {
-    // Delete a session
-    // const sessionId = session.sessionId;
     const sessionFile = getSessionFilePath(sessionId);
     if (!fs.existsSync(sessionFile)) {
       throw new Error(`Session file ${sessionFile} does not exist`);
     }
-    // const workspaceDirectory = session.workspaceDirectory;
     fs.copyFileSync(
       sessionFile,
       getWorkspaceSessionFilePath(workspaceDirectory, sessionId),

--- a/core/util/history.ts
+++ b/core/util/history.ts
@@ -1,6 +1,10 @@
 import * as fs from "fs";
 import { PersistedSessionInfo, SessionInfo } from "..";
-import { getSessionFilePath, getSessionsListPath } from "./paths";
+import {
+  getWorkspaceSessionFilePath,
+  getSessionFilePath,
+  getSessionsListPath,
+} from "./paths";
 
 class HistoryManager {
   list(): SessionInfo[] {
@@ -122,6 +126,20 @@ class HistoryManager {
         );
       }
     }
+  }
+
+  copy(sessionId: string, workspaceDirectory: string) {
+    // Delete a session
+    // const sessionId = session.sessionId;
+    const sessionFile = getSessionFilePath(sessionId);
+    if (!fs.existsSync(sessionFile)) {
+      throw new Error(`Session file ${sessionFile} does not exist`);
+    }
+    // const workspaceDirectory = session.workspaceDirectory;
+    fs.copyFileSync(
+      sessionFile,
+      getWorkspaceSessionFilePath(workspaceDirectory, sessionId),
+    );
   }
 }
 

--- a/core/util/messageIde.ts
+++ b/core/util/messageIde.ts
@@ -55,6 +55,10 @@ export class MessageIde implements IDE {
     return this.request("isTelemetryEnabled", undefined);
   }
 
+  isHistoryMirroringEnabled(): Promise<boolean> {
+    return this.request("isHistoryMirroringEnabled", undefined);
+  }
+
   getUniqueId(): Promise<string> {
     return this.request("getUniqueId", undefined);
   }

--- a/core/util/paths.ts
+++ b/core/util/paths.ts
@@ -15,8 +15,31 @@ export function getContinueGlobalPath(): string {
   return continuePath;
 }
 
+export function getContinueWorkspacePath(workspaceDirectory: string): string {
+  // Note: it might be cleaner to have a single getContinuePath() that accepts an
+  // argument indicating whether destination is global or local/workspace
+  const continuePath = path.join(workspaceDirectory, ".continue");
+  if (!fs.existsSync(continuePath)) {
+    fs.mkdirSync(continuePath);
+  }
+  return continuePath;
+}
+
 export function getSessionsFolderPath(): string {
   const sessionsPath = path.join(getContinueGlobalPath(), "sessions");
+  if (!fs.existsSync(sessionsPath)) {
+    fs.mkdirSync(sessionsPath);
+  }
+  return sessionsPath;
+}
+
+export function getWorkspaceSessionsFolderPath(
+  workspaceDirectory: string,
+): string {
+  const sessionsPath = path.join(
+    getContinueWorkspacePath(workspaceDirectory),
+    "sessions",
+  );
   if (!fs.existsSync(sessionsPath)) {
     fs.mkdirSync(sessionsPath);
   }
@@ -33,6 +56,16 @@ export function getIndexFolderPath(): string {
 
 export function getSessionFilePath(sessionId: string): string {
   return path.join(getSessionsFolderPath(), `${sessionId}.json`);
+}
+
+export function getWorkspaceSessionFilePath(
+  workspaceDirectory: string,
+  sessionId: string,
+): string {
+  return path.join(
+    getWorkspaceSessionsFolderPath(workspaceDirectory),
+    `${sessionId}.json`,
+  );
 }
 
 export function getSessionsListPath(): string {

--- a/core/web/webviewProtocol.ts
+++ b/core/web/webviewProtocol.ts
@@ -54,6 +54,7 @@ export type IdeProtocol = {
   ];
   getAvailableThreads: [undefined, Thread[]];
   isTelemetryEnabled: [undefined, boolean];
+  isHistoryMirroringEnabled: [undefined, boolean];
   getUniqueId: [undefined, string];
   getTags: [string, IndexTag[]];
 };

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessenger.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessenger.kt
@@ -85,6 +85,7 @@ class CoreMessenger(esbuildPath: String, continueCorePath: String, ideProtocolCl
     private val ideMessageTypes = listOf(
         "readRangeInFile",
         "isTelemetryEnabled",
+        "isHistoryMirroringEnabled",
         "getUniqueId",
         "getWorkspaceConfigs",
         "getDiff",

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
@@ -199,6 +199,10 @@ class IdeProtocolClient (
                         respond(true)
                     }
 
+                    "isHistoryMirroringEnabled" -> {
+                        respond(true)
+                    }
+
                     "readRangeInFile" -> {
                         val fullContents = readFile((data as Map<String, String>)["filepath"] as String)
                         val range = data["range"] as Map<String, Any>

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -59,6 +59,11 @@
           "default": true,
           "markdownDescription": "Continue collects anonymous usage data, cleaned of PII, to help us improve the product for our users. Read more  at [continue.dev › Telemetry](https://continue.dev/docs/telemetry)."
         },
+        "continue.mirrorHistoryToWorkspace": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enable saving of Continue session files to the active workspace, in addition to the default location (~/.continue/sessions). "
+        },
         "continue.showInlineTip": {
           "type": "boolean",
           "default": true,

--- a/extensions/vscode/src/ideProtocol.ts
+++ b/extensions/vscode/src/ideProtocol.ts
@@ -98,6 +98,13 @@ class VsCodeIde implements IDE {
         .get("telemetryEnabled")) ?? true
     );
   }
+  async isHistoryMirroringEnabled(): Promise<boolean> {
+    return (
+      (await vscode.workspace
+        .getConfiguration("continue")
+        .get("mirrorHistoryToWorkspace")) ?? true
+    );
+  }
   getUniqueId(): Promise<string> {
     return Promise.resolve(vscode.env.machineId);
   }

--- a/extensions/vscode/src/util/util.ts
+++ b/extensions/vscode/src/util/util.ts
@@ -100,6 +100,12 @@ export function getMetaKeyLabel() {
   }
 }
 
+export function mirrorHistoryToWorkspace() {
+  return vscode.workspace
+    .getConfiguration("continue")
+    .get<boolean>("mirrorHistoryToWorkspace");
+}
+
 export function getExtensionVersion() {
   const extension = vscode.extensions.getExtension("continue.continue");
   return extension?.packageJSON.version || "";

--- a/extensions/vscode/src/webviewProtocol.ts
+++ b/extensions/vscode/src/webviewProtocol.ts
@@ -212,7 +212,8 @@ export class VsCodeWebviewProtocol {
       return historyManager.list();
     });
     this.on("history/save", (msg) => {
-      historyManager.save(msg.data);
+      // const mirroringEnabled = await ide.isHistoryMirroringEnabled() || false;
+      historyManager.save(msg.data, true);
     });
     this.on("history/copy", (msg) => {
       historyManager.copy(msg.data.id, msg.data.workspaceDirectory);

--- a/extensions/vscode/src/webviewProtocol.ts
+++ b/extensions/vscode/src/webviewProtocol.ts
@@ -214,6 +214,9 @@ export class VsCodeWebviewProtocol {
     this.on("history/save", (msg) => {
       historyManager.save(msg.data);
     });
+    this.on("history/copy", (msg) => {
+      historyManager.copy(msg.data.id, msg.data.workspaceDirectory);
+    });
     this.on("history/delete", (msg) => {
       historyManager.delete(msg.data.id);
     });

--- a/gui/src/hooks/useHistory.tsx
+++ b/gui/src/hooks/useHistory.tsx
@@ -75,6 +75,11 @@ function useHistory(dispatch: Dispatch) {
     return await ideRequest("history/save", sessionInfo);
   }
 
+  async function copySessionToWorkspace(id: string, workspaceDirectory: string) {
+
+    return await ideRequest("history/copy", { id, workspaceDirectory });
+  }
+
   async function deleteSession(id: string) {
     return await ideRequest("history/delete", { id });
   }
@@ -83,7 +88,7 @@ function useHistory(dispatch: Dispatch) {
     return await ideRequest("history/load", { id });
   }
 
-  return { getHistory, saveSession, deleteSession, loadSession };
+  return { getHistory, saveSession, copySessionToWorkspace, deleteSession, loadSession };
 }
 
 export default useHistory;

--- a/gui/src/hooks/useHistory.tsx
+++ b/gui/src/hooks/useHistory.tsx
@@ -27,7 +27,7 @@ function useHistory(dispatch: Dispatch) {
     return await ideRequest("history/list", undefined);
   }
 
-  async function saveSession() {
+  async function saveSession(mirrorHistoryToWorkspace: boolean = false) {
     if (state.history.length === 0) return;
 
     const stateCopy = { ...state };
@@ -72,7 +72,8 @@ function useHistory(dispatch: Dispatch) {
       sessionId: stateCopy.sessionId,
       workspaceDirectory: window.workspacePaths?.[0] || "",
     };
-    return await ideRequest("history/save", sessionInfo);
+    // const mirrorHistoryToWorkspace: boolean = true;
+    return await ideRequest("history/save", {sessionInfo, mirrorHistoryToWorkspace});
   }
 
   async function copySessionToWorkspace(id: string, workspaceDirectory: string) {

--- a/gui/src/pages/history.tsx
+++ b/gui/src/pages/history.tsx
@@ -135,7 +135,6 @@ function TableRow({
             className="mr-2"
             text="Copy to Workspace"
             onClick={async () => {
-              // Implement the function to copy the session to the "sessions" directory
               copySessionToWorkspace(session.sessionId, workspaceDirectory)
             }}
           >

--- a/gui/src/pages/history.tsx
+++ b/gui/src/pages/history.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeftIcon, TrashIcon } from "@heroicons/react/24/outline";
+import { ArrowLeftIcon, TrashIcon, DocumentDuplicateIcon } from "@heroicons/react/24/outline";
 import { PersistedSessionInfo, SessionInfo } from "core";
 import MiniSearch from "minisearch";
 import React, { Fragment, useEffect, useState } from "react";
@@ -91,9 +91,10 @@ function TableRow({
   const navigate = useNavigate();
   const apiUrl = window.serverUrl;
   const workspacePaths = window.workspacePaths || [""];
+  const workspaceDirectory = workspacePaths?.[0] || "";
   const [hovered, setHovered] = useState(false);
 
-  const { saveSession, deleteSession, loadSession } = useHistory(dispatch);
+  const { saveSession, copySessionToWorkspace, deleteSession, loadSession } = useHistory(dispatch);
 
   return (
     <td
@@ -129,6 +130,18 @@ function TableRow({
             {lastPartOfPath(session.workspaceDirectory || "")}/
           </div>
         </TdDiv>
+        {hovered && (
+          <HeaderButtonWithText
+            className="mr-2"
+            text="Copy to Workspace"
+            onClick={async () => {
+              // Implement the function to copy the session to the "sessions" directory
+              copySessionToWorkspace(session.sessionId, workspaceDirectory)
+            }}
+          >
+            <DocumentDuplicateIcon width="1.3em" height="1.3em" />
+          </HeaderButtonWithText>
+        )}
 
         {hovered && (
           <HeaderButtonWithText


### PR DESCRIPTION
I want to be able to keep a log of my LLM interactions for a given project within the repo for that project and this feels like one decent way to do that (I've also started work on a related feature to enable a config setting that enables automatically saving a copy of a session to the workspace in which it's created). I haven't gotten my dev environment for JetBrains builds up and running yet so I'd appreciate assistance testing that the way I've implemented getting the workspace directory works for that and in general would appreciate any suggestions on how this could be implemented better.