### PR TITLE
ignore .svn folder for indexing

### DIFF
--- a/core/indexing/ignore.ts
+++ b/core/indexing/ignore.ts
@@ -69,6 +69,7 @@ export const DEFAULT_IGNORE_FILETYPES = [
 export const defaultIgnoreFile = ignore().add(DEFAULT_IGNORE_FILETYPES);
 export const DEFAULT_IGNORE_DIRS = [
   ".git",
+  ".svn",
   ".vscode",
   ".idea",
   ".vs",


### PR DESCRIPTION
## Description

Add .svn folder to ignore list for indexing.

I'm working on a project versioned under SVN rather than Git and have noticed slow indexing, hope this fixes the issue.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created
