### PR TITLE
docs: Fix typos related to voyage AI

### DIFF
--- a/docs/docs/setup/configuration.md
+++ b/docs/docs/setup/configuration.md
@@ -71,7 +71,7 @@ This setup uses Claude 3.5 Sonnet for chatting, Codestral for autocomplete, and 
     "apiKey": "[CODESTRAL_API_KEY]"
   },
   "embeddingsProvider": {
-    "provider": "openai",
+    "provider": "voyage",
     "model": "voyage-code-2",
     "apiBase": "https://api.voyageai.com/v1/",
     "apiKey": "[VOYAGE_AI_API_KEY]"

--- a/docs/docs/walkthroughs/codebase-embeddings.md
+++ b/docs/docs/walkthroughs/codebase-embeddings.md
@@ -114,7 +114,7 @@ Voyage AI offers the best embeddings for code with their voyage-code-2 model. Af
 ```json title="~/.continue/config.json"
 {
   "embeddingsProvider": {
-    "provider": "openai",
+    "provider": "voyage",
     "model": "voyage-code-2",
     "apiBase": "https://api.voyageai.com/v1/",
     "apiKey": "<VOYAGE_API_KEY>"


### PR DESCRIPTION
## Description

Fixing a few typos on Voyage AI being used with the wrong provider. I couldn't find any usage in code where the provider is used/validated when the model "voyage-code-2" is being configured. Feel free to close this issue if you don't think it's important enough.

This addresses: https://github.com/continuedev/continue/issues/1693

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

N/A

## Testing

N/A
