### PR TITLE
ui: change line decoration color to use vscode theme

### DIFF
--- a/extensions/vscode/src/diff/verticalPerLine/decorations.ts
+++ b/extensions/vscode/src/diff/verticalPerLine/decorations.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 
 export const redDecorationType = vscode.window.createTextEditorDecorationType({
   isWholeLine: true,
-  backgroundColor: { id: "diffEditor.removedTextBackground" },
+  backgroundColor: { id: "diffEditor.removedLineBackground" },
   color: "#808080",
   outlineWidth: "1px",
   outlineStyle: "solid",
@@ -13,7 +13,7 @@ export const redDecorationType = vscode.window.createTextEditorDecorationType({
 export const greenDecorationType = vscode.window.createTextEditorDecorationType(
   {
     isWholeLine: true,
-    backgroundColor: { id: "diffEditor.insertedTextBackground" },
+    backgroundColor: { id: "diffEditor.insertedLineBackground" },
     outlineWidth: "1px",
     outlineStyle: "solid",
     outlineColor: { id: "diffEditor.insertedTextBorder" },

--- a/extensions/vscode/src/diff/verticalPerLine/decorations.ts
+++ b/extensions/vscode/src/diff/verticalPerLine/decorations.ts
@@ -2,15 +2,21 @@ import * as vscode from "vscode";
 
 export const redDecorationType = vscode.window.createTextEditorDecorationType({
   isWholeLine: true,
-  backgroundColor: "rgba(255, 0, 0, 0.2)",
-  color: "rgb(200, 200, 200)",
+  backgroundColor: { id: "diffEditor.removedTextBackground" },
+  color: "#808080",
+  outlineWidth: "1px",
+  outlineStyle: "solid",
+  outlineColor: { id: "diffEditor.removedTextBorder" },
   rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
 });
 
 export const greenDecorationType = vscode.window.createTextEditorDecorationType(
   {
     isWholeLine: true,
-    backgroundColor: "rgba(0, 255, 0, 0.2)",
+    backgroundColor: { id: "diffEditor.insertedTextBackground" },
+    outlineWidth: "1px",
+    outlineStyle: "solid",
+    outlineColor: { id: "diffEditor.insertedTextBorder" },
     rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
   },
 );


### PR DESCRIPTION
First of all, this is a great vscode extension. One of the things I like is the consistent UI that blends very well with the other elements in VSCode workbench. I found an improvement on that area so let me try this as my first PR in this project.

## Description

I changed color decoration in `extensions\vscode\src\diff\verticalPerLine\decorations.ts` to follow the color defined in vscode.
for red decoration uses `diffEditor.removedLineBackground`, green uses `diffEditor.insertedLineBackground`.
I also added outline (border), using `diffEditor.removedTextBorder` and `diffEditor.insertedTextBorder`, respectively. This setting will respect the theme setting of the border, so if the border color is not defined, then it will not be shown. For people who uses high contrast theme, for example, they will be shown.

Reason: this will give users a more consistent behavior when looking at the diff because the color (background and border) are the same with the one they usually see on a git diff view, for example.

I also noticed that for the will-be-removed text you use a grey-ish color to indicate that it will be removed, which I think is a really great idea. I changed it from `rgb(200,200,200)` to `#808080` (a medium gray) to give the same contrast (or the be exact: same mute) between light and dark theme. Unfortunately since we cannot use vscode token color (eg. comment color), we cannot make it adjustable and following the theme. 


## How to test:
when using inline change (and the red/green decoration is shown), change the theme
- for non-contrast theme, it will just change the red/green background
- for contrast theme, it will change the background and the border color
- you can also change using the following setting

```json
"workbench.colorCustomizations": {
                "diffEditor.insertedLineBackground": "#7bd88f0c",  
		"diffEditor.insertedTextBorder": "#7bd88f",
		"diffEditor.removedLineBackground": "#fc618d0c",
		"diffEditor.removedTextBorder": "#fc618d",
}
```


https://github.com/continuedev/continue/assets/146386738/89eca0ff-ca17-4cca-a446-696a77b40e62



## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
