### PR TITLE
Con 991: Diff Manager Improvements

### DIFF
--- a/extensions/vscode/manual-testing-sandbox/example.ts
+++ b/extensions/vscode/manual-testing-sandbox/example.ts
@@ -10,3 +10,4 @@ console.log(d);
 
 let e = factorial(3);
 console.log(e);
+

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -160,11 +160,11 @@ const commandsMap: (
 		verticalDiffManager.clearForFilepath(newFilepath, false);
 		await diffManager.rejectDiff(newFilepath);
 	},
-	"continue.acceptVerticalDiffBlock": (filepath?: string, index?: number) => {
-		verticalDiffManager.acceptRejectVerticalDiffBlock(true, filepath, index);
+	"continue.acceptVerticalDiffBlock": (filepath?: string, index?: number, all?:boolean) => {
+		verticalDiffManager.acceptRejectVerticalDiffBlock(true, filepath, index, all);
 	},
-	"continue.rejectVerticalDiffBlock": (filepath?: string, index?: number) => {
-		verticalDiffManager.acceptRejectVerticalDiffBlock(false, filepath, index);
+	"continue.rejectVerticalDiffBlock": (filepath?: string, index?: number, all?:boolean) => {
+		verticalDiffManager.acceptRejectVerticalDiffBlock(false, filepath, index, all);
 	},
 	"continue.quickFix": async (message: string, code: string, edit: boolean) => {
 		sidebar.webviewProtocol?.request("newSessionWithPrompt", {

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -254,7 +254,7 @@ const commandsMap: (
 				"getDefaultModelTitle",
 				undefined,
 			);
-			await verticalDiffManager.streamEdit(text, modelName);
+			await verticalDiffManager.streamEdit(text, modelName, previousInput);
 		} else {
 			// Pick context first
 			const selectedProviders = await vscode.window.showQuickPick(

--- a/extensions/vscode/src/diff/verticalPerLine/handler.ts
+++ b/extensions/vscode/src/diff/verticalPerLine/handler.ts
@@ -362,19 +362,24 @@ export class VerticalPerLineDiffHandler {
     this.greenDecorationManager.shiftDownAfterLine(startLine, offset);
 
     // Shift the codelens objects
-    const blocks =
-      this.editorToVerticalDiffCodeLens
-        .get(this.filepath)
-        ?.filter((x) => x.start !== startLine)
-        .map((x) => {
-          if (x.start > startLine) {
-            return { ...x, start: x.start + offset };
-          }
-          return x;
-        }) || [];
-    this.editorToVerticalDiffCodeLens.set(this.filepath, blocks);
+    this.shiftCodeLensObjects(startLine, offset)
+  }
 
-    this.refreshCodeLens();
+  private shiftCodeLensObjects(startLine: number, offset: number){  
+      // Shift the codelens objects
+      const blocks =
+        this.editorToVerticalDiffCodeLens
+          .get(this.filepath)
+          ?.filter((x) => x.start !== startLine)
+          .map((x) => {
+            if (x.start > startLine) {
+              return { ...x, start: x.start + offset };
+            }
+            return x;
+          }) || [];
+      this.editorToVerticalDiffCodeLens.set(this.filepath, blocks);
+  
+      this.refreshCodeLens();
   }
 
   public updateLineDelta(filepath: string, startLine: number, lineDelta: number) {
@@ -394,14 +399,14 @@ export class VerticalPerLineDiffHandler {
       else if (startLine < block.start + block.numGreen) {
         block.numGreen += lineDelta
       }
-      //if file changes occur after the block, that doesn't change anything for the block
+      // If file changes occur after the block, that doesn't change anything for the block
       return block;
     }).filter(block => block.numRed > 0 || block.numGreen > 0); // Remove blocks with no red or green lines
     
     // Update the map with the filtered blocks
     this.editorToVerticalDiffCodeLens.set(filepath, updatedBlocks);
 
-    // Refresh the CodeLens display
-    this.refreshCodeLens();
+    // Adjust the code lens's accordingly
+    this.shiftCodeLensObjects(startLine, lineDelta)
   }
 }

--- a/extensions/vscode/src/diff/verticalPerLine/handler.ts
+++ b/extensions/vscode/src/diff/verticalPerLine/handler.ts
@@ -338,7 +338,6 @@ export class VerticalPerLineDiffHandler {
     numGreen: number,
     numRed: number,
   ) {
-    console.log("AcceptRejectBlock. Startline: ", startLine, " NumGreen: ", numGreen, " NumRed: ", numRed)
     if (numGreen > 0) {
       // Delete the editor decoration
       this.greenDecorationManager.deleteRangeStartingAt(startLine + numRed);
@@ -380,7 +379,6 @@ export class VerticalPerLineDiffHandler {
   }
 
   public updateLineDelta(filepath: string, startLine: number, lineDelta: number) {
-    console.log("updating diff")
     // Retrieve the diff blocks for the given file
     const blocks = this.editorToVerticalDiffCodeLens.get(filepath);
     if (!blocks) {
@@ -390,25 +388,21 @@ export class VerticalPerLineDiffHandler {
     // Update the diff blocks based on the line delta
     const updatedBlocks = blocks.map(block => {
       // If the change occurs before the block, adjust the block's start line
-      console.log("startLine: ", startLine, " block.start: ", block.start)
       if (startLine <= block.start) { 
         block.start += lineDelta;
       }
-      // If the change occurs within the block, adjust the number of lines
+      // If the change occurs within the block, adjust the number of green lines (red lines can't be edited)
       else if (startLine < block.start + block.numGreen) {
-        //ToDo: this may not be correct
         block.numGreen += lineDelta
-        console.log("numGreen: ", block.numGreen, " numRed: ", block.numRed)
       }
+      //if file changes occur after the block, that doesn't change anything for the block
       return block;
     }).filter(block => block.numRed > 0 || block.numGreen > 0); // Remove blocks with no red or green lines
     
-    console.log("before: ", blocks.length, " after: ", updatedBlocks.length)
     // Update the map with the filtered blocks
     this.editorToVerticalDiffCodeLens.set(filepath, updatedBlocks);
 
     // Refresh the CodeLens display
-    console.log("refeshing code lens")
     this.refreshCodeLens();
   }
 }

--- a/extensions/vscode/src/diff/verticalPerLine/handler.ts
+++ b/extensions/vscode/src/diff/verticalPerLine/handler.ts
@@ -8,7 +8,6 @@ import {
   redDecorationType,
 } from "./decorations";
 import { VerticalDiffCodeLens } from "./manager";
-import { start } from "repl";
 
 export class VerticalPerLineDiffHandler {
   private editor: vscode.TextEditor;

--- a/extensions/vscode/src/diff/verticalPerLine/manager.ts
+++ b/extensions/vscode/src/diff/verticalPerLine/manager.ts
@@ -107,6 +107,7 @@ export class VerticalPerLineDiffManager {
     accept: boolean,
     filepath?: string,
     index?: number,
+    all?:boolean
   ) {
     if (!filepath) {
       const activeEditor = vscode.window.activeTextEditor;
@@ -120,26 +121,38 @@ export class VerticalPerLineDiffManager {
       index = 0;
     }
 
-    let blocks = this.filepathToCodeLens.get(filepath);
-    const block = blocks?.[index];
-    if (!blocks || !block) {
-      return;
-    }
-
     const handler = this.getHandlerForFile(filepath);
     if (!handler) {
       return;
     }
 
-    // CodeLens object removed from editorToVerticalDiffCodeLens here
-    handler.acceptRejectBlock(
-      accept,
-      block.start,
-      block.numGreen,
-      block.numRed,
-    );
+    let blocks = this.filepathToCodeLens.get(filepath);
+    if (!blocks) {
+      return;
+    }
 
-    if (blocks.length === 1) {
+    let toHandle
+    //if all is specified, handle all blocks. Otherwise select specific one
+    if (!all) {
+      toHandle = blocks[index];
+      if (!toHandle){
+        return;
+      }
+    } else {
+      toHandle = blocks
+    }
+
+    for (const block of toHandle) {
+      // CodeLens object removed from editorToVerticalDiffCodeLens here
+      handler.acceptRejectBlock(
+        accept,
+        block.start,
+        block.numGreen,
+        block.numRed,
+      );
+    }
+
+    if (blocks.length === 1 || all) {
       this.clearForFilepath(filepath, true);
     }
   }

--- a/extensions/vscode/src/diff/verticalPerLine/manager.ts
+++ b/extensions/vscode/src/diff/verticalPerLine/manager.ts
@@ -184,14 +184,6 @@ export class VerticalPerLineDiffManager {
 
     let selectedRange = editor.selection;
 
-    // Only if the selection is empty, use exact prefix/suffix instead of by line
-    // if (!selectedRange.isEmpty) {
-    //   selectedRange = new vscode.Range(
-    //     editor.selection.start.with(undefined, 0),
-    //     editor.selection.end.with(undefined, Number.MAX_SAFE_INTEGER),
-    //   );
-    // }
-
     const llm = await this.configHandler.llmFromTitle(modelTitle);
     const rangeContent = editor.document.getText(selectedRange);
     const prefix = pruneLinesFromTop(

--- a/extensions/vscode/src/diff/verticalPerLine/manager.ts
+++ b/extensions/vscode/src/diff/verticalPerLine/manager.ts
@@ -137,17 +137,10 @@ export class VerticalPerLineDiffManager {
       if (!blocks || blocks.length <= index) {
         return;
       }
-      
-      //remove all entries except for entry at index
       toHandle.push(blocks[index])
-      // Clear the array and push the item of interest
-      // blocks.length = 0; // This clears the array
-      // blocks.push(blockOfInterest);
     } else {
       toHandle = blocks.slice()
     }
-    console.log("blocks len: ", blocks.length)
-    console.log("toHandle len: ", toHandle.length)
 
     for (const block of toHandle) {
       // CodeLens object removed from editorToVerticalDiffCodeLens here

--- a/extensions/vscode/src/diff/verticalPerLine/manager.ts
+++ b/extensions/vscode/src/diff/verticalPerLine/manager.ts
@@ -144,7 +144,7 @@ export class VerticalPerLineDiffManager {
     }
   }
 
-  async streamEdit(input: string, modelTitle: string | undefined, previousInput?: string) {
+  async streamEdit(input: string, modelTitle: string | undefined, quickEdit?: string) {
     vscode.commands.executeCommand("setContext", "continue.diffVisible", true);
 
     const editor = vscode.window.activeTextEditor;
@@ -160,10 +160,10 @@ export class VerticalPerLineDiffManager {
 
     //initialize start/end line to existing handler if it exists and should reuse previousInput,
     // otherwise, use the editor selection
-    const startLine = (previousInput && existingHandler) ? existingHandler.range.start.line : editor.selection.start.line
-    const endLine = (previousInput && existingHandler) ? existingHandler.range.end.line : editor.selection.end.line
+    const startLine = (quickEdit && existingHandler) ? existingHandler.range.start.line : editor.selection.start.line
+    const endLine = (quickEdit && existingHandler) ? existingHandler.range.end.line : editor.selection.end.line
 
-    if (existingHandler && !previousInput) { //If there is an existing handler and should not reuse block
+    if (existingHandler && !quickEdit) { //If there is an existing handler and should not reuse block
       //reject the existing diff
       console.log("New diff being created - rejecting previous diff in: ", filepath)
       this.acceptRejectVerticalDiffBlock(false, filepath)

--- a/extensions/vscode/src/diff/verticalPerLine/manager.ts
+++ b/extensions/vscode/src/diff/verticalPerLine/manager.ts
@@ -55,8 +55,7 @@ export class VerticalPerLineDiffManager {
     return this.filepathToHandler.get(filepath);
   }
 
-  //called by constructor
-  //Creates a listener for document changes
+  //Creates a listener for document changes (called by constructor)
   private setupDocumentChangeListener() {
     vscode.workspace.onDidChangeTextDocument((event) => {
       // Check if there is an active handler for the affected file
@@ -154,14 +153,12 @@ export class VerticalPerLineDiffManager {
     }
 
     const filepath = editor.document.uri.fsPath;
-    const startLine = editor.selection.start.line;
-    const endLine = editor.selection.end.line;
         
     //Check for existing diffs in the same file the new one will be created in
     const existingHandler = this.getHandlerForFile(filepath);
     if (existingHandler) {
       //reject the existing diff
-      console.log("New diff being created - rejecting previous diff in : ", filepath)
+      console.log("New diff being created - rejecting previous diff in: ", filepath)
       this.acceptRejectVerticalDiffBlock(false, filepath)
     }
 
@@ -170,6 +167,11 @@ export class VerticalPerLineDiffManager {
     await new Promise((resolve) => {
       setTimeout(resolve, 200);
     });
+
+    const startLine = editor.selection.start.line;
+    const endLine = editor.selection.end.line;
+
+    //Create new handler
     const diffHandler = this.createVerticalPerLineDiffHandler(
       filepath,
       startLine,
@@ -180,15 +182,15 @@ export class VerticalPerLineDiffManager {
       return;
     }
 
-    let selectedRange = existingHandler?.range ?? editor.selection;
+    let selectedRange = editor.selection;
 
     // Only if the selection is empty, use exact prefix/suffix instead of by line
-    if (!selectedRange.isEmpty) {
-      selectedRange = new vscode.Range(
-        editor.selection.start.with(undefined, 0),
-        editor.selection.end.with(undefined, Number.MAX_SAFE_INTEGER),
-      );
-    }
+    // if (!selectedRange.isEmpty) {
+    //   selectedRange = new vscode.Range(
+    //     editor.selection.start.with(undefined, 0),
+    //     editor.selection.end.with(undefined, Number.MAX_SAFE_INTEGER),
+    //   );
+    // }
 
     const llm = await this.configHandler.llmFromTitle(modelTitle);
     const rangeContent = editor.document.getText(selectedRange);

--- a/extensions/vscode/src/diff/verticalPerLine/manager.ts
+++ b/extensions/vscode/src/diff/verticalPerLine/manager.ts
@@ -131,16 +131,23 @@ export class VerticalPerLineDiffManager {
       return;
     }
 
-    let toHandle
-    //if all is specified, handle all blocks. Otherwise select specific one
-    if (!all) {
-      toHandle = blocks[index];
-      if (!toHandle){
+    //if 'all' is false, only handle the block at the specified index
+    let toHandle = []
+    if (!all && blocks.length > 1) {
+      if (!blocks || blocks.length <= index) {
         return;
       }
+      
+      //remove all entries except for entry at index
+      toHandle.push(blocks[index])
+      // Clear the array and push the item of interest
+      // blocks.length = 0; // This clears the array
+      // blocks.push(blockOfInterest);
     } else {
-      toHandle = blocks
+      toHandle = blocks.slice()
     }
+    console.log("blocks len: ", blocks.length)
+    console.log("toHandle len: ", toHandle.length)
 
     for (const block of toHandle) {
       // CodeLens object removed from editorToVerticalDiffCodeLens here

--- a/extensions/vscode/src/lang-server/codeLens.ts
+++ b/extensions/vscode/src/lang-server/codeLens.ts
@@ -46,12 +46,12 @@ class VerticalPerLineCodeLensProvider implements vscode.CodeLensProvider {
           new vscode.CodeLens(range, {
             title: `Accept All (${getMetaKeyLabel()}⇧↩)`,
             command: "continue.acceptVerticalDiffBlock",
-            arguments: [filepath, i],
+            arguments: [filepath, i, true],
           }),
           new vscode.CodeLens(range, {
             title: `Reject All (${getMetaKeyLabel()}⇧⌫)`,
             command: "continue.rejectVerticalDiffBlock",
-            arguments: [filepath, i],
+            arguments: [filepath, i, true],
           }),
         );
       }

--- a/extensions/vscode/src/lang-server/codeLens.ts
+++ b/extensions/vscode/src/lang-server/codeLens.ts
@@ -29,6 +29,7 @@ class VerticalPerLineCodeLensProvider implements vscode.CodeLensProvider {
   ): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
     const filepath = document.uri.fsPath;
     const blocks = this.editorToVerticalDiffCodeLens.get(filepath);
+    console.log("num blocks in provideCodeLenses: ", blocks?.length)
     if (!blocks) {
       return [];
     }

--- a/extensions/vscode/yarn.lock
+++ b/extensions/vscode/yarn.lock
@@ -368,15 +368,15 @@
     tar "^6.0.5"
     yargs "^17.0.1"
 
-"@esbuild/darwin-arm64@0.17.19":
+"@esbuild/linux-x64@0.17.19":
   version "0.17.19"
-  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz"
-  integrity sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==
+  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz"
+  integrity sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==
 
-"@esbuild/darwin-arm64@0.18.20":
+"@esbuild/linux-x64@0.18.20":
   version "0.18.20"
-  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz"
-  integrity sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==
+  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz"
+  integrity sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==
 
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
@@ -691,15 +691,10 @@
   resolved "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
-"@lancedb/vectordb-darwin-arm64@*":
-  version "0.4.16"
-  resolved "https://registry.npmjs.org/@lancedb/vectordb-darwin-arm64/-/vectordb-darwin-arm64-0.4.16.tgz"
-  integrity sha512-RtuizzrZIVDYQ4ZZIMQRHGuV0DvOV93lyvivJJBLP1zCORMHEtEduaVbFE/+H0OCo0oqPsKXEpbc0nUEXKQqRg==
-
-"@lancedb/vectordb-darwin-arm64@0.4.12":
+"@lancedb/vectordb-linux-x64-gnu@0.4.12":
   version "0.4.12"
-  resolved "https://registry.npmjs.org/@lancedb/vectordb-darwin-arm64/-/vectordb-darwin-arm64-0.4.12.tgz"
-  integrity sha512-38/rkJRlWXkPWXuj9onzvbrhnIWcIUQjgEp5G9v5ixPosBowm7A4j8e2Q8CJMsVSNcVX2JLqwWVldiWegZFuYw==
+  resolved "https://registry.npmjs.org/@lancedb/vectordb-linux-x64-gnu/-/vectordb-linux-x64-gnu-0.4.12.tgz"
+  integrity sha512-gJqYR0aymrS+C60xc4EQPzmQ5/69XfeFv2ofBvAj7qW+c6BcnoAcfVl+7s1IrcWeGz251sm5cD5Lx4AzJd89dA==
 
 "@lukeed/csprng@^1.0.0":
   version "1.1.0"
@@ -3449,11 +3444,6 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
-
-fsevents@^2.3.2, fsevents@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
# This work has been continued in https://github.com/continuedev/continue/pull/1198

## Description
This MR fixes two main issues:
1) Edits to a file while a vertical diff was open would not be acknowledged by diff manager, and so the accept/reject would be applied at the wrong location.
2) Diff closure was not handled properly when new diffs were created in same file, so new diffs would generate at old diff location

Also, a bug was discovered: Reject/Accept all does not work when there are multiple blocks - instead only the first block receives the apply (I plan on fixing this soon (this weekend))
Update: 4/18 - added accept/reject all blocks on 'accept/reject all'

### Resolves:
https://github.com/continuedev/continue/issues/991
