### PR TITLE
fix: tutorial run error

### DIFF
--- a/extensions/vscode/src/lang-server/codeLens/providers/TutorialCodeLensProvider.ts
+++ b/extensions/vscode/src/lang-server/codeLens/providers/TutorialCodeLensProvider.ts
@@ -56,10 +56,10 @@ const actions: TutorialCodeLensItems[] = [
         title: "Run the file",
         command: "continue.sendToTerminal",
         arguments: [
-          `python ${path.join(
+          `python "${path.join(
             getExtensionUri().fsPath,
             "continue_tutorial.py",
-          )}\n`,
+          )}"\n`,
         ],
       },
     ],


### PR DESCRIPTION
## Description
Some people may have usernames with spaces in the path, in which case running Python file from the tutorial will not work properly.
So I added quotes to the command to make it work in this case.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]
![image](https://github.com/user-attachments/assets/45f1d6ea-5fbe-4893-b22b-109332976875)

## Testing

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change. ]
