### PR TITLE
Fix schema to allow 'AUTODETECT' sentinel for model when provider is …

### DIFF
--- a/docs/static/schemas/config.json
+++ b/docs/static/schemas/config.json
@@ -814,7 +814,8 @@
                   "mistral-8x7b",
                   "gemma",
                   "llama3-8b",
-                  "llama3-70b"
+                  "llama3-70b",
+                  "AUTODETECT"
                 ]
               }
             }

--- a/extensions/intellij/src/main/resources/config_schema.json
+++ b/extensions/intellij/src/main/resources/config_schema.json
@@ -814,7 +814,8 @@
                   "mistral-8x7b",
                   "gemma",
                   "llama3-8b",
-                  "llama3-70b"
+                  "llama3-70b",
+                  "AUTODETECT"
                 ]
               }
             }

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -814,7 +814,8 @@
                   "mistral-8x7b",
                   "gemma",
                   "llama3-8b",
-                  "llama3-70b"
+                  "llama3-70b",
+                  "AUTODETECT"
                 ]
               }
             }

--- a/extensions/vscode/continue_rc_schema.json
+++ b/extensions/vscode/continue_rc_schema.json
@@ -895,7 +895,8 @@
                   "mistral-8x7b",
                   "gemma",
                   "llama3-8b",
-                  "llama3-70b"
+                  "llama3-70b",
+                  "AUTODETECT"
                 ]
               }
             }


### PR DESCRIPTION
## Description

Allow "AUTODETECT" to be used as a sentinel when the provider is "groq". Just fixes slightly annoying validation error/warning against the schema when editing the config.json file. AUTODETECT seems to work fine for groq already.

## Checklist

- [X] The base branch of this PR is `preview`, rather than `main`
