### PR TITLE
Feat/gemini flash

### DIFF
--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -563,6 +563,7 @@ declare global {
     // Gemini
     | "gemini-pro"
     | "gemini-1.5-pro-latest"
+    | "gemini-1.5-flash-latest"
     // Mistral
     | "mistral-tiny"
     | "mistral-small"

--- a/core/llm/autodetect.ts
+++ b/core/llm/autodetect.ts
@@ -93,7 +93,6 @@ const PARALLEL_PROVIDERS: ModelProvider[] = [
   "bedrock",
   "deepinfra",
   "gemini",
-  "gemini",
   "huggingface-inference-api",
   "huggingface-tgi",
   "mistral",

--- a/docs/docs/reference/Model Providers/geminiapi.md
+++ b/docs/docs/reference/Model Providers/geminiapi.md
@@ -1,6 +1,6 @@
 # Gemini API
 
-The Google Gemini API is currently in beta. You can [create an API key in Google AI Studio](https://aistudio.google.com) and use `gemini-1.5-pro-latest`. Change `~/.continue/config.json` to look like this:
+The Google Gemini API is currently in beta. You can [create an API key in Google AI Studio](https://aistudio.google.com) and use `gemini-1.5-pro-latest`. Change `~/.continue/config.json` to include the following entry in the "models" array:
 
 ```json title="~/.continue/config.json"
 {
@@ -14,5 +14,7 @@ The Google Gemini API is currently in beta. You can [create an API key in Google
   ]
 }
 ```
+
+Google has also released a more lightweight version of the model that still has a one-million-token context window and multimodal capabilities named Gemini Flash. It can be accessed by adding an entry in the models array similar to the above, but substituting "flash" for "pro" in the `title` and `model` values.
 
 [View the source](https://github.com/continuedev/continue/blob/main/core/llm/llms/Gemini.ts)

--- a/docs/docs/setup/select-model.md
+++ b/docs/docs/setup/select-model.md
@@ -43,7 +43,7 @@ You likely want to use a model that is 30B+ parameters for chat.
 #### Gemini Pro from Google
 
 - Unlimited budget: `gemini-pro-1.5-latest`
-- Limited budget: `gemini-pro-1.0`
+- Limited budget: `gemini-flash-1.5-latest` or `gemini-pro-1.0`
 
 *You can also use other commercial chat models by adding them to your `config.json`.*
 

--- a/docs/static/schemas/config.json
+++ b/docs/static/schemas/config.json
@@ -610,7 +610,8 @@
                 "enum": [
                   "chat-bison-001",
                   "gemini-pro",
-                  "gemini-1.5-pro-latest"
+                  "gemini-1.5-pro-latest",
+                  "gemini-1.5-flash-latest"
                 ]
               }
             }
@@ -985,6 +986,7 @@
                       "chat-bison-001",
                       "gemini-pro",
                       "gemini-1.5-pro-latest",
+                      "gemini-1.5-flash-latest",
                       "mistral-tiny",
                       "mistral-small",
                       "mistral-medium",

--- a/extensions/intellij/src/main/resources/config_schema.json
+++ b/extensions/intellij/src/main/resources/config_schema.json
@@ -610,7 +610,8 @@
                 "enum": [
                   "chat-bison-001",
                   "gemini-pro",
-                  "gemini-1.5-pro-latest"
+                  "gemini-1.5-pro-latest",
+                  "gemini-1.5-flash-latest"
                 ]
               }
             }
@@ -985,6 +986,7 @@
                       "chat-bison-001",
                       "gemini-pro",
                       "gemini-1.5-pro-latest",
+                      "gemini-1.5-flash-latest",
                       "mistral-tiny",
                       "mistral-small",
                       "mistral-medium",

--- a/extensions/vscode/continue_rc_schema.json
+++ b/extensions/vscode/continue_rc_schema.json
@@ -669,7 +669,8 @@
                 "enum": [
                   "chat-bison-001",
                   "gemini-pro",
-                  "gemini-1.5-pro-latest"
+                  "gemini-1.5-pro-latest",
+                  "gemini-1.5-flash-latest"
                 ]
               }
             }
@@ -1092,6 +1093,7 @@
                       "chat-bison-001",
                       "gemini-pro",
                       "gemini-1.5-pro-latest",
+                      "gemini-1.5-flash-latest",
                       "mistral-tiny",
                       "mistral-small",
                       "mistral-medium",


### PR DESCRIPTION
## Description

Added references to Gemini Flash in a few more locations where 1.5 Pro was listed but Flash wasn't. Also updates documentation and removes a duplicate reference to "gemini".

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`

## Additional comments
- It seems reasonable to me to add Flash to the free trial similar to how Haiku and GPT 3.5 are provided to enable comparison of the lightweight version of those models, but didn't make such changes because anything relating to the trial feels like maybe it should be handled by Nate/Ty.
- In `Gemini.ts (15-18)` the default model is still specified as "gemini-pro". It seems perhaps this should be updated to 1.5, but I don't know for certain what differences may cause unexpected problems so I left it alone for now.
```ts
static defaultOptions: Partial<LLMOptions> = {
    model: "gemini-pro",
    apiBase: "https://generativelanguage.googleapis.com/v1beta/",
  };
```
