### PR TITLE
autocomplete: prevent unauthorized error per #1396

### DIFF
--- a/docs/docs/features/tab-autocomplete.md
+++ b/docs/docs/features/tab-autocomplete.md
@@ -12,6 +12,7 @@ If you want to have the best autocomplete experience, we recommend using Codestr
     "title": "Codestral",
     "provider": "mistral",
     "model": "codestral-latest",
+    "apiBase": "https://api.mistral.ai/v1",
     "apiKey": "YOUR_API_KEY"
   }
 }


### PR DESCRIPTION
## Description

Updating the documentation to reflect current error messages returned when a real Mistral autocomplete API key gets defaulted to the wrong API base because API base is not supplied.

## Checklist

- [ X ] The base branch of this PR is `dev`, rather than `main`
- [ X ] The relevant docs, if any, have been updated or created

## Screenshots

Not applicable

## Testing

Without this change, autocomplete with the paid version of Mistral doesn't work (which is what that part of the docs is trying to show how to use). With this change, it does work.
