### PR TITLE
Add stream support for Bedrock Anthropic

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -19,6 +19,7 @@
     "ts-jest": "^29.1.1"
   },
   "dependencies": {
+    "@aws-sdk/client-bedrock-runtime": "^3.574.0",
     "@mozilla/readability": "^0.5.0",
     "@octokit/rest": "^20.0.2",
     "@types/jsdom": "^21.1.6",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "continue",
   "icon": "media/icon.png",
-  "version": "0.9.93",
+  "version": "0.9.94",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION
## Description

- Adding dependency on official aws-sdk bedrock runtime library to have better support for the API
- Using stream API for Bedrock Anthropic

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
