### PR TITLE
docs: comment out unused providers

### DIFF
--- a/core/context/providers/CodeOutlineContextProvider.ts
+++ b/core/context/providers/CodeOutlineContextProvider.ts
@@ -6,8 +6,6 @@ import {
 import { getBasename } from "../../util/index.js";
 import { BaseContextProvider } from "../index.js";
 
-// import { getOutlines } from "llm-code-highlighter/dist/index.continue";
-
 class CodeOutlineContextProvider extends BaseContextProvider {
   static description: ContextProviderDescription = {
     title: "outline",

--- a/core/context/providers/index.ts
+++ b/core/context/providers/index.ts
@@ -1,7 +1,6 @@
 import { ContextProviderName } from "../../index.js";
 import { BaseContextProvider } from "../index.js";
 import CodeContextProvider from "./CodeContextProvider.js";
-// import CodeHighlightsContextProvider from "./CodeHighlightsContextProvider.js";
 import CodebaseContextProvider from "./CodebaseContextProvider.js";
 import CurrentFileContextProvider from "./CurrentFileContextProvider.js";
 import DatabaseContextProvider from "./DatabaseContextProvider.js";
@@ -23,6 +22,13 @@ import SearchContextProvider from "./SearchContextProvider.js";
 import TerminalContextProvider from "./TerminalContextProvider.js";
 import URLContextProvider from "./URLContextProvider.js";
 
+/**
+ * Note: We are currently omitting the following providers due to bugs:
+ * - `CodeOutlineContextProvider`
+ * - `CodeHighlightsContextProvider`
+ *
+ * See this issue for details: https://github.com/continuedev/continue/issues/1365
+ */
 const Providers: (typeof BaseContextProvider)[] = [
   DiffContextProvider,
   FileTreeContextProvider,
@@ -39,8 +45,6 @@ const Providers: (typeof BaseContextProvider)[] = [
   FolderContextProvider,
   DocsContextProvider,
   GitLabMergeRequestContextProvider,
-  // CodeHighlightsContextProvider,
-  // CodeOutlineContextProvider,
   JiraIssuesContextProvider,
   PostgresContextProvider,
   DatabaseContextProvider,

--- a/docs/docs/customization/context-providers.md
+++ b/docs/docs/customization/context-providers.md
@@ -202,7 +202,12 @@ assignee = currentUser() AND resolution = Unresolved order by updated DESC
 
 You can override this query by setting the `issueQuery` parameter.
 
-### Code Outline
+ <!-- 
+ Note: We are currently omitting the following providers due to bugs.
+ See this issue for details: https://github.com/continuedev/continue/issues/1365 
+ -->
+
+<!-- ### Code Outline
 
 Type '@outline' to reference the outline of all currently open files. The outline of a files consists of only the function and class definitions in the file. Supported file extensions are '.js', '.mjs', '.go', '.c', '.cc', '.cs', '.cpp', '.el', '.ex', '.elm', '.java', '.ml', '.php', '.ql', '.rb', '.rs', '.ts'
 
@@ -216,7 +221,7 @@ Type '@highlights' to reference the 'highlights' from all currently open files. 
 
 ```json
 { "name": "highlights" }
-```
+``` -->
 
 ### PostgreSQL
 


### PR DESCRIPTION
## Description

Comment out unused providers: `CodeOutlineContextProvider`, `CodeHighlightsContextProvider`

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created
