### PR TITLE
feat: add tutorial card

### DIFF
--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -920,9 +920,9 @@
       }
     },
     "node_modules/@heroicons/react": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.1.3.tgz",
-      "integrity": "sha512-fEcPfo4oN345SoqdlCDdSa4ivjaKbk0jTd+oubcgNxnNgAfzysfwWfQUr+51wigiWHQQRiZNd1Ao0M5Y3M2EGg==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.1.5.tgz",
+      "integrity": "sha512-FuzFN+BsHa+7OxbvAERtgBTNeZpUjgM/MIizfVkSCL2/edriN0Hx/DWRCR//aPYwO5QX/YlgLGXk+E3PcfZwjA==",
       "peerDependencies": {
         "react": ">= 16"
       }

--- a/gui/src/components/mainInput/TutorialCard.tsx
+++ b/gui/src/components/mainInput/TutorialCard.tsx
@@ -1,0 +1,87 @@
+import {
+  PencilSquareIcon,
+  Cog6ToothIcon,
+  BookOpenIcon,
+  ClipboardDocumentIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline";
+import { getMetaKeyLabel } from "../../util";
+import styled from "styled-components";
+import { lightGray } from "..";
+
+interface TutorialCardProps {
+  onClose: () => void;
+}
+
+const TutorialCardDiv = styled.div`
+  border: 1px solid ${lightGray};
+  border-radius: 0.125rem;
+  padding: 0.5rem;
+  margin: 1.5rem;
+  max-width: 28rem;
+  position: relative;
+`;
+
+export function TutorialCard({ onClose }: TutorialCardProps) {
+  return (
+    <TutorialCardDiv>
+      <div
+        onClick={onClose}
+        className="absolute top-2 right-2 p-1 text-gray-400 hover:text-gray-600 transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 bg-white rounded-full cursor-pointer shadow-sm"
+        role="button"
+        aria-label="Close"
+      >
+        <XMarkIcon width="1.4em" height="1.4em" />
+      </div>
+
+      <ul className="text-gray-300 space-y-4">
+        <li className="flex items-start">
+          <PencilSquareIcon
+            width="1.4em"
+            height="1.4em"
+            className="align-middle pr-3"
+          />
+          <span>
+            Press <code>{getMetaKeyLabel() + "I"}</code> to quickly edit code
+            from an open file
+          </span>
+        </li>
+        <li className="flex items-start">
+          <ClipboardDocumentIcon
+            width="1.4em"
+            height="1.4em"
+            className="align-middle pr-3"
+          />
+          <span>
+            Highlight code and press <code>{getMetaKeyLabel() + "L"}</code> to
+            copy from an open file into chat
+          </span>
+        </li>
+        <li className="flex items-start">
+          <Cog6ToothIcon
+            width="1.4em"
+            height="1.4em"
+            className="align-middle pr-3"
+          />
+          <span>
+            Click the gear icon in the bottom right to open your configuration
+            settings
+          </span>
+        </li>
+        <li className="flex items-start">
+          <BookOpenIcon
+            width="1.4em"
+            height="1.4em"
+            className="align-middle pr-3"
+          />
+          <span>
+            <a href="https://docs.continue.dev" target="_blank">
+              Read our documentation
+            </a>{" "}
+            to learn more
+          </span>
+        </li>
+      </ul>
+    </TutorialCardDiv>
+  );
+}

--- a/gui/src/components/mainInput/TutorialCard.tsx
+++ b/gui/src/components/mainInput/TutorialCard.tsx
@@ -42,8 +42,8 @@ export function TutorialCard({ onClose }: TutorialCardProps) {
             className="align-middle pr-3"
           />
           <span>
-            Press <code>{getMetaKeyLabel() + "I"}</code> to quickly edit code
-            from an open file
+            Highlight code and press <code>{getMetaKeyLabel() + "I"}</code> to
+            quickly make natural language edits
           </span>
         </li>
         <li className="flex items-start">
@@ -53,8 +53,8 @@ export function TutorialCard({ onClose }: TutorialCardProps) {
             className="align-middle pr-3"
           />
           <span>
-            Highlight code and press <code>{getMetaKeyLabel() + "L"}</code> to
-            copy from an open file into chat
+            Highlight code and press <code>{getMetaKeyLabel() + "L"}</code> o
+            add it to the chat window
           </span>
         </li>
         <li className="flex items-start">
@@ -64,8 +64,7 @@ export function TutorialCard({ onClose }: TutorialCardProps) {
             className="align-middle pr-3"
           />
           <span>
-            Click the gear icon in the bottom right to open your configuration
-            settings
+            Click the gear icon in the bottom right to configure Continue
           </span>
         </li>
         <li className="flex items-start">

--- a/gui/src/pages/gui.tsx
+++ b/gui/src/pages/gui.tsx
@@ -12,7 +12,6 @@ import {
   useCallback,
   useContext,
   useEffect,
-  useLayoutEffect,
   useRef,
   useState,
 } from "react";
@@ -56,6 +55,7 @@ import {
 import { getLocalStorage, setLocalStorage } from "../util/localStorage";
 import { FREE_TRIAL_LIMIT_REQUESTS } from "../util/freeTrial";
 import { ChatScrollAnchor } from "../components/ChatScrollAnchor";
+import { TutorialCard } from "../components/mainInput/TutorialCard";
 
 const TopGuiDiv = styled.div`
   overflow-y: scroll;
@@ -144,11 +144,7 @@ function fallbackRender({ error, resetErrorBoundary }) {
   );
 }
 
-interface GUIProps {
-  firstObservation?: any;
-}
-
-function GUI(props: GUIProps) {
+function GUI() {
   const posthog = usePostHog();
   const dispatch = useDispatch();
   const navigate = useNavigate();
@@ -168,6 +164,16 @@ function GUI(props: GUIProps) {
   const [isAtBottom, setIsAtBottom] = useState<boolean>(false);
 
   const state = useSelector((state: RootState) => state.state);
+
+  const [showTutorialCard, setShowTutorialCard] = useState<boolean>(
+    getLocalStorage("showTutorialCard"),
+  );
+
+  const onCloseTutorialCard = () => {
+    posthog.capture("closedTutorialCard");
+    setLocalStorage("showTutorialCard", false);
+    setShowTutorialCard(false);
+  };
 
   const handleScroll = () => {
     // Temporary fix to account for additional height when code blocks are added
@@ -461,17 +467,27 @@ function GUI(props: GUIProps) {
             >
               New Session ({getMetaKeyLabel()} {isJetBrains() ? "J" : "L"})
             </NewSessionButton>
-          ) : getLastSessionId() ? (
-            <NewSessionButton
-              onClick={async () => {
-                loadLastSession();
-              }}
-              className="mr-auto flex items-center gap-1"
-            >
-              <ArrowLeftIcon width="11px" height="11px" />
-              Last Session
-            </NewSessionButton>
-          ) : null}
+          ) : (
+            <>
+              {getLastSessionId() ? (
+                <NewSessionButton
+                  onClick={async () => {
+                    loadLastSession();
+                  }}
+                  className="mr-auto flex items-center gap-1"
+                >
+                  <ArrowLeftIcon width="11px" height="11px" />
+                  Last Session
+                </NewSessionButton>
+              ) : null}
+
+              {!!showTutorialCard && (
+                <div className="flex justify-center w-full">
+                  <TutorialCard onClose={onCloseTutorialCard} />
+                </div>
+              )}
+            </>
+          )}
         </div>
 
         <ChatScrollAnchor

--- a/gui/src/pages/onboarding/utils.ts
+++ b/gui/src/pages/onboarding/utils.ts
@@ -35,6 +35,7 @@ export function useOnboarding() {
 
     if (onboardingStatus === "Started") {
       setLocalStorage("onboardingStatus", "Completed");
+      setLocalStorage("showTutorialCard", true);
       posthog.capture("Onboarding Step", { status: "Completed" });
     }
 

--- a/gui/src/util/localStorage.ts
+++ b/gui/src/util/localStorage.ts
@@ -14,6 +14,7 @@ type LocalStorageTypes = {
   indexingState: IndexingProgressUpdate;
   signedInToGh: boolean;
   isOnboardingInProgress: boolean;
+  showTutorialCard: boolean;
 };
 
 export function getLocalStorage<T extends keyof LocalStorageTypes>(


### PR DESCRIPTION
## Description

Adds a "Tutorial Card" to give users tips after onboarding.

- Only is displayed once a user completes onboarding
- If dismissed, currently no way to recall

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots
<img width="599" alt="Screenshot 2024-07-11 at 4 48 09 PM" src="https://github.com/user-attachments/assets/0b8097f3-2a6c-4925-b439-c4286b877bf2">

## Testing

[ For new or modified features, provide testing instructions. ]
