### PR TITLE
fix: delete old docs index on force re-index

### DIFF
--- a/core/indexing/docs/DocsService.ts
+++ b/core/indexing/docs/DocsService.ts
@@ -296,6 +296,12 @@ export class DocsService {
       status: "indexing",
     };
 
+    // Clear old index if re-indexing.
+    if (reIndex) {
+      console.log("Deleting old embeddings");
+      await this.delete(startUrl.toString());
+    }
+
     await this.add(siteIndexingConfig.title, startUrl, chunks, embeddings);
     this.docsIndexingQueue.delete(startUrl.toString());
 


### PR DESCRIPTION
## Description

fix: delete old docs index on force re-index

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created
