### PR TITLE
fallback for non-sse response

### DIFF
--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -235,6 +235,10 @@ class OpenAI extends BaseLLM {
       if (value.choices?.[0]?.delta?.content) {
         yield value.choices[0].delta;
       }
+
+      if (value.choices?.[0]?.message?.content) {
+        yield value.choices[0].message;
+      }
     }
   }
 

--- a/core/llm/stream.ts
+++ b/core/llm/stream.ts
@@ -60,6 +60,13 @@ function parseSseLine(line: string): { done: boolean; data: any } {
   if (line.startsWith(": ping")) {
     return { done: true, data: undefined };
   }
+  try {
+    // if it's complete JSON i.e gpt4all doesn't support SSE
+    const data = JSON.parse(line);
+    return { done: false, data };
+  } catch (e) {
+    // ignore
+  }
   return { done: false, data: undefined };
 }
 


### PR DESCRIPTION
## Description

- Solution for https://github.com/nomic-ai/gpt4all/issues/2174, gpt4all doesn't support SSE, this is a fallback in case the response is non-SSE.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

## continue.dev loading from gpt4all

![Screenshot 2024-08-25 at 12 33 55 PM](https://github.com/user-attachments/assets/7cceb106-9fc9-4417-b3df-4b2d4c0efeaa)

## gpt4all logs

![Screenshot 2024-08-25 at 12 39 57 PM](https://github.com/user-attachments/assets/92059eb7-08f0-414d-9300-0e5ae97acf48)



## Testing
- start gpt4all with the server mode.
- in continue.dev use it as an OpenAI compatible provider.
- ask something, it should respond.
