### PR TITLE
Fix a build breakage on MacOS

### DIFF
--- a/core/indexing/chunk/ChunkCodebaseIndex.ts
+++ b/core/indexing/chunk/ChunkCodebaseIndex.ts
@@ -170,7 +170,7 @@ export class ChunkCodebaseIndex implements CodebaseIndex {
   }
 
   private async computeChunks(paths: PathAndCacheKey[]): Promise<Chunk[]> {
-    const chunkLists = await Promise.all(paths.map(this.packToChunks.bind(this)));
+    const chunkLists = await Promise.all(paths.map(p => this.packToChunks(p)));
     return chunkLists.flat();
   }
 


### PR DESCRIPTION
Without this change, the following error occurs on MacOS (but not linux):

  ../core/indexing/chunk/ChunkCodebaseIndex.ts:175:5 - error TS2322: Type 'unknown[]' is not assignable to type 'Chunk[]'.
    Type '{}' is missing the following properties from type 'Chunk': digest, filepath, index, content, and 2 more.

  175     return chunkLists.flat();
          ~~~~~~~~~~~~~~~~~~~~~~~~~

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created
