### PR TITLE
docs: add privacy section in docs sidebar

### DIFF
--- a/docs/docs/development-data.md
+++ b/docs/docs/development-data.md
@@ -1,11 +1,55 @@
 ---
-title: 🧑‍💻 Development data
+title: Development Data
 description: Collecting data on how you build software
-keywords: [development data, dev data, LLM-aided development]
+keywords: [development data, dev data, LLM-aided development, software development, coding feedback]
 ---
 
-# 🧑‍💻 Development Data
+# Development Data
 
-When you use Continue, you automatically collect data on how you build software. By default, this development data is saved to `.continue/dev_data` on your local machine. When combined with the code that you ultimately commit, it can be used to improve the LLM that you or your team use (if you allow).
+## Why You Need Development Data
 
-You can read more about how development data is generated as a byproduct of LLM-aided development and why we believe that you should start collecting it now: [It’s time to collect data on how you build software](https://blog.continue.dev/its-time-to-collect-data-on-how-you-build-software)
+Development data is essential for any organization aiming to optimize its software development process. It provides crucial insights into how software is built by capturing the detailed workflow, context behind decisions, and natural language reasoning used during coding. Collecting and utilizing this data helps in:
+
+- **Improving LLMs**: Enhancing the performance and relevance of Large Language Models (LLMs) that assist in coding, making them more accurate and helpful.
+- **Understanding Developer Challenges**: Identifying what frustrates developers and how they overcome challenges.
+- **Demonstrating ROI**: Calculating the return on investment (ROI) of using LLMs within your organization.
+- **Continual Improvement**: Establishing a continuous feedback loop to keep LLMs updated with the latest information, code, and preferred styles.
+
+## Understanding Development Data
+
+### Data Components
+
+- **Step-by-Step Process**: Detailed record of each step taken while completing a task.
+- **Context Capture**: Information used to make decisions, such as code snippets, documentation, and logs.
+- **Natural Language Reasoning**: Explanations and decisions made in natural language during coding.
+
+### Data Storage
+
+By default, the development data collected by Continue is stored locally on your machine in the directory `~/.continue/dev_data`.
+
+The data remains within your control on your local machine. If you choose to share your data with Continue for improving LLMs or other services, you must give explicit consent. If you are interested in working with us, please email us at [data@continue.dev](mailto:data@continue.dev).
+
+## Utilizing Development Data
+
+When combined with the code you commit, the development data can significantly improve the performance and relevance of LLMs. This results in more accurate suggestions and assistance during coding. Continue helps establish a continuous feedback loop to ensure LLMs always have fresh information, code, and preferred styles.
+
+Continue plays a critical role in leveraging development data for enhancing LLMs:
+
+- **Automatic Data Collection**: Continue automatically collects development data, including the step-by-step process, context, and natural language reasoning.
+  
+- **Improvement of LLMs**: The collected data is used to create a continuous feedback loop, ensuring the LLMs are constantly updated with fresh and relevant information, thus improving their performance and accuracy.
+
+- **Development Data Engine**: Continue aids organizations in setting up development data engines. These engines offer visibility into how developers interact with LLMs, help calculate the ROI, identify frustrations, and enhance the models to overcome challenges.
+
+- **Open-Source Coding Autopilot**: Continue is building an open-source coding autopilot that enables the automatic collection and utilization of development data, providing flexibility, customization, and better privacy and security.
+
+- **Customized Improvement**: Continue allows teams to track and improve the metrics that matter most to their specific definitions of "great" software.
+
+- **Addressing Budget and Data Staleness**: Continue supports organizations in justifying their LLM budgets and managing data staleness by helping them extract, load, and transform their data effectively.
+
+## Privacy, Security, and Additional Resources
+
+Understanding the privacy and security implications of development data collection is crucial. Ensure that sensitive information is safeguarded and that data collection aligns with your organization's privacy policies. For more detailed insights and guidelines, refer to the following:
+
+- [Privacy Policy](https://continue.dev/privacy)
+- [It’s time to collect data on how you build software](https://blog.continue.dev/its-time-to-collect-data-on-how-you-build-software) (Article)

--- a/docs/docs/telemetry.md
+++ b/docs/docs/telemetry.md
@@ -1,40 +1,53 @@
 ---
-title: 🦔 Telemetry
-description: Continue collects anonymous usage information
+title: Telemetry
+description: Learn how Continue collects anonymous usage information and how you can opt out.
 keywords: [telemetry, anonymous, usage info, opt out]
 ---
 
-# 🦔 Telemetry
+# Telemetry
 
 ## Overview
 
-Continue collects and reports **anonymous** usage information.
+Continue collects and reports **anonymous** usage information to help us improve our product. This data enables us to understand user interactions and optimize the user experience effectively. You can opt out of telemetry collection at any time if you prefer not to share your usage information.
 
-This data is essential to understanding how we should improve the product. You can opt out of it at any time.
+We utilize [Posthog](https://posthog.com/), an open-source platform for product analytics, to gather and store this data. For transparency, you can review the implementation code [here](https://github.com/continuedev/continue/blob/main/gui/src/hooks/CustomPostHogProvider.tsx) or read our [official privacy policy](https://continue.dev/privacy).
 
-We use [Posthog](https://posthog.com/), an open source platform for product analytics, to collect and store the data. You can review the code [here](https://github.com/continuedev/continue/blob/main/gui/src/hooks/CustomPostHogProvider.tsx), or review our official policy [here](https://continue.dev/privacy).
+## Tracking Policy
 
-## Tracking policy
+All data collected by Continue is anonymized and stripped of personally identifiable information (PII) before being sent to PostHog. We are committed to maintaining the privacy and security of your data.
 
-All data is anonymous and cleaned of PII before being sent to PostHog.
+## What We Track
 
-## What we track
+The following usage information is collected and reported:
 
-- Whether you accept or reject suggestions (never including the code or the prompt)
-- The name of the model and command used
-- The number of tokens generated
-- The name of your OS and IDE
-- Pageviews
+- **Suggestion Interactions:** Whether you accept or reject suggestions (excluding the actual code or prompts involved).
+- **Model and Command Information:** The name of the model and command used.
+- **Token Metrics:** The number of tokens generated.
+- **System Information:** The name of your operating system (OS) and integrated development environment (IDE).
+- **Pageviews:** General pageview statistics.
 
-## How to opt out
+## How to Opt Out
 
-The `~/.continue` directory contains a `config.json` file that looks like this:
+You can disable anonymous telemetry by modifying the `config.json` file located in the `~/.continue` directory. This file typically includes the following entry:
 
 ```json title="~/.continue/config.json"
 {
     "allowAnonymousTelemetry": true,
-    ...
 }
 ```
 
-You can turn off anonymous telemetry by changing the value of `allowAnonymousTelemetry` to `false`. Alternatively, you can uncheck the "Continue: Telemetry Enabled" box in VS Code settings.
+To opt out, change the value of `allowAnonymousTelemetry` to `false`. Alternatively, you can disable telemetry through your VS Code settings by unchecking the "Continue: Telemetry Enabled" box.
+
+### Steps to Disable Telemetry via Configuration File
+
+1. Open the `~/.continue/config.json` file in your text editor.
+2. Locate the `"allowAnonymousTelemetry"` setting.
+3. Change the value from `true` to `false`.
+4. Save the file.
+
+### Steps to Disable Telemetry via VS Code Settings
+
+1. Open VS Code.
+2. Navigate to `File` > `Preferences` > `Settings` (or use the keyboard shortcut `Ctrl+,` on Windows/Linux or `Cmd+,` on macOS).
+3. In the search bar, type "Continue: Telemetry Enabled".
+4. Uncheck the "Continue: Telemetry Enabled" checkbox.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -59,8 +59,21 @@ const sidebars = {
       collapsed: true,
       items: ["walkthroughs/set-up-codestral", "walkthroughs/llama3.1"],
     },
-    "development-data",
-    "telemetry",
+    {
+      type: "category",
+      label: "🧑‍💻 Privacy",
+      collapsible: true,
+      collapsed: true,
+      items: [
+        "development-data",
+        "telemetry",
+        {
+          type: 'link',
+          label: 'Privacy Policy',
+          href: 'https://www.continue.dev/privacy',
+        },
+      ],
+    },
     "troubleshooting",
     {
       type: "category",


### PR DESCRIPTION
## Description

Add privacy section with more details on telemetry and development data.

Related: #1887

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created
