### PR TITLE
🐛 set supportsCompletions based on useLegacyCompletionsEndpoint model setting

### DIFF
--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -52,7 +52,8 @@ export abstract class BaseLLM implements ILLM {
     if (this.providerName === "openai") {
       if (
         this.apiBase?.includes("api.groq.com") ||
-        this.apiBase?.includes(":1337")
+        this.apiBase?.includes(":1337") ||
+        this._llmOptions.useLegacyCompletionsEndpoint?.valueOf() === false
       ) {
         // Jan + Groq don't support completions : (
         return false;

--- a/docs/docs/reference/Model Providers/openai.md
+++ b/docs/docs/reference/Model Providers/openai.md
@@ -52,4 +52,10 @@ If you are [using an OpenAI compatible server / API](../../model-setup/select-pr
 }
 ```
 
+To force usage of `chat/completions` instead of `completions` endpoint you can set
+
+```json
+"useLegacyCompletionsEndpoint": false
+```
+
 [View the source](https://github.com/continuedev/continue/blob/main/core/llm/llms/OpenAI.ts)


### PR DESCRIPTION
Closes #1132

## Description

For self-hosted OpenAI compatible endpoints `/v1/completions`  is used instead of `/v1/chat/completions`. With this PR the setting `useLegacyCompletionsEndpoint` is considered as well so people can control the endpoint to be used.

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
