### PR TITLE
feat: add new model styling improvements

### DIFF
--- a/gui/src/pages/AddNewModel/AddNewModel.tsx
+++ b/gui/src/pages/AddNewModel/AddNewModel.tsx
@@ -29,7 +29,7 @@ const IntroDiv = styled.div`
 const GridDiv = styled.div`
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  grid-gap: 2rem;
+  grid-gap: 1.25rem;
   justify-items: center;
   align-items: center;
 `;

--- a/gui/src/pages/AddNewModel/AddNewModel.tsx
+++ b/gui/src/pages/AddNewModel/AddNewModel.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeftIcon } from "@heroicons/react/24/outline";
+import { ArrowLeftIcon, Cog6ToothIcon } from "@heroicons/react/24/outline";
 import _ from "lodash";
 import React, { useContext } from "react";
 import { useDispatch } from "react-redux";
@@ -22,14 +22,14 @@ const IntroDiv = styled.div`
   padding: 8px 12px;
   border-radius: ${defaultBorderRadius};
   border: 1px solid ${lightGray};
-  margin: 1rem;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
 `;
 
 const GridDiv = styled.div`
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   grid-gap: 2rem;
-  padding: 1rem;
   justify-items: center;
   align-items: center;
 `;
@@ -62,7 +62,7 @@ function AddNewModel() {
   const [providersSelected, setProvidersSelected] = React.useState(true);
 
   return (
-    <div className="overflow-y-scroll">
+    <div className="overflow-y-scroll px-6 mb-6">
       <div
         className="items-center flex m-0 p-0 sticky top-0"
         style={{
@@ -95,7 +95,7 @@ function AddNewModel() {
         to learn more.
       </IntroDiv>
 
-      <GridDiv>
+      <div className="col-span-full py-4">
         <Toggle
           selected={providersSelected}
           optionOne={"Start with a provider"}
@@ -104,18 +104,22 @@ function AddNewModel() {
             setProvidersSelected((prev) => !prev);
           }}
         ></Toggle>
-        {providersSelected ? (
-          <>
-            <div className="text-center">
-              <h2>Providers</h2>
-              <p>
-                Select a provider below, or configure your own in{" "}
-                <code>config.json</code>
-              </p>
-            </div>
+      </div>
 
-            {Object.entries(providers).map(([providerName, modelInfo]) => (
+      {providersSelected ? (
+        <>
+          <div className="text-center leading-relaxed col-span-full mb-8">
+            <h2 className="mb-0">Providers</h2>
+            <p className="mt-2">
+              Select a provider below, or configure your own in{" "}
+              <code>config.json</code>
+            </p>
+          </div>
+
+          <GridDiv>
+            {Object.entries(providers).map(([providerName, modelInfo], i) => (
               <ModelCard
+                key={`${providerName}-${i}`}
                 title={modelInfo.title}
                 description={modelInfo.description}
                 tags={modelInfo.tags}
@@ -129,85 +133,87 @@ function AddNewModel() {
                 }}
               />
             ))}
-          </>
-        ) : (
-          <>
-            <div className="text-center">
-              <h2>Models</h2>
-              <p>
-                Select a model from the most popular options below, or configure
-                your own in <code>config.json</code>
-              </p>
-            </div>
+          </GridDiv>
+        </>
+      ) : (
+        <>
+          <div className="text-center leading-relaxed col-span-full">
+            <h2 className="mb-0">Models</h2>
+            <p className="mt-2">
+              Select a model from the most popular options below, or configure
+              your own in <code>config.json</code>
+            </p>
+          </div>
 
-            {Object.entries(modelsByProvider).map(
-              ([providerTitle, modelConfigsByProviderTitle]) => (
-                <div>
-                  <div className="-my-8 grid grid-cols-[auto_1fr] w-full items-center mb-2">
-                    <h3 className="">{providerTitle}</h3>
-                    <hr
-                      className="ml-2"
-                      style={{
-                        height: "0px",
-                        width: "calc(100% - 16px)",
-                        color: lightGray,
-                        border: `1px solid ${lightGray}`,
-                        borderRadius: "2px",
-                      }}
-                    ></hr>
-                  </div>
-
-                  {modelConfigsByProviderTitle.map((config) => (
-                    <div className="mb-8">
-                      <ModelCard
-                        title={config.title}
-                        description={config.description}
-                        tags={config.tags}
-                        icon={config.icon}
-                        dimensions={config.dimensions}
-                        providerOptions={config.providerOptions}
-                        onClick={(e, dimensionChoices, selectedProvider) => {
-                          const model = {
-                            ...config.params,
-                            ..._.merge(
-                              {},
-                              ...(config.dimensions?.map((dimension, i) => {
-                                if (!dimensionChoices?.[i]) return {};
-                                return {
-                                  ...dimension.options[dimensionChoices[i]],
-                                };
-                              }) || []),
-                            ),
-                            provider: providers[selectedProvider].provider,
-                          };
-                          ideMessenger.post("config/addModel", { model });
-                          dispatch(
-                            setDefaultModel({
-                              title: model.title,
-                              force: true,
-                            }),
-                          );
-                          navigate("/");
-                        }}
-                      />
-                    </div>
-                  ))}
+          {Object.entries(modelsByProvider).map(
+            ([providerTitle, modelConfigsByProviderTitle]) => (
+              <div className="flex flex-col mb-6">
+                <div className="w-full items-center mb-4">
+                  <h3 className="">{providerTitle}</h3>
+                  <hr
+                    style={{
+                      height: "0px",
+                      width: "100%",
+                      color: lightGray,
+                      border: `1px solid ${lightGray}`,
+                      borderRadius: "2px",
+                    }}
+                  />
                 </div>
-              ),
-            )}
-          </>
-        )}
 
-        <CustomModelButton
-          className="w-full"
-          disabled={false}
-          onClick={(e) => {
-            ideMessenger.post("openConfigJson", undefined);
-          }}
-        >
-          <h3 className="text-center my-2">Open config.json</h3>
-        </CustomModelButton>
-      </GridDiv>
+                <GridDiv>
+                  {modelConfigsByProviderTitle.map((config) => (
+                    <ModelCard
+                      title={config.title}
+                      description={config.description}
+                      tags={config.tags}
+                      icon={config.icon}
+                      dimensions={config.dimensions}
+                      providerOptions={config.providerOptions}
+                      onClick={(e, dimensionChoices, selectedProvider) => {
+                        const model = {
+                          ...config.params,
+                          ..._.merge(
+                            {},
+                            ...(config.dimensions?.map((dimension, i) => {
+                              if (!dimensionChoices?.[i]) return {};
+                              return {
+                                ...dimension.options[dimensionChoices[i]],
+                              };
+                            }) || []),
+                          ),
+                          provider: providers[selectedProvider].provider,
+                        };
+                        ideMessenger.post("config/addModel", { model });
+                        dispatch(
+                          setDefaultModel({
+                            title: model.title,
+                            force: true,
+                          }),
+                        );
+                        navigate("/");
+                      }}
+                    />
+                  ))}
+                </GridDiv>
+              </div>
+            ),
+          )}
+        </>
+      )}
+
+      <CustomModelButton
+        className="w-full mt-12"
+        disabled={false}
+        onClick={(e) => {
+          ideMessenger.post("openConfigJson", undefined);
+        }}
+      >
+        <h3 className="text-center my-2">
+          <Cog6ToothIcon className="inline-block h-5 w-5 align-middle px-4" />
+          Open config.json
+        </h3>
+      </CustomModelButton>
     </div>
   );
 }


### PR DESCRIPTION
## Description

Fixes broken styling for the add new models settings screen on wider viewports.

- Closes #1604

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Testing

- Open the "Add new model" screen
- Scroll through both providers and models tab, confirm the width of the cards and the width of the horizontal rule look appropriate
- Go full screen
- Repeat

## Screenshots

### Default width
<img width="530" alt="Screenshot 2024-06-28 at 9 45 00 AM" src="https://github.com/continuedev/continue/assets/20157849/9d0705df-6137-4cc3-821a-b0725500346c">

### Increased width
<img width="905" alt="Screenshot 2024-06-28 at 9 45 11 AM" src="https://github.com/continuedev/continue/assets/20157849/4947b1ac-5ad5-4e1e-919b-3b64d410a129">
