### PR TITLE
docs: update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,4 +4,5 @@
 
 ## Checklist
 
-- [ ] The base branch of this PR is `preview`, rather than `main`
+- [ ] The base branch of this PR is `dev`, rather than `main`
+- [ ] The relevant docs, if any, have been updated or created


### PR DESCRIPTION
## Description

Updates the PR template to specify `dev` branch rather than `preview`, and adds a checkbox for docs updates.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
