### PR TITLE
feat: single default quick pick to edit

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,9 +12,7 @@
         // To bundle the code the same way we do for publishing
         "vscode-extension:esbuild",
         // Start the React app that is used in the extension
-        "gui:dev",
-        // Start the docs site, without opening the browser
-        "docs:start"
+        "gui:dev"
       ],
       "group": {
         "kind": "build",

--- a/binary/package-lock.json
+++ b/binary/package-lock.json
@@ -46,6 +46,8 @@
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.574.0",
         "@aws-sdk/credential-providers": "^3.596.0",
+        "@continuedev/config-types": "^1.0.6",
+        "@continuedev/llm-info": "^1.0.1",
         "@mozilla/readability": "^0.5.0",
         "@octokit/rest": "^20.0.2",
         "@types/jsdom": "^21.1.6",
@@ -61,7 +63,7 @@
         "commander": "^12.0.0",
         "comment-json": "^4.2.3",
         "dbinfoz": "^0.1.4",
-        "dotenv": "^16.3.1",
+        "dotenv": "^16.4.5",
         "fastest-levenshtein": "^1.0.16",
         "follow-redirects": "^1.15.5",
         "handlebars": "^4.7.8",
@@ -91,7 +93,8 @@
         "vectordb": "^0.4.20",
         "web-tree-sitter": "^0.21.0",
         "win-ca": "^3.5.1",
-        "yaml": "^2.4.2"
+        "yaml": "^2.4.2",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.24.7",

--- a/docs/docs/walkthroughs/quick-actions.md
+++ b/docs/docs/walkthroughs/quick-actions.md
@@ -1,13 +1,13 @@
 ---
 title: Quick Actions (experimental, VS Code only)
-description: Quick Actions automate repetitive tasks and streamline your development workflow
+description: Quick Actions streamline your development workflow by allowing quick edits on selected classes or functions
 keywords: [experimental, automate, configuration]
 toc_max_heading_level: 5
 ---
 
-# Quick Actions (experimental, VS Code only)
+## Quick Actions (experimental, VS Code only)
 
-Quick Actions automate repetitive tasks and streamline your development workflow. Configure custom actions to execute complex operations with a single click.
+Quick Actions streamline your development workflow by providing a tool to quickly select an entire class or function to perform a quick edit on. Configure custom actions to execute complex operations with a single click.
 
 ![Quick actions example](/img/quick-actions-demo.gif)
 
@@ -19,10 +19,9 @@ For the language of the file you have open, you must have the Language Server Pr
 
 Quick Actions use a CodeLens provider to add interactive elements above functions and classes in your code.
 
-By default, Quick Actions include two predefined actions:
+By default, Quick Actions include a single predefined action:
 
-1. `Explain`: This action provides a short explanation of the selected code.
-2. `Docstring`: This action generates a docstring comment and inserts it above the code.
+1. `Continue`: This action allows you to perform a quick edit on the selected class or function.
 
 ## How to disable Quick Actions
 

--- a/docs/docs/walkthroughs/quick-actions.md
+++ b/docs/docs/walkthroughs/quick-actions.md
@@ -21,7 +21,7 @@ Quick Actions use a CodeLens provider to add interactive elements above function
 
 By default, Quick Actions include a single predefined action:
 
-1. `Continue`: This action allows you to perform a quick edit on the selected class or function.
+- `Continue`: This action allows you to perform a quick edit on the selected class or function.
 
 ## How to disable Quick Actions
 

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "0.9.182",
+  "version": "0.9.184",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "0.9.182",
+      "version": "0.9.184",
       "license": "Apache-2.0",
       "dependencies": {
         "@electron/rebuild": "^3.2.10",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "continue",
   "icon": "media/icon.png",
-  "version": "0.9.182",
+  "version": "0.9.184",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -22,7 +22,7 @@ import {
 import { ContinueGUIWebviewViewProvider } from "./ContinueGUIWebviewViewProvider";
 import { DiffManager } from "./diff/horizontal";
 import { VerticalPerLineDiffManager } from "./diff/verticalPerLine/manager";
-import { QuickEdit } from "./quickEdit/QuickEditQuickPick";
+import { QuickEdit, QuickEditShowParams } from "./quickEdit/QuickEditQuickPick";
 import { Battery } from "./util/battery";
 import type { VsCodeWebviewProtocol } from "./webviewProtocol";
 
@@ -259,27 +259,6 @@ const commandsMap: (
 
       vscode.commands.executeCommand("continue.continueGUIView.focus");
     },
-    "continue.defaultQuickActionDocstring": async (range: vscode.Range) => {
-      captureCommandTelemetry("defaultQuickActionDocstring");
-
-      streamInlineEdit(
-        "docstring",
-        "Write a docstring for this code. Do not change anything about the code itself.",
-        true,
-        range,
-      );
-    },
-    "continue.defaultQuickActionExplain": async (range: vscode.Range) => {
-      captureCommandTelemetry("defaultQuickActionExplain");
-
-      const prompt =
-        `Explain the above code in a few sentences without ` +
-        `going into detail on specific methods.`;
-
-      addCodeToContextFromRange(range, sidebar.webviewProtocol, prompt);
-
-      vscode.commands.executeCommand("continue.continueGUIView.focus");
-    },
     "continue.customQuickActionSendToChat": async (
       prompt: string,
       range: vscode.Range,
@@ -346,9 +325,9 @@ const commandsMap: (
         await addHighlightedCodeToContext(sidebar.webviewProtocol);
       }
     },
-    "continue.quickEdit": async (initialPrompt?: string) => {
+    "continue.quickEdit": async (args: QuickEditShowParams) => {
       captureCommandTelemetry("quickEdit");
-      quickEdit.show(initialPrompt);
+      quickEdit.show(args);
     },
     "continue.writeCommentsForCode": async () => {
       captureCommandTelemetry("writeCommentsForCode");

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -259,6 +259,11 @@ const commandsMap: (
 
       vscode.commands.executeCommand("continue.continueGUIView.focus");
     },
+    // Passthrough for telemetry purposes
+    "continue.defaultQuickAction": async (args: QuickEditShowParams) => {
+      captureCommandTelemetry("defaultQuickAction");
+      vscode.commands.executeCommand("continue.quickEdit", args);
+    },
     "continue.customQuickActionSendToChat": async (
       prompt: string,
       range: vscode.Range,

--- a/extensions/vscode/src/lang-server/codeLens/providers/QuickActionsCodeLensProvider.ts
+++ b/extensions/vscode/src/lang-server/codeLens/providers/QuickActionsCodeLensProvider.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../util/workspaceConfig";
 import { isTutorialFile } from "./TutorialCodeLensProvider";
 import { Telemetry } from "core/util/posthog";
+import { QuickEditShowParams } from "../../../quickEdit/QuickEditQuickPick";
 
 export const ENABLE_QUICK_ACTIONS_KEY = "enableQuickActions";
 
@@ -83,20 +84,14 @@ export class QuickActionsCodeLensProvider implements vscode.CodeLensProvider {
     });
   }
 
-  getDefaultCommands(range: vscode.Range): vscode.Command[] {
-    const explain: vscode.Command = {
-      command: "continue.defaultQuickActionExplain",
-      title: "Explain",
-      arguments: [range],
+  getDefaultCommand(range: vscode.Range): vscode.Command[] {
+    const quickEdit: vscode.Command = {
+      command: "continue.quickEdit",
+      title: "Continue",
+      arguments: [{ range } as QuickEditShowParams],
     };
 
-    const comment: vscode.Command = {
-      command: "continue.defaultQuickActionDocstring",
-      title: "Docstring",
-      arguments: [range],
-    };
-
-    return [explain, comment];
+    return [quickEdit];
   }
 
   async provideCodeLenses(
@@ -129,7 +124,7 @@ export class QuickActionsCodeLensProvider implements vscode.CodeLensProvider {
     return filteredSmybols.flatMap(({ range }) => {
       const commands: vscode.Command[] = !!this.customQuickActionsConfig
         ? this.getCustomCommands(range, this.customQuickActionsConfig)
-        : this.getDefaultCommands(range);
+        : this.getDefaultCommand(range);
 
       return commands.map((command) => new vscode.CodeLens(range, command));
     });

--- a/extensions/vscode/src/lang-server/codeLens/providers/QuickActionsCodeLensProvider.ts
+++ b/extensions/vscode/src/lang-server/codeLens/providers/QuickActionsCodeLensProvider.ts
@@ -86,7 +86,7 @@ export class QuickActionsCodeLensProvider implements vscode.CodeLensProvider {
 
   getDefaultCommand(range: vscode.Range): vscode.Command[] {
     const quickEdit: vscode.Command = {
-      command: "continue.quickEdit",
+      command: "continue.defaultQuickAction",
       title: "Continue",
       arguments: [{ range } as QuickEditShowParams],
     };

--- a/extensions/vscode/src/lang-server/codeLens/providers/TutorialCodeLensProvider.ts
+++ b/extensions/vscode/src/lang-server/codeLens/providers/TutorialCodeLensProvider.ts
@@ -3,6 +3,7 @@ import path from "path";
 import * as vscode from "vscode";
 import { getPlatform } from "../../../util/util";
 import { getExtensionUri } from "../../../util/vscode";
+import { QuickEditShowParams } from "../../../quickEdit/QuickEditQuickPick";
 
 interface TutorialCodeLensItems {
   lineIncludes: string;
@@ -44,7 +45,7 @@ const actions: TutorialCodeLensItems[] = [
       {
         title: `${cmdCtrl}+I`,
         command: "continue.quickEdit",
-        arguments: ["Add comments"],
+        arguments: [{ initialPrompt: "Add comments" } as QuickEditShowParams],
       },
     ],
   },

--- a/extensions/vscode/src/quickEdit/QuickEditQuickPick.ts
+++ b/extensions/vscode/src/quickEdit/QuickEditQuickPick.ts
@@ -24,6 +24,15 @@ enum QuickEditInitialItemLabels {
   Submit = "Submit",
 }
 
+export type QuickEditShowParams = {
+  initialPrompt?: string;
+  /**
+   * Used for Quick Actions where the user has not highlighted code.
+   * Instead the range comes from the document symbol.
+   */
+  range?: vscode.Range;
+};
+
 type FileMiniSearchResult = { filename: string };
 
 /**
@@ -42,6 +51,10 @@ export class QuickEdit {
   );
 
   private static maxFileSearchResults = 20;
+
+  private range?: vscode.Range;
+  private initialPrompt?: string;
+
   private miniSearch = new MiniSearch<FileMiniSearchResult>({
     fields: ["filename"],
     storeFields: ["filename"],
@@ -141,10 +154,14 @@ export class QuickEdit {
     }
 
     const fileName = vscode.workspace.asRelativePath(uri, true);
-    const { start, end } = this.editorWhenOpened.selection;
-    const selectionEmpty = this.editorWhenOpened.selection.isEmpty;
 
-    return selectionEmpty
+    const { start, end } = !!this.range
+      ? this.range
+      : this.editorWhenOpened.selection;
+
+    const isSelectionEmpty = start.isEqual(end);
+
+    return isSelectionEmpty
       ? `Edit ${fileName}`
       : `Edit ${fileName}:${start.line}${
           end.line > start.line ? `-${end.line}` : ""
@@ -182,12 +199,11 @@ export class QuickEdit {
       modelTitle,
       undefined,
       this.previousInput,
+      this.range,
     );
   }
 
-  async _getInitialQuickPickVal(
-    injectedPrompt?: string,
-  ): Promise<string | undefined> {
+  async _getInitialQuickPickVal(): Promise<string | undefined> {
     const modelTitle = await this._getCurModelTitle();
 
     const initialItems: vscode.QuickPickItem[] = [
@@ -236,7 +252,7 @@ export class QuickEdit {
       "Enter a prompt to edit your code (@ to search files, ⏎ to submit)";
     quickPick.title = this._getQuickPickTitle();
     quickPick.ignoreFocusOut = true;
-    quickPick.value = injectedPrompt ?? "";
+    quickPick.value = this.initialPrompt ?? "";
 
     quickPick.show();
 
@@ -342,17 +358,34 @@ export class QuickEdit {
   }
 
   /**
+   * Reset the state of the quick pick
+   */
+  private clear() {
+    this.initialPrompt = undefined;
+    this.range = undefined;
+  }
+
+  /**
    * Shows the Quick Edit Quick Pick, allowing the user to select an initial item or enter a prompt.
    * Displays a quick pick for "History" or "ContextProviders" to set the prompt or context provider string.
    * Displays a quick pick for "Model" to set the current model title.
    * Appends the entered prompt to the history and streams the edit with input and context.
    */
-  async show(initialPrompt?: string) {
+  async show(args?: QuickEditShowParams) {
+    // Clean up state from previous quick picks, e.g. if a user pressed `esc`
+    this.clear();
+
     const config = await this.configHandler.loadConfig();
 
-    const selectedLabelOrInputVal = await this._getInitialQuickPickVal(
-      initialPrompt,
-    );
+    if (!!args?.initialPrompt) {
+      this.initialPrompt = args.initialPrompt;
+    }
+
+    if (!!args?.range) {
+      this.range = args.range;
+    }
+
+    const selectedLabelOrInputVal = await this._getInitialQuickPickVal();
 
     Telemetry.capture("quickEditSelection", {
       selection: selectedLabelOrInputVal,
@@ -374,7 +407,7 @@ export class QuickEdit {
         this.contextProviderStr = contextProviderVal ?? "";
 
         // Recurse back to let the user write their prompt
-        this.show(initialPrompt);
+        this.show(args);
 
         break;
 
@@ -391,7 +424,7 @@ export class QuickEdit {
         }
 
         // Recurse back to let the user write their prompt
-        this.show(initialPrompt);
+        this.show(args);
 
         break;
 


### PR DESCRIPTION
## Description

Removes the default `Explain` and `Docstring` quick picks and instead uses the quick pick as a shorthand to pull in a given document symbol to quick edit.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

[ "For visual changes, include screenshots." ]

## Testing
