### PR TITLE
fix: preserve indentation in code blocks

### DIFF
--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -70,7 +70,9 @@ async function addHighlightedCodeToContext(
       // }
       return;
     }
-    const range = new vscode.Range(selection.start, selection.end);
+    // adjust starting position to include indentation
+    const start = new vscode.Position(selection.start.line, 0);
+    const range = new vscode.Range(start, selection.end);
     const contents = editor.document.getText(range);
     const rangeInFileWithContents = {
       filepath: editor.document.uri.fsPath,

--- a/gui/src/components/markdown/CodeSnippetPreview.tsx
+++ b/gui/src/components/markdown/CodeSnippetPreview.tsx
@@ -156,7 +156,7 @@ function CodeSnippetPreview(props: CodeSnippetPreviewProps) {
         <StyledMarkdownPreview
           source={`${fence}${getMarkdownLanguageTagForFile(
             props.item.description,
-          )}\n${props.item.content.trim()}\n${fence}`}
+          )}\n${props.item.content.trimEnd()}\n${fence}`}
           showCodeBorder={false}
         />
       </div>


### PR DESCRIPTION
## Description
- Updated highlighted code range to include indentation on first line
- Replaced trim() with trimEnd() in order to preserve leading whitespace in code snippets
- fixes #1518 

## Checklist
- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created
