### PR TITLE
docs: Changed to apiType from openai to azure and provided JSON example

### DIFF
--- a/docs/docs/customize/model-providers/top-level/azure.md
+++ b/docs/docs/customize/model-providers/top-level/azure.md
@@ -15,7 +15,7 @@ We recommend configuring **GPT-4o** as your chat model.
     "apiBase": "<YOUR_DEPLOYMENT_BASE>",
     "engine": "<YOUR_ENGINE>",
     "apiVersion": "<YOUR_API_VERSION>",
-    "apiType": "openai",
+    "apiType": "azure",
     "apiKey": "<MY_API_KEY>"
 }]
 ```
@@ -32,7 +32,7 @@ We recommend configuring **Codestral** as your autocomplete model.
     "apiBase": "<YOUR_DEPLOYMENT_BASE>",
     "engine": "<YOUR_ENGINE>",
     "apiVersion": "<YOUR_API_VERSION>",
-    "apiType": "openai",
+    "apiType": "azure",
     "apiKey": "<MY_API_KEY>"
 }]
 ```
@@ -48,7 +48,7 @@ We recommend configuring **text-embedding-3-large** as your embeddings model.
     "apiBase": "<YOUR_DEPLOYMENT_BASE>",
     "engine": "<YOUR_ENGINE>",
     "apiVersion": "<YOUR_API_VERSION>",
-    "apiType": "openai",
+    "apiType": "azure",
     "apiKey": "<MY_API_KEY>"
 }]
 ```
@@ -75,9 +75,17 @@ Azure OpenAI requires a handful of additional parameters to be configured, such 
 
 To find this information in _Azure AI Studio_, first select the model that you would like to connect. Then visit _Endpoint_ > _Target URI_.
 
-For example, a Target URI of `<https://just-an-example.openai.azure.com/openai/deployments/gpt-4o/chat/completions?api-version=2023-13-15-preview>` would map to the following:
+For example, a Target URI of `<https://just-an-example.openai.azure.com/openai/deployments/gpt-4o/chat/completions?api-version=2023-03-15-preview>` would map to the following:
 
-- model = gpt-4o
-- engine = gpt-4o
-- apiVersion = 2023-13-15-preview
-- apiBase = just-an-example.openai.azure.com
+```json
+{
+  "title": "GPT-4o Azure",
+  "model": "gpt-4o",
+  "provider": "azure",
+  "apiBase": "https://just-an-example.openai.azure.com",
+  "apiType": "azure",
+  "engine": "gpt-4o",
+  "apiVersion": "2023-03-15-preview",
+  "apiKey": "<MY_API_KEY>"
+}
+```


### PR DESCRIPTION
## Description
Couldn't get Azure models working, but after changing `apiType` to `azure` it worked. Got a hint in this [issue comment](https://github.com/continuedev/continue/issues/1803#issuecomment-2245565128)

**Changes**

- Updated docs by changing to `apiType` from `openai` to  `azure` 
- Changed example to JSON format.

## Checklist

- [ ] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created
