### PR TITLE
fix(core): remove eslint config and fix errors

### DIFF
--- a/core/.eslintrc.json
+++ b/core/.eslintrc.json
@@ -5,20 +5,10 @@
     "ecmaVersion": 6,
     "sourceType": "module"
   },
-  "extends": ["plugin:require-extensions/recommended"],
-  "plugins": ["@typescript-eslint", "import", "require-extensions"],
+  "plugins": ["@typescript-eslint", "import"],
   "rules": {
     "quotes": ["warn", "double", {}],
-    "import/extensions": [
-      "error",
-      "always",
-      {
-        "js": "never",
-        "jsx": "never",
-        "ts": "never",
-        "tsx": "never"
-      }
-    ],
+    "import/extensions": ["error", "ignorePackages"],
     "@typescript-eslint/naming-convention": "warn",
     "@typescript-eslint/semi": "warn",
     "curly": "warn",

--- a/core/autocomplete/languages.ts
+++ b/core/autocomplete/languages.ts
@@ -1,4 +1,4 @@
-import { LineFilter } from "./lineStream";
+import type { LineFilter } from "./lineStream";
 
 export interface AutocompleteLanguageInfo {
   topLevelKeywords: string[];

--- a/core/autocomplete/postprocessing.ts
+++ b/core/autocomplete/postprocessing.ts
@@ -1,4 +1,4 @@
-import { ILLM } from "..";
+import type { ILLM } from "..";
 
 export function postprocessCompletion({
   completion,

--- a/core/config/promptFile.ts
+++ b/core/config/promptFile.ts
@@ -1,8 +1,8 @@
+import type { IDE, SlashCommand } from "..";
 import * as YAML from "yaml";
-import { IDE, SlashCommand } from "..";
-import { stripImages } from "../llm/countTokens";
-import { renderTemplatedString } from "../llm/llms";
-import { getBasename } from "../util";
+import { stripImages } from "../llm/countTokens.js";
+import { renderTemplatedString } from "../llm/llms/index.js";
+import { getBasename } from "../util/index.js";
 
 export async function getPromptFiles(
   ide: IDE,

--- a/core/context/providers/DocsContextProvider.ts
+++ b/core/context/providers/DocsContextProvider.ts
@@ -30,7 +30,7 @@ class DocsContextProvider extends BaseContextProvider {
       );
     }
 
-    const { retrieveDocs } = await import("../../indexing/docs/db");
+    const { retrieveDocs } = await import("../../indexing/docs/db.js");
     const embeddingsProvider = new TransformersJsEmbeddingsProvider();
     const [vector] = await embeddingsProvider.embed([extras.fullInput]);
 
@@ -88,7 +88,7 @@ class DocsContextProvider extends BaseContextProvider {
   async loadSubmenuItems(
     args: LoadSubmenuItemsArgs,
   ): Promise<ContextSubmenuItem[]> {
-    const { listDocs } = await import("../../indexing/docs/db");
+    const { listDocs } = await import("../../indexing/docs/db.js");
     const docs = await listDocs();
     const submenuItems = docs.map((doc) => ({
       title: doc.title,

--- a/core/context/providers/FolderContextProvider.ts
+++ b/core/context/providers/FolderContextProvider.ts
@@ -21,7 +21,7 @@ class FolderContextProvider extends BaseContextProvider {
     extras: ContextProviderExtras,
   ): Promise<ContextItem[]> {
     const { retrieveContextItemsFromEmbeddings } = await import(
-      "../retrieval/retrieval"
+      "../retrieval/retrieval.js"
     );
     return retrieveContextItemsFromEmbeddings(extras, this.options, query);
   }

--- a/core/core.ts
+++ b/core/core.ts
@@ -1,35 +1,35 @@
-import { v4 as uuidv4 } from "uuid";
-import {
+import type {
   ContextItemId,
   IDE,
   IndexingProgressUpdate,
   SiteIndexingConfig,
 } from ".";
-import { CompletionProvider } from "./autocomplete/completionProvider";
-import { ConfigHandler } from "./config/handler";
+import type { FromCoreProtocol, ToCoreProtocol } from "./protocol";
+import type { IMessenger, Message } from "./util/messenger";
+import { v4 as uuidv4 } from "uuid";
+import { CompletionProvider } from "./autocomplete/completionProvider.js";
+import { ConfigHandler } from "./config/handler.js";
 import {
   setupApiKeysMode,
   setupFreeTrialMode,
   setupLocalAfterFreeTrial,
   setupLocalMode,
   setupOptimizedExistingUserMode,
-} from "./config/onboarding";
-import { addModel, addOpenAIKey, deleteModel } from "./config/util";
-import { ContinueServerClient } from "./continueServer/stubs/client";
-import { indexDocs } from "./indexing/docs";
-import TransformersJsEmbeddingsProvider from "./indexing/embeddings/TransformersJsEmbeddingsProvider";
-import { CodebaseIndexer, PauseToken } from "./indexing/indexCodebase";
-import Ollama from "./llm/llms/Ollama";
-import { FromCoreProtocol, ToCoreProtocol } from "./protocol";
-import { GlobalContext } from "./util/GlobalContext";
-import { logDevData } from "./util/devdata";
-import { DevDataSqliteDb } from "./util/devdataSqlite";
-import { fetchwithRequestOptions } from "./util/fetchWithOptions";
-import historyManager from "./util/history";
-import type { IMessenger, Message } from "./util/messenger";
-import { editConfigJson, getConfigJsonPath } from "./util/paths";
-import { Telemetry } from "./util/posthog";
-import { streamDiffLines } from "./util/verticalEdit";
+} from "./config/onboarding.js";
+import { addModel, addOpenAIKey, deleteModel } from "./config/util.js";
+import { ContinueServerClient } from "./continueServer/stubs/client.js";
+import { indexDocs } from "./indexing/docs/index.js";
+import TransformersJsEmbeddingsProvider from "./indexing/embeddings/TransformersJsEmbeddingsProvider.js";
+import { CodebaseIndexer, PauseToken } from "./indexing/indexCodebase.js";
+import Ollama from "./llm/llms/Ollama.js";
+import { GlobalContext } from "./util/GlobalContext.js";
+import { logDevData } from "./util/devdata.js";
+import { DevDataSqliteDb } from "./util/devdataSqlite.js";
+import { fetchwithRequestOptions } from "./util/fetchWithOptions.js";
+import historyManager from "./util/history.js";
+import { editConfigJson, getConfigJsonPath } from "./util/paths.js";
+import { Telemetry } from "./util/posthog.js";
+import { streamDiffLines } from "./util/verticalEdit.js";
 
 export class Core {
   // implements IMessenger<ToCoreProtocol, FromCoreProtocol>
@@ -251,7 +251,9 @@ export class Core {
       const provider = config.contextProviders?.find(
         (provider) => provider.description.title === name,
       );
-      if (!provider) return [];
+      if (!provider) {
+        return [];
+      }
 
       try {
         const id: ContextItemId = {
@@ -496,12 +498,12 @@ export class Core {
         mode === "local"
           ? setupLocalMode
           : mode === "freeTrial"
-            ? setupFreeTrialMode
-            : mode === "localAfterFreeTrial"
-              ? setupLocalAfterFreeTrial
-              : mode === "apiKeys"
-                ? setupApiKeysMode
-                : setupOptimizedExistingUserMode,
+          ? setupFreeTrialMode
+          : mode === "localAfterFreeTrial"
+          ? setupLocalAfterFreeTrial
+          : mode === "apiKeys"
+          ? setupApiKeysMode
+          : setupOptimizedExistingUserMode,
       );
       this.configHandler.reloadConfig();
     });

--- a/core/llm/llms/index.ts
+++ b/core/llm/llms/index.ts
@@ -29,7 +29,7 @@ import Replicate from "./Replicate.js";
 import TextGenWebUI from "./TextGenWebUI.js";
 import Together from "./Together.js";
 import ContinueProxy from "./stubs/ContinueProxy.js";
-import Cloudflare from "./Cloudflare";
+import Cloudflare from "./Cloudflare.js";
 
 function convertToLetter(num: number): string {
   let result = "";

--- a/core/llm/llms/stubs/ContinueProxy.ts
+++ b/core/llm/llms/stubs/ContinueProxy.ts
@@ -1,5 +1,5 @@
-import { LLMOptions, ModelProvider } from "../../..";
-import OpenAI from "../OpenAI";
+import type { LLMOptions, ModelProvider } from "../../..";
+import OpenAI from "../OpenAI.js";
 
 class ContinueProxy extends OpenAI {
   static providerName: ModelProvider = "continue-proxy";

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -64,7 +64,6 @@
         "esbuild": "0.17.19",
         "eslint": "^8",
         "eslint-plugin-import": "^2.29.1",
-        "eslint-plugin-require-extensions": "^0.1.3",
         "jest": "^29.7.0",
         "onnxruntime-common": "1.14.0",
         "onnxruntime-web": "1.14.0",
@@ -7164,18 +7163,6 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/eslint-plugin-require-extensions": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-require-extensions/-/eslint-plugin-require-extensions-0.1.3.tgz",
-      "integrity": "sha512-T3c1PZ9PIdI3hjV8LdunfYI8gj017UQjzAnCrxuo3wAjneDbTPHdE3oNWInOjMA+z/aBkUtlW5vC0YepYMZIug==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "eslint": "*"
       }
     },
     "node_modules/eslint-scope": {

--- a/core/package.json
+++ b/core/package.json
@@ -23,7 +23,6 @@
     "esbuild": "0.17.19",
     "eslint": "^8",
     "eslint-plugin-import": "^2.29.1",
-    "eslint-plugin-require-extensions": "^0.1.3",
     "jest": "^29.7.0",
     "onnxruntime-common": "1.14.0",
     "onnxruntime-web": "1.14.0",

--- a/core/protocol/core.ts
+++ b/core/protocol/core.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   BrowserSerializedContinueConfig,
   ChatMessage,
   ContextItemWithId,
@@ -13,8 +13,8 @@ import {
   SessionInfo,
   SiteIndexingConfig,
 } from "..";
-import { AutocompleteInput } from "../autocomplete/completionProvider";
-import { IdeSettings } from "./ideWebview";
+import type { AutocompleteInput } from "../autocomplete/completionProvider";
+import type { IdeSettings } from "./ideWebview";
 
 export type ProtocolGeneratorType<T> = AsyncGenerator<{
   done?: boolean;

--- a/core/protocol/coreWebview.ts
+++ b/core/protocol/coreWebview.ts
@@ -1,5 +1,5 @@
-import { ToCoreFromIdeOrWebviewProtocol } from "./core";
-import { ToWebviewFromIdeOrCoreProtocol } from "./webview";
+import { ToCoreFromIdeOrWebviewProtocol } from "./core.js";
+import { ToWebviewFromIdeOrCoreProtocol } from "./webview.js";
 
 export type ToCoreFromWebviewProtocol = ToCoreFromIdeOrWebviewProtocol;
 export type ToWebviewFromCoreProtocol = ToWebviewFromIdeOrCoreProtocol;

--- a/core/protocol/ide.ts
+++ b/core/protocol/ide.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ContinueRcJson,
   DiffLine,
   FileType,
@@ -8,7 +8,7 @@ import {
   Range,
   Thread,
 } from "..";
-import { IdeSettings } from "./ideWebview";
+import type { IdeSettings } from "./ideWebview";
 
 export type ToIdeFromWebviewOrCoreProtocol = {
   // Methods from IDE type

--- a/core/protocol/ideCore.ts
+++ b/core/protocol/ideCore.ts
@@ -1,5 +1,5 @@
-import { ToCoreFromIdeOrWebviewProtocol } from "./core";
-import { ToIdeFromWebviewOrCoreProtocol } from "./ide";
+import { ToCoreFromIdeOrWebviewProtocol } from "./core.js";
+import { ToIdeFromWebviewOrCoreProtocol } from "./ide.js";
 
 export type ToIdeFromCoreProtocol = ToIdeFromWebviewOrCoreProtocol;
 export type ToCoreFromIdeProtocol = ToCoreFromIdeOrWebviewProtocol;

--- a/core/protocol/ideWebview.ts
+++ b/core/protocol/ideWebview.ts
@@ -1,7 +1,7 @@
 import type { ContextItemWithId, ContextSubmenuItem } from "..";
 import type { RangeInFileWithContents } from "../commands/util";
-import { ToIdeFromWebviewOrCoreProtocol } from "./ide";
-import { ToWebviewFromIdeOrCoreProtocol } from "./webview";
+import { ToIdeFromWebviewOrCoreProtocol } from "./ide.js";
+import { ToWebviewFromIdeOrCoreProtocol } from "./webview.js";
 
 export interface IdeSettings {
   remoteConfigServerUrl: string | undefined;

--- a/core/protocol/index.ts
+++ b/core/protocol/index.ts
@@ -1,12 +1,12 @@
 import {
   ToCoreFromWebviewProtocol,
   ToWebviewFromCoreProtocol,
-} from "./coreWebview";
-import { ToCoreFromIdeProtocol, ToIdeFromCoreProtocol } from "./ideCore";
+} from "./coreWebview.js";
+import { ToCoreFromIdeProtocol, ToIdeFromCoreProtocol } from "./ideCore.js";
 import {
   ToIdeFromWebviewProtocol,
   ToWebviewFromIdeProtocol,
-} from "./ideWebview";
+} from "./ideWebview.js";
 
 export type IProtocol = Record<string, [any, any]>;
 

--- a/core/protocol/passThrough.ts
+++ b/core/protocol/passThrough.ts
@@ -1,7 +1,7 @@
 import {
   ToCoreFromWebviewProtocol,
   ToWebviewFromCoreProtocol,
-} from "./coreWebview";
+} from "./coreWebview.js";
 
 // Message types to pass through from webview to core
 export const WEBVIEW_TO_CORE_PASS_THROUGH: (keyof ToCoreFromWebviewProtocol)[] =

--- a/core/protocol/webview.ts
+++ b/core/protocol/webview.ts
@@ -1,4 +1,4 @@
-import { IndexingProgressUpdate } from "..";
+import type { IndexingProgressUpdate } from "..";
 
 export type ToWebviewFromIdeOrCoreProtocol = {
   configUpdate: [undefined, void];

--- a/core/util/GlobalContext.ts
+++ b/core/util/GlobalContext.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs";
-import { getGlobalContextFilePath } from "./paths";
-import { IndexingProgressUpdate } from "..";
+import { getGlobalContextFilePath } from "./paths.js";
 
 export type GlobalContextType = {
   indexingPaused: boolean;


### PR DESCRIPTION
closes #1455 

## Description

Implements changes outlined in #1455 

- Updates `import/extensions` and removes `eslint-plugin-require-extensions` from `core/package.json`
- Fixes existing linting issues in `core`

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`

## Testing

1. Run the following command to verify that all `import/extensions` errors in `core` have been resolved. It should output zero.
```bash
npm run lint | grep -c "import/extensions"
```

2. Run the following command to verify the build is still compiling successfully:
```bash
npm run build:npm
```
