### PR TITLE
Corrected typo in link to examples

### DIFF
--- a/docs/docs/features/prompt-files.md
+++ b/docs/docs/features/prompt-files.md
@@ -5,7 +5,7 @@ Prompt files provide a convenient way to standardize common patterns and share a
 ## Quick start
 
 :::tip[Prompt library]
-To assist you in getting started, [we've curated a small library of `.prompt` files](https://github.com/continuedev/prompt-file-example). We encourage community contributions to this repository, so please consider opening up a pull request with your own prompts!
+To assist you in getting started, [we've curated a small library of `.prompt` files](https://github.com/continuedev/prompt-file-examples). We encourage community contributions to this repository, so please consider opening up a pull request with your own prompts!
 :::
 
 Below is a quick example of setting up a prompt file to write unit tests using Jest.


### PR DESCRIPTION
Corrected typo in link to examples.

## Description

Corrected typo in link to examples

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

[ "For visual changes, include screenshots." ]

## Testing

[ For new or modified features, provide testing instructions. ]
