### PR TITLE
Don't read the user's clipboard for autocomplete

### DIFF
--- a/core/autocomplete/completionProvider.ts
+++ b/core/autocomplete/completionProvider.ts
@@ -34,7 +34,6 @@ export interface AutocompleteInput {
   pos: Position;
   recentlyEditedFiles: RangeInFileWithContents[];
   recentlyEditedRanges: RangeInFileWithContents[];
-  clipboardText: string;
 }
 
 export interface AutocompleteOutcome {
@@ -88,7 +87,6 @@ export async function getTabCompletion(
     pos,
     recentlyEditedFiles,
     recentlyEditedRanges,
-    clipboardText,
   } = input;
   const fileContents = await ide.readFile(filepath);
   const fileLines = fileContents.split("\n");
@@ -149,7 +147,6 @@ export async function getTabCompletion(
       pos.line,
       fullPrefix,
       fullSuffix,
-      clipboardText,
       lang,
       options,
       recentlyEditedRanges,

--- a/core/autocomplete/constructPrompt.ts
+++ b/core/autocomplete/constructPrompt.ts
@@ -83,7 +83,6 @@ export async function constructAutocompletePrompt(
   cursorLine: number,
   fullPrefix: string,
   fullSuffix: string,
-  clipboardText: string,
   language: AutocompleteLanguageInfo,
   options: TabAutocompleteOptions,
   recentlyEditedRanges: RangeInFileWithContents[],

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/AutocompleteService.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/AutocompleteService.kt
@@ -59,7 +59,6 @@ class AutocompleteService(private val project: Project) {
             ),
             "recentlyEditedFiles" to emptyList<String>(),
             "recentlyEditedRanges" to emptyList<String>(),
-            "clipboardText" to ""
         )
 
         val lineStart = editor.document.getLineStartOffset(editor.caretModel.primaryCaret.logicalPosition.line)

--- a/extensions/vscode/src/autocomplete/completionProvider.ts
+++ b/extensions/vscode/src/autocomplete/completionProvider.ts
@@ -68,7 +68,6 @@ export class ContinueCompletionProvider
         pos: { line: position.line, character: position.character },
         recentlyEditedFiles: [],
         recentlyEditedRanges: [],
-        clipboardText: await vscode.env.clipboard.readText(),
       };
 
       setupStatusBar(true, true);


### PR DESCRIPTION
Currently, the Continue VSCode extension reads the user's clipboard on every keystroke to feed the autocomplete system, but it doesn't do anything with the clipboard text. On some browsers, trying to get the clipboard can be problematic, so I believe the best solution would be to simply remove the code which reads the clipboard.