### PR TITLE
fix: maxTokens to respect the settings in ~/.continue/config.json

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -760,6 +760,7 @@ export interface ModelDescription {
   model: string;
   apiKey?: string;
   apiBase?: string;
+  maxTokens?: number;
   contextLength?: number;
   maxStopWords?: number;
   template?: TemplateType;

--- a/core/llm/llms/index.ts
+++ b/core/llm/llms/index.ts
@@ -107,6 +107,7 @@ export async function llmFromDescription(
       ...finalCompletionOptions,
       model: (desc.model || cls.defaultOptions?.model) ?? "codellama-7b",
       maxTokens:
+        desc.maxTokens ??
         finalCompletionOptions.maxTokens ??
         cls.defaultOptions?.completionOptions?.maxTokens ??
         DEFAULT_MAX_TOKENS,


### PR DESCRIPTION
Change-Id: Id29f505aa92542b51fd48bc671e3c625d18beec0

## Description

Let maxTokens to respect the settings in ~/.continue/config.json, but not always the default value

## Checklist

- [ Yes ] The base branch of this PR is `dev`, rather than `main`
- [ Yes ] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change. ]
