### PR TITLE
Jupiter is not the 9th planet

### DIFF
--- a/core/autocomplete/templates.ts
+++ b/core/autocomplete/templates.ts
@@ -242,7 +242,7 @@ The 5th {{FILL_HERE}} is Jupiter.
 
 ## CORRECT COMPLETION:
 
-<COMPLETION>the 5th planet after Mars</COMPLETION>
+<COMPLETION>planet from the Sun</COMPLETION>
 
 ## EXAMPLE QUERY:
 


### PR DESCRIPTION
If the reference to "after Mars," is
desired for some reason, punctuation should
probably be added for clarity. E.g., "planet,
after Mars,", or "planet, following Mars,". Note
also that because this is a FIM example and "the
5th" is part of the sentence to be filled, it
shouldn't be included as part of the completion.

## Description

Fixed a FIM example

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
