### PR TITLE
Project file path in LLM context for highlighted code

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor.tsx
@@ -12,7 +12,7 @@ import {
   RangeInFile,
 } from "core";
 import { modelSupportsImages } from "core/llm/autodetect";
-import { getBasename } from "core/util";
+import { getBasename, getRelativePath } from "core/util";
 import { useContext, useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
@@ -590,12 +590,13 @@ function TipTapEditor(props: TipTapEditorProps) {
         const rif: RangeInFile & { contents: string } =
           data.rangeInFileWithContents;
         const basename = getBasename(rif.filepath);
+        const relativePath = getRelativePath(rif.filepath, await ideMessenger.ide.getWorkspaceDirs());
+        const rangeStr = `(${rif.range.start.line + 1}-${rif.range.end.line + 1})`;
         const item: ContextItemWithId = {
           content: rif.contents,
-          name: `${basename} (${rif.range.start.line + 1}-${
-            rif.range.end.line + 1
-          })`,
-          description: rif.filepath,
+          name: `${basename} ${rangeStr}`,
+          // Description is passed on to the LLM to give more context on file path
+          description: `${relativePath} ${rangeStr}`,
           id: {
             providerTitle: "code",
             itemId: rif.filepath,

--- a/gui/src/components/mainInput/resolveInput.ts
+++ b/gui/src/components/mainInput/resolveInput.ts
@@ -55,7 +55,7 @@ async function resolveEditorContent(
     } else if (p.type === "codeBlock") {
       if (!p.attrs.item.editing) {
         const text =
-          "```" + p.attrs.item.name + "\n" + p.attrs.item.content + "\n```";
+          "```" + p.attrs.item.description + "\n" + p.attrs.item.content + "\n```";
         if (parts[parts.length - 1]?.type === "text") {
           parts[parts.length - 1].text += "\n" + text;
         } else {


### PR DESCRIPTION
## Description

Follow-up to #1407
Adds the project file-path to the LLM for selected/highlighted code, rather than just the filename.

Allow the LLM to understand the selected code in context of @filetree, or to allow the LLM to distinguish between multiple files with the same name (but in a different path).

<img width="1097" alt="Screenshot 2024-06-18 at 16 04 21" src="https://github.com/continuedev/continue/assets/140654/d250d766-b343-4579-bde8-84d0f1aeed16">

Notice how the editor just shows the filename, but the LLM sees the project path.

 
## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
