### PR TITLE
Remove a copy / pasta section that duplicated the work done in ChunkCodebaseIndexer

### DIFF
--- a/core/indexing/chunk/ChunkCodebaseIndex.ts
+++ b/core/indexing/chunk/ChunkCodebaseIndex.ts
@@ -122,24 +122,6 @@ export class ChunkCodebaseIndex implements CodebaseIndex {
         status: "indexing",
       };
       markComplete([item], IndexResultType.Compute);
-      // Insert chunks
-      for await (const chunk of chunkDocument(
-        item.path,
-        contents[i],
-        this.maxChunkSize,
-        item.cacheKey,
-      )) {
-        handleChunk(chunk);
-      }
-
-      accumulatedProgress =
-        (i / results.compute.length) * (1 - progressReservedForTagging);
-      yield {
-        progress: accumulatedProgress,
-        desc: `Chunking ${getBasename(item.path)}`,
-        status: "indexing",
-      };
-      markComplete([item], IndexResultType.Compute);
     }
 
     // Add tag


### PR DESCRIPTION
This cuts the amount of time spent in this section of indexing in half. On my local machine, indexing the `continue` repo, this section of indexing went from 2:22 to 1:12.

## Description

This section of code is completely duplicated right above & below (expand the diff to see) -- this was doubling the amount of work done in the ChunkCodebaseIndexer for new runs.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

