### PR TITLE
fix(core): delete indexed docs if re-indexing

### DIFF
--- a/core/indexing/docs/DocsService.ts
+++ b/core/indexing/docs/DocsService.ts
@@ -291,8 +291,8 @@ export default class DocsService {
       status: "indexing",
     };
 
-    // Clear old index if re-indexing.
-    if (reIndex) {
+    // Delete indexed docs if re-indexing
+    if (reIndex && await this.has(startUrl.toString())) {
       console.log("Deleting old embeddings");
       await this.delete(startUrl);
     }


### PR DESCRIPTION
## Description

fixes delete indexed docs if re-indexing. Where you can technically run force reindex even if you don't have docs already indexed.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created