### PR TITLE
[IntelliJ README]: `@docs` is platform-agnostic

### DIFF
--- a/extensions/intellij/README.md
+++ b/extensions/intellij/README.md
@@ -24,7 +24,7 @@
 
 ## Quickly use documentation as context
 
-`@docs` (MacOS) / `@docs` (Windows)
+`@docs`
 
 </div>
 


### PR DESCRIPTION
I don't see `@docs` working in WebStorm 2024.2.1 on Linux but whether it works or not, the invocation isn't platform-dependent.

![image](https://github.com/user-attachments/assets/dcbab329-4aae-4ab1-b2ea-a8b1b629005f)
