### PR TITLE
Enable custom domains for Github Issue provider

### DIFF
--- a/core/context/providers/GitHubIssuesContextProvider.ts
+++ b/core/context/providers/GitHubIssuesContextProvider.ts
@@ -21,9 +21,11 @@ class GitHubIssuesContextProvider extends BaseContextProvider {
   ): Promise<ContextItem[]> {
     const issueId = query;
     const { Octokit } = await import("@octokit/rest");
+    const domain = this.options?.domain ?? "github.com";
 
     const octokit = new Octokit({
       auth: this.options?.githubToken,
+      baseUrl: `https://${domain}/api/v3`,
       request: {
         fetch: extras.fetch,
       },

--- a/docs/docs/customization/context-providers.md
+++ b/docs/docs/customization/context-providers.md
@@ -138,6 +138,26 @@ Type '@issue' to reference the conversation in a GitHub issue. Make sure to incl
 }
 ```
 
+#### Using Github Enterprise Server
+
+When using with Github Enterprise Server, you can set the `domain` parameter to your server's hostname. By default this is set to `github.com`.
+
+```json
+{
+  "name": "issue",
+  "params": {
+    "repos": [
+      {
+        "owner": "continuedev",
+        "repo": "continue"
+      }
+    ],
+    "githubToken": "ghp_xxx",
+    "domain": "github.acme-inc.com"
+  }
+}
+```
+
 ### GitLab Merge Request
 
 Type `@gitlab-mr` to reference an open MR for this branch on GitLab.


### PR DESCRIPTION
## Description

Enables users to pass custom domains for the github issue provider
## Checklist

- [X] The base branch of this PR is `dev`, rather than `main`
- [X] The relevant docs, if any, have been updated or created

## Testing

Able to set the domain name to the user's choice, e.g.:

```
{
  "name": "issue",
  "params": {
    "repos": [
      {
        "owner": "continuedev",
        "repo": "continue"
      }
    ],
    "githubToken": "ghp_xxx",
    "domain": "github.acme-inc.com"
  }
}
```