### PR TITLE
Update autocomplete.md - Fix broken link

### DIFF
--- a/docs/docs/customize/model-types/autocomplete.md
+++ b/docs/docs/customize/model-types/autocomplete.md
@@ -13,4 +13,4 @@ In Continue, these models are used to display inline [Autocomplete](../../chat/h
 
 If you have the ability to use any model, we recommend [Codestral](../model-providers/top-level/mistral.md) from Mistral.
 
-If you want to run a model locally, we recommend [Starcoder2-3B] with [Ollama]../model-providers/top-level/ollama.md).
+If you want to run a model locally, we recommend [Starcoder2-3B] with [Ollama](../model-providers/top-level/ollama.md).


### PR DESCRIPTION
Fixed the link to ollama in the docs

## Description
The link to Ollama was missing a `(` so I added it. Now the hyperlink is valid and takes you to the desired target. 

## Checklist

- [X] The base branch of this PR is `dev`, rather than `main`
- [X] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing

Clicking on the link for Ollama takes you to the relevant page in your documentation now. 