### PR TITLE
Update Bedrock.ts to support apiBase and headers from config.json file

### DIFF
--- a/core/llm/llms/Bedrock.ts
+++ b/core/llm/llms/Bedrock.ts
@@ -49,14 +49,34 @@ class Bedrock extends BaseLLM {
     options: CompletionOptions,
   ): AsyncGenerator<ChatMessage> {
     const credentials = await this._getCredentials();
+    
     const client = new BedrockRuntimeClient({
       region: this.region,
+      endpoint: this.apiBase,
       credentials: {
         accessKeyId: credentials.accessKeyId,
         secretAccessKey: credentials.secretAccessKey,
         sessionToken: credentials.sessionToken || "",
       },
     });
+
+    let config_headers = this.requestOptions && this.requestOptions.headers ? this.requestOptions.headers : {};
+    // AWS SigV4 requires strict canonicalization of headers.
+    // DO NOT USE "_" in your header name. It will return an error like below.
+    // "The request signature we calculated does not match the signature you provided."
+
+    client.middlewareStack.add(
+      (next) => async (args) => {
+          args.request.headers = {
+            ...args.request.headers,
+            ...config_headers
+          };
+        return next(args);
+      },
+      {
+        step: 'build'
+      }
+    );
 
     const input = this._generateConverseInput(messages, options);
     const command = new ConverseStreamCommand(input);


### PR DESCRIPTION

## Description

Deployments inside security-conscious organizations often require the use of **alternate endpoints** (usually proxies) and **custom headers** (to be added to the HTTP request before it reaches the endpoint).

[ What changed? Feel free to be brief. ]
We extend the code at `core/llm/llms/Bedrock.ts` for the `BedrockRuntimeClient` to
- support `endpoint` in the constructor in order to pass an `apiBase` parameter from `config.json`.
- support new headers defined in `config.json`, using `middlewareStack.add`


## Checklist

- [X] The base branch of this PR is `dev`, rather than `main`
- [X] The relevant docs, if any, have been updated or created

The change add two functionalities that already exist for other LLMs (e.g. `Anthropic.ts`).


## Screenshots

N/A

## Testing

This is not a new feature.
The code was tested against a Bedrock deployment. The change does not affect the behavior.
The `apiBase` change and the insertion of new headers were tested locally by redirecting to `127.0.0.1`.

During the testing, we identified an issue when headers to be inserted contain an underscore.
It makes AWS SigV4 return the following error:  "The request signature we calculated does not match the signature you provided." Using headers that don't contain "_" avoids the issue. A note was added to the code.
 
