### PR TITLE
fix type for gemma of groq

### DIFF
--- a/core/llm/llms/Groq.ts
+++ b/core/llm/llms/Groq.ts
@@ -10,7 +10,7 @@ class Groq extends OpenAI {
   private static modelConversion: { [key: string]: string } = {
     "llama2-70b": "llama2-70b-4096",
     "mistral-8x7b": "mixtral-8x7b-32768",
-    gemma: "gemma-7b-it",
+    "gemma": "gemma-7b-it",
   };
   protected _convertModelName(model: string): string {
     return Groq.modelConversion[model] ?? model;


### PR DESCRIPTION
The gemma here should be "gemma" as a string key.
And I can not find this model in vscode. This should be a bug.