### PR TITLE
extensions: add remote config sync job to IDEA

### DIFF
--- a/extensions/intellij/build.gradle.kts
+++ b/extensions/intellij/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     alias(libs.plugins.changelog) // Gradle Changelog Plugin
     alias(libs.plugins.qodana) // Gradle Qodana Plugin
     alias(libs.plugins.kover) // Gradle Kover Plugin
+    kotlin("plugin.serialization") version "1.8.0"
 }
 
 group = properties("pluginGroup").get()
@@ -38,6 +39,7 @@ dependencies {
         exclude(group = "org.slf4j", module = "slf4j-api")
     }
     implementation("com.posthog.java:posthog:1.+")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0")
 }
 
 
@@ -147,7 +149,7 @@ tasks {
         // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
         // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
         channels.set(listOf(environment("RELEASE_CHANNEL").getOrElse("eap")))
-        
+
         // We always hide the stable releases until a few days of EAP have proven them stable
 //        hidden = environment("RELEASE_CHANNEL").map { it == "stable" }.getOrElse(false)
     }

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/activities/ContinuePluginStartupActivity.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/activities/ContinuePluginStartupActivity.kt
@@ -134,6 +134,8 @@ class ContinuePluginStartupActivity : StartupActivity, Disposable, DumbAware {
                 showTutorial(project)
             }
 
