### PR TITLE
(feat) Add support to onPaste for images

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor.tsx
@@ -208,20 +208,22 @@ function TipTapEditor(props: TipTapEditorProps) {
   const active = useSelector((state: RootState) => state.state.active);
   const activeRef = useUpdatingRef(active);
 
-  const supportedImageTypes = [
-    "image/jpeg",
-    "image/jpg",
-    "image/png",
-    "image/gif",
-    "image/svg",
-    "image/webp",
-  ];
   async function handleImageFile(
     file: File,
   ): Promise<[HTMLImageElement, string] | undefined> {
     let filesize = file.size / 1024 / 1024; // filesize in MB
     // check image type and size
-    if (supportedImageTypes.includes(file.type) && filesize < 10) {
+    if (
+      [
+        "image/jpeg",
+        "image/jpg",
+        "image/png",
+        "image/gif",
+        "image/svg",
+        "image/webp",
+      ].includes(file.type) &&
+      filesize < 10
+    ) {
       // check dimensions
       let _URL = window.URL || window.webkitURL;
       let img = new window.Image();
@@ -252,7 +254,6 @@ function TipTapEditor(props: TipTapEditorProps) {
 
     if (
       pasteElement.kind !== "file" ||
-      !supportedImageTypes.includes(pasteElement.type) ||
       !defaultModel ||
       !modelSupportsImages(
         defaultModel.provider,
@@ -262,6 +263,7 @@ function TipTapEditor(props: TipTapEditorProps) {
     ) {
       return;
     }
+
     const file = pasteElement.getAsFile();
     handleImageFile(file).then(([_img, dataUrl]) => {
       const { schema } = editor.state;


### PR DESCRIPTION
## Description

I was missing the feature to just copy image to clickboard and simply paste it to continue the conversation window. That is my attempt to implement this feature, let me know if this is fine and what else needs to be changed. 

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created


## Testing

Copy the image to clickboard (on mac: `Command + Control + Shift + 4`) and paste it into the input