### PR TITLE
Change ChunkCodebaseIndex to add a tag for known chunks rather than rechunking the file

### DIFF
--- a/core/indexing/chunk/ChunkCodebaseIndex.ts
+++ b/core/indexing/chunk/ChunkCodebaseIndex.ts
@@ -127,29 +127,20 @@ export class ChunkCodebaseIndex implements CodebaseIndex {
     }
 
     // Add tag
-    const addContents = await Promise.all(
-      results.addTag.map(({ path }) => this.readFile(path)),
-    );
-    for (let i = 0; i < results.addTag.length; i++) {
-      const item = results.addTag[i];
-
-      // Insert chunks
-      if (contents.length) {
-        for await (const chunk of chunkDocument({
-          filepath: item.path,
-          contents: contents[i],
-          maxChunkSize: this.maxChunkSize,
-          digest: item.cacheKey,
-        })) {
-          handleChunk(chunk);
-        }
-      }
-
+    for (const item of results.addTag) {
+      await db.run(
+        `
+        INSERT INTO chunk_tags (chunkId, tag)
+        SELECT id, ? FROM chunks
+        WHERE cacheKey = ? AND path = ?
+      `,
+        [tagString, item.cacheKey, item.path],
+      );
       markComplete([item], IndexResultType.AddTag);
       accumulatedProgress += 1 / results.addTag.length / 4;
       yield {
         progress: accumulatedProgress,
-        desc: `Chunking ${getBasename(item.path)}`,
+        desc: `Adding ${getBasename(item.path)}`,
         status: "indexing",
       };
     }


### PR DESCRIPTION
## Description

Note that the prior logic referenced the wrong file contents (`contents` variable vs `addContents` variable) so it was likely impacting the accuracy of portions of the index that use the chunks table.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created
