### PR TITLE
fix: update streamResponse function to fix broken characters

### DIFF
--- a/core/llm/stream.ts
+++ b/core/llm/stream.ts
@@ -14,7 +14,7 @@ export async function* streamResponse(
   const decoder = new TextDecoder("utf-8");
 
   for await (const chunk of stream) {
-    yield decoder.decode(chunk);
+    yield decoder.decode(chunk, { stream: true, });
   }
 }
 


### PR DESCRIPTION
## Description

In the Gemini API, UTF-8 multibyte characters may be broken.
This is because the Gemini API stream response may break chunks in the middle of a character.
The broken character is converted to a Replacement Charactor (U+FFFD) and displayed as shown in the attached image.
This is most noticeable in Japanese, Chinese, and Korean, but can also occur in other multibyte languages.

![image](https://github.com/continuedev/continue/assets/1710774/aa711678-4bba-4a69-9deb-77b472d19a82)

This can be fixed by adding the { stream: true } option to TextDecoder.decode().
A similar fix has recently been made for LangChain, see also
https://github.com/langchain-ai/langchainjs/issues/5285

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
