### PR TITLE
chore: skip chromium install w/ puppeteer

### DIFF
--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -7,6 +7,8 @@ set -e
 
 echo "Installing Core extension dependencies..."
 pushd core
+## This flag is set because we pull down Chromium at runtime
+export PUPPETEER_SKIP_DOWNLOAD='true'
 npm install
 npm link
 


### PR DESCRIPTION
## Description

Sets a flag for our install script that skips downloading chromium. 

We do this for two reasons:
- To mimic the behavior of an end user, e.g. having it pulled down at runtime
- To avoid having to configure at install time the location of the Chromium binary. This also prevents us from having to track that location both in this script and in the actual source code.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

[ "For visual changes, include screenshots." ]

## Testing

[ For new or modified features, provide testing instructions. ]
