### PR TITLE
Feat/improve gemini api calling

### DIFF
--- a/core/llm/llms/Gemini.ts
+++ b/core/llm/llms/Gemini.ts
@@ -17,6 +17,30 @@ class Gemini extends BaseLLM {
     apiBase: "https://generativelanguage.googleapis.com/v1beta/",
   };
 
+  // Function to convert completion options to Gemini format
+  private _convertArgs(options: CompletionOptions) {
+    const finalOptions: any = {}; // Initialize an empty object
+
+    // Map known options
+    if (options.topK) {
+      finalOptions.topK = options.topK;
+    }
+    if (options.topP) {
+      finalOptions.topP = options.topP;
+    }
+    if (options.temperature !== undefined && options.temperature !== null) {
+      finalOptions.temperature = options.temperature;
+    }
+    if (options.maxTokens) {
+      finalOptions.maxOutputTokens = options.maxTokens;
+    }
+    if (options.stop) {
+      finalOptions.stopSequences = options.stop.filter((x) => x.trim() !== "");
+    }
+
+    return { generationConfig: finalOptions }; // Wrap options under 'generationConfig'
+  }
+
   protected async *_streamComplete(
     prompt: string,
     options: CompletionOptions,
@@ -121,6 +145,7 @@ class Gemini extends BaseLLM {
       .filter((c) => c !== null);
 
     const body = {
+      ...this._convertArgs(options),
       contents,
       // if this.systemMessage is defined, reformat it for Gemini API
       ...(this.systemMessage &&

--- a/core/llm/llms/Gemini.ts
+++ b/core/llm/llms/Gemini.ts
@@ -123,9 +123,10 @@ class Gemini extends BaseLLM {
     const body = {
       contents,
       // if this.systemMessage is defined, reformat it for Gemini API
-      ...(this.systemMessage && isV1API && {
-        systemInstruction: { parts: [{ text: this.systemMessage }] },
-      }),
+      ...(this.systemMessage &&
+        !isV1API && {
+          systemInstruction: { parts: [{ text: this.systemMessage }] },
+        }),
     };
     const response = await this.fetch(apiURL, {
       method: "POST",


### PR DESCRIPTION
## Description

Continue completionOptions are converted to Gemini GenerationConfig object and passed in request
systemMessage is converted to a Gemini systemInstruction Content object

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`

## Additional notes

Gemini provides a few other configuration options that aren't included here. For now, the goal is just to make sure some standard completion options users might specify (e.g., temperature, topK, etc.) get passed correctly

resolves https://github.com/continuedev/continue/issues/1468