### PR TITLE
add toString

### DIFF
--- a/core/context/providers/DocsContextProvider.ts
+++ b/core/context/providers/DocsContextProvider.ts
@@ -114,7 +114,8 @@ class DocsContextProvider extends BaseContextProvider {
         return 1;
       } else {
         // Secondary criterion: Alphabetical order when both items are in the same category
-        return a.title.toString().localeCompare(b.title.toString());      }
+        return a.title.toString().localeCompare(b.title.toString()); 
+      }
     });
 
     return submenuItems;

--- a/core/context/providers/DocsContextProvider.ts
+++ b/core/context/providers/DocsContextProvider.ts
@@ -114,8 +114,7 @@ class DocsContextProvider extends BaseContextProvider {
         return 1;
       } else {
         // Secondary criterion: Alphabetical order when both items are in the same category
-        return a.title.localeCompare(b.title);
-      }
+        return a.title.toString().localeCompare(b.title.toString());      }
     });
 
     return submenuItems;


### PR DESCRIPTION
## Description

One of my recent MRs caused this bug if the user has titles that are composed solely of numbers:
Error loading submenu items from docs: TypeError: a.title.localeCompare is not a function

Fix: Convert the titles to strings.