### PR TITLE
test: Add basic unit test to baseLLM

### DIFF
--- a/core/test/baseLLM.test.ts
+++ b/core/test/baseLLM.test.ts
@@ -1,0 +1,140 @@
+import { ChatMessage, LLMOptions, ModelProvider } from "../index";
+import { BaseLLM } from "../llm/index.js";
+
+class DummyLLM extends BaseLLM {
+  static providerName: ModelProvider = "openai";
+  static defaultOptions: Partial<LLMOptions> = {
+    model: "dummy-model",
+    contextLength: 200_000,
+    completionOptions: {
+      model: "some-model",
+      maxTokens: 4096,
+    },
+    apiBase: "https://api.test-api-dummy.com/v1/",
+  };
+}
+describe("BaseLLM", () => {
+  let baseLLM: BaseLLM;
+
+  beforeEach(() => {
+    const options: LLMOptions = {
+      model: "dummy-model",
+    };
+    // Instantiate a DummyLLM instance
+    baseLLM = new DummyLLM(options);
+  });
+
+  describe("BaseLLM constructor", () => {
+    it("should correctly initialize with given options", () => {
+      const templatMessagesFunction = (messages: ChatMessage[]) => {
+        return messages[0]?.content.toString() ?? "";
+      };
+      const writeLogFunction = async () => {};
+      const options: LLMOptions = {
+        model: "gpt-3.5-turbo",
+        uniqueId: "testId",
+        systemMessage: "Test System Message",
+        contextLength: 1024,
+        completionOptions: {
+          model: "some-model",
+          maxTokens: 150,
+        },
+        requestOptions: {},
+        promptTemplates: {},
+        templateMessages: templatMessagesFunction,
+        writeLog: writeLogFunction,
+        llmRequestHook: () => {},
+        apiKey: "testApiKey",
+        aiGatewaySlug: "testSlug",
+        apiBase: "https://api.example.com",
+        accountId: "testAccountId",
+        engine: "davinci",
+        apiVersion: "v1",
+        apiType: "public",
+        region: "us",
+        projectId: "testProjectId",
+      };
+
+      const instance = new DummyLLM(options);
+
+      expect(instance.title).toBeDefined();
+      expect(instance.uniqueId).toBe("testId");
+      expect(instance.model).toBe("gpt-3.5-turbo");
+      expect(instance.systemMessage).toBe("Test System Message");
+      expect(instance.contextLength).toBe(1024);
+      expect(instance.completionOptions.maxTokens).toBe(150);
+      expect(instance.requestOptions).toEqual({});
+      expect(instance.promptTemplates).toEqual({});
+      expect(instance.templateMessages).toEqual(templatMessagesFunction);
+      expect(instance.writeLog).toBe(writeLogFunction);
+      expect(instance.apiKey).toBe("testApiKey");
+      expect(instance.aiGatewaySlug).toBe("testSlug");
+      expect(instance.apiBase).toBe("https://api.example.com/");
+      expect(instance.accountId).toBe("testAccountId");
+      expect(instance.engine).toBe("davinci");
+      expect(instance.apiVersion).toBe("v1");
+      expect(instance.apiType).toBe("public");
+      expect(instance.region).toBe("us");
+      expect(instance.projectId).toBe("testProjectId");
+    });
+  });
+
+  test("model should return correct provider model", () => {
+    expect(baseLLM.model).toBe("dummy-model");
+  });
+
+  test("supportsFim should always return false", () => {
+    expect(baseLLM.supportsFim()).toBe(false);
+  });
+
+  describe("supportsImages", () => {
+    test("should return true when modelSupportsImages returns true", () => {
+      baseLLM.model = "gpt-4-vision";
+      expect(baseLLM.supportsImages()).toBe(true);
+    });
+
+    test("should return false when modelSupportsImages returns false", () => {
+      expect(baseLLM.supportsImages()).toBe(false);
+    });
+  });
+
+  describe("supportsCompletions", () => {
+    test("should return correctly under specific conditions", () => {
+      // Mocking properties and scenarios to match the conditions in supportsCompletions
+      baseLLM.apiBase = "api.groq.com";
+      expect(baseLLM.supportsCompletions()).toBe(false);
+
+      baseLLM.apiBase = "api.mistral.ai";
+      expect(baseLLM.supportsCompletions()).toBe(false);
+
+      baseLLM.apiBase = ":1337";
+      expect(baseLLM.supportsCompletions()).toBe(false);
+
+      baseLLM.apiBase = "something:3000";
+      expect(baseLLM.supportsCompletions()).toBe(true);
+    });
+  });
+  describe("supportsPrefill", () => {
+    test("should return correctly under specific conditions", () => {
+      expect(baseLLM.supportsPrefill()).toBe(false);
+
+      class PrefillLLM extends BaseLLM {
+        static providerName: ModelProvider = "ollama";
+      }
+      const prefillLLM = new PrefillLLM({ model: "some-model" });
+      expect(prefillLLM.supportsPrefill()).toBe(true);
+    });
+  });
+  describe("fetch", () => {
+    // TODO: Implement tests for fetch method
+  });
+  describe("*_streamFim", () => {
+    // TODO: Implement tests for *_streamFim method
+  });
+  describe("complete", () => {
+    // TODO: Implement tests for complete method
+  });
+  describe("*streamChat", () => {
+    // TODO: Implement tests for *streamChat method
+  });
+});

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "continue",
   "icon": "media/icon.png",
-  "version": "0.9.172",
+  "version": "0.9.174",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION
  ## Description

Related to [#15](https://github.com/continuedev/contribution-ideas/issues/15). Adding unit test to the base abstract class of BaseLLM.