### PR TITLE
feat: add `applyCodeBlock` experimental prop

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -797,6 +797,7 @@ interface ContextMenuConfig {
 
 interface ModelRoles {
   inlineEdit?: string;
+  applyCodeBlock?: string;
 }
 
 interface ExperimentalConfig {

--- a/extensions/vscode/src/extension/VsCodeMessenger.ts
+++ b/extensions/vscode/src/extension/VsCodeMessenger.ts
@@ -18,6 +18,7 @@ import {
   ToCoreOrIdeFromWebviewProtocol,
   VsCodeWebviewProtocol,
 } from "../webviewProtocol";
+import { ConfigHandler } from "core/config/handler";
 
 /**
  * A shared messenger class between Core and Webview
@@ -69,6 +70,7 @@ export class VsCodeMessenger {
     private readonly webviewProtocol: VsCodeWebviewProtocol,
     private readonly ide: VsCodeIde,
     private readonly verticalDiffManagerPromise: Promise<VerticalPerLineDiffManager>,
+    private readonly configHandlerPromise: Promise<ConfigHandler>,
   ) {
     /** WEBVIEW ONLY LISTENERS **/
     this.onWebview("showFile", (msg) => {
@@ -116,9 +118,11 @@ export class VsCodeMessenger {
         msg.data.stepIndex,
       );
     });
+
     this.onWebview("applyToCurrentFile", async (msg) => {
       // Select the entire current file
       const editor = vscode.window.activeTextEditor;
+
       if (!editor) {
         vscode.window.showErrorMessage("No active editor to apply edits to");
         return;
@@ -134,11 +138,19 @@ export class VsCodeMessenger {
         editor.selection = new vscode.Selection(start, end);
       }
 
-      (await this.verticalDiffManagerPromise).streamEdit(
-        `The following code was suggested as an edit:\n\`\`\`\n${msg.data.text}\n\`\`\`\nPlease apply it to the previous code.`,
-        await this.webviewProtocol.request("getDefaultModelTitle", undefined),
-      );
+      const verticalDiffManager = await this.verticalDiffManagerPromise;
+      const prompt = `The following code was suggested as an edit:\n\`\`\`\n${msg.data.text}\n\`\`\`\nPlease apply it to the previous code.`;
+
+      const configHandler = await configHandlerPromise;
+      const config = await configHandler.loadConfig();
+
+      const modelTitle =
+        config.experimental?.modelRoles?.applyCodeBlock ??
+        (await this.webviewProtocol.request("getDefaultModelTitle", undefined));
+
+      verticalDiffManager.streamEdit(prompt, modelTitle);
     });
+
     this.onWebview("showTutorial", async (msg) => {
       const tutorialPath = path.join(
         getExtensionUri().fsPath,

--- a/extensions/vscode/src/extension/vscodeExtension.ts
+++ b/extensions/vscode/src/extension/vscodeExtension.ts
@@ -87,12 +87,15 @@ export class VsCodeExtension {
       ToCoreProtocol,
       FromCoreProtocol
     >();
-    const vscodeMessenger = new VsCodeMessenger(
+
+    new VsCodeMessenger(
       inProcessMessenger,
       this.sidebar.webviewProtocol,
       this.ide,
       verticalDiffManagerPromise,
+      configHandlerPromise,
     );
+
     this.core = new Core(inProcessMessenger, this.ide, async (log: string) => {
       outputChannel.appendLine(
         "==========================================================================",


### PR DESCRIPTION
## Description

Adds the `applyCodeBlock` option to the experimental `modelRoles` property.

- Closes #1568

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created
  - @sestinj we currently don't have docs for the `modelRoles` property. Thoughts on whether to add some?
