### PR TITLE
Fix: Create .continuerc.json file in configuration directory to prevent it's indexing (and infinite loops).

### DIFF
--- a/core/util/paths.ts
+++ b/core/util/paths.ts
@@ -139,6 +139,24 @@ export function getTsConfigPath(): string {
   return tsConfigPath;
 }
 
+export function getContinueRcPath(): string {
+  // Disable indexing of the config folder to prevent infinite loops
+  const continuercPath = path.join(getContinueGlobalPath(), ".continuerc.json");
+  if (!fs.existsSync(continuercPath)) {
+    fs.writeFileSync(
+      continuercPath,
+      JSON.stringify(
+        {
+          disableIndexing: true,
+        },
+        null,
+        2,
+      ),
+    );
+  }
+  return continuercPath;
+}
+
 export function devDataPath(): string {
   const sPath = path.join(getContinueGlobalPath(), "dev_data");
   if (!fs.existsSync(sPath)) {

--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -1,4 +1,4 @@
-import { getTsConfigPath, migrate } from "core/util/paths";
+import { getTsConfigPath, getContinueRcPath, migrate } from "core/util/paths";
 import { Telemetry } from "core/util/posthog";
 import path from "node:path";
 import * as vscode from "vscode";
@@ -13,6 +13,7 @@ import { setupInlineTips } from "./inlineTips";
 export async function activateExtension(context: vscode.ExtensionContext) {
   // Add necessary files
   getTsConfigPath();
+  getContinueRcPath();
 
   // Register commands and providers
   registerQuickFixProvider();


### PR DESCRIPTION
## Description

Fixes #1654 by creating a `.continuerc.json` file in the configuration directory via `activate.ts`.

## Checklist

- [X] The base branch of this PR is `dev`, rather than `main`
- [X] The relevant docs, if any, have been updated or created

## Screenshots

When the user opens their configuration directory they will see
![image](https://github.com/user-attachments/assets/9d2596d3-477e-49af-b57c-e16c946b6ac0)
