### PR TITLE
Set the Index Progress indicator to paused on startup

### DIFF
--- a/core/core.ts
+++ b/core/core.ts
@@ -145,9 +145,14 @@ export class Core {
       // Index on initialization
       this.ide
         .getWorkspaceDirs()
-        .then((dirs) => {
+        .then(async (dirs) => {
           // Respect pauseCodebaseIndexOnStart user settings
           if (ideSettings.pauseCodebaseIndexOnStart) {
+            await this.messenger.request("indexProgress", {
+              progress: 100,
+              desc: "Initial Indexing Skipped",
+              status: "paused",
+            });
             return;
           }
 


### PR DESCRIPTION
## Description

Fixes an issue introduced in https://github.com/continuedev/continue/pull/1788 where the index progress indicator was stuck on initializing and wouldn't let you manually trigger an index.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

Now shows the paused status with `pauseCodebaseIndexOnStart` enabled.
<img width="339" alt="image" src="https://github.com/user-attachments/assets/a25aa04a-39ad-4b41-930a-33cca481edd8">

## Testing

1. Load this extension with `pauseCodebaseIndexOnStart` enabled.
2. See that the Index Progress indicator is paused and no index has been run.
