### PR TITLE
Update completionProvider.ts

### DIFF
--- a/core/autocomplete/completionProvider.ts
+++ b/core/autocomplete/completionProvider.ts
@@ -207,6 +207,7 @@ export async function getTabCompletion(
     let stop = [
       ...(completionOptions?.stop || []),
       "\n\n",
+      "\r\n\r\n",
       "/src/",
       "```",
       ...lang.stopWords,


### PR DESCRIPTION
Add \r\n\r\n stop to tab completion, it necessary when using \r\n for new lines instead of just \n