### PR TITLE
fix(gui): ctx rendering w/ renderInlineAs: ""

### DIFF
--- a/extensions/vscode/CONTRIBUTING.md
+++ b/extensions/vscode/CONTRIBUTING.md
@@ -7,11 +7,11 @@ This is the Continue VS Code Extension. Its primary jobs are
 
 # How to run the extension
 
-See [Environment Setup](../CONTRIBUTING.md#environment-setup)
+See [Environment Setup](../../CONTRIBUTING.md#environment-setup)
 
 # How to run and debug tests
 
-After following the setup in [Environment Setup](../CONTRIBUTING.md#environment-setup) you can run the `Extension (VSCode)` launch configuration in VS Code.
+After following the setup in [Environment Setup](../../CONTRIBUTING.md#environment-setup) you can run the `Extension (VSCode)` launch configuration in VS Code.
 
 ## Notes
 

--- a/gui/src/components/mainInput/resolveInput.ts
+++ b/gui/src/components/mainInput/resolveInput.ts
@@ -42,6 +42,9 @@ async function resolveEditorContent(
       if (foundSlashCommand && typeof slashCommand === "undefined") {
         slashCommand = foundSlashCommand;
       }
+
+      contextItemAttrs.push(...ctxItems);
+
       if (text === "") {
         continue;
       }
@@ -51,11 +54,14 @@ async function resolveEditorContent(
       } else {
         parts.push({ type: "text", text });
       }
-      contextItemAttrs.push(...ctxItems);
     } else if (p.type === "codeBlock") {
       if (!p.attrs.item.editing) {
         const text =
-          "```" + p.attrs.item.description + "\n" + p.attrs.item.content + "\n```";
+          "```" +
+          p.attrs.item.description +
+          "\n" +
+          p.attrs.item.content +
+          "\n```";
         if (parts[parts.length - 1]?.type === "text") {
           parts[parts.length - 1].text += "\n" + text;
         } else {
@@ -96,7 +102,10 @@ async function resolveEditorContent(
     if (item.itemType === "file") {
       // This is a quick way to resolve @file references
       const basename = getBasename(item.id);
-      const relativeFilePath = getRelativePath(item.id, await ideMessenger.ide.getWorkspaceDirs());
+      const relativeFilePath = getRelativePath(
+        item.id,
+        await ideMessenger.ide.getWorkspaceDirs(),
+      );
       const rawContent = await ideMessenger.ide.readFile(item.id);
       const content = `\`\`\`${relativeFilePath}\n${rawContent}\n\`\`\`\n`;
       contextItemsText += content;


### PR DESCRIPTION
## Description

Fixes a bug where setting `renderInlineAs: ""` caused context providers to not pass a value unless further input text was provided.

Also some Prettier formatting, and fixes a broken docs link.

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
