### PR TITLE
fix-aws-expired-profile

### DIFF
--- a/core/indexing/embeddings/BedrockEmbeddingsProvider.ts
+++ b/core/indexing/embeddings/BedrockEmbeddingsProvider.ts
@@ -78,7 +78,8 @@ class BedrockEmbeddingsProvider extends BaseEmbeddingsProvider {
     try {
       return await
       fromIni({
-        profile: this.profile
+        profile: this.profile,
+        ignoreCache: true
       })();
     } catch (e) {
       console.warn(

--- a/core/llm/llms/Bedrock.ts
+++ b/core/llm/llms/Bedrock.ts
@@ -153,6 +153,7 @@ class Bedrock extends BaseLLM {
     try {
       return await fromIni({
         profile: this.profile,
+        ignoreCache: true
       })();
     } catch (e) {
       console.warn(

--- a/core/llm/llms/BedrockImport.ts
+++ b/core/llm/llms/BedrockImport.ts
@@ -82,7 +82,8 @@ class BedrockImport extends BaseLLM {
     try {
       return await
       fromIni({
-        profile: this.profile
+        profile: this.profile,
+        ignoreCache: true
       })();
     } catch (e) {
       console.warn(

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "0.9.211",
+  "version": "0.9.212",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "0.9.211",
+      "version": "0.9.212",
       "license": "Apache-2.0",
       "dependencies": {
         "@electron/rebuild": "^3.2.10",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "0.9.211",
+  "version": "0.9.212",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION
## Description

Update the fromIni method used to retrieve AWS credentials so that it ignores credential file caching.

Without this setting the credentials are read a single time when the extension is started and if the user refreshes the credentials manually via SSO login for example, the extension won't see the refreshed credentials and will continue to throw security token errors. Currently the only way to fix this is to restart VSCode completely.

## Checklist

- [X] The base branch of this PR is `dev`, rather than `main`
- [X] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing

I have manually tested Imported, Base and Embedded models with AWS Bedrock.
I have expired the AWS credentials and observed the token errors.
I have logged back into AWS and noted the credentials are refreshed and the extension stars working correctly again.