### PR TITLE
Extension API for VS Code v1

### DIFF
--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -40,7 +40,7 @@ function showRefactorMigrationMessage(
   }
 }
 
-export async function activateExtension(context: vscode.ExtensionContext) {
+export async function activateExtension(context: vscode.ExtensionContext): Promise<VsCodeExtension> {
   // Add necessary files
   getTsConfigPath();
 
@@ -67,4 +67,6 @@ export async function activateExtension(context: vscode.ExtensionContext) {
       extensionVersion: getExtensionVersion(),
     });
   }
+
+  return vscodeExtension;
 }

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -4,12 +4,14 @@
 
 import { Telemetry } from "core/util/posthog";
 import * as vscode from "vscode";
+import { IVsCodeExtensionAPI } from "./extension/api";
 import { getExtensionVersion } from "./util/util";
 
-async function dynamicImportAndActivate(context: vscode.ExtensionContext) {
+async function dynamicImportAndActivate(context: vscode.ExtensionContext): Promise<IVsCodeExtensionAPI | null> {
   const { activateExtension } = await import("./activation/activate");
   try {
-    await activateExtension(context);
+    const instance = await activateExtension(context);
+    return { instance };
   } catch (e) {
     console.log("Error activating extension: ", e);
     vscode.window
@@ -26,11 +28,12 @@ async function dynamicImportAndActivate(context: vscode.ExtensionContext) {
           vscode.commands.executeCommand("workbench.action.reloadWindow");
         }
       });
+    return null;
   }
 }
 
-export function activate(context: vscode.ExtensionContext) {
-  dynamicImportAndActivate(context);
+export async function activate(context: vscode.ExtensionContext): Promise<IVsCodeExtensionAPI | null> {
+  return dynamicImportAndActivate(context);
 }
 
 export function deactivate() {

--- a/extensions/vscode/src/extension/api.ts
+++ b/extensions/vscode/src/extension/api.ts
@@ -1,0 +1,8 @@
+import { VsCodeExtension } from "./vscodeExtension";
+
+export interface IVsCodeExtensionAPI {
+  // For now, the internal VsCodeExtension will be exposed, enabling full access to the internal data.
+  // Once it's clear, which functionality is most useful, we should design a proper API with limited access
+  // and remove the instance here.
+  instance: VsCodeExtension;
+}


### PR DESCRIPTION
## Description

This is a PR for #1041. It is as simple as possible, basically exporting the `VsCodeExtension` instance to be usable by other extensions. 

This could for example be used to directly communicate with the models (e.g. via `model.streamChat` etc.) or to communicate with the chat webview, for example:
```ts
continueInstance.webviewProtocol.request("userInput", {
  input: "Please do X for me!",
});
```

I believe it is currently ok to export the `VsCodeExtension` instance, despite giving full access to internals of `continue`, in order to figure out what features are actually useful for other extension authors. Later on, the `instance` property should be deprecated in favor of a better designed external API. 

Maybe the author of #803 could make use of this simple API, too, instead of adding the proposed functionality to `continue` itself.

For a better Typescript experience, the types of the API should also be exposed as an npm package.

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`



