### PR TITLE
chore: reduce vscode extension bundle size

### DIFF
--- a/extensions/vscode/.vscodeignore
+++ b/extensions/vscode/.vscodeignore
@@ -25,3 +25,6 @@ scripts
 server/exe/**
 !out/node_modules/**
 !node_modules/@vscode/ripgrep/bin/rg
+
+media/**/*.gif
+!media/sidebar.gif

--- a/extensions/vscode/scripts/esbuild.js
+++ b/extensions/vscode/scripts/esbuild.js
@@ -9,7 +9,7 @@ const esbuildConfig = {
   external: ["vscode", "esbuild", "./xhr-sync-worker.js"],
   format: "cjs",
   platform: "node",
-  sourcemap: true,
+  sourcemap: false,
   loader: {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     ".node": "file",


### PR DESCRIPTION
## Description

reduce vscode extension bundle size

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created

## Screenshots

If your updates include visual changes, please share screenshots below.
