### PR TITLE
Use XDG directory on Linux.

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/ServerConstants.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/ServerConstants.kt
@@ -1,5 +1,6 @@
 package com.github.continuedev.continueintellijextension.constants
 
+import com.github.continuedev.continueintellijextension.utils.getContinueGlobalDir
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -74,7 +75,7 @@ export {
 """
 
 fun getContinueGlobalPath(): String {
-    val continuePath = Paths.get(System.getProperty("user.home"), ".continue")
+    val continuePath = getContinueGlobalDir()
     if (Files.notExists(continuePath)) {
         Files.createDirectories(continuePath)
     }

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/Diffs.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/Diffs.kt
@@ -2,6 +2,7 @@ package com.github.continuedev.continueintellijextension.`continue`
 
 import com.github.continuedev.continueintellijextension.services.ContinuePluginService
 import com.github.continuedev.continueintellijextension.utils.getAltKeyLabel
+import com.github.continuedev.continueintellijextension.utils.getContinueGlobalDir
 import com.intellij.diff.DiffContentFactory
 import com.intellij.diff.DiffManager
 import com.intellij.diff.DiffRequestPanel
@@ -27,8 +28,7 @@ import javax.swing.JComponent
 
 
 fun getDiffDirectory(): File {
-    val homeDirectory = System.getProperty("user.home")
-    val diffDirPath = Paths.get(homeDirectory).resolve(".continue").resolve(".diffs").toString()
+    val diffDirPath = getContinueGlobalDir().resolve(".diffs").toString()
     val diffDir = File(diffDirPath)
     if (!diffDir.exists()) {
         diffDir.mkdirs()

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
@@ -179,7 +179,8 @@ class AsyncFileSaveListener : AsyncFileListener {
     }
     override fun prepareChange(events: MutableList<out VFileEvent>): AsyncFileListener.ChangeApplier? {
         for (event in events) {
-            if (event.path.endsWith(".continue/config.json") || event.path.endsWith(".continue/config.ts") || event.path.endsWith(".continue\\config.json") || event.path.endsWith(".continue\\config.ts") || event.path.endsWith(".continuerc.json")) {
+            val fileName = event.file?.name ?: continue
+            if (fileName == "config.json" || fileName == "config.ts" || fileName == ".continuerc.json") {
                 return object : AsyncFileListener.ChangeApplier {
                     override fun afterVfsChange() {
                         val config = readConfigJson()

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/utils/Utils.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/utils/Utils.kt
@@ -3,6 +3,8 @@ package com.github.continuedev.continueintellijextension.utils
 import org.jetbrains.plugins.terminal.TerminalView
 import java.awt.Toolkit
 import java.awt.event.KeyEvent
+import java.nio.file.Path
+import java.nio.file.Paths
 
 enum class Os {
     MAC, WINDOWS, LINUX
@@ -37,3 +39,34 @@ fun getAltKeyLabel(): String {
 
 fun TerminalView.isNotAvailable(): Boolean =
     toolWindow == null || !toolWindow.isVisible || !toolWindow.isAvailable || toolWindow.isDisposed
+
+// Should be in sync with core/util/paths.ts
+fun getContinueGlobalDir(): Path {
+    val envGlobalDir = System.getenv("CONTINUE_GLOBAL_DIR")
+    if (envGlobalDir != null) {
+        return Paths.get(envGlobalDir)
+    }
+
+    val defaultDotDir = Paths.get(System.getProperty("user.home"), ".continue")
+
+    // Backwards compatibility: use ~/.continue if it already exists
+    if (defaultDotDir.toFile().exists()) {
+        return defaultDotDir
+    }
+
+    // on Linux, prefer XDG directories by default
+    // https://specifications.freedesktop.org/basedir-spec/latest/index.html
+    val xdgDataDir = System.getenv("XDG_DATA_HOME")
+    if (xdgDataDir != null) {
+        return Paths.get(xdgDataDir, "Continue")
+    }
+
+    // on Windows, prefer ~\AppData\Local
+    val localAppDataDir = System.getenv("LOCALAPPDATA")
+    if (localAppDataDir != null) {
+        return Paths.get(localAppDataDir, "Continue")
+    }
+
+    // Use ~/.continue everywhere else.
+    return defaultDotDir
+}

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -10,7 +10,11 @@ import { ContinueServerClient } from "core/continueServer/stubs/client";
 import { Core } from "core/core";
 import { walkDirAsync } from "core/indexing/walkDir";
 import { GlobalContext } from "core/util/GlobalContext";
-import { getConfigJsonPath, getDevDataFilePath } from "core/util/paths";
+import {
+  getContinueGlobalPath,
+  getConfigJsonPath,
+  getDevDataFilePath,
+} from "core/util/paths";
 import { Telemetry } from "core/util/posthog";
 import readLastLines from "read-last-lines";
 import {
@@ -386,7 +390,7 @@ const commandsMap: (
       captureCommandTelemetry("viewLogs");
 
       // Open ~/.continue/continue.log
-      const logFile = path.join(os.homedir(), ".continue", "continue.log");
+      const logFile = path.join(getContinueGlobalPath(), "continue.log");
       // Make sure the file/directory exist
       if (!fs.existsSync(logFile)) {
         fs.mkdirSync(path.dirname(logFile), { recursive: true });

--- a/extensions/vscode/src/diff/horizontal.ts
+++ b/extensions/vscode/src/diff/horizontal.ts
@@ -1,4 +1,4 @@
-import { devDataPath } from "core/util/paths";
+import { devDataPath, getContinueGlobalPath } from "core/util/paths";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -27,7 +27,7 @@ async function writeFile(uri: vscode.Uri, contents: string) {
 
 // THIS IS LOCAL
 export const DIFF_DIRECTORY = path
-  .join(os.homedir(), ".continue", ".diffs")
+  .join(getContinueGlobalPath(), ".diffs")
   .replace(/^C:/, "c:");
 
 export class DiffManager {

--- a/gui/src/pages/settings.tsx
+++ b/gui/src/pages/settings.tsx
@@ -155,12 +155,7 @@ function Settings() {
           <h3 className="text-lg font-bold m-2 inline-block">Settings</h3>
           <ConfigJsonButton
             onClick={() => {
-              ideMessenger.post("showFile", {
-                filepath:
-                  getPlatform() == "windows"
-                    ? "~\\.continue\\config.json"
-                    : "~/.continue/config.json",
-              });
+              ideMessenger.post("openConfigJson", undefined);
             }}
           >
             Open config.json


### PR DESCRIPTION
## Description

Fixes #558.

I personally think that polluting the home directory with dotfiles is a pretty lazy and bad practice.

This PR currently only addresses said problem on Linux, by making Continue [follow the XDG Base Directory specification](https://specifications.freedesktop.org/basedir-spec/latest/). 

This change is backwards compatible and only affects new setups, `~/.continue` is still used if it already exists.

I didn't do anything about other platforms yet, Windows and macOS continues to use `~/.continue` just like before.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created
