### PR TITLE
Fix typo in slash commands docs

### DIFF
--- a/docs/docs/customization/slash-commands.md
+++ b/docs/docs/customization/slash-commands.md
@@ -44,11 +44,11 @@ Type "/share" to generate a shareable markdown transcript of your current chat h
 {
   "name": "share",
   "description": "Export the current chat session to markdown",
-  "params": { "ouputDir": "~/.continue/session-transcripts" }
+  "params": { "outputDir": "~/.continue/session-transcripts" }
 }
 ```
 
-Use the `ouputDir` parameter to specify where you want to the markdown file to be saved.
+Use the `outputDir` parameter to specify where you want to the markdown file to be saved.
 
 ### `/cmd`
 


### PR DESCRIPTION
## Description
Embarrassingly, this made me very confused for a few mins, when I copy and pasted it and tried to search for the option in the code and nothing showed up! Thought I'd fix it in a separate PR.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created