### PR TITLE
increase gemini 1.5 pro contextLength

### DIFF
--- a/gui/src/pages/AddNewModel/configs/models.ts
+++ b/gui/src/pages/AddNewModel/configs/models.ts
@@ -374,7 +374,7 @@ export const models: { [key: string]: ModelPackage } = {
     params: {
       title: "Gemini 1.5 Pro",
       model: "gemini-1.5-pro-latest",
-      contextLength: 1_000_000,
+      contextLength: 2_000_000,
       apiKey: "<API_KEY>",
     },
     icon: "gemini.png",


### PR DESCRIPTION
## Description

Gemini 1.5 Pro increased context window to 2M tokens: https://developers.googleblog.com/en/new-features-for-the-gemini-api-and-google-ai-studio/

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created
