### PR TITLE
History: Default Filter to Current Workspace & Style Tweaks

### DIFF
--- a/gui/src/pages/history.tsx
+++ b/gui/src/pages/history.tsx
@@ -23,13 +23,20 @@ import useHistory from "../hooks/useHistory";
 import { useNavigationListener } from "../hooks/useNavigationListener";
 import { getFontSize } from "../util";
 
+const SearchBarContainer = styled.div`
+  display: flex;
+  max-width: 500px;
+  padding: 0 8px 0 8px;
+  margin: 0 auto;
+  align-items: center;
+  justify-content: center;
+`;
+
 const SearchBar = styled.input`
   padding: 4px 8px;
   border-radius: ${defaultBorderRadius};
   border: 0.5px solid #888;
   outline: none;
-  width: 90vw;
-  max-width: 500px;
   margin: 8px auto;
   display: block;
   background-color: ${vscInputBackground};
@@ -60,14 +67,15 @@ const parseDate = (date: string): Date => {
 };
 
 const SectionHeader = styled.tr`
+  display: flex;
+  user-select: none;
   padding: 4px;
-  padding-left: 16px;
-  padding-right: 16px;
   background-color: ${vscInputBackground};
   width: 100%;
   font-weight: bold;
   text-align: center;
   align-items: center;
+  justify-content: center;
   margin: 0;
   position: sticky;
   height: 1.5em;
