### PR TITLE
Update extensionKind to workspace only

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -8,7 +8,6 @@
     "url": "https://github.com/continuedev/continue"
   },
   "extensionKind": [
-    "ui",
     "workspace"
   ],
   "bugs": {


### PR DESCRIPTION
This PR updates the `extensionKind` in the VS Code extension's `package.json` to only include "workspace".
Fixes #2253

## Changes
- Removed "ui" from the `extensionKind` array in `extensions/vscode/package.json`

## Reason for Change
This change ensures that the Continue extension runs in the WSL environment when used with VS Code's Remote - WSL feature. It prevents issues where the extension might run on the Windows host instead of the WSL environment, causing file path resolution problems.

## Testing
I've tested this change in a Windows 10 + WSL2 environment, and it resolves the file opening issues previously encountered when using the extension with WSL.