### PR TITLE
Update completionProvider.ts (warning tab-autocomplete for codestral) 

### DIFF
--- a/core/autocomplete/completionProvider.ts
+++ b/core/autocomplete/completionProvider.ts
@@ -440,7 +440,8 @@ export class CompletionProvider {
     if (
       !shownGptClaudeWarning &&
       nonAutocompleteModels.some((model) => llm.model.includes(model)) &&
-      !llm.model.includes("deepseek")
+      !llm.model.includes("deepseek") &&
+      !llm.model.includes("codestral")
     ) {
       shownGptClaudeWarning = true;
       throw new Error(


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]
Added a boolean condition to ensure the model is not a version of codestral. It still displays a warning for other mistral models.
## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created
