### PR TITLE
fix: update CodebaseIndexer path

### DIFF
--- a/core/indexing/README.md
+++ b/core/indexing/README.md
@@ -18,7 +18,7 @@ The indexing process does the following:
 
 ## Existing `CodebaseIndex`es
 
-All indexes must be returned by `getIndexesToBuild` in [`indexCodebase.ts`](./indexCodebase.ts) if they are to be used.
+All indexes must be returned by `getIndexesToBuild` in [`CodebaseIndexer.ts`](./CodebaseIndexer.ts) if they are to be used.
 
 `CodeSnippetsCodebaseIndex`: uses tree-sitter queries to get a list of functions, classes, and other top-level code objects in each file
 `FullTextSearchCodebaseIndex`: creates a full-text search index using SQLite FTS5


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

The existing link leads to 404 as the file name has been changed

## Checklist

- [ ] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created

## Screenshots

[ "For visual changes, include screenshots." ]

## Testing

[ For new or modified features, provide testing instructions. ]