+            settings.addRemoteSyncJob()
+
             val ideProtocolClient = IdeProtocolClient(
                     continuePluginService,
                     defaultStrategy,

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/ServerConstants.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/ServerConstants.kt
@@ -81,17 +81,32 @@ fun getContinueGlobalPath(): String {
     return continuePath.toString()
 }
 
-fun getConfigJsonPath(): String {
-    val path = Paths.get(getContinueGlobalPath(), "config.json")
+fun getContinueRemoteConfigPath(remoteHostname: String): String {
+    val path = Paths.get(getContinueGlobalPath(), ".configs")
+    if (Files.notExists(path)) {
+        Files.createDirectories(path)
+    }
+    return Paths.get(path.toString(), remoteHostname).toString()
+}
+
+
+fun getConfigJsonPath(remoteHostname: String? = null): String {
+    val path = Paths.get(
+        if (remoteHostname != null) getContinueRemoteConfigPath(remoteHostname) else getContinueGlobalPath(),
+        "config.json"
+    )
     if (Files.notExists(path)) {
         Files.createFile(path)
-        Files.writeString(path, DEFAULT_CONFIG);
+        Files.writeString(path, if (remoteHostname == null) DEFAULT_CONFIG else "{}")
     }
     return path.toString()
 }
 
-fun getConfigJsPath(): String {
-    val path = Paths.get(getContinueGlobalPath(), "config.js")
+fun getConfigJsPath(remoteHostname: String? = null): String {
+    val path = Paths.get(
+        if (remoteHostname != null) getContinueRemoteConfigPath(remoteHostname) else getContinueGlobalPath(),
+        "config.js"
+    )
     if (Files.notExists(path)) {
         Files.createFile(path)
         Files.writeString(path, DEFAULT_CONFIG_JS);

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/services/ContinueExtensionSettingsService.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/services/ContinueExtensionSettingsService.kt
@@ -1,12 +1,24 @@
 package com.github.continuedev.continueintellijextension.services
 
+import com.github.continuedev.continueintellijextension.constants.getConfigJsPath
+import com.github.continuedev.continueintellijextension.constants.getConfigJsonPath
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.*
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.project.DumbAware
+import com.intellij.util.concurrency.AppExecutorUtil
 import com.intellij.util.messages.Topic
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import okhttp3.Request
 import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
+import java.io.File
+import java.io.IOException
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
 import javax.swing.*
 
 class ContinueSettingsComponent: DumbAware {
@@ -53,6 +65,12 @@ class ContinueSettingsComponent: DumbAware {
     }
 }
 
+@Serializable
+class ContinueRemoteConfigSyncResponse {
+    var configJson: String? = null
+    var configJs: String? = null
+}
+
 @State(
     name = "com.github.continuedev.continueintellijextension.services.ContinueExtensionSettings",
     storages = [Storage("ContinueExtensionSettings.xml")]
@@ -73,6 +91,8 @@ open class ContinueExtensionSettings : PersistentStateComponent<ContinueExtensio
 
     var continueState: ContinueState = ContinueState()
 
+    private var remoteSyncFuture: ScheduledFuture<*>? = null
+
     override fun getState(): ContinueState {
         return continueState
     }
@@ -84,6 +104,72 @@ open class ContinueExtensionSettings : PersistentStateComponent<ContinueExtensio
     companion object {
         val instance: ContinueExtensionSettings
             get() = ServiceManager.getService(ContinueExtensionSettings::class.java)
+    }
+
+    // Sync remote config from server
+    private fun syncRemoteConfig() {
+        val state = instance.continueState
+
+        if (state.remoteConfigServerUrl != null) {
+            // download remote config as json file
+
+            val client = OkHttpClient()
+            val baseUrl = state.remoteConfigServerUrl?.removeSuffix("/")
+
+            val requestBuilder = Request.Builder().url("${baseUrl}/sync")
+
+            if (state.userToken != null) {
+                requestBuilder.addHeader("Authorization", "Bearer ${state.userToken}")
+            }
+
+            val request = requestBuilder.build()
+            var configResponse: ContinueRemoteConfigSyncResponse? = null
+
+            try {
+                client.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) throw IOException("Unexpected code $response")
+
+                    response.body?.string()?.let { responseBody ->
+                        try {
+                            configResponse =
+                                Json.decodeFromString<ContinueRemoteConfigSyncResponse>(responseBody)
+                        } catch (e: Exception) {
+                            e.printStackTrace()
+                            return
+                        }
+                    }
+                }
+            } catch (e: IOException) {
+                e.printStackTrace()
+                return
+            }
+
+            if (configResponse?.configJson?.isNotEmpty()!!) {
+                val file = File(getConfigJsonPath(request.url.host))
+                file.writeText(configResponse!!.configJson!!)
+            }
+
+            if (configResponse?.configJs?.isNotEmpty()!!) {
+                val file = File(getConfigJsPath(request.url.host))
+                file.writeText(configResponse!!.configJs!!)
+            }
+        }
+    }
+
+    // Create a scheduled task to sync remote config every `remoteConfigSyncPeriod` minutes
+    fun addRemoteSyncJob() {
+
+        if (remoteSyncFuture != null) {
+            remoteSyncFuture?.cancel(false)
+        }
+
+        instance.remoteSyncFuture = AppExecutorUtil.getAppScheduledExecutorService()
+            .scheduleWithFixedDelay(
+                { syncRemoteConfig() },
+                0,
+                continueState.remoteConfigSyncPeriod.toLong(),
+                TimeUnit.MINUTES
+            )
     }
 }
 
@@ -124,6 +210,7 @@ class ContinueExtensionConfigurable : Configurable {
         settings.continueState.displayEditorTooltip = mySettingsComponent?.displayEditorTooltip?.isSelected ?: true
 
         ApplicationManager.getApplication().messageBus.syncPublisher(SettingsListener.TOPIC).settingsUpdated(settings.continueState)
+        ContinueExtensionSettings.instance.addRemoteSyncJob()
     }
 
     override fun reset() {
@@ -134,6 +221,8 @@ class ContinueExtensionConfigurable : Configurable {
         mySettingsComponent?.enableTabAutocomplete?.isSelected = settings.continueState.enableTabAutocomplete
         mySettingsComponent?.enableContinueTeamsBeta?.isSelected = settings.continueState.enableContinueTeamsBeta
         mySettingsComponent?.displayEditorTooltip?.isSelected = settings.continueState.displayEditorTooltip
+
+        ContinueExtensionSettings.instance.addRemoteSyncJob()
     }
 
     override fun disposeUIResources() {


### PR DESCRIPTION
## Description

Now remote config set in IDEA Plugin settings is synced periodically the same way as in VSCode.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Testing

1. Check configs in `~/.continue/.configs`
2. Set remote config server in IDEA Plugin.
3. Check `~/.continue/.configs`. There should be new folder with your server hostname and a `config.js`/`config.json` 
    (If server returns JSON with `configJs` and `configJson` keys.)

