### PR TITLE
Add Missing Tokens for CodeGeeX4 AutoComplete

### DIFF
--- a/core/autocomplete/templates.ts
+++ b/core/autocomplete/templates.ts
@@ -168,20 +168,20 @@ const codegeexFimTemplate: AutocompleteTemplate = {
       ...snippets.map((snippet) => snippet.filepath),
       filepath,
     ]);
-    const baseTemplate = `###PATH:${relativePaths[relativePaths.length - 1]}\n###LANGUAGE:\n###MODE:\n<｜code_suffix｜>${suffix}<｜code_prefix｜>${prefix}<｜code_middle｜>`;
+    const baseTemplate = `###PATH:${relativePaths[relativePaths.length - 1]}\n###LANGUAGE:\n###MODE:BLOCK\n<|code_suffix|>${suffix}<|code_prefix|>${prefix}<|code_middle|>`;
     if (snippets.length == 0)
     {
-      return baseTemplate;
+      return `<|user|>\n${baseTemplate}<|assistant|>\n`;
     }
     const references =
       `###REFERENCE:\n${snippets
       .map((snippet, i) => `###PATH:${relativePaths[i]}\n${snippet.contents}\n`)
       .join("###REFERENCE:\n")}`;
-    const prompt = `${references}\n${baseTemplate}`;
+    const prompt = `<|user|>\n${references}\n${baseTemplate}<|assistant|>\n`;
     return prompt;
   },
   completionOptions: {
-    stop: ["<｜code_suffix｜>", "<｜code_prefix｜>", "<｜code_middle｜>"],
+    stop: ["<|user|>", "<|code_suffix|>", "<|code_prefix|>", "<|code_middle|>", "<|assistant|>", "<|endoftext|>"],
   },
 };
 


### PR DESCRIPTION
## Description

Follow up on #1815, Handles #1742

Previous attempts at using the normal pipe char with CodeGeeX FIM tokens resulted in empty completion output. However, this was due to `<|user|>` and `<|assistant|>` tokens being necessary for completion. The earlier working change omitted these tokens, and its functionality through using the deepseek pipe char was merely coincidental. This change now properly follows the CodeGeeX infill guides and should match what the model expects.

In addition to `<|user|>` and `<|assistant|>`, the `<|endoftext|>` token was added as a stop token.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

[ "For visual changes, include screenshots." ]

## Testing

Same as #1815
