### PR TITLE
chore: clearer naming for `useSuffix`

### DIFF
--- a/core/autocomplete/README.md
+++ b/core/autocomplete/README.md
@@ -90,7 +90,7 @@ This is just another object like the ones in the `"models"` array of `config.jso
 This object allows you to customize the behavior of tab-autocomplete. The available options are:
 
 - `useCopyBuffer`: Determines whether the copy buffer will be considered when constructing the prompt. (Boolean)
-- `useSuffix`: Determines whether to use the file suffix in the prompt. (Boolean)
+- `useFileSuffix`: Determines whether to use the file suffix in the prompt. (Boolean)
 - `maxPromptTokens`: The maximum number of prompt tokens to use. A smaller number will yield faster completions, but less context. (Number)
 - `debounceDelay`: The delay in milliseconds before triggering autocomplete after a keystroke. (Number)
 - `maxSuffixPercentage`: The maximum percentage of the prompt that can be dedicated to the suffix. (Number)

--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -676,7 +676,7 @@ declare global {
   export interface TabAutocompleteOptions {
     disable: boolean;
     useCopyBuffer: boolean;
-    useSuffix: boolean;
+    useFileSuffix: boolean;
     maxPromptTokens: number;
     debounceDelay: number;
     maxSuffixPercentage: number;

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -769,7 +769,7 @@ export interface Reranker {
 export interface TabAutocompleteOptions {
   disable: boolean;
   useCopyBuffer: boolean;
-  useSuffix: boolean;
+  useFileSuffix: boolean;
   maxPromptTokens: number;
   debounceDelay: number;
   maxSuffixPercentage: number;

--- a/core/util/parameters.ts
+++ b/core/util/parameters.ts
@@ -3,7 +3,7 @@ import { TabAutocompleteOptions } from "../index.js";
 export const DEFAULT_AUTOCOMPLETE_OPTS: TabAutocompleteOptions = {
   disable: false,
   useCopyBuffer: false,
-  useSuffix: true,
+  useFileSuffix: true,
   maxPromptTokens: 1024,
   prefixPercentage: 0.85,
   maxSuffixPercentage: 0.25,

--- a/docs/docs/walkthroughs/tab-autocomplete.md
+++ b/docs/docs/walkthroughs/tab-autocomplete.md
@@ -94,7 +94,7 @@ This object allows you to customize the behavior of tab-autocomplete. The availa
 - `disable`: Disable autocomplete (can also be done from IDE settings)
 - `template`: An optional template string to be used for autocomplete. It will be rendered with the Mustache templating language, and is passed the 'prefix' and 'suffix' variables. (String)
 - `useCopyBuffer`: Determines whether the copy buffer will be considered when constructing the prompt. (Boolean)
-- `useSuffix`: Determines whether to use the file suffix in the prompt. (Boolean)
+- `useFileSuffix`: Determines whether to use the file suffix in the prompt. (Boolean)
 - `maxPromptTokens`: The maximum number of prompt tokens to use. A smaller number will yield faster completions, but less context. (Number)
 - `prefixPercentage`: The percentage of the input that should be dedicated to the prefix. (Number)
 - `maxSuffixPercentage`: The maximum percentage of the prompt that can be dedicated to the suffix. (Number)

--- a/docs/static/schemas/config.json
+++ b/docs/static/schemas/config.json
@@ -2071,7 +2071,7 @@
               "type": "boolean",
               "description": "Determines whether the copy buffer will be considered when contructing the prompt."
             },
-            "useSuffix": {
+            "useFileSuffix": {
               "type": "boolean",
               "description": "Determines whether to use the file suffix in the prompt."
             },

--- a/extensions/intellij/src/main/resources/config_schema.json
+++ b/extensions/intellij/src/main/resources/config_schema.json
@@ -2071,7 +2071,7 @@
               "type": "boolean",
               "description": "Determines whether the copy buffer will be considered when contructing the prompt."
             },
-            "useSuffix": {
+            "useFileSuffix": {
               "type": "boolean",
               "description": "Determines whether to use the file suffix in the prompt."
             },

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -2071,7 +2071,7 @@
               "type": "boolean",
               "description": "Determines whether the copy buffer will be considered when contructing the prompt."
             },
-            "useSuffix": {
+            "useFileSuffix": {
               "type": "boolean",
               "description": "Determines whether to use the file suffix in the prompt."
             },

--- a/extensions/vscode/continue_rc_schema.json
+++ b/extensions/vscode/continue_rc_schema.json
@@ -2326,7 +2326,7 @@
               "type": "boolean",
               "description": "Determines whether the copy buffer will be considered when contructing the prompt."
             },
-            "useSuffix": {
+            "useFileSuffix": {
               "type": "boolean",
               "description": "Determines whether to use the file suffix in the prompt."
             },

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "continue",
+  "name": "testname",
   "version": "0.9.181",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "continue",
+      "name": "testname",
       "version": "0.9.181",
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
## Description

Renames `useSuffix` -> `useFileSuffix`

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

[ "For visual changes, include screenshots." ]

## Testing

[ For new or modified features, provide testing instructions. ]
