### PR TITLE
Add CodeGeeX4 code completion support

### DIFF
--- a/core/autocomplete/templates.ts
+++ b/core/autocomplete/templates.ts
@@ -155,6 +155,36 @@ const deepseekFimTemplate: AutocompleteTemplate = {
   },
 };
 
+// https://github.com/THUDM/CodeGeeX4/blob/main/guides/Infilling_guideline.md
+const codegeexFimTemplate: AutocompleteTemplate = {
+  template: (
+    prefix: string,
+    suffix: string,
+    filepath: string,
+    reponame: string,
+    snippets: AutocompleteSnippet[],
+  ): string => {
+    const relativePaths = shortestRelativePaths([
+      ...snippets.map((snippet) => snippet.filepath),
+      filepath,
+    ]);
+    const baseTemplate = `###PATH:${relativePaths[relativePaths.length - 1]}\n###LANGUAGE:\n###MODE:\n<｜code_suffix｜>${suffix}<｜code_prefix｜>${prefix}<｜code_middle｜>`;
+    if (snippets.length == 0)
+    {
+      return baseTemplate;
+    }
+    const references =
+      `###REFERENCE:\n${snippets
+      .map((snippet, i) => `###PATH:${relativePaths[i]}\n${snippet.contents}\n`)
+      .join("###REFERENCE:\n")}`;
+    const prompt = `${references}\n${baseTemplate}`;
+    return prompt;
+  },
+  completionOptions: {
+    stop: ["<｜code_suffix｜>", "<｜code_prefix｜>", "<｜code_middle｜>"],
+  },
+};
+
 const gptAutocompleteTemplate: AutocompleteTemplate = {
   template: `\`\`\`
 {{{prefix}}}[BLANK]{{{suffix}}}
@@ -300,6 +330,10 @@ export function getTemplateForModel(model: string): AutocompleteTemplate {
 
   if (lowerCaseModel.includes("deepseek")) {
     return deepseekFimTemplate;
+  }
+
+  if (lowerCaseModel.includes("codegeex")) {
+    return codegeexFimTemplate;
   }
 
   if (


### PR DESCRIPTION
## Description
Handles #1742

I added support for autocomplete using using the new CodeGeeX4 model.
Following their FIM guide, this change also includes support for context through code snippets.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

[ "For visual changes, include screenshots." ]

## Testing

Modify config.json with the following:
```json
  "tabAutocompleteModel": {
    "title": "Tab Autocomplete Model",
    "provider": "ollama",
    "model": "codegeex4:{quant}"
  },
```

I'm running the quant 9b-all-q6_K, but should work similarly with other quantizations.