### PR TITLE
Fix handling remote unix paths on Windows over Remote Tunnels

### DIFF
--- a/extensions/vscode/src/util/vscode.ts
+++ b/extensions/vscode/src/util/vscode.ts
@@ -125,7 +125,7 @@ function windowsToPosix(windowsPath: string): string {
 function isWindowsLocalButNotRemote(): boolean {
   return (
     vscode.env.remoteName !== undefined &&
-    ["wsl", "ssh-remote", "dev-container", "attached-container"].includes(
+    ["wsl", "ssh-remote", "dev-container", "attached-container", "tunnel"].includes(
       vscode.env.remoteName,
     ) &&
     process.platform === "win32"


### PR DESCRIPTION
## Description

The function `isWindowsLocalButNotRemote()` determines whether a windows host is connected to a remote unix server and is used for conversions between Windows path foramt and Unix path format.
The function did not handle the case of a [remote tunnel](https://code.visualstudio.com/docs/remote/tunnels) which led to exceptions being thrown by context providers trying to read remote files when connected over a tunnel.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created