### PR TITLE
quick fix: ocktokit bug in crawl.ts

### DIFF
--- a/core/indexing/docs/crawl.ts
+++ b/core/indexing/docs/crawl.ts
@@ -21,7 +21,7 @@ const GITHUB_PATHS_TO_TRAVERSE = ["/blob/", "/tree/"];
 async function getDefaultBranch(owner: string, repo: string): Promise<string> {
   const octokit = new Octokit({ auth: undefined });
 
-  const repoInfo = await octokit.repos.get({
+  const repoInfo = await octokit.rest.repos.get({
     owner,
     repo,
   });


### PR DESCRIPTION
## Description

According to [here](https://github.com/octokit/octokit.js?tab=readme-ov-file#octokitrest-endpoint-methods) and [here](https://github.com/octokit/plugin-rest-endpoint-methods.js/blob/main/src/generated/method-types.ts#L9243), the correct method is `octokit.rest.repos` NOT `octokit.repos`. 


## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
