### PR TITLE
Fix:fix duplicate processes in multiple windows

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessenger.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessenger.kt
@@ -5,6 +5,7 @@ import com.github.continuedev.continueintellijextension.services.ContinuePluginS
 import com.github.continuedev.continueintellijextension.services.TelemetryService
 import com.github.continuedev.continueintellijextension.toolWindow.MessageTypes
 import com.google.gson.Gson
+import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import java.io.*
@@ -168,14 +169,13 @@ class CoreMessenger(private val project: Project, esbuildPath: String, continueC
                 println("An error occurred: ${e.message}")
             }
         } else {
-            // Set proper permissions
-            setPermissions(continueCorePath)
-            setPermissions(esbuildPath)
 
-            // Start the subprocess
-            val processBuilder = ProcessBuilder(continueCorePath)
-                    .directory(File(continueCorePath).parentFile)
-            process = processBuilder.start()
+            // Register for full service, multiple windows using the same process instance
+            val service = ServiceManager.getService(GlobalContinueService::class.java)
+            if (service.getGlobalContinueProcess() == null){
+                service.initProcess(esbuildPath, continueCorePath)
+            }
+            process = service.getGlobalContinueProcess()?.getContinueProcess()
 
             val outputStream = process!!.outputStream
             val inputStream = process!!.inputStream

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessenger.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessenger.kt
@@ -173,6 +173,8 @@ class CoreMessenger(private val project: Project, esbuildPath: String, continueC
             // Register for full service, multiple windows using the same process instance
             val service = ServiceManager.getService(GlobalContinueService::class.java)
             if (service.getGlobalContinueProcess() == null){
+                setPermissions(continueCorePath)
+                setPermissions(esbuildPath)
                 service.initProcess(esbuildPath, continueCorePath)
             }
             process = service.getGlobalContinueProcess()?.getContinueProcess()

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/GlobalContinueService.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/GlobalContinueService.kt
@@ -1,0 +1,64 @@
+package com.github.continuedev.continueintellijextension.`continue`
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.nio.file.attribute.PosixFilePermission
+
+@Service
+class GlobalContinueService {
+
+    private var continueProcess: ContinueProcess? = null
+
+    // 初始化进程
+    fun initProcess(esbuildPath: String, continueCorePath: String) {
+        if (continueProcess == null) {
+            continueProcess = ContinueProcess(esbuildPath, continueCorePath)
+            this.continueProcess = continueProcess
+        }
+    }
+
+    // 获取进程
+    fun getGlobalContinueProcess(): ContinueProcess? {
+        return continueProcess
+    }
+
+    // 以下为ContinueProcess类的简化版本
+    class ContinueProcess(esbuildPath: String, continueCorePath: String) {
+        private var continueProcess: Process? = null
+        private val esbuildPath: String
+        private val continueCorePath: String
+
+        init {
+            this.esbuildPath = esbuildPath
+            this.continueCorePath = continueCorePath
+            if (this.continueProcess == null) {
+                this.continueProcess = ProcessBuilder(continueCorePath).directory(File(continueCorePath).parentFile).start()
+            }
+        }
+
+        fun getContinueProcess(): Process? {
+            return continueProcess
+        }
+
+        private fun setPermissions(destination: String) {
+            val osName = System.getProperty("os.name").toLowerCase()
+            if (osName.contains("mac") || osName.contains("darwin")) {
+                ProcessBuilder("xattr", "-dr", "com.apple.quarantine", destination).start()
+                setFilePermissions(destination, "rwxr-xr-x")
+            } else if (osName.contains("nix") || osName.contains("nux") || osName.contains("mac")) {
+                setFilePermissions(destination, "rwxr-xr-x")
+            }
+        }
+
+        private fun setFilePermissions(path: String, posixPermissions: String) {
+            val perms = HashSet<PosixFilePermission>()
+            if (posixPermissions.contains("r")) perms.add(PosixFilePermission.OWNER_READ)
+            if (posixPermissions.contains("w")) perms.add(PosixFilePermission.OWNER_WRITE)
+            if (posixPermissions.contains("x")) perms.add(PosixFilePermission.OWNER_EXECUTE)
+            Files.setPosixFilePermissions(Paths.get(path), perms)
+        }
+    }
+}


### PR DESCRIPTION
## Description
In IDEA, every time a new editor is opened, a new process is created to start continue, rather than using the process from the previous window. By registering a service, this issue is fixed by loading previously started processes during startup; if no existing process is found, a new thread will be created. This improves memory utilization efficiency.

## Checklist

- [yes] The base branch of this PR is `dev`, rather than `main`
- [no] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ] no visual changes

## Testing
Open IDEA for the first time
![ef9a0e095b207f34a921307a24035b6](https://github.com/user-attachments/assets/6d37b5a5-340a-41d2-815a-82c36b27b05b)

Subsequently, open IDEA using the previous process
![ff7a117a8f682210169a1bbb56badcd](https://github.com/user-attachments/assets/0fe53f26-a16c-4d6c-8650-cbfdabf51a16)

Additionally, the Task Manager does not show the core binary process.
![b02e2ab9aa0c3c7348707adb4802401](https://github.com/user-attachments/assets/24d502c6-0616-4586-84fd-d7599346c340)
