### PR TITLE
Fix codestral name warning

### DIFF
--- a/core/autocomplete/completionProvider.ts
+++ b/core/autocomplete/completionProvider.ts
@@ -1,4 +1,4 @@
-import ignore from "ignore";
+fimport ignore from "ignore";
 import OpenAI from "openai";
 import path from "path";
 import { v4 as uuidv4 } from "uuid";
@@ -459,7 +459,7 @@ export class CompletionProvider {
       !shownGptClaudeWarning &&
       nonAutocompleteModels.some((model) => llm.model.includes(model)) &&
       !llm.model.includes("deepseek") &&
-      !llm.model.includes("codestral")
+      !llm.model.includes("Codestral")
     ) {
       shownGptClaudeWarning = true;
       throw new Error(

--- a/core/autocomplete/completionProvider.ts
+++ b/core/autocomplete/completionProvider.ts
@@ -1,4 +1,4 @@
-fimport ignore from "ignore";
+import ignore from "ignore";
 import OpenAI from "openai";
 import path from "path";
 import { v4 as uuidv4 } from "uuid";


### PR DESCRIPTION
## Description

Avoid the warning message popup "mistralai/Codestral-22B[...] is not trained for tab-autocomplete ..." when using a codestral model as completion provider

## Checklist

- [X] The base branch of this PR is `dev`, rather than `main`
- [X] The relevant docs, if any, have been updated or created

## Screenshots

![image](https://github.com/user-attachments/assets/3d76ddca-332f-4823-82cd-4b033581ff33)

## Testing

NA
