### PR TITLE
fix: missing Content-Type header in OllamaEmbeddingsProvider

### DIFF
--- a/core/indexing/embeddings/OllamaEmbeddingsProvider.ts
+++ b/core/indexing/embeddings/OllamaEmbeddingsProvider.ts
@@ -22,6 +22,9 @@ async function embedOne(
         model: options.model,
         prompt: chunk,
       }),
+      headers: {
+        "Content-Type": "application/json",
+      },
     });
 
     if (!resp.ok) {


### PR DESCRIPTION
## Description

Added the Content-Type: application/json header to OllamaEmbeddingsProvider

Fixes: #1836

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created