### PR TITLE
Resolve the issue of failed accept code functionality in the JetBrains plugin on windows platform

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/Diffs.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/Diffs.kt
@@ -37,7 +37,7 @@ fun getDiffDirectory(): File {
     return diffDir
 }
 fun escapeFilepath(filepath: String): String {
-    return filepath.replace("/", "_f_").replace("\\", "_b_")
+    return filepath.replace("/", "_f_").replace("\\", "_b_").replace(":", "_h_")
 }
 
 interface DiffInfo {


### PR DESCRIPTION
Resolve the issue of failed accept code functionality in the JetBrains plugin on windows platform
