### PR TITLE
feat: Add Text-to-Speech

### DIFF
--- a/core/config/profile/doLoadConfig.ts
+++ b/core/config/profile/doLoadConfig.ts
@@ -10,6 +10,7 @@ import {
 import ContinueProxyEmbeddingsProvider from "../../indexing/embeddings/ContinueProxyEmbeddingsProvider.js";
 import ContinueProxy from "../../llm/llms/stubs/ContinueProxy.js";
 import { Telemetry } from "../../util/posthog.js";
+import { TTS } from "../../util/tts.js";
 import { loadFullConfigNode } from "../load.js";
 
 export default async function doLoadConfig(
@@ -50,6 +51,9 @@ export default async function doLoadConfig(
     await ide.getUniqueId(),
     ideInfo.extensionVersion,
   );
+
+  // TODO: pass config to pre-load non-system TTS models
+  await TTS.setup();
 
   if (newConfig.analytics) {
     await TeamAnalytics.setup(

--- a/core/core.ts
+++ b/core/core.ts
@@ -26,6 +26,7 @@ import historyManager from "./util/history";
 import type { IMessenger, Message } from "./util/messenger";
 import { editConfigJson } from "./util/paths";
 import { Telemetry } from "./util/posthog";
+import { TTS } from "./util/tts";
 import { streamDiffLines } from "./util/verticalEdit";
 
 export class Core {
@@ -381,6 +382,11 @@ export class Core {
         }
         yield { content: next.value.content };
         next = await gen.next();
+      }
+
+      const config = await configHandler.loadConfig();
+      if(config.experimental?.readResponseTTS && "completion" in next.value) {
+        TTS.read(next.value?.completion);
       }
 
       return { done: true, content: next.value };

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -887,6 +887,11 @@ interface ExperimentalConfig {
    * function and class declarations.
    */
   quickActions?: QuickActionConfig[];
+  
+  /**
+   * Automatically read LLM chat responses aloud using system TTS models
+   */
+  readResponseTTS?: boolean;
 }
 
 interface AnalyticsConfig {

--- a/core/protocol/core.ts
+++ b/core/protocol/core.ts
@@ -129,6 +129,7 @@ export type ToCoreFromIdeOrWebviewProtocol = {
     undefined,
     { model: string; promptTokens: number; generatedTokens: number }[],
   ];
+  "tts/kill": [undefined, void];
   "index/setPaused": [boolean, void];
   "index/forceReIndex": [
     undefined | { dir?: string; shouldClearIndexes?: boolean },

--- a/core/protocol/ideWebview.ts
+++ b/core/protocol/ideWebview.ts
@@ -31,8 +31,7 @@ export type ToIdeFromWebviewProtocol = ToIdeFromWebviewOrCoreProtocol & {
 
 export type ToWebviewFromIdeProtocol = ToWebviewFromIdeOrCoreProtocol & {
   setInactive: [undefined, void];
-  setTTSActive: [undefined, void];
-  setTTSInactive: [undefined, void];
+  setTTSActive: [boolean, void];
   submitMessage: [{ message: any }, void]; // any -> JSONContent from TipTap
   updateSubmenuItems: [
     { provider: string; submenuItems: ContextSubmenuItem[] },

--- a/core/protocol/ideWebview.ts
+++ b/core/protocol/ideWebview.ts
@@ -31,6 +31,8 @@ export type ToIdeFromWebviewProtocol = ToIdeFromWebviewOrCoreProtocol & {
 
 export type ToWebviewFromIdeProtocol = ToWebviewFromIdeOrCoreProtocol & {
   setInactive: [undefined, void];
+  setTTSActive: [undefined, void];
+  setTTSInactive: [undefined, void];
   submitMessage: [{ message: any }, void]; // any -> JSONContent from TipTap
   updateSubmenuItems: [
     { provider: string; submenuItems: ContextSubmenuItem[] },

--- a/core/protocol/passThrough.ts
+++ b/core/protocol/passThrough.ts
@@ -30,6 +30,7 @@ export const WEBVIEW_TO_CORE_PASS_THROUGH: (keyof ToCoreFromWebviewProtocol)[] =
     "autocomplete/cancel",
     "autocomplete/accept",
     "command/run",
+    "tts/kill",
     "llm/complete",
     "llm/streamComplete",
     "llm/streamChat",
@@ -57,4 +58,6 @@ export const CORE_TO_WEBVIEW_PASS_THROUGH: (keyof ToWebviewFromCoreProtocol)[] =
     "refreshSubmenuItems",
     "isContinueInputFocused",
     "didChangeAvailableProfiles",
+    "setTTSActive",
+    "setTTSInactive",
   ];

--- a/core/protocol/passThrough.ts
+++ b/core/protocol/passThrough.ts
@@ -59,5 +59,4 @@ export const CORE_TO_WEBVIEW_PASS_THROUGH: (keyof ToWebviewFromCoreProtocol)[] =
     "isContinueInputFocused",
     "didChangeAvailableProfiles",
     "setTTSActive",
-    "setTTSInactive",
   ];

--- a/core/protocol/webview.ts
+++ b/core/protocol/webview.ts
@@ -13,6 +13,5 @@ export type ToWebviewFromIdeOrCoreProtocol = {
     },
     void,
   ];
-  setTTSInactive: [undefined, void];
-  setTTSActive: [undefined, void];
+  setTTSActive: [boolean, void];
 };

--- a/core/protocol/webview.ts
+++ b/core/protocol/webview.ts
@@ -13,4 +13,6 @@ export type ToWebviewFromIdeOrCoreProtocol = {
     },
     void,
   ];
+  setTTSInactive: [undefined, void];
+  setTTSActive: [undefined, void];
 };

--- a/core/util/tts.ts
+++ b/core/util/tts.ts
@@ -81,10 +81,10 @@ export class TTS {
         return;
     }
 
-    TTS.messenger.request("setTTSActive", undefined);
+    TTS.messenger.request("setTTSActive", true);
 
     TTS.handle?.once("exit", () => {
-      TTS.messenger.request("setTTSInactive", undefined);
+      TTS.messenger.request("setTTSActive", false);
     });
   }
 

--- a/core/util/tts.ts
+++ b/core/util/tts.ts
@@ -1,0 +1,108 @@
+import os from "node:os";
+import { exec, ChildProcess } from "child_process";
+
+// The amount of time before a process is declared
+// a zombie after executing .kill()
+const ttsKillTimeout: number = 5000;
+
+/**
+ * Removes code blocks from a message.
+ *
+ * Return modified message text.
+ */
+function removeCodeBlocks(msgText: string): string {
+  const codeBlockRegex = /```[\s\S]*?```/g;
+
+  // Remove code blocks from the message text
+  const textWithoutCodeBlocks = msgText.replace(codeBlockRegex, "");
+
+  return textWithoutCodeBlocks.trim();
+}
+
+/**
+ * Cleans a message text to safely be used in 'exec' context on host.
+ *
+ * Return modified message text.
+ */
+function sanitizeMessageForTTS(message: string): string {
+  message = removeCodeBlocks(message);
+
+  // Remove or replace problematic characters
+  message = message
+    .replace(/"/g, "")
+    .replace(/`/g, "")
+    .replace(/\$/g, "")
+    .replace(/\\/g, "")
+    .replace(/[&|;()<>]/g, "");
+
+  message = message.trim().replace(/\s+/g, " ");
+
+  return message;
+}
+
+export class TTS {
+  static os: string | undefined = undefined;
+  static handle: ChildProcess | undefined = undefined;
+
+  static async read(message: string) {
+    message = sanitizeMessageForTTS(message);
+
+    try {
+      // Kill any active TTS processes
+      await TTS.kill();
+    } catch (e) {
+      console.warn("Error killing TTS process: ", e);
+      return;
+    }
+
+    switch (TTS.os) {
+      case "darwin":
+        TTS.handle = exec(`say "${message}"`);
+        break;
+      case "win32":
+        // Replace single quotes on windows
+        TTS.handle = exec(
+          `powershell -Command "Add-Type -AssemblyName System.Speech; (New-Object System.Speech.Synthesis.SpeechSynthesizer).Speak('${message.replace(
+            /'/g,
+            "''",
+          )}')"`,
+        );
+        break;
+      case "linux":
+        TTS.handle = exec(`espeak "${message}"`);
+        break;
+      default:
+        console.log(
+          "Text-to-speech is not supported on this operating system.",
+        );
+        break;
+    }
+  }
+
+  static async kill(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      // Only kill a TTS process if it's still running
+      if (TTS.handle && TTS.handle.exitCode === null) {
+        // Use a timeout in case of zombie processes
+        let killTimeout: NodeJS.Timeout = setTimeout(() => {
+          reject(`Unable to kill TTS process: ${TTS.handle?.pid}`);
+        }, ttsKillTimeout);
+
+        // Resolve our promise once the program has exited
+        TTS.handle.once("exit", () => {
+          clearTimeout(killTimeout);
+          TTS.handle = undefined;
+          resolve();
+        });
+
+        TTS.handle.kill();
+      } else {
+        resolve();
+      }
+    });
+  }
+
+  static async setup() {
+    TTS.os = os.platform();
+  }
+}

