### PR TITLE
fix: addContextItem in SlashCommands

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/MessageTypes.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/MessageTypes.kt
@@ -57,7 +57,8 @@ class MessageTypes {
             "getDefaultModelTitle",
             "indexProgress",
             "refreshSubmenuItems",
-            "didChangeAvailableProfiles"
+            "didChangeAvailableProfiles",
+            "addContextItem"
         )
     }
 }


### PR DESCRIPTION
## Description
Fix issue with `addContextItem` not working in JetBrains SlashCommands (e.g., `StackOverflowSlashCommand`) .

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created