### PR TITLE
Fix azure link in model-providers.md

### DIFF
--- a/docs/docs/setup/model-providers.md
+++ b/docs/docs/setup/model-providers.md
@@ -88,7 +88,7 @@ You can use commercial LLMs via APIs using:
 
 - [Anthrophic API](../reference/Model%20Providers/anthropicllm.md)
 - [OpenAI API](../reference/Model%20Providers/openai.md)
-- [Azure OpenAI Service](../reference/Model%20Providers/openai.md)
+- [Azure OpenAI Service](../reference/Model%20Providers/azure.md)
 - [Amazon Bedrock](../reference/Model%20Providers/bedrock.md)
 - [Google Gemini API](../reference/Model%20Providers/geminiapi.md)
 - [Mistral API](../reference/Model%20Providers/mistral.md)


### PR DESCRIPTION
## Description

"Azure OpenAI Service" link was going to OpenAI when it should have gone to the Azure OpenAI page.

## Checklist

- [X] The base branch of this PR is `dev`, rather than `main`
- [X] The relevant docs, if any, have been updated or created

## Screenshots

N/A

## Testing

N/A
