### PR TITLE
Move the bulk insert resolve into the COMMIT callback

### DIFF
--- a/core/indexing/LanceDbIndex.ts
+++ b/core/indexing/LanceDbIndex.ts
@@ -268,14 +268,6 @@ export class LanceDbIndex implements CodebaseIndex {
 
     const dbRows = await this.computeRows(results.compute);
     await this.insertRows(sqlite, dbRows);
-    await Promise.all(
-      results.compute.map((item) => {
-        addComputedLanceDbRows(
-          item,
-          dbRows.filter((row) => row.path === item.path),
-        );
-      }),
-    );
     await markComplete(results.compute, IndexResultType.Compute);
     let accumulatedProgress = 0;
 
@@ -481,9 +473,10 @@ export class LanceDbIndex implements CodebaseIndex {
                 { cause: err },
               ),
             );
+          } else {
+            resolve();
           }
         });
-        resolve();
       });
     });
   }

--- a/core/indexing/chunk/ChunkCodebaseIndex.ts
+++ b/core/indexing/chunk/ChunkCodebaseIndex.ts
@@ -133,7 +133,6 @@ export class ChunkCodebaseIndex implements CodebaseIndex {
     }
   }
 
-
   private async createTables(db: DatabaseConnection) {
     await db.exec(`CREATE TABLE IF NOT EXISTS chunks (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -201,9 +200,10 @@ export class ChunkCodebaseIndex implements CodebaseIndex {
         db.db.exec("COMMIT", (err: Error | null) => {
           if (err) {
             reject(new Error("error while committing insert chunks transaction", { cause: err }));
+          } else {
+            resolve();
           }
         });
-        resolve();
       });
     });
   }


### PR DESCRIPTION
## Description

db.db.serialize(...) guarantees that each statement runs in order. However, the function itself will terminate execution long before all the statements are executed. Therefore, we should only resolve the promise when the last COMMIT transaction has run. In the other cases, there will have been an error and we'll have call reject(err).

This also removed the need for the extra insert that was recently added so it was removed (in fact the extra insert was causing conflict errors).

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created
