### PR TITLE
fix(extensions): schema for db ctx provider

### DIFF
--- a/docs/static/schemas/config.json
+++ b/docs/static/schemas/config.json
@@ -1318,7 +1318,8 @@
                 "code",
                 "system",
                 "currentFile",
-                "url"
+                "url",
+                "database"
               ],
               "markdownEnumDescriptions": [
                 "Reference the contents of the current changes as given by `git diff`",
@@ -1341,7 +1342,8 @@
                 "Reference specific functions and classes from throughout your codebase",
                 "Reference your operating system and cpu",
                 "Reference the contents of the currently active file",
-                "Reference the contents of a page at a URL"
+                "Reference the contents of a page at a URL",
+                "Reference table schemas"
               ],
               "type": "string"
             },
@@ -1457,56 +1459,63 @@
             }
           },
           "then": {
-            "connections": {
-              "type": "array",
-              "description": "A list of database connections",
-              "items": {
-                "type": "object",
+            "properties": {
+              "params": {
                 "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "A unique name for this database connection"
-                  },
-                  "connection_type": {
-                    "type": "string",
-                    "description": "The type of database (e.g., 'postgres', 'mysql')",
-                    "enum": ["postgres", "mysql", "sqlite"]
-                  },
-                  "connection": {
-                    "type": "object",
-                    "properties": {
-                      "user": {
-                        "type": "string",
-                        "description": "The database user name"
+                  "connections": {
+                    "type": "array",
+                    "description": "A list of database connections",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "A unique name for this database connection"
+                        },
+                        "connection_type": {
+                          "type": "string",
+                          "description": "The type of database (e.g., 'postgres', 'mysql')",
+                          "enum": ["postgres", "mysql", "sqlite"]
+                        },
+                        "connection": {
+                          "type": "object",
+                          "properties": {
+                            "user": {
+                              "type": "string",
+                              "description": "The database user name"
+                            },
+                            "host": {
+                              "type": "string",
+                              "description": "The host address of the database server"
+                            },
+                            "database": {
+                              "type": "string",
+                              "description": "The name of the database to connect to"
+                            },
+                            "password": {
+                              "type": "string",
+                              "description": "The password for the database user"
+                            },
+                            "port": {
+                              "type": "integer",
+                              "description": "The port number to connect to at the host"
+                            },
+                            "filename": {
+                              "type": "string",
+                              "description": "File location for simple file DB's"
+                            }
+                          },
+                          "required": []
+                        }
                       },
-                      "host": {
-                        "type": "string",
-                        "description": "The host address of the database server"
-                      },
-                      "database": {
-                        "type": "string",
-                        "description": "The name of the database to connect to"
-                      },
-                      "password": {
-                        "type": "string",
-                        "description": "The password for the database user"
-                      },
-                      "port": {
-                        "type": "integer",
-                        "description": "The port number to connect to at the host"
-                      },
-                      "filename": {
-                        "type": "string",
-                        "description": "File location for simple file DB's"
-                      }
-                    },
-                    "required": []
+                      "required": ["name", "connection_type", "connection"]
+                    }
                   }
                 },
-                "required": ["name", "type", "connection"]
+                "required": ["connections"]
               }
             },
-            "required": ["connections"]
+            "required": ["params"]
           }
         },
         {

--- a/extensions/intellij/src/main/resources/config_schema.json
+++ b/extensions/intellij/src/main/resources/config_schema.json
@@ -1318,7 +1318,8 @@
                 "code",
                 "system",
                 "currentFile",
-                "url"
+                "url",
+                "database"
               ],
               "markdownEnumDescriptions": [
                 "Reference the contents of the current changes as given by `git diff`",
@@ -1341,7 +1342,8 @@
                 "Reference specific functions and classes from throughout your codebase",
                 "Reference your operating system and cpu",
                 "Reference the contents of the currently active file",
-                "Reference the contents of a page at a URL"
+                "Reference the contents of a page at a URL",
+                "Reference table schemas"
               ],
               "type": "string"
             },
