### PR TITLE
Convert ChunkCodebaseIndexer's sqlite inserts into a single bulk insert to improve performance

### DIFF
--- a/core/indexing/chunk/ChunkCodebaseIndex.ts
+++ b/core/indexing/chunk/ChunkCodebaseIndex.ts
@@ -1,10 +1,13 @@
+import { RunResult } from "sqlite3";
 import { IContinueServerClient } from "../../continueServer/interface.js";
 import { Chunk, IndexTag, IndexingProgressUpdate } from "../../index.js";
 import { getBasename } from "../../util/index.js";
+import { getLanguageForFile } from "../../util/treeSitter.js";
 import { DatabaseConnection, SqliteDb, tagToString } from "../refreshIndex.js";
 import {
   IndexResultType,
   MarkCompleteCallback,
+  PathAndCacheKey,
   RefreshIndexResults,
   type CodebaseIndex,
 } from "../types.js";
@@ -23,27 +26,6 @@ export class ChunkCodebaseIndex implements CodebaseIndex {
     this.readFile = readFile;
   }
 
-  private async _createTables(db: DatabaseConnection) {
-    await db.exec("PRAGMA journal_mode=WAL;");
-    
-    await db.exec(`CREATE TABLE IF NOT EXISTS chunks (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      cacheKey TEXT NOT NULL,
-      path TEXT NOT NULL,
-      idx INTEGER NOT NULL,
-      startLine INTEGER NOT NULL,
-      endLine INTEGER NOT NULL,
-      content TEXT NOT NULL
-    )`);
-
-    await db.exec(`CREATE TABLE IF NOT EXISTS chunk_tags (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        tag TEXT NOT NULL,
-        chunkId INTEGER NOT NULL,
-        FOREIGN KEY (chunkId) REFERENCES chunks (id)
-    )`);
-  }
-
   async *update(
     tag: IndexTag,
     results: RefreshIndexResults,
@@ -51,27 +33,8 @@ export class ChunkCodebaseIndex implements CodebaseIndex {
     repoName: string | undefined,
   ): AsyncGenerator<IndexingProgressUpdate, any, unknown> {
     const db = await SqliteDb.get();
-    await this._createTables(db);
+    await this.createTables(db);
     const tagString = tagToString(tag);
-
-    async function handleChunk(chunk: Chunk) {
-      const { lastID } = await db.run(
-        "INSERT INTO chunks (cacheKey, path, idx, startLine, endLine, content) VALUES (?, ?, ?, ?, ?, ?)",
-        [
-          chunk.digest,
-          chunk.filepath,
-          chunk.index,
-          chunk.startLine,
-          chunk.endLine,
-          chunk.content,
-        ],
-      );
-
-      await db.run("INSERT INTO chunk_tags (chunkId, tag) VALUES (?, ?)", [
-        lastID,
-        tagString,
-      ]);
-    }
 
     // Check the remote cache
     if (this.continueServerClient.connected) {
@@ -84,9 +47,7 @@ export class ChunkCodebaseIndex implements CodebaseIndex {
         );
 
         for (const [cacheKey, chunks] of Object.entries(resp.files)) {
-          for (const chunk of chunks) {
-            await handleChunk(chunk);
-          }
+          await this.insertChunks(db, tagString, chunks);
         }
         results.compute = results.compute.filter(
           (item) => !resp.files[item.cacheKey],
@@ -96,37 +57,15 @@ export class ChunkCodebaseIndex implements CodebaseIndex {
       }
     }
 
-    const progressReservedForTagging = 0.3;
     let accumulatedProgress = 0;
 
-    // Compute chunks for new files
-    const contents = await Promise.all(
-      results.compute.map(({ path }) => this.readFile(path)),
-    );
-    for (let i = 0; i < results.compute.length; i++) {
-      const item = results.compute[i];
-
-      // Insert chunks
-      if (contents.length) {
-        for await (const chunk of chunkDocument({
-          filepath: item.path,
-          contents: contents[i],
-          maxChunkSize: this.maxChunkSize,
-          digest: item.cacheKey,
-        })) {
-          await handleChunk(chunk);
-        }
-      }
-
-      accumulatedProgress =
-        (i / results.compute.length) * (1 - progressReservedForTagging);
-      yield {
-        progress: accumulatedProgress,
-        desc: `Chunking ${getBasename(item.path)}`,
-        status: "indexing",
-      };
-      markComplete([item], IndexResultType.Compute);
-    }
+    yield {
+      desc: `Chunking ${results.compute.length} ${this.formatListPlurality("file", results.compute.length)}`,
+      status: "indexing",
+      progress: accumulatedProgress,
+    };
+    const chunks = await this.computeChunks(results.compute);
+    await this.insertChunks(db, tagString, chunks);
 
     // Add tag
     for (const item of results.addTag) {
@@ -188,5 +127,86 @@ export class ChunkCodebaseIndex implements CodebaseIndex {
         status: "indexing",
       };
     }
+  }
+
+
+  private async createTables(db: DatabaseConnection) {
+    await db.exec("PRAGMA journal_mode=WAL;");
+
+    await db.exec(`CREATE TABLE IF NOT EXISTS chunks (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      cacheKey TEXT NOT NULL,
+      path TEXT NOT NULL,
+      idx INTEGER NOT NULL,
+      startLine INTEGER NOT NULL,
+      endLine INTEGER NOT NULL,
+      content TEXT NOT NULL
+    )`);
+
+    await db.exec(`CREATE TABLE IF NOT EXISTS chunk_tags (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        tag TEXT NOT NULL,
+        chunkId INTEGER NOT NULL,
+        FOREIGN KEY (chunkId) REFERENCES chunks (id)
+    )`);
+  }
+
+  private async packToChunks(pack: PathAndCacheKey): Promise<Chunk[]> {
+    const contents = await this.readFile(pack.path);
+    if (!contents.length) {
+      return [];
+    }
+    const chunks: Chunk[] = [];
+    const chunkParams = {
+      filepath: pack.path,
+      contents,
+      maxChunkSize: this.maxChunkSize,
+      digest: pack.cacheKey,
+    };
+    for await (const c of chunkDocument(chunkParams)) {
+      chunks.push(c);
+    }
+    return chunks;
+  }
+
+  private async computeChunks(paths: PathAndCacheKey[]): Promise<Chunk[]> {
+    const chunkLists = await Promise.all(paths.map(this.packToChunks.bind(this)));
+    return chunkLists.flat();
+  }
+
+  private async insertChunks(db: DatabaseConnection, tagString: string, chunks: Chunk[]) {
+    await new Promise<void>((resolve, reject) => {
+      db.db.serialize(() => {
+        db.db.exec("BEGIN", (err: Error | null) => {
+          if (err) {
+            reject(new Error("error creating transaction", { cause: err }));
+          }
+        });
+        const chunksSQL = "INSERT INTO chunks (cacheKey, path, idx, startLine, endLine, content) VALUES (?, ?, ?, ?, ?, ?)";
+        chunks.map(c => {
+          db.db.run(chunksSQL, [c.digest, c.filepath, c.index, c.startLine, c.endLine, c.content], (result: RunResult, err: Error) => {
+            if (err) {
+              reject(new Error("error inserting into chunks table", { cause: err }));
+            }
+          });
+          const chunkTagsSQL = "INSERT INTO chunk_tags (chunkId, tag) VALUES (last_insert_rowid(), ?)";
+          db.db.run(chunkTagsSQL, [ tagString ], (result: RunResult, err: Error) => {
+            if (err) {
+              reject(new Error("error inserting into chunk_tags table", { cause: err }));
+            }
+          });
+        });
+        db.db.exec("COMMIT", (err: Error | null) => {
+          if (err) {
+            reject(new Error("error while committing insert chunks transaction", { cause: err }));
+          }
+        });
+        resolve();
+      });
+    });
+  }
+
+  private formatListPlurality(word: string, length: number): string {
+    return length <= 1 ? word : `${word}s`;
   }
 }


### PR DESCRIPTION
## Description

This change greatly improves the performance when inserting chunks. There is almost no time spent in this indexer after this change. Once a similar change is made for the other Indexers the time spent in indexing will be greatly improved.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created