### PR TITLE
docs: prompt-file-examples repo link fix

### DIFF
--- a/docs/docs/features/prompt-files.md
+++ b/docs/docs/features/prompt-files.md
@@ -5,7 +5,7 @@ Prompt files provide a convenient way to standardize common patterns and share a
 ## Quick start
 
 :::tip[Prompt library]
-To assist you in getting started, [we've curated a small library of `.prompt` files](https://github.com/continuedev/prompt-file-example). We encourage community contributions to this repository, so please consider opening up a pull request with your own prompts!
+To assist you in getting started, [we've curated a small library of `.prompt` files](https://github.com/continuedev/prompt-file-examples). We encourage community contributions to this repository, so please consider opening up a pull request with your own prompts!
 :::
 
 Below is a quick example of setting up a prompt file to write unit tests using Jest.

--- a/docs/docs/reference/Model Providers/openai.md
+++ b/docs/docs/reference/Model Providers/openai.md
@@ -19,7 +19,7 @@ OpenAI compatible APIs
 - [Anyscale Endpoints](https://github.com/continuedev/deploy-os-code-llm#others)
 - [Anyscale Private Endpoints](https://github.com/continuedev/deploy-os-code-llm#anyscale-private-endpoints)
 
-If you are [using an OpenAI compatible server / API](../../setup/select-provider#local), you can change the `apiBase` like this:
+If you are [using an OpenAI compatible server / API](../../setup/model-providers.md#local), you can change the `apiBase` like this:
 
 ```json title="~/.continue/config.json"
 {
@@ -42,6 +42,5 @@ To force usage of `chat/completions` instead of `completions` endpoint you can s
 ```
 
 [^1]: Use the [Vllm Model Provider](./vllm.md) instead.
-
 
 [View the source](https://github.com/continuedev/continue/blob/main/core/llm/llms/OpenAI.ts)


### PR DESCRIPTION
## Description

There was a one-character typo in the link to the `prompt-file-examples` repo in the docs! I was able to guess which letter was missing :)

## Checklist

- [ x ] The base branch of this PR is `dev`, rather than `main`
- [ x ] The relevant docs, if any, have been updated or created

## Screenshots

...

## Testing

...