### PR TITLE
Change indexing to operate on batches as returned by getComputeDeleteAddRemove to fix problems

### DIFF
--- a/core/indexing/CodeSnippetsIndex.ts
+++ b/core/indexing/CodeSnippetsIndex.ts
@@ -28,8 +28,6 @@ export class CodeSnippetsCodebaseIndex implements CodebaseIndex {
   constructor(private readonly ide: IDE) {}
 
   private static async _createTables(db: DatabaseConnection) {
-    await db.exec("PRAGMA journal_mode=WAL;");
-
     await db.exec(`CREATE TABLE IF NOT EXISTS code_snippets (
         id INTEGER PRIMARY KEY,
         path TEXT NOT NULL,

--- a/core/indexing/FullTextSearch.ts
+++ b/core/indexing/FullTextSearch.ts
@@ -20,8 +20,6 @@ export class FullTextSearchCodebaseIndex implements CodebaseIndex {
   artifactId = "sqliteFts";
 
   private async _createTables(db: DatabaseConnection) {
-    await db.exec("PRAGMA journal_mode=WAL;");
-
     await db.exec(`CREATE VIRTUAL TABLE IF NOT EXISTS fts USING fts5(
         path,
         content,

--- a/core/indexing/docs/DocsService.ts
+++ b/core/indexing/docs/DocsService.ts
@@ -476,7 +476,9 @@ export default class DocsService {
 
       await runSqliteMigrations(db);
 
-      await db.exec("PRAGMA journal_mode=WAL;");
+      // This next line, setting the journal_mode, can be removed once all databases are back to the default
+      // journal_mode and not using WAL.
+      await db.exec("PRAGMA journal_mode=DELETE;");
       await db.exec(`CREATE TABLE IF NOT EXISTS ${DocsService.sqlitebTableName} (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             title STRING NOT NULL,

--- a/core/indexing/types.ts
+++ b/core/indexing/types.ts
@@ -11,7 +11,7 @@ export enum IndexResultType {
 export type MarkCompleteCallback = (
   items: PathAndCacheKey[],
   resultType: IndexResultType,
-) => void;
+) => Promise<void>;
 
 export interface CodebaseIndex {
   artifactId: string;

--- a/core/util/devdataSqlite.ts
+++ b/core/util/devdataSqlite.ts
@@ -8,8 +8,6 @@ export class DevDataSqliteDb {
   static db: DatabaseConnection | null = null;
 
   private static async createTables(db: DatabaseConnection) {
-    await db.exec("PRAGMA journal_mode=WAL;");
-
     await db.exec(
       `CREATE TABLE IF NOT EXISTS tokens_generated (
             id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
The prior approach, of batching on lists of files as returned by walkDir(...) broke the assumptions made by
getComputeDeleteAddRemove(...). Instead, call
getComputeDeleteAddRemove() and then batch on its results. This approach uses a bit more memory but is roughly just as fast.

In addition, made markComplete(...)'s signature return Promise<void> as it is an async function. Awaiting this async function has made everything "slow" again because we do not do bulk inserts for markComplete database rows. However, that can be fixed in a subsequent commit.

Also disabled WAL mode for SQLite as we do not completely control the program lifecycle so was noticing a lot of times where indexing resutls were not checkpointed to disk.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created