### PR TITLE
Improved Jira Issues config docs for authentication

### DIFF
--- a/docs/docs/customization/context-providers.md
+++ b/docs/docs/customization/context-providers.md
@@ -167,14 +167,13 @@ If you select some code to be edited, you can have the context provider filter o
 
 ### Jira Issues
 
-Type '@jira' to reference the conversation in a Jira issue. Make sure to include your own [Atlassian API Token](https://id.atlassian.com/manage-profile/security/api-tokens).
+Type '@jira' to reference the conversation in a Jira issue. Make sure to include your own [Atlassian API Token](https://id.atlassian.com/manage-profile/security/api-tokens), or use your `email` and `token`, with token set to your password for basic authentication. If you use your own Atlassian API Token, don't configure your email.
 
 ```json
 {
   "name": "jira",
   "params": {
     "domain": "company.atlassian.net",
-    "email": "someone@somewhere.com",
     "token ": "ATATT..."
   }
 }


### PR DESCRIPTION
If you provide the email and Atlassian API token as written, the JiraClient assumes the token is a password and tries to call the API with username (=email) and password (=token). This doesn't work.
## Description

Adjusted the config example and added a sentence explaining the two options: a) using a personal access token or b) using email and password to authenticate with the JiraClient.

## Checklist

- [ ] The base branch of this PR is `preview`, rather than `main`
