### PR TITLE
Fix routing of acceptall rejectall commands

### DIFF
--- a/extensions/vscode/src/lang-server/codeLens.ts
+++ b/extensions/vscode/src/lang-server/codeLens.ts
@@ -45,12 +45,12 @@ class VerticalPerLineCodeLensProvider implements vscode.CodeLensProvider {
         codeLenses.push(
           new vscode.CodeLens(range, {
             title: `Accept All (${getMetaKeyLabel()}⇧↩)`,
-            command: "continue.acceptVerticalDiffBlock",
+            command: "continue.acceptDiff",
             arguments: [filepath, i],
           }),
           new vscode.CodeLens(range, {
             title: `Reject All (${getMetaKeyLabel()}⇧⌫)`,
-            command: "continue.rejectVerticalDiffBlock",
+            command: "continue.rejectDiff",
             arguments: [filepath, i],
           }),
         );


### PR DESCRIPTION
## Description

Accept/Reject All was inadvertantly being routed to the commands to perform just Accept/Reject.  This fixes that routing and fixes the issue where Accept/Reject All only accpts/rejects a single diff hunk.

## Checklist

- [X] The base branch of this PR is `preview`, rather than `main`
