### PR TITLE
feat: add autocomplete support for Qwen2.5-Coder

### DIFF
--- a/core/autocomplete/templates.ts
+++ b/core/autocomplete/templates.ts
@@ -54,7 +54,7 @@ const qwenCoderFimTemplate: AutocompleteTemplate = {
       "<|repo_name|>",
       "<|file_sep|>",
       "<|im_start|>",
-      "<|im_end|",
+      "<|im_end|>",
     ],
   },
 };

--- a/core/autocomplete/templates.ts
+++ b/core/autocomplete/templates.ts
@@ -41,6 +41,24 @@ const stableCodeFimTemplate: AutocompleteTemplate = {
   },
 };
 
+// https://github.com/QwenLM/Qwen2.5-Coder?tab=readme-ov-file#3-file-level-code-completion-fill-in-the-middle
+const qwenCoderFimTemplate: AutocompleteTemplate = {
+  template:
+    "<|fim_prefix|>{{{prefix}}}<|fim_suffix|>{{{suffix}}}<|fim_middle|>",
+  completionOptions: {
+    stop: [
+      "<|fim_prefix|>",
+      "<|fim_middle|>",
+      "<|fim_suffix|>",
+      "<|fim_pad|>",
+      "<|repo_name|>",
+      "<|file_sep|>",
+      "<|im_start|>",
+      "<|im_end|",
+    ],
+  },
+};
+
 const codestralFimTemplate: AutocompleteTemplate = {
   template: "[SUFFIX]{{{suffix}}}[PREFIX]{{{prefix}}}",
   completionOptions: {
@@ -317,6 +335,10 @@ export function getTemplateForModel(model: string): AutocompleteTemplate {
   // if (lowerCaseModel.includes("starcoder2")) {
   //   return starcoder2FimTemplate;
   // }
+
+  if (lowerCaseModel.includes("qwen") && lowerCaseModel.includes("coder")) {
+    return qwenCoderFimTemplate;
+  }
 
   if (
     lowerCaseModel.includes("starcoder") ||


### PR DESCRIPTION
## Description

With the upgrade to Qwen 2.5, the instruction format changed, causing issues with the previous autocomplete functionality. This PR introduces code adjustments to resolve these issues and support the new format.

In **CodeQwen1.5**, the `<fim_prefix>` format was used:
[QwenLM/Qwen2.5-Coder (codeqwen1_5)](https://github.com/QwenLM/Qwen2.5-Coder/tree/codeqwen1_5?tab=readme-ov-file).

However, in **Qwen2.5-Coder**, the format was updated to `<|fim_prefix|>`:
[QwenLM/Qwen2.5-Coder](https://github.com/QwenLM/Qwen2.5-Coder/).

The previous implementation did not work with this updated format, and this PR adapts the code accordingly to restore functionality.

closes #2330

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

[ No visual changes. ]

## Testing

With `vllm serve`, an OpenAI-compatible server, modify `config.json` with the following configuration:

```json
  "tabAutocompleteModel": {
    "model": "Qwen/Qwen2.5-Coder-7B",
    "title": "vLLM OpenAI-compatible server",
    "provider": "openai",
    "apiKey": "sk-xxxx",
    "apiBase": "http://165.x.x.x:10103/v1"
  }
```

1. Confirm that the Qwen2.5-Coder model loads correctly.
2. Verify that the autocomplete functionality, which previously failed due to the format change, now works as expected with the updated `<|fim_prefix|>` format.
   
   - **Current (AS-IS)**:
     - ![image](https://github.com/user-attachments/assets/3f6f8b00-842f-4c1e-8cdf-f0c4e5226cb2)
     - Uses `<fim_prefix>` format.

   - **Updated (TO-BE)**:
     - ![image](https://github.com/user-attachments/assets/012d45fb-b7a7-44e2-8302-08671600a534)
     - Now uses `<|fim_prefix|>` format.
