### PR TITLE
CON-1067: Create 'indexing failed', 'indexing not loaded', states

### DIFF
--- a/core/context/providers/FolderContextProvider.ts
+++ b/core/context/providers/FolderContextProvider.ts
@@ -11,7 +11,7 @@ import { getBasename, getLastNPathParts } from "../../util";
 class FolderContextProvider extends BaseContextProvider {
   static description: ContextProviderDescription = {
     title: "folder",
-    displayTitle: "Folders",
+    displayTitle: "Folder",
     description: "Type to search",
     type: "submenu",
   };

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -37,7 +37,7 @@ export interface Chunk extends ChunkWithoutID {
 export interface IndexingProgressUpdate {
   progress: number;
   desc: string;
-  indexingFailed?: boolean;
+  failed?: boolean;
 }
 
 export interface LLMReturnValue {

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -37,6 +37,7 @@ export interface Chunk extends ChunkWithoutID {
 export interface IndexingProgressUpdate {
   progress: number;
   desc: string;
+  indexingFailed?: boolean;
 }
 
 export interface LLMReturnValue {

--- a/core/indexing/indexCodebase.ts
+++ b/core/indexing/indexCodebase.ts
@@ -150,7 +150,6 @@ export class CodebaseIndexer {
           console.warn(
             `Error updating the ${codebaseIndex.artifactId} index: ${e}`,
           );
-          yield { progress: 1, desc: "error updating index" }
         }
       }
 

--- a/core/indexing/indexCodebase.ts
+++ b/core/indexing/indexCodebase.ts
@@ -71,7 +71,6 @@ export class CodebaseIndexer {
     }
 
     //Test to see if embeddings provider is configured properly
-    // let indexingFailed = false;
     try {
       await config.embeddingsProvider.embed(['sample text']);
     } catch (error) {
@@ -150,7 +149,7 @@ export class CodebaseIndexer {
           console.warn(
             `Error updating the ${codebaseIndex.artifactId} index: ${e}`,
           );
-          yield {progress: 1, desc: "error updating index", indexingFailed: true}
+          yield {progress: 1, desc: "error updating index"} 
         }
       }
 

--- a/core/indexing/indexCodebase.ts
+++ b/core/indexing/indexCodebase.ts
@@ -9,7 +9,7 @@ import { getComputeDeleteAddRemove } from "./refreshIndex";
 import { CodebaseIndex } from "./types";
 
 export class PauseToken {
-  constructor(private _paused: boolean) {}
+  constructor(private _paused: boolean) { }
 
   set paused(value: boolean) {
     this._paused = value;
@@ -150,7 +150,7 @@ export class CodebaseIndexer {
           console.warn(
             `Error updating the ${codebaseIndex.artifactId} index: ${e}`,
           );
-          yield {progress: 1, desc: "error updating index", failed: true} 
+          yield { progress: 1, desc: "error updating index" }
         }
       }
 

--- a/core/indexing/indexCodebase.ts
+++ b/core/indexing/indexCodebase.ts
@@ -74,7 +74,7 @@ export class CodebaseIndexer {
     try {
       await config.embeddingsProvider.embed(['sample text']);
     } catch (error) {
-      yield { progress: 1, desc: "Indexing failed while testing provider", indexingFailed: true };
+      yield { progress: 1, desc: "Indexing failed while testing provider", failed: true };
       return
     }
 
@@ -88,6 +88,7 @@ export class CodebaseIndexer {
     yield {
       progress: 0,
       desc: "Starting indexing...",
+      failed: false
     };
 
     for (let directory of workspaceDirs) {
@@ -122,7 +123,7 @@ export class CodebaseIndexer {
               yield {
                 progress: 1,
                 desc: "Indexing cancelled",
-                indexingFailed: true
+                failed: true
               };
               return;
             }
@@ -149,7 +150,7 @@ export class CodebaseIndexer {
           console.warn(
             `Error updating the ${codebaseIndex.artifactId} index: ${e}`,
           );
-          yield {progress: 1, desc: "error updating index"} 
+          yield {progress: 1, desc: "error updating index", failed: true} 
         }
       }
 

--- a/core/indexing/indexCodebase.ts
+++ b/core/indexing/indexCodebase.ts
@@ -70,6 +70,15 @@ export class CodebaseIndexer {
       return;
     }
 
+    //Test to see if embeddings provider is configured properly
+    // let indexingFailed = false;
+    try {
+      await config.embeddingsProvider.embed(['sample text']);
+    } catch (error) {
+      yield { progress: 1, desc: "Indexing failed while testing provider", indexingFailed: true };
+      return
+    }
+
     const indexesToBuild = await this.getIndexesToBuild();
 
     let completedDirs = 0;
@@ -114,6 +123,7 @@ export class CodebaseIndexer {
               yield {
                 progress: 1,
                 desc: "Indexing cancelled",
+                indexingFailed: true
               };
               return;
             }
@@ -140,6 +150,7 @@ export class CodebaseIndexer {
           console.warn(
             `Error updating the ${codebaseIndex.artifactId} index: ${e}`,
           );
+          yield {progress: 1, desc: "error updating index", indexingFailed: true}
         }
       }
 

--- a/core/web/webviewProtocol.ts
+++ b/core/web/webviewProtocol.ts
@@ -74,6 +74,7 @@ export type WebviewProtocol = Protocol &
     errorPopup: [{ message: string }, void];
     "index/setPaused": [boolean, void];
     "index/forceReIndex": [undefined, void];
+    "index/setIndexingFailed": [{message: string, failed: boolean}, void];
     openUrl: [string, void];
     applyToCurrentFile: [{ text: string }, void];
     showTutorial: [undefined, void];
@@ -128,6 +129,7 @@ export type ReverseWebviewProtocol = {
   openSettings: [undefined, void];
   viewHistory: [undefined, void];
   indexProgress: [{ progress: number; desc: string }, void];
+  setIndexingFailed: [{message: string, failed: boolean}, void];
   newSession: [undefined, void];
   refreshSubmenuItems: [undefined, void];
   setTheme: [{ theme: any }, void];

--- a/core/web/webviewProtocol.ts
+++ b/core/web/webviewProtocol.ts
@@ -74,7 +74,8 @@ export type WebviewProtocol = Protocol &
     errorPopup: [{ message: string }, void];
     "index/setPaused": [boolean, void];
     "index/forceReIndex": [undefined, void];
-    "index/setIndexingFailed": [{message: string, failed: boolean}, void];
+    "index/setIndexingFailed": [{failed: boolean}, void];
+    "index/indexingProgressBarInitialized": [{ready: boolean}, void]
     openUrl: [string, void];
     applyToCurrentFile: [{ text: string }, void];
     showTutorial: [undefined, void];
@@ -129,7 +130,8 @@ export type ReverseWebviewProtocol = {
   openSettings: [undefined, void];
   viewHistory: [undefined, void];
   indexProgress: [{ progress: number; desc: string }, void];
-  setIndexingFailed: [{message: string, failed: boolean}, void];
+  setIndexingFailed: [{failed: boolean}, void];
+  indexingProgressBarInitialized: [{ready: boolean}, void]
   newSession: [undefined, void];
   refreshSubmenuItems: [undefined, void];
   setTheme: [{ theme: any }, void];

--- a/core/web/webviewProtocol.ts
+++ b/core/web/webviewProtocol.ts
@@ -74,7 +74,6 @@ export type WebviewProtocol = Protocol &
     errorPopup: [{ message: string }, void];
     "index/setPaused": [boolean, void];
     "index/forceReIndex": [undefined, void];
-    "index/setIndexingFailed": [{failed: boolean}, void];
     "index/indexingProgressBarInitialized": [{ready: boolean}, void]
     openUrl: [string, void];
     applyToCurrentFile: [{ text: string }, void];
@@ -129,8 +128,7 @@ export type ReverseWebviewProtocol = {
   addModel: [undefined, void];
   openSettings: [undefined, void];
   viewHistory: [undefined, void];
-  indexProgress: [{ progress: number; desc: string }, void];
-  setIndexingFailed: [{failed: boolean}, void];
+  indexProgress: [{ progress: number; desc: string; failed?: boolean }, void];
   indexingProgressBarInitialized: [{ready: boolean}, void]
   newSession: [undefined, void];
   refreshSubmenuItems: [undefined, void];

--- a/extensions/vscode/src/extension/vscodeExtension.ts
+++ b/extensions/vscode/src/extension/vscodeExtension.ts
@@ -113,7 +113,6 @@ export class VsCodeExtension {
       this.ide
         .getWorkspaceDirs()
         .then((dirs) => this.refreshCodebaseIndex(dirs, context));
-      context.globalState.update("continue.indexingFailed", false)
     });
     this.webviewProtocol.on("index/indexingProgressBarInitialized", (msg) => {
       // Triggered when progress bar is initialized. Purpose: To relay global state values to the progress bar
@@ -277,7 +276,8 @@ export class VsCodeExtension {
 
   private async refreshCodebaseIndex(dirs: string[], context: vscode.ExtensionContext) {
     //reset all state variables
-    this.webviewProtocol?.request("indexProgress", {progress:0, desc: "", failed:false});
+    console.log("Codebase indexing starting up")
+    this.webviewProtocol?.request("indexProgress", {progress: 0, desc: "", failed:false});
     context.globalState.update("continue.indexingFailed", false)
     context.globalState.update("continue.indexingProgress", 0)
     context.globalState.update("continue.indexingDesc", "")

--- a/extensions/vscode/src/extension/vscodeExtension.ts
+++ b/extensions/vscode/src/extension/vscodeExtension.ts
@@ -120,10 +120,21 @@ export class VsCodeExtension {
       context.globalState.update("continue.indexingFailed", msg.data)
     });
     this.webviewProtocol.on("index/indexingProgressBarInitialized", (msg) => {
+      // Triggered when progress bar is initialized.
+      // Purpose: To relay global state values to the progress bar
+      
+      // Update indexingFailed
       if (context.globalState.get("continue.indexingFailed")){
         this.webviewProtocol?.request("setIndexingFailed", {failed: true});
       } else {
         this.webviewProtocol?.request("setIndexingFailed", {failed: false});
+      }
+
+      // Update indexingProgress
+      if (context.globalState.get("continue.indexingProgress")){
+        let progress = context.globalState.get<number>("continue.indexingProgress") as number
+        let desc = context.globalState.get<string>("continue.indexingDesc") as string
+        this.webviewProtocol?.request("indexProgress", {progress, desc})
       }
     });
     
@@ -280,8 +291,11 @@ export class VsCodeExtension {
   private indexingCancellationController: AbortController | undefined;
 
   private async refreshCodebaseIndex(dirs: string[], context: vscode.ExtensionContext) {
+    //reset all state variables
     this.webviewProtocol?.request("setIndexingFailed", {failed:false});
     context.globalState.update("continue.indexingFailed", false)
+    context.globalState.update("continue.indexingProgress", 0)
+    context.globalState.update("continue.indexingDesc", "")
 
     if (this.indexingCancellationController) {
       this.indexingCancellationController.abort();
@@ -295,12 +309,14 @@ export class VsCodeExtension {
       if (update.indexingFailed) {
         err = update.desc
 
-        // Signal to front-end
+        // Signal failure to front-end
         this.webviewProtocol?.request("setIndexingFailed", {failed: true});
         context.globalState.update("continue.indexingFailed", true)
-
         break
       } else {
+      // Save progress
+        context.globalState.update("continue.indexingProgress", update.progress)
+        context.globalState.update("continue.indexingDesc", update.desc)
         this.webviewProtocol.request("indexProgress", update);
       }
     }

--- a/gui/src/components/Layout.tsx
+++ b/gui/src/components/Layout.tsx
@@ -167,6 +167,13 @@ const Layout = () => {
     setIndexingTask(data.desc);
   });
 
+
+  //ToDO: does this update
+  useWebviewListener("setIndexingFailed", async (data) => {
+    console.log("setting indexing failed to (i think): ", data.failed)
+    setIndexingFailed(data.failed);
+  });
+
   useEffect(() => {
     if (isJetBrains()) {
       return;
@@ -187,6 +194,7 @@ const Layout = () => {
 
   const [indexingProgress, setIndexingProgress] = useState(1);
   const [indexingTask, setIndexingTask] = useState("Indexing Codebase");
+  const [indexingFailed, setIndexingFailed] = useState(false); //ToDO: is this default? Or what it changes it to?
 
   return (
     <LayoutTopDiv>
@@ -259,6 +267,7 @@ const Layout = () => {
                     currentlyIndexing={indexingTask}
                     completed={indexingProgress * 100}
                     total={100}
+                    indexingFailed={indexingFailed}
                   />
                 )}
               </div>

--- a/gui/src/components/Layout.tsx
+++ b/gui/src/components/Layout.tsx
@@ -169,32 +169,8 @@ const Layout = () => {
     setIndexingTask(data.desc);
   });
 
-  // let indexingProgressBarInitialized: boolean = false 
-  // let messageQueue: {failed:boolean}[] = [];
-  // useWebviewListener("indexingProgressBarInitialized", async (data) => { 
-  //   indexingProgressBarInitialized = true
-  //   console.log("webview, initializing progress bar. message queue len: ", messageQueue.length)
-
-  //   for (let i = 0; i < messageQueue.length; i++) {
-  //     setIndexingFailed(messageQueue[i].failed)
-  //   }
-  //   messageQueue = []
-  // });
-
   useWebviewListener("setIndexingFailed", async (data) => {
     setIndexingFailed(data.failed)
-
-    // // Check if bar has been initialized
-    // if (indexingProgressBarInitialized) {
-    //   console.log("no pushing to queue")
-    //   setIndexingFailed(data.failed)
-    // } else {
-    //   console.log("pushing to queue")
-    //   messageQueue.push(data)
-    // }
-    console.log("From layout. setting indexing failed to : ", data.failed)
-    //postToIde("index/setIndexingFailed", {failed: data.failed})
-    //setIndexingFailed(data.failed); //may not needs this if switch to global
   });
 
   useEffect(() => {

--- a/gui/src/components/Layout.tsx
+++ b/gui/src/components/Layout.tsx
@@ -165,9 +165,6 @@ const Layout = () => {
   useWebviewListener("indexProgress", async (data) => {
     setIndexingProgress(data.progress);
     setIndexingTask(data.desc);
-  });
-
-  useWebviewListener("setIndexingFailed", async (data) => {
     setIndexingFailed(data.failed)
   });
 

--- a/gui/src/components/Layout.tsx
+++ b/gui/src/components/Layout.tsx
@@ -28,6 +28,8 @@ import TextDialog from "./dialogs";
 import IndexingProgressBar from "./loaders/IndexingProgressBar";
 import ProgressBar from "./loaders/ProgressBar";
 import ModelSelect from "./modelSelection/ModelSelect";
+import * as vscode from "../../../extensions/vscode";
+
 
 // #region Styled Components
 const FOOTER_HEIGHT = "1.8em";
@@ -167,11 +169,32 @@ const Layout = () => {
     setIndexingTask(data.desc);
   });
 
+  // let indexingProgressBarInitialized: boolean = false 
+  // let messageQueue: {failed:boolean}[] = [];
+  // useWebviewListener("indexingProgressBarInitialized", async (data) => { 
+  //   indexingProgressBarInitialized = true
+  //   console.log("webview, initializing progress bar. message queue len: ", messageQueue.length)
 
-  //ToDO: does this update
+  //   for (let i = 0; i < messageQueue.length; i++) {
+  //     setIndexingFailed(messageQueue[i].failed)
+  //   }
+  //   messageQueue = []
+  // });
+
   useWebviewListener("setIndexingFailed", async (data) => {
-    console.log("setting indexing failed to (i think): ", data.failed)
-    setIndexingFailed(data.failed);
+    setIndexingFailed(data.failed)
+
+    // // Check if bar has been initialized
+    // if (indexingProgressBarInitialized) {
+    //   console.log("no pushing to queue")
+    //   setIndexingFailed(data.failed)
+    // } else {
+    //   console.log("pushing to queue")
+    //   messageQueue.push(data)
+    // }
+    console.log("From layout. setting indexing failed to : ", data.failed)
+    //postToIde("index/setIndexingFailed", {failed: data.failed})
+    //setIndexingFailed(data.failed); //may not needs this if switch to global
   });
 
   useEffect(() => {
@@ -194,7 +217,7 @@ const Layout = () => {
 
   const [indexingProgress, setIndexingProgress] = useState(1);
   const [indexingTask, setIndexingTask] = useState("Indexing Codebase");
-  const [indexingFailed, setIndexingFailed] = useState(false); //ToDO: is this default? Or what it changes it to?
+  const [indexingFailed, setIndexingFailed] = useState(false); 
 
   return (
     <LayoutTopDiv>

--- a/gui/src/components/Layout.tsx
+++ b/gui/src/components/Layout.tsx
@@ -28,8 +28,6 @@ import TextDialog from "./dialogs";
 import IndexingProgressBar from "./loaders/IndexingProgressBar";
 import ProgressBar from "./loaders/ProgressBar";
 import ModelSelect from "./modelSelection/ModelSelect";
-import * as vscode from "../../../extensions/vscode";
-
 
 // #region Styled Components
 const FOOTER_HEIGHT = "1.8em";

--- a/gui/src/components/Layout.tsx
+++ b/gui/src/components/Layout.tsx
@@ -191,7 +191,7 @@ const Layout = () => {
     }
   }, [location]);
 
-  const [indexingProgress, setIndexingProgress] = useState(1);
+  const [indexingProgress, setIndexingProgress] = useState(-1);
   const [indexingTask, setIndexingTask] = useState("Indexing Codebase");
   const [indexingFailed, setIndexingFailed] = useState(false); 
 

--- a/gui/src/components/loaders/IndexingProgressBar.tsx
+++ b/gui/src/components/loaders/IndexingProgressBar.tsx
@@ -59,7 +59,7 @@ const IndexingProgressBar = ({
   completed,
   total,
   currentlyIndexing,
-  indexingFailed,
+  indexingFailed = false
 }: ProgressBarProps) => {
   const fillPercentage = Math.min(100, Math.max(0, (completed / total) * 100));
 
@@ -69,23 +69,21 @@ const IndexingProgressBar = ({
   const [hovered, setHovered] = useState(false);
 
   useEffect(() => {
+    console.log("posting initialization from progress bar")
+    postToIde("index/indexingProgressBarInitialized", {ready:true})
+  }, []);
+  
+  useEffect(() => {
     postToIde("index/setPaused", !expanded);
   }, [expanded]);
-
-  // useEffect(() => {
-  //   setFailed(true);
-  //   console.log("In progress bar use effect: ", indexingFailed)
-  // }, [indexingFailed]);
 
   return (
     <div
       onClick={() => {
+        console.log(completed, " | ", total, " | ", expanded)
         if (completed < total) {
           setExpanded((prev) => !prev);
         } else {
-          // console.log("indexingFailed was: ", indexingFailed)
-          indexingFailed = false
-          // console.log("setting failed to False")
           postToIde("index/forceReIndex", undefined);
         }
       }}

--- a/gui/src/components/loaders/IndexingProgressBar.tsx
+++ b/gui/src/components/loaders/IndexingProgressBar.tsx
@@ -52,12 +52,14 @@ interface ProgressBarProps {
   completed: number;
   total: number;
   currentlyIndexing?: string;
+  indexingFailed?: boolean;
 }
 
 const IndexingProgressBar = ({
   completed,
   total,
   currentlyIndexing,
+  indexingFailed,
 }: ProgressBarProps) => {
   const fillPercentage = Math.min(100, Math.max(0, (completed / total) * 100));
 
@@ -70,18 +72,38 @@ const IndexingProgressBar = ({
     postToIde("index/setPaused", !expanded);
   }, [expanded]);
 
+  // useEffect(() => {
+  //   setFailed(true);
+  //   console.log("In progress bar use effect: ", indexingFailed)
+  // }, [indexingFailed]);
+
   return (
     <div
       onClick={() => {
         if (completed < total) {
           setExpanded((prev) => !prev);
         } else {
+          // console.log("indexingFailed was: ", indexingFailed)
+          indexingFailed = false
+          // console.log("setting failed to False")
           postToIde("index/forceReIndex", undefined);
         }
       }}
       className="cursor-pointer"
     >
-      {completed >= total ? (
+      {
+        indexingFailed ? ( //red 'failed' dot
+        <>
+        <CircleDiv data-tooltip-id="indexingFailed_dot" color="#ff0000"></CircleDiv>
+        {tooltipPortalDiv &&
+          ReactDOM.createPortal(
+            <StyledTooltip id="indexingFailed_dot" place="top">
+              Codebase not indexed. Click to retry
+            </StyledTooltip>,
+            tooltipPortalDiv,
+          )}
+        </>
+        ) : completed >= total ? ( //indexing complete green dot
         <>
           <CircleDiv data-tooltip-id="progress_dot" color="#090"></CircleDiv>
           {tooltipPortalDiv &&
@@ -92,7 +114,7 @@ const IndexingProgressBar = ({
               tooltipPortalDiv,
             )}
         </>
-      ) : expanded ? (
+      ) : expanded ? ( //progress bar
         <>
           <GridDiv
             data-tooltip-id="usage_progress_bar"
@@ -116,7 +138,7 @@ const IndexingProgressBar = ({
               tooltipPortalDiv,
             )}
         </>
-      ) : (
+      ) : ( //yellow 'paused' dot
         <>
           <CircleDiv data-tooltip-id="progress_dot" color="#bb0"></CircleDiv>
           {tooltipPortalDiv &&

--- a/gui/src/components/loaders/IndexingProgressBar.tsx
+++ b/gui/src/components/loaders/IndexingProgressBar.tsx
@@ -88,7 +88,18 @@ const IndexingProgressBar = ({
       className="cursor-pointer"
     >
       {
-        indexingFailed ? ( //red 'failed' dot
+        completed < 0 ? ( //
+        <>
+        <CircleDiv data-tooltip-id="indexingNotLoaded_dot" color="#72aec2"></CircleDiv>
+        {tooltipPortalDiv &&
+          ReactDOM.createPortal(
+            <StyledTooltip id="indexingNotLoaded_dot" place="top">
+              Codebase indexing is starting up.
+            </StyledTooltip>,
+            tooltipPortalDiv,
+          )}
+        </>
+        ) : indexingFailed ? ( //red 'failed' dot
         <>
         <CircleDiv data-tooltip-id="indexingFailed_dot" color="#ff0000"></CircleDiv>
         {tooltipPortalDiv &&
@@ -99,7 +110,7 @@ const IndexingProgressBar = ({
             tooltipPortalDiv,
           )}
         </>
-        ) : completed >= total ? ( //indexing complete green dot
+        ) : completed >= total  ? ( //indexing complete green dot
         <>
           <CircleDiv data-tooltip-id="progress_dot" color="#090"></CircleDiv>
           {tooltipPortalDiv &&

--- a/gui/src/components/loaders/IndexingProgressBar.tsx
+++ b/gui/src/components/loaders/IndexingProgressBar.tsx
@@ -79,7 +79,9 @@ const IndexingProgressBar = ({
   return (
     <div
       onClick={() => {
-        if (completed < total) {
+        console.log("progress bar clicked")
+        console.log(completed, " | ", total)
+        if (completed < total && completed >= 0) {
           setExpanded((prev) => !prev);
         } else {
           postToIde("index/forceReIndex", undefined);
@@ -88,7 +90,7 @@ const IndexingProgressBar = ({
       className="cursor-pointer"
     >
       {
-        completed < 0 ? ( //
+        (completed < 0 && !indexingFailed) ? ( // ice-blue 'indexing starting up' dot
         <>
         <CircleDiv data-tooltip-id="indexingNotLoaded_dot" color="#72aec2"></CircleDiv>
         {tooltipPortalDiv &&
@@ -110,7 +112,7 @@ const IndexingProgressBar = ({
             tooltipPortalDiv,
           )}
         </>
-        ) : completed >= total  ? ( //indexing complete green dot
+        ) : completed >= total ? ( //indexing complete green dot
         <>
           <CircleDiv data-tooltip-id="progress_dot" color="#090"></CircleDiv>
           {tooltipPortalDiv &&

--- a/gui/src/components/loaders/IndexingProgressBar.tsx
+++ b/gui/src/components/loaders/IndexingProgressBar.tsx
@@ -79,7 +79,7 @@ const IndexingProgressBar = ({
   return (
     <div
       onClick={() => {
-        if (completed < total && completed >= 0) {
+        if (!indexingFailed && completed < total && completed >= 0) {
           setExpanded((prev) => !prev);
         } else {
           postToIde("index/forceReIndex", undefined);

--- a/gui/src/components/loaders/IndexingProgressBar.tsx
+++ b/gui/src/components/loaders/IndexingProgressBar.tsx
@@ -79,8 +79,6 @@ const IndexingProgressBar = ({
   return (
     <div
       onClick={() => {
-        console.log("progress bar clicked")
-        console.log(completed, " | ", total)
         if (completed < total && completed >= 0) {
           setExpanded((prev) => !prev);
         } else {

--- a/gui/src/components/loaders/IndexingProgressBar.tsx
+++ b/gui/src/components/loaders/IndexingProgressBar.tsx
@@ -69,7 +69,6 @@ const IndexingProgressBar = ({
   const [hovered, setHovered] = useState(false);
 
   useEffect(() => {
-    console.log("posting initialization from progress bar")
     postToIde("index/indexingProgressBarInitialized", {ready:true})
   }, []);
   
@@ -80,7 +79,6 @@ const IndexingProgressBar = ({
   return (
     <div
       onClick={() => {
-        console.log(completed, " | ", total, " | ", expanded)
         if (completed < total) {
           setExpanded((prev) => !prev);
         } else {


### PR DESCRIPTION
## Description

Failed state:
When indexing fails, the 'indexing state' dot indicator defaults to green. This is causing a confusion for users.
This pr attempts to catch indexing failures and present a red 'indexing failed' dot.
![Screenshot from 2024-05-03 18-45-03](https://github.com/continuedev/continue/assets/42585006/4840ee3e-3c84-4cf3-bc77-21206a4a9d5b)


Pre-indexing state:
If the sidebar is opened shortly after the ide starts up, the indexing may not have started - Rather than default to the progress bar, I've created an ice-blue 'codebase indexing is starting up' dot state. 
When indexing starts, this state will then transition to the progress bar (or another state if it should). This way we don't have the progress bar sitting at 0% for a long time before indexing even starts.
![Screenshot from 2024-05-03 18-44-43](https://github.com/continuedev/continue/assets/42585006/c359b1c5-237c-4ad7-939f-3c189b40cd34)


Related to: https://github.com/continuedev/continue/issues/1067
- I was able to reproduce the empty results on folders dropdown on multiple branches... but not consistently. 
- I think it has to do with at what stage indexing fails (very early)
- This pr does not solve or identify the issue, but it will make it more apparent that your indexing has failed, maybe helping us find the issue later


**Development notes:**
- I chose to display a generic 'codebase not indexed, click to retry' on hover over the dot, rather than a specific error message. I think this is best for now because the errors messages can be quite long (too much for hover), and I want to observe what the failure points are a bit more before trying to filter them in some way.

- Bug: Sometimes, if you attempt to re-index early in extension loading, the indexing will fail due to the abortController aborting - I believe this is unrelated to this pr, and I'll look into what could be causing this.

- I'm using global state as well as props because the props can not be updated while the indexingProgressBar has not been initialized. (Indexing begins, and can fail, before indexingProgressBar has been initialized)

- I've ensured that global states are created/updated as well for progress updates- this way, when the sidebar is opened, regardless of what stage indexing is in, it can trigger an update via the global states and get the indexing status display to the correct state.


### Test cases:
- initialize with bad config, open sidebar before indexing completes
    - show expected (maybe blue momentarily, then red) when sidebar loads
    - show ability to correct state based on config updates

https://github.com/continuedev/continue/assets/42585006/f59a6302-ef99-4186-b7c8-a78d33f0debf

   
- initialize with good config, open sidebar before indexing completes
    - show expected (blue, then green) when sidebar loads
    - show ability to correct state based on config updates

https://github.com/continuedev/continue/assets/42585006/38039331-415b-4b06-adc6-fa266b8c5a61


- initialize with bad config, open sidebar after indexing completes
    - show expected (red) when sidebar loaded
    - show ability to correct state based on config updates

https://github.com/continuedev/continue/assets/42585006/08b866e8-2d63-4a63-acfe-8495d64da3f9


- initialize with good config, open sidebar after indexing completes
    - show expected when sidebar loads
    - show ability to correct state based on config updates

https://github.com/continuedev/continue/assets/42585006/d7ffc3af-ef83-4cca-a45b-c41bdfc68e0a