--- a/docs/static/schemas/config.json
+++ b/docs/static/schemas/config.json
@@ -2397,6 +2397,11 @@
                 }
               }
             },
+            "readResponseTTS": {
+              "type": "boolean",
+              "default": true,
+              "description": "Automatically read LLM chat responses aloud using system TTS models"
+            },
             "promptPath": {
               "type": "string"
             },

--- a/extensions/intellij/src/main/resources/config_schema.json
+++ b/extensions/intellij/src/main/resources/config_schema.json
@@ -2397,6 +2397,11 @@
                 }
               }
             },
+            "readResponseTTS": {
+              "type": "boolean",
+              "default": true,
+              "description": "Automatically read LLM chat responses aloud using system TTS models"
+            },
             "promptPath": {
               "type": "string"
             },

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -2397,6 +2397,11 @@
                 }
               }
             },
+            "readResponseTTS": {
+              "type": "boolean",
+              "default": true,
+              "description": "Automatically read LLM chat responses aloud using system TTS models"
+            },
             "promptPath": {
               "type": "string"
             },

--- a/extensions/vscode/continue_rc_schema.json
+++ b/extensions/vscode/continue_rc_schema.json
@@ -2692,6 +2692,11 @@
                 }
               }
             },
+            "readResponseTTS": {
+              "type": "boolean",
+              "default": true,
+              "description": "Automatically read LLM chat responses aloud using system TTS models"
+            },
             "promptPath": {
               "type": "string"
             },

