### PR TITLE
Make the useCopyBuffer option effective and disable it by default

### DIFF
--- a/core/autocomplete/parameters.ts
+++ b/core/autocomplete/parameters.ts
@@ -1,7 +1,7 @@
 import { TabAutocompleteOptions } from "..";
 
 export const DEFAULT_AUTOCOMPLETE_OPTS: TabAutocompleteOptions = {
-  useCopyBuffer: true,
+  useCopyBuffer: false,
   useSuffix: true,
   maxPromptTokens: 500,
   prefixPercentage: 0.85,

--- a/extensions/vscode/src/autocomplete/completionProvider.ts
+++ b/extensions/vscode/src/autocomplete/completionProvider.ts
@@ -62,13 +62,20 @@ export class ContinueCompletionProvider
       const abortController = new AbortController();
       const signal = abortController.signal;
       token.onCancellationRequested(() => abortController.abort());
+
+      const config = await this.configHandler.loadConfig();
+      let clipboardText = "";
+      if (config.tabAutocompleteOptions?.useCopyBuffer === true) {
+        clipboardText = await vscode.env.clipboard.readText();
+      }
+
       const input: AutocompleteInput = {
         completionId: uuidv4(),
         filepath: document.uri.fsPath,
         pos: { line: position.line, character: position.character },
         recentlyEditedFiles: [],
         recentlyEditedRanges: [],
-        clipboardText: await vscode.env.clipboard.readText(),
+        clipboardText: clipboardText
       };
 
       setupStatusBar(true, true);


### PR DESCRIPTION
This PR would fix #1060 by making the `useCopyBuffer` option disable the clipboard reading behavior. It also changes this option to default to false, since the clipboard text is not yet taken into consideration by the autocomplete system.