### PR TITLE
Feat/gemini error handling

### DIFF
--- a/core/llm/llms/Gemini.ts
+++ b/core/llm/llms/Gemini.ts
@@ -181,23 +181,30 @@ class Gemini extends BaseLLM {
           data = JSON.parse(part);
         } catch (e) {
           foundIncomplete = true;
-          continue;
+          continue; // yo!
         }
         if (data.error) {
           throw new Error(data.error.message);
         }
-
-        // Incrementally stream the content to make it smoother
-        const content = data.candidates[0].content.parts[0].text;
-        const words = content.split(/(\s+)/);
-        const delaySeconds = Math.min(4.0 / (words.length + 1), 0.1);
-        while (words.length > 0) {
-          const wordsToYield = Math.min(3, words.length);
-          yield {
-            role: "assistant",
-            content: words.splice(0, wordsToYield).join(""),
-          };
-          await delay(delaySeconds);
+        // Check for existence of each level before accessing the final 'text' property
+        if (data && data.candidates && data.candidates.length > 0 && data.candidates[0].content &&
+            data.candidates[0].content.parts && data.candidates[0].content.parts.length > 0 &&
+            data.candidates[0].content.parts[0].text) {
+          // Incrementally stream the content to make it smoother
+          const content = data.candidates[0].content.parts[0].text;
+          const words = content.split(/(\s+)/);
+          const delaySeconds = Math.min(4.0 / (words.length + 1), 0.1);
+          while (words.length > 0) {
+            const wordsToYield = Math.min(3, words.length);
+            yield {
+              role: "assistant",
+              content: words.splice(0, wordsToYield).join(""),
+            };
+            await delay(delaySeconds);
+          }
+        } else {
+          // Handle the case where the expected data structure is not found
+          console.warn('Unexpected response format:', data);
         }
       }
       if (foundIncomplete) {

--- a/core/llm/llms/Gemini.ts
+++ b/core/llm/llms/Gemini.ts
@@ -187,9 +187,7 @@ class Gemini extends BaseLLM {
           throw new Error(data.error.message);
         }
         // Check for existence of each level before accessing the final 'text' property
-        if (data && data.candidates && data.candidates.length > 0 && data.candidates[0].content &&
-            data.candidates[0].content.parts && data.candidates[0].content.parts.length > 0 &&
-            data.candidates[0].content.parts[0].text) {
+        if (data?.candidates?.[0]?.content?.parts?.[0]?.text) {
           // Incrementally stream the content to make it smoother
           const content = data.candidates[0].content.parts[0].text;
           const words = content.split(/(\s+)/);


### PR DESCRIPTION
## Description

This PR checks that the return has the correct format before attempting to parse it and prints a more helpful error message to the debug console if not. This is an incomplete first step to handling instances where the Gemini streaming API returns something other than the desired response text. In particular, in testing with certain parameters I was getting a partial response and then the Continue chat panel popped up an error message that wasn't very helpful and the partial response disappeared. Troubleshooting revealed it to be that the API was returning FinishReason: Recitation (described in frustrating lack of detail here: https://ai.google.dev/api/rest/v1beta/Candidate , and a potentially broader Gemini issue here: https://issuetracker.google.com/issues/331677495 ), which in turn caused Continue to error out when the expected content text field was missing. A more complete solution would be to ensure coverage of the various ways the API might respond and how Continue should handle each, but for now this is at least a step in that direction.

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
