### PR TITLE
Add Language Name Param to AutocompleteTemplate

### DIFF
--- a/core/autocomplete/completionProvider.ts
+++ b/core/autocomplete/completionProvider.ts
@@ -586,7 +586,7 @@ export class CompletionProvider {
       });
     } else {
       // Let the template function format snippets
-      prompt = template(prefix, suffix, filepath, reponame, snippets);
+      prompt = template(prefix, suffix, filepath, reponame, lang.name, snippets);
     }
 
     // Completion

--- a/core/autocomplete/templates.ts
+++ b/core/autocomplete/templates.ts
@@ -19,6 +19,7 @@ interface AutocompleteTemplate {
         suffix: string,
         filepath: string,
         reponame: string,
+        language: string,
         snippets: AutocompleteSnippet[],
       ) => string);
   completionOptions?: Partial<CompletionOptions>;
@@ -78,6 +79,7 @@ const codestralMultifileFimTemplate: AutocompleteTemplate = {
     suffix: string,
     filepath: string,
     reponame: string,
+    language: string,
     snippets: AutocompleteSnippet[],
   ): string => {
     return `[SUFFIX]${suffix}[PREFIX]${prefix}`;
@@ -109,6 +111,7 @@ const starcoder2FimTemplate: AutocompleteTemplate = {
     suffix: string,
     filename: string,
     reponame: string,
+    language: string,
     snippets: AutocompleteSnippet[],
   ): string => {
     const otherFiles =
@@ -162,13 +165,14 @@ const codegeexFimTemplate: AutocompleteTemplate = {
     suffix: string,
     filepath: string,
     reponame: string,
+    language: string,
     snippets: AutocompleteSnippet[],
   ): string => {
     const relativePaths = shortestRelativePaths([
       ...snippets.map((snippet) => snippet.filepath),
       filepath,
     ]);
-    const baseTemplate = `###PATH:${relativePaths[relativePaths.length - 1]}\n###LANGUAGE:\n###MODE:BLOCK\n<|code_suffix|>${suffix}<|code_prefix|>${prefix}<|code_middle|>`;
+    const baseTemplate = `###PATH:${relativePaths[relativePaths.length - 1]}\n###LANGUAGE:${language}\n###MODE:BLOCK\n<|code_suffix|>${suffix}<|code_prefix|>${prefix}<|code_middle|>`;
     if (snippets.length == 0) {
       return `<|user|>\n${baseTemplate}<|assistant|>\n`;
     }
@@ -205,6 +209,7 @@ const holeFillerTemplate: AutocompleteTemplate = {
     suffix: string,
     filename: string,
     reponame: string,
+    language: string,
     snippets: AutocompleteSnippet[],
   ) => {
     // From https://github.com/VictorTaelin/AI-scripts


### PR DESCRIPTION
## Description

Language name was previously added as a parameter only for string autocomplete templates. This change provides this same information to template functions that implement the AutocompleteTemplate interface.

Language name is explicitly supported for the CodeGeeX4 autocomplete template, and is added here in this change. Explicit language awareness could also be added for other templates in a future change, like the holeFillerTemplate used for models without explicit completion support.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

[ "For visual changes, include screenshots." ]

## Testing

This change specifically targets CodeGeeX4, so modify config.json with the following:

```json
  "tabAutocompleteModel": {
    "title": "Tab Autocomplete Model",
    "provider": "ollama",
    "model": "codegeex4:{quant}"
  },
```

I'm running the quant `9b-all-q6_K`, but should work similarly with other quantizations.
