### PR TITLE
Fix: Amazon Bedrock Documents

### DIFF
--- a/docs/docs/reference/Model Providers/bedrock.md
+++ b/docs/docs/reference/Model Providers/bedrock.md
@@ -1,4 +1,4 @@
-# AWS Bedrock
+# Amazon Bedrock
 
 To setup Bedrock, add the following to your `config.json` file:
 
@@ -6,11 +6,11 @@ To setup Bedrock, add the following to your `config.json` file:
 {
   "models": [
     {
-      "title": "Bedrock: Claude 3 Sonnet",
+      "title": "Bedrock: Claude 3.5 Sonnet",
       "provider": "bedrock",
-      "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+      "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
       "region": "us-east-1",
-      "profile": "bedrock",
+      "profile": "bedrock"
     }
   ]
 }

--- a/docs/docs/reference/Model Providers/bedrockimport.md
+++ b/docs/docs/reference/Model Providers/bedrockimport.md
@@ -1,4 +1,4 @@
-# AWS Bedrock Custom Imported Models
+# Amazon Bedrock Custom Imported Models
 
 To setup Bedrock using custom imported models, add the following to your `config.json` file:
 

--- a/docs/docs/setup/model-providers.md
+++ b/docs/docs/setup/model-providers.md
@@ -17,8 +17,8 @@ keywords:
     Gemini,
     Ollama,
     HuggingFace,
-    AWS Bedrock,
-    AWS SageMaker,
+    Amazon Bedrock,
+    Amazon SageMaker,
   ]
 ---
 
@@ -80,7 +80,6 @@ You can run open-source LLMs with cloud services like:
 - [Replicate](../reference/Model%20Providers/replicatellm.md)
 - [Deepinfra](../reference/Model%20Providers/deepinfra.md)
 - [Groq](../reference/Model%20Providers/openai.md) (OpenAI compatible API)
-- [AWS Bedrock](../reference/Model%20Providers/bedrock.md)
 
 ### Commercial models
 
@@ -89,6 +88,7 @@ You can use commercial LLMs via APIs using:
 - [Anthrophic API](../reference/Model%20Providers/anthropicllm.md)
 - [OpenAI API](../reference/Model%20Providers/openai.md)
 - [Azure OpenAI Service](../reference/Model%20Providers/openai.md)
+- [Amazon Bedrock](../reference/Model%20Providers/bedrock.md)
 - [Google Gemini API](../reference/Model%20Providers/geminiapi.md)
 - [Mistral API](../reference/Model%20Providers/mistral.md)
 - [Voyage AI API](../features/codebase-embeddings.md#openai)


### PR DESCRIPTION
## Description

- Correct service name from AWS Bedrock to Amazon Bedrock
- Change service category for Amazon Bedrock from Open-source models to Commercial models
- Change default model name from Claude 3 Sonnet to Claude 3.5 Sonnet
- Documentation changes only, no code modifications

## Checklist

- [check] The base branch of this PR is `dev`, rather than `main`
- [check] The relevant docs, if any, have been updated or created

## Screenshots

![image](https://github.com/user-attachments/assets/556bf7a0-e2a3-45a9-a9cd-557f430d0172)
![image](https://github.com/user-attachments/assets/7a038664-9067-4912-ba9f-2f4a45da9196)


## Testing

This PR involves documentation changes only, no code modifications.
