### PR TITLE
Example adding Entra Auth to OpenAI provider

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -64,6 +64,7 @@ export interface ILLM extends LLMOptions {
   llmRequestHook?: (model: string, prompt: string) => any;
   apiKey?: string;
   apiBase?: string;
+  authType?: string;
 
   engine?: string;
   apiVersion?: string;
@@ -321,6 +322,7 @@ export interface LLMOptions {
   engine?: string;
   apiVersion?: string;
   apiType?: string;
+  authType?: string;
 
   // GCP Options
   region?: string;

--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -93,6 +93,7 @@ export abstract class BaseLLM implements ILLM {
   llmRequestHook?: (model: string, prompt: string) => any;
   apiKey?: string;
   apiBase?: string;
+  authType?: string;
 
   engine?: string;
   apiVersion?: string;
@@ -158,6 +159,7 @@ export abstract class BaseLLM implements ILLM {
     this.engine = options.engine;
     this.apiVersion = options.apiVersion;
     this.apiType = options.apiType;
+    this.authType = options.authType;
     this.region = options.region;
     this.projectId = options.projectId;
   }

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -566,6 +566,7 @@
     "esbuild": "^0.17.19",
     "vscode-languageclient": "^8.0.2",
     "ws": "^8.13.0",
-    "yarn": "^1.22.21"
+    "yarn": "^1.22.21",
+    "@azure/identity": "^4.3.0"
   }
 }


### PR DESCRIPTION
## Description

Added a new attribute to base LLM to allow for handling non-apikey based authentication models.  Also moved the OpenAI header logic to async to allow for making calls to an IdP (Entra in this case).

Related to thread https://discord.com/channels/1108621136150929458/1131313996750917835/1251283613362683994

Note I know supporting SSO is a hot topic especially between the Open and possible value added release so this implementation may not be the best one to be reused by all the products.

I know we kicked around doing this IdP hit in config.ts as well, but the config load is sync for the moment so that would need to be an async model.  I also had issues with filtering the model this code would be invoked on.  If there was a LLM.model load generic (vs just a global load) it might allow for staging these environmental nuances to be staged in ~/.continue vs in the Extension itself.  Sort of pre-commit hook type world.

So this code may not be the right thing to merge, but figured it could be an example of approaching this problem and rather than bespoke providers providing a baseLLM method for auth that could be done using userspace and ideally just config.json.  One challenge in doing that might be module loading as in my example azure/identity is needed.

## Checklist
- [x] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created

If this path is valuable I have no problem amending the PR to include doc on using authType as control logic in a provider.

## Testing
So assumes that the OpenAI endpoint is in Azure OpenAI and uses Entra for authentication, but ideally it should allow for end to end authentication using Browser path to get the access_token and refresh if its expired within the session.  This is similar to the AWS Bedrock use, but instead of requiring the user to make sure the STS is in their .aws path before calling it the token can be grabbed dynamically.  I did poke at mimicking this with azcli, but they obfuscate the access token now and sort of force you to use azcli to expose it.
