### PR TITLE
[indexing] Adds additional ignores for C-fmilies languages

### DIFF
--- a/core/indexing/ignore.ts
+++ b/core/indexing/ignore.ts
@@ -25,6 +25,7 @@ const DEFAULT_IGNORE_FILETYPES = [
   "*.dll",
   "*.obj",
   "*.o",
+  "*.o.d",
   "*.a",
   "*.lib",
   "*.so",
@@ -54,6 +55,9 @@ const DEFAULT_IGNORE_FILETYPES = [
   "*.sqlite",
   "*.wasm",
   "*.plist",
+  "*.profraw",
+  "*.gcda",
+  "*.gcno",
 ];
 export const defaultIgnoreFile = ignore().add(DEFAULT_IGNORE_FILETYPES);
 export const DEFAULT_IGNORE_DIRS = [
@@ -76,5 +80,6 @@ export const DEFAULT_IGNORE_DIRS = [
   ".continue",
   "__pycache__",
   "site-packages",
+  ".cache",
 ];
 export const defaultIgnoreDir = ignore().add(DEFAULT_IGNORE_DIRS);


### PR DESCRIPTION
## Description

Adds additional extensions and directory to default lists for ignore files of indexing

Ignored:
- cache directory `.cache`, used by clangd
- dependency files `*.o.d`, used by object files
- LLVM and GNU coverage files: `*.profraw`, `*.gcda` and `*.gcno`

The dependency and coverage files, in most cases stored in build directory. So this PR most useful in cases, when used [vscode-clangd](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd) extension for C, C++, Objective-C, Objective-C++ or CUDA languages, because this extension stores LSP cache in `.cache` directory.

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
