### PR TITLE
Fix an issue where CMD+K does not clear the terminal when the terminal has focus

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -317,7 +317,8 @@
       {
         "command": "continue.toggleTabAutocompleteEnabled",
         "mac": "cmd+k cmd+a",
-        "key": "ctrl+k ctrl+a"
+        "key": "ctrl+k ctrl+a",
+        "when": "!terminalFocus"
       }
     ],
     "submenus": [


### PR DESCRIPTION
## Description

On MacOS, ⌘+K is bound, by default, to Terminal:Clear. Without this change ⌘+K does not clear the terminal but instead iniates a chord sequence and waits for the next stroke of the chord.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created