### PR TITLE
Bugfix for /comment slash command which does nothing.

### DIFF
--- a/core/commands/slash/edit.ts
+++ b/core/commands/slash/edit.ts
@@ -250,7 +250,8 @@ const EditSlashCommand: SlashCommand = {
       `\`\`\`${contextItemToEdit.name}\n${contextItemToEdit.content}\n\`\`\`\n`,
       "",
     );
-
+    // if the above replace fails to find a match, the code will still be present
+    // in the userInput. Replace it with input if available.
     if (userInput.includes("\`\`\`") && (input !== "" || !input)) {
       userInput = input;
     }

--- a/core/commands/slash/edit.ts
+++ b/core/commands/slash/edit.ts
@@ -241,13 +241,19 @@ const EditSlashCommand: SlashCommand = {
           part.text = part.text.replace("/edit", "").trimStart();
         }
       });
-    } else {
+    } else if (input?.startsWith("/edit")) {
       content = input.replace("/edit", "").trimStart();
+    } else if (input?.startsWith("/comment")) {
+      content = input.replace("/comment", "").trimStart();
     }
-    const userInput = stripImages(content).replace(
+    let userInput = stripImages(content).replace(
       `\`\`\`${contextItemToEdit.name}\n${contextItemToEdit.content}\n\`\`\`\n`,
       "",
     );
+
+    if (userInput.includes("\`\`\`") && (input !== "" || !input)) {
+      userInput = input;
+    }
 
     const rif: RangeInFileWithContents =
       contextItemToRangeInFileWithContents(contextItemToEdit);


### PR DESCRIPTION
## Description

- the default behavior of /comment doesn't do anything unless the user adds additional prompt. It'll essentially perform the same as an /edit with no additional instruction.
- edit.ts was ignoring the default input prompt from comment.ts

## Checklist

- [ ] Review code
