### PR TITLE
Get context from context provider in slash commands

### DIFF
--- a/gui/src/hooks/useChatHandler.ts
+++ b/gui/src/hooks/useChatHandler.ts
@@ -5,6 +5,7 @@ import {
   ChatHistory,
   ChatHistoryItem,
   ChatMessage,
+  ContextItemWithId,
   InputModifiers,
   MessageContent,
   PromptLog,
@@ -22,6 +23,7 @@ import { IIdeMessenger } from "../context/IdeMessenger";
 import { defaultModelSelector } from "../redux/selectors/modelSelectors";
 import {
   addPromptCompletionPair,
+  addContextItems,
   clearLastResponse,
   initNewActiveMessage,
   resubmitAtIndex,
@@ -115,6 +117,7 @@ function useChatHandler(dispatch: Dispatch, ideMessenger: IIdeMessenger) {
     input: string,
     historyIndex: number,
     selectedCode: RangeInFile[],
+    contextItems: ContextItemWithId[],
   ) {
     const abortController = new AbortController();
     const cancelToken = abortController.signal;
@@ -171,6 +174,7 @@ function useChatHandler(dispatch: Dispatch, ideMessenger: IIdeMessenger) {
         modifiers,
         ideMessenger,
       );
+      dispatch(addContextItems(contextItems));
 
       // Automatically use currently open file
       if (!modifiers.noContext && (history.length === 0 || index === 0)) {
@@ -252,6 +256,7 @@ function useChatHandler(dispatch: Dispatch, ideMessenger: IIdeMessenger) {
           commandInput,
           historyIndex,
           selectedCode,
+          contextItems,
         );
       }
     } catch (e) {


### PR DESCRIPTION
## Description

This PR mainly focuses on getting context from context provider in slash commands.
- Currently unable to get the selected context from the context providers using slash commands.
- It is always returning `contextProvider` array as empty to the slash commands.
- Only for `\edit` and `\comment` slash commands, the context is getting added. For other commands by selecting the context provider in the slash command prompt, the context is not getting added. This is fixed now.

## Checklist

- [*] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created

## Screenshots

N/A

## Testing

Manual testing is done.
