### PR TITLE
Remove the PRAGMA setting of journal_mode which attempted to revert to the default journal_mode

### DIFF
--- a/core/indexing/docs/DocsService.ts
+++ b/core/indexing/docs/DocsService.ts
@@ -476,9 +476,6 @@ export default class DocsService {
 
       await runSqliteMigrations(db);
 
-      // This next line, setting the journal_mode, can be removed once all databases are back to the default
-      // journal_mode and not using WAL.
-      await db.exec("PRAGMA journal_mode=DELETE;");
       await db.exec(`CREATE TABLE IF NOT EXISTS ${DocsService.sqlitebTableName} (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             title STRING NOT NULL,

--- a/core/indexing/refreshIndex.ts
+++ b/core/indexing/refreshIndex.ts
@@ -91,9 +91,6 @@ export class SqliteDb {
       driver: sqlite3.Database,
     });
 
-    // This next line, setting the journal_mode, can be removed once all databases are back to the default
-    // journal_mode and not using WAL.
-    const result = await SqliteDb.db.exec("PRAGMA journal_mode=DELETE;");
     await SqliteDb.createTables(SqliteDb.db);
 
     return SqliteDb.db;


### PR DESCRIPTION
## Description

The intention of the PRAGMA was to revert the databse back from WAL, however, this pragma is creating problems when multiple instances of continue are open

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created
