### PR TITLE
Fix sidebar indexing status timing-related bugs

### DIFF
--- a/binary/build.js
+++ b/binary/build.js
@@ -51,7 +51,7 @@ async function installNodeModuleInTempDirAndCopyToCurrent(packageName, toCopy) {
   console.log(`Copying ${packageName} to ${toCopy}`);
   // This is a way to install only one package without npm trying to install all the dependencies
   // Create a temporary directory for installing the package
-  const adjustedName = packageName.replace(/^@/, "").replace("/", "-");
+  const adjustedName = toCopy.replace(/^@/, "").replace("/", "-");
   const tempDir = path.join(
     __dirname,
     "tmp",

--- a/core/core.ts
+++ b/core/core.ts
@@ -67,8 +67,6 @@ export class Core {
       (() => this.messenger.send("configUpdate", undefined)).bind(this),
     );
 
-    //this.indexingState = new IndexingProgre
-
     // Codebase Indexer and ContinueServerClient depend on IdeSettings
     const indexingPauseToken = new PauseToken(
       new GlobalContext().get("indexingPaused") === true,
@@ -527,7 +525,6 @@ export class Core {
       this.messenger.request("indexProgress", update);
       console.log("setting stored indexingProgress to: ", update.status)
       this.indexingState = update
-      // new GlobalContext().update("IndexingProgress", update)
     }
   }
 }

--- a/core/core.ts
+++ b/core/core.ts
@@ -494,16 +494,13 @@ export class Core {
       new GlobalContext().update("indexingPaused", msg.data);
       indexingPauseToken.paused = msg.data;
     });
-    // on("index/setIndexingStatus", (msg) => {
-    //   new GlobalContext().update("indexingStatus", msg.data);
-    // });
     on("index/indexingProgressBarInitialized", async (msg) => {
-      console.log("message: ", msg)
       // Triggered when progress bar is initialized.
       const storedIndexingProgress = new GlobalContext().get("IndexingProgress")
       
       //If a state has been stored, update the indexing display to that state
       if (storedIndexingProgress) {
+        console.log("Passing stored state: ", storedIndexingProgress.status)
         this.messenger.request("indexProgress", storedIndexingProgress);
       }
     });
@@ -516,14 +513,13 @@ export class Core {
       this.indexingCancellationController.abort();
     }
     this.indexingCancellationController = new AbortController();
-    const global = new GlobalContext()
     for await (const update of (await this.codebaseIndexerPromise).refresh(
       dirs,
       this.indexingCancellationController.signal,
     )) {
-      console.log("core.ts updte: ", update.status)
       this.messenger.request("indexProgress", update);
-      global.update("IndexingProgress", update)
+      console.log("setting global indexingProgress to: ", update.status)
+      new GlobalContext().update("IndexingProgress", update)
     }
   }
 }

--- a/core/core.ts
+++ b/core/core.ts
@@ -499,13 +499,8 @@ export class Core {
     });
     on("index/indexingProgressBarInitialized", async (msg) => {
       // Triggered when progress bar is initialized.
-      // const storedIndexingProgress = new GlobalContext().get("IndexingProgress")
-      
-      // const stored = this.indexingState
-
-      //If a non-default state has been stored, update the indexing display to that state
+      // If a non-default state has been stored, update the indexing display to that state
       if (this.indexingState.status != 'loading') {
-        console.log("Passing stored state: ", this.indexingState.status)
         this.messenger.request("indexProgress", this.indexingState);
       }
     });
@@ -523,7 +518,6 @@ export class Core {
       this.indexingCancellationController.signal,
     )) {
       this.messenger.request("indexProgress", update);
-      console.log("setting stored indexingProgress to: ", update.status)
       this.indexingState = update
     }
   }

--- a/core/core.ts
+++ b/core/core.ts
@@ -494,6 +494,19 @@ export class Core {
       new GlobalContext().update("indexingPaused", msg.data);
       indexingPauseToken.paused = msg.data;
     });
