### PR TITLE
[CON-245] Add docs through config.json

### DIFF
--- a/core/protocol/core.ts
+++ b/core/protocol/core.ts
@@ -50,6 +50,8 @@ export type ToCoreFromIdeOrWebviewProtocol = {
   "config/getBrowserSerialized": [undefined, BrowserSerializedContinueConfig];
   "config/deleteModel": [{ title: string }, void];
   "config/reload": [undefined, BrowserSerializedContinueConfig];
+  "config/getDocsSitesConfig": [undefined, SiteIndexingConfig[]];
+  "docs/hasIndexed": [{ id: string }, { data: boolean }];
   "context/getContextItems": [
     {
       name: string;

--- a/core/protocol/passThrough.ts
+++ b/core/protocol/passThrough.ts
@@ -21,6 +21,8 @@ export const WEBVIEW_TO_CORE_PASS_THROUGH: (keyof ToCoreFromWebviewProtocol)[] =
     "config/getBrowserSerialized",
     "config/deleteModel",
     "config/reload",
+    "config/getDocsSitesConfig",
+    "docs/hasIndexed",
     "context/getContextItems",
     "context/loadSubmenuItems",
     "context/addDocs",

--- a/gui/src/components/Layout.tsx
+++ b/gui/src/components/Layout.tsx
@@ -254,8 +254,10 @@ const Layout = () => {
           <DropdownPortalDiv id="model-select-top-div"></DropdownPortalDiv>
           {HIDE_FOOTER_ON_PAGES.includes(location.pathname) || (
             <Footer>
-              <div className="mr-auto flex gap-2 items-center">
-                <ModelSelect />
+              <div className="mr-auto flex flex-grow gap-2 items-center overflow-hidden">
+                <div className="flex-shrink-0">
+                  <ModelSelect />
+                </div>
                 {indexingState.status !== "indexing" && // Would take up too much space together with indexing progress
                   defaultModel?.provider === "free-trial" && (
                     <ProgressBar

--- a/gui/src/components/loaders/IndexingProgressBar.tsx
+++ b/gui/src/components/loaders/IndexingProgressBar.tsx
@@ -22,7 +22,6 @@ const ProgressBarWrapper = styled.div`
   height: 6px;
   border-radius: 6px;
   border: 0.5px solid ${lightGray};
-  margin-top: 6px;
 `;
 
 const ProgressBarFill = styled.div<{ completed: number; color?: string }>`
@@ -41,12 +40,25 @@ const GridDiv = styled.div`
   margin-left: 8px;
 `;
 
-const P = styled.p`
-  margin: 0;
-  margin-top: 2px;
+const FlexDiv = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  overflow: hidden;
+  margin-bottom: 3px;
+`;
+
+const IndexFeed = styled.div`
+  font-size: ${getFontSize() - 3.5}px;
+  color: ${lightGray};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const IndexStatus = styled.div`
   font-size: ${getFontSize() - 2.5}px;
   color: ${lightGray};
-  text-align: center;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -197,7 +209,7 @@ const IndexingProgressBar = ({
         </>
       ) : indexingState.status === "indexing" ? ( //progress bar
         <>
-          <GridDiv
+          <FlexDiv
             data-tooltip-id="usage_progress_bar"
             onMouseEnter={() => setHovered(true)}
             onMouseLeave={() => setHovered(false)}
@@ -208,12 +220,13 @@ const IndexingProgressBar = ({
             <ProgressBarWrapper>
               <ProgressBarFill completed={fillPercentage} />
             </ProgressBarWrapper>
-            <P>
+            <IndexStatus>
               {hovered
                 ? "Click to pause"
                 : `Indexing (${Math.trunc(indexingState.progress * 100)}%)`}
-            </P>
-          </GridDiv>
+            </IndexStatus>
+          </FlexDiv>
+          <IndexFeed>{indexingState.desc}</IndexFeed>
           {tooltipPortalDiv &&
             ReactDOM.createPortal(
               <StyledTooltip id="usage_progress_bar" place="top">

--- a/gui/src/components/mainInput/types.d.ts
+++ b/gui/src/components/mainInput/types.d.ts
@@ -6,7 +6,8 @@ export type ComboBoxItemType =
   | "file"
   | "query"
   | "folder"
-  | "action";
+  | "action"
+  | "docs";
 
 export interface ComboBoxItem {
   title: string;


### PR DESCRIPTION
## Description

Closes #1442 
- [x] add showing docs options
- [x] enable showing indexing status
- [x] add and expose docs endpoints
- [x] refactor trigger docs indexing
- [x] add crawler progress calculator 
- [x] fix embedding progress calculator
- [ ] fix crawler sometimes creating invalid links
- [ ] docs are not indexing code blocks
- [ ] add docs embedding provider config support 
- [ ] Crawler limitations with dynamic docs
- [ ] indexing continues even if paused by user
- [ ] update docs

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
