### PR TITLE
Fix: Correct codestral model name typo in docs

### DIFF
--- a/docs/docs/setup/examples.md
+++ b/docs/docs/setup/examples.md
@@ -27,7 +27,7 @@ This uses Claude 3 Opus for chat, Codestral for autocomplete, and Voyage AI for 
   "tabAutocompleteModel": {
     "title": "Codestral",
     "provider": "mistral",
-    "model": "codestral:latest",
+    "model": "codestral-latest",
     "apiKey": "[CODESTRAL_API_KEY]"
   },
   "embeddingsProvider": {


### PR DESCRIPTION
## Description

`codestral:latest` should be `codestral-latest` in the example docs
See model names here - https://docs.mistral.ai/getting-started/models/

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
