### PR TITLE
📝 `config.ts` is a TypeScript file, not a Python file

### DIFF
--- a/docs/docs/customization/code-config.md
+++ b/docs/docs/customization/code-config.md
@@ -1,6 +1,6 @@
 # Code Configuration
 
-To allow added flexibility and eventually support an entire plugin ecosystem, Continue can be configured programmatically in a Python file, `~/.continue/config.ts`.
+To allow added flexibility and eventually support an entire plugin ecosystem, Continue can be configured programmatically in a TypeScript file, `~/.continue/config.ts`.
 
 Whenever Continue loads, it carries out the following steps:
 


### PR DESCRIPTION
## Description

Fix the programming language text in `config.ts`

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
