### PR TITLE
Fix error after sending an empty value to the Voyage reranker API

### DIFF
--- a/core/context/rerankers/voyage.ts
+++ b/core/context/rerankers/voyage.ts
@@ -12,6 +12,9 @@ export class VoyageReranker implements Reranker {
   ) {}
 
   async rerank(query: string, chunks: Chunk[]): Promise<number[]> {
+    if (!query) {
+      return [];
+    }
     const resp = await fetch("https://api.voyageai.com/v1/rerank", {
       method: "POST",
       headers: {

--- a/core/context/rerankers/voyage.ts
+++ b/core/context/rerankers/voyage.ts
@@ -12,7 +12,7 @@ export class VoyageReranker implements Reranker {
   ) {}
 
   async rerank(query: string, chunks: Chunk[]): Promise<number[]> {
-    if (!query) {
+    if (!query || chunks.length === 0) {
       return [];
     }
     const resp = await fetch("https://api.voyageai.com/v1/rerank", {


### PR DESCRIPTION
## Description

If the query or documents values are empty, the Voyage API returns an error, with this handy explanation "The request body is not valid JSON, or some arguments were not specified properly. In particular, Error for argument 'query': Value error, Cannot be empty list or empty string; Error for argument 'documents': Value error, Cannot be empty list or empty string".

In this PR, if query or chunks are empty, we return an empty array and we don't make a request to the API.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created