### PR TITLE
Move NVIDIA NIMs to both OSS and commercial providers

### DIFF
--- a/docs/docs/setup/model-providers.md
+++ b/docs/docs/setup/model-providers.md
@@ -64,6 +64,7 @@ You can access both open-source and commercial LLMs via:
 
 - [OpenRouter](../reference/Model%20Providers/openrouter.md)
 - [Kindo](../reference/Model%20Providers/kindo.md)
+- [Nvidia NIMS](../reference/Model%20Providers/openai.md) (OpenAI compatible server)
 
 ### Open-source models
 
@@ -77,7 +78,6 @@ You can run open-source LLMs with cloud services like:
 - [Deepinfra](../reference/Model%20Providers/deepinfra.md)
 - [Groq](../reference/Model%20Providers/openai.md) (OpenAI compatible API)
 - [AWS Bedrock](../reference/Model%20Providers/bedrock.md)
-- [Nvidia NIMS](../reference/Model%20Providers/openai.md) (OpenAI compatible server)
 
 ### Commercial models
 

--- a/docs/docs/setup/model-providers.md
+++ b/docs/docs/setup/model-providers.md
@@ -60,6 +60,8 @@ You can deploy a model in your [AWS](https://github.com/continuedev/deploy-os-co
 
 ## SaaS
 
+### Open-source and commercial models 
+
 You can access both open-source and commercial LLMs via:
 
 - [OpenRouter](../reference/Model%20Providers/openrouter.md)


### PR DESCRIPTION
## Description

Correct NVIDIA NIM location in model provider page

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

![Screenshot 2024-08-28 at 2 00 10 PM](https://github.com/user-attachments/assets/a7e1af9d-5f13-4d13-9a86-156aff132aa5)


## Testing

N/A
