### PR TITLE
Fix Input Toolbar layout

### DIFF
--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -23,27 +23,19 @@ import {
 } from "../../util";
 import ModelSelect from "../modelSelection/ModelSelect";
 
-const paddingTop = 4;
-const height = 20;
-
-const StyledDiv = styled.div<{ hidden?: boolean }>`
+const StyledDiv = styled.div<{ isHidden: boolean }>`
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap-reverse;
   flex-direction: row-reverse;
   gap: 1px;
   background-color: ${vscInputBackground};
-  padding-top: ${paddingTop}px;
-
-  height: ${height}px;
-
-  ${(props) => (props.hidden ? "display: none;" : "")}
-
   align-items: center;
   z-index: 50;
   font-size: ${getFontSize() - 4}px;
-
-  cursor: text;
+  cursor: ${props => props.isHidden ? 'default' : 'text'};
+  opacity: ${props => props.isHidden ? 0 : 1};
+  pointer-events: ${props => props.isHidden ? 'none' : 'auto'};
 
   & > * {
     flex: 0 0 auto;
@@ -90,11 +82,8 @@ function InputToolbar(props: InputToolbarProps) {
 
   return (
     <>
-      {props.hidden && (
-        <div style={{ height: `${height + paddingTop}px` }}></div>
-      )}
       <StyledDiv
-        hidden={props.hidden}
+        isHidden={props.hidden}
         onClick={props.onClick}
         id="input-toolbar"
       >

--- a/gui/src/components/mainInput/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor.tsx
@@ -80,7 +80,8 @@ const InputBoxDiv = styled.div`
     color: ${lightGray}cc;
   }
 
-  position: relative;
+  display: flex;
+  flex-direction: column;
 `;
 
 const HoverDiv = styled.div`


### PR DESCRIPTION
## Description

The Input Toolbar now sizes itself to the content and displays it in a flex column under the user's EditorContent message.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots
**Before:**
<img width="302" alt="image" src="https://github.com/user-attachments/assets/302510d7-06cb-4240-9c0f-15e439038293">

**After:**
<img width="305" alt="image" src="https://github.com/user-attachments/assets/c4ed8ddc-21b4-4f11-9e47-6fa79aa1af4a">


## Testing

1. Check the Input Toolbar looks like the above screenshot.
