### PR TITLE
Enable Gemini system message use

### DIFF
--- a/core/llm/llms/Gemini.ts
+++ b/core/llm/llms/Gemini.ts
@@ -47,7 +47,15 @@ class Gemini extends BaseLLM {
     messages: ChatMessage[],
     options: CompletionOptions,
   ): AsyncGenerator<ChatMessage> {
-    const convertedMsgs = this.removeSystemMessage(messages);
+    // Ensure this.apiBase is used if available, otherwise use default
+    const apiBase = this.apiBase || Gemini.defaultOptions?.apiBase || "https://generativelanguage.googleapis.com/v1beta/";    // Determine if it's a v1 API call based on apiBase
+    const isV1API = apiBase.includes("/v1/");
+
+    // Conditionally apply removeSystemMessage
+    const convertedMsgs = isV1API
+      ? this.removeSystemMessage(messages)
+      : messages;
+
     if (options.model.includes("gemini")) {
       for await (const message of this.streamChatGemini(
         convertedMsgs,


### PR DESCRIPTION
Older versions of the Google API apparently didn't 
support passing a "system" parameter so a shim 
was used here to convert such a parameter into the
first user message instead. This is no longer
necessary as of the v1beta API, so this change
makes sure the shim is only applied if the user
has specified API version v1. I should also note
that there may still be a bug with this method if
using v1; the reason I found this is I was
experiencing a bug where the message ultimately
being sent after applying the shim was [Object]
[object] or something like that. I fixed it this
way because the system message shouldn't be
removed with v1beta (and presumably later
versions)

## Description

[ What changed? Feel free to be brief. ]

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
