### PR TITLE
Remove keybinding conflict with core VSCode

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -251,8 +251,8 @@
       },
       {
         "command": "continue.focusContinueInputWithoutClear",
-        "mac": "cmd+shift+l",
-        "key": "ctrl+shift+l"
+        "mac": "alt+shift+l",
+        "key": "alt+shift+l"
       },
       {
         "command": "continue.toggleAuxiliaryBar",


### PR DESCRIPTION
## Description

`cmd+shift+L` is one of the core bindings for VSCode, allowing a user to quickly "Select all occurrences of current selection" via `editor.action.selectHighlights` ref: https://code.visualstudio.com/docs/getstarted/keybindings

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

[ "For visual changes, include screenshots." ]

## Testing

Confirm that using `alt+shift+L` will trigger a Continue.Dev action, and `cmd+shift+L` allows you to once again select text
