### PR TITLE
fix: config-types "useSuffix" to "useFileSuffix"

### DIFF
--- a/packages/config-types/src/index.ts
+++ b/packages/config-types/src/index.ts
@@ -128,7 +128,7 @@ export type UiOptions = z.infer<typeof uiOptionsSchema>;
 export const tabAutocompleteOptionsSchema = z.object({
   disable: z.boolean(),
   useCopyBuffer: z.boolean(),
-  useSuffix: z.boolean(),
+  useFileSuffix: z.boolean(),
   maxPromptTokens: z.number(),
   debounceDelay: z.number(),
   maxSuffixPercentage: z.number(),


### PR DESCRIPTION
## Description

`core/index.d.ts` interface TabAutocompleteOptions key is "useFileSuffix"
`packages/config-types/src/index.ts` tabAutocompleteOptionsSchema object key is "useSuffix"

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created

## Screenshots

N/A

## Testing

N/A