### PR TITLE
fix: StackTrace source code retrieval for some type of debug session

### DIFF
--- a/extensions/vscode/src/util/ideUtils.ts
+++ b/extensions/vscode/src/util/ideUtils.ts
@@ -19,6 +19,8 @@ import {
   uriFromFilePath,
 } from "./vscode";
 
+import _ from "lodash";
+
 const util = require("node:util");
 const asyncExec = util.promisify(require("node:child_process").exec);
 
@@ -485,7 +487,9 @@ export class VsCodeIdeUtils {
 
             const scope = scopeResponse.scopes[0];
 
-            return await this.retrieveSource(scope.source ? scope : stackFrame);
+            return await this.retrieveSource(
+              scope.source && !_.isEmpty(scope.source) ? scope : stackFrame,
+            );
           }),
       );
 
@@ -520,7 +524,7 @@ export class VsCodeIdeUtils {
       return await this.readRangeInFile(
         sourceContainer.source.path,
         new vscode.Range(
-          sourceContainer.line - 3,
+          Math.max(0, sourceContainer.line - 3),
           0,
           sourceContainer.line + 2,
           0,


### PR DESCRIPTION
## Description

`@locals` context provider can now correctly retrieve the stack trace source code in some debug sessions including python (but not ipynb, because the ipynb has the source file look like `vscode-notebook-cell:/home/commandblock2/git_repo/continue/extensions/vscode/manual-testing-sandbox/example.ipynb#W0sZmlsZQ%3D%3D`).

## Checklist

- [x] The base branch of this PR is `preview`, rather than `main`
