### PR TITLE
feat: Client Certificate Options Support

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -667,6 +667,13 @@ export interface RequestOptions {
   headers?: { [key: string]: string };
   extraBodyProperties?: { [key: string]: any };
   noProxy?: string[];
+  clientCertificate?: ClientCertificateOptions;
+}
+
+export interface ClientCertificateOptions {
+  cert: string;
+  key: string;
+  passphrase?: string;
 }
 
 export interface StepWithParams {

--- a/core/util/fetchWithOptions.ts
+++ b/core/util/fetchWithOptions.ts
@@ -42,7 +42,7 @@ export function fetchwithRequestOptions(
 
   const timeout = (requestOptions?.timeout ?? TIMEOUT) * 1000; // measured in ms
 
-  const agentOptions = {
+  const agentOptions: {[key: string]: any} = {
     ca,
     rejectUnauthorized: requestOptions?.verifySsl,
     timeout,
@@ -50,6 +50,15 @@ export function fetchwithRequestOptions(
     keepAlive: true,
     keepAliveMsecs: timeout,
   };
+
+  // Handle ClientCertificateOptions
+  if (requestOptions?.clientCertificate){
+    agentOptions.cert = fs.readFileSync(requestOptions.clientCertificate.cert,"utf8");
+    agentOptions.key = fs.readFileSync(requestOptions.clientCertificate.key,"utf8");
+    if(requestOptions.clientCertificate.passphrase){
+      agentOptions.passphrase = requestOptions.clientCertificate.passphrase;
+    }
+  }
 
   const proxy = requestOptions?.proxy;
 

--- a/docs/docs/setup/configuration.md
+++ b/docs/docs/setup/configuration.md
@@ -135,18 +135,23 @@ If you need to send custom headers for authentication, you may use the `requestO
 
 ```json title="~/.continue/config.json"
 {
-  "models": [
-    {
-      "title": "Ollama",
-      "provider": "ollama",
-      "model": "llama2-7b",
-      "requestOptions": {
-        "headers": {
-          "X-Auth-Token": "xxx"
-        }
+   "models": [
+      {
+         "title": "Ollama",
+         "provider": "ollama",
+         "model": "llama2-7b",
+         "requestOptions": {
+            "headers": {
+               "X-Auth-Token": "xxx"
+            },
+            "clientCertificate": {
+               "cert": "C:\temp\cert.pem",
+               "key": "C:\temp\cert.key",
+               "passphrase": "c0nt!nu3"
+            }
+         }
       }
-    }
-  ]
+   ]
 }
 ```
 

--- a/docs/docs/setup/configuration.md
+++ b/docs/docs/setup/configuration.md
@@ -143,10 +143,26 @@ If you need to send custom headers for authentication, you may use the `requestO
          "requestOptions": {
             "headers": {
                "X-Auth-Token": "xxx"
-            },
+            }
+         }
+      }
+   ]
+}
+```
+
+Similarly if your model requires a Certificate for authentication, you may use the `requestOptions.clientCertificate` property like in the example below:
+
+```json title="~/.continue/config.json"
+{
+   "models": [
+      {
+         "title": "Ollama",
+         "provider": "ollama",
+         "model": "llama2-7b",
+         "requestOptions": {
             "clientCertificate": {
-               "cert": "C:\temp\cert.pem",
-               "key": "C:\temp\cert.key",
+               "cert": "C:\temp\ollama.pem",
+               "key": "C:\temp\ollama.key",
                "passphrase": "c0nt!nu3"
             }
          }

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "0.9.170",
+  "version": "0.9.171",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "0.9.170",
+      "version": "0.9.171",
       "license": "Apache-2.0",
       "dependencies": {
         "@electron/rebuild": "^3.2.10",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "continue",
   "icon": "media/icon.png",
-  "version": "0.9.170",
+  "version": "0.9.171",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION
## Description

Added support to provide a Client Certificate, a key and a passphrase with it.
This is done to support models requiring a certificate authentication.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created