### PR TITLE
Fix a merge mistake that results in a full reindex on file save

### DIFF
--- a/extensions/vscode/src/extension/VsCodeExtension.ts
+++ b/extensions/vscode/src/extension/VsCodeExtension.ts
@@ -259,9 +259,6 @@ export class VsCodeExtension {
         const indexer = await this.core.codebaseIndexerPromise;
         indexer.refreshFile(filepath);
       }
-
-      // Reindex the workspaces
-      this.core.invoke("index/forceReIndex", undefined);
     });
 
     // When GitHub sign-in status changes, reload config


### PR DESCRIPTION
In https://github.com/continuedev/continue/pull/1873, the file save handler was changed to only reindex the single saved file. However, in the merge commit d0f3209dff29002e6dd6fa1cc47b5769d5c75106 the change was partially reverted and now the entire index is being refreshed on single file save.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created