+    // on("index/setIndexingStatus", (msg) => {
+    //   new GlobalContext().update("indexingStatus", msg.data);
+    // });
+    // on("index/indexingProgressBarInitialized", (msg)) => {
+    //   // Triggered when progress bar is initialized. Purpose: To relay global state values to the progress bar
+    //   const globalContext = new GlobalContext()
+    //   globalContext.get("")
+    //   let progress = globalContext.get("continue.indexingProgress") as number
+    //   let desc = globalContext.get("continue.indexingDesc") as string
+    //   let failed = globalContext.get<boolean>("continue.indexingFailed") as boolean
+    //   this.messenger.request("indexProgress", {progress, desc});
+    //   this.webviewProtocol?.request("indexProgress", {progress, desc, failed})
+    // }
   }
 
   private indexingCancellationController: AbortController | undefined;

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -37,7 +37,7 @@ export interface Chunk extends ChunkWithoutID {
 export interface IndexingProgressUpdate {
   progress: number;
   desc: string;
-  status: "starting" | "indexing" | "done" | "failed" | "paused" | "disabled";
+  status: "loading" | "indexing" | "done" | "failed" | "paused" | "disabled";
 }
 
 export type PromptTemplate =

--- a/core/indexing/LanceDbIndex.ts
+++ b/core/indexing/LanceDbIndex.ts
@@ -148,8 +148,8 @@ export class LanceDbIndex implements CodebaseIndex {
 
     // Compute
     let table: Table<number[]> | undefined = undefined;
-    let needToCreateTable = true;
     const existingTables = await db.tableNames();
+    let needToCreateTable = !existingTables.includes(tableName);
 
     const addComputedLanceDbRows = async (
       pathAndCacheKey: PathAndCacheKey,

--- a/core/indexing/indexCodebase.ts
+++ b/core/indexing/indexCodebase.ts
@@ -28,8 +28,6 @@ export class CodebaseIndexer {
     private readonly continueServerClient: IContinueServerClient,
   ) {}
 
-  
-
   private async getIndexesToBuild(): Promise<CodebaseIndex[]> {
     const config = await this.configHandler.loadConfig();
 
@@ -54,8 +52,6 @@ export class CodebaseIndexer {
     workspaceDirs: string[],
     abortSignal: AbortSignal,
   ): AsyncGenerator<IndexingProgressUpdate> {
-    console.log("Indexing starting")
-
     if (workspaceDirs.length === 0) {
       yield {
         progress: 0,
@@ -184,6 +180,5 @@ export class CodebaseIndexer {
         status: "done",
       };
     }
-    console.log("Indexing finished")
   }
 }

--- a/core/indexing/indexCodebase.ts
+++ b/core/indexing/indexCodebase.ts
@@ -69,7 +69,7 @@ export class CodebaseIndexer {
     if (config.disableIndexing) {
       yield {
         progress: 0,
-        desc: "Indexing is disabled in the config.json",
+        desc: "Indexing is disabled in config.json",
         status: "disabled",
       };
       return;

--- a/core/indexing/indexCodebase.ts
+++ b/core/indexing/indexCodebase.ts
@@ -52,11 +52,12 @@ export class CodebaseIndexer {
     workspaceDirs: string[],
     abortSignal: AbortSignal,
   ): AsyncGenerator<IndexingProgressUpdate> {
+    console.log("Indexing Starting")
     if (workspaceDirs.length === 0) {
       yield {
         progress: 0,
         desc: "Nothing to index",
-        status: "disabled",
+        status: "disabled",     //ToDo: This should maybe be green
       };
       return;
     }
@@ -73,7 +74,7 @@ export class CodebaseIndexer {
       yield {
         progress: 0,
         desc: "Starting indexing",
-        status: "starting",
+        status: "loading",
       };
     }
 
@@ -88,7 +89,7 @@ export class CodebaseIndexer {
     yield {
       progress: 0,
       desc: "Starting indexing...",
-      status: "starting",
+      status: "loading",
     };
 
     for (const directory of workspaceDirs) {
@@ -161,9 +162,15 @@ export class CodebaseIndexer {
             status: "indexing",
           };
         } catch (e) {
+          yield {
+            progress: 0, 
+            desc: `${e}`,
+            status: "failed"
+          }
           console.warn(
             `Error updating the ${codebaseIndex.artifactId} index: ${e}`,
           );
+          return
         }
       }
 
@@ -174,5 +181,6 @@ export class CodebaseIndexer {
         status: "done",
       };
     }
+    console.log("Indexing Completed")
   }
 }

--- a/core/indexing/indexCodebase.ts
+++ b/core/indexing/indexCodebase.ts
@@ -28,6 +28,8 @@ export class CodebaseIndexer {
     private readonly continueServerClient: IContinueServerClient,
   ) {}
 
+  
+
   private async getIndexesToBuild(): Promise<CodebaseIndex[]> {
     const config = await this.configHandler.loadConfig();
 
@@ -52,16 +54,17 @@ export class CodebaseIndexer {
     workspaceDirs: string[],
     abortSignal: AbortSignal,
   ): AsyncGenerator<IndexingProgressUpdate> {
-    console.log("Indexing Starting")
+    console.log("Indexing starting")
+
     if (workspaceDirs.length === 0) {
       yield {
         progress: 0,
         desc: "Nothing to index",
-        status: "disabled",     //ToDo: This should maybe be green
+        status: "disabled",     
       };
       return;
     }
-
+    
     const config = await this.configHandler.loadConfig();
     if (config.disableIndexing) {
       yield {
@@ -181,6 +184,6 @@ export class CodebaseIndexer {
         status: "done",
       };
     }
-    console.log("Indexing Completed")
+    console.log("Indexing finished")
   }
 }

--- a/core/protocol/core.ts
+++ b/core/protocol/core.ts
@@ -120,7 +120,7 @@ export type ToCoreFromIdeOrWebviewProtocol = {
   ];
   "index/setPaused": [boolean, void];
   "index/forceReIndex": [undefined | string, void];
-  "index/indexingProgressBarInitialized": [{ready: boolean}, void]
+  "index/indexingProgressBarInitialized": [string, void];
   completeOnboarding: [
     {
       mode:

--- a/core/protocol/core.ts
+++ b/core/protocol/core.ts
@@ -120,6 +120,7 @@ export type ToCoreFromIdeOrWebviewProtocol = {
   ];
   "index/setPaused": [boolean, void];
   "index/forceReIndex": [undefined | string, void];
+  "index/indexingProgressBarInitialized": [{ready: boolean}, void]
   completeOnboarding: [
     {
       mode:

--- a/core/protocol/core.ts
+++ b/core/protocol/core.ts
@@ -120,7 +120,7 @@ export type ToCoreFromIdeOrWebviewProtocol = {
   ];
   "index/setPaused": [boolean, void];
   "index/forceReIndex": [undefined | string, void];
-  "index/indexingProgressBarInitialized": [string, void];
+  "index/indexingProgressBarInitialized": [undefined, void];
   completeOnboarding: [
     {
       mode:

--- a/core/protocol/passThrough.ts
+++ b/core/protocol/passThrough.ts
@@ -36,6 +36,7 @@ export const WEBVIEW_TO_CORE_PASS_THROUGH: (keyof ToCoreFromWebviewProtocol)[] =
     "stats/getTokensPerModel",
     "index/setPaused",
     "index/forceReIndex",
+    "index/indexingProgressBarInitialized",
     "completeOnboarding",
   ];
 

--- a/core/util/GlobalContext.ts
+++ b/core/util/GlobalContext.ts
@@ -4,7 +4,6 @@ import { IndexingProgressUpdate } from "..";
 
 export type GlobalContextType = {
   indexingPaused: boolean;
-  //IndexingProgress: IndexingProgressUpdate;
 };
 
 /**

--- a/core/util/GlobalContext.ts
+++ b/core/util/GlobalContext.ts
@@ -1,8 +1,10 @@
 import fs from "node:fs";
 import { getGlobalContextFilePath } from "./paths";
+import { IndexingProgressUpdate } from "..";
 
 export type GlobalContextType = {
   indexingPaused: boolean;
+  IndexingProgress: IndexingProgressUpdate;
 };
 
 /**

--- a/core/util/GlobalContext.ts
+++ b/core/util/GlobalContext.ts
@@ -4,7 +4,7 @@ import { IndexingProgressUpdate } from "..";
 
 export type GlobalContextType = {
   indexingPaused: boolean;
-  IndexingProgress: IndexingProgressUpdate;
+  //IndexingProgress: IndexingProgressUpdate;
 };
 
 /**

--- a/extensions/vscode/scripts/prepackage.js
+++ b/extensions/vscode/scripts/prepackage.js
@@ -316,7 +316,7 @@ const exe = os === "win32" ? ".exe" : "";
     console.log(`Copying ${packageName} to ${toCopy}`);
     // This is a way to install only one package without npm trying to install all the dependencies
     // Create a temporary directory for installing the package
-    const adjustedName = packageName.replace(/^@/, "").replace("/", "-");
+    const adjustedName = toCopy.replace(/^@/, "").replace("/", "-");
 
     const tempDir = `/tmp/continue-node_modules-${adjustedName}`;
     const currentDir = process.cwd();

--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -14,11 +14,6 @@ export const vscodeExtensionPromise: Promise<VsCodeExtension> = new Promise(
   (resolve) => (resolveVsCodeExtension = resolve),
 );
 
-let resolveVsCodeExtension = (_: VsCodeExtension): void => {};
-export const vscodeExtensionPromise: Promise<VsCodeExtension> = new Promise(
-  (resolve) => (resolveVsCodeExtension = resolve),
-);
-
 export async function activateExtension(context: vscode.ExtensionContext) {
   // Add necessary files
   getTsConfigPath();

--- a/gui/src/components/Layout.tsx
+++ b/gui/src/components/Layout.tsx
@@ -169,6 +169,7 @@ const Layout = () => {
   );
 
   useWebviewListener("indexProgress", async (data) => {
+    console.log("indexingProgress from layout: ", data.status)
     setIndexingState(data);
   });
 
@@ -220,10 +221,12 @@ const Layout = () => {
     }
   }, [location]);
 
-  const [indexingState, setIndexingState] = useState<IndexingProgressUpdate>({
-    desc: "Indexing disabled",
+  //ToDO: I think this is initialization - if it is, this should be 'starting up'
+  // Actually, it should read whatever
+  const [indexingState, setIndexingState] = useState<IndexingProgressUpdate>({ 
+    desc: "Loading indexing config",
     progress: 0.0,
-    status: "disabled",
+    status: "loading",
   });
 
   return (

--- a/gui/src/components/Layout.tsx
+++ b/gui/src/components/Layout.tsx
@@ -221,8 +221,6 @@ const Layout = () => {
     }
   }, [location]);
 
-  //ToDO: I think this is initialization - if it is, this should be 'starting up'
-  // Actually, it should read whatever
   const [indexingState, setIndexingState] = useState<IndexingProgressUpdate>({ 
     desc: "Loading indexing config",
     progress: 0.0,

--- a/gui/src/components/Layout.tsx
+++ b/gui/src/components/Layout.tsx
@@ -169,7 +169,7 @@ const Layout = () => {
   );
 
   useWebviewListener("indexProgress", async (data) => {
-    console.log("indexingProgress from layout: ", data.status)
+    console.log("Setting indexing state to: ", data.status)
     setIndexingState(data);
   });
 

--- a/gui/src/components/Layout.tsx
+++ b/gui/src/components/Layout.tsx
@@ -169,7 +169,6 @@ const Layout = () => {
   );
 
   useWebviewListener("indexProgress", async (data) => {
-    console.log("Setting indexing state to: ", data.status)
     setIndexingState(data);
   });
 

--- a/gui/src/components/loaders/IndexingProgressBar.tsx
+++ b/gui/src/components/loaders/IndexingProgressBar.tsx
@@ -70,10 +70,10 @@ const IndexingProgressBar = ({ indexingState }: ProgressBarProps) => {
 
   let initialized = false
   useEffect(() => {
-    console.log("useEffect triggered")
     if (!initialized) {
+      console.log("useEffect triggered")
       // Retrieves possible non-default states set prior to IndexingProgressBar initialization
-      ideMessenger.post("index/indexingProgressBarInitialized", "")
+      ideMessenger.post("index/indexingProgressBarInitialized", undefined)
       initialized = true
     }
   }, []);

--- a/gui/src/components/loaders/IndexingProgressBar.tsx
+++ b/gui/src/components/loaders/IndexingProgressBar.tsx
@@ -5,7 +5,6 @@ import styled from "styled-components";
 import { StyledTooltip, lightGray, vscForeground } from "..";
 import { IdeMessengerContext } from "../../context/IdeMessenger";
 import { getFontSize } from "../../util";
-import { init } from "web-tree-sitter";
 
 const DIAMETER = 6;
 const CircleDiv = styled.div<{ color: string }>`
@@ -129,7 +128,7 @@ const IndexingProgressBar = ({ indexingState: indexingStateProp }: ProgressBarPr
           {tooltipPortalDiv &&
             ReactDOM.createPortal(
               <StyledTooltip id="indexingFailed_dot" place="top">
-                Error indexing codebase. {indexingState.desc}
+                Error indexing codebase: {indexingState.desc}
                 <br />
                 Click to retry
               </StyledTooltip>,

--- a/gui/src/components/loaders/IndexingProgressBar.tsx
+++ b/gui/src/components/loaders/IndexingProgressBar.tsx
@@ -5,6 +5,7 @@ import styled from "styled-components";
 import { StyledTooltip, lightGray, vscForeground } from "..";
 import { IdeMessengerContext } from "../../context/IdeMessenger";
 import { getFontSize } from "../../util";
+import { init } from "web-tree-sitter";
 
 const DIAMETER = 6;
 const CircleDiv = styled.div<{ color: string }>`
@@ -67,8 +68,14 @@ const IndexingProgressBar = ({ indexingState }: ProgressBarProps) => {
   const [paused, setPaused] = useState<boolean | undefined>(undefined);
   const [hovered, setHovered] = useState(false);
 
+  let initialized = false
   useEffect(() => {
-    ideMessenger.post("index/indexingProgressBarInitialized", {ready:true})
+    console.log("useEffect triggered")
+    if (!initialized) {
+      // Retrieves possible non-default states set prior to IndexingProgressBar initialization
+      ideMessenger.post("index/indexingProgressBarInitialized", "")
+      initialized = true
+    }
   }, []);
 
   useEffect(() => {
@@ -100,7 +107,7 @@ const IndexingProgressBar = ({ indexingState }: ProgressBarProps) => {
           {tooltipPortalDiv &&
             ReactDOM.createPortal(
               <StyledTooltip id="indexingNotLoaded_dot" place="top">
-                Reading indexing config
+                Continue is initializing
               </StyledTooltip>,
               tooltipPortalDiv,
             )}

--- a/gui/src/components/loaders/IndexingProgressBar.tsx
+++ b/gui/src/components/loaders/IndexingProgressBar.tsx
@@ -68,6 +68,10 @@ const IndexingProgressBar = ({ indexingState }: ProgressBarProps) => {
   const [hovered, setHovered] = useState(false);
 
   useEffect(() => {
+    ideMessenger.post("index/indexingProgressBarInitialized", {ready:true})
+  }, []);
+
+  useEffect(() => {
     if (paused === undefined) return;
     ideMessenger.post("index/setPaused", paused);
   }, [paused]);
@@ -87,7 +91,7 @@ const IndexingProgressBar = ({ indexingState }: ProgressBarProps) => {
       }}
       className="cursor-pointer"
     >
-      {indexingState.status === "starting" ? ( // ice-blue 'indexing starting up' dot
+      {indexingState.status === "loading" ? ( // ice-blue 'indexing loading up' dot
         <>
           <CircleDiv
             data-tooltip-id="indexingNotLoaded_dot"
@@ -96,7 +100,7 @@ const IndexingProgressBar = ({ indexingState }: ProgressBarProps) => {
           {tooltipPortalDiv &&
             ReactDOM.createPortal(
               <StyledTooltip id="indexingNotLoaded_dot" place="top">
-                Codebase indexing is starting up.
+                Reading indexing config
               </StyledTooltip>,
               tooltipPortalDiv,
             )}
@@ -110,7 +114,7 @@ const IndexingProgressBar = ({ indexingState }: ProgressBarProps) => {
           {tooltipPortalDiv &&
             ReactDOM.createPortal(
               <StyledTooltip id="indexingFailed_dot" place="top">
-                Error indexing codebase: {indexingState.desc}
+                Error indexing codebase. Check your config.json file.
                 <br />
                 Click to retry
               </StyledTooltip>,


### PR DESCRIPTION
## Description

Bugs targeted:
- When sidebar is opened until indexing completes, it opens as grey, yet indexing has actually occurred. Re-indexing button is not interactive in this case, so its a dead end for the user.
- When sidebar opened before backend is initialized, it loads in as disabled regardless of disabled/enabled settings, this is confusing for the user.


Changes:
- Rename the light blue state from 'starting up' to 'loading'. Purpose is to indicate that continue is loading, indexing has no status yet (has not started, may not start if disabled)
- Make light blue state default when app is loaded
- Provide a mechanism for loading a non-default state in cases where indexing has completed before the sidebar has been opened (otherwise, the default state will not be updated)
- Re-add yield failed state (it was removed at some point)
- Discovered a flaw in table creation logic (table creation is attempted despite table existing). Made a quick fix. Looking further into the logic is on to-do list


Testing:
- Open in each state before indexing complete
- Open in each state after indexing complete
