### PR TITLE
Change the onDidSaveTextDocument handler to only reindex the single saved file

### DIFF
--- a/extensions/vscode/src/extension/VsCodeExtension.ts
+++ b/extensions/vscode/src/extension/VsCodeExtension.ts
@@ -252,11 +252,13 @@ export class VsCodeExtension {
         filepath.endsWith(".continueignore") ||
         filepath.endsWith(".gitignore")
       ) {
-        // Update embeddings! (TODO)
+        // Reindex the workspaces
+        this.core.invoke("index/forceReIndex", undefined);
+      } else {
+        // Reindex the file
+        const indexer = await this.core.codebaseIndexerPromise;
+        indexer.refreshFile(filepath);
       }
-
-      // Reindex the workspaces
-      this.core.invoke("index/forceReIndex", undefined);
     });
 
     // When GitHub sign-in status changes, reload config


### PR DESCRIPTION
## Description

This will improve scale as before the indexing process was restarted on every file save. There is a bit of code duplication between this new function and the existing refresh function. It will be solved in the next commit which builds on top of this one.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created