@@ -150,16 +158,19 @@ function TableRow({
           </div>
 
           <div style={{ color: "#9ca3af" }}>
-            {date.toLocaleString("en-US", {
-              year: "2-digit",
-              month: "2-digit",
-              day: "2-digit",
-              hour: "numeric",
-              minute: "2-digit",
-              hour12: true,
-            })}
-            {" | "}
             {lastPartOfPath(session.workspaceDirectory || "")}
+            {!hovered && (
+              <span className="inline-block float-right">
+                {date.toLocaleString("en-US", {
+                  year: "2-digit",
+                  month: "2-digit",
+                  day: "2-digit",
+                  hour: "numeric",
+                  minute: "2-digit",
+                  hour12: true,
+                })}
+              </span>
+            )}
           </div>
         </TdDiv>
 
@@ -214,7 +225,8 @@ function History() {
     );
   };
 
-  const [filteringByWorkspace, setFilteringByWorkspace] = useState(false);
+  const searchInputRef = React.useRef<HTMLInputElement>(null);
+
   const stickyHistoryHeaderRef = React.useRef<HTMLDivElement>(null);
   const [headerHeight, setHeaderHeight] = useState(0);
 
@@ -247,8 +259,12 @@ function History() {
   }, []);
 
   useEffect(() => {
+    // When searchTerm is empty only show sessions from the current workspace
+    let filteringByWorkspace = searchTerm === "";
+
+    // When the searchTerm is wildcard (asterisk) then show ALL sessions, otherwise use minisearch to search for user input
     const sessionIds = minisearch
-      .search(searchTerm, {
+      .search(searchTerm === "*" ? "" : searchTerm, {
         fuzzy: 0.1,
       })
       .map((result) => result.id);
@@ -267,7 +283,11 @@ function History() {
         })
         // Filter by search term
         .filter((session) => {
-          return searchTerm === "" || sessionIds.includes(session.sessionId);
+          return (
+            searchTerm === "*" ||
+            filteringByWorkspace ||
+            sessionIds.includes(session.sessionId)
+          );
         })
         .sort(
           (a, b) =>
@@ -275,7 +295,7 @@ function History() {
             parseDate(a.dateCreated).getTime(),
         ),
     );
-  }, [filteringByWorkspace, sessions, searchTerm, minisearch]);
+  }, [sessions, searchTerm, minisearch]);
 
   useEffect(() => {
     setHeaderHeight(stickyHistoryHeaderRef.current?.clientHeight || 100);
@@ -319,11 +339,33 @@ function History() {
       </div>
 
       <div>
-        <SearchBar
-          placeholder="Search past sessions"
-          type="text"
-          onChange={(e) => setSearchTerm(e.target.value)}
-        />
+        <SearchBarContainer className="space-x-2">
+          <SearchBar
+            className="flex-1 w-full"
+            ref={searchInputRef}
+            placeholder="Search past sessions"
+            type="text"
+            onChange={(e) => setSearchTerm(e.target.value)}
+          />
+          <span
+            className="block px-2 py-1.5 rounded-md z-10 mx-1 my-2 select-none"
+            style={{
+              cursor: searchTerm === "*" ? "" : "pointer",
+              fontSize: "11px",
+              opacity: searchTerm === "*" ? "50%" : "",
+              backgroundColor:
+                searchTerm === "*" ? vscInputBackground : vscBadgeBackground,
+            }}
+            onClick={() => {
+              if (searchInputRef.current.value !== "*") {
+                searchInputRef.current.value = "*";
+                setSearchTerm("*");
+              }
+            }}
+          >
+            Show All
+          </span>
+        </SearchBarContainer>
 
         {filteredAndSortedSessions.length === 0 && (
           <div className="text-center m-4">

--- a/gui/src/pages/history.tsx
+++ b/gui/src/pages/history.tsx
@@ -348,22 +348,23 @@ function History() {
             onChange={(e) => setSearchTerm(e.target.value)}
           />
           <span
-            className="block px-2 py-1.5 rounded-md z-10 mx-1 my-2 select-none"
+            className="block text-center px-2 py-1.5 rounded-md w-12 mx-1 my-2 select-none cursor-pointer"
             style={{
-              cursor: searchTerm === "*" ? "" : "pointer",
               fontSize: "11px",
-              opacity: searchTerm === "*" ? "50%" : "",
               backgroundColor:
-                searchTerm === "*" ? vscInputBackground : vscBadgeBackground,
+                searchTerm !== "" ? vscInputBackground : vscBadgeBackground,
             }}
             onClick={() => {
-              if (searchInputRef.current.value !== "*") {
+              if (searchInputRef.current.value === "") {
                 searchInputRef.current.value = "*";
                 setSearchTerm("*");
+              } else {
+                searchInputRef.current.value = "";
+                setSearchTerm("");
               }
             }}
           >
-            Show All
+            {searchTerm === "" ? "Show All" : "Clear"}
           </span>
         </SearchBarContainer>
 


### PR DESCRIPTION
## Description

This PR makes the following changes within the history tab:
* minor style modifications
  - section headings vertically centered with a little more breathing room
  - show each session's workspace name on the left, date-time on the right
  - date-time is hidden when a user hovers the row (to make way for the edit & delete icons) 

* the current workspace's history is now shown by default when the search input is blank

* a 'Show All' button to the right of the search bar has been added that updates the search input to '*' and will show results from all sessions

* when the user inputs their own search terms it functions the same as before and a 'Clear' button replaces the 'Show All' button to clear the search input

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

<img width="447" alt="image" src="https://github.com/user-attachments/assets/802090a7-ecd0-4041-a839-a5c8f5889e1f">

_Results are now filtered to current workspace when the search input is blank (`manual-testing-sandbox` in this case). Clicking the new **Show All** button will show results for all sessions_

<img width="507" alt="image" src="https://github.com/user-attachments/assets/6f782bab-71ac-47e7-a6f5-eaba168679f1">

_The **Show All** button turns to a **Clear** button when the input is populated; when the search is "*" all results across all sessions will be shown_

<img width="506" alt="image" src="https://github.com/user-attachments/assets/6eaf82a8-5cf2-488d-9547-d91368e45a81">

_When the user inputs their own text, regular search will work the same as before_

## Testing

There are no specific settings you need to set for this to be enabled, simply pull and debug this branch then open your History tab to see the changes.
