### PR TITLE
Add Gemini 1.5 Flash support

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -568,6 +568,7 @@ export type ModelName =
   // Gemini
   | "gemini-pro"
   | "gemini-1.5-pro-latest"
+  | "gemini-1.5-flash-latest"
   // Mistral
   | "mistral-tiny"
   | "mistral-small"

--- a/core/llm/autodetect.ts
+++ b/core/llm/autodetect.ts
@@ -62,6 +62,7 @@ const MODEL_SUPPORTS_IMAGES: string[] = [
   "claude-3",
   "gemini-ultra",
   "gemini-1.5-pro",
+  "gemini-1.5-flash",
   "sonnet",
   "opus",
   "haiku",

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -612,7 +612,8 @@
                 "enum": [
                   "chat-bison-001",
                   "gemini-pro",
-                  "gemini-1.5-pro-latest"
+                  "gemini-1.5-pro-latest",
+                  "gemini-1.5-flash-latest"
                 ]
               }
             }
@@ -987,6 +988,7 @@
                       "chat-bison-001",
                       "gemini-pro",
                       "gemini-1.5-pro-latest",
+                      "gemini-1.5-flash-latest",
                       "mistral-tiny",
                       "mistral-small",
                       "mistral-medium",

--- a/gui/src/util/modelData.ts
+++ b/gui/src/util/modelData.ts
@@ -454,6 +454,18 @@ const gemini15Pro: ModelPackage = {
   icon: "gemini.png",
   providerOptions: ["gemini", "freetrial"],
 };
+const gemini15Flash: ModelPackage = {
+  title: "Gemini 1.5 Flash",
+  description: "Fast and versatile multimodal model for scaling across diverse tasks",
+  params: {
+    title: "Gemini 1.5 Flash",
+    model: "gemini-1.5-flash-latest",
+    contextLength: 1_000_000,
+    apiKey: "<API_KEY>",
+  },
+  icon: "gemini.png",
+  providerOptions: ["gemini"],
+};
 
 const deepseek: ModelPackage = {
   title: "DeepSeek-Coder",
@@ -660,6 +672,7 @@ export const MODEL_INFO: (ModelPackage | string)[] = [
   "Gemini",
   gemini15Pro,
   geminiPro,
+  gemini15Flash,
   "Open Source",
   llama3Chat,
   deepseek,
@@ -863,7 +876,7 @@ export const PROVIDER_INFO: { [key: string]: ModelInfo } = {
         required: true,
       },
     ],
-    packages: [gemini15Pro, geminiPro],
+    packages: [gemini15Pro, geminiPro, gemini15Flash],
   },
   mistral: {
     title: "Mistral API",


### PR DESCRIPTION
This PR adds support for [Google Gemini 1.5 Flash](https://ai.google.dev/gemini-api/docs/models/gemini#gemini-1.5-flash) to the existing LLM provider [Google Gemini](https://github.com/continuedev/continue/blob/main/core/llm/llms/Gemini.ts).

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
