### PR TITLE
feat: Add custom icon support for context providers

### DIFF
--- a/binary/package-lock.json
+++ b/binary/package-lock.json
@@ -57,6 +57,7 @@
         "adf-to-md": "^1.1.0",
         "async-mutex": "^0.5.0",
         "axios": "^1.6.7",
+        "cheerio": "^1.0.0-rc.12",
         "commander": "^12.0.0",
         "comment-json": "^4.2.3",
         "dbinfoz": "^0.1.4",

--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -99,12 +99,35 @@ declare global {
 
   export type ContextProviderType = "normal" | "query" | "submenu";
 
+  export type IconName =
+    | "file"
+    | "code"
+    | "terminal"
+    | "diff"
+    | "search"
+    | "url"
+    | "open"
+    | "codebase"
+    | "problems"
+    | "folder"
+    | "docs"
+    | "issue"
+    | "trash"
+    | "/edit"
+    | "/clear"
+    | "/comment"
+    | "/share"
+    | "/cmd";
+
+
   export interface ContextProviderDescription {
     title: string;
     displayTitle: string;
     description: string;
     renderInlineAs?: string;
     type: ContextProviderType;
+    icon?: IconName;
+    dependsOnIndexing?: boolean;
   }
 
   export type FetchFunction = (url: string | URL, init?: any) => Promise<any>;
@@ -132,6 +155,7 @@ declare global {
     description?: string;
     renderInlineAs?: string;
     type?: ContextProviderType;
+    icon?: IconName;
     getContextItems(
       query: string,
       extras: ContextProviderExtras,

--- a/core/context/providers/CustomContextProvider.ts
+++ b/core/context/providers/CustomContextProvider.ts
@@ -20,6 +20,7 @@ class CustomContextProviderClass implements IContextProvider {
       description: this.custom.description ?? "",
       type: this.custom.type ?? "normal",
       renderInlineAs: this.custom.renderInlineAs,
+      icon: this.custom.icon ?? "file",
     };
   }
 

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -50,6 +50,26 @@ export type PromptTemplate =
       otherData: Record<string, string>,
     ) => string | ChatMessage[]);
 
+export type IconName =
+  | "file"
+  | "code"
+  | "terminal"
+  | "diff"
+  | "search"
+  | "url"
+  | "open"
+  | "codebase"
+  | "problems"
+  | "folder"
+  | "docs"
+  | "issue"
+  | "trash"
+  | "/edit"
+  | "/clear"
+  | "/comment"
+  | "/share"
+  | "/cmd";
+
 export interface ILLM extends LLMOptions {
   get providerName(): ModelProvider;
 
@@ -126,6 +146,7 @@ export interface ContextProviderDescription {
   description: string;
   renderInlineAs?: string;
   type: ContextProviderType;
+  icon?: IconName;
   dependsOnIndexing?: boolean;
 }
 
@@ -154,6 +175,7 @@ export interface CustomContextProvider {
   description?: string;
   renderInlineAs?: string;
   type?: ContextProviderType;
+  icon?: IconName;
   getContextItems(
     query: string,
     extras: ContextProviderExtras,

--- a/gui/src/components/mainInput/MentionList.tsx
+++ b/gui/src/components/mainInput/MentionList.tsx
@@ -45,8 +45,9 @@ import HeaderButtonWithText from "../HeaderButtonWithText";
 import SafeImg from "../SafeImg";
 import AddDocsDialog from "../dialogs/AddDocsDialog";
 import { ComboBoxItem } from "./types";
+import { IconName } from "core";
 
-const ICONS_FOR_DROPDOWN: { [key: string]: any } = {
+const ICONS_FOR_DROPDOWN: { [key in IconName]: any } = {
   file: FolderIcon,
   code: CodeBracketIcon,
   terminal: CommandLineIcon,
@@ -84,29 +85,50 @@ function DropdownIcon(props: { className?: string; item: ComboBoxItem }) {
     }
   })();
 
+  // Use custom icon if provided
+  if (props.item.contextProvider?.icon) {
+    if (props.item.contextProvider.icon in ICONS_FOR_DROPDOWN) {
+      const IconComponent =
+        ICONS_FOR_DROPDOWN[props.item.contextProvider.icon as IconName];
+      return (
+        <IconComponent
+          className={`${props.className} flex-shrink-0`}
+          height="1.2em"
+          width="1.2em"
+        />
+      );
+    } else {
+      return (
+        <SafeImg
+          className={`${props.className} flex-shrink-0`}
+          src={props.item.icon}
+          height="1.2em"
+          width="1.2em"
+          fallback={
+            <AtSymbolIcon
+              className={props.className}
+              height="1.2em"
+              width="1.2em"
+            />
+          }
+        />
+      );
+    }
+  }
+
   const IconComponent =
     ICONS_FOR_DROPDOWN[provider] ??
-    (props.item.type === "contextProvider" ? AtSymbolIcon : BoltIcon);
+    (props.item.type === "contextProvider"
+      ? AtSymbolIcon
+      : props.item.contextProvider?.icon
+      ? ICONS_FOR_DROPDOWN[props.item.contextProvider.icon]
+      : BoltIcon);
 
-  const fallbackIcon = (
+  return (
     <IconComponent
       className={`${props.className} flex-shrink-0`}
       height="1.2em"
       width="1.2em"
-    />
-  );
-
-  if (!props.item.icon) {
-    return fallbackIcon;
-  }
-
-  return (
-    <SafeImg
-      className="flex-shrink-0 pr-2"
-      src={props.item.icon}
-      height="18em"
-      width="18em"
-      fallback={fallbackIcon}
     />
   );
 }


### PR DESCRIPTION
## Description

This PR adds support for custom icons in context providers. It introduces a new `IconName` type and extends the `ContextProviderDescription` and `CustomContextProvider` interfaces to include an optional `icon` property. The changes allow for more flexible and visually appealing context provider representations in the UI.

## Key Changes

- Added `IconName` type in `core/config/types.ts` and `core/index.d.ts`
- Extended `ContextProviderDescription` and `CustomContextProvider` interfaces to include `icon` property
- Updated `CustomContextProviderClass` to use the new `icon` property
- Modified `MentionList.tsx` to handle custom icons in the dropdown

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Testing

To test this change:
1. Create a custom context provider with an `icon` property
2. Verify that the specified icon appears correctly in the UI dropdown
3. Test with both built-in icon names and custom icon URLs
4. Ensure fallback behavior works as expected when an invalid icon is specified

## Screenshots

<img width="419" alt="image" src="https://github.com/user-attachments/assets/e489c9f2-3ec7-4b9b-9b4d-cef929b9aba1">
