### PR TITLE
CON-232 bring custom docs to top, alphabetize doc results, make scrol…

### DIFF
--- a/core/context/providers/DocsContextProvider.ts
+++ b/core/context/providers/DocsContextProvider.ts
@@ -24,7 +24,7 @@ class DocsContextProvider extends BaseContextProvider {
     extras: ContextProviderExtras,
   ): Promise<ContextItem[]> {
     const { retrieveDocs } = await import("../../indexing/docs/db");
-
+    console.log("getContextItems")
     const embeddingsProvider = new TransformersJsEmbeddingsProvider();
     const [vector] = await embeddingsProvider.embed([extras.fullInput]);
 
@@ -102,6 +102,23 @@ class DocsContextProvider extends BaseContextProvider {
           id: config.startUrl,
         })),
     );
+
+    // Sort submenuItems such that the objects with titles which don't occur in configs occur first, and alphabetized
+    submenuItems.sort((a, b) => {
+      const aTitleInConfigs = !!configs.find(config => config.title === a.title);
+      const bTitleInConfigs = !!configs.find(config => config.title === b.title);
+    
+      // Primary criterion: Items not in configs come first
+      if (!aTitleInConfigs && bTitleInConfigs) {
+        return -1;
+      } else if (aTitleInConfigs && !bTitleInConfigs) {
+        return 1;
+      } else {
+        // Secondary criterion: Alphabetical order when both items are in the same category
+        return a.title.localeCompare(b.title);
+      }
+    });
+
     return submenuItems;
   }
 }

--- a/core/context/providers/DocsContextProvider.ts
+++ b/core/context/providers/DocsContextProvider.ts
@@ -24,7 +24,6 @@ class DocsContextProvider extends BaseContextProvider {
     extras: ContextProviderExtras,
   ): Promise<ContextItem[]> {
     const { retrieveDocs } = await import("../../indexing/docs/db");
-    console.log("getContextItems")
     const embeddingsProvider = new TransformersJsEmbeddingsProvider();
     const [vector] = await embeddingsProvider.embed([extras.fullInput]);
 

--- a/gui/src/components/mainInput/MentionList.tsx
+++ b/gui/src/components/mainInput/MentionList.tsx
@@ -108,6 +108,8 @@ const ItemsDiv = styled.div`
     0px 10px 20px rgba(0, 0, 0, 0.1);
   font-size: 0.9rem;
   overflow-x: hidden;
+  overflow-y: auto;
+  max-height: 330px;
   padding: 0.2rem;
   position: relative;
 

--- a/gui/src/hooks/useSubmenuContextProviders.tsx
+++ b/gui/src/hooks/useSubmenuContextProviders.tsx
@@ -13,7 +13,7 @@ const MINISEARCH_OPTIONS = {
   fuzzy: 2,
 };
 
-const MAX_LENGTH = 10;
+const MAX_LENGTH = 70;
 
 function useSubmenuContextProviders() {
   // TODO: Refresh periodically


### PR DESCRIPTION
## Description

Resolves: https://github.com/continuedev/continue/issues/1195

I've made three changes:
- Ensure that custom docs are sorted to the top of the suggestions list (I think they should be even without the sorting regardless though? I couldn't reproduce the custom docs not showing up at the top)
- Alphabetize suggestion list
- Make suggestion list scrollable (not just for docs, but also for folders, and others which make use of MentionList)

Note: Potential downside of making scrollable is that the 'add docs' button isn't always visible - If you think it should be, I can pin that to the bottom (as it's own diff) of the suggestions list so that it's always visible regardless of the scrolling.

Two custom docs show at the top
![Screenshot from 2024-05-05 21-11-19](https://github.com/continuedev/continue/assets/42585006/9cc85dfe-5100-40f0-880f-43a85627f5ab)

Scroll to the bottom and see add docs
![Screenshot from 2024-05-05 21-11-45](https://github.com/continuedev/continue/assets/42585006/47e6fc86-61b0-4a9c-815f-9eb5ca88a8e1)
