### PR TITLE
Add --no-dependencies to vsce package

### DIFF
--- a/extensions/vscode/scripts/package.js
+++ b/extensions/vscode/scripts/package.js
@@ -9,8 +9,8 @@ if (!fs.existsSync("build")) {
 }
 
 const command = isPreRelease
-  ? "npx vsce package --out ./build patch --pre-release" // --yarn"
-  : "npx vsce package --out ./build patch"; // --yarn";
+  ? "npx vsce package --out ./build patch --pre-release --no-dependencies" // --yarn"
+  : "npx vsce package --out ./build patch --no-dependencies"; // --yarn";
 
 exec(command, (error) => {
   if (error) throw error;


### PR DESCRIPTION
## Description
`vsce pack` has weird behavior where it tries to package all your dependencies from your node_modules itself. This can cause issues depending on the package manager configuration, and prevents modern package managers from being used.

since we are already running esbuild in the prepublish step we can just skip the dependency packing from vsce with the `--no-dependencies` flag

see: microsoft/vscode-vsce#421 (comment)

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
