### PR TITLE
SQLITE_BUSY: Implement busy_timeout and WAL for all connections

### DIFF
--- a/core/autocomplete/cache.ts
+++ b/core/autocomplete/cache.ts
@@ -20,6 +20,10 @@ export class AutocompleteLruCache {
       driver: sqlite3.Database,
     });
 
+
+    await db.exec("PRAGMA journal_mode=WAL;");
+    await db.exec("PRAGMA busy_timeout = 3000;");
+
     await db.run(`
       CREATE TABLE IF NOT EXISTS cache (
         key TEXT PRIMARY KEY,

--- a/core/indexing/docs/DocsService.ts
+++ b/core/indexing/docs/DocsService.ts
@@ -475,6 +475,9 @@ export default class DocsService {
         driver: sqlite3.Database,
       });
 
+      await db.exec("PRAGMA journal_mode=WAL;");
+      await db.exec("PRAGMA busy_timeout = 3000;");
+
       await runSqliteMigrations(db);
 
       await db.exec(`CREATE TABLE IF NOT EXISTS ${DocsService.sqlitebTableName} (

--- a/core/indexing/refreshIndex.ts
+++ b/core/indexing/refreshIndex.ts
@@ -24,8 +24,6 @@ export class SqliteDb {
   static db: DatabaseConnection | null = null;
 
   private static async createTables(db: DatabaseConnection) {
-    await db.exec("PRAGMA journal_mode=WAL;");
-
     await db.exec(
       `CREATE TABLE IF NOT EXISTS tag_catalog (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -91,6 +89,9 @@ export class SqliteDb {
       filename: SqliteDb.indexSqlitePath,
       driver: sqlite3.Database,
     });
+
+    await SqliteDb.db.exec("PRAGMA journal_mode=WAL;");
+    await SqliteDb.db.exec("PRAGMA busy_timeout = 3000;");
 
     await SqliteDb.createTables(SqliteDb.db);
 

--- a/core/util/devdataSqlite.ts
+++ b/core/util/devdataSqlite.ts
@@ -79,6 +79,9 @@ export class DevDataSqliteDb {
       driver: sqlite3.Database,
     });
 
+    await DevDataSqliteDb.db.exec("PRAGMA journal_mode=WAL;");
+    await DevDataSqliteDb.db.exec("PRAGMA busy_timeout = 3000;");
+
     await DevDataSqliteDb.createTables(DevDataSqliteDb.db!);
 
     return DevDataSqliteDb.db;


### PR DESCRIPTION
## Description

Add busy_timeout and WAL to all SQLite connections

- Set `busy_timeout` on all SQLite connections to avoid SQLITE_BUSY errors during concurrent access.
- Enable Write-Ahead Logging (WAL) for better concurrency and performance.
- These changes improve the reliability and robustness of database operations under load.

## Checklist

- [x ] The base branch of this PR is `dev`, rather than `main`

