### PR TITLE
Recommend Sonnet 3.5 over Opus in select-model.md

### DIFF
--- a/docs/docs/setup/select-model.md
+++ b/docs/docs/setup/select-model.md
@@ -32,7 +32,7 @@ _You can also use other open-source chat models by adding them to your `config.j
 
 #### Claude 3 from Anthropic
 
-- Unlimited budget: `claude-3-opus-20240229`
+- Unlimited budget: `claude-3-5-sonnet-20240620`
 - Limited budget: `claude-3-sonnet-20240229`
 
 #### GPT-4o from OpenAI


### PR DESCRIPTION
## Description

[Sonnet 3.5 is more budget-friendly than Opus](https://www.anthropic.com/news/claude-3-5-sonnet)

## Checklist

- [ ] The base branch of this PR is `dev`, rather than `main` - sorry, this is unusual, will branch off of `dev` next time
- [x] The relevant docs, if any, have been updated or created
