### PR TITLE
Fix-bedrock-embeddings

### DIFF
--- a/core/indexing/embeddings/BedrockEmbeddingsProvider.ts
+++ b/core/indexing/embeddings/BedrockEmbeddingsProvider.ts
@@ -49,7 +49,7 @@ class BedrockEmbeddingsProvider extends BaseEmbeddingsProvider {
 
           if (response.body) {
             const responseBody = JSON.parse(new TextDecoder().decode(response.body));
-            return responseBody.embedding;
+            return [responseBody.embedding];
           }
         }),
       )
@@ -62,7 +62,7 @@ class BedrockEmbeddingsProvider extends BaseEmbeddingsProvider {
   ): any {
     const payload = {
       "inputText": prompt,
-      "dimensions": 1024,
+      "dimensions": 512,
       "normalize": true
     };
 

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "0.9.207",
+  "version": "0.9.208",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "0.9.207",
+      "version": "0.9.208",
       "license": "Apache-2.0",
       "dependencies": {
         "@electron/rebuild": "^3.2.10",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "0.9.207",
+  "version": "0.9.208",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION
## Description

* Updated dimensions of the vectors generated to be 512 instead of 1024. Using 1024 was causing lookup failures into the index during subsequent use of contexts.
* Returning an array of the chunked results instead of the array iteself so that they can be flattened into a single vector for storage.

## Checklist

- [X] The base branch of this PR is `dev`, rather than `main`
- [X] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing

* Extensive tesitng with the context providers using bedrock as the embeddings provider.