### PR TITLE
CON-240: Updated FileContextProvider, FolderContextProvider and useSubmenuContextProvider to increment display of path parts to ensure unique displays when duplicates exist in the items list

### DIFF
--- a/core/context/providers/FileContextProvider.ts
+++ b/core/context/providers/FileContextProvider.ts
@@ -5,7 +5,7 @@ import {
   ContextSubmenuItem,
   LoadSubmenuItemsArgs,
 } from "../../index.js";
-import { getBasename, getLastNPathParts } from "../../util/index.js";
+import { getBasename, groupByLastNPathParts, getUniqueFilePath } from "../../util/index.js";
 import { BaseContextProvider } from "../index.js";
 
 const MAX_SUBMENU_ITEMS = 10_000;
@@ -43,12 +43,14 @@ class FileContextProvider extends BaseContextProvider {
         return args.ide.listWorkspaceContents(dir);
       }),
     );
-    const files = results.flat().slice(-MAX_SUBMENU_ITEMS);
+    const files = results.flat().slice(-MAX_SUBMENU_ITEMS);    
+    const fileGroups = groupByLastNPathParts(files, 2);
+    
     return files.map((file) => {
       return {
         id: file,
         title: getBasename(file),
-        description: getLastNPathParts(file, 2),
+        description: getUniqueFilePath(file, fileGroups),
       };
     });
   }

--- a/core/context/providers/FolderContextProvider.ts
+++ b/core/context/providers/FolderContextProvider.ts
@@ -5,7 +5,7 @@ import {
   ContextSubmenuItem,
   LoadSubmenuItemsArgs,
 } from "../../index.js";
-import { getBasename, getLastNPathParts } from "../../util/index.js";
+import { getBasename, groupByLastNPathParts, getUniqueFilePath } from "../../util/index.js";
 import { BaseContextProvider } from "../index.js";
 
 class FolderContextProvider extends BaseContextProvider {
@@ -29,11 +29,13 @@ class FolderContextProvider extends BaseContextProvider {
     args: LoadSubmenuItemsArgs,
   ): Promise<ContextSubmenuItem[]> {
     const folders = await args.ide.listFolders();
+    const folderGroups = groupByLastNPathParts(folders, 2);
+
     return folders.map((folder) => {
       return {
         id: folder,
         title: getBasename(folder),
-        description: getLastNPathParts(folder, 2),
+        description: getUniqueFilePath(folder, folderGroups)
       };
     });
   }

--- a/core/util/index.ts
+++ b/core/util/index.ts
@@ -99,6 +99,37 @@ export function getLastNPathParts(filepath: string, n: number): string {
   return filepath.split(SEP_REGEX).slice(-n).join("/");
 }
 
+export function groupByLastNPathParts(filepaths: string[], n: number): Record<string, string[]> {
+  return filepaths.reduce((groups, item) => {
+    const lastNParts = getLastNPathParts(item, n);
+    if (!groups[lastNParts]) {
+      groups[lastNParts] = [];
+    }
+    groups[lastNParts].push(item);
+    return groups;
+  }, {} as Record<string, string[]>);
+}
+
+export function getUniqueFilePath(item: string, itemGroups: Record<string, string[]>): string {
+  const lastTwoParts = getLastNPathParts(item, 2);
+  const group = itemGroups[lastTwoParts];
+
+  let n = 2;
+  if (group.length > 1) {
+    while (
+      group.some(
+        (otherItem) =>
+          otherItem !== item &&
+          getLastNPathParts(otherItem, n) === getLastNPathParts(item, n)
+      )
+    ) {
+      n++;
+    }
+  }
+  
+  return getLastNPathParts(item, n);
+}
+
 export function shortestRelativePaths(paths: string[]): string[] {
   if (paths.length === 0) return [];
 

--- a/gui/src/hooks/useSubmenuContextProviders.tsx
+++ b/gui/src/hooks/useSubmenuContextProviders.tsx
@@ -1,5 +1,5 @@
 import { ContextSubmenuItem } from "core";
-import { deduplicateArray, getBasename, getLastNPathParts } from "core/util";
+import { deduplicateArray, getBasename, groupByLastNPathParts, getUniqueFilePath } from "core/util";
 import MiniSearch, { SearchResult } from "minisearch";
 import { useContext, useEffect, useState } from "react";
 import { useSelector } from "react-redux";
@@ -34,11 +34,13 @@ function useSubmenuContextProviders() {
 
   async function getOpenFileItems() {
     const openFiles = await ideMessenger.ide.getOpenFiles();
+    const openFileGroups = groupByLastNPathParts(openFiles, 2);
+
     return openFiles.map((file) => {
       return {
         id: file,
         title: getBasename(file),
-        description: getLastNPathParts(file, 2),
+        description: getUniqueFilePath(file, openFileGroups),
         providerTitle: "file",
       };
     });


### PR DESCRIPTION
## Description

Fixes #1347: in cases where there are two distinct folders named "util", both of which have a file named "index.ts", there is no way to distinguish in the dropdown which of the two I am selecting.

This PR resolves the issue by grouping file paths by their last two parts and de-duplicating them by incrementing path parts by 1 until it is no longer a duplicate of the others in the group.

## Checklist

- [x ] The base branch of this PR is `preview`, rather than `main`
