### PR TITLE
fix: deepseek doesn't support 'https://api.deepseek.com/completions' …

### DIFF
--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -76,7 +76,7 @@ export abstract class BaseLLM implements ILLM {
         return false;
       }
     }
-    if (["groq", "mistral"].includes(this.providerName)) {
+    if (["groq", "mistral", "deepseek"].includes(this.providerName)) {
       return false;
     }
     return true;


### PR DESCRIPTION
Deepseek doesn't support 'https://api.deepseek.com/completions' URL currently. When user selecting code in editor, and then use 'CMD +I' command to tell model to modify codes, 400 error happens.

## Description
when providerName is deepseek , supportsCompletions() should return false.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots
### Before
![before1](https://github.com/user-attachments/assets/e1ae14c2-e3e7-445e-a68c-4767c5653e0f)
![before2](https://github.com/user-attachments/assets/89d91410-b5c1-4796-8143-4e5c5ee8c2e6)
![before3](https://github.com/user-attachments/assets/52bf3172-2c51-42c3-885f-d7fdac692a5e)

[ For visual changes, include screenshots. ]

## Testing
![after png](https://github.com/user-attachments/assets/b9b16e6a-5695-46ff-9ec5-4f4ddbe5e498)
![after2](https://github.com/user-attachments/assets/e188866c-45ff-4417-b5db-3a43f0754e06)

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change. ]

