### PR TITLE
fix delete chat message button

### DIFF
--- a/gui/src/components/gui/StepContainer.tsx
+++ b/gui/src/components/gui/StepContainer.tsx
@@ -203,16 +203,18 @@ function StepContainer(props: StepContainerProps) {
                   />
                 </HeaderButtonWithText>
               )}
-              <HeaderButtonWithText text="Delete Message">
-                <TrashIcon
-                  color={lightGray}
-                  width="1.2em"
-                  height="1.2em"
-                  onClick={() => {
-                    props.onDelete();
-                  }}
-                />
-              </HeaderButtonWithText>
+              {!props.isLast && (
+                <HeaderButtonWithText text="Delete Message">
+                  <TrashIcon
+                    color={lightGray}
+                    width="1.2em"
+                    height="1.2em"
+                    onClick={() => {
+                      props.onDelete();
+                    }}
+                  />
+                </HeaderButtonWithText>
+              )}
             </div>
           )}
       </div>

--- a/gui/src/redux/slices/stateSlice.ts
+++ b/gui/src/redux/slices/stateSlice.ts
@@ -249,21 +249,12 @@ export const stateSlice = createSlice({
       // state.contextItems = [];
       state.active = true;
     },
+
     deleteMessage: (state, action: PayloadAction<number>) => {
       const index = action.payload;
-
-      if (index >= 0 && index < state.history.length) {
-        // Delete the current message
-        state.history.splice(index, 1);
-
-        // If the next message is an assistant message, delete it too
-        if (
-          index < state.history.length &&
-          state.history[index].message.role === "assistant"
-        ) {
-          state.history.splice(index, 1);
-        }
-      }
+      const startIndex = Math.max(0, index - 1);
+      const deleteCount = index === 0 ? 1 : 2;
+      state.history.splice(startIndex, deleteCount);
     },
 
     initNewActiveMessage: (

--- a/gui/src/redux/slices/stateSlice.ts
+++ b/gui/src/redux/slices/stateSlice.ts
@@ -250,7 +250,7 @@ export const stateSlice = createSlice({
       state.active = true;
     },
     deleteMessage: (state, action: PayloadAction<number>) => {
-      const index = action.payload + 1;
+      const index = action.payload;
 
       if (index >= 0 && index < state.history.length) {
         // Delete the current message


### PR DESCRIPTION
## Description

The purpose of having delete button was to delete any previous chat history to reduce the input length to LLM.

- [x] fix out of index issue on delete chat message.
- [x] fix deleting related chat prompt.
- [x] hide delete on last response.

Closes #2065 

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created