### PR TITLE
Con-1037: Toggle full screen bug

### DIFF
--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -373,13 +373,12 @@ const commandsMap: (
     const fullScreenTab = getFullScreenTab();
 
     // Check if the active editor is the Continue GUI View
-    if (fullScreenTab && fullScreenTab.isActive) {
-      vscode.commands.executeCommand("workbench.action.closeActiveEditor");
-      vscode.commands.executeCommand("continue.focusContinueInput");
+    if (fullScreenTab && fullScreenTab.isActive) { //Full screen open and focused - close it
+      vscode.commands.executeCommand("workbench.action.closeActiveEditor"); //this will trigger the onDidDispose listener below
       return;
     }
 
-    if (fullScreenTab) {
+    if (fullScreenTab) { //Full screen open, but not focused - focus it
       // Focus the tab
       const openOptions = {
         preserveFocus: true,
@@ -395,15 +394,21 @@ const commandsMap: (
       return;
     }
 
+    //Full screen not open - open it
+
     // Close the sidebar.webviews
     // vscode.commands.executeCommand("workbench.action.closeSidebar");
     vscode.commands.executeCommand("workbench.action.closeAuxiliaryBar");
     // vscode.commands.executeCommand("workbench.action.toggleZenMode");
-    const panel = vscode.window.createWebviewPanel(
+
+    //create the full screen panel
+    let panel = vscode.window.createWebviewPanel(
       "continue.continueGUIView",
       "Continue",
       vscode.ViewColumn.One,
     );
+    
+    //Add content to the panel
     panel.webview.html = sidebar.getSidebarContent(
       extensionContext,
       panel,
@@ -414,6 +419,13 @@ const commandsMap: (
       undefined,
       true,
     );
+    
+    //When panel closes, reset the webview and focus
+    panel.onDidDispose(() => {
+      sidebar.resetWebviewProtocolWebview();
+      vscode.commands.executeCommand("continue.focusContinueInput");
+    }, null, extensionContext.subscriptions); 
+    
   },
   "continue.selectFilesAsContext": (
     firstUri: vscode.Uri,

--- a/extensions/vscode/src/debugPanel.ts
+++ b/extensions/vscode/src/debugPanel.ts
@@ -33,6 +33,12 @@ export class ContinueGUIWebviewViewProvider
     return this._webview;
   }
 
+  public resetWebviewProtocolWebview(): void {
+    if (this._webview) { 
+      this.webviewProtocol.webview = this._webview;
+    }
+  }
+
   sendMainUserInput(input: string) {
     this.webview?.postMessage({
       type: "userInput",

--- a/extensions/vscode/src/debugPanel.ts
+++ b/extensions/vscode/src/debugPanel.ts
@@ -36,6 +36,8 @@ export class ContinueGUIWebviewViewProvider
   public resetWebviewProtocolWebview(): void {
     if (this._webview) { 
       this.webviewProtocol.webview = this._webview;
+    } else{
+      console.warn("no webview found during reset")
     }
   }
 


### PR DESCRIPTION
Fix for #1037

When user toggles full screen on, the webviewProtocol.webview is set to the full screen's. 

When user toggles full screen off, this property was not reassigned to the sidebar's webview, so requests would hang.

I've added a listener for full screen panel closure and a function to reset the webview when this happens.

Note: 
If a user has full screen open, the sidebar chat is still unusable - I think enabling both to be functional concurrently would require a larger rework of decoupling webviewProtocol from specific webview instances. 
This might involve keeping a list of active webviews and some method of differentiating them.
