### PR TITLE
#1382 - fix[core]: add alternate implementation for autocomplete ReadableStream.from

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -19,6 +19,10 @@ declare global {
       messageIde: string,
     ) => void;
   }
+
+  interface ReadableStream<R = any> {
+    [Symbol.asyncIterator](): AsyncIterableIterator<R>;
+  }
 }
 
 export interface ChunkWithoutID {


### PR DESCRIPTION
fix for #1382 

## Description

The binaries that are built using `pkg` only support up to node18, but there was code that was dependent on node20. So any binary used in a non-VS Code environment would fail because it was packaged with node18. The code in question is the use of `ReadableStream.from()` in core/llm/stream.ts. I made my own crude implementation of `from()` that runs if `from()` can't be found on `ReadableStream`.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`  -----> This is *not* mentioned in the Contributing docs. It says to compare with the preview branch which would make one assume to branch off that in your fork...
- [ ] The relevant docs, if any, have been updated or created
