### PR TITLE
Fix issues parsing Ollama /api/show endpoint payloads.

### DIFF
--- a/core/llm/llms/Ollama.ts
+++ b/core/llm/llms/Ollama.ts
@@ -38,12 +38,12 @@ class Ollama extends BaseLLM {
         if (body.parameters) {
           const params = [];
           for (let line of body.parameters.split("\n")) {
-            let parts = line.split(" ");
+            let parts = line.match(/^(\S+)\s+((?:".*")|\S+)$/);
             if (parts.length < 2) {
               continue;
             }
-            let key = parts[0];
-            let value = parts[parts.length - 1];
+            let key = parts[1];
+            let value = parts[2];
             switch (key) {
               case "num_ctx":
                 this.contextLength = parseInt(value);
@@ -52,7 +52,12 @@ class Ollama extends BaseLLM {
                 if (!this.completionOptions.stop) {
                   this.completionOptions.stop = [];
                 }
-                this.completionOptions.stop.push(JSON.parse(value));
+                try {
+                  this.completionOptions.stop.push(JSON.parse(value));
+                }
+                catch(e) {
+                  console.warn('Error parsing stop parameter value "{value}: ${e}');
+                }
                 break;
               default:
                 break;


### PR DESCRIPTION
## Description

Adjusted parsing of ollama stop parameters to handle the case where the stop parameter value contains spaces.

## Checklist

- [X] The base branch of this PR is `preview`, rather than `main`
