### PR TITLE
Change treeSitter to cache the Language objects it loads from wasm

### DIFF
--- a/core/util/treeSitter.ts
+++ b/core/util/treeSitter.ts
@@ -93,6 +93,11 @@ export async function getParserForFile(filepath: string) {
   }
 }
 
+// Loading the wasm files to create a Language object is an expensive operation and with
+// sufficient number of files can result in errors, instead keep a map of language name
+// to Language object
+const nameToLanguage = new Map<string, Language>();
+
 export async function getLanguageForFile(
   filepath: string,
 ): Promise<Language | undefined> {
@@ -100,18 +105,15 @@ export async function getLanguageForFile(
     await Parser.init();
     const extension = path.extname(filepath).slice(1);
 
-    if (!supportedLanguages[extension]) {
+    const languageName = supportedLanguages[extension];
+    if (!languageName) {
       return undefined;
     }
-
-    const wasmPath = path.join(
-      __dirname,
-      ...(process.env.NODE_ENV === "test"
-        ? ["node_modules", "tree-sitter-wasms", "out"]
-        : ["tree-sitter-wasms"]),
-      `tree-sitter-${supportedLanguages[extension]}.wasm`,
-    );
-    const language = await Parser.Language.load(wasmPath);
+    let language = nameToLanguage.get(languageName);
+    if (!language) {
+        language = await loadLanguageForFileExt(extension);
+        nameToLanguage.set(languageName, language);
+    }
     return language;
   } catch (e) {
     console.error("Unable to load language for file", filepath, e);
@@ -148,4 +150,15 @@ export async function getQueryForFile(
 
   const query = language.query(querySource);
   return query;
+}
+
+async function loadLanguageForFileExt(fileExtension: string): Promise<Language> {
+  const wasmPath = path.join(
+    __dirname,
+    ...(process.env.NODE_ENV === "test"
+      ? ["node_modules", "tree-sitter-wasms", "out"]
+      : ["tree-sitter-wasms"]),
+    `tree-sitter-${supportedLanguages[fileExtension]}.wasm`,
+  );
+  return await Parser.Language.load(wasmPath);
 }


### PR DESCRIPTION
## Description

Without this change, for a repository with 600 typescript files, the indexer would fail to finish correctly and there would be many of the following errors in the webview console log:

'Unable to load language for file ${path} RuntimeError: table index is out of bounds'

The following bash will create a repo that reproduces the problem:

```lang=bash
current_path="."

for ((i=1; i<=20; i++)); do
    new_folder="folder-$i"
    mkdir -p "$current_path/$new_folder"
    current_path="$current_path/$new_folder"

    for ((a=1; a<=30; a++)); do
      head -c 10000 /dev/urandom | base64 > "$current_path/file-$a.ts"
    done
done
```

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created