--- a/gui/src/hooks/useSetup.ts
+++ b/gui/src/hooks/useSetup.ts
@@ -8,7 +8,6 @@ import {
   addContextItemsAtIndex,
   setConfig,
   setTTSActive,
-  setTTSInactive,
   setInactive,
   setSelectedProfileId,
 } from "../redux/slices/stateSlice";
@@ -83,12 +82,8 @@ function useSetup(dispatch: Dispatch<any>) {
     dispatch(setInactive());
   });
 
-  useWebviewListener("setTTSActive", async () => {
-    dispatch(setTTSActive());
-  });
-
-  useWebviewListener("setTTSInactive", async () => {
-    dispatch(setTTSInactive());
+  useWebviewListener("setTTSActive", async (status) => {
+    dispatch(setTTSActive(status));
   });
 
   useWebviewListener("setColors", async (colors) => {

--- a/gui/src/hooks/useSetup.ts
+++ b/gui/src/hooks/useSetup.ts
@@ -7,6 +7,8 @@ import { setVscMachineId } from "../redux/slices/configSlice";
 import {
   addContextItemsAtIndex,
   setConfig,
+  setTTSActive,
+  setTTSInactive,
   setInactive,
   setSelectedProfileId,
 } from "../redux/slices/stateSlice";
@@ -79,6 +81,14 @@ function useSetup(dispatch: Dispatch<any>) {
   // IDE event listeners
   useWebviewListener("setInactive", async () => {
     dispatch(setInactive());
+  });
+
+  useWebviewListener("setTTSActive", async () => {
+    dispatch(setTTSActive());
+  });
+
+  useWebviewListener("setTTSInactive", async () => {
+    dispatch(setTTSInactive());
   });
 
   useWebviewListener("setColors", async (colors) => {

--- a/gui/src/pages/gui.tsx
+++ b/gui/src/pages/gui.tsx
@@ -195,6 +195,7 @@ function GUI() {
 
   const defaultModel = useSelector(defaultModelSelector);
 
+  const ttsActive = useSelector((state: RootState) => state.state.ttsActive);
   const active = useSelector((state: RootState) => state.state.active);
 
   const [stepsOpen, setStepsOpen] = useState<(boolean | undefined)[]>([]);
@@ -549,6 +550,16 @@ function GUI() {
           trackVisibility={active}
         />
       </TopGuiDiv>
+      {ttsActive && (
+        <StopButton
+          className="mt-2 mb-4"
+          onClick={() => {
+            ideMessenger.post("tts/kill", undefined);
+          }}
+        >
+          ■ Stop TTS
+        </StopButton>
+      )}
       {active && (
         <StopButton
           className="mt-auto mb-4"

--- a/gui/src/redux/slices/stateSlice.ts
+++ b/gui/src/redux/slices/stateSlice.ts
@@ -170,8 +170,8 @@ export const stateSlice = createSlice({
         ? lastHistory.promptLogs.concat(payload)
         : payload;
     },
-    setTTSActive: (state) => {
-      state.ttsActive = true;
+    setTTSActive: (state, { payload }: PayloadAction<boolean>) => {
+      state.ttsActive = payload;
     },
     setActive: (state) => {
       state.active = true;
@@ -333,9 +333,6 @@ export const stateSlice = createSlice({
         return;
       }
       historyItem.contextItems.push(...payload.contextItems);
-    },
-    setTTSInactive: (state) => {
-      state.ttsActive = false;
     },
     setInactive: (state) => {
       state.active = false;
@@ -508,7 +505,6 @@ export const {
   setContextItemsAtIndex,
   addContextItems,
   addContextItemsAtIndex,
-  setTTSInactive,
   setInactive,
   streamUpdate,
   newSession,

--- a/gui/src/redux/slices/stateSlice.ts
+++ b/gui/src/redux/slices/stateSlice.ts
@@ -98,6 +98,7 @@ fn bubble_sort<T: Ord>(values: &mut[T]) {
 type State = {
   history: ChatHistory;
   contextItems: ContextItemWithId[];
+  ttsActive: boolean;
   active: boolean;
   config: BrowserSerializedContinueConfig;
   title: string;
@@ -110,6 +111,7 @@ type State = {
 const initialState: State = {
   history: [],
   contextItems: [],
+  ttsActive: false,
   active: false,
   config: {
     slashCommands: [
@@ -167,6 +169,9 @@ export const stateSlice = createSlice({
       lastHistory.promptLogs = lastHistory.promptLogs
         ? lastHistory.promptLogs.concat(payload)
         : payload;
+    },
+    setTTSActive: (state) => {
+      state.ttsActive = true;
     },
     setActive: (state) => {
       state.active = true;
@@ -328,6 +333,9 @@ export const stateSlice = createSlice({
         return;
       }
       historyItem.contextItems.push(...payload.contextItems);
+    },
+    setTTSInactive: (state) => {
+      state.ttsActive = false;
     },
     setInactive: (state) => {
       state.active = false;
@@ -500,6 +508,7 @@ export const {
   setContextItemsAtIndex,
   addContextItems,
   addContextItemsAtIndex,
+  setTTSInactive,
   setInactive,
   streamUpdate,
   newSession,
@@ -510,6 +519,7 @@ export const {
   setDefaultModel,
   setConfig,
   addPromptCompletionPair,
+  setTTSActive,
   setActive,
   setEditingContextItemAtIndex,
   initNewActiveMessage,


### PR DESCRIPTION
## Description

This PR adds text-to-speech functionality using built-in, system TTS programs ("say ...", "espeak ...", etc).

It can be enabled via `experimental.readResponseTTS` in continue's config.json

TTS should work for OSX, Windows, and linux where `espeak` is available – this PR still needs testing on Windows and Linux to confirm their implementations.

When enabled, TTS will start after the full chat has been streamed. It will skip reading code blocks and only read the top level text response. When initiating a new chat it will automatically stop any current TTS. Additionally, there's a button added to the bottom of the sidebar (shown below) to manually stop TTS.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created

## Screenshots

<img width="626" alt="image" src="https://github.com/user-attachments/assets/8f5cb174-ac70-4b2d-9db4-72994f9ecc18">

_A `Stop TTS` button has been added to the bottom of the sidebar while TTS is active. Clicking the button will stop the current TTS_

## Testing

Pull and debug this branch then set `experimental.readResponseTTS` to `true` in your config. Initiate a new chat with an LLM and after receiving the full response it should start reading aloud using your system's TTS capabilities. 
