### PR TITLE
Add stable versions of latest gemini models

### DIFF
--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -562,7 +562,9 @@ declare global {
     // Gemini
     | "gemini-pro"
     | "gemini-1.5-pro-latest"
+    | "gemini-1.5-pro"
     | "gemini-1.5-flash-latest"
+    | "gemini-1.5-flash"
     // Mistral
     | "mistral-tiny"
     | "mistral-small"

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -614,7 +614,9 @@ export type ModelName =
   // Gemini
   | "gemini-pro"
   | "gemini-1.5-pro-latest"
+  | "gemini-1.5-pro"
   | "gemini-1.5-flash-latest"
+  | "gemini-1.5-flash"
   // Mistral
   | "mistral-tiny"
   | "mistral-small"

--- a/docs/static/schemas/config.json
+++ b/docs/static/schemas/config.json
@@ -685,7 +685,9 @@
                   "chat-bison-001",
                   "gemini-pro",
                   "gemini-1.5-pro-latest",
-                  "gemini-1.5-flash-latest"
+                  "gemini-1.5-pro",
+                  "gemini-1.5-flash-latest",
+                  "gemini-1.5-flash"
                 ]
               }
             }
@@ -1094,7 +1096,9 @@
                       "chat-bison-001",
                       "gemini-pro",
                       "gemini-1.5-pro-latest",
+                      "gemini-1.5-pro",
                       "gemini-1.5-flash-latest",
+                      "gemini-1.5-flash",
                       "mistral-tiny",
                       "mistral-small",
                       "mistral-medium",

--- a/extensions/intellij/src/main/resources/config_schema.json
+++ b/extensions/intellij/src/main/resources/config_schema.json
@@ -685,7 +685,9 @@
                   "chat-bison-001",
                   "gemini-pro",
                   "gemini-1.5-pro-latest",
-                  "gemini-1.5-flash-latest"
+                  "gemini-1.5-pro",
+                  "gemini-1.5-flash-latest",
+                  "gemini-1.5-flash"
                 ]
               }
             }
@@ -1094,7 +1096,9 @@
                       "chat-bison-001",
                       "gemini-pro",
                       "gemini-1.5-pro-latest",
+                      "gemini-1.5-pro",
                       "gemini-1.5-flash-latest",
+                      "gemini-1.5-flash",
                       "mistral-tiny",
                       "mistral-small",
                       "mistral-medium",

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -685,7 +685,9 @@
                   "chat-bison-001",
                   "gemini-pro",
                   "gemini-1.5-pro-latest",
-                  "gemini-1.5-flash-latest"
+                  "gemini-1.5-pro",
+                  "gemini-1.5-flash-latest",
+                  "gemini-1.5-flash"
                 ]
               }
             }
@@ -1094,7 +1096,9 @@
                       "chat-bison-001",
                       "gemini-pro",
                       "gemini-1.5-pro-latest",
+                      "gemini-1.5-pro",
                       "gemini-1.5-flash-latest",
+                      "gemini-1.5-flash",
                       "mistral-tiny",
                       "mistral-small",
                       "mistral-medium",

--- a/extensions/vscode/continue_rc_schema.json
+++ b/extensions/vscode/continue_rc_schema.json
@@ -748,7 +748,9 @@
                   "chat-bison-001",
                   "gemini-pro",
                   "gemini-1.5-pro-latest",
-                  "gemini-1.5-flash-latest"
+                  "gemini-1.5-pro",
+                  "gemini-1.5-flash-latest",
+                  "gemini-1.5-flash"
                 ]
               }
             }
@@ -1218,7 +1220,9 @@
                       "chat-bison-001",
                       "gemini-pro",
                       "gemini-1.5-pro-latest",
+                      "gemini-1.5-pro",
                       "gemini-1.5-flash-latest",
+                      "gemini-1.5-flash",
                       "mistral-tiny",
                       "mistral-small",
                       "mistral-medium",


### PR DESCRIPTION
## Description

Enables users to specify the latest _stable_ version of gemini 1.5 Pro and Flash. 
See [Gemini API Docs](https://ai.google.dev/gemini-api/docs/models/gemini#model-versions)

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
