### PR TITLE
Add support for Kindo provider

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -588,6 +588,7 @@ type ModelProvider =
   | "ollama"
   | "huggingface-tgi"
   | "huggingface-inference-api"
+  | "kindo"
   | "llama.cpp"
   | "replicate"
   | "text-gen-webui"

--- a/core/llm/llms/Kindo.ts
+++ b/core/llm/llms/Kindo.ts
@@ -1,0 +1,16 @@
+import { LLMOptions, ModelProvider } from "../..";
+import OpenAI from "./OpenAI";
+
+class Kindo extends OpenAI {
+    static providerName: ModelProvider = "kindo";
+    static defaultOptions: Partial<LLMOptions> = {
+        apiBase: "https://llm.kindo.ai/v1",
+        requestOptions: {
+            headers: {
+                "kindo-token-transaction-type": "CONTINUE"
+            }
+        }
+    };
+}
+
+export default Kindo;

--- a/core/llm/llms/index.ts
+++ b/core/llm/llms/index.ts
@@ -22,6 +22,7 @@ import Gemini from "./Gemini";
 import Groq from "./Groq";
 import HuggingFaceInferenceAPI from "./HuggingFaceInferenceAPI";
 import HuggingFaceTGI from "./HuggingFaceTGI";
+import Kindo from "./Kindo";
 import LMStudio from "./LMStudio";
 import LlamaCpp from "./LlamaCpp";
 import Llamafile from "./Llamafile";
@@ -48,6 +49,7 @@ const LLMs = [
   Together,
   HuggingFaceTGI,
   HuggingFaceInferenceAPI,
+  Kindo,
   LlamaCpp,
   OpenAI,
   LMStudio,

--- a/docs/docs/reference/Model Providers/kindo.md
+++ b/docs/docs/reference/Model Providers/kindo.md
@@ -1,0 +1,42 @@
+# Kindo
+Kindo offers centralized control over your organization's AI operations, ensuring data protection and compliance with internal policies while supporting various commercial and open-source models. To get started, sign up [here](https://app.kindo.ai/), create your API key on the [API keys page](https://app.kindo.ai/settings/api), and choose a model from the list of supported models in the [plugins tab](https://app.kindo.ai/plugins).
+
+## Config Example
+
+```json title="~/.continue/config.json"
+{
+  "models": [
+    {
+      "title": "Claude 3.5 Sonnet",
+      "provider": "kindo",
+      "model": "claude-3-5-sonnet-20240620",
+      "apiKey": "<KINDO_API_KEY>"
+    }
+  ]
+}
+```
+
+## Tab Autocomplete Config Example
+
+```json title="~/.continue/config.json"
+{
+  "tabAutocompleteModel": [
+    {
+      "title": "WhiteRabbitNeo",
+      "provider": "kindo",
+      "model": "/models/WhiteRabbitNeo-33B-DeepSeekCoder",
+      "apiKey": "<KINDO_API_KEY>"
+    },
+    {
+      "title": "DeepSeek",
+      "provider": "kindo",
+      "model": "deepseek-ai/deepseek-coder-33b-instruct",
+      "apiKey": "<KINDO_API_KEY>"
+    }
+  ]
+}
+```
+
+## Security
+
+To update your organization's model access, adjust the controls in [security settings](https://app.kindo.ai/security-settings).

--- a/docs/docs/setup/model-providers.md
+++ b/docs/docs/setup/model-providers.md
@@ -63,6 +63,7 @@ You can deploy a model in your [AWS](https://github.com/continuedev/deploy-os-co
 You can access both open-source and commercial LLMs via:
 
 - [OpenRouter](../reference/Model%20Providers/openrouter.md)
+- [Kindo](../reference/Model%20Providers/kindo.md)
 
 ### Open-source models
 


### PR DESCRIPTION
## Description

This PR adds support for Kindo as a provider. 

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Testing

Configure the new provider with a Kindo API key and confirm that chat and tab autocomplete requests are completed.