### PR TITLE
Bedrock client refactoring and move to @aws-sdk/credential-providers

### DIFF
--- a/binary/package-lock.json
+++ b/binary/package-lock.json
@@ -42,6 +42,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.574.0",
+        "@aws-sdk/credential-providers": "^3.596.0",
         "@mozilla/readability": "^0.5.0",
         "@octokit/rest": "^20.0.2",
         "@types/jsdom": "^21.1.6",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.574.0",
+        "@aws-sdk/credential-providers": "^3.596.0",
         "@mozilla/readability": "^0.5.0",
         "@octokit/rest": "^20.0.2",
         "@types/jsdom": "^21.1.6",
@@ -277,6 +278,591 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-cognito-identity": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.598.0.tgz",
+      "integrity": "sha512-N/1lnkhkzk1Il8WEZBWR713/7sDEqBtl/1AS6dfgw6Zh7NWUYSwBkZx6xdN8KogDu4CFExRHhilNOgI1JMug3w==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.598.0",
+        "@aws-sdk/client-sts": "3.598.0",
+        "@aws-sdk/core": "3.598.0",
+        "@aws-sdk/credential-provider-node": "3.598.0",
+        "@aws-sdk/middleware-host-header": "3.598.0",
+        "@aws-sdk/middleware-logger": "3.598.0",
+        "@aws-sdk/middleware-recursion-detection": "3.598.0",
+        "@aws-sdk/middleware-user-agent": "3.598.0",
+        "@aws-sdk/region-config-resolver": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-endpoints": "3.598.0",
+        "@aws-sdk/util-user-agent-browser": "3.598.0",
+        "@aws-sdk/util-user-agent-node": "3.598.0",
+        "@smithy/config-resolver": "^3.0.2",
+        "@smithy/core": "^2.2.1",
+        "@smithy/fetch-http-handler": "^3.0.2",
+        "@smithy/hash-node": "^3.0.1",
+        "@smithy/invalid-dependency": "^3.0.1",
+        "@smithy/middleware-content-length": "^3.0.1",
+        "@smithy/middleware-endpoint": "^3.0.2",
+        "@smithy/middleware-retry": "^3.0.4",
+        "@smithy/middleware-serde": "^3.0.1",
+        "@smithy/middleware-stack": "^3.0.1",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/node-http-handler": "^3.0.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/url-parser": "^3.0.1",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.4",
+        "@smithy/util-defaults-mode-node": "^3.0.4",
+        "@smithy/util-endpoints": "^2.0.2",
+        "@smithy/util-middleware": "^3.0.1",
+        "@smithy/util-retry": "^3.0.1",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sso": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.598.0.tgz",
+      "integrity": "sha512-nOI5lqPYa+YZlrrzwAJywJSw3MKVjvu6Ge2fCqQUNYMfxFB0NAaDFnl0EPjXi+sEbtCuz/uWE77poHbqiZ+7Iw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.598.0",
+        "@aws-sdk/middleware-host-header": "3.598.0",
+        "@aws-sdk/middleware-logger": "3.598.0",
+        "@aws-sdk/middleware-recursion-detection": "3.598.0",
+        "@aws-sdk/middleware-user-agent": "3.598.0",
+        "@aws-sdk/region-config-resolver": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-endpoints": "3.598.0",
+        "@aws-sdk/util-user-agent-browser": "3.598.0",
+        "@aws-sdk/util-user-agent-node": "3.598.0",
+        "@smithy/config-resolver": "^3.0.2",
+        "@smithy/core": "^2.2.1",
+        "@smithy/fetch-http-handler": "^3.0.2",
+        "@smithy/hash-node": "^3.0.1",
+        "@smithy/invalid-dependency": "^3.0.1",
+        "@smithy/middleware-content-length": "^3.0.1",
+        "@smithy/middleware-endpoint": "^3.0.2",
+        "@smithy/middleware-retry": "^3.0.4",
+        "@smithy/middleware-serde": "^3.0.1",
+        "@smithy/middleware-stack": "^3.0.1",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/node-http-handler": "^3.0.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/url-parser": "^3.0.1",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.4",
+        "@smithy/util-defaults-mode-node": "^3.0.4",
+        "@smithy/util-endpoints": "^2.0.2",
+        "@smithy/util-middleware": "^3.0.1",
+        "@smithy/util-retry": "^3.0.1",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.598.0.tgz",
+      "integrity": "sha512-jfdH1pAO9Tt8Nkta/JJLoUnwl7jaRdxToQTJfUtE+o3+0JP5sA4LfC2rBkJSWcU5BdAA+kyOs5Lv776DlN04Vg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sts": "3.598.0",
+        "@aws-sdk/core": "3.598.0",
+        "@aws-sdk/credential-provider-node": "3.598.0",
+        "@aws-sdk/middleware-host-header": "3.598.0",
+        "@aws-sdk/middleware-logger": "3.598.0",
+        "@aws-sdk/middleware-recursion-detection": "3.598.0",
+        "@aws-sdk/middleware-user-agent": "3.598.0",
+        "@aws-sdk/region-config-resolver": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-endpoints": "3.598.0",
+        "@aws-sdk/util-user-agent-browser": "3.598.0",
+        "@aws-sdk/util-user-agent-node": "3.598.0",
+        "@smithy/config-resolver": "^3.0.2",
+        "@smithy/core": "^2.2.1",
+        "@smithy/fetch-http-handler": "^3.0.2",
+        "@smithy/hash-node": "^3.0.1",
+        "@smithy/invalid-dependency": "^3.0.1",
+        "@smithy/middleware-content-length": "^3.0.1",
+        "@smithy/middleware-endpoint": "^3.0.2",
+        "@smithy/middleware-retry": "^3.0.4",
+        "@smithy/middleware-serde": "^3.0.1",
+        "@smithy/middleware-stack": "^3.0.1",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/node-http-handler": "^3.0.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/url-parser": "^3.0.1",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.4",
+        "@smithy/util-defaults-mode-node": "^3.0.4",
+        "@smithy/util-endpoints": "^2.0.2",
+        "@smithy/util-middleware": "^3.0.1",
+        "@smithy/util-retry": "^3.0.1",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sts": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.598.0.tgz",
+      "integrity": "sha512-bXhz/cHL0iB9UH9IFtMaJJf4F8mV+HzncETCRFzZ9SyUMt5rP9j8A7VZknqGYSx/6mI8SsB1XJQkWSbhn6FiSQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.598.0",
+        "@aws-sdk/core": "3.598.0",
+        "@aws-sdk/credential-provider-node": "3.598.0",
+        "@aws-sdk/middleware-host-header": "3.598.0",
+        "@aws-sdk/middleware-logger": "3.598.0",
+        "@aws-sdk/middleware-recursion-detection": "3.598.0",
+        "@aws-sdk/middleware-user-agent": "3.598.0",
+        "@aws-sdk/region-config-resolver": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-endpoints": "3.598.0",
+        "@aws-sdk/util-user-agent-browser": "3.598.0",
+        "@aws-sdk/util-user-agent-node": "3.598.0",
+        "@smithy/config-resolver": "^3.0.2",
+        "@smithy/core": "^2.2.1",
+        "@smithy/fetch-http-handler": "^3.0.2",
+        "@smithy/hash-node": "^3.0.1",
+        "@smithy/invalid-dependency": "^3.0.1",
+        "@smithy/middleware-content-length": "^3.0.1",
+        "@smithy/middleware-endpoint": "^3.0.2",
+        "@smithy/middleware-retry": "^3.0.4",
+        "@smithy/middleware-serde": "^3.0.1",
+        "@smithy/middleware-stack": "^3.0.1",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/node-http-handler": "^3.0.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/url-parser": "^3.0.1",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.4",
+        "@smithy/util-defaults-mode-node": "^3.0.4",
+        "@smithy/util-endpoints": "^2.0.2",
+        "@smithy/util-middleware": "^3.0.1",
+        "@smithy/util-retry": "^3.0.1",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/core": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.598.0.tgz",
+      "integrity": "sha512-HaSjt7puO5Cc7cOlrXFCW0rtA0BM9lvzjl56x0A20Pt+0wxXGeTOZZOkXQIepbrFkV2e/HYukuT9e99vXDm59g==",
+      "dependencies": {
+        "@smithy/core": "^2.2.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/signature-v4": "^3.1.0",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.598.0.tgz",
+      "integrity": "sha512-vi1khgn7yXzLCcgSIzQrrtd2ilUM0dWodxj3PQ6BLfP0O+q1imO3hG1nq7DVyJtq7rFHs6+9N8G4mYvTkxby2w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.598.0.tgz",
+      "integrity": "sha512-N7cIafi4HVlQvEgvZSo1G4T9qb/JMLGMdBsDCT5XkeJrF0aptQWzTFH0jIdZcLrMYvzPcuEyO3yCBe6cy/ba0g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/fetch-http-handler": "^3.0.2",
+        "@smithy/node-http-handler": "^3.0.1",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-stream": "^3.0.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.598.0.tgz",
+      "integrity": "sha512-/ppcIVUbRwDIwJDoYfp90X3+AuJo2mvE52Y1t2VSrvUovYn6N4v95/vXj6LS8CNDhz2jvEJYmu+0cTMHdhI6eA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.598.0",
+        "@aws-sdk/credential-provider-http": "3.598.0",
+        "@aws-sdk/credential-provider-process": "3.598.0",
+        "@aws-sdk/credential-provider-sso": "3.598.0",
+        "@aws-sdk/credential-provider-web-identity": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/credential-provider-imds": "^3.1.1",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.598.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.598.0.tgz",
+      "integrity": "sha512-sXTlqL5I/awlF9Dg2MQ17SfrEaABVnsj2mf4jF5qQrIRhfbvQOIYdEqdy8Rn1AWlJMz/N450SGzc0XJ5owxxqw==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.598.0",
+        "@aws-sdk/credential-provider-http": "3.598.0",
+        "@aws-sdk/credential-provider-ini": "3.598.0",
+        "@aws-sdk/credential-provider-process": "3.598.0",
+        "@aws-sdk/credential-provider-sso": "3.598.0",
+        "@aws-sdk/credential-provider-web-identity": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/credential-provider-imds": "^3.1.1",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.598.0.tgz",
+      "integrity": "sha512-rM707XbLW8huMk722AgjVyxu2tMZee++fNA8TJVNgs1Ma02Wx6bBrfIvlyK0rCcIRb0WdQYP6fe3Xhiu4e8IBA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.598.0.tgz",
+      "integrity": "sha512-5InwUmrAuqQdOOgxTccRayMMkSmekdLk6s+az9tmikq0QFAHUCtofI+/fllMXSR9iL6JbGYi1940+EUmS4pHJA==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.598.0",
+        "@aws-sdk/token-providers": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.598.0.tgz",
+      "integrity": "sha512-GV5GdiMbz5Tz9JO4NJtRoFXjW0GPEujA0j+5J/B723rTN+REHthJu48HdBKouHGhdzkDWkkh1bu52V02Wprw8w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.598.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.598.0.tgz",
+      "integrity": "sha512-WiaG059YBQwQraNejLIi0gMNkX7dfPZ8hDIhvMr5aVPRbaHH8AYF3iNSsXYCHvA2Cfa1O9haYXsuMF9flXnCmA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.598.0.tgz",
+      "integrity": "sha512-bxBjf/VYiu3zfu8SYM2S9dQQc3tz5uBAOcPz/Bt8DyyK3GgOpjhschH/2XuUErsoUO1gDJqZSdGOmuHGZQn00Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.598.0.tgz",
+      "integrity": "sha512-vjT9BeFY9FeN0f8hm2l6F53tI0N5bUq6RcDkQXKNabXBnQxKptJRad6oP2X5y3FoVfBLOuDkQgiC2940GIPxtQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.598.0.tgz",
+      "integrity": "sha512-4tjESlHG5B5MdjUaLK7tQs/miUtHbb6deauQx8ryqSBYOhfHVgb1ZnzvQR0bTrhpqUg0WlybSkDaZAICf9xctg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-endpoints": "3.598.0",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.598.0.tgz",
+      "integrity": "sha512-oYXhmTokSav4ytmWleCr3rs/1nyvZW/S0tdi6X7u+dLNL5Jee+uMxWGzgOrWK6wrQOzucLVjS4E/wA11Kv2GTw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/token-providers": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.598.0.tgz",
+      "integrity": "sha512-TKY1EVdHVBnZqpyxyTHdpZpa1tUpb6nxVeRNn1zWG8QB5MvH4ALLd/jR+gtmWDNQbIG4cVuBOZFVL8hIYicKTA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.598.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/types": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.598.0.tgz",
+      "integrity": "sha512-742uRl6z7u0LFmZwDrFP6r1wlZcgVPw+/TilluDJmCAR8BgRw3IR+743kUXKBGd8QZDRW2n6v/PYsi/AWCDDMQ==",
+      "dependencies": {
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.598.0.tgz",
+      "integrity": "sha512-Qo9UoiVVZxcOEdiOMZg3xb1mzkTxrhd4qSlg5QQrfWPJVx/QOg+Iy0NtGxPtHtVZNHZxohYwDwV/tfsnDSE2gQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-endpoints": "^2.0.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.598.0.tgz",
+      "integrity": "sha512-36Sxo6F+ykElaL1mWzWjlg+1epMpSe8obwhCN1yGE7Js9ywy5U6k6l+A3q3YM9YRbm740sNxncbwLklMvuhTKw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/types": "^3.1.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.598.0.tgz",
+      "integrity": "sha512-oyWGcOlfTdzkC6SVplyr0AGh54IMrDxbhg5RxJ5P+V4BKfcDoDcZV9xenUk9NsOi9MuUjxMumb9UJGkDhM1m0A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-sso": {
       "version": "3.577.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.577.0.tgz",
@@ -442,6 +1028,33 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.598.0.tgz",
+      "integrity": "sha512-u6oocRReswkA2mFlOwtCetgmEr9B+Yhle3K13x37rb1lQgq1wUuWUvHU7U9v26hUZIhfUpigV/Mgr/RQZB6+Yw==",
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/types": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.598.0.tgz",
+      "integrity": "sha512-742uRl6z7u0LFmZwDrFP6r1wlZcgVPw+/TilluDJmCAR8BgRw3IR+743kUXKBGd8QZDRW2n6v/PYsi/AWCDDMQ==",
+      "dependencies": {
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.577.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.577.0.tgz",
@@ -567,6 +1180,566 @@
       },
       "peerDependencies": {
         "@aws-sdk/client-sts": "^3.577.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.598.0.tgz",
+      "integrity": "sha512-IFZwH3F2rA2WbpYFUxOeu/M3/9p4+oRbKVLDZlaaDtwwuZ9VHEbnkUm20zOgSXeVExa3qgYhJvg7H5JrqxP97A==",
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.598.0",
+        "@aws-sdk/client-sso": "3.598.0",
+        "@aws-sdk/client-sts": "3.598.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.598.0",
+        "@aws-sdk/credential-provider-env": "3.598.0",
+        "@aws-sdk/credential-provider-http": "3.598.0",
+        "@aws-sdk/credential-provider-ini": "3.598.0",
+        "@aws-sdk/credential-provider-node": "3.598.0",
+        "@aws-sdk/credential-provider-process": "3.598.0",
+        "@aws-sdk/credential-provider-sso": "3.598.0",
+        "@aws-sdk/credential-provider-web-identity": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/credential-provider-imds": "^3.1.1",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.598.0.tgz",
+      "integrity": "sha512-nOI5lqPYa+YZlrrzwAJywJSw3MKVjvu6Ge2fCqQUNYMfxFB0NAaDFnl0EPjXi+sEbtCuz/uWE77poHbqiZ+7Iw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.598.0",
+        "@aws-sdk/middleware-host-header": "3.598.0",
+        "@aws-sdk/middleware-logger": "3.598.0",
+        "@aws-sdk/middleware-recursion-detection": "3.598.0",
+        "@aws-sdk/middleware-user-agent": "3.598.0",
+        "@aws-sdk/region-config-resolver": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-endpoints": "3.598.0",
+        "@aws-sdk/util-user-agent-browser": "3.598.0",
+        "@aws-sdk/util-user-agent-node": "3.598.0",
+        "@smithy/config-resolver": "^3.0.2",
+        "@smithy/core": "^2.2.1",
+        "@smithy/fetch-http-handler": "^3.0.2",
+        "@smithy/hash-node": "^3.0.1",
+        "@smithy/invalid-dependency": "^3.0.1",
+        "@smithy/middleware-content-length": "^3.0.1",
+        "@smithy/middleware-endpoint": "^3.0.2",
+        "@smithy/middleware-retry": "^3.0.4",
+        "@smithy/middleware-serde": "^3.0.1",
+        "@smithy/middleware-stack": "^3.0.1",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/node-http-handler": "^3.0.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/url-parser": "^3.0.1",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.4",
+        "@smithy/util-defaults-mode-node": "^3.0.4",
+        "@smithy/util-endpoints": "^2.0.2",
+        "@smithy/util-middleware": "^3.0.1",
+        "@smithy/util-retry": "^3.0.1",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.598.0.tgz",
+      "integrity": "sha512-jfdH1pAO9Tt8Nkta/JJLoUnwl7jaRdxToQTJfUtE+o3+0JP5sA4LfC2rBkJSWcU5BdAA+kyOs5Lv776DlN04Vg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sts": "3.598.0",
+        "@aws-sdk/core": "3.598.0",
+        "@aws-sdk/credential-provider-node": "3.598.0",
+        "@aws-sdk/middleware-host-header": "3.598.0",
+        "@aws-sdk/middleware-logger": "3.598.0",
+        "@aws-sdk/middleware-recursion-detection": "3.598.0",
+        "@aws-sdk/middleware-user-agent": "3.598.0",
+        "@aws-sdk/region-config-resolver": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-endpoints": "3.598.0",
+        "@aws-sdk/util-user-agent-browser": "3.598.0",
+        "@aws-sdk/util-user-agent-node": "3.598.0",
+        "@smithy/config-resolver": "^3.0.2",
+        "@smithy/core": "^2.2.1",
+        "@smithy/fetch-http-handler": "^3.0.2",
+        "@smithy/hash-node": "^3.0.1",
+        "@smithy/invalid-dependency": "^3.0.1",
+        "@smithy/middleware-content-length": "^3.0.1",
+        "@smithy/middleware-endpoint": "^3.0.2",
+        "@smithy/middleware-retry": "^3.0.4",
+        "@smithy/middleware-serde": "^3.0.1",
+        "@smithy/middleware-stack": "^3.0.1",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/node-http-handler": "^3.0.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/url-parser": "^3.0.1",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.4",
+        "@smithy/util-defaults-mode-node": "^3.0.4",
+        "@smithy/util-endpoints": "^2.0.2",
+        "@smithy/util-middleware": "^3.0.1",
+        "@smithy/util-retry": "^3.0.1",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sts": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.598.0.tgz",
+      "integrity": "sha512-bXhz/cHL0iB9UH9IFtMaJJf4F8mV+HzncETCRFzZ9SyUMt5rP9j8A7VZknqGYSx/6mI8SsB1XJQkWSbhn6FiSQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.598.0",
+        "@aws-sdk/core": "3.598.0",
+        "@aws-sdk/credential-provider-node": "3.598.0",
+        "@aws-sdk/middleware-host-header": "3.598.0",
+        "@aws-sdk/middleware-logger": "3.598.0",
+        "@aws-sdk/middleware-recursion-detection": "3.598.0",
+        "@aws-sdk/middleware-user-agent": "3.598.0",
+        "@aws-sdk/region-config-resolver": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-endpoints": "3.598.0",
+        "@aws-sdk/util-user-agent-browser": "3.598.0",
+        "@aws-sdk/util-user-agent-node": "3.598.0",
+        "@smithy/config-resolver": "^3.0.2",
+        "@smithy/core": "^2.2.1",
+        "@smithy/fetch-http-handler": "^3.0.2",
+        "@smithy/hash-node": "^3.0.1",
+        "@smithy/invalid-dependency": "^3.0.1",
+        "@smithy/middleware-content-length": "^3.0.1",
+        "@smithy/middleware-endpoint": "^3.0.2",
+        "@smithy/middleware-retry": "^3.0.4",
+        "@smithy/middleware-serde": "^3.0.1",
+        "@smithy/middleware-stack": "^3.0.1",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/node-http-handler": "^3.0.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/url-parser": "^3.0.1",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.4",
+        "@smithy/util-defaults-mode-node": "^3.0.4",
+        "@smithy/util-endpoints": "^2.0.2",
+        "@smithy/util-middleware": "^3.0.1",
+        "@smithy/util-retry": "^3.0.1",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/core": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.598.0.tgz",
+      "integrity": "sha512-HaSjt7puO5Cc7cOlrXFCW0rtA0BM9lvzjl56x0A20Pt+0wxXGeTOZZOkXQIepbrFkV2e/HYukuT9e99vXDm59g==",
+      "dependencies": {
+        "@smithy/core": "^2.2.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/signature-v4": "^3.1.0",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.598.0.tgz",
+      "integrity": "sha512-vi1khgn7yXzLCcgSIzQrrtd2ilUM0dWodxj3PQ6BLfP0O+q1imO3hG1nq7DVyJtq7rFHs6+9N8G4mYvTkxby2w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.598.0.tgz",
+      "integrity": "sha512-N7cIafi4HVlQvEgvZSo1G4T9qb/JMLGMdBsDCT5XkeJrF0aptQWzTFH0jIdZcLrMYvzPcuEyO3yCBe6cy/ba0g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/fetch-http-handler": "^3.0.2",
+        "@smithy/node-http-handler": "^3.0.1",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-stream": "^3.0.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.598.0.tgz",
+      "integrity": "sha512-/ppcIVUbRwDIwJDoYfp90X3+AuJo2mvE52Y1t2VSrvUovYn6N4v95/vXj6LS8CNDhz2jvEJYmu+0cTMHdhI6eA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.598.0",
+        "@aws-sdk/credential-provider-http": "3.598.0",
+        "@aws-sdk/credential-provider-process": "3.598.0",
+        "@aws-sdk/credential-provider-sso": "3.598.0",
+        "@aws-sdk/credential-provider-web-identity": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/credential-provider-imds": "^3.1.1",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.598.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.598.0.tgz",
+      "integrity": "sha512-sXTlqL5I/awlF9Dg2MQ17SfrEaABVnsj2mf4jF5qQrIRhfbvQOIYdEqdy8Rn1AWlJMz/N450SGzc0XJ5owxxqw==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.598.0",
+        "@aws-sdk/credential-provider-http": "3.598.0",
+        "@aws-sdk/credential-provider-ini": "3.598.0",
+        "@aws-sdk/credential-provider-process": "3.598.0",
+        "@aws-sdk/credential-provider-sso": "3.598.0",
+        "@aws-sdk/credential-provider-web-identity": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/credential-provider-imds": "^3.1.1",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.598.0.tgz",
+      "integrity": "sha512-rM707XbLW8huMk722AgjVyxu2tMZee++fNA8TJVNgs1Ma02Wx6bBrfIvlyK0rCcIRb0WdQYP6fe3Xhiu4e8IBA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.598.0.tgz",
+      "integrity": "sha512-5InwUmrAuqQdOOgxTccRayMMkSmekdLk6s+az9tmikq0QFAHUCtofI+/fllMXSR9iL6JbGYi1940+EUmS4pHJA==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.598.0",
+        "@aws-sdk/token-providers": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.598.0.tgz",
+      "integrity": "sha512-GV5GdiMbz5Tz9JO4NJtRoFXjW0GPEujA0j+5J/B723rTN+REHthJu48HdBKouHGhdzkDWkkh1bu52V02Wprw8w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.598.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.598.0.tgz",
+      "integrity": "sha512-WiaG059YBQwQraNejLIi0gMNkX7dfPZ8hDIhvMr5aVPRbaHH8AYF3iNSsXYCHvA2Cfa1O9haYXsuMF9flXnCmA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.598.0.tgz",
+      "integrity": "sha512-bxBjf/VYiu3zfu8SYM2S9dQQc3tz5uBAOcPz/Bt8DyyK3GgOpjhschH/2XuUErsoUO1gDJqZSdGOmuHGZQn00Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.598.0.tgz",
+      "integrity": "sha512-vjT9BeFY9FeN0f8hm2l6F53tI0N5bUq6RcDkQXKNabXBnQxKptJRad6oP2X5y3FoVfBLOuDkQgiC2940GIPxtQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.598.0.tgz",
+      "integrity": "sha512-4tjESlHG5B5MdjUaLK7tQs/miUtHbb6deauQx8ryqSBYOhfHVgb1ZnzvQR0bTrhpqUg0WlybSkDaZAICf9xctg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-endpoints": "3.598.0",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.598.0.tgz",
+      "integrity": "sha512-oYXhmTokSav4ytmWleCr3rs/1nyvZW/S0tdi6X7u+dLNL5Jee+uMxWGzgOrWK6wrQOzucLVjS4E/wA11Kv2GTw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/token-providers": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.598.0.tgz",
+      "integrity": "sha512-TKY1EVdHVBnZqpyxyTHdpZpa1tUpb6nxVeRNn1zWG8QB5MvH4ALLd/jR+gtmWDNQbIG4cVuBOZFVL8hIYicKTA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.598.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/types": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.598.0.tgz",
+      "integrity": "sha512-742uRl6z7u0LFmZwDrFP6r1wlZcgVPw+/TilluDJmCAR8BgRw3IR+743kUXKBGd8QZDRW2n6v/PYsi/AWCDDMQ==",
+      "dependencies": {
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.598.0.tgz",
+      "integrity": "sha512-Qo9UoiVVZxcOEdiOMZg3xb1mzkTxrhd4qSlg5QQrfWPJVx/QOg+Iy0NtGxPtHtVZNHZxohYwDwV/tfsnDSE2gQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-endpoints": "^2.0.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.598.0.tgz",
+      "integrity": "sha512-36Sxo6F+ykElaL1mWzWjlg+1epMpSe8obwhCN1yGE7Js9ywy5U6k6l+A3q3YM9YRbm740sNxncbwLklMvuhTKw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/types": "^3.1.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.598.0.tgz",
+      "integrity": "sha512-oyWGcOlfTdzkC6SVplyr0AGh54IMrDxbhg5RxJ5P+V4BKfcDoDcZV9xenUk9NsOi9MuUjxMumb9UJGkDhM1m0A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
@@ -4042,11 +5215,11 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-p6GlFGBt9K4MYLu72YuJ523NVR4A8oHlC5M2JO6OmQqN8kAc/uh1JqLE+FizTokrSJGg0CSvC+BrsmGzKtsZKA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.0.1.tgz",
+      "integrity": "sha512-Jb7jg4E+C+uvrUQi+h9kbILY6ts6fglKZzseMCHlH9ayq+1f5QdpYf8MV/xppuiN6DAMJAmwGz53GwP3213dmA==",
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4054,14 +5227,14 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.0.tgz",
-      "integrity": "sha512-2GzOfADwYLQugYkKQhIyZyQlM05K+tMKvRnc6eFfZcpJGRfKoMUMYdPlBKmqHwQFXQKBrGV6cxL9oymWgDzvFw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.2.tgz",
+      "integrity": "sha512-wUyG6ezpp2sWAvfqmSYTROwFUmJqKV78GLf55WODrosBcT0BAMd9bOLO4HRhynWBgAobPml2cF9ZOdgCe00r+g==",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
         "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4069,17 +5242,17 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-rcMkjvwxH/bER+oZUPR0yTA0ELD6m3A+d92+CFkdF6HJFCBB1bXo7P5pm21L66XwTN01B6bUhSCQ7cymWRD8zg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.2.1.tgz",
+      "integrity": "sha512-R8Pzrr2v2oGUoj4CTZtKPr87lVtBsz7IUBGhSwS1kc6Cj0yPwNdYbkzhFsxhoDE9+BPl09VN/6rFsW9GJzWnBA==",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.0.0",
-        "@smithy/middleware-retry": "^3.0.1",
-        "@smithy/middleware-serde": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/smithy-client": "^3.0.1",
-        "@smithy/types": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/middleware-endpoint": "^3.0.2",
+        "@smithy/middleware-retry": "^3.0.4",
+        "@smithy/middleware-serde": "^3.0.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-middleware": "^3.0.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4087,14 +5260,14 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.0.0.tgz",
-      "integrity": "sha512-lfmBiFQcA3FsDAPxNfY0L7CawcWtbyWsBOHo34nF095728JLkBX4Y9q/VPPE2r7fqMVK+drmDigqE2/SSQeVRA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.1.1.tgz",
+      "integrity": "sha512-htndP0LwHdE3R3Nam9ZyVWhwPYOmD4xCL79kqvNxy8u/bv0huuy574CSiRY4cvEICgimv8jlVfLeZ7zZqbnB2g==",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/property-provider": "^3.0.0",
-        "@smithy/types": "^3.0.0",
-        "@smithy/url-parser": "^3.0.0",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "@smithy/url-parser": "^3.0.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4164,23 +5337,23 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.0.1.tgz",
-      "integrity": "sha512-uaH74i5BDj+rBwoQaXioKpI0SHBJFtOVwzrCpxZxphOW0ki5jhj7dXvDMYM2IJem8TpdFvS2iC08sjOblfFGFg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.0.2.tgz",
+      "integrity": "sha512-0nW6tLK0b7EqSsfKvnOmZCgJqnodBAnvqcrlC5dotKfklLedPTRGsQamSVbVDWyuU/QGg+YbZDJUQ0CUufJXZQ==",
       "dependencies": {
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/querystring-builder": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/querystring-builder": "^3.0.1",
+        "@smithy/types": "^3.1.0",
         "@smithy/util-base64": "^3.0.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.0.tgz",
-      "integrity": "sha512-84qXstNemP3XS5jcof0el6+bDfjzuvhJPQTEfro3lgtbCtKgzPm3MgiS6ehXVPjeQ5+JS0HqmTz8f/RYfzHVxw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.1.tgz",
+      "integrity": "sha512-w2ncjgk2EYO2+WhAsSQA8owzoOSY7IL1qVytlwpnL1pFGWTjIoIh5nROkEKXY51unB63bMGZqDiVoXaFbyKDlg==",
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.1.0",
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
@@ -4190,11 +5363,11 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.0.tgz",
-      "integrity": "sha512-F6wBBaEFgJzj0s4KUlliIGPmqXemwP6EavgvDqYwCH40O5Xr2iMHvS8todmGVZtuJCorBkXsYLyTu4PuizVq5g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.1.tgz",
+      "integrity": "sha512-RSNF/32BKygXKKMyS7koyuAq1rcdW5p5c4EFa77QenBFze9As+JiRnV9OWBh2cB/ejGZalEZjvIrMLHwJl7aGA==",
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       }
     },
@@ -4210,12 +5383,12 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.0.tgz",
-      "integrity": "sha512-3C4s4d/iGobgCtk2tnWW6+zSTOBg1PRAm2vtWZLdriwTroFbbWNSr3lcyzHdrQHnEXYCC5K52EbpfodaIUY8sg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.1.tgz",
+      "integrity": "sha512-6QdK/VbrCfXD5/QolE2W/ok6VqxD+SM28Ds8iSlEHXZwv4buLsvWyvoEEy0322K/g5uFgPzBmZjGqesTmPL+yQ==",
       "dependencies": {
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4223,16 +5396,16 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.0.tgz",
-      "integrity": "sha512-aXOAWztw/5qAfp0NcA2OWpv6ZI/E+Dh9mByif7i91D/0iyYNUcKvskmXiowKESFkuZ7PIMd3VOR4fTibZDs2OQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.2.tgz",
+      "integrity": "sha512-gWEaGYB3Bei17Oiy/F2IlUPpBazNXImytoOdJ1xbrUOaJKAOiUhx8/4FOnYLLJHdAwa9PlvJ2ULda2f/Dnwi9w==",
       "dependencies": {
-        "@smithy/middleware-serde": "^3.0.0",
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/shared-ini-file-loader": "^3.0.0",
-        "@smithy/types": "^3.0.0",
-        "@smithy/url-parser": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/middleware-serde": "^3.0.1",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
+        "@smithy/url-parser": "^3.0.1",
+        "@smithy/util-middleware": "^3.0.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4240,17 +5413,17 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.1.tgz",
-      "integrity": "sha512-hBhSEuL841FhJBK/19WpaGk5YWSzFk/P2UaVjANGKRv3eYNO8Y1lANWgqnuPWjOyCEWMPr58vELFDWpxvRKANw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.4.tgz",
+      "integrity": "sha512-Tu+FggbLNF5G9L6Wi8o32Mg4bhlBInWlhhaFKyytGRnkfxGopxFVXJQn7sjZdFYJyTz6RZZa06tnlvavUgtoVg==",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/service-error-classification": "^3.0.0",
-        "@smithy/smithy-client": "^3.0.1",
-        "@smithy/types": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.0",
-        "@smithy/util-retry": "^3.0.0",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/service-error-classification": "^3.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-middleware": "^3.0.1",
+        "@smithy/util-retry": "^3.0.1",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
@@ -4259,11 +5432,11 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.0.tgz",
-      "integrity": "sha512-I1vKG1foI+oPgG9r7IMY1S+xBnmAn1ISqployvqkwHoSb8VPsngHDTOgYGYBonuOKndaWRUGJZrKYYLB+Ane6w==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.1.tgz",
+      "integrity": "sha512-ak6H/ZRN05r5+SR0/IUc5zOSyh2qp3HReg1KkrnaSLXmncy9lwOjNqybX4L4x55/e5mtVDn1uf/gQ6bw5neJPw==",
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4271,11 +5444,11 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.0.tgz",
-      "integrity": "sha512-+H0jmyfAyHRFXm6wunskuNAqtj7yfmwFB6Fp37enytp2q047/Od9xetEaUbluyImOlGnGpaVGaVfjwawSr+i6Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.1.tgz",
+      "integrity": "sha512-fS5uT//y1SlBdkzIvgmWQ9FufwMXrHSSbuR25ygMy1CRDIZkcBMoF4oTMYNfR9kBlVBcVzlv7joFdNrFuQirPA==",
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4283,13 +5456,13 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.0.0.tgz",
-      "integrity": "sha512-buqfaSdDh0zo62EPLf8rGDvcpKwGpO5ho4bXS2cdFhlOta7tBkWJt+O5uiaAeICfIOfPclNOndshDNSanX2X9g==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.1.tgz",
+      "integrity": "sha512-z5G7+ysL4yUtMghUd2zrLkecu0mTfnYlt5dR76g/HsFqf7evFazwiZP1ag2EJenGxNBDwDM5g8nm11NPogiUVA==",
       "dependencies": {
-        "@smithy/property-provider": "^3.0.0",
-        "@smithy/shared-ini-file-loader": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^3.1.1",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4297,14 +5470,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.0.0.tgz",
-      "integrity": "sha512-3trD4r7NOMygwLbUJo4eodyQuypAWr7uvPnebNJ9a70dQhVn+US8j/lCnvoJS6BXfZeF7PkkkI0DemVJw+n+eQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.0.1.tgz",
+      "integrity": "sha512-hlBI6MuREA4o1wBMEt+QNhUzoDtFFvwR6ecufimlx9D79jPybE/r8kNorphXOi91PgSO9S2fxRjcKCLk7Jw8zA==",
       "dependencies": {
-        "@smithy/abort-controller": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/querystring-builder": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/abort-controller": "^3.0.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/querystring-builder": "^3.0.1",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4312,11 +5485,11 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.0.0.tgz",
-      "integrity": "sha512-LmbPgHBswdXCrkWWuUwBm9w72S2iLWyC/5jet9/Y9cGHtzqxi+GVjfCfahkvNV4KXEwgnH8EMpcrD9RUYe0eLQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.1.tgz",
+      "integrity": "sha512-YknOMZcQkB5on+MU0DvbToCmT2YPtTETMXW0D3+/Iln7ezT+Zm1GMHhCW1dOH/X/+LkkQD9aXEoCX/B10s4Xdw==",
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4324,11 +5497,11 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.0.tgz",
-      "integrity": "sha512-qOQZOEI2XLWRWBO9AgIYuHuqjZ2csyr8/IlgFDHDNuIgLAMRx2Bl8ck5U5D6Vh9DPdoaVpuzwWMa0xcdL4O/AQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.1.tgz",
+      "integrity": "sha512-eBhm9zwcFPEazc654c0BEWtxYAzrw+OhoSf5pkwKzfftWKXRoqEhwOE2Pvn30v0iAdo7Mfsfb6pi1NnZlGCMpg==",
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4336,11 +5509,11 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.0.tgz",
-      "integrity": "sha512-bW8Fi0NzyfkE0TmQphDXr1AmBDbK01cA4C1Z7ggwMAU5RDz5AAv/KmoRwzQAS0kxXNf/D2ALTEgwK0U2c4LtRg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.1.tgz",
+      "integrity": "sha512-vKitpnG/2KOMVlx3x1S3FkBH075EROG3wcrcDaNerQNh8yuqnSL23btCD2UyX4i4lpPzNW6VFdxbn2Z25b/g5Q==",
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.1.0",
         "@smithy/util-uri-escape": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -4349,11 +5522,11 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.0.tgz",
-      "integrity": "sha512-UzHwthk0UEccV4dHzPySnBy34AWw3V9lIqUTxmozQ+wPDAO9csCWMfOLe7V9A2agNYy7xE+Pb0S6K/J23JSzfQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.1.tgz",
+      "integrity": "sha512-Qt8DMC05lVS8NcQx94lfVbZSX+2Ym7032b/JR8AlboAa/D669kPzqb35dkjkvAG6+NWmUchef3ENtrD6F+5n8Q==",
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4361,22 +5534,22 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.0.tgz",
-      "integrity": "sha512-3BsBtOUt2Gsnc3X23ew+r2M71WwtpHfEDGhHYHSDg6q1t8FrWh15jT25DLajFV1H+PpxAJ6gqe9yYeRUsmSdFA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.1.tgz",
+      "integrity": "sha512-ubFUvIePjDCyIzZ+pLETqNC6KXJ/fc6g+/baqel7Zf6kJI/kZKgjwkCI7zbUhoUuOZ/4eA/87YasVu40b/B4bA==",
       "dependencies": {
-        "@smithy/types": "^3.0.0"
+        "@smithy/types": "^3.1.0"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.0.0.tgz",
-      "integrity": "sha512-REVw6XauXk8xE4zo5aGL7Rz4ywA8qNMUn8RtWeTRQsgAlmlvbJ7CEPBcaXU2NDC3AYBgYAXrGyWD8XrN8UGDog==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.1.tgz",
+      "integrity": "sha512-nD6tXIX2126/P9e3wqRY1bm9dTtPZwRDyjVOd18G28o+1UOG+kOVgUwujE795HslSuPlEgqzsH5sgNP1hDjj9g==",
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4384,14 +5557,14 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.0.0.tgz",
-      "integrity": "sha512-kXFOkNX+BQHe2qnLxpMEaCRGap9J6tUGLzc3A9jdn+nD4JdMwCKTJ+zFwQ20GkY+mAXGatyTw3HcoUlR39HwmA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.1.0.tgz",
+      "integrity": "sha512-m0/6LW3IQ3/JBcdhqjpkpABPTPhcejqeAn0U877zxBdNLiWAnG2WmCe5MfkUyVuvpFTPQnQwCo/0ZBR4uF5kxg==",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.1.0",
         "@smithy/util-hex-encoding": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.1",
         "@smithy/util-uri-escape": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
@@ -4401,15 +5574,15 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.0.1.tgz",
-      "integrity": "sha512-KAiFY4Y4jdHxR+4zerH/VBhaFKM8pbaVmJZ/CWJRwtM/CmwzTfXfvYwf6GoUwiHepdv+lwiOXCuOl6UBDUEINw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.2.tgz",
+      "integrity": "sha512-f3eQpczBOFUtdT/ptw2WpUKu1qH1K7xrssrSiHYtd9TuLXkvFqb88l9mz9FHeUVNSUxSnkW1anJnw6rLwUKzQQ==",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.0.0",
-        "@smithy/middleware-stack": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.0",
-        "@smithy/types": "^3.0.0",
-        "@smithy/util-stream": "^3.0.1",
+        "@smithy/middleware-endpoint": "^3.0.2",
+        "@smithy/middleware-stack": "^3.0.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-stream": "^3.0.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4417,9 +5590,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.0.0.tgz",
-      "integrity": "sha512-VvWuQk2RKFuOr98gFhjca7fkBS+xLLURT8bUjk5XQoV0ZLm7WPwWPPY3/AwzTLuUBDeoKDCthfe1AsTUWaSEhw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.1.0.tgz",
+      "integrity": "sha512-qi4SeCVOUPjhSSZrxxB/mB8DrmuSFUcJnD9KXjuP+7C3LV/KFV4kpuUSH3OHDZgQB9TEH/1sO/Fq/5HyaK9MPw==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -4428,12 +5601,12 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.0.tgz",
-      "integrity": "sha512-2XLazFgUu+YOGHtWihB3FSLAfCUajVfNBXGGYjOaVKjLAuAxx3pSBY3hBgLzIgB17haf59gOG3imKqTy8mcrjw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.1.tgz",
+      "integrity": "sha512-G140IlNFlzYWVCedC4E2d6NycM1dCUbe5CnsGW1hmGt4hYKiGOw0v7lVru9WAn5T2w09QEjl4fOESWjGmCvVmg==",
       "dependencies": {
-        "@smithy/querystring-parser": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/querystring-parser": "^3.0.1",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       }
     },
@@ -4493,13 +5666,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.1.tgz",
-      "integrity": "sha512-nW5kEzdJn1Bn5TF+gOPHh2rcPli8JU9vSSXLbfg7uPnfR1TMRQqs9zlYRhIb87NeSxIbpdXOI94tvXSy+fvDYg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.4.tgz",
+      "integrity": "sha512-sXtin3Mue3A3xo4+XkozpgPptgmRwvNPOqTvb3ANGTCzzoQgAPBNjpE+aXCINaeSMXwHmv7E2oEn2vWdID+SAQ==",
       "dependencies": {
-        "@smithy/property-provider": "^3.0.0",
-        "@smithy/smithy-client": "^3.0.1",
-        "@smithy/types": "^3.0.0",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -4508,16 +5681,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.1.tgz",
-      "integrity": "sha512-TFk+Qb+elLc/MOhtSp+50fstyfZ6avQbgH2d96xUBpeScu+Al9elxv+UFAjaTHe0HQe5n+wem8ZLpXvU8lwV6Q==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.4.tgz",
+      "integrity": "sha512-CUF6TyxLh3CgBRVYgZNOPDfzHQjeQr0vyALR6/DkQkOm7rNfGEzW1BRFi88C73pndmfvoiIT7ochuT76OPz9Dw==",
       "dependencies": {
-        "@smithy/config-resolver": "^3.0.0",
-        "@smithy/credential-provider-imds": "^3.0.0",
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/property-provider": "^3.0.0",
-        "@smithy/smithy-client": "^3.0.1",
-        "@smithy/types": "^3.0.0",
+        "@smithy/config-resolver": "^3.0.2",
+        "@smithy/credential-provider-imds": "^3.1.1",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/property-provider": "^3.1.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4525,12 +5698,12 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.0.tgz",
-      "integrity": "sha512-+exaXzEY3DNt2qtA2OtRNSDlVrE4p32j1JSsQkzA5AdP0YtJNjkYbYhJxkFmPYcjI1abuwopOZCwUmv682QkiQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.2.tgz",
+      "integrity": "sha512-4zFOcBFQvifd2LSD4a1dKvfIWWwh4sWNtS3oZ7mpob/qPPmJseqKB148iT+hWCDsG//TmI+8vjYPgZdvnkYlTg==",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4549,11 +5722,11 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.0.tgz",
-      "integrity": "sha512-q5ITdOnV2pXHSVDnKWrwgSNTDBAMHLptFE07ua/5Ty5WJ11bvr0vk2a7agu7qRhrCFRQlno5u3CneU5EELK+DQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.1.tgz",
+      "integrity": "sha512-WRODCQtUsO7vIvfrdxS8RFPeLKcewYtaCglZsBsedIKSUGIIvMlZT5oh+pCe72I+1L+OjnZuqRNpN2LKhWA4KQ==",
       "dependencies": {
-        "@smithy/types": "^3.0.0",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4561,12 +5734,12 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.0.tgz",
-      "integrity": "sha512-nK99bvJiziGv/UOKJlDvFF45F00WgPLKVIGUfAK+mDhzVN2hb/S33uW2Tlhg5PVBoqY7tDVqL0zmu4OxAHgo9g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.1.tgz",
+      "integrity": "sha512-5lRtYm+8fNFEUTdqZXg5M4ppVp40rMIJfR1TpbHAhKQgPIDpWT+iYMaqgnwEbtpi9U1smyUOPv5Sg+M1neOBgw==",
       "dependencies": {
-        "@smithy/service-error-classification": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/service-error-classification": "^3.0.1",
+        "@smithy/types": "^3.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4574,13 +5747,13 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.0.1.tgz",
-      "integrity": "sha512-7F7VNNhAsfMRA8I986YdOY5fE0/T1/ZjFF6OLsqkvQVNP3vZ/szYDfGCyphb7ioA09r32K/0qbSFfNFU68aSzA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.0.2.tgz",
+      "integrity": "sha512-n5Obp5AnlI6qHo8sbupwrcpBe6vFp4qkl0SRNuExKPNrH3ABAMG2ZszRTIUIv2b4AsFrCO+qiy4uH1Q3z1dxTA==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^3.0.1",
-        "@smithy/node-http-handler": "^3.0.0",
-        "@smithy/types": "^3.0.0",
+        "@smithy/fetch-http-handler": "^3.0.2",
+        "@smithy/node-http-handler": "^3.0.1",
+        "@smithy/types": "^3.1.0",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-hex-encoding": "^3.0.0",

--- a/core/package.json
+++ b/core/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.574.0",
+    "@aws-sdk/credential-providers": "^3.596.0",
     "@mozilla/readability": "^0.5.0",
     "@octokit/rest": "^20.0.2",
     "@types/jsdom": "^21.1.6",

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "0.9.159",
+  "version": "0.9.160",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "0.9.159",
+      "version": "0.9.160",
       "license": "Apache-2.0",
       "dependencies": {
         "@electron/rebuild": "^3.2.10",
@@ -94,6 +94,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.574.0",
+        "@aws-sdk/credential-providers": "^3.596.0",
         "@mozilla/readability": "^0.5.0",
         "@octokit/rest": "^20.0.2",
         "@types/jsdom": "^21.1.6",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "continue",
   "icon": "media/icon.png",
-  "version": "0.9.159",
+  "version": "0.9.160",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -87,6 +87,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.574.0",
+        "@aws-sdk/credential-providers": "^3.596.0",
         "@mozilla/readability": "^0.5.0",
         "@octokit/rest": "^20.0.2",
         "@types/jsdom": "^21.1.6",


### PR DESCRIPTION
## Description

- Minor refactoring of the Bedrock client
- Move to @aws-sdk/credential-providers, to have wider support for the different features of ~/.aws/credentials file (we can't assume that there will be ready credentials). More information can be found here: https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html
- Partially solves https://github.com/continuedev/continue/issues/1123

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
