### PR TITLE
Fix slash command params loading

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "tabWidth": 2,
-  "useTabs": false
+  "useTabs": false,
+  "trailingComma": "all"
 }

--- a/core/config/load.ts
+++ b/core/config/load.ts
@@ -309,10 +309,10 @@ function finalToBrowserConfig(
     })),
     systemMessage: final.systemMessage,
     completionOptions: final.completionOptions,
-    slashCommands: final.slashCommands?.map((m) => ({
-      name: m.name,
-      description: m.description,
-      options: m.params,
+    slashCommands: final.slashCommands?.map((s) => ({
+      name: s.name,
+      description: s.description,
+      params: s.params, //PZTODO: is this why params aren't referenced properly by slash commands?
     })),
     contextProviders: final.contextProviders?.map((c) => c.description),
     disableIndexing: final.disableIndexing,


### PR DESCRIPTION
## Description

Existing slash commands expect an object named
"params" so mapping to "options" here caused
params to be undefined within the run scope. 
- Renamed "options" to "params" for slash command
property mapping.
- Also renamed from 'm' to 's' just to avoid potential
confusion with the model property mapping above.

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
