### PR TITLE
Fix issue with the Docs reranking prompt

### DIFF
--- a/core/context/providers/DocsContextProvider.ts
+++ b/core/context/providers/DocsContextProvider.ts
@@ -37,7 +37,7 @@ class DocsContextProvider extends BaseContextProvider {
 
     if (extras.reranker) {
       try {
-        const scores = await extras.reranker.rerank(query, chunks);
+        const scores = await extras.reranker.rerank(extras.fullInput, chunks);
         chunks.sort(
           (a, b) => scores[chunks.indexOf(b)] - scores[chunks.indexOf(a)],
         );


### PR DESCRIPTION
I fixed a bug where you were sending the query variable (which holds the base URL of the doc) to the rerank method, and it made no sense to rerank the chunks based on a URL. So I changed it to extras.fullInput because it should rerank based on the user input, which should provide better results.

## Description

[ What changed? Feel free to be brief. ]

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
