### PR TITLE
Add support for the HuggingFace Text Embeddings Inference server

### DIFF
--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -639,6 +639,7 @@ declare global {
   }
   
   export type EmbeddingsProviderName =
+    | "huggingface-tei"
     | "transformers.js"
     | "ollama"
     | "openai"

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -722,6 +722,7 @@ export interface ModelDescription {
 }
 
 export type EmbeddingsProviderName =
+  | "huggingface-tei"
   | "transformers.js"
   | "ollama"
   | "openai"

--- a/core/indexing/embeddings/HuggingFaceTEIEmbeddingsProvider.ts
+++ b/core/indexing/embeddings/HuggingFaceTEIEmbeddingsProvider.ts
@@ -1,0 +1,103 @@
+import fetch, { Response } from "node-fetch";
+import { EmbedOptions, FetchFunction } from "../..";
+import { withExponentialBackoff } from "../../util/withExponentialBackoff";
+import BaseEmbeddingsProvider from "./BaseEmbeddingsProvider";
+
+class HuggingFaceTEIEmbeddingsProvider extends BaseEmbeddingsProvider {
+  private maxBatchSize = 32;
+
+  static defaultOptions: Partial<EmbedOptions> | undefined = {
+    apiBase: "http://localhost:8080",
+    model: "tei",
+  };
+
+  constructor(options: EmbedOptions, fetch: FetchFunction) {
+    super(options, fetch);
+    // without this extra slash the last portion of the path will be dropped from the URL when using the node.js URL constructor
+    if (!this.options.apiBase?.endsWith("/")) {
+      this.options.apiBase += "/";
+    }
+    this.doInfoRequest().then(response => {
+      this.options.model = response.model_id;
+      this.maxBatchSize = response.max_client_batch_size;
+    });
+  }
+
+  async embed(chunks: string[]) {
+    const promises = [];
+    for (let i = 0; i < chunks.length; i += this.maxBatchSize) {
+      promises.push(this.doEmbedRequest(chunks.slice(i, i + this.maxBatchSize)));
+    }
+    const results = await Promise.all(promises);
+    return results.flat();
+  }
+
+  async doEmbedRequest(batch: string[]): Promise<number[][]> {
+    const resp = await withExponentialBackoff<Response>(() =>
+      this.fetch(new URL("embed", this.options.apiBase), {
+        method: "POST",
+        body: JSON.stringify({
+          inputs: batch
+        }),
+        headers: {
+          "Content-Type": "application/json",
+        }
+      }),
+    );
+    if (!resp.ok) {
+      const text = await resp.text();
+      const embedError = JSON.parse(text) as TEIEmbedErrorResponse;
+      if (!embedError.error_type || !embedError.error) {
+        throw new Error(text);
+      }
+      throw new TEIEmbedError(embedError);
+    }
+    return (await resp.json()) as number[][];
+  }
+
+  async doInfoRequest(): Promise<TEIInfoResponse> {
+    const resp = await withExponentialBackoff<Response>(() =>
+      this.fetch(new URL("info", this.options.apiBase), {
+        method: "GET",
+      }),
+    );
+    if (!resp.ok) {
+      throw new Error(await resp.text());
+    }
+    return (await resp.json()) as TEIInfoResponse;
+  }
+}
+
+class TEIEmbedError extends Error {
+  constructor(teiResponse: TEIEmbedErrorResponse) {
+    super(JSON.stringify(teiResponse));
+  }
+}
+
+type TEIEmbedErrorResponse = {
+  error: string
+  error_type: string
+}
+
+type TEIInfoResponse = {
+  model_id: string;
+  model_sha: string;
+  model_dtype: string;
+  model_type: {
+    embedding: {
+      pooling: string;
+    }
+  };
+  max_concurrent_requests: number;
+  max_input_length: number;
+  max_batch_tokens: number;
+  max_batch_requests: number;
+  max_client_batch_size: number;
+  auto_truncate: boolean;
+  tokenization_workers: number;
+  version: string;
+  sha: string;
+  docker_label: string;
+};
+
+export default HuggingFaceTEIEmbeddingsProvider;

--- a/core/indexing/embeddings/index.ts
+++ b/core/indexing/embeddings/index.ts
@@ -2,6 +2,7 @@ import { EmbeddingsProviderName } from "../../index.js";
 import BaseEmbeddingsProvider from "./BaseEmbeddingsProvider.js";
 import CohereEmbeddingsProvider from "./CohereEmbeddingsProvider.js";
 import FreeTrialEmbeddingsProvider from "./FreeTrialEmbeddingsProvider.js";
+import HuggingFaceTEIEmbeddingsProvider from "./HuggingFaceTEIEmbeddingsProvider.js";
 import OllamaEmbeddingsProvider from "./OllamaEmbeddingsProvider.js";
 import OpenAIEmbeddingsProvider from "./OpenAIEmbeddingsProvider.js";
 import TransformersJsEmbeddingsProvider from "./TransformersJsEmbeddingsProvider.js";
@@ -22,5 +23,7 @@ export const allEmbeddingsProviders: Record<
   cohere: CohereEmbeddingsProvider,
   // eslint-disable-next-line @typescript-eslint/naming-convention
   "free-trial": FreeTrialEmbeddingsProvider,
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  "huggingface-tei": HuggingFaceTEIEmbeddingsProvider,
   gemini: GeminiEmbeddingsProvider,
 };

--- a/docs/docs/walkthroughs/codebase-embeddings.md
+++ b/docs/docs/walkthroughs/codebase-embeddings.md
@@ -94,6 +94,19 @@ We also support other methods of generating embeddings, which can be configured 
 }
 ```
 
+### Text Embeddings Inference
+
+[Hugging Face Text Embeddings Inference](https://huggingface.co/docs/text-embeddings-inference/en/index) enables you to host your own embeddings endpoint. You can configure embeddings to use your endpoint as follows:
+
+```json title="~/.continue/config.json"
+{
+  "embeddingsProvider": {
+    "provider": "huggingface-tei",
+    "apiBase": "http://localhost:8080"
+  }
+}
+```
+
 ### Voyage AI
 
 Voyage AI offers the best embeddings for code with their voyage-code-2 model. After obtaining an API key from [here](https://www.voyageai.com/), you can configure like this:

--- a/docs/static/schemas/config.json
+++ b/docs/static/schemas/config.json
@@ -1857,6 +1857,7 @@
           "properties": {
             "provider": {
               "enum": [
+                "huggingface-tei",
                 "transformers.js",
                 "ollama",
                 "openai",

--- a/extensions/intellij/src/main/resources/config_schema.json
+++ b/extensions/intellij/src/main/resources/config_schema.json
@@ -1857,6 +1857,7 @@
           "properties": {
             "provider": {
               "enum": [
+                "huggingface-tei",
                 "transformers.js",
                 "ollama",
                 "openai",

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -1857,6 +1857,7 @@
           "properties": {
             "provider": {
               "enum": [
+                "huggingface-tei",
                 "transformers.js",
                 "ollama",
                 "openai",

--- a/extensions/vscode/continue_rc_schema.json
+++ b/extensions/vscode/continue_rc_schema.json
@@ -2067,6 +2067,7 @@
           "properties": {
             "provider": {
               "enum": [
+                "huggingface-tei",
                 "transformers.js",
                 "ollama",
                 "openai",


### PR DESCRIPTION
## Description

Added support for the HuggingFace [Text Embeddings Inference Server](https://huggingface.co/docs/text-embeddings-inference/en/index) as an embeddings provider. 

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

