### PR TITLE
Fix broken link in autocomplete model docs

### DIFF
--- a/docs/docs/customize/model-types/autocomplete.md
+++ b/docs/docs/customize/model-types/autocomplete.md
@@ -11,6 +11,6 @@ In Continue, these models are used to display inline [Autocomplete](../../chat/h
 
 ## Recommended Autocomplete models
 
-If you have the ability to use any model, we recommend [Codestral](../model-providers/top-level/mistral.md) from Mistral.
+If you have the ability to use any model, we recommend `Codestral` with [Mistral](../model-providers/top-level/mistral.md#autocomplete-model).
 
-If you want to run a model locally, we recommend [Starcoder2-3B] with [Ollama]../model-providers/top-level/ollama.md).
+If you want to run a model locally, we recommend `Starcoder2-3B` with [Ollama](../model-providers/top-level/ollama.md#autocomplete-model).


### PR DESCRIPTION
## Description
Fixed a broken link in the [Autocomplete model](https://docs.continue.dev/customize/model-types/autocomplete) docs and matched the linking/wording to those in [Embeddings model](https://docs.continue.dev/customize/model-types/embeddings).

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots


## Testing
Rendered the markdown and checked the URLs.