### PR TITLE
Fullscreen fixes

### DIFF
--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -17,6 +17,8 @@ import { VerticalPerLineDiffManager } from "./diff/verticalPerLine/manager";
 import { getPlatform } from "./util/util";
 import type { VsCodeWebviewProtocol } from "./webviewProtocol";
 
+let fullScreenPanel: vscode.WebviewPanel | undefined;
+
 function getFullScreenTab() {
   const tabs = vscode.window.tabGroups.all.flatMap((tabGroup) => tabGroup.tabs);
   return tabs.find((tab) =>
@@ -210,8 +212,13 @@ const commandsMap: (
       }
     },
     "continue.focusContinueInput": async () => {
-      if (!getFullScreenTab()) {
+      const fullScreenTab = getFullScreenTab();
+      if (!fullScreenTab) {
+        // focus sidebar
         vscode.commands.executeCommand("continue.continueGUIView.focus");
+      } else {
+        // focus fullscreen
+        fullScreenPanel?.reveal();
       }
       sidebar.webviewProtocol?.request("focusContinueInput", undefined);
       await addHighlightedCodeToContext(false, sidebar.webviewProtocol);
@@ -445,20 +452,9 @@ const commandsMap: (
         return;
       }
 
-      if (fullScreenTab) {
+      if (fullScreenTab && fullScreenPanel) {
         //Full screen open, but not focused - focus it
-        // Focus the tab
-        const openOptions = {
-          preserveFocus: true,
-          preview: fullScreenTab.isPreview,
-          viewColumn: fullScreenTab.group.viewColumn,
-        };
-
-        vscode.commands.executeCommand(
-          "vscode.open",
-          (fullScreenTab.input as any).uri,
-          openOptions,
-        );
+        fullScreenPanel.reveal();
         return;
       }
 
@@ -474,7 +470,11 @@ const commandsMap: (
         "continue.continueGUIView",
         "Continue",
         vscode.ViewColumn.One,
+        {
+          retainContextWhenHidden: true,
+        },
       );
+      fullScreenPanel = panel;
 
       //Add content to the panel
       panel.webview.html = sidebar.getSidebarContent(


### PR DESCRIPTION
## Description

- Adjusted focusContinueInput command to properly focus webview panel when in fullscreen mode
- Set retainContextWhileHidden to true on webview panel to prevent continue input resetting after switching to other tabs.
- Fixes #1543 

## Issues
From VS Code documentation:

> retainContextWhenHidden has a high memory overhead and should only be used if your panel's context cannot be quickly saved and restored.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created
