### PR TITLE
Add support for Solidity language through tree-sitter

### DIFF
--- a/binary/package-lock.json
+++ b/binary/package-lock.json
@@ -68,7 +68,7 @@
         "socket.io-client": "^4.7.3",
         "sqlite": "^5.1.1",
         "sqlite3": "^5.1.7",
-        "tree-sitter-wasms": "^0.1.6",
+        "tree-sitter-wasms": "^0.1.11",
         "uuid": "^9.0.1",
         "vectordb": "0.4.12",
         "web-tree-sitter": "^0.21.0"

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -42,7 +42,7 @@
         "socket.io-client": "^4.7.3",
         "sqlite": "^5.1.1",
         "sqlite3": "^5.1.7",
-        "tree-sitter-wasms": "^0.1.6",
+        "tree-sitter-wasms": "^0.1.11",
         "uuid": "^9.0.1",
         "vectordb": "0.4.12",
         "web-tree-sitter": "^0.21.0"
@@ -9395,9 +9395,9 @@
       }
     },
     "node_modules/tree-sitter-wasms": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/tree-sitter-wasms/-/tree-sitter-wasms-0.1.7.tgz",
-      "integrity": "sha512-/EnmSDDqEnSnIuCqVhSOc14T8r792LmiztqlZMFSRg+4ACrgUWNLvEr2AUP1K76XCJrvuH8liSWfkdQpK41hIA=="
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/tree-sitter-wasms/-/tree-sitter-wasms-0.1.11.tgz",
+      "integrity": "sha512-26sE4+qoTi1CbzHdo9sHs9pRE/jXVFVRigSG/5TNAbwhSMVjHfMAg4UjmOhAFAIx5UxgoQuaURwqhm0SRNrpWA=="
     },
     "node_modules/ts-jest": {
       "version": "29.1.2",

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     "socket.io-client": "^4.7.3",
     "sqlite": "^5.1.1",
     "sqlite3": "^5.1.7",
-    "tree-sitter-wasms": "^0.1.6",
+    "tree-sitter-wasms": "^0.1.11",
     "uuid": "^9.0.1",
     "vectordb": "0.4.12",
     "web-tree-sitter": "^0.21.0"

--- a/core/util/treeSitter.ts
+++ b/core/util/treeSitter.ts
@@ -70,6 +70,7 @@ export const supportedLanguages: { [key: string]: string } = {
   rs: "rust",
   rdl: "systemrdl",
   toml: "toml",
+  sol: "solidity",
 
   // jl: "julia",
   // swift: "swift",

--- a/core/yarn.lock
+++ b/core/yarn.lock
@@ -5512,10 +5512,10 @@ tr46@~0.0.3:
   resolved "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
-tree-sitter-wasms@^0.1.6:
-  version "0.1.7"
-  resolved "https://registry.npmjs.org/tree-sitter-wasms/-/tree-sitter-wasms-0.1.7.tgz"
-  integrity sha512-/EnmSDDqEnSnIuCqVhSOc14T8r792LmiztqlZMFSRg+4ACrgUWNLvEr2AUP1K76XCJrvuH8liSWfkdQpK41hIA==
+tree-sitter-wasms@^0.1.11, tree-sitter-wasms@^0.1.6:
+  version "0.1.11"
+  resolved "https://registry.npmjs.org/tree-sitter-wasms/-/tree-sitter-wasms-0.1.11.tgz"
+  integrity sha512-26sE4+qoTi1CbzHdo9sHs9pRE/jXVFVRigSG/5TNAbwhSMVjHfMAg4UjmOhAFAIx5UxgoQuaURwqhm0SRNrpWA==
 
 ts-jest@^29.1.1:
   version "29.1.2"

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "0.8.22",
+  "version": "0.9.93",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "0.8.22",
+      "version": "0.9.93",
       "license": "Apache-2.0",
       "dependencies": {
         "@electron/rebuild": "^3.2.10",
@@ -122,7 +122,7 @@
         "socket.io-client": "^4.7.3",
         "sqlite": "^5.1.1",
         "sqlite3": "^5.1.7",
-        "tree-sitter-wasms": "^0.1.6",
+        "tree-sitter-wasms": "^0.1.11",
         "uuid": "^9.0.1",
         "vectordb": "0.4.12",
         "web-tree-sitter": "^0.21.0"

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "continue",
   "icon": "media/icon.png",
-  "version": "0.9.92",
+  "version": "0.9.93",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"

--- a/extensions/vscode/yarn.lock
+++ b/extensions/vscode/yarn.lock
@@ -2384,7 +2384,7 @@ core-util-is@1.0.2:
     socket.io-client "^4.7.3"
     sqlite "^5.1.1"
     sqlite3 "^5.1.7"
-    tree-sitter-wasms "^0.1.6"
+    tree-sitter-wasms "^0.1.11"
     uuid "^9.0.1"
     vectordb "0.4.12"
     web-tree-sitter "^0.21.0"

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -111,7 +111,7 @@
         "socket.io-client": "^4.7.3",
         "sqlite": "^5.1.1",
         "sqlite3": "^5.1.7",
-        "tree-sitter-wasms": "^0.1.6",
+        "tree-sitter-wasms": "^0.1.11",
         "uuid": "^9.0.1",
         "vectordb": "0.4.12",
         "web-tree-sitter": "^0.21.0"


### PR DESCRIPTION
## Description

It updates tree-sitter-wasms dependency so that we can add support for Solidity through TS (see https://github.com/Gregoor/tree-sitter-wasms/pull/28).
Kinda a continuation of https://github.com/continuedev/continue/pull/964 .

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
