### PR TITLE
fix: add code range for quick actions/fixes

### DIFF
--- a/core/protocol/ideWebview.ts
+++ b/core/protocol/ideWebview.ts
@@ -41,7 +41,14 @@ export type ToWebviewFromIdeProtocol = ToWebviewFromIdeOrCoreProtocol & {
   focusContinueInput: [undefined, void];
   focusContinueInputWithoutClear: [undefined, void];
   focusContinueInputWithNewSession: [undefined, void];
-  highlightedCode: [{ rangeInFileWithContents: RangeInFileWithContents }, void];
+  highlightedCode: [
+    {
+      rangeInFileWithContents: RangeInFileWithContents;
+      prompt?: string;
+      shouldRun?: boolean;
+    },
+    void,
+  ];
   addModel: [undefined, void];
   openSettings: [undefined, void];
   viewHistory: [undefined, void];

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/actions/ContinuePluginActions.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/actions/ContinuePluginActions.kt
@@ -172,22 +172,7 @@ class ViewLogsAction : AnAction() {
     }
 }
 
-class ToggleAuxiliaryBarAction : AnAction() {
-    override fun actionPerformed(e: AnActionEvent) {
-        val project = e.project ?: return
-        val toolWindowManager = ToolWindowManager.getInstance(project)
-        val toolWindow = toolWindowManager.getToolWindow("Continue")
 
-        if (toolWindow != null) {
-            if (toolWindow.isVisible) {
-                toolWindow.component.transferFocus()
-                toolWindow.hide(null)
-            } else {
-                toolWindow.activate(null)
-            }
-        }
-    }
-}
 
 class FocusContinueInputWithoutClearAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {

--- a/extensions/intellij/src/main/resources/META-INF/plugin.xml
+++ b/extensions/intellij/src/main/resources/META-INF/plugin.xml
@@ -89,12 +89,7 @@
                 description="View Continue Server Logs">
             <!-- No shortcut defined -->
         </action>
-        <action id="continue.toggleAuxiliaryBar"
-                class="com.github.continuedev.continueintellijextension.actions.ToggleAuxiliaryBarAction"
-                text="Toggle Right Sidebar" description="Toggle Right Sidebar">
-            <keyboard-shortcut keymap="$default" first-keystroke="alt ctrl J"/>
-            <keyboard-shortcut keymap="Mac OS X" first-keystroke="alt meta J"/>
-        </action>
+       
         <action id="continue.focusContinueInputWithoutClear"
                 class="com.github.continuedev.continueintellijextension.actions.FocusContinueInputWithoutClearAction"
                 text="Add selected code to context"

--- a/extensions/vscode/manual-testing-sandbox/test.js
+++ b/extensions/vscode/manual-testing-sandbox/test.js
@@ -1,6 +1,6 @@
 class Calculator {
   constructor() {
-    this.result: string = 0;
+    this.result = 0;
   }
 
   add(number) {

--- a/extensions/vscode/manual-testing-sandbox/test.js
+++ b/extensions/vscode/manual-testing-sandbox/test.js
@@ -1,6 +1,6 @@
 class Calculator {
   constructor() {
-    this.result = 0;
+    this.result: string = 0;
   }
 
   add(number) {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -144,12 +144,6 @@
         "group": "Continue"
       },
       {
-        "command": "continue.toggleAuxiliaryBar",
-        "category": "Continue",
-        "title": "Toggle Right Sidebar",
-        "group": "Continue"
-      },
-      {
         "command": "continue.focusContinueInput",
         "category": "Continue",
         "title": "Add Highlighted Code to Context",
@@ -304,11 +298,6 @@
         "key": "ctrl+i"
       },
       {
-        "command": "continue.toggleAuxiliaryBar",
-        "mac": "alt+cmd+l",
-        "key": "alt+ctrl+l"
-      },
-      {
         "command": "continue.debugTerminal",
         "mac": "cmd+shift+r",
         "key": "ctrl+shift+r"
@@ -336,9 +325,6 @@
       "commandPalette": [
         {
           "command": "continue.quickEdit"
-        },
-        {
-          "command": "continue.toggleAuxiliaryBar"
         },
         {
           "command": "continue.focusContinueInput"

--- a/extensions/vscode/src/lang-server/codeActions.ts
+++ b/extensions/vscode/src/lang-server/codeActions.ts
@@ -15,34 +15,29 @@ class ContinueQuickFixProvider implements vscode.CodeActionProvider {
       return [];
     }
 
-    const createQuickFix = (edit: boolean) => {
-      const diagnostic = context.diagnostics[0];
-      const quickFix = new vscode.CodeAction(
-        edit ? "Fix with Continue" : "Ask Continue",
-        vscode.CodeActionKind.QuickFix,
-      );
-      quickFix.isPreferred = false;
-      const surroundingRange = new vscode.Range(
-        Math.max(0, range.start.line - 3),
-        0,
-        Math.min(document.lineCount, range.end.line + 3),
-        0,
-      );
-      quickFix.command = {
-        command: "continue.quickFix",
-        title: "Continue Quick Fix",
-        arguments: [
-          diagnostic.message,
-          document.getText(surroundingRange),
-          edit,
-        ],
-      };
-      return quickFix;
+    const diagnostic = context.diagnostics[0];
+
+    const quickFix = new vscode.CodeAction(
+      "Ask Continue",
+      vscode.CodeActionKind.QuickFix,
+    );
+
+    quickFix.isPreferred = false;
+
+    const surroundingRange = new vscode.Range(
+      Math.max(0, range.start.line - 3),
+      0,
+      Math.min(document.lineCount, range.end.line + 3),
+      0,
+    );
+
+    quickFix.command = {
+      command: "continue.quickFix",
+      title: "Continue Quick Fix",
+      arguments: [surroundingRange, diagnostic.message],
     };
-    return [
-      // createQuickFix(true),
-      createQuickFix(false),
-    ];
+
+    return [quickFix];
   }
 }
 

--- a/extensions/vscode/src/lang-server/codeLens/providers/QuickActionsCodeLensProvider.ts
+++ b/extensions/vscode/src/lang-server/codeLens/providers/QuickActionsCodeLensProvider.ts
@@ -65,7 +65,6 @@ export class QuickActionsCodeLensProvider implements vscode.CodeLensProvider {
   }
 
   getCustomCommands(
-    code: string,
     range: vscode.Range,
     quickActionConfigs: QuickActionConfig[],
   ): vscode.Command[] {
@@ -74,7 +73,7 @@ export class QuickActionsCodeLensProvider implements vscode.CodeLensProvider {
         ? {
             title,
             command: "continue.customQuickActionSendToChat",
-            arguments: [prompt, code],
+            arguments: [prompt, range],
           }
         : {
             title,
@@ -84,11 +83,11 @@ export class QuickActionsCodeLensProvider implements vscode.CodeLensProvider {
     });
   }
 
-  getDefaultCommands(code: string, range: vscode.Range): vscode.Command[] {
+  getDefaultCommands(range: vscode.Range): vscode.Command[] {
     const explain: vscode.Command = {
       command: "continue.defaultQuickActionExplain",
       title: "Explain",
-      arguments: [code],
+      arguments: [range],
     };
 
     const comment: vscode.Command = {
@@ -124,11 +123,9 @@ export class QuickActionsCodeLensProvider implements vscode.CodeLensProvider {
     );
 
     return filteredSmybols.flatMap(({ range }) => {
-      const code = editor.document.getText(range);
-
       const commands: vscode.Command[] = !!this.customQuickActionsConfig
-        ? this.getCustomCommands(code, range, this.customQuickActionsConfig)
-        : this.getDefaultCommands(code, range);
+        ? this.getCustomCommands(range, this.customQuickActionsConfig)
+        : this.getDefaultCommands(range);
 
       return commands.map((command) => new vscode.CodeLens(range, command));
     });

--- a/gui/src/components/mainInput/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor.tsx
@@ -597,7 +597,9 @@ function TipTapEditor(props: TipTapEditorProps) {
           rif.filepath,
           await ideMessenger.ide.getWorkspaceDirs(),
         );
-        const rangeStr = `(${rif.range.start.line + 1}-${rif.range.end.line + 1})`;
+        const rangeStr = `(${rif.range.start.line + 1}-${
+          rif.range.end.line + 1
+        })`;
         const item: ContextItemWithId = {
           content: rif.contents,
           name: `${basename} ${rangeStr}`,
@@ -626,6 +628,16 @@ function TipTapEditor(props: TipTapEditorProps) {
             },
           })
           .run();
+
+        if (data.prompt) {
+          editor.commands.focus("end");
+          editor.commands.insertContent(data.prompt);
+        }
+
+        if (data.shouldRun) {
+          onEnterRef.current({ useCodebase: false, noContext: true });
+        }
+
         setTimeout(() => {
           editor.commands.blur();
           editor.commands.focus("end");
@@ -639,6 +651,7 @@ function TipTapEditor(props: TipTapEditorProps) {
       historyLength,
       ignoreHighlightedCode,
       props.isMainInput,
+      onEnterRef.current,
     ],
   );
 


### PR DESCRIPTION
## Description

Adds a code block for quick action/fixes instead of plaintext code. Also removes a no longer needed `ToggleAuxiliaryBarAction` action.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

If your updates include visual changes, please share screenshots below.

## Testing

- Create a syntax error in a file, use a quick fix, confirm a code block is added and the prompt is automatically submitted
- Use the `Explain` quick action, confirm the same behaviors
