### PR TITLE
add PySide6 docs to preindexed docs

### DIFF
--- a/core/indexing/docs/preIndexedDocs.ts
+++ b/core/indexing/docs/preIndexedDocs.ts
@@ -226,6 +226,11 @@ const configs: SiteIndexingConfig[] = [
     startUrl: "https://developer.wordpress.org/reference/",
     rootUrl: "https://developer.wordpress.org/reference/",
   },
+  {
+    title: "PySide6",
+    startUrl: "https://doc.qt.io/qtforpython-6/quickstart.html",
+    rootUrl: "https://doc.qt.io/qtforpython-6/api.html",
+  },
 ];
 
 export default configs;


### PR DESCRIPTION
## Description

Added PySide6 docs to preindexed docs

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
