### PR TITLE
Update build.js

### DIFF
--- a/binary/build.js
+++ b/binary/build.js
@@ -94,7 +94,7 @@ async function installNodeModuleInTempDirAndCopyToCurrent(package, toCopy) {
     });
   } finally {
     // Clean up the temporary directory
-    rimrafSync(tempDir);
+    // rimrafSync(tempDir);
 
     // Return to the original directory
     process.chdir(currentDir);


### PR DESCRIPTION
Fix error that happens when we run the task install-all-dependencies on VS Code, Windows 11 Pro: EBUSY: resource busy or locked, rmdir '...\continue\binary\tmp\continue-node_modules-lancedb'

## Description

[ What changed? Feel free to be brief. ]

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
