### PR TITLE
Configurable `maxChunkSize` for embedding providers

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -743,6 +743,7 @@ export interface EmbedOptions {
   apiType?: string;
   apiVersion?: string;
   requestOptions?: RequestOptions;
+  maxChunkSize?: number;
 }
 
 export interface EmbeddingsProviderDescription extends EmbedOptions {
@@ -751,6 +752,7 @@ export interface EmbeddingsProviderDescription extends EmbedOptions {
 
 export interface EmbeddingsProvider {
   id: string;
+  maxChunkSize: number;
   embed(chunks: string[]): Promise<number[][]>;
 }
 

--- a/core/indexing/CodebaseIndexer.ts
+++ b/core/indexing/CodebaseIndexer.ts
@@ -36,6 +36,7 @@ export class CodebaseIndexer {
       new ChunkCodebaseIndex(
         this.ide.readFile.bind(this.ide),
         this.continueServerClient,
+        config.embeddingsProvider.maxChunkSize,
       ), // Chunking must come first
       new LanceDbIndex(
         config.embeddingsProvider,

--- a/core/indexing/LanceDbIndex.ts
+++ b/core/indexing/LanceDbIndex.ts
@@ -9,7 +9,6 @@ import {
   IndexTag,
   IndexingProgressUpdate,
 } from "../index.js";
-import { MAX_CHUNK_SIZE } from "../llm/constants.js";
 import { getBasename } from "../util/index.js";
 import { getLanceDbPath, migrate } from "../util/paths.js";
 import { chunkDocument } from "./chunk/chunk.js";
@@ -35,8 +34,6 @@ export class LanceDbIndex implements CodebaseIndex {
   get artifactId(): string {
     return `vectordb::${this.embeddingsProvider.id}`;
   }
-
-  static MAX_CHUNK_SIZE = MAX_CHUNK_SIZE;
 
   constructor(
     private readonly embeddingsProvider: EmbeddingsProvider,
@@ -99,7 +96,7 @@ export class LanceDbIndex implements CodebaseIndex {
       for await (const chunk of chunkDocument(
         items[i].path,
         content,
-        LanceDbIndex.MAX_CHUNK_SIZE,
+        this.embeddingsProvider.maxChunkSize,
         items[i].cacheKey,
       )) {
         if (chunk.content.length == 0) {

--- a/core/indexing/chunk/ChunkCodebaseIndex.ts
+++ b/core/indexing/chunk/ChunkCodebaseIndex.ts
@@ -1,6 +1,5 @@
 import { IContinueServerClient } from "../../continueServer/interface.js";
 import { Chunk, IndexTag, IndexingProgressUpdate } from "../../index.js";
-import { MAX_CHUNK_SIZE } from "../../llm/constants.js";
 import { getBasename } from "../../util/index.js";
 import { DatabaseConnection, SqliteDb, tagToString } from "../refreshIndex.js";
 import {
@@ -19,6 +18,7 @@ export class ChunkCodebaseIndex implements CodebaseIndex {
   constructor(
     private readonly readFile: (filepath: string) => Promise<string>,
     private readonly continueServerClient: IContinueServerClient,
+    private readonly maxChunkSize: number
   ) {
     this.readFile = readFile;
   }
@@ -108,7 +108,7 @@ export class ChunkCodebaseIndex implements CodebaseIndex {
       for await (const chunk of chunkDocument(
         item.path,
         contents[i],
-        MAX_CHUNK_SIZE,
+        this.maxChunkSize,
         item.cacheKey,
       )) {
         handleChunk(chunk);

--- a/core/indexing/chunk/chunk.ts
+++ b/core/indexing/chunk/chunk.ts
@@ -1,5 +1,4 @@
 import { Chunk, ChunkWithoutID } from "../../index.js";
-import { MAX_CHUNK_SIZE } from "../../llm/constants.js";
 import { countTokens } from "../../llm/countTokens.js";
 import { supportedLanguages } from "../../util/treeSitter.js";
 import { basicChunker } from "./basic.js";
@@ -43,7 +42,7 @@ export async function* chunkDocument(
     contents,
     maxChunkSize,
   )) {
-    if (countTokens(chunkWithoutId.content) > MAX_CHUNK_SIZE) {
+    if (countTokens(chunkWithoutId.content) > maxChunkSize) {
       console.warn(
         `Chunk with more than ${maxChunkSize} tokens constructed: `,
         filepath,

--- a/core/indexing/docs/DocsService.ts
+++ b/core/indexing/docs/DocsService.ts
@@ -253,7 +253,7 @@ export class DocsService {
 
       try {
         const subpathEmbeddings = await embeddingsProvider.embed(
-          chunkArticle(article).map((chunk) => {
+          chunkArticle(article, embeddingsProvider.maxChunkSize).map((chunk) => {
             chunks.push(chunk);
 
             return chunk.content;

--- a/core/indexing/docs/article.ts
+++ b/core/indexing/docs/article.ts
@@ -1,7 +1,6 @@
 import { Readability } from "@mozilla/readability";
 import { JSDOM } from "jsdom";
 import { Chunk } from "../../index.js";
-import { MAX_CHUNK_SIZE } from "../../llm/constants.js";
 import { cleanFragment, cleanHeader } from "../chunk/markdown.js";
 import { PageData } from "./crawl.js";
 
@@ -21,6 +20,7 @@ function breakdownArticleComponent(
   url: string,
   article: ArticleComponent,
   subpath: string,
+  max_chunk_size: number,
 ): Chunk[] {
   const chunks: Chunk[] = [];
 
@@ -32,7 +32,7 @@ function breakdownArticleComponent(
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
-    if (content.length + line.length <= MAX_CHUNK_SIZE) {
+    if (content.length + line.length <= max_chunk_size) {
       content += `${line}\n`;
       endLine = i;
     } else {
@@ -79,7 +79,10 @@ function breakdownArticleComponent(
   return chunks.filter((c) => c.content.trim().length > 20);
 }
 
-export function chunkArticle(articleResult: Article): Chunk[] {
+export function chunkArticle(
+  articleResult: Article,
+  maxChunkSize: number,
+): Chunk[] {
   let chunks: Chunk[] = [];
 
   for (const article of articleResult.article_components) {
@@ -87,6 +90,7 @@ export function chunkArticle(articleResult: Article): Chunk[] {
       articleResult.url,
       article,
       articleResult.subpath,
+      maxChunkSize,
     );
     chunks = [...chunks, ...articleChunks];
   }

--- a/core/indexing/embeddings/BaseEmbeddingsProvider.ts
+++ b/core/indexing/embeddings/BaseEmbeddingsProvider.ts
@@ -4,6 +4,8 @@ import {
   FetchFunction,
 } from "../../index.js";
 
+import { MAX_CHUNK_SIZE } from "../../llm/constants.js";
+
 export interface IBaseEmbeddingsProvider extends EmbeddingsProvider {
   options: EmbedOptions;
   fetch: FetchFunction;
@@ -29,10 +31,19 @@ abstract class BaseEmbeddingsProvider implements IBaseEmbeddingsProvider {
       ...options,
     };
     this.fetch = fetch;
-    this.id = `${this.constructor.name}::${this.options.model}`;
+    // Include the `max_chunk_size` if it is not the default, since we need to create other indices for different chunk_sizes
+    if (this.maxChunkSize !== MAX_CHUNK_SIZE) {
+      this.id = `${this.constructor.name}::${this.options.model}::${this.maxChunkSize}`;
+    } else {
+      this.id = `${this.constructor.name}::${this.options.model}`;
+    }
   }
 
   abstract embed(chunks: string[]): Promise<number[][]>;
+
+  get maxChunkSize(): number {
+    return this.options.maxChunkSize ?? MAX_CHUNK_SIZE;
+  }
 
   static getBatchedChunks(chunks: string[]): string[][] {
     if (!this.maxBatchSize) {

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -1906,6 +1906,13 @@
               "title": "Request Options",
               "description": "Request options to be used in any fetch requests made by the embeddings provider",
               "$ref": "#/definitions/RequestOptions"
+            },
+            "maxChunkSize": {
+              "title": "Maximum Chunk Size",
+              "description": "The maximum number of tokens that each chunk of a document is allowed to have",
+              "type": "integer",
+              "minimum": 128,
+              "exclusiveMaximum": 2147483647
             }
           },
           "required": ["provider"],


### PR DESCRIPTION
## Description

Add `maxChunkSize` to `EmbeddingsProvider` and makes it configurable via `config.json`.
An embedding providers `id` will now also include the `maxChunkSize` to avoid collisions between indices with different chunck lengths if it is not the default. 

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Testing

Set `maxChunkSize` for an embedding provider that does support longer sequences, e.g. : 
```json
"embeddingsProvider": {
    "provider": "huggingface-tei",
    "model": "jina-embeddings-v2-base-code",
    "apiBase": "[URL]",
    "maxChunkSize": 1024
  },
```
Then index a new project.