### PR TITLE
Full project file path in context

### DIFF
--- a/core/context/providers/FileTreeContextProvider.ts
+++ b/core/context/providers/FileTreeContextProvider.ts
@@ -4,20 +4,12 @@ import {
   ContextProviderExtras,
 } from "../../index.js";
 import { BaseContextProvider } from "../index.js";
+import { splitPath } from "../../util/index.js";
 
 interface Directory {
   name: string;
   files: string[];
   directories: Directory[];
-}
-
-function splitPath(path: string, withRoot?: string): string[] {
-  let parts = path.includes("/") ? path.split("/") : path.split("\\");
-  if (withRoot !== undefined) {
-    const rootParts = splitPath(withRoot);
-    parts = parts.slice(rootParts.length - 1);
-  }
-  return parts;
 }
 
 function formatFileTree(tree: Directory, indentation = ""): string {

--- a/core/context/providers/OpenFilesContextProvider.ts
+++ b/core/context/providers/OpenFilesContextProvider.ts
@@ -3,7 +3,7 @@ import {
   ContextProviderDescription,
   ContextProviderExtras,
 } from "../../index.js";
-import { getBasename } from "../../util/index.js";
+import { getBasename, getRelativePath } from "../../util/index.js";
 import { BaseContextProvider } from "../index.js";
 
 class OpenFilesContextProvider extends BaseContextProvider {
@@ -26,7 +26,7 @@ class OpenFilesContextProvider extends BaseContextProvider {
       openFiles.map(async (filepath: string) => {
         return {
           description: filepath,
-          content: `\`\`\`${getBasename(filepath)}\n${await ide.readFile(
+          content: `\`\`\`${await getRelativePath(filepath, await extras.ide.getWorkspaceDirs())}\n${await ide.readFile(
             filepath,
           )}\n\`\`\``,
           name: (filepath.split("/").pop() ?? "").split("\\").pop() ?? "",

--- a/core/context/retrieval/retrieval.ts
+++ b/core/context/retrieval/retrieval.ts
@@ -6,7 +6,7 @@ import {
 } from "../../index.js";
 import { LanceDbIndex } from "../../indexing/LanceDbIndex.js";
 
-import { deduplicateArray, getBasename } from "../../util/index.js";
+import { deduplicateArray, getRelativePath } from "../../util/index.js";
 import { RETRIEVAL_PARAMS } from "../../util/parameters.js";
 import { retrieveFts } from "./fullTextSearch.js";
 
@@ -149,7 +149,7 @@ export async function retrieveContextItemsFromEmbeddings(
 
   return [
     ...results.map((r) => {
-      const name = `${getBasename(r.filepath)} (${r.startLine}-${r.endLine})`;
+      const name = `${getRelativePath(r.filepath, workspaceDirs)} (${r.startLine}-${r.endLine})`;
       const description = `${r.filepath} (${r.startLine}-${r.endLine})`;
       return {
         name,

--- a/core/util/index.ts
+++ b/core/util/index.ts
@@ -1,3 +1,7 @@
+import {
+    ContextProviderExtras,
+  } from "../index.js";
+
 export function removeQuotesAndEscapes(output: string): string {
   output = output.trim();
 
@@ -95,6 +99,26 @@ export function getBasename(filepath: string, n = 1): string {
 
 export function getLastNPathParts(filepath: string, n: number): string {
   return filepath.split(/[\\/]/).slice(-n).join("/");
+}
+
+export function getRelativePath(filepath: string, workspaceDirs: string[]): string {
+    for (const workspaceDir of workspaceDirs) {
+        const filepathParts = splitPath(filepath);
+        const workspaceDirParts = splitPath(workspaceDir);
+        if (filepathParts.slice(0, workspaceDirParts.length).join('/') === workspaceDirParts.join('/')) {
+            return filepathParts.slice(workspaceDirParts.length).join('/');
+        }
+    }
+    return splitPath(filepath).pop() ?? ''; // If the file is not in any of the workspaces, return the plain filename
+}
+
+export function splitPath(path: string, withRoot?: string): string[] {
+    let parts = path.includes("/") ? path.split("/") : path.split("\\");
+    if (withRoot !== undefined) {
+        const rootParts = splitPath(withRoot);
+        parts = parts.slice(rootParts.length - 1);
+    }
+    return parts;
 }
 
 export function getMarkdownLanguageTagForFile(filepath: string): string {

--- a/gui/src/components/mainInput/resolveInput.ts
+++ b/gui/src/components/mainInput/resolveInput.ts
@@ -7,7 +7,7 @@ import {
   RangeInFile,
 } from "core";
 import { stripImages } from "core/llm/countTokens";
-import { getBasename } from "core/util";
+import { getBasename, getRelativePath } from "core/util";
 import { IIdeMessenger } from "../../context/IdeMessenger";
 
 interface MentionAttrs {
@@ -96,8 +96,9 @@ async function resolveEditorContent(
     if (item.itemType === "file") {
       // This is a quick way to resolve @file references
       const basename = getBasename(item.id);
+      const relativeFilePath = getRelativePath(item.id, await ideMessenger.ide.getWorkspaceDirs());
       const rawContent = await ideMessenger.ide.readFile(item.id);
-      const content = `\`\`\`title="${basename}"\n${rawContent}\n\`\`\`\n`;
+      const content = `\`\`\`${relativeFilePath}\n${rawContent}\n\`\`\`\n`;
       contextItemsText += content;
       contextItems.push({
         name: basename,

--- a/gui/src/hooks/useChatHandler.ts
+++ b/gui/src/hooks/useChatHandler.ts
@@ -13,7 +13,7 @@ import {
 } from "core";
 import { constructMessages } from "core/llm/constructMessages";
 import { stripImages } from "core/llm/countTokens";
-import { getBasename } from "core/util";
+import { getBasename, getRelativePath } from "core/util";
 import { usePostHog } from "posthog-js/react";
 import { useEffect, useRef } from "react";
 import { useSelector } from "react-redux";
@@ -179,8 +179,9 @@ function useChatHandler(dispatch: Dispatch, ideMessenger: IIdeMessenger) {
               .join("\n");
           }
           contextItems.unshift({
-            content: `The following file is currently open. Don't reference it if it's not relevant to the user's message.\n\n\`\`\`${getBasename(
+            content: `The following file is currently open. Don't reference it if it's not relevant to the user's message.\n\n\`\`\`${getRelativePath(
               currentFilePath,
+              await ideMessenger.ide.getWorkspaceDirs(),
             )}\n${currentFileContents}\n\`\`\``,
             name: `Active file: ${getBasename(currentFilePath)}`,
             description: currentFilePath,


### PR DESCRIPTION
## Description

For many types of projects (like index.ts in react/next.js) there's many files with the same file name that live in a different path in the project. Since continue was previously only giving the filename without the path to the LLM, the LLM wouldn't always understand correctly which file is including which.

This MR gives the full file path from the workspace root to the LLM, for:
- @Open Files
- @Files (named files added by hand to the context)
- The 'use active file' (alt-return) context

For example:

Before:
```
"'''test.js
<...>
'''

'''helloNested.py
<...>
'''

What files do you see? Open Files "
```

After:
```
"'''manual-testing-sandbox/test.js
<...>
'''

'''manual-testing-sandbox/nested-folder/helloNested.py
<...>
'''

What files do you see? Open Files "
```


## Checklist

- [🦄] The base branch of this PR is `preview`, rather than `main`
