### PR TITLE
Fix passing codebaseContext parameter and InputToolbar flickering

### DIFF
--- a/core/config/load.ts
+++ b/core/config/load.ts
@@ -355,9 +355,11 @@ async function intermediateToFinalConfig(
 
   // These context providers are always included, regardless of what, if anything,
   // the user has configured in config.json
+
+  const codebaseContextParams = ((config.contextProviders || []).filter(isContextProviderWithParams).find(cp => cp.name === "codebase") as ContextProviderWithParams | undefined)?.params || {};
   const DEFAULT_CONTEXT_PROVIDERS = [
     new FileContextProvider({}),
-    new CodebaseContextProvider({}),
+    new CodebaseContextProvider(codebaseContextParams),
   ];
 
   const DEFAULT_CONTEXT_PROVIDERS_TITLES = DEFAULT_CONTEXT_PROVIDERS.map(

--- a/gui/src/components/mainInput/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor.tsx
@@ -56,6 +56,7 @@ import {
   getSlashCommandDropdownOptions,
 } from "./getSuggestion";
 import { ComboBoxItem } from "./types";
+import { debounce } from "lodash";
 
 const InputBoxDiv = styled.div`
   resize: none;
@@ -473,6 +474,31 @@ function TipTapEditor(props: TipTapEditorProps) {
     },
   });
 
+  const [shouldHideToolbar, setShouldHideToolbar] = useState(false);
+  const debouncedShouldHideToolbar = debounce((value) => {
+    setShouldHideToolbar(value);
+  }, 200);
+
+  useEffect(() => {
+    if (editor) {
+      const handleFocus = () => {
+        debouncedShouldHideToolbar(false);
+      }
+
+      const handleBlur = () => {
+        debouncedShouldHideToolbar(true);
+      };
+
+      editor.on('focus', handleFocus);
+      editor.on('blur', handleBlur);
+
+      return () => {
+        editor.off('focus', handleFocus);
+        editor.off('blur', handleBlur);
+      };
+    }
+  }, [editor]);
+
   const editorFocusedRef = useUpdatingRef(editor?.isFocused, [editor]);
 
   useEffect(() => {
@@ -831,7 +857,7 @@ function TipTapEditor(props: TipTapEditorProps) {
       />
       <InputToolbar
         showNoContext={optionKeyHeld}
-        hidden={!(editorFocusedRef.current || props.isMainInput)}
+        hidden={shouldHideToolbar && !props.isMainInput}
         onAddContextItem={() => {
           if (editor.getText().endsWith("@")) {
           } else {


### PR DESCRIPTION
I discovered two bugs in the VSCode extension. First, the nFinal value set in config.json for the codebase contextProvider wasn't taking effect. After investigating, I found that load.ts wasn't passing the parameter, so I modified it to include the parameter. Second, clicking buttons in input toolbars that weren't the last one wasn't working. I tracked this down to a rapid switching of the hidden state, so I changed it to use a debounced hidden state. I hope my code changes can be merged to fix these two bugs.