### PR TITLE
feat: toast notification for config updates

### DIFF
--- a/core/config/handler.ts
+++ b/core/config/handler.ts
@@ -40,14 +40,15 @@ export class ConfigHandler {
     this.updateListeners.push(listener);
   }
 
-  reloadConfig() {
+  async reloadConfig() {
     this.savedConfig = undefined;
     this.savedBrowserConfig = undefined;
-    this.loadConfig().then(() => {
-      for (const listener of this.updateListeners) {
-        listener();
-      }
-    });
+
+    await this.loadConfig();
+
+    for (const listener of this.updateListeners) {
+      listener();
+    }
   }
 
   async getSerializedConfig(): Promise<BrowserSerializedContinueConfig> {

--- a/core/core.ts
+++ b/core/core.ts
@@ -14,7 +14,7 @@ import {
   setupLocalMode,
   setupOptimizedExistingUserMode,
 } from "./config/onboarding.js";
-import { createNewPromptFile } from "./config/promptFile";
+import { createNewPromptFile } from "./config/promptFile.js";
 import { addModel, addOpenAIKey, deleteModel } from "./config/util.js";
 import { ContinueServerClient } from "./continueServer/stubs/client.js";
 import { indexDocs } from "./indexing/docs/index.js";
@@ -500,12 +500,12 @@ export class Core {
         mode === "local"
           ? setupLocalMode
           : mode === "freeTrial"
-            ? setupFreeTrialMode
-            : mode === "localAfterFreeTrial"
-              ? setupLocalAfterFreeTrial
-              : mode === "apiKeys"
-                ? setupApiKeysMode
-                : setupOptimizedExistingUserMode,
+          ? setupFreeTrialMode
+          : mode === "localAfterFreeTrial"
+          ? setupLocalAfterFreeTrial
+          : mode === "apiKeys"
+          ? setupApiKeysMode
+          : setupOptimizedExistingUserMode,
       );
       this.configHandler.reloadConfig();
     });
@@ -539,7 +539,7 @@ export class Core {
     on("index/indexingProgressBarInitialized", async (msg) => {
       // Triggered when progress bar is initialized.
       // If a non-default state has been stored, update the indexing display to that state
-      if (this.indexingState.status != "loading") {
+      if (this.indexingState.status !== "loading") {
         this.messenger.request("indexProgress", this.indexingState);
       }
     });

--- a/extensions/vscode/src/extension/vscodeExtension.ts
+++ b/extensions/vscode/src/extension/vscodeExtension.ts
@@ -164,20 +164,17 @@ export class VsCodeExtension {
 
     // Listen for file saving - use global file watcher so that changes
     // from outside the window are also caught
-    fs.watchFile(getConfigJsonPath(), { interval: 1000 }, (stats) => {
-      this.configHandler.reloadConfig();
+    fs.watchFile(getConfigJsonPath(), { interval: 1000 }, async (stats) => {
+      await this.configHandler.reloadConfig();
+
+      // Trigger a toast notification to provide UI feedback that config
+      // has been updated
+      vscode.window.showInformationMessage("Config updated");
     });
+
     fs.watchFile(getConfigTsPath(), { interval: 1000 }, (stats) => {
       this.configHandler.reloadConfig();
     });
-
-    // Trigger a toast notification to provide UI feedback that config
-    // has been refreshed
-    this.configHandler.onConfigUpdate(() =>
-      vscode.window.showInformationMessage(
-        "Updated config successfully applied",
-      ),
-    );
 
     this.configHandler.onConfigUpdate(
       this.tabAutocompleteModel.clearLlm.bind(this.tabAutocompleteModel),

--- a/extensions/vscode/src/extension/vscodeExtension.ts
+++ b/extensions/vscode/src/extension/vscodeExtension.ts
@@ -171,6 +171,14 @@ export class VsCodeExtension {
       this.configHandler.reloadConfig();
     });
 
+    // Trigger a toast notification to provide UI feedback that config
+    // has been refreshed
+    this.configHandler.onConfigUpdate(() =>
+      vscode.window.showInformationMessage(
+        "Updated config successfully applied",
+      ),
+    );
+
     this.configHandler.onConfigUpdate(
       this.tabAutocompleteModel.clearLlm.bind(this.tabAutocompleteModel),
     );
@@ -246,6 +254,7 @@ export class VsCodeExtension {
 
   static continueVirtualDocumentScheme = "continue";
 
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   private PREVIOUS_BRANCH_FOR_WORKSPACE_DIR: { [dir: string]: string } = {};
 
   registerCustomContextProvider(contextProvider: IContextProvider) {


### PR DESCRIPTION
## Description

Adds a listener to `onConfigUpdate` that triggers a toast notification. This gives the user confirmation that their updates have been successfully applied, and they don't need to restart VSCode.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots
![Screenshot 2024-06-24 at 1 44 48 PM](https://github.com/continuedev/continue/assets/20157849/393eeecb-8528-4bd2-bb65-8aac47246ba8)

## Testing
Open up config, save, confirm that the toast notification appears.