### PR TITLE
docs: remove stale docs

### DIFF
--- a/docs/static/schemas/config.json
+++ b/docs/static/schemas/config.json
@@ -1920,12 +1920,6 @@
           "description": "An optional token to identify the user.",
           "type": "string"
         },
-        "dataServerUrl": {
-          "title": "Data Server Url",
-          "description": "The URL of the server where development data is sent. No data is sent unless a valid user token is provided.",
-          "default": "https://us-west1-autodebug.cloudfunctions.net",
-          "type": "string"
-        },
         "disableSummaries": {
           "title": "Disable Summaries",
           "markdownDescription": "If set to `true`, Continue will not generate summaries for each Step. This can be useful if you want to save on compute.",

--- a/extensions/intellij/src/main/resources/config_schema.json
+++ b/extensions/intellij/src/main/resources/config_schema.json
@@ -1920,12 +1920,6 @@
           "description": "An optional token to identify the user.",
           "type": "string"
         },
-        "dataServerUrl": {
-          "title": "Data Server Url",
-          "description": "The URL of the server where development data is sent. No data is sent unless a valid user token is provided.",
-          "default": "https://us-west1-autodebug.cloudfunctions.net",
-          "type": "string"
-        },
         "disableSummaries": {
           "title": "Disable Summaries",
           "markdownDescription": "If set to `true`, Continue will not generate summaries for each Step. This can be useful if you want to save on compute.",

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -1964,12 +1964,6 @@
           "description": "An optional token to identify the user.",
           "type": "string"
         },
-        "dataServerUrl": {
-          "title": "Data Server Url",
-          "description": "The URL of the server where development data is sent. No data is sent unless a valid user token is provided.",
-          "default": "https://us-west1-autodebug.cloudfunctions.net",
-          "type": "string"
-        },
         "disableSummaries": {
           "title": "Disable Summaries",
           "markdownDescription": "If set to `true`, Continue will not generate summaries for each Step. This can be useful if you want to save on compute.",

--- a/extensions/vscode/continue_rc_schema.json
+++ b/extensions/vscode/continue_rc_schema.json
@@ -2136,12 +2136,6 @@
           "description": "An optional token to identify the user.",
           "type": "string"
         },
-        "dataServerUrl": {
-          "title": "Data Server Url",
-          "description": "The URL of the server where development data is sent. No data is sent unless a valid user token is provided.",
-          "default": "https://us-west1-autodebug.cloudfunctions.net",
-          "type": "string"
-        },
         "disableSummaries": {
           "title": "Disable Summaries",
           "markdownDescription": "If set to `true`, Continue will not generate summaries for each Step. This can be useful if you want to save on compute.",


### PR DESCRIPTION
## Description

Removes the `dataServerUrl` doc 

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

[ "For visual changes, include screenshots." ]

## Testing

[ For new or modified features, provide testing instructions. ]
