### PR TITLE
Add debug terminal context menu

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -140,7 +140,7 @@
       {
         "command": "continue.debugTerminal",
         "category": "Continue",
-        "title": "Debug Terminal",
+        "title": "Continue: Debug Terminal",
         "group": "Continue"
       },
       {
@@ -386,6 +386,12 @@
           "command": "continue.toggleFullScreen",
           "group": "navigation@1",
           "when": "activeWebviewPanelId == continue.continueGUIView"
+        }
+      ],
+      "terminal/context": [
+        {
+          "command": "continue.debugTerminal",
+          "group": "navigation@top"
         }
       ]
     },


### PR DESCRIPTION
## Description

Adds the debug terminal command to the terminal context menu. I didn't know this shortcut existed, but had checked the context menu, and only saw copilot. Should be helpful for others if they aren't aware the shortcut exists.

<img width="608" alt="Screenshot 2024-05-10 at 12 36 53 PM" src="https://github.com/continuedev/continue/assets/6018174/97eeea3a-31ea-4e62-9a16-996651c86db2">

## development notes
- I used `navigation@top` for the group so its up on top, but happy to change to another one.
- I changed the title of the command with the prefix `Continue:` because it wasn't clear to me by the command name that it used the extension. Open to other ideas but this is what Copilot does in it's context menus

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
