### PR TITLE
Change the indexing batch size to a static value of 100

### DIFF
--- a/core/indexing/CodebaseIndexer.ts
+++ b/core/indexing/CodebaseIndexer.ts
@@ -270,8 +270,7 @@ export class CodebaseIndexer {
   }
 
   private getBatchSize(workspaceSize: number): number {
-    // at least 10 and as much as 100 (in a repository with 10000 files)
-    return Math.min(100, Math.max(10, Math.floor(workspaceSize / 100)));
+    return 100;
   }
 
   /*


### PR DESCRIPTION
## Description

This appears to have a positive impact on indexing throughput on my M1 mac

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created
