### PR TITLE
fix: wrap editor buttons when out of space

### DIFF
--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -24,13 +24,13 @@ import {
 import ModelSelect from "../modelSelection/ModelSelect";
 
 const StyledDiv = styled.div<{ hidden?: boolean }>`
-  position: absolute;
   display: flex;
-  gap: 4px;
-  right: 4px;
-  bottom: 4px;
-  width: calc(100% - 10px);
+  justify-content: space-between;
+  flex-wrap: wrap-reverse;
+  flex-direction: row-reverse;
+  gap: 1px;
   background-color: ${vscInputBackground};
+  padding-top: 4px;
 
   ${(props) => (props.hidden ? "display: none;" : "")}
 
@@ -85,7 +85,60 @@ function InputToolbar(props: InputToolbarProps) {
 
   return (
     <StyledDiv hidden={props.hidden} onClick={props.onClick} id="input-toolbar">
-      <span className="cursor-pointer mr-auto flex items-center">
+      <span className="flex items-center whitespace-nowrap">
+        {props.showNoContext ? (
+          <span
+            style={{
+              color: props.usingCodebase ? vscBadgeBackground : lightGray,
+              backgroundColor: props.usingCodebase
+                ? lightGray + "33"
+                : undefined,
+              borderRadius: defaultBorderRadius,
+              padding: "2px 4px",
+            }}
+          >
+            {getAltKeyLabel()} ⏎{" "}
+            {useActiveFile ? "No context" : "Use active file"}
+          </span>
+        ) : (
+          <span
+            style={{
+              color: props.usingCodebase ? vscBadgeBackground : lightGray,
+              backgroundColor: props.usingCodebase
+                ? lightGray + "33"
+                : undefined,
+              borderRadius: defaultBorderRadius,
+              padding: "2px 4px",
+            }}
+            onClick={(e) => {
+              props.onEnter({
+                useCodebase: true,
+                noContext: !useActiveFile,
+              });
+            }}
+            className={"hover:underline cursor-pointer float-right"}
+          >
+            {getMetaKeyLabel()} ⏎ Use codebase
+          </span>
+        )}
+        <EnterButton
+          offFocus={props.usingCodebase}
+          // disabled={
+          //   !active &&
+          //   (!(inputRef.current as any)?.value ||
+          //     typeof client === "undefined")
+          // }
+          onClick={(e) => {
+            props.onEnter({
+              useCodebase: isMetaEquivalentKeyPressed(e),
+              noContext: useActiveFile ? e.altKey : !e.altKey,
+            });
+          }}
+        >
+          ⏎ Enter
+        </EnterButton>
+      </span>
+      <span className="flex flex-wrap-reverse items-center whitespace-nowrap">
         <ModelSelect />
         <span
           style={{
@@ -142,53 +195,6 @@ function InputToolbar(props: InputToolbarProps) {
             </span>
           )}
       </span>
-      {props.showNoContext ? (
-        <span
-          style={{
-            color: props.usingCodebase ? vscBadgeBackground : lightGray,
-            backgroundColor: props.usingCodebase ? lightGray + "33" : undefined,
-            borderRadius: defaultBorderRadius,
-            padding: "2px 4px",
-          }}
-        >
-          {getAltKeyLabel()} ⏎{" "}
-          {useActiveFile ? "No context" : "Use active file"}
-        </span>
-      ) : (
-        <span
-          style={{
-            color: props.usingCodebase ? vscBadgeBackground : lightGray,
-            backgroundColor: props.usingCodebase ? lightGray + "33" : undefined,
-            borderRadius: defaultBorderRadius,
-            padding: "2px 4px",
-          }}
-          onClick={(e) => {
-            props.onEnter({
-              useCodebase: true,
-              noContext: !useActiveFile,
-            });
-          }}
-          className={"hover:underline cursor-pointer float-right"}
-        >
-          {getMetaKeyLabel()} ⏎ Use codebase
-        </span>
-      )}
-      <EnterButton
-        offFocus={props.usingCodebase}
-        // disabled={
-        //   !active &&
-        //   (!(inputRef.current as any)?.value ||
-        //     typeof client === "undefined")
-        // }
-        onClick={(e) => {
-          props.onEnter({
-            useCodebase: isMetaEquivalentKeyPressed(e),
-            noContext: useActiveFile ? e.altKey : !e.altKey,
-          });
-        }}
-      >
-        ⏎ Enter
-      </EnterButton>
     </StyledDiv>
   );
 }

--- a/gui/src/components/mainInput/TipTapEditor.css
+++ b/gui/src/components/mainInput/TipTapEditor.css
@@ -22,6 +22,7 @@
   float: left;
   height: 0;
   pointer-events: none;
+  white-space: nowrap;
 }
 
 .gap-cursor {

--- a/gui/src/components/mainInput/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor.tsx
@@ -58,7 +58,7 @@ const InputBoxDiv = styled.div`
   resize: none;
 
   padding: 8px;
-  padding-bottom: 24px;
+  padding-bottom: 4px;
   font-family: inherit;
   border-radius: ${defaultBorderRadius};
   margin: 0;
@@ -70,7 +70,6 @@ const InputBoxDiv = styled.div`
   border: 0.5px solid ${vscInputBorder};
   outline: none;
   font-size: ${getFontSize()}px;
-
   &:focus {
     outline: none;
 


### PR DESCRIPTION
## Description

Editor button sections now wrap instead of overflowing out of the container. Also fixed editor placeholder text from wrapping and showing just the top of each letter. Solves issue #1721 

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

<img width="403" alt="Screenshot 2024-07-11 at 11 25 51 PM" src="https://github.com/user-attachments/assets/412e77da-fa32-4017-9e76-87c309d24785">
<img width="268" alt="Screenshot 2024-07-11 at 11 25 40 PM" src="https://github.com/user-attachments/assets/37b2dbb6-1c43-4078-bc98-e0401839fc8f">


## Testing

Resize the continue sidebar to view the wrapping and placeholder text changes. An alternative solution is to hide the "+ Add context" and "⌘ ⏎ Use codebase" buttons when the sidebar reaches a certain size which looks cleaner and fits in a single row at the cost of no longer displaying these options directly in the editor.