### PR TITLE
Fix issue with @codebase provider when n becomes odd due to a divide …

### DIFF
--- a/core/indexing/FullTextSearch.ts
+++ b/core/indexing/FullTextSearch.ts
@@ -121,7 +121,7 @@ export class FullTextSearchCodebaseIndex implements CodebaseIndex {
     let results = await db.all(query, [
       ...tagStrings,
       ...(filterPaths || []),
-      n,
+      Math.ceil(n),
     ]);
 
     results = results.filter((result) => result.rank <= bm25Threshold);


### PR DESCRIPTION
…by 2 during the full text search portion of the query.

## Description

If nFinal is odd in the @codebase provider, the divide by 2 that happens results in a value of n that is a fractional value.  When this is passed to the sqllite database query it throws a datatype mismatch error.  I picked ceil over floor to ensure that the pathological case of nFinal = 1 results in 1 rather than 0.

## Checklist

- [X] The base branch of this PR is `preview`, rather than `main`
