### PR TITLE
Disable autocomplete in config.json

### DIFF
--- a/core/autocomplete/completionProvider.ts
+++ b/core/autocomplete/completionProvider.ts
@@ -52,7 +52,7 @@ import { getTemplateForModel } from "./templates.js";
 import { GeneratorReuseManager } from "./util.js";
 // @prettier-ignore
 import Handlebars from "handlebars";
-import { getContinueGlobalPath } from "../util/paths.js";
+import { getConfigJsonPath } from "../util/paths.js";
 
 export interface AutocompleteInput {
   completionId: string;
@@ -249,6 +249,11 @@ export class CompletionProvider {
         ...DEFAULT_AUTOCOMPLETE_OPTS,
         ...config.tabAutocompleteOptions,
       };
+
+      // Check if we're in the continue config.json file
+      if (path.relative(getConfigJsonPath(), input.filepath) === "") {
+        return undefined;
+      }
 
       // Check whether autocomplete is disabled for this file
       if (options.disableInFiles) {
@@ -535,16 +540,6 @@ export class CompletionProvider {
     if (manuallyPassPrefix) {
       prefix = manuallyPassPrefix;
       suffix = "";
-    }
-
-    const relativePath = path.relative(getContinueGlobalPath(), filepath);
-    // Check if we're in the continue directory
-    if (!relativePath.startsWith("..") && !path.isAbsolute(relativePath)) {
-      const apiKeys = await this.configHandler.apiKeys();
-      apiKeys.forEach(key => {
-        prefix = prefix.replace(key, "SECRET");
-        suffix = suffix.replace(key, "SECRET");
-      });
     }
 
     // Template prompt

--- a/core/autocomplete/completionProvider.ts
+++ b/core/autocomplete/completionProvider.ts
@@ -52,6 +52,7 @@ import { getTemplateForModel } from "./templates.js";
 import { GeneratorReuseManager } from "./util.js";
 // @prettier-ignore
 import Handlebars from "handlebars";
+import { getContinueGlobalPath } from "../util/paths.js";
 
 export interface AutocompleteInput {
   completionId: string;
@@ -536,11 +537,15 @@ export class CompletionProvider {
       suffix = "";
     }
 
-    const apiKeys = await this.configHandler.apiKeys();
-    apiKeys.forEach(key => {
-      prefix = prefix.replace(key, "SECRET");
-      suffix = suffix.replace(key, "SECRET");
-    });
+    const relativePath = path.relative(getContinueGlobalPath(), filepath);
+    // Check if we're in the continue directory
+    if (!relativePath.startsWith("..") && !path.isAbsolute(relativePath)) {
+      const apiKeys = await this.configHandler.apiKeys();
+      apiKeys.forEach(key => {
+        prefix = prefix.replace(key, "SECRET");
+        suffix = suffix.replace(key, "SECRET");
+      });
+    }
 
     // Template prompt
     const {

--- a/core/autocomplete/completionProvider.ts
+++ b/core/autocomplete/completionProvider.ts
@@ -250,8 +250,8 @@ export class CompletionProvider {
         ...config.tabAutocompleteOptions,
       };
 
-      // Check if we're in the continue config.json file
-      if (path.relative(getConfigJsonPath(), input.filepath) === "") {
+      // Check whether we're in the continue config.json file
+      if (input.filepath === getConfigJsonPath()) {
         return undefined;
       }
 

--- a/core/autocomplete/completionProvider.ts
+++ b/core/autocomplete/completionProvider.ts
@@ -536,6 +536,12 @@ export class CompletionProvider {
       suffix = "";
     }
 
+    const apiKeys = await this.configHandler.apiKeys();
+    apiKeys.forEach(key => {
+      prefix = prefix.replace(key, "SECRET");
+      suffix = suffix.replace(key, "SECRET");
+    });
+
     // Template prompt
     const {
       template,

--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -285,6 +285,28 @@ export class ConfigHandler {
     return model;
   }
 
+  async apiKeys(): Promise<string[]> {
+    const apiKeys: string[] = [];
+
+    function traverse(current: any) {
+        if (current !== null && typeof current === "object") {
+            for (const key in current) {
+                if (key === "apiKey") {
+                    apiKeys.push(current[key]);
+                }
+                traverse(current[key]);
+            }
+        } else if (Array.isArray(current)) {
+            for (const item of current) {
+                traverse(item);
+            }
+        }
+    }
+
+    traverse(await this.loadConfig());
+    return Array.from(new Set(apiKeys));
+  };
+
   registerCustomContextProvider(contextProvider: IContextProvider) {
     this.additionalContextProviders.push(contextProvider);
     this.reloadConfig();

--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -285,28 +285,6 @@ export class ConfigHandler {
     return model;
   }
 
-  async apiKeys(): Promise<string[]> {
-    const apiKeys: string[] = [];
-
-    function traverse(current: any) {
-        if (current !== null && typeof current === "object") {
-            for (const key in current) {
-                if (key === "apiKey") {
-                    apiKeys.push(current[key]);
-                }
-                traverse(current[key]);
-            }
-        } else if (Array.isArray(current)) {
-            for (const item of current) {
-                traverse(item);
-            }
-        }
-    }
-
-    traverse(await this.loadConfig());
-    return Array.from(new Set(apiKeys));
-  };
-
   registerCustomContextProvider(contextProvider: IContextProvider) {
     this.additionalContextProviders.push(contextProvider);
     this.reloadConfig();


### PR DESCRIPTION
## Description

Currently, if you edit the `config.json` in an editor with autocomplete enabled, apiKeys may be included in the prompt to the autocomplete provider. Since it is fairly common to edit the `config.json` in editor, this PR replaces configured API keys with the string "SECRET".

### Example
Before:
```
{
  "models": [
    {
      "title": "Claude 3.5 Sonnet",
      "provider": "anthropic",
      "model": "claude-3-5-sonnet-20240620",
      "apiKey": "[ANTHROPIC_API_KEY]"
    }
  ],
  "tabAutocompleteModel": {
    "title": "Codestral",
    "provider": "mistral",
    "model": "codestral-latest",
    "apiKey": "[CODESTRAL_API_KEY]"
  },
  "embeddingsProvider": {
    "provider": "openai",
    "model": "voyage-code-2",
    "apiBase": "https://api.voyageai.com/v1/",
    "apiKey": "[VOYAGE_AI_API_KEY]"
  },
  "reranker": {
    "name": "voyage",
    "params": {
      "apiKey": "[VOYAGE_AI_API_KEY]"
    }
  }
}
```

After:
```
{
  "models": [
    {
      "title": "Claude 3.5 Sonnet",
      "provider": "anthropic",
      "model": "claude-3-5-sonnet-20240620",
      "apiKey": "SECRET"
    }
  ],
  "tabAutocompleteModel": {
    "title": "Codestral",
    "provider": "mistral",
    "model": "codestral-latest",
    "apiKey": "SECRET"
  },
  "embeddingsProvider": {
    "provider": "openai",
    "model": "voyage-code-2",
    "apiBase": "https://api.voyageai.com/v1/",
    "apiKey": "SECRET"
  },
  "reranker": {
    "name": "voyage",
    "params": {
      "apiKey": "SECRET"
    }
  }
}
```

As this is my first contribution, feel free to let me know if any improvements could be made. For example, is this the correct place for the replacement to be made? Is the ConfigHandler the correct file for the `apiKeys()` function? Do we need to traverse like this or could we just get them from the known typed values? Could we just work on the serialised config instead?

I'm also happy to add any tests if needed.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created