### PR TITLE
Skip embedding files that do not chunk properly

### DIFF
--- a/core/indexing/LanceDbIndex.ts
+++ b/core/indexing/LanceDbIndex.ts
@@ -79,13 +79,24 @@ export class LanceDbIndex implements CodebaseIndex {
       const content = contents[i];
       const chunks: Chunk[] = [];
 
+      let hasEmptyChunks = false;
+
       for await (const chunk of chunkDocument(
         items[i].path,
         content,
         LanceDbIndex.MAX_CHUNK_SIZE,
         items[i].cacheKey,
       )) {
+        if (chunk.content.length == 0) {
+          hasEmptyChunks = true;
+          break;
+        }
         chunks.push(chunk);
+      }
+
+      if (hasEmptyChunks) {
+        // File did not chunk properly, let's skip it.
+        continue;
       }
 
       if (chunks.length > 20) {


### PR DESCRIPTION
## Description

Skip sending a file to the embedding model if any of its chunks are empty. Empty chunks are usually result of chunking a binary blob.

A better solution would be to detect a binary file and skip it or perhaps have an allowlist of extensions, but this is a reasonable work around.

## Checklist

- [x ] The base branch of this PR is `preview`, rather than `main`
