### PR TITLE
Refresh index fixes

### DIFF
--- a/core/indexing/CodebaseIndexer.ts
+++ b/core/indexing/CodebaseIndexer.ts
@@ -6,7 +6,7 @@ import { FullTextSearchCodebaseIndex } from "./FullTextSearch.js";
 import { LanceDbIndex } from "./LanceDbIndex.js";
 import { ChunkCodebaseIndex } from "./chunk/ChunkCodebaseIndex.js";
 import { getComputeDeleteAddRemove } from "./refreshIndex.js";
-import { CodebaseIndex } from "./types.js";
+import { CodebaseIndex, IndexResultType } from "./types.js";
 import { walkDir } from "./walkDir.js";
 
 export class PauseToken {
@@ -112,7 +112,7 @@ export class CodebaseIndexer {
           branch,
           artifactId: codebaseIndex.artifactId,
         };
-        const [results, markComplete] = await getComputeDeleteAddRemove(
+        const [results, lastUpdated, markComplete] = await getComputeDeleteAddRemove(
           tag,
           { ...stats },
           (filepath) => this.ide.readFile(filepath),
@@ -158,6 +158,10 @@ export class CodebaseIndexer {
               status: "indexing",
             };
           }
+
+          lastUpdated.forEach((lastUpdated, path) => {
+            markComplete([lastUpdated], IndexResultType.UpdateLastUpdated);
+          });
 
           completedRelativeExpectedTime += codebaseIndex.relativeExpectedTime;
           yield {

--- a/core/indexing/refreshIndex.ts
+++ b/core/indexing/refreshIndex.ts
@@ -325,6 +325,8 @@ function mapIndexResultTypeToAddRemoveResultType(
   resultType: IndexResultType,
 ): AddRemoveResultType {
   switch (resultType) {
+    case "updateLastUpdated":
+      return AddRemoveResultType.UpdateLastUpdated;
     case "compute":
       return AddRemoveResultType.Compute;
     case "addTag":
@@ -430,7 +432,7 @@ export class GlobalCacheCodeBaseIndex implements CodebaseIndex {
     _: MarkCompleteCallback,
     repoName: string | undefined,
   ): AsyncGenerator<IndexingProgressUpdate> {
-    const add = [...results.compute, ...results.addTag];
+    const add = results.addTag;
     const remove = [...results.del, ...results.removeTag];
     await Promise.all([
       ...remove.map(({ cacheKey }) => {

--- a/core/indexing/types.ts
+++ b/core/indexing/types.ts
@@ -5,6 +5,7 @@ export enum IndexResultType {
   Delete = "del",
   AddTag = "addTag",
   RemoveTag = "removeTag",
+  UpdateLastUpdated = "updateLastUpdated"
 }
 
 export type MarkCompleteCallback = (


### PR DESCRIPTION
## Description

Fixes some issues with insertions in `refreshIndex`.

* Separates out `Compute` and `UpdateLastUpdated` operations into their own separate `AddRemoveResultType` and `IndexResultType`. 
* We now update the last updated at field even if the item hasn't changed. 
* We now only insert items into `UpdateNewVersion` if the `cacheKey` has changed.
* Delete duplicate rows in the `tag_catalog` and `global_cache` if they exist.
* Adds unique constraints on `tag_catalog` and `global_cache` to prevent application errors in the future and restrict duplicate insertions.
* CodebaseIndexer now marks all `UpdateLastUpdated` operations as completed when they are returned by the indexers.
* The `results.addTag` loop in `CodebaseIndexer` always inserts.
* 
## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Testing

1. Hitting the reindex button multiple times should be a noop.
