### PR TITLE
chore: move quick edit instantiation to activation

### DIFF
--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -169,6 +169,7 @@ const commandsMap: (
   verticalDiffManager: VerticalPerLineDiffManager,
   continueServerClientPromise: Promise<ContinueServerClient>,
   battery: Battery,
+  quickEdit: QuickEdit,
 ) => { [command: string]: (...args: any) => any } = (
   ide,
   extensionContext,
@@ -178,6 +179,7 @@ const commandsMap: (
   verticalDiffManager,
   continueServerClientPromise,
   battery,
+  quickEdit,
 ) => {
   /**
    * Streams an inline edit to the vertical diff manager.
@@ -346,17 +348,6 @@ const commandsMap: (
     },
     "continue.quickEdit": async (initialPrompt?: string) => {
       captureCommandTelemetry("quickEdit");
-
-      const config = await configHandler.loadConfig();
-
-      const quickEdit = new QuickEdit(
-        verticalDiffManager,
-        config,
-        sidebar.webviewProtocol,
-        ide,
-        extensionContext,
-      );
-
       quickEdit.show(initialPrompt);
     },
     "continue.writeCommentsForCode": async () => {
@@ -693,6 +684,7 @@ export function registerAllCommands(
   verticalDiffManager: VerticalPerLineDiffManager,
   continueServerClientPromise: Promise<ContinueServerClient>,
   battery: Battery,
+  quickEdit: QuickEdit,
 ) {
   for (const [command, callback] of Object.entries(
     commandsMap(
@@ -704,6 +696,7 @@ export function registerAllCommands(
       verticalDiffManager,
       continueServerClientPromise,
       battery,
+      quickEdit,
     ),
   )) {
     context.subscriptions.push(

--- a/extensions/vscode/src/extension/VsCodeExtension.ts
+++ b/extensions/vscode/src/extension/VsCodeExtension.ts
@@ -26,6 +26,7 @@ import { Battery } from "../util/battery";
 import { TabAutocompleteModel } from "../util/loadAutocompleteModel";
 import type { VsCodeWebviewProtocol } from "../webviewProtocol";
 import { VsCodeMessenger } from "./VsCodeMessenger";
+import { QuickEdit } from "../quickEdit/QuickEditQuickPick";
 
 export class VsCodeExtension {
   // Currently some of these are public so they can be used in testing (test/test-suites)
@@ -53,8 +54,6 @@ export class VsCodeExtension {
     this.ide = new VsCodeIde(this.diffManager, this.webviewProtocolPromise);
     this.extensionContext = context;
     this.windowId = uuidv4();
-
-    const ideSettings = this.ide.getIdeSettingsSync();
 
     // Dependencies of core
     let resolveVerticalDiffManager: any = undefined;
@@ -177,6 +176,14 @@ export class VsCodeExtension {
     context.subscriptions.push(this.battery);
     context.subscriptions.push(monitorBatteryChanges(this.battery));
 
+    const quickEdit = new QuickEdit(
+      this.verticalDiffManager,
+      this.configHandler,
+      this.sidebar.webviewProtocol,
+      this.ide,
+      context,
+    );
+
     // Commands
     registerAllCommands(
       context,
@@ -188,6 +195,7 @@ export class VsCodeExtension {
       this.verticalDiffManager,
       this.core.continueServerClientPromise,
       this.battery,
+      quickEdit,
     );
 
     registerDebugTracker(this.sidebar.webviewProtocol, this.ide);


### PR DESCRIPTION
## Description

Moves the  quick edit instantiation to activation

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

[ "For visual changes, include screenshots." ]

## Testing

[ For new or modified features, provide testing instructions. ]
