### PR TITLE
[VSCode] Pause completion on battery (configurable)

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -71,6 +71,11 @@
           "default": true,
           "markdownDescription": "Enable Continue's tab autocomplete feature. Read our walkthrough to learn about configuration and how to share feedback: [continue.dev › Walkthrough: Tab Autocomplete](https://docs.continue.dev/walkthroughs/tab-autocomplete)"
         },
+        "continue.pauseTabAutocompleteOnBattery": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Pause the Continue's tab autocomplete feature, when you device is on battery."
+        },
         "continue.remoteConfigServerUrl": {
           "type": "string",
           "default": null,
@@ -548,6 +553,7 @@
     "request": "^2.88.2",
     "socket.io-client": "^4.7.2",
     "strip-ansi": "^7.1.0",
+    "systeminformation": "^5.22.10",
     "tailwindcss": "^3.3.2",
     "undici": "^6.2.0",
     "uuid": "^9.0.1",

--- a/extensions/vscode/src/autocomplete/completionProvider.ts
+++ b/extensions/vscode/src/autocomplete/completionProvider.ts
@@ -10,7 +10,7 @@ import * as vscode from "vscode";
 import type { TabAutocompleteModel } from "../util/loadAutocompleteModel";
 import { getDefinitionsFromLsp } from "./lsp";
 import { RecentlyEditedTracker } from "./recentlyEdited";
-import { setupStatusBar, stopStatusBarLoading } from "./statusBar";
+import { StatusBarStatus, setupStatusBar, stopStatusBarLoading, getStatusBarStatus } from "./statusBar";
 
 interface VsCodeCompletionInput {
   document: vscode.TextDocument;
@@ -73,10 +73,7 @@ export class ContinueCompletionProvider
     token: vscode.CancellationToken,
     //@ts-ignore
   ): ProviderResult<InlineCompletionItem[] | InlineCompletionList> {
-    const enableTabAutocomplete =
-      vscode.workspace
-        .getConfiguration("continue")
-        .get<boolean>("enableTabAutocomplete") || false;
+    const enableTabAutocomplete = getStatusBarStatus() === StatusBarStatus.Enabled;
     if (token.isCancellationRequested || !enableTabAutocomplete) {
       return null;
     }
@@ -195,7 +192,7 @@ export class ContinueCompletionProvider
         injectDetails,
       };
 
-      setupStatusBar(true, true);
+      setupStatusBar(undefined, true);
       const outcome =
         await this.completionProvider.provideInlineCompletionItems(
           input,

--- a/extensions/vscode/src/autocomplete/statusBar.ts
+++ b/extensions/vscode/src/autocomplete/statusBar.ts
@@ -1,22 +1,48 @@
 import * as vscode from "vscode";
+import { Battery } from "../util/battery";
 
-const statusBarItemText = (enabled: boolean | undefined) =>
-  enabled ? "$(check) Continue" : "$(circle-slash) Continue";
+export enum StatusBarStatus {
+  Disabled,
+  Enabled,
+  Paused,
+};
 
-const statusBarItemTooltip = (enabled: boolean | undefined) =>
-  enabled ? "Tab autocomplete is enabled" : "Click to enable tab autocomplete";
+const statusBarItemText = (status: StatusBarStatus | undefined) => {
+  switch (status) {
+    case undefined:
+    case StatusBarStatus.Disabled:
+      return "$(circle-slash) Continue";
+    case StatusBarStatus.Enabled:
+      return "$(check) Continue";
+    case StatusBarStatus.Paused:
+      return "$(debug-pause) Continue";
+  }
+}
 
+const statusBarItemTooltip = (status: StatusBarStatus | undefined) => {
+  switch (status) {
+    case undefined:
+    case StatusBarStatus.Disabled:
+      return "Click to enable tab autocomplete";
+    case StatusBarStatus.Enabled:
+      return "Tab autocomplete is enabled";
+    case StatusBarStatus.Paused:
+      return "Tab autocomplete is paused";
+  }
+}
+
+let statusBarStatus: StatusBarStatus | undefined = undefined;
 let statusBarItem: vscode.StatusBarItem | undefined = undefined;
 let statusBarFalseTimeout: NodeJS.Timeout | undefined = undefined;
 
 export function stopStatusBarLoading() {
   statusBarFalseTimeout = setTimeout(() => {
-    setupStatusBar(true, false);
+    setupStatusBar(StatusBarStatus.Enabled, false);
   }, 100);
 }
 
 export function setupStatusBar(
-  enabled: boolean | undefined,
+  status: StatusBarStatus | undefined,
   loading?: boolean,
 ) {
   if (loading !== false) {
@@ -33,17 +59,35 @@ export function setupStatusBar(
 
   statusBarItem.text = loading
     ? "$(loading~spin) Continue"
-    : statusBarItemText(enabled);
-  statusBarItem.tooltip = statusBarItemTooltip(enabled);
+    : statusBarItemText(status);
+  statusBarItem.tooltip = statusBarItemTooltip(status ?? statusBarStatus);
   statusBarItem.command = "continue.toggleTabAutocompleteEnabled";
 
   statusBarItem.show();
+  if (status !== undefined)
+    statusBarStatus = status;
 
   vscode.workspace.onDidChangeConfiguration((event) => {
     if (event.affectsConfiguration("continue")) {
       const config = vscode.workspace.getConfiguration("continue");
       const enabled = config.get<boolean>("enableTabAutocomplete");
-      setupStatusBar(enabled);
+      if (enabled && statusBarStatus === StatusBarStatus.Paused) return;
+      setupStatusBar(enabled ? StatusBarStatus.Enabled : StatusBarStatus.Disabled);
+    }
+  });
+}
+
+export function getStatusBarStatus(): StatusBarStatus | undefined {
+  return statusBarStatus;
+}
+
+export function monitorBatteryChanges(battery: Battery): vscode.Disposable {
+  return battery.onChangeAC((acConnected: boolean) => {
+    const config = vscode.workspace.getConfiguration("continue");
+    const enabled = config.get<boolean>("enableTabAutocomplete");
+    if (!!enabled) {
+      const pauseOnBattery = config.get<boolean>("pauseTabAutocompleteOnBattery");
+      setupStatusBar(acConnected || !pauseOnBattery ? StatusBarStatus.Enabled : StatusBarStatus.Paused);
     }
   });
 }

--- a/extensions/vscode/src/util/battery.ts
+++ b/extensions/vscode/src/util/battery.ts
@@ -1,0 +1,49 @@
+import { Disposable, EventEmitter } from "vscode";
+import * as si from "systeminformation";
+
+const UPDATE_INTERVAL_MS = 1000;
+
+export class Battery implements Disposable {
+    private updateTimeout: NodeJS.Timeout | undefined;
+    private readonly onChangeACEmitter = new EventEmitter<boolean>();
+    private readonly onChangeLevelEmitter = new EventEmitter<number>();
+    private acConnected: boolean = true;
+    private level = 100;
+
+    constructor() {
+        this.updateTimeout = setInterval(() => this.update(), UPDATE_INTERVAL_MS);
+    }
+
+    dispose() {
+        if (this.updateTimeout) {
+            clearInterval(this.updateTimeout);
+        }
+    }
+
+    private async update() {
+        const stats = await si.battery();
+        const isACConnected = !stats.hasBattery || stats.acConnected;
+        const level = stats.hasBattery ? stats.percent : 100;
+
+        if (isACConnected !== this.acConnected) {
+            this.acConnected = isACConnected;
+            this.onChangeACEmitter.fire(isACConnected);
+        }
+
+        if (level !== this.level) {
+            this.level = level;
+            this.onChangeLevelEmitter.fire(level);
+        }
+    }
+
+    public getLevel(): number {
+        return this.level;
+    }
+
+    public isACConnected(): boolean {
+        return this.acConnected;
+    }
+
+    public readonly onChangeLevel = this.onChangeLevelEmitter.event;
+    public readonly onChangeAC = this.onChangeACEmitter.event;
+}

--- a/extensions/vscode/src/util/battery.ts
+++ b/extensions/vscode/src/util/battery.ts
@@ -22,8 +22,8 @@ export class Battery implements Disposable {
 
     private async update() {
         const stats = await si.battery();
-        const isACConnected = !stats.hasBattery || stats.acConnected;
         const level = stats.hasBattery ? stats.percent : 100;
+        const isACConnected = !stats.hasBattery || stats.acConnected || level == 100;
 
         if (isACConnected !== this.acConnected) {
             this.acConnected = isACConnected;


### PR DESCRIPTION
## Description

![image](https://github.com/continuedev/continue/assets/12231048/56279b3b-c2ab-47c7-bb4c-9fc35b92425d)
![image](https://github.com/continuedev/continue/assets/12231048/e11b47ab-d804-4bd2-9624-85cd4db48d49)

This PR adds setting to pause tab autocompletion, when disconnected AC. This pause can be disabled by clicking on statusbar icon or trigger `Toggle Autocomplete Enabled` command.

When laptop on battery clicking on status bar switching status in cycle `Disabled->Pause->Enabled`

This setting is disabled by default!

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
