### PR TITLE
added @ open files context provider "pinned" option in intellij.

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
@@ -31,6 +31,7 @@ import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.TextEditor
+import com.intellij.openapi.fileEditor.impl.FileEditorManagerImpl
 import com.intellij.openapi.progress.DumbProgressIndicator
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.project.DumbAware
@@ -44,6 +45,8 @@ import com.intellij.openapi.wm.WindowManager
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.testFramework.LightVirtualFile
 import com.intellij.ui.awt.RelativePoint
+import com.intellij.ui.content.ContentManagerUtil
+import com.intellij.util.concurrency.annotations.RequiresEdt
 import kotlinx.coroutines.*
 import java.awt.Toolkit
 import java.awt.datatransfer.StringSelection
@@ -605,8 +608,10 @@ class IdeProtocolClient (
                         respond(currentFile)
                     }
                     "getPinnedFiles" -> {
-                        val openFiles = visibleFiles()
-                        respond(openFiles)
+                        ApplicationManager.getApplication().invokeLater {
+                            val pinnedFiles = pinnedFiles()
+                            respond(pinnedFiles)
+                        }
                     }
                     "insertAtCursor" -> {
                         val msg = data as Map<String, String>;
@@ -962,6 +967,14 @@ class IdeProtocolClient (
     private fun visibleFiles(): List<String> {
         val fileEditorManager = FileEditorManager.getInstance(project)
         return fileEditorManager.openFiles.toList().map { it.path }
+    }
+
+    @RequiresEdt
+    private fun pinnedFiles(): List<String> {
+        val fileEditorManager = FileEditorManager.getInstance(project) as? FileEditorManagerImpl ?: return listOf()
+        val openFiles = fileEditorManager.openFiles.map { it.path }.toList()
+        val pinnedFiles = fileEditorManager.windows.flatMap { window -> window.files.filter { window.isFilePinned(it) } }.map { it.path }.toSet()
+        return openFiles.intersect(pinnedFiles).toList()
     }
 
     private fun currentFile(): String? {


### PR DESCRIPTION
## Description

Added option to include only pinned files as context in intellij. I am attempting my first contribution as requested in https://github.com/continuedev/contribution-ideas/issues/23, and willing to take the rest on the list if needed.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

[ "For visual changes, include screenshots." ]

## Testing

[ For new or modified features, provide testing instructions. ]
added option to include only pinned files in intellij plugin as requested in 
https://github.com/continuedev/contribution-ideas/issues/23

As described in https://docs.continue.dev/customization/context-providers#open-files, 
when onlyPinned is enabled, plugin will include only pinned files from current active project window.
