### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/docs/walkthroughs/set-up-codestral.md
+++ b/docs/docs/walkthroughs/set-up-codestral.md
@@ -39,7 +39,7 @@ keywords: [codestral, mistral, model setup]
 
 5. If you run into any issues or have any questions, please join our Discord and post in the `#help` channel [here](https://discord.gg/EfJEfdFnDQ)
 
-## Trobleshooting
+## Troubleshooting
 
 ### Temporary workaround for JetBrains
 


### PR DESCRIPTION
In  set-up-codestral.md
"Trobleshooting" -> "Troubleshooting"

## Description

[ What changed? Feel free to be brief. ]

## Checklist

- [ ] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created

## Screenshots

[ "For visual changes, include screenshots." ]

## Testing

[ For new or modified features, provide testing instructions. ]
