### PR TITLE
Enable debug logs

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -422,6 +422,7 @@ export interface IdeSettings {
   remoteConfigSyncPeriod: number;
   userToken: string;
   enableControlServerBeta: boolean;
+  enableDebugLogs: boolean
 }
 
 export interface IDE {

--- a/core/util/filesystem.ts
+++ b/core/util/filesystem.ts
@@ -38,6 +38,7 @@ class FileSystemIde implements IDE {
       remoteConfigSyncPeriod: 60,
       userToken: "",
       enableControlServerBeta: false,
+      enableDebugLogs: false,
     };
   }
   async getGitHubAuthToken(): Promise<string | undefined> {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -94,6 +94,11 @@
           "default": false,
           "markdownDescription": "Pause Continue's tab autocomplete feature when your battery is low."
         },
+        "continue.enableDebugLogs": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enable Continue Debug Logs in the Output panel."
+        },
         "continue.remoteConfigServerUrl": {
           "type": "string",
           "default": null,

--- a/extensions/vscode/src/ContinueGUIWebviewViewProvider.ts
+++ b/extensions/vscode/src/ContinueGUIWebviewViewProvider.ts
@@ -12,6 +12,46 @@ export class ContinueGUIWebviewViewProvider
   public static readonly viewType = "continue.continueGUIView";
   public webviewProtocol: VsCodeWebviewProtocol;
 
+  private updateDebugLogsStatus() {
+    const settings = vscode.workspace.getConfiguration("continue");
+    this.enableDebugLogs = settings.get<boolean>("enableDebugLogs", false);
+    if (this.enableDebugLogs) {
+      this.outputChannel.show(true);
+    } else {
+      this.outputChannel.hide();
+    }
+  }
+
+  // Show or hide the output channel on enableDebugLogs
+  private setupDebugLogsListener() {
+    vscode.workspace.onDidChangeConfiguration((event) => {
+      if (event.affectsConfiguration('continue.enableDebugLogs')) {
+        const settings = vscode.workspace.getConfiguration("continue");
+        const enableDebugLogs = settings.get<boolean>("enableDebugLogs", false);
+        if (enableDebugLogs) {
+          this.outputChannel.show(true);
+        } else {
+          this.outputChannel.hide();
+        }
+      }
+    });
+  }
+
+  private async handleWebviewMessage(message: any) {
+  if (message.messageType === "log") {
+    const settings = vscode.workspace.getConfiguration("continue");
+    const enableDebugLogs = settings.get<boolean>("enableDebugLogs", false);
+
+    if (message.level === "debug" && !enableDebugLogs) {
+      return; // Skip debug logs if enableDebugLogs is false
+    }
+
+    const timestamp = new Date().toISOString().split(".")[0];
+    const logMessage = `[${timestamp}] [${message.level.toUpperCase()}] ${message.text}`;
+    this.outputChannel.appendLine(logMessage);
+  }
+}
+
   resolveWebviewView(
     webviewView: vscode.WebviewView,
     _context: vscode.WebviewViewResolveContext,
@@ -26,6 +66,8 @@ export class ContinueGUIWebviewViewProvider
 
   private _webview?: vscode.Webview;
   private _webviewView?: vscode.WebviewView;
+  private outputChannel: vscode.OutputChannel;
+  private enableDebugLogs: boolean;
 
   get isVisible() {
     return this._webviewView?.visible;
@@ -50,11 +92,17 @@ export class ContinueGUIWebviewViewProvider
     });
   }
 
