### PR TITLE
Un-shadow file context provider

### DIFF
--- a/gui/src/components/mainInput/resolveInput.ts
+++ b/gui/src/components/mainInput/resolveInput.ts
@@ -99,27 +99,7 @@ async function resolveEditorContent(
   let contextItemsText = "";
   let contextItems: ContextItemWithId[] = [];
   for (const item of contextItemAttrs) {
-    // if (item.itemType === "file") {
-    //   // This is a quick way to resolve @file references
-    //   const basename = getBasename(item.id);
-    //   const relativeFilePath = getRelativePath(
-    //     item.id,
-    //     await ideMessenger.ide.getWorkspaceDirs(),
-    //   );
-    //   const rawContent = await ideMessenger.ide.readFile(item.id);
-    //   const content = `\`\`\`${relativeFilePath}\n${rawContent}\n\`\`\`\n`;
-    //   contextItemsText += content;
-    //   contextItems.push({
-    //     name: basename,
-    //     description: item.id,
-    //     content,
-    //     id: {
-    //       providerTitle: "file",
-    //       itemId: item.id,
-    //     },
-    //   });
-    // } else {
-    const data = {
+  const data = {
       name: item.itemType === "contextProvider" ? item.id : item.itemType,
       query: item.query,
       fullInput: stripImages(parts),

--- a/gui/src/components/mainInput/resolveInput.ts
+++ b/gui/src/components/mainInput/resolveInput.ts
@@ -99,40 +99,39 @@ async function resolveEditorContent(
   let contextItemsText = "";
   let contextItems: ContextItemWithId[] = [];
   for (const item of contextItemAttrs) {
-    if (item.itemType === "file") {
-      // This is a quick way to resolve @file references
-      const basename = getBasename(item.id);
-      const relativeFilePath = getRelativePath(
-        item.id,
-        await ideMessenger.ide.getWorkspaceDirs(),
-      );
-      const rawContent = await ideMessenger.ide.readFile(item.id);
-      const content = `\`\`\`${relativeFilePath}\n${rawContent}\n\`\`\`\n`;
-      contextItemsText += content;
-      contextItems.push({
-        name: basename,
-        description: item.id,
-        content,
-        id: {
-          providerTitle: "file",
-          itemId: item.id,
-        },
-      });
-    } else {
-      const data = {
-        name: item.itemType === "contextProvider" ? item.id : item.itemType,
-        query: item.query,
-        fullInput: stripImages(parts),
-        selectedCode,
-      };
-      const resolvedItems = await ideMessenger.request(
-        "context/getContextItems",
-        data,
-      );
-      contextItems.push(...resolvedItems);
-      for (const resolvedItem of resolvedItems) {
-        contextItemsText += resolvedItem.content + "\n\n";
-      }
+    // if (item.itemType === "file") {
+    //   // This is a quick way to resolve @file references
+    //   const basename = getBasename(item.id);
+    //   const relativeFilePath = getRelativePath(
+    //     item.id,
+    //     await ideMessenger.ide.getWorkspaceDirs(),
+    //   );
+    //   const rawContent = await ideMessenger.ide.readFile(item.id);
+    //   const content = `\`\`\`${relativeFilePath}\n${rawContent}\n\`\`\`\n`;
+    //   contextItemsText += content;
+    //   contextItems.push({
+    //     name: basename,
+    //     description: item.id,
+    //     content,
+    //     id: {
+    //       providerTitle: "file",
+    //       itemId: item.id,
+    //     },
+    //   });
+    // } else {
+    const data = {
+      name: item.itemType === "contextProvider" ? item.id : item.itemType,
+      query: item.query,
+      fullInput: stripImages(parts),
+      selectedCode,
+    };
+    const resolvedItems = await ideMessenger.request(
+      "context/getContextItems",
+      data,
+    );
+    contextItems.push(...resolvedItems);
+    for (const resolvedItem of resolvedItems) {
+      contextItemsText += resolvedItem.content + "\n\n";
     }
   }
 


### PR DESCRIPTION
## Description

Functionality defined in `FileContextProvider.ts` was effectively shadowed/over-ridden by `resolveInput.ts`
For now I merely commented out the responsible code in case it's desired to include any of it in `FileContextProvider.ts`, but if others agree this is otherwise a good change, these lines should probably just be deleted.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created


## Testing

I'd appreciate guidance on what tests exist to be modified or where I should add testing
