### PR TITLE
Add differentiation of drop down items

### DIFF
--- a/gui/src/components/mainInput/MentionList.tsx
+++ b/gui/src/components/mainInput/MentionList.tsx
@@ -339,7 +339,9 @@ const MentionList = forwardRef((props: MentionListProps, ref) => {
                         <DropdownIcon item={item} className="mr-2" />
                       </>
                     )}
-                    {item.title}
+                    <span title={item.id}> 
+                      {item.title}
+                    </span>
                     {"  "}
                   </div>
                   <span


### PR DESCRIPTION
## Description

Users can't differentiate between files with the same folder/filename. This MR adds a span over the title of the dropdown list that can be hovered over to display the full path.

https://github.com/continuedev/continue/assets/42585006/6529e0a2-2a88-477f-bf4f-2c59218c5bad

