### PR TITLE
fix(core): use `TextDecoderStream` for stream response

### DIFF
--- a/core/llm/stream.ts
+++ b/core/llm/stream.ts
@@ -9,13 +9,9 @@ export async function* streamResponse(
     throw new Error("No response body returned.");
   }
 
-  const stream = response.body as any;
+  const stream = (ReadableStream as any).from(response.body);
 
-  const decoder = new TextDecoder("utf-8");
-
-  for await (const chunk of stream) {
-    yield decoder.decode(chunk, { stream: true, });
-  }
+  yield* stream.pipeThrough(new TextDecoderStream("utf-8"));
 }
 
 function parseDataLine(line: string): any {


### PR DESCRIPTION
Closes #1492

## Description

This PR changes the implementation of `streamResponse` function to use `TextDecoderStream` rather than to use `TextDecoder` for each chunk from streaming response.

The current implementation sometimes break the response non-ASCII characters and this PR will fix it. see #1492 for more detail.

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
