### PR TITLE
tsx files are typically typescript files

### DIFF
--- a/core/util/treeSitter.ts
+++ b/core/util/treeSitter.ts
@@ -34,7 +34,7 @@ export const supportedLanguages: { [key: string]: string } = {
   ts: "typescript",
   mts: "typescript",
   cts: "typescript",
-  tsx: "tsx",
+  tsx: "typescript",
   vue: "vue",
   // The .wasm file being used is faulty, and yaml is split line-by-line anyway for the most part
   // yaml: "yaml",


### PR DESCRIPTION
These files were not showing it by that code search. This way might be why.

## Description

[ What changed? Feel free to be brief. ]

## Checklist

- [ x] The base branch of this PR is `preview`, rather than `main`