@@ -1457,56 +1459,63 @@
             }
           },
           "then": {
-            "connections": {
-              "type": "array",
-              "description": "A list of database connections",
-              "items": {
-                "type": "object",
+            "properties": {
+              "params": {
                 "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "A unique name for this database connection"
-                  },
-                  "connection_type": {
-                    "type": "string",
-                    "description": "The type of database (e.g., 'postgres', 'mysql')",
-                    "enum": ["postgres", "mysql", "sqlite"]
-                  },
-                  "connection": {
-                    "type": "object",
-                    "properties": {
-                      "user": {
-                        "type": "string",
-                        "description": "The database user name"
+                  "connections": {
+                    "type": "array",
+                    "description": "A list of database connections",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "A unique name for this database connection"
+                        },
+                        "connection_type": {
+                          "type": "string",
+                          "description": "The type of database (e.g., 'postgres', 'mysql')",
+                          "enum": ["postgres", "mysql", "sqlite"]
+                        },
+                        "connection": {
+                          "type": "object",
+                          "properties": {
+                            "user": {
+                              "type": "string",
+                              "description": "The database user name"
+                            },
+                            "host": {
+                              "type": "string",
+                              "description": "The host address of the database server"
+                            },
+                            "database": {
+                              "type": "string",
+                              "description": "The name of the database to connect to"
+                            },
+                            "password": {
+                              "type": "string",
+                              "description": "The password for the database user"
+                            },
+                            "port": {
+                              "type": "integer",
+                              "description": "The port number to connect to at the host"
+                            },
+                            "filename": {
+                              "type": "string",
+                              "description": "File location for simple file DB's"
+                            }
+                          },
+                          "required": []
+                        }
                       },
-                      "host": {
-                        "type": "string",
-                        "description": "The host address of the database server"
-                      },
-                      "database": {
-                        "type": "string",
-                        "description": "The name of the database to connect to"
-                      },
-                      "password": {
-                        "type": "string",
-                        "description": "The password for the database user"
-                      },
-                      "port": {
-                        "type": "integer",
-                        "description": "The port number to connect to at the host"
-                      },
-                      "filename": {
-                        "type": "string",
-                        "description": "File location for simple file DB's"
-                      }
-                    },
-                    "required": []
+                      "required": ["name", "connection_type", "connection"]
+                    }
                   }
                 },
-                "required": ["name", "type", "connection"]
+                "required": ["connections"]
               }
             },
-            "required": ["connections"]
+            "required": ["params"]
           }
         },
         {

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -1318,7 +1318,8 @@
                 "code",
                 "system",
                 "currentFile",
-                "url"
+                "url",
+                "database"
               ],
               "markdownEnumDescriptions": [
                 "Reference the contents of the current changes as given by `git diff`",
@@ -1341,7 +1342,8 @@
                 "Reference specific functions and classes from throughout your codebase",
                 "Reference your operating system and cpu",
                 "Reference the contents of the currently active file",
-                "Reference the contents of a page at a URL"
+                "Reference the contents of a page at a URL",
+                "Reference table schemas"
               ],
               "type": "string"
             },
@@ -1457,56 +1459,63 @@
             }
           },
           "then": {
-            "connections": {
-              "type": "array",
-              "description": "A list of database connections",
-              "items": {
-                "type": "object",
+            "properties": {
+              "params": {
                 "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "A unique name for this database connection"
-                  },
-                  "connection_type": {
-                    "type": "string",
-                    "description": "The type of database (e.g., 'postgres', 'mysql')",
-                    "enum": ["postgres", "mysql", "sqlite"]
-                  },
-                  "connection": {
-                    "type": "object",
-                    "properties": {
-                      "user": {
-                        "type": "string",
-                        "description": "The database user name"
+                  "connections": {
+                    "type": "array",
+                    "description": "A list of database connections",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "A unique name for this database connection"
+                        },
+                        "connection_type": {
+                          "type": "string",
+                          "description": "The type of database (e.g., 'postgres', 'mysql')",
+                          "enum": ["postgres", "mysql", "sqlite"]
+                        },
+                        "connection": {
+                          "type": "object",
+                          "properties": {
+                            "user": {
+                              "type": "string",
+                              "description": "The database user name"
+                            },
+                            "host": {
+                              "type": "string",
+                              "description": "The host address of the database server"
+                            },
+                            "database": {
+                              "type": "string",
+                              "description": "The name of the database to connect to"
+                            },
+                            "password": {
+                              "type": "string",
+                              "description": "The password for the database user"
+                            },
+                            "port": {
+                              "type": "integer",
+                              "description": "The port number to connect to at the host"
+                            },
+                            "filename": {
+                              "type": "string",
+                              "description": "File location for simple file DB's"
+                            }
+                          },
+                          "required": []
+                        }
                       },
-                      "host": {
-                        "type": "string",
-                        "description": "The host address of the database server"
-                      },
-                      "database": {
-                        "type": "string",
-                        "description": "The name of the database to connect to"
-                      },
-                      "password": {
-                        "type": "string",
-                        "description": "The password for the database user"
-                      },
-                      "port": {
-                        "type": "integer",
-                        "description": "The port number to connect to at the host"
-                      },
-                      "filename": {
-                        "type": "string",
-                        "description": "File location for simple file DB's"
-                      }
-                    },
-                    "required": []
+                      "required": ["name", "connection_type", "connection"]
+                    }
                   }
                 },
-                "required": ["name", "type", "connection"]
+                "required": ["connections"]
               }
             },
