### PR TITLE
support indexing of multiple modules in jetbrains ides

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/activities/ContinuePluginStartupActivity.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/activities/ContinuePluginStartupActivity.kt
@@ -33,6 +33,8 @@ import javax.swing.*
 import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.components.service
 import com.intellij.openapi.extensions.PluginId
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
 import org.jetbrains.plugins.terminal.TerminalToolWindowFactory
@@ -188,11 +190,16 @@ class ContinuePluginStartupActivity : StartupActivity, Disposable, DumbAware {
                         )
 
                 // Reload the WebView
-                continuePluginService?.let {
-                    val workspacePaths =
-                            if (project.basePath != null) arrayOf(project.basePath) else emptyList<String>()
+                continuePluginService?.let { pluginService ->
+                    val allModulePaths = ModuleManager.getInstance(project).modules
+                        .flatMap { module -> ModuleRootManager.getInstance(module).contentRoots.map { it.path } }
+                        .map { Paths.get(it).normalize() }
 
-                    continuePluginService.workspacePaths = workspacePaths as Array<String>
+                    val topLevelModulePaths = allModulePaths
+                        .filter { modulePath -> allModulePaths.none { it != modulePath && modulePath.startsWith(it) } }
+                        .map { it.toString() }
+
+                    pluginService.workspacePaths = topLevelModulePaths.toTypedArray()
                 }
 
                 EditorFactory.getInstance().eventMulticaster.addSelectionListener(

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
@@ -480,8 +480,9 @@ class IdeProtocolClient (
                     }
                     "getBranch" -> {
                         // Get the current branch name
+                        val dir = (data as Map<String, Any>)["dir"] as String
                         val builder = ProcessBuilder("git", "rev-parse", "--abbrev-ref", "HEAD")
-                        builder.directory(File(workspacePath ?: "."))
+                        builder.directory(File(dir))
                         val process = builder.start()
 
                         val reader = BufferedReader(InputStreamReader(process.inputStream))
@@ -492,15 +493,21 @@ class IdeProtocolClient (
                     }
                     "getRepoName" -> {
                         // Get the current repository name
+                        val dir = (data as Map<String, Any>)["dir"] as String
                         val builder = ProcessBuilder("git", "config", "--get", "remote.origin.url")
-                        builder.directory(File(workspacePath ?: "."))
-                        val process = builder.start()
+                        builder.directory(File(dir))
+                        var output = "NONE"
+                        try {
+                            val process = builder.start()
 
-                        val reader = BufferedReader(InputStreamReader(process.inputStream))
-                        val output = reader.readLine()
-                        process.waitFor()
+                            val reader = BufferedReader(InputStreamReader(process.inputStream))
+                            output = reader.readLine()
+                            process.waitFor()
+                        } catch (error: Exception) {
+                            println("Git not found: " + error)
+                        }
 
-                        respond(output ?: "NONE")
+                        respond(output)
                     }
 
                     // NEW //
@@ -870,10 +877,15 @@ class IdeProtocolClient (
     }
 
     private fun workspaceDirectories(): Array<String> {
+        val dirs = this.continuePluginService.workspacePaths
+        if (dirs?.isNotEmpty() == true) {
+            return dirs
+        }
+
         if (this.workspacePath != null) {
             return arrayOf(this.workspacePath)
         }
-        return arrayOf<String>();
+        return arrayOf()
     }
 
     private fun listDirectoryContents(directory: String?): List<String> {


### PR DESCRIPTION
## Description
Fixes issue #2056 

workspaceDirectories function updated to return all _top-level_ modules from the project.

## Checklist

- [ x ] The base branch of this PR is `dev`, rather than `main`
- [ x ] The relevant docs, if any, have been updated or created

## Testing

From an existing jetbrains project, import an additional module by using File -> New -> Module from Existing Sources... Reload the Continue plugin window and reindex. Indexes should now be created for both modules.
