### PR TITLE
feat: `--noEmit` for tsc checks in CI

### DIFF
--- a/.github/workflows/ts-check.yaml
+++ b/.github/workflows/ts-check.yaml
@@ -72,19 +72,19 @@ jobs:
       - name: tsc core
         run: |
           cd core
-          npx tsc
+          npx tsc --noEmit
 
       - name: tsc extensions/vscode
         run: |
           cd extensions/vscode
-          npx tsc
+          npx tsc --noEmit
 
       - name: tsc binary
         run: |
           cd binary
-          npx tsc
+          npx tsc --noEmit
 
       - name: tsc gui
         run: |
           cd gui
-          npx tsc
+          npx tsc --noEmit


### PR DESCRIPTION
## Description

Adds the `--noEmit` flag for Typescript type checks in CI. This will speed up type checking.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created
