### PR TITLE
feat: create "rebuild index" dialog

### DIFF
--- a/core/core.ts
+++ b/core/core.ts
@@ -638,8 +638,13 @@ export class Core {
       const rows = await DevDataSqliteDb.getTokensPerModel();
       return rows;
     });
-    on("index/forceReIndex", async (msg) => {
-      const dirs = msg.data ? [msg.data] : await this.ide.getWorkspaceDirs();
+    on("index/forceReIndex", async ({ data }) => {
+      if (data?.shouldClearIndexes) {
+        const codebaseIndexer = await this.codebaseIndexerPromise;
+        await codebaseIndexer.clearIndexes();
+      }
+
+      const dirs = data?.dir ? [data.dir] : await this.ide.getWorkspaceDirs();
       await this.refreshCodebaseIndex(dirs);
     });
     on("index/setPaused", (msg) => {

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -37,6 +37,7 @@ export interface Chunk extends ChunkWithoutID {
 export interface IndexingProgressUpdate {
   progress: number;
   desc: string;
+  shouldClearIndexes?: boolean;
   status: "loading" | "indexing" | "done" | "failed" | "paused" | "disabled";
 }
 

--- a/core/indexing/CodebaseIndexer.ts
+++ b/core/indexing/CodebaseIndexer.ts
@@ -1,6 +1,7 @@
 import { ConfigHandler } from "../config/ConfigHandler.js";
 import { IContinueServerClient } from "../continueServer/interface.js";
 import { IDE, IndexTag, IndexingProgressUpdate } from "../index.js";
+import { getIndexSqlitePath, getLanceDbPath } from "../util/paths.js";
 import { ChunkCodebaseIndex } from "./chunk/ChunkCodebaseIndex.js";
 import { CodeSnippetsCodebaseIndex } from "./CodeSnippetsIndex.js";
 import { FullTextSearchCodebaseIndex } from "./FullTextSearch.js";
@@ -12,6 +13,7 @@ import {
   RefreshIndexResults,
 } from "./types.js";
 import { walkDirAsync } from "./walkDir.js";
+import * as fs from "fs/promises";
 
 export class PauseToken {
   constructor(private _paused: boolean) {}
@@ -26,12 +28,40 @@ export class PauseToken {
 }
 
 export class CodebaseIndexer {
+  // Note that we exclude certain Sqlite errors that we do not want to clear the indexes on,
+  // e.g. a `SQLITE_BUSY` error.
+  errorsRegexesToClearIndexesOn = [
+    /Invalid argument error: Values length (d+) is less than the length ((d+)) multiplied by the value size (d+)/,
+    /SQLITE_CONSTRAINT/,
+    /SQLITE_ERROR/,
+    /SQLITE_CORRUPT/,
+    /SQLITE_IOERR/,
+    /SQLITE_FULL/,
+  ];
+
   constructor(
     private readonly configHandler: ConfigHandler,
     protected readonly ide: IDE,
     private readonly pauseToken: PauseToken,
     private readonly continueServerClient: IContinueServerClient,
   ) {}
+
+  async clearIndexes() {
+    const sqliteFilepath = getIndexSqlitePath();
+    const lanceDbFolder = getLanceDbPath();
+
+    try {
+      await fs.unlink(sqliteFilepath);
+    } catch (error) {
+      console.error(`Error deleting ${sqliteFilepath} folder: ${error}`);
+    }
+
+    try {
+      await fs.rm(lanceDbFolder, { recursive: true, force: true });
+    } catch (error) {
+      console.error(`Error deleting ${lanceDbFolder}: ${error}`);
+    }
+  }
 
   protected async getIndexesToBuild(): Promise<CodebaseIndex[]> {
     const config = await this.configHandler.loadConfig();
@@ -203,7 +233,6 @@ export class CodebaseIndexer {
         yield this.handleErrorAndGetProgressUpdate(err);
         return;
       }
-      completedDirs += 1;
     }
     yield {
       progress: 100,
@@ -227,20 +256,25 @@ export class CodebaseIndexer {
   }
 
   private errorToProgressUpdate(err: Error): IndexingProgressUpdate {
-    const errorRegex =
-      /Invalid argument error: Values length (\d+) is less than the length \((\d+)\) multiplied by the value size \(\d+\)/;
-    const match = err.message.match(errorRegex);
-    let errMsg: string;
-    if (match) {
-      const [_, valuesLength, expectedLength] = match;
-      errMsg = `Generated embedding had length ${valuesLength} but was expected to be ${expectedLength}. This may be solved by deleting ~/.continue/index and refreshing the window to re-index.`;
-    } else {
-      errMsg = `${err}`;
+    let errMsg: string = `${err}`;
+    let shouldClearIndexes = false;
+
+    // Check if any of the error regexes match
+    for (const regexStr of this.errorsRegexesToClearIndexesOn) {
+      const regex = new RegExp(regexStr);
+      const match = err.message.match(regex);
+
+      if (match !== null) {
+        shouldClearIndexes = true;
+        break;
+      }
     }
+
     return {
       progress: 0,
       desc: errMsg,
       status: "failed",
+      shouldClearIndexes,
     };
   }
 

--- a/core/protocol/core.ts
+++ b/core/protocol/core.ts
@@ -130,7 +130,10 @@ export type ToCoreFromIdeOrWebviewProtocol = {
     { model: string; promptTokens: number; generatedTokens: number }[],
   ];
   "index/setPaused": [boolean, void];
-  "index/forceReIndex": [undefined | string, void];
+  "index/forceReIndex": [
+    undefined | { dir?: string; shouldClearIndexes?: boolean },
+    void,
+  ];
   "index/indexingProgressBarInitialized": [undefined, void];
   completeOnboarding: [
     {

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -49,7 +49,7 @@ On JetBrains, the "pre-release" happens through their Early Access Program (EAP)
 1. Open JetBrains settings (cmd/ctrl+,) and go to "Plugins"
 2. Click the gear icon at the top
 3. Select "Manage Plugin Repositories..."
-4. Add "https://plugins.jetbrains.com/plugins/eap/list" to the list
+4. Add "<https://plugins.jetbrains.com/plugins/eap/list>" to the list
 5. You'll now always be able to download the latest EAP version from the marketplace
 
 ## Download an Older Version
@@ -107,6 +107,12 @@ By default the Continue window is on the left side of VS Code, but it can be dra
 ### I'm getting a 404 error from OpenAI
 
 If you have entered a valid API key and model, but are still getting a 404 error from OpenAI, this may be because you need to add credits to your billing account. You can do so from the [billing console](https://platform.openai.com/settings/organization/billing/overview). If you just want to check that this is in fact the cause of the error, you can try adding $1 to your account and checking whether the error persists.
+
+### Indexing issues
+
+If you are having persistent errors with indexing, our recommendation is to rebuild your index from scratch. Note that for large codebases this may take some time.
+
+This can be accomplished using the following command: `Continue: Rebuild codebase index`.
 
 ## Still having trouble?
 

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -130,6 +130,7 @@
         "ollama": "^0.4.6",
         "onnxruntime-node": "1.14.0",
         "openai": "^4.20.1",
+        "p-limit": "^6.1.0",
         "pg": "^8.11.3",
         "posthog-node": "^3.6.3",
         "quick-lru": "^7.0.0",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -253,6 +253,12 @@
         "group": "Continue"
       },
       {
+        "command": "continue.rebuildCodebaseIndex",
+        "category": "Continue",
+        "title": "Rebuild codebase index",
+        "group": "Continue"
+      },
+      {
         "command": "continue.docsIndex",
         "category": "Continue",
         "title": "Docs Index",
@@ -275,11 +281,6 @@
         "command": "continue.focusContinueInputWithoutClear",
         "mac": "cmd+shift+l",
         "key": "ctrl+shift+l"
-      },
-      {
-        "command": "continue.toggleAuxiliaryBar",
-        "mac": "alt+cmd+l",
-        "key": "alt+ctrl+l"
       },
       {
         "command": "continue.acceptDiff",

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -284,11 +284,11 @@ const commandsMap: (
 
       streamInlineEdit("docstring", prompt, false, range);
     },
-    "continue.toggleAuxiliaryBar": () => {
-      vscode.commands.executeCommand("workbench.action.toggleAuxiliaryBar");
-    },
     "continue.codebaseForceReIndex": async () => {
       core.invoke("index/forceReIndex", undefined);
+    },
+    "continue.rebuildCodebaseIndex": async () => {
+      core.invoke("index/forceReIndex", { shouldClearIndexes: true });
     },
     "continue.docsIndex": async () => {
       core.invoke("context/indexDocs", { reIndex: false });

--- a/extensions/vscode/src/extension/VsCodeExtension.ts
+++ b/extensions/vscode/src/extension/VsCodeExtension.ts
@@ -293,7 +293,7 @@ export class VsCodeExtension {
                   currentBranch !== this.PREVIOUS_BRANCH_FOR_WORKSPACE_DIR[dir]
                 ) {
                   // Trigger refresh of index only in this directory
-                  this.core.invoke("index/forceReIndex", dir);
+                  this.core.invoke("index/forceReIndex", { dir });
                 }
               }
 

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -123,6 +123,7 @@
         "ollama": "^0.4.6",
         "onnxruntime-node": "1.14.0",
         "openai": "^4.20.1",
+        "p-limit": "^6.1.0",
         "pg": "^8.11.3",
         "posthog-node": "^3.6.3",
         "quick-lru": "^7.0.0",

--- a/gui/src/components/dialogs/ConfirmationDialog.tsx
+++ b/gui/src/components/dialogs/ConfirmationDialog.tsx
@@ -36,7 +36,7 @@ function ConfirmationDialog(props: ConfirmationDialogProps) {
   return (
     <div className="p-4">
       <h3>{props.title ?? "Confirmation"}</h3>
-      <p>{props.text}</p>
+      <p style={{ whiteSpace: "pre-wrap" }}>{props.text}</p>
 
       <GridDiv>
         {!!props.hideCancelButton || (

--- a/gui/src/components/loaders/IndexingProgressBar.tsx
+++ b/gui/src/components/loaders/IndexingProgressBar.tsx
@@ -2,13 +2,18 @@ import { IndexingProgressUpdate } from "core";
 import TransformersJsEmbeddingsProvider from "core/indexing/embeddings/TransformersJsEmbeddingsProvider";
 import { useContext, useEffect, useState } from "react";
 import ReactDOM from "react-dom";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import styled from "styled-components";
 import { StyledTooltip, lightGray, vscForeground } from "..";
 import { IdeMessengerContext } from "../../context/IdeMessenger";
 import { RootState } from "../../redux/store";
 import { getFontSize, isJetBrains } from "../../util";
 import StatusDot from "./StatusDot";
+import ConfirmationDialog from "../dialogs/ConfirmationDialog";
+import {
+  setDialogMessage,
+  setShowDialog,
+} from "../../redux/slices/uiStateSlice";
 
 const STATUS_COLORS = {
   DISABLED: lightGray, // light gray
@@ -69,16 +74,35 @@ interface ProgressBarProps {
 const IndexingProgressBar = ({
   indexingState: indexingStateProp,
 }: ProgressBarProps) => {
+  const dispatch = useDispatch();
+  const ideMessenger = useContext(IdeMessengerContext);
+
+  const [paused, setPaused] = useState<boolean | undefined>(undefined);
+  const [hovered, setHovered] = useState(false);
+
+  const embeddingsProvider = useSelector(
+    (state: RootState) => state.state.config.embeddingsProvider,
+  );
+
   // If sidebar is opened before extension initiates, define a default indexingState
   const defaultIndexingState: IndexingProgressUpdate = {
     status: "loading",
     progress: 0,
     desc: "",
   };
+
   const indexingState = indexingStateProp || defaultIndexingState;
+
+  const fillPercentage = Math.min(
+    100,
+    Math.max(0, indexingState.progress * 100),
+  );
+
+  const tooltipPortalDiv = document.getElementById("tooltip-portal-div");
 
   // If sidebar is opened after extension initializes, retrieve saved states.
   let initialized = false;
+
   useEffect(() => {
     if (!initialized) {
       // Triggers retrieval for possible non-default states set prior to IndexingProgressBar initialization
@@ -87,58 +111,78 @@ const IndexingProgressBar = ({
     }
   }, []);
 
-  const fillPercentage = Math.min(
-    100,
-    Math.max(0, indexingState.progress * 100),
-  );
-
-  const ideMessenger = useContext(IdeMessengerContext);
-
-  const embeddingsProvider = useSelector(
-    (state: RootState) => state.state.config.embeddingsProvider,
-  );
-
-  const tooltipPortalDiv = document.getElementById("tooltip-portal-div");
-
-  const [paused, setPaused] = useState<boolean | undefined>(undefined);
-  const [hovered, setHovered] = useState(false);
-
   useEffect(() => {
     if (paused === undefined) return;
     ideMessenger.post("index/setPaused", paused);
   }, [paused]);
+
+  function onClick() {
+    switch (indexingState.status) {
+      case "failed":
+        if (indexingState.shouldClearIndexes) {
+          dispatch(setShowDialog(true));
+          dispatch(
+            setDialogMessage(
+              <ConfirmationDialog
+                title="Rebuild codebase index"
+                confirmText="Rebuild"
+                text={
+                  "Your index appears corrupted. We recommend clearing and rebuilding it, " +
+                  "which may take time for large codebases.\n\n" +
+                  "Alternatively, you can close this and use the 'Continue: Force Codebase Re-Indexing' " +
+                  "command to attempt a faster rebuild without clearing data, though it may be " +
+                  "less reliable for persistent issues."
+                }
+                onConfirm={() => {
+                  ideMessenger.post("index/forceReIndex", {
+                    shouldClearIndexes: true,
+                  });
+                }}
+              />,
+            ),
+          );
+        } else {
+          ideMessenger.post("index/forceReIndex", undefined);
+        }
+
+        break;
+      case "indexing":
+      case "paused":
+        if (indexingState.progress < 1 && indexingState.progress >= 0) {
+          setPaused((prev) => !prev);
+        } else {
+          ideMessenger.post("index/forceReIndex", undefined);
+        }
+
+        break;
+      default:
+        ideMessenger.post("index/forceReIndex", undefined);
+        break;
+    }
+  }
 
   function getIndexingErrMsg(msg: string): string {
     if (
       isJetBrains() &&
       embeddingsProvider === TransformersJsEmbeddingsProvider.model
     ) {
-      return "The 'transformers.js' embeddingsProvider is currently unsupported in JetBrains. To enable codebase indexing, you can use any of the other providers described in the docs: https://docs.continue.dev/walkthroughs/codebase-embeddings#embeddings-providers";
+      return (
+        "The 'transformers.js' embeddingsProvider is currently unsupported in JetBrains. " +
+        "To enable codebase indexing, you can use any of the other providers described " +
+        "in the docs: https://docs.continue.dev/walkthroughs/codebase-embeddings#embeddings-providers"
+      );
     }
+
     return msg;
   }
 
   return (
-    <div
-      onClick={() => {
-        if (
-          indexingState.status !== "failed" &&
-          indexingState.progress < 1 &&
-          indexingState.progress >= 0
-        ) {
-          setPaused((prev) => !prev);
-        } else {
-          ideMessenger.post("index/forceReIndex", undefined);
-        }
-      }}
-      className="cursor-pointer"
-    >
+    <div onClick={onClick} className="cursor-pointer">
       {indexingState.status === "failed" ? (
         <FlexDiv data-tooltip-id="indexingFailed_dot">
           <StatusDot color={STATUS_COLORS.FAILED}></StatusDot>
           <div>
             <StatusHeading>Indexing error - click to retry</StatusHeading>
-            {/* <StatusInfo>{getIndexingErrMsg(indexingState.desc)}</StatusInfo> */}
           </div>
           {tooltipPortalDiv &&
             ReactDOM.createPortal(


### PR DESCRIPTION
## Description

This PR allows users to clear their codebase index either through a new command, `Continue: Rebuild codebase index`, or through a dialog that can be activated when clicking on an indexing error status. This dialog will only be available when we've identified the error is from a pre-defined list of indexing errors that we believe warrant a rebuild.

```ts
  // Note that we exclude certain Sqlite errors that we do not want to clear the indexes on,
  // e.g. a `SQLITE_BUSY` error.
  errorsRegexesToClearIndexesOn = [
    /Invalid argument error: Values length (d+) is less than the length ((d+)) multiplied by the value size (d+)/,
    /SQLITE_CONSTRAINT/,
    /SQLITE_ERROR/,
    /SQLITE_CORRUPT/,
    /SQLITE_IOERR/,
    /SQLITE_FULL/,
  ];
```

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots
<img width="590" alt="Screenshot 2024-08-12 at 5 58 48 PM" src="https://github.com/user-attachments/assets/fb2a0122-e490-4715-8c6b-59bfdf2b9069">


## Testing

[ For new or modified features, provide testing instructions. ]