+
   constructor(
     private readonly configHandlerPromise: Promise<ConfigHandler>,
     private readonly windowId: string,
     private readonly extensionContext: vscode.ExtensionContext,
   ) {
+    this.outputChannel = vscode.window.createOutputChannel("Continue");
+    this.enableDebugLogs = false;
+    this.updateDebugLogsStatus();
+    this.setupDebugLogsListener();
+
     this.webviewProtocol = new VsCodeWebviewProtocol(
       (async () => {
         const configHandler = await this.configHandlerPromise;
@@ -131,6 +179,22 @@ export class ContinueGUIWebviewViewProvider
       <body>
         <div id="root"></div>
 
+        ${`<script>
+        function log(level, ...args) {
+          const text = args.map(arg =>
+            typeof arg === 'object' ? JSON.stringify(arg) : String(arg)
+          ).join(' ');
+          vscode.postMessage({ messageType: 'log', level, text, messageId: "log" });
+        }
+
+        window.console.log = (...args) => log('log', ...args);
+        window.console.info = (...args) => log('info', ...args);
+        window.console.warn = (...args) => log('warn', ...args);
+        window.console.error = (...args) => log('error', ...args);
+        window.console.debug = (...args) => log('debug', ...args);
+
+        console.debug('Logging initialized');
+        </script>`}
         ${
           inDevelopmentMode
             ? `<script type="module">

--- a/extensions/vscode/src/ContinueGUIWebviewViewProvider.ts
+++ b/extensions/vscode/src/ContinueGUIWebviewViewProvider.ts
@@ -58,6 +58,9 @@ export class ContinueGUIWebviewViewProvider
     _token: vscode.CancellationToken,
   ): void | Thenable<void> {
     this._webview = webviewView.webview;
+    this._webview.onDidReceiveMessage((message) =>
+      this.handleWebviewMessage(message),
+    );
     webviewView.webview.html = this.getSidebarContent(
       this.extensionContext,
       webviewView,

--- a/extensions/vscode/src/ideProtocol.ts
+++ b/extensions/vscode/src/ideProtocol.ts
@@ -522,6 +522,7 @@ class VsCodeIde implements IDE {
       ),
       userToken: settings.get<string>("userToken", ""),
       enableControlServerBeta: internalBetaPathExists(),
+      enableDebugLogs: settings.get<boolean>("enableDebugLogs", false),
       // settings.get<boolean>(
       //   "enableControlServerBeta",
       //   false,

--- a/gui/src/hooks/useSubmenuContextProviders.tsx
+++ b/gui/src/hooks/useSubmenuContextProviders.tsx
@@ -6,7 +6,7 @@ import {
   groupByLastNPathParts,
 } from "core/util";
 import MiniSearch, { SearchResult } from "minisearch";
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 import { IdeMessengerContext } from "../context/IdeMessenger";
 import { selectContextProviderDescriptions } from "../redux/selectors";
@@ -107,6 +107,90 @@ function useSubmenuContextProviders() {
     };
   }, []);
 
+  const getSubmenuSearchResults = useMemo(
+    () =>
+      (providerTitle: string | undefined, query: string): SearchResult[] => {
+        console.debug(
+          "Executing getSubmenuSearchResults. Provider:",
+          providerTitle,
+          "Query:",
+          query,
+        );
+        console.debug("Current minisearches:", Object.keys(minisearches));
+        if (providerTitle === undefined) {
+          // Return search combined from all providers
+          const results = Object.keys(minisearches).map((providerTitle) => {
+            const results = minisearches[providerTitle].search(
+              query,
+              MINISEARCH_OPTIONS,
+            );
+            console.debug(`Search results for ${providerTitle}:`, results.length);
+            return results.map((result) => {
+              return { ...result, providerTitle };
+            });
+          });
+
+          return results.flat().sort((a, b) => b.score - a.score);
+        }
+        if (!minisearches[providerTitle]) {
+          console.debug(`No minisearch found for provider: ${providerTitle}`);
+          return [];
+        }
+
+        const results = minisearches[providerTitle]
+          .search(query, MINISEARCH_OPTIONS)
+          .map((result) => {
+            return { ...result, providerTitle };
+          });
+        console.debug(`Search results for ${providerTitle}:`, results.length);
+
+        return results;
+      },
+    [minisearches],
+  );
+
+  const getSubmenuContextItems = useMemo(
+    () =>
+      (
+        providerTitle: string | undefined,
+        query: string,
+        limit: number = MAX_LENGTH,
+      ): (ContextSubmenuItem & { providerTitle: string })[] => {
+        console.debug(
+          "Executing getSubmenuContextItems. Provider:",
+          providerTitle,
+          "Query:",
+          query,
+          "Limit:",
+          limit,
+        );
+
+        const results = getSubmenuSearchResults(providerTitle, query);
+        if (results.length === 0) {
+          const fallbackItems = (fallbackResults[providerTitle] ?? [])
+            .slice(0, limit)
+            .map((result) => {
+              return {
+                ...result,
+                providerTitle,
+              };
+            });
+          console.debug("Using fallback results:", fallbackItems.length);
+          return fallbackItems;
+        }
+        const limitedResults = results.slice(0, limit).map((result) => {
+          return {
+            id: result.id,
+            title: result.title,
+            description: result.description,
+            providerTitle: result.providerTitle,
+          };
+        });
+        return limitedResults;
+      },
+    [fallbackResults, getSubmenuSearchResults],
+  );
+
   useEffect(() => {
     if (contextProviderDescriptions.length === 0 || loaded) {
       return;
@@ -140,61 +224,6 @@ function useSubmenuContextProviders() {
       }
     });
   }, [contextProviderDescriptions, loaded]);
-
-  function getSubmenuSearchResults(
-    providerTitle: string | undefined,
-    query: string,
-  ): SearchResult[] {
-    if (providerTitle === undefined) {
-      // Return search combined from all providers
-      const results = Object.keys(minisearches).map((providerTitle) => {
-        const results = minisearches[providerTitle].search(
-          query,
-          MINISEARCH_OPTIONS,
-        );
-        return results.map((result) => {
-          return { ...result, providerTitle };
-        });
-      });
-
-      return results.flat().sort((a, b) => b.score - a.score);
-    }
-    if (!minisearches[providerTitle]) {
-      return [];
-    }
-
-    return minisearches[providerTitle]
-      .search(query, MINISEARCH_OPTIONS)
-      .map((result) => {
-        return { ...result, providerTitle };
-      });
-  }
-
-  function getSubmenuContextItems(
-    providerTitle: string | undefined,
-    query: string,
-    limit: number = MAX_LENGTH,
-  ): (ContextSubmenuItem & { providerTitle: string })[] {
-    const results = getSubmenuSearchResults(providerTitle, query);
-    if (results.length === 0) {
-      return (fallbackResults[providerTitle] ?? [])
-        .slice(0, limit)
-        .map((result) => {
-          return {
-            ...result,
-            providerTitle,
-          };
-        });
-    }
-    return results.slice(0, limit).map((result) => {
-      return {
-        id: result.id,
-        title: result.title,
-        description: result.description,
-        providerTitle: result.providerTitle,
-      };
-    });
-  }
 
   return {
     getSubmenuContextItems,


### PR DESCRIPTION
## Description

Added an `enableDebugLogs` user settings flag that logs to a Continue `vscode.outputChannel`. Useful for debugging GUI code we can't breakpoint in yet. Also generally consolidates logging to an output channel.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created

## Screenshots

<img width="1106" alt="image" src="https://github.com/user-attachments/assets/90fe86b4-3646-410a-86b1-ce588f291d9e">

## Testing

1. Enable Debug Logs in Continue User Settings
2. Expect debug logs to print in the Continue output channel in the console
3. There are some debug logs in `useSubmenuContextProviders` so they should show up if you @ some code.
