### PR TITLE
bugfix: quick actions undefined array

### DIFF
--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "testname",
+  "name": "continue",
   "version": "0.9.181",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "testname",
+      "name": "continue",
       "version": "0.9.181",
       "license": "Apache-2.0",
       "dependencies": {

--- a/extensions/vscode/src/lang-server/codeLens/providers/QuickActionsCodeLensProvider.ts
+++ b/extensions/vscode/src/lang-server/codeLens/providers/QuickActionsCodeLensProvider.ts
@@ -115,8 +115,12 @@ export class QuickActionsCodeLensProvider implements vscode.CodeLensProvider {
     }
 
     const symbols = await vscode.commands.executeCommand<
-      Array<vscode.DocumentSymbol>
+      Array<vscode.DocumentSymbol> | undefined
     >("vscode.executeDocumentSymbolProvider", document.uri);
+
+    if (!symbols) {
+      return [];
+    }
 
     const filteredSmybols = symbols?.filter((def) =>
       QuickActionsCodeLensProvider.quickActionSymbolKinds.includes(def.kind),


### PR DESCRIPTION
## Description

Fixes a bug where quick actions receives an empty array of values.

## Checklist

- [ ] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created

## Screenshots

[ "For visual changes, include screenshots." ]

## Testing

[ For new or modified features, provide testing instructions. ]
