### PR TITLE
Set SQLite busy_timeout to prevent lock contention issues

### DIFF
--- a/core/autocomplete/cache.ts
+++ b/core/autocomplete/cache.ts
@@ -20,6 +20,8 @@ export class AutocompleteLruCache {
       driver: sqlite3.Database,
     });
 
+    db.exec("PRAGMA busy_timeout = 3000;");
+
     await db.run(`
       CREATE TABLE IF NOT EXISTS cache (
         key TEXT PRIMARY KEY,

--- a/core/autocomplete/cache.ts
+++ b/core/autocomplete/cache.ts
@@ -20,7 +20,7 @@ export class AutocompleteLruCache {
       driver: sqlite3.Database,
     });
 
-    db.exec("PRAGMA busy_timeout = 3000;");
+    await db.exec("PRAGMA busy_timeout = 3000;");
 
     await db.run(`
       CREATE TABLE IF NOT EXISTS cache (

--- a/core/indexing/docs/DocsService.ts
+++ b/core/indexing/docs/DocsService.ts
@@ -475,6 +475,8 @@ export default class DocsService {
         driver: sqlite3.Database,
       });
 
+      db.exec("PRAGMA busy_timeout = 3000;");
+
       await runSqliteMigrations(db);
 
       await db.exec(`CREATE TABLE IF NOT EXISTS ${DocsService.sqlitebTableName} (

--- a/core/indexing/docs/DocsService.ts
+++ b/core/indexing/docs/DocsService.ts
@@ -475,7 +475,7 @@ export default class DocsService {
         driver: sqlite3.Database,
       });
 
-      db.exec("PRAGMA busy_timeout = 3000;");
+      await db.exec("PRAGMA busy_timeout = 3000;");
 
       await runSqliteMigrations(db);
 

--- a/core/indexing/refreshIndex.ts
+++ b/core/indexing/refreshIndex.ts
@@ -92,7 +92,7 @@ export class SqliteDb {
       driver: sqlite3.Database,
     });
 
-    SqliteDb.db.exec("PRAGMA busy_timeout = 3000;");
+    await SqliteDb.db.exec("PRAGMA busy_timeout = 3000;");
 
     await SqliteDb.createTables(SqliteDb.db);
 

--- a/core/indexing/refreshIndex.ts
+++ b/core/indexing/refreshIndex.ts
@@ -92,6 +92,8 @@ export class SqliteDb {
       driver: sqlite3.Database,
     });
 
+    SqliteDb.db.exec("PRAGMA busy_timeout = 3000;");
+
     await SqliteDb.createTables(SqliteDb.db);
 
     return SqliteDb.db;

--- a/core/util/devdataSqlite.ts
+++ b/core/util/devdataSqlite.ts
@@ -79,8 +79,8 @@ export class DevDataSqliteDb {
       driver: sqlite3.Database,
     });
 
-    DevDataSqliteDb.db.exec("PRAGMA busy_timeout = 3000;");
-    
+    await DevDataSqliteDb.db.exec("PRAGMA busy_timeout = 3000;");
+
     await DevDataSqliteDb.createTables(DevDataSqliteDb.db!);
 
     return DevDataSqliteDb.db;

--- a/core/util/devdataSqlite.ts
+++ b/core/util/devdataSqlite.ts
@@ -79,6 +79,8 @@ export class DevDataSqliteDb {
       driver: sqlite3.Database,
     });
 
+    DevDataSqliteDb.db.exec("PRAGMA busy_timeout = 3000;");
+    
     await DevDataSqliteDb.createTables(DevDataSqliteDb.db!);
 
     return DevDataSqliteDb.db;


### PR DESCRIPTION
## Description

This PR introduces a PRAGMA busy_timeout = 3000; statement to the database initialization code. The busy_timeout is set to 3000ms, which allows the SQLite engine to wait up to 3 seconds for a locked database to become available before returning an error.

## Reason:

In high-concurrency scenarios or situations where multiple processes are accessing the database, SQLite can encounter lock contention issues, leading to failed transactions. This timeout helps mitigate those issues by providing a buffer period, improving database transaction stability and reducing the likelihood of errors due to locked resources.

## Checklist

- [x ] The base branch of this PR is `dev`, rather than `main`
