### PR TITLE
fix: change broken path for node sqlite

### DIFF
--- a/binary/build.js
+++ b/binary/build.js
@@ -228,7 +228,7 @@ async function installNodeModuleInTempDirAndCopyToCurrent(packageName, toCopy) {
     if (platform === currentPlatform && arch === currentArch) {
       fs.copyFileSync(
         `${targetDir}/node_sqlite3.node`,
-        `build/node_sqlite3.node`,
+        `${targetDir}/build/node_sqlite3.node`,
       );
     }
 


### PR DESCRIPTION
## Description

- While installing dependencies, VSCode says `ENOENT: no such file or directory, copyfile 'bin/darwin-x64/node_sqlite3.node' -> 'build/node_sqlite3.node`, this happens because build folder is not inside `binary`, it's inside `targetDir` path.

Fixes [#1428](https://github.com/continuedev/continue/issues/1428)

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
