### PR TITLE
fix(gui): passing style props on StyledTooltip

### DIFF
--- a/gui/src/components/index.tsx
+++ b/gui/src/components/index.tsx
@@ -192,7 +192,12 @@ const TooltipStyles = {
 };
 
 export function StyledTooltip(props: any) {
-  return <Tooltip {...props} style={TooltipStyles} />;
+  const combinedStyles = {
+    ...TooltipStyles,
+    ...props.style, // Merge any additional styles passed via props
+  };
+
+  return <Tooltip {...props} style={combinedStyles} />;
 }
 
 export const TextArea = styled.textarea`


### PR DESCRIPTION
## Description

fixes passing style props on StyledTooltip

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created
