### PR TITLE
[CON-245] Add docs through config.json

### DIFF
--- a/core/indexing/docs/DocsService.ts
+++ b/core/indexing/docs/DocsService.ts
@@ -30,6 +30,7 @@ export class DocsService {
   private static instance: DocsService;
   private static DOCS_TABLE_NAME = "docs";
   private _sqliteTable: Database | undefined;
+  private docsIndexingQueue: Set<string> = new Set();
 
   public static getInstance(): DocsService {
     if (!DocsService.instance) {
@@ -204,10 +205,16 @@ export class DocsService {
   async *indexAndAdd(
     siteIndexingConfig: SiteIndexingConfig,
     embeddingsProvider: EmbeddingsProvider,
+    reIndex: boolean = false,
   ): AsyncGenerator<IndexingProgressUpdate> {
-    const startUrl = new URL(siteIndexingConfig.startUrl);
+    const startUrl = new URL(siteIndexingConfig.startUrl.toString());
 
-    if (await this.has(siteIndexingConfig.startUrl.toString())) {
+    if (this.docsIndexingQueue.has(startUrl.toString())) {
+      console.log("Already in queue");
+      return;
+    }
+
+    if (!reIndex && await this.has(startUrl.toString())) {
       yield {
         progress: 1,
         desc: "Already indexed",
@@ -216,6 +223,9 @@ export class DocsService {
       return;
     }
 
+    // Mark the site as currently being indexed
+    this.docsIndexingQueue.add(startUrl.toString());
+
     yield {
       progress: 0,
       desc: "Finding subpages",
@@ -223,20 +233,31 @@ export class DocsService {
     };
 
     const articles: Article[] = [];
+    let processedPages = 0;
+    let maxKnownPages = 1;
 
     // Crawl pages and retrieve info as articles
     for await (const page of crawlPage(startUrl, siteIndexingConfig.maxDepth)) {
+      processedPages++;
       const article = pageToArticle(page);
       if (!article) {
         continue;
       }
       articles.push(article);
 
+      // Use a heuristic approach for progress calculation
+      const progress = Math.min(processedPages / maxKnownPages, 1);
+
       yield {
-        progress: 0,
+        progress, // Yield the heuristic progress
         desc: `Finding subpages (${page.path})`,
         status: "indexing",
       };
+
+      // Increase maxKnownPages to delay progress reaching 100% too soon
+      if (processedPages === maxKnownPages) {
+        maxKnownPages *= 2;
+      }
     }
 
     const chunks: Chunk[] = [];
@@ -244,10 +265,11 @@ export class DocsService {
 
     // Create embeddings of retrieved articles
     console.log("Creating Embeddings for ", articles.length, " articles");
-    for (const article of articles) {
+    for (let i = 0; i < articles.length; i++) {
+      const article = articles[i];
       yield {
-        progress: Math.max(1, Math.floor(100 / (articles.length + 1))),
-        desc: `${article.subpath}`,
+        progress: i / articles.length,
+        desc: `Creating Embeddings: ${article.subpath}`,
         status: "indexing",
       };
 
@@ -268,7 +290,14 @@ export class DocsService {
 
     // Add docs to databases
     console.log("Adding ", embeddings.length, " embeddings to db");
+    yield {
+      progress: 0.5,
+      desc: `Adding ${embeddings.length} embeddings to db`,
+      status: "indexing",
+    };
+
     await this.add(siteIndexingConfig.title, startUrl, chunks, embeddings);
+    this.docsIndexingQueue.delete(startUrl.toString());
 
     yield {
       progress: 1,

--- a/core/protocol/core.ts
+++ b/core/protocol/core.ts
@@ -69,6 +69,7 @@ export type ToCoreFromIdeOrWebviewProtocol = {
   "autocomplete/complete": [AutocompleteInput, string[]];
   "context/addDocs": [SiteIndexingConfig, void];
   "context/removeDocs": [{ baseUrl: string }, void];
+  "context/indexDocs": [{ reIndex: boolean }, void];
   "autocomplete/cancel": [undefined, void];
   "autocomplete/accept": [{ completionId: string }, void];
   "command/run": [

--- a/core/protocol/passThrough.ts
+++ b/core/protocol/passThrough.ts
@@ -25,6 +25,7 @@ export const WEBVIEW_TO_CORE_PASS_THROUGH: (keyof ToCoreFromWebviewProtocol)[] =
     "context/loadSubmenuItems",
     "context/addDocs",
     "context/removeDocs",
+    "context/indexDocs",
     "autocomplete/complete",
     "autocomplete/cancel",
     "autocomplete/accept",

--- a/docs/docs/customization/context-providers.md
+++ b/docs/docs/customization/context-providers.md
@@ -58,6 +58,28 @@ Type `@docs` to index and retrieve snippets from any documentation site. You can
 
 Continue also pre-indexes a number of common sites, listed [here](https://github.com/continuedev/continue/blob/main/core/indexing/docs/preIndexedDocs.ts). The embeddings for these sites are hosted by us, but downloaded for local use after the first time. All other indexing occurs entirely locally.
 
+#### Adding a Documentation Site via Configuration
+
+To add a documentation site via configuration, update the `config.json` file as follows:
+
+```json
+{
+  "name": "docs",
+  "params": {
+    "sites": [
+      {
+        "title": "ExampleDocs",
+        "startUrl": "https://exampledocs.com/docs",
+        "rootUrl": "https://exampledocs.com",
+        "maxDepth": 3 // Default
+      }
+    ]
+  }
+}
+```
+
+The docs are indexed when you modify the configuration file, unless indexing is disabled. If you want to manually trigger the indexing, you can use the command `Continue: Docs Index`. For force indexing, you can use the command `Continue: Docs Force Re-Index`. Note that these commands will work even if automatic indexing is disabled.
+
 ### Open Files
 
 Type '@open' to reference the contents of all of your open files. Set `onlyPinned` to `true` to only reference pinned files.

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -229,6 +229,18 @@
         "category": "Continue",
         "title": "Fix Grammar / Spelling",
         "group": "Continue"
+      },
+      {
+        "command": "continue.docsIndex",
+        "category": "Continue",
+        "title": "Docs Index",
+        "group": "Continue"
+      },
+      {
+        "command": "continue.docsReIndex",
+        "category": "Continue",
+        "title": "Docs Force Re-Index",
+        "group": "Continue"
       }
     ],
     "keybindings": [

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -25,6 +25,7 @@ import { VerticalPerLineDiffManager } from "./diff/verticalPerLine/manager";
 import { QuickEdit } from "./quickEdit/QuickEditQuickPick";
 import { Battery } from "./util/battery";
 import type { VsCodeWebviewProtocol } from "./webviewProtocol";
+import { Core } from "core/core";
 
 let fullScreenPanel: vscode.WebviewPanel | undefined;
 
@@ -170,6 +171,7 @@ const commandsMap: (
   continueServerClientPromise: Promise<ContinueServerClient>,
   battery: Battery,
   quickEdit: QuickEdit,
+  core: Core,
 ) => { [command: string]: (...args: any) => any } = (
   ide,
   extensionContext,
@@ -180,6 +182,7 @@ const commandsMap: (
   continueServerClientPromise,
   battery,
   quickEdit,
+  core
 ) => {
   /**
    * Streams an inline edit to the vertical diff manager.
@@ -300,6 +303,12 @@ const commandsMap: (
     },
     "continue.toggleAuxiliaryBar": () => {
       vscode.commands.executeCommand("workbench.action.toggleAuxiliaryBar");
+    },
+    "continue.docsIndex": async () => {
+      core.invoke("context/indexDocs", {reIndex: false});
+    },
+    "continue.docsReIndex": async () => {
+      core.invoke("context/indexDocs", {reIndex: true});
     },
     "continue.focusContinueInput": async () => {
       const fullScreenTab = getFullScreenTab();
@@ -685,6 +694,7 @@ export function registerAllCommands(
   continueServerClientPromise: Promise<ContinueServerClient>,
   battery: Battery,
   quickEdit: QuickEdit,
+  core: Core,
 ) {
   for (const [command, callback] of Object.entries(
     commandsMap(
@@ -697,6 +707,7 @@ export function registerAllCommands(
       continueServerClientPromise,
       battery,
       quickEdit,
+      core
     ),
   )) {
     context.subscriptions.push(

--- a/extensions/vscode/src/extension/VsCodeExtension.ts
+++ b/extensions/vscode/src/extension/VsCodeExtension.ts
@@ -196,6 +196,7 @@ export class VsCodeExtension {
       this.core.continueServerClientPromise,
       this.battery,
       quickEdit,
+      this.core
     );
 
     registerDebugTracker(this.sidebar.webviewProtocol, this.ide);

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -64,6 +64,7 @@
       "devDependencies": {
         "@swc/cli": "^0.3.12",
         "@swc/core": "^1.5.25",
+        "@types/lodash": "^4.17.6",
         "@types/node": "^20.5.6",
         "@types/node-fetch": "^2.6.4",
         "@types/react": "^18.0.27",
@@ -1998,6 +1999,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.6.tgz",
+      "integrity": "sha512-OpXEVoCKSS3lQqjx9GGGOapBeuW5eUboYHRlHP9urXPX25IKZ6AnP5ZRxtVf63iieUbsHxLn8NQ5Nlftc6yzAA==",
+      "dev": true
     },
     "node_modules/@types/mdast": {
       "version": "4.0.4",

--- a/gui/package.json
+++ b/gui/package.json
@@ -66,6 +66,7 @@
   "devDependencies": {
     "@swc/cli": "^0.3.12",
     "@swc/core": "^1.5.25",
+    "@types/lodash": "^4.17.6",
     "@types/node": "^20.5.6",
     "@types/node-fetch": "^2.6.4",
     "@types/react": "^18.0.27",

--- a/gui/src/util/localStorage.ts
+++ b/gui/src/util/localStorage.ts
@@ -16,6 +16,7 @@ type LocalStorageTypes = {
   isOnboardingInProgress: boolean;
   showTutorialCard: boolean;
   shownProfilesIntroduction: boolean;
+  disableIndexing: boolean;
 };
 
 export function getLocalStorage<T extends keyof LocalStorageTypes>(


### PR DESCRIPTION
## Description

- [x] Add showing docs submenu from config
- [x] Fix docs indexing progress calculator
- [x] Avoid showing duplicate docs in submenu
- [x] Add indexing commands to manual trigger
- [x] Add auto indexing with debounce (If disableIndexing options is false).

**Note**: This PR do not show the indexing progress in UI due to possible collision with progress updates with Code Indexing. This will be resolved in a separate PR.

Closes #1442 

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created
