### PR TITLE
Feat/enhanced share

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "tabWidth": 2,
-  "useTabs": false
+  "useTabs": false,
+  "trailingComma": "all"
 }

--- a/core/commands/slash/share.ts
+++ b/core/commands/slash/share.ts
@@ -22,8 +22,18 @@ const ShareSlashCommand: SlashCommand = {
     if (outputDir.startsWith("~")) {
       outputDir = outputDir.replace(/~/, homedir);
     }
+    const workspaceDirs = await ide.getWorkspaceDirs();
+    
+    // Although the most common situation is to have one directory open in a
+    // workspace it's also possible to have just a file open without an
+    // associated directory or to use multi-root workspaces in which multiple
+    // folders are included. We default to using the first item in the list, if
+    // it exists.
+    const workspaceDirectory = workspaceDirs?.[0] || "";
+    outputDir = outputDir.replace(/CURRENT_WORKSPACE/, workspaceDirectory);
+    const outPath = path.join(outputDir, `session.md`); //TODO: more flexible naming
 
-    const outPath = path.join(outputDir, `session.md`);
+
     await ide.writeFile(outPath, content);
     await ide.openFile(outPath);
 

--- a/core/commands/slash/share.ts
+++ b/core/commands/slash/share.ts
@@ -1,10 +1,11 @@
 import path from "path";
+import { homedir } from "os";
 import { SlashCommand } from "../..";
 import { stripImages } from "../../llm/countTokens";
 
 const ShareSlashCommand: SlashCommand = {
   name: "share",
-  description: "Download and share this session",
+  description: "Export the current chat session to markdown",
   run: async function* ({ ide, history, params }) {
     let content = `This is a session transcript from [Continue](https://continue.dev) on ${new Date().toLocaleString()}.`;
 
@@ -14,16 +15,19 @@ const ShareSlashCommand: SlashCommand = {
       }\n\n${stripImages(msg.content)}`;
     }
 
-    let outputDir = params?.outputDir;
+    let outputDir: string = params?.outputDir;
     if (!outputDir) {
       outputDir = await ide.getContinueDir();
+    }
+    if (outputDir.startsWith("~")) {
+      outputDir = outputDir.replace(/~/, homedir);
     }
 
     const outPath = path.join(outputDir, `session.md`);
     await ide.writeFile(outPath, content);
     await ide.openFile(outPath);
 
-    yield `The session transcript has been saved to a markdown file at \`${path}\`.`;
+    yield `The session transcript has been saved to a markdown file at \`${outPath}\`.`;
   },
 };
 

--- a/core/commands/slash/share.ts
+++ b/core/commands/slash/share.ts
@@ -40,19 +40,23 @@ const ShareSlashCommand: SlashCommand = {
   run: async function* ({ ide, history, params }) {
     const now = new Date();
 
-    let content = `This is a session transcript from [Continue](https://continue.dev) on ${now.toLocaleString()}.`;
+    let content = `### [Continue](https://continue.dev) session transcript\n Exported: ${now.toLocaleString()}`;
 
-    for (const msg of history) {
+    // As currently implemented, the /share command is by definition the last
+    // message in the chat history, this will omit it
+    for (const msg of history.slice(0, history.length - 1)) {
       let msgText = msg.content;
       msgText = stripImages(msg.content);
 
-      // if (msg.role === "user" && msgText.search("```") !== -1) {
       if (msg.role === "user" && msgText.search("```") > -1) {
         msgText = reformatCodeBlocks(msgText);
       }
 
-      content += `\n\n## ${
-        msg.role === "user" ? "User" : "Assistant"
+      // format messages as blockquotes
+      msgText = msgText.replace(/^/gm, "> ");
+
+      content += `\n\n#### ${
+        msg.role === "user" ? "_User_" : "_Assistant_"
       }\n\n${msgText}`;
     }
 

--- a/core/commands/slash/share.ts
+++ b/core/commands/slash/share.ts
@@ -3,11 +3,30 @@ import { homedir } from "os";
 import { SlashCommand } from "../..";
 import { stripImages } from "../../llm/countTokens";
 
+// If useful elsewhere, helper funcs should move to core/util/index.ts or similar
+function getOffsetDatetime(date: Date): Date {
+  const offset = date.getTimezoneOffset();
+  const offsetHours = Math.floor(offset / 60);
+  const offsetMinutes = offset % 60;
+  date.setHours(date.getHours() - offsetHours);
+  date.setMinutes(date.getMinutes() - offsetMinutes);
+
+  return date;
+}
+
+function asBasicISOString(date: Date): string {
+  const isoString = date.toISOString();
+
+  return isoString.replace(/[-:]/g, "").replace(/\.\d+Z/, "");
+}
+
 const ShareSlashCommand: SlashCommand = {
   name: "share",
   description: "Export the current chat session to markdown",
   run: async function* ({ ide, history, params }) {
-    let content = `This is a session transcript from [Continue](https://continue.dev) on ${new Date().toLocaleString()}.`;
+    const now = new Date();
+
+    let content = `This is a session transcript from [Continue](https://continue.dev) on ${now.toLocaleString()}.`;
 
     for (const msg of history) {
       content += `\n\n## ${
@@ -22,8 +41,10 @@ const ShareSlashCommand: SlashCommand = {
     if (outputDir.startsWith("~")) {
       outputDir = outputDir.replace(/~/, homedir);
     }
+    //TODO: error handling, create path if it doesn't exist?
+
     const workspaceDirs = await ide.getWorkspaceDirs();
-    
+
     // Although the most common situation is to have one directory open in a
     // workspace it's also possible to have just a file open without an
     // associated directory or to use multi-root workspaces in which multiple
@@ -31,8 +52,9 @@ const ShareSlashCommand: SlashCommand = {
     // it exists.
     const workspaceDirectory = workspaceDirs?.[0] || "";
     outputDir = outputDir.replace(/CURRENT_WORKSPACE/, workspaceDirectory);
-    const outPath = path.join(outputDir, `session.md`); //TODO: more flexible naming
-
+    const dtString = asBasicISOString(getOffsetDatetime(now));
+    const outPath = path.join(outputDir, `${dtString}_session.md`); //TODO: more flexible naming
+    //TODO: more flexible naming
 
     await ide.writeFile(outPath, content);
     await ide.openFile(outPath);

--- a/core/commands/slash/share.ts
+++ b/core/commands/slash/share.ts
@@ -1,10 +1,11 @@
+import path from "path";
 import { SlashCommand } from "../..";
 import { stripImages } from "../../llm/countTokens";
 
 const ShareSlashCommand: SlashCommand = {
   name: "share",
   description: "Download and share this session",
-  run: async function* ({ ide, history }) {
+  run: async function* ({ ide, history, params }) {
     let content = `This is a session transcript from [Continue](https://continue.dev) on ${new Date().toLocaleString()}.`;
 
     for (const msg of history) {
@@ -13,10 +14,14 @@ const ShareSlashCommand: SlashCommand = {
       }\n\n${stripImages(msg.content)}`;
     }
 
-    const continueDir = await ide.getContinueDir();
-    const path = `${continueDir}/session.md`;
-    await ide.writeFile(path, content);
-    await ide.openFile(path);
+    let outputDir = params?.outputDir;
+    if (!outputDir) {
+      outputDir = await ide.getContinueDir();
+    }
+
+    const outPath = path.join(outputDir, `session.md`);
+    await ide.writeFile(outPath, content);
+    await ide.openFile(outPath);
 
     yield `The session transcript has been saved to a markdown file at \`${path}\`.`;
   },

--- a/core/commands/slash/share.ts
+++ b/core/commands/slash/share.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import * as fs from "fs";
 import { homedir } from "os";
 import { SlashCommand } from "../..";
 import { stripImages } from "../../llm/countTokens";
@@ -55,6 +56,9 @@ const ShareSlashCommand: SlashCommand = {
       const workspaceDirectory = workspaceDirs?.[0] || "";
       outputDir = outputDir.replace(/^./, workspaceDirectory);
     }
+
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true });
     }
 
     const dtString = asBasicISOString(getOffsetDatetime(now));

--- a/core/commands/slash/share.ts
+++ b/core/commands/slash/share.ts
@@ -51,10 +51,16 @@ const ShareSlashCommand: SlashCommand = {
     // folders are included. We default to using the first item in the list, if
     // it exists.
     const workspaceDirectory = workspaceDirs?.[0] || "";
-    outputDir = outputDir.replace(/CURRENT_WORKSPACE/, workspaceDirectory);
+    if (
+      outputDir.startsWith("./") ||
+      outputDir.startsWith(`.\\`) ||
+      outputDir === "."
+    ) {
+      outputDir = outputDir.replace(".", workspaceDirectory);
+    }
+
     const dtString = asBasicISOString(getOffsetDatetime(now));
-    const outPath = path.join(outputDir, `${dtString}_session.md`); //TODO: more flexible naming
-    //TODO: more flexible naming
+    const outPath = path.join(outputDir, `${dtString}_session.md`); //TODO: more flexible naming?
 
     await ide.writeFile(outPath, content);
     await ide.openFile(outPath);

--- a/core/commands/slash/share.ts
+++ b/core/commands/slash/share.ts
@@ -31,7 +31,7 @@ const ShareSlashCommand: SlashCommand = {
 
     for (const msg of history) {
       content += `\n\n## ${
-        msg.role === "user" ? "User" : "Continue"
+        msg.role === "user" ? "User" : "Assistant"
       }\n\n${stripImages(msg.content)}`;
     }
 

--- a/core/commands/slash/share.ts
+++ b/core/commands/slash/share.ts
@@ -18,7 +18,7 @@ function getOffsetDatetime(date: Date): Date {
 function asBasicISOString(date: Date): string {
   const isoString = date.toISOString();
 
-  return isoString.replace(/[-:]/g, "").replace(/\.\d+Z/, "");
+  return isoString.replace(/[-:]|(\.\d+Z)/g, "");
 }
 
 const ShareSlashCommand: SlashCommand = {

--- a/core/commands/slash/share.ts
+++ b/core/commands/slash/share.ts
@@ -23,14 +23,15 @@ function asBasicISOString(date: Date): string {
 }
 
 function reformatCodeBlocks(msgText: string): string {
-  const codeBlockRegex = /```((.*?\.(\w+))\s*.*)\n/g;
-
-  return msgText.replace(codeBlockRegex,
+  const codeBlockFenceRegex = /```((.*?\.(\w+))\s*.*)\n/g;
+  msgText = msgText.replace(codeBlockFenceRegex,
     (match, metadata, filename, extension) => {
       const lang = languageForFilepath(filename);
       return `\`\`\`${extension}\n${lang.comment} ${metadata}\n`;
     },
   );
+  // Appease the markdown linter
+  return msgText.replace(/```\n```/g, '```\n\n```');
 }
 
 const ShareSlashCommand: SlashCommand = {

--- a/core/commands/slash/share.ts
+++ b/core/commands/slash/share.ts
@@ -23,7 +23,7 @@ function asBasicISOString(date: Date): string {
 }
 
 function reformatCodeBlocks(msgText: string): string {
-  const codeBlockRegex = /```(.*?\.(\w+)\s*.*)\n/g;
+  const codeBlockRegex = /```((.*?\.(\w+))\s*.*)\n/g;
 
   return msgText.replace(codeBlockRegex,
     (match, metadata, filename, extension) => {

--- a/core/commands/slash/share.ts
+++ b/core/commands/slash/share.ts
@@ -38,25 +38,23 @@ const ShareSlashCommand: SlashCommand = {
     if (!outputDir) {
       outputDir = await ide.getContinueDir();
     }
+
     if (outputDir.startsWith("~")) {
-      outputDir = outputDir.replace(/~/, homedir);
-    }
-    //TODO: error handling, create path if it doesn't exist?
-
-    const workspaceDirs = await ide.getWorkspaceDirs();
-
-    // Although the most common situation is to have one directory open in a
-    // workspace it's also possible to have just a file open without an
-    // associated directory or to use multi-root workspaces in which multiple
-    // folders are included. We default to using the first item in the list, if
-    // it exists.
-    const workspaceDirectory = workspaceDirs?.[0] || "";
-    if (
+      outputDir = outputDir.replace(/^~/, homedir);
+    } else if (
       outputDir.startsWith("./") ||
       outputDir.startsWith(`.\\`) ||
       outputDir === "."
     ) {
-      outputDir = outputDir.replace(".", workspaceDirectory);
+      const workspaceDirs = await ide.getWorkspaceDirs();
+      // Although the most common situation is to have one directory open in a
+      // workspace it's also possible to have just a file open without an
+      // associated directory or to use multi-root workspaces in which multiple
+      // folders are included. We default to using the first item in the list, if
+      // it exists.
+      const workspaceDirectory = workspaceDirs?.[0] || "";
+      outputDir = outputDir.replace(/^./, workspaceDirectory);
+    }
     }
 
     const dtString = asBasicISOString(getOffsetDatetime(now));

--- a/core/commands/slash/share.ts
+++ b/core/commands/slash/share.ts
@@ -25,11 +25,12 @@ function asBasicISOString(date: Date): string {
 function reformatCodeBlocks(msgText: string): string {
   const codeBlockRegex = /```(.*?\.(\w+)\s*.*)\n/g;
 
-  return msgText.replace(codeBlockRegex, (match, metadata, extension) => {
-    const filename = metadata.split(" ")[0];
-    const lang = languageForFilepath(filename);
-    return `\`\`\`${extension}\n${lang.comment} ${metadata}\n`;
-  });
+  return msgText.replace(codeBlockRegex,
+    (match, metadata, filename, extension) => {
+      const lang = languageForFilepath(filename);
+      return `\`\`\`${extension}\n${lang.comment} ${metadata}\n`;
+    },
+  );
 }
 
 const ShareSlashCommand: SlashCommand = {

--- a/core/config/default.ts
+++ b/core/config/default.ts
@@ -39,7 +39,8 @@ export const defaultConfig: SerializedContinueConfig = {
     },
     {
       name: "share",
-      description: "Export this session as markdown",
+      description: "Export the current chat session to markdown",
+      params: { ouputDir: "Directory in which to export this session" },
     },
     {
       name: "cmd",
@@ -110,7 +111,8 @@ export const defaultConfigJetBrains: SerializedContinueConfig = {
     },
     {
       name: "share",
-      description: "Export this session as markdown",
+      description: "Export the current chat session to markdown",
+      params: { ouputDir: "Directory in which to export this session" },
     },
   ],
   customCommands: [

--- a/core/config/load.ts
+++ b/core/config/load.ts
@@ -334,10 +334,10 @@ function finalToBrowserConfig(
     })),
     systemMessage: final.systemMessage,
     completionOptions: final.completionOptions,
-    slashCommands: final.slashCommands?.map((m) => ({
-      name: m.name,
-      description: m.description,
-      options: m.params,
+    slashCommands: final.slashCommands?.map((s) => ({
+      name: s.name,
+      description: s.description,
+      params: s.params, //PZTODO: is this why params aren't referenced properly by slash commands?
     })),
     contextProviders: final.contextProviders?.map((c) => c.description),
     disableIndexing: final.disableIndexing,

--- a/core/llm/autodetect.ts
+++ b/core/llm/autodetect.ts
@@ -62,12 +62,21 @@ const MODEL_SUPPORTS_IMAGES: string[] = [
   "haiku",
 ];
 
-function modelSupportsImages(provider: ModelProvider, model: string): boolean {
+function modelSupportsImages(
+  provider: ModelProvider,
+  model: string,
+  title: string | undefined,
+): boolean {
   if (!PROVIDER_SUPPORTS_IMAGES.includes(provider)) {
     return false;
   }
 
-  if (MODEL_SUPPORTS_IMAGES.includes(model.toLowerCase())) {
+  const lower = model.toLowerCase();
+  if (
+    MODEL_SUPPORTS_IMAGES.some(
+      (modelName) => lower.includes(modelName) || title?.includes(modelName),
+    )
+  ) {
     return true;
   }
 

--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -45,7 +45,7 @@ export abstract class BaseLLM implements ILLM {
   }
 
   supportsImages(): boolean {
-    return modelSupportsImages(this.providerName, this.model);
+    return modelSupportsImages(this.providerName, this.model, this.title);
   }
 
   supportsCompletions(): boolean {

--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -52,7 +52,8 @@ export abstract class BaseLLM implements ILLM {
     if (this.providerName === "openai") {
       if (
         this.apiBase?.includes("api.groq.com") ||
-        this.apiBase?.includes(":1337")
+        this.apiBase?.includes(":1337") ||
+        this._llmOptions.useLegacyCompletionsEndpoint?.valueOf() === false
       ) {
         // Jan + Groq don't support completions : (
         return false;

--- a/core/llm/llms/Bedrock.ts
+++ b/core/llm/llms/Bedrock.ts
@@ -1,4 +1,5 @@
 import * as fs from "fs";
+import os from "os";
 import { join as joinPath } from "path";
 import { promisify } from "util";
 import { BaseLLM } from "..";
@@ -143,7 +144,7 @@ class Bedrock extends BaseLLM {
 
     try {
       const data = await readFile(
-        joinPath(process.env.HOME!, ".aws", "credentials"),
+        joinPath(process.env.HOME ?? os.homedir(), ".aws", "credentials"),
         "utf8",
       );
       const credentials = this._parseCredentialsFile(data);

--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -38,12 +38,11 @@ const CHAT_ONLY_MODELS = [
 ];
 
 class OpenAI extends BaseLLM {
-  public useLegacyCompletionsEndpoint = false;
+  public useLegacyCompletionsEndpoint: boolean | undefined = undefined;
 
   constructor(options: LLMOptions) {
     super(options);
-    this.useLegacyCompletionsEndpoint =
-      options.useLegacyCompletionsEndpoint ?? false;
+    this.useLegacyCompletionsEndpoint = options.useLegacyCompletionsEndpoint;
   }
 
   static providerName: ModelProvider = "openai";

--- a/docs/docs/config-file-migration.md
+++ b/docs/docs/config-file-migration.md
@@ -131,7 +131,8 @@ After the "Full example" these examples will only show the relevant portion of t
     },
     {
       "name": "share",
-      "description": "Download and share this session",
+      "description": "Export the current chat session to markdown",
+      "params": { "ouputDir": "Directory in which to export this session" },
       "step": "ShareSessionStep"
     },
     {

--- a/docs/docs/customization/slash-commands.md
+++ b/docs/docs/customization/slash-commands.md
@@ -43,7 +43,8 @@ Type "/share" to generate a shareable markdown transcript of your current chat h
 ```json
 {
   "name": "share",
-  "description": "Download and share this session"
+  "description": "Export the current chat session to markdown",
+  "params": { "ouputDir": "Directory in which to export this session" }
 }
 ```
 

--- a/docs/docs/reference/Model Providers/openai.md
+++ b/docs/docs/reference/Model Providers/openai.md
@@ -52,4 +52,10 @@ If you are [using an OpenAI compatible server / API](../../model-setup/select-pr
 }
 ```
 
+To force usage of `chat/completions` instead of `completions` endpoint you can set
+
+```json
+"useLegacyCompletionsEndpoint": false
+```
+
 [View the source](https://github.com/continuedev/continue/blob/main/core/llm/llms/OpenAI.ts)

--- a/docs/docs/walkthroughs/config-file-migration.md
+++ b/docs/docs/walkthroughs/config-file-migration.md
@@ -130,7 +130,8 @@ After the "Full example" these examples will only show the relevant portion of t
     },
     {
       "name": "share",
-      "description": "Download and share this session",
+      "description": "Export the current chat session to markdown",
+      "params": { "ouputDir": "Directory in which to save this session" },
       "step": "ShareSessionStep"
     },
     {

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/ServerConstants.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/ServerConstants.kt
@@ -41,7 +41,7 @@ const val DEFAULT_CONFIG = """
     },
     {
       "name": "share",
-      "description": "Download and share this session",
+      "description": "Export the current chat session to markdown",
       "step": "ShareSessionStep"
     },
     {

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -1102,6 +1102,29 @@
               }
             }
           }
+        },
+        {
+          "if": {
+            "properties": {
+              "name": {
+                "enum": [
+                  "share"
+                ]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "params": {
+                "properties": {
+                  "outputDir": {
+                    "type": "string",
+                    "markdownDescription": "If outputDir is set to `.` or begins with `./` or `.\\`, file will be saved to the current workspace or a subdirectory thereof, respectively. `~` can similarly be used to specify the user's home directory."
+                  }
+                }
+              }
+            }
+          }
         }
       ],
       "required": ["name", "description"]

--- a/gui/src/redux/slices/stateSlice.ts
+++ b/gui/src/redux/slices/stateSlice.ts
@@ -108,7 +108,8 @@ const initialState: State = {
       },
       {
         name: "share",
-        description: "Download and share this session",
+        description: "Export the current chat session to markdown",
+        params: { ouputDir: "Directory in which to save this session" },
       },
       {
         name: "cmd",


### PR DESCRIPTION
## Description

Added ability to specify an output directory in which to export markdown session file with the "share" slash-command
- Includes option to do pseudo-tilde expansion in case user enters that instead of full path
- Included ability to use the constant `CURRENT_WORKSPACE` in the file path
- default filename includes a datetimestamp to avoid clobbering previously exported sessions

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
