### PR TITLE
Enable SQLite WAL (Write-Ahead Logging) mode for improved concurrency

### DIFF
--- a/core/indexing/CodeSnippetsIndex.ts
+++ b/core/indexing/CodeSnippetsIndex.ts
@@ -27,6 +27,8 @@ export class CodeSnippetsCodebaseIndex implements CodebaseIndex {
   constructor(private readonly ide: IDE) {}
 
   private static async _createTables(db: DatabaseConnection) {
+    await db.exec("PRAGMA journal_mode=WAL;");
+
     await db.exec(`CREATE TABLE IF NOT EXISTS code_snippets (
         id INTEGER PRIMARY KEY,
         path TEXT NOT NULL,

--- a/core/indexing/FullTextSearch.ts
+++ b/core/indexing/FullTextSearch.ts
@@ -20,6 +20,8 @@ export class FullTextSearchCodebaseIndex implements CodebaseIndex {
   artifactId = "sqliteFts";
 
   private async _createTables(db: DatabaseConnection) {
+    await db.exec("PRAGMA journal_mode=WAL;");
+
     await db.exec(`CREATE VIRTUAL TABLE IF NOT EXISTS fts USING fts5(
         path,
         content,

--- a/core/indexing/LanceDbIndex.ts
+++ b/core/indexing/LanceDbIndex.ts
@@ -46,6 +46,8 @@ export class LanceDbIndex implements CodebaseIndex {
   }
 
   private async createSqliteCacheTable(db: DatabaseConnection) {
+    await db.exec("PRAGMA journal_mode=WAL;");
+
     await db.exec(`CREATE TABLE IF NOT EXISTS lance_db_cache (
         uuid TEXT PRIMARY KEY,
         cacheKey TEXT NOT NULL,

--- a/core/indexing/chunk/ChunkCodebaseIndex.ts
+++ b/core/indexing/chunk/ChunkCodebaseIndex.ts
@@ -24,6 +24,8 @@ export class ChunkCodebaseIndex implements CodebaseIndex {
   }
 
   private async _createTables(db: DatabaseConnection) {
+    await db.exec("PRAGMA journal_mode=WAL;");
+    
     await db.exec(`CREATE TABLE IF NOT EXISTS chunks (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       cacheKey TEXT NOT NULL,

--- a/core/indexing/docs/DocsService.ts
+++ b/core/indexing/docs/DocsService.ts
@@ -476,7 +476,8 @@ export default class DocsService {
 
       await runSqliteMigrations(db);
 
-      db.exec(`CREATE TABLE IF NOT EXISTS ${DocsService.sqlitebTableName} (
+      await db.exec("PRAGMA journal_mode=WAL;");
+      await db.exec(`CREATE TABLE IF NOT EXISTS ${DocsService.sqlitebTableName} (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             title STRING NOT NULL,
             startUrl STRING NOT NULL UNIQUE,

--- a/core/indexing/refreshIndex.ts
+++ b/core/indexing/refreshIndex.ts
@@ -23,6 +23,8 @@ export class SqliteDb {
   static db: DatabaseConnection | null = null;
 
   private static async createTables(db: DatabaseConnection) {
+    await db.exec("PRAGMA journal_mode=WAL;");
+
     await db.exec(
       `CREATE TABLE IF NOT EXISTS tag_catalog (
             id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/core/util/devdataSqlite.ts
+++ b/core/util/devdataSqlite.ts
@@ -8,6 +8,8 @@ export class DevDataSqliteDb {
   static db: DatabaseConnection | null = null;
 
   private static async createTables(db: DatabaseConnection) {
+    await db.exec("PRAGMA journal_mode=WAL;");
+
     await db.exec(
       `CREATE TABLE IF NOT EXISTS tokens_generated (
             id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## Description

Enabled Write-Ahead Logging (WAL) mode for the SQLite database. This change is intended to enhance both the performance and stability of database operations, particularly when handling concurrent transactions and large volumes of data.

WAL is very standard across many well-known databases eg. MySQL, PostgreSQL, and MongoDB. The WAL mode in SQLite is kinda similar and **is not enabled by default**. More about it here: https://www.sqlite.org/wal.html

This also resolves the concurrency issues pointed out in and related to #1850 . **However, it does not improve the performance of indexing.** The indexing might be actually slower as mentioned in the above WAL references. For large codebase the performance will be noticeably slow by minutes For example the below:

**Codebase** - (Django Framework Repo) 
**Without WAL** - 13:48 Minutes
**With WAL** - 16:48 Minutes

**Note: The current change only enables WAL while creating SQLite files for the first time. A fresh run of continue (delete the index folder to test it out). The migration for the existing SQLite file is to be implemented (in Next PR).** 

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created
