### PR TITLE
Adjust package naming

### DIFF
--- a/binary/build.js
+++ b/binary/build.js
@@ -43,10 +43,11 @@ async function installNodeModuleInTempDirAndCopyToCurrent(package, toCopy) {
   console.log(`Copying ${package} to ${toCopy}`);
   // This is a way to install only one package without npm trying to install all the dependencies
   // Create a temporary directory for installing the package
+  const adjustedName = toCopy.replace(/^@/, "").replace("/", "-");
   const tempDir = path.join(
     __dirname,
     "tmp",
-    `continue-node_modules-${toCopy}`,
+    `continue-node_modules-${adjustedName}`,
   );
   const currentDir = process.cwd();
 

--- a/extensions/vscode/scripts/prepackage.js
+++ b/extensions/vscode/scripts/prepackage.js
@@ -309,7 +309,9 @@ const exe = os === "win32" ? ".exe" : "";
     console.log(`Copying ${package} to ${toCopy}`);
     // This is a way to install only one package without npm trying to install all the dependencies
     // Create a temporary directory for installing the package
-    const tempDir = `/tmp/continue-node_modules-${toCopy}`;
+    const adjustedName = toCopy.replace(/^@/, "").replace("/", "-");
+
+    const tempDir = `/tmp/continue-node_modules-${adjustedName}`;
     const currentDir = process.cwd();
 
     // Remove the dir we will be copying to


### PR DESCRIPTION
## Description

Build succeeded after slight modification to package naming.

Without this change I see the below error:

```
13 verbose stack Error: Invalid name: "continue-node_modules-@esbuild"

13 verbose stack at normalize (/home/jmilner/.nvm/versions/node/v20.13.1/lib/node_modules/npm/node_modules/@npmcli/package-json/lib/normalize.js:139:15)

13 verbose stack at PackageJson.normalize (/home/jmilner/.nvm/versions/node/v20.13.1/lib/node_modules/npm/node_modules/@npmcli/package-json/lib/index.js:263:11)

13 verbose stack at init (/home/jmilner/.nvm/versions/node/v20.13.1/lib/node_modules/npm/node_modules/init-package-json/lib/init-package-json.js:80:13)

13 verbose stack at async Init.template (/home/jmilner/.nvm/versions/node/v20.13.1/lib/node_modules/npm/lib/commands/init.js:168:20)

13 verbose stack at async Init.exec (/home/jmilner/.nvm/versions/node/v20.13.1/lib/node_modules/npm/lib/commands/init.js:48:5)

13 verbose stack at async module.exports (/home/jmilner/.nvm/versions/node/v20.13.1/lib/node_modules/npm/lib/cli/entry.js:74:5)
```

