### PR TITLE
Add `HuggingFaceTEIReranker`

### DIFF
--- a/core/context/rerankers/index.ts
+++ b/core/context/rerankers/index.ts
@@ -3,10 +3,12 @@ import { CohereReranker } from "./cohere.js";
 import { FreeTrialReranker } from "./freeTrial.js";
 import { LLMReranker } from "./llm.js";
 import { VoyageReranker } from "./voyage.js";
+import {HuggingFaceTEIReranker} from "./tei.js"
 
 export const AllRerankers: { [key in RerankerName]: any } = {
   cohere: CohereReranker,
   llm: LLMReranker,
   voyage: VoyageReranker,
   "free-trial": FreeTrialReranker,
+  "huggingface-tei": HuggingFaceTEIReranker
 };

--- a/core/context/rerankers/tei.ts
+++ b/core/context/rerankers/tei.ts
@@ -1,0 +1,49 @@
+import fetch from "node-fetch";
+import { Chunk, Reranker } from "../../index.js";
+
+export class HuggingFaceTEIReranker implements Reranker {
+  name = "huggingface-tei";
+
+  static defaultOptions = {
+    apiBase: "http://localhost:8080",
+    truncate: true,
+    truncation_direction: "Right"
+  };
+
+  constructor(
+    private readonly params: {
+      apiBase?: string;
+      truncate?: boolean;
+      truncation_direction?: string;
+    },
+  ) {}
+
+  async rerank(query: string, chunks: Chunk[]): Promise<number[]> {
+    let apiBase = this.params.apiBase ?? HuggingFaceTEIReranker.defaultOptions.apiBase;
+    if (!apiBase.endsWith("/")) {
+      apiBase += "/";
+    }
+
+    const resp = await fetch(new URL("rerank", apiBase), {
+      method: "POST",
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        query: query,
+        return_text: false,
+        raw_scores: false,
+        texts: chunks.map((chunk) => chunk.content),
+        truncation_direction: this.params.truncation_direction ?? HuggingFaceTEIReranker.defaultOptions.truncation_direction,
+        truncate: this.params.truncate ?? HuggingFaceTEIReranker.defaultOptions.truncate
+      }),
+    });
+
+    if (!resp.ok) {
+      throw new Error(await resp.text());
+    }
+
+    const data = (await resp.json()) as any;
+    // Resort into original order and extract scores
+    const results = data.sort((a: any, b: any) => a.index - b.index);
+    return results.map((result: any) => result.score);
+  }
+}

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -754,7 +754,7 @@ export interface EmbeddingsProvider {
   embed(chunks: string[]): Promise<number[][]>;
 }
 
-export type RerankerName = "cohere" | "voyage" | "llm" | "free-trial";
+export type RerankerName = "cohere" | "voyage" | "llm" | "free-trial" | "huggingface-tei";
 
 export interface RerankerDescription {
   name: RerankerName;

--- a/docs/docs/walkthroughs/codebase-embeddings.md
+++ b/docs/docs/walkthroughs/codebase-embeddings.md
@@ -231,7 +231,7 @@ export function modifyConfig(config: Config): Config {
 
 The reranker plays a crucial role in refining the results retrieved from your codebase. It processes the initial set of results obtained through embeddings-based retrieval, improving their relevance and accuracy for your queries.
 
-Continue offers several reranking options: `cohere`, `voyage`, `llm`, and `free-trial`, which can be configured in `config.json`.
+Continue offers several reranking options: `cohere`, `voyage`, `llm`, `hugginface-tei`, and `free-trial`, which can be configured in `config.json`.
 
 ### Voyage AI
 
@@ -281,6 +281,23 @@ If you only have access to a single LLM, then you can use it as a reranker. This
 ```
 
 The `"modelTitle"` field must match one of the models in your "models" array in config.json.
+
+### Text Embeddings Inference
+
+[Hugging Face Text Embeddings Inference](https://huggingface.co/docs/text-embeddings-inference/en/index) enables you to host your own [reranker endpoint](https://huggingface.github.io/text-embeddings-inference/#/Text%20Embeddings%20Inference/rerank). You can configure your reranker as follows:
+
+```json title="~/.continue/config.json"
+{
+  "reranker": {
+    "name": "huggingface-tei",
+    "params": {
+        "apiBase": "http://localhost:8080",
+        "truncate": true,
+        "truncation_direction": "Right"
+    }
+  },
+}
+```
 
 ### Free Trial (Voyage AI)
 


### PR DESCRIPTION
## Description

See #1701

Adds HugginfaceTEI as a reranker

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Testing

1. Create a TEI reranker server with a reranking model, e.g. [BAAI/bge-reranker-base](https://huggingface.co/BAAI/bge-reranker-base)
2. Add the reranker to the `config.json`, e.g.:
```json
{
  "reranker": {
    "name": "huggingface-tei",
    "params": {
        "apiBase": "http://localhost:8080",
        "truncate": true,
        "truncation_direction": "Right"
    }
  },
}
```

