### PR TITLE
Fix chat meta keyboard shortcuts for Windows

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor.tsx
@@ -337,7 +337,7 @@ function TipTapEditor(props: TipTapEditorProps) {
               return true;
             },
 
-            "Cmd-Enter": () => {
+            "Mod-Enter": () => {
               onEnterRef.current({
                 useCodebase: true,
                 noContext: !useActiveFile,
@@ -354,7 +354,7 @@ function TipTapEditor(props: TipTapEditorProps) {
 
               return true;
             },
-            "Cmd-Backspace": () => {
+            "Mod-Backspace": () => {
               // If you press cmd+backspace wanting to cancel,
               // but are inside of a text box, it shouldn't
               // delete the text


### PR DESCRIPTION
## Description

Changed `addKeyboardShortcuts()` in ` \gui\src\components\mainInput\TipTapEditor.tsx` to use `Mod-Enter` and `Mod-Backspace` instead of `Cmd-Enter` and `Cmd-Backspace` since `Cmd` is Mac specific and you can use `Mod` as a shorthand for `Cmd` on Mac and `Control` on other platforms: [https://tiptap.dev/docs/editor/core-concepts/keyboard-shortcuts](https://tiptap.dev/docs/editor/core-concepts/keyboard-shortcuts)

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

No visual changes.

## Testing

1. Open the chat window on Windows
2. Press CTRL + Enter when sending a chat message, to trigger a message with `@codebase` context

---

1. Open the chat window on Mac
2. Press Cmd + Enter when sending a chat message, to trigger a message with `@codebase` context
