### PR TITLE
fix: convert `walkDir` to an async generator

### DIFF
--- a/core/indexing/CodebaseIndexer.ts
+++ b/core/indexing/CodebaseIndexer.ts
@@ -100,8 +100,6 @@ export class CodebaseIndexer {
 
     for (const directory of workspaceDirs) {
       const files = await walkDir(directory, this.ide);
-      console.log(`num files processed: ${files.length}`);
-
       const stats = await this.ide.getLastModified(files);
       const branch = await this.ide.getBranch(directory);
       const repoName = await this.ide.getRepoName(directory);

--- a/core/indexing/CodebaseIndexer.ts
+++ b/core/indexing/CodebaseIndexer.ts
@@ -100,6 +100,8 @@ export class CodebaseIndexer {
 
     for (const directory of workspaceDirs) {
       const files = await walkDir(directory, this.ide);
+      console.log(`num files processed: ${files.length}`);
+
       const stats = await this.ide.getLastModified(files);
       const branch = await this.ide.getBranch(directory);
       const repoName = await this.ide.getRepoName(directory);

--- a/core/test/walkDir.test.ts
+++ b/core/test/walkDir.test.ts
@@ -264,7 +264,7 @@ describe("walkDir", () => {
   });
 
   test("should walk continue/extensions/vscode without getting any files in the .continueignore", async () => {
-    const vscodePath = path.join(__dirname, "..", "extensions", "vscode");
+    const vscodePath = path.join(__dirname, "../..", "extensions", "vscode");
     const results = await walkDir(vscodePath, ide, {
       ignoreFiles: [".gitignore", ".continueignore"],
     });


### PR DESCRIPTION
## Description

Converts `walkDir` to an async generator.

Closes #1774 #1771 #1705 

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

[ "For visual changes, include screenshots." ]

## Testing

- Confirm all tests in `core/test/walkDir.test.ts` are passing
- Open a very large project (e.g. https://github.com/torvalds/linux) and verify that the IDE is responsive while indexing
