### PR TITLE
fix: autocomplete label after selecting a query type context provider

### DIFF
--- a/gui/src/components/mainInput/MentionList.tsx
+++ b/gui/src/components/mainInput/MentionList.tsx
@@ -242,6 +242,22 @@ const MentionList = forwardRef((props: MentionListProps, ref) => {
     }
 
     if (item.contextProvider?.type === "query") {
+      // complete selected query in editor
+      const { tr } = props.editor.view.state;
+      const text = tr.doc.textBetween(0, tr.selection.from);
+      const lastAtIndex = text.lastIndexOf("@");
+      const position = tr.selection.from;
+
+      props.editor.view.dispatch(
+        tr
+          .replaceWith(
+            lastAtIndex,
+            position,
+            props.editor.view.state.schema.text(`@${item.title}`),
+          )
+          .scrollIntoView(),
+      );
+
       setSubMenuTitle(item.description);
       setQuerySubmenuItem(item);
       return;

--- a/gui/src/components/mainInput/MentionList.tsx
+++ b/gui/src/components/mainInput/MentionList.tsx
@@ -83,8 +83,8 @@ function DropdownIcon(props: { className?: string; item: ComboBoxItem }) {
     props.item.type === "contextProvider"
       ? props.item.id
       : props.item.type === "slashCommand"
-        ? props.item.id
-        : props.item.type;
+      ? props.item.id
+      : props.item.type;
 
   const iconClass = `${props.className} flex-shrink-0`;
 
@@ -120,9 +120,7 @@ function DropdownIcon(props: { className?: string; item: ComboBoxItem }) {
 
 const ItemsDiv = styled.div`
   border-radius: ${defaultBorderRadius};
-  box-shadow:
-    0 0 0 1px rgba(0, 0, 0, 0.05),
-    0px 10px 20px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.05), 0px 10px 20px rgba(0, 0, 0, 0.1);
   font-size: 0.9rem;
   overflow-x: hidden;
   overflow-y: auto;
@@ -242,20 +240,13 @@ const MentionList = forwardRef((props: MentionListProps, ref) => {
     }
 
     if (item.contextProvider?.type === "query") {
-      // complete selected query in editor
+      // update editor to complete context provider title
       const { tr } = props.editor.view.state;
       const text = tr.doc.textBetween(0, tr.selection.from);
-      const lastAtIndex = text.lastIndexOf("@");
-      const position = tr.selection.from;
-
+      const partialText = text.slice(text.lastIndexOf("@") + 1);
+      const remainingText = item.title.slice(partialText.length);
       props.editor.view.dispatch(
-        tr
-          .replaceWith(
-            lastAtIndex,
-            position,
-            props.editor.view.state.schema.text(`@${item.title}`),
-          )
-          .scrollIntoView(),
+        tr.insertText(remainingText, tr.selection.from),
       );
 
       setSubMenuTitle(item.description);


### PR DESCRIPTION
## Description

- After selecting a query type context provider from the dropdown, the editor will now update to complete the provider label.
- Resolves #1540

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created
