### PR TITLE
[CON-244] Ability to change session title in history page

### DIFF
--- a/core/util/history.ts
+++ b/core/util/history.ts
@@ -102,7 +102,6 @@ class HistoryManager {
         if (sessionInfo.sessionId === session.sessionId) {
           sessionInfo.title = session.title;
           sessionInfo.workspaceDirectory = session.workspaceDirectory;
-          sessionInfo.dateCreated = String(Date.now());
           found = true;
           break;
         }

--- a/gui/src/hooks/useHistory.tsx
+++ b/gui/src/hooks/useHistory.tsx
@@ -40,13 +40,16 @@ function useHistory(dispatch: Dispatch) {
     dispatch(newSession());
     await new Promise((resolve) => setTimeout(resolve, 10));
 
-    let title = truncateText(
-      stripImages(stateCopy.history[0].message.content)
-        .split("\n")
-        .filter((l) => l.trim() !== "")
-        .slice(-1)[0] || "",
-      50,
-    );
+    let title =
+      stateCopy.title === "New Session"
+        ? truncateText(
+            stripImages(stateCopy.history[0].message.content)
+              .split("\n")
+              .filter((l) => l.trim() !== "")
+              .slice(-1)[0] || "",
+            50,
+          )
+        : (await getSession(stateCopy.sessionId)).title; // to ensure titles are synced with updates from history page.
 
     if (
       false && // Causing maxTokens to be set to 20 for main requests sometimes, so disabling until resolved


### PR DESCRIPTION
## Description

- Adds ability to change session title under history by clicking edit icon alongside the delete button.
- Fixes issue with updating existing session touching createdAt timestamp
- Fixes recalculating title when switching between sessions.

Closes #1426
Related #479 

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