-            "required": ["connections"]
+            "required": ["params"]
           }
         },
         {

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -1316,7 +1316,6 @@
                 "outline",
                 "postgres",
                 "code",
-                "system",
                 "currentFile",
                 "url",
                 "database"
@@ -1324,6 +1323,7 @@
               "markdownEnumDescriptions": [
                 "Reference the contents of the current changes as given by `git diff`",
                 "Reference the contents of the terminal",
+                "Reference the contents of the local variables with top n level (defaulting to 3) of call stack for that thread",
                 "Reference the contents of all open or pinned files.",
                 "Enter a search phrase and include the Google search results as context",
                 "Reference the results of a ripgrep search in your codebase",
@@ -1333,14 +1333,11 @@
                 "Include important files from a folder in the prompt, as determined by similarity search",
                 "Reference GitHub issues from a repository",
                 "Retrieve important pages from a documentation website, as determined by similarity search",
-                "Index and retrieve the contents of any documentation site, using embeddings to find important snippets",
                 "Display a file tree of the current workspace",
+                "Include important highlighted sections from your code",
                 "Include a repo map showing important code objects",
-                "Displays important snippets of code from the currently open files",
-                "Displays definition lines from the currently open files",
                 "References Postgres table schema and sample rows",
                 "Reference specific functions and classes from throughout your codebase",
-                "Reference your operating system and cpu",
                 "Reference the contents of the currently active file",
                 "Reference the contents of a page at a URL",
                 "Reference table schemas"

--- a/extensions/vscode/continue_rc_schema.json
+++ b/extensions/vscode/continue_rc_schema.json
@@ -1461,7 +1461,8 @@
                 "code",
                 "system",
                 "currentFile",
-                "url"
+                "url",
+                "database"
               ],
               "markdownEnumDescriptions": [
                 "Reference the contents of the current changes as given by `git diff`",
@@ -1484,7 +1485,8 @@
                 "Reference specific functions and classes from throughout your codebase",
                 "Reference your operating system and cpu",
                 "Reference the contents of the currently active file",
-                "Reference the contents of a page at a URL"
+                "Reference the contents of a page at a URL",
+                "Reference table schemas"
               ],
               "type": "string"
             },
@@ -1623,65 +1625,74 @@
             }
           },
           "then": {
-            "connections": {
-              "type": "array",
-              "description": "A list of database connections",
-              "items": {
-                "type": "object",
+            "properties": {
+              "params": {
                 "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "A unique name for this database connection"
-                  },
-                  "connection_type": {
-                    "type": "string",
-                    "description": "The type of database (e.g., 'postgres', 'mysql')",
-                    "enum": [
-                      "postgres",
-                      "mysql",
-                      "sqlite"
-                    ]
-                  },
-                  "connection": {
-                    "type": "object",
-                    "properties": {
-                      "user": {
-                        "type": "string",
-                        "description": "The database user name"
+                  "connections": {
+                    "type": "array",
+                    "description": "A list of database connections",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "A unique name for this database connection"
+                        },
+                        "connection_type": {
+                          "type": "string",
+                          "description": "The type of database (e.g., 'postgres', 'mysql')",
+                          "enum": [
+                            "postgres",
+                            "mysql",
+                            "sqlite"
+                          ]
+                        },
+                        "connection": {
+                          "type": "object",
+                          "properties": {
+                            "user": {
+                              "type": "string",
+                              "description": "The database user name"
+                            },
+                            "host": {
+                              "type": "string",
+                              "description": "The host address of the database server"
+                            },
+                            "database": {
+                              "type": "string",
+                              "description": "The name of the database to connect to"
+                            },
+                            "password": {
+                              "type": "string",
+                              "description": "The password for the database user"
+                            },
+                            "port": {
+                              "type": "integer",
+                              "description": "The port number to connect to at the host"
+                            },
+                            "filename": {
+                              "type": "string",
+                              "description": "File location for simple file DB's"
+                            }
+                          },
+                          "required": []
+                        }
                       },
-                      "host": {
-                        "type": "string",
-                        "description": "The host address of the database server"
-                      },
-                      "database": {
-                        "type": "string",
-                        "description": "The name of the database to connect to"
-                      },
-                      "password": {
-                        "type": "string",
-                        "description": "The password for the database user"
-                      },
-                      "port": {
-                        "type": "integer",
-                        "description": "The port number to connect to at the host"
-                      },
-                      "filename": {
-                        "type": "string",
-                        "description": "File location for simple file DB's"
-                      }
-                    },
-                    "required": []
+                      "required": [
+                        "name",
+                        "connection_type",
+                        "connection"
+                      ]
+                    }
                   }
                 },
                 "required": [
-                  "name",
-                  "type",
-                  "connection"
+                  "connections"
                 ]
               }
             },
             "required": [
-              "connections"
+              "params"
             ]
           }
         },


### PR DESCRIPTION
## Description

Fixes an invalid schema for the database context provider. Previously it wasn't checking for a `params` property, just a top level `connections` property.

See the relevant docs here: https://docs.continue.dev/customization/context-providers#database-tables

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
