### PR TITLE
Refactor HttpContextProvider to allow for an array of ContextItems

### DIFF
--- a/core/context/providers/HttpContextProvider.ts
+++ b/core/context/providers/HttpContextProvider.ts
@@ -39,14 +39,15 @@ class HttpContextProvider extends BaseContextProvider {
       }),
     });
 
-    const json: any = await response.json();
-    return [
-      {
-        description: json.description || "HTTP Context Item",
-        content: json.content || "",
-        name: json.name || this.options.title || "HTTP",
-      },
-    ];
+    const json = await response.json();
+
+    const createContextItem = (item: any) => ({
+      description: item.description ?? "HTTP Context Item",
+      content: item.content ?? "",
+      name: item.name ?? this.options.title ?? "HTTP",
+    });
+
+    return Array.isArray(json) ? json.map(createContextItem) : [createContextItem(json)];
   }
 }
 

--- a/docs/docs/customize/context-providers.md
+++ b/docs/docs/customize/context-providers.md
@@ -435,6 +435,49 @@ Reference the architecture and platform of your current operating system.
 }
 ```
 
+### `@HTTP`
+
+The HttpContextProvider makes a POST request to the url passed in the configuration. The server must return 200 OK with a ContextItem object or an array of ContextItems.
+
+```json title="config.json"
+{
+  "contextProviders": [
+    {
+      "name": "http",
+      "params": {
+        "url": "https://api.example.com/v1/users",
+      }
+    }
+  ]
+}
+```
+
+The receiving URL should expect to receive the following parameters:
+```json title="POST parameters"
+{
+  query: string,
+  fullInput: string
+}
+```
+
+The response 200 OK should be a JSON object with the following structure:
+```json title="Response"
+[
+  {
+    "name": "",
+    "description": "",
+    "content": ""
+  }
+]
+
+// OR
+{
+  "name": "",
+  "description": "",
+  "content": ""
+}
+```
+
 ### Requesting Context Providers
 
 Not seeing what you want? Create an issue [here](https://github.com/continuedev/continue/issues/new?assignees=TyDunn&labels=enhancement&projects=&template=feature-request-%F0%9F%92%AA.md&title=) to request a new Context Provider.


### PR DESCRIPTION
## Description
Currently the HttpContextProvider only supports a single ContextItem object from the response. This is not very useful if you want to leverage this existing context provide to interact with a RAG Server for instance. (See the Custom Code Rag documentation).

This change preserves existing behavior in addition to allow for the HttpContextProvider to accept multiple ContextItems in the response.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Testing

Start a basic server - you can use the example script below.
```
#!/usr/bin/env python3

from fastapi import FastAPI, Request
from pydantic import BaseModel

app = FastAPI()

class ContextProviderInput(BaseModel):
    query: str
    fullInput: str

@app.post("/retrieve")
async def create_item(item: ContextProviderInput):
    # Construct the "context item" format expected by Continue
    context_items = [
        {
            "name": "/tmp/somefile.txt",
            "description": "/tmp/somefile.txt",
            "content": "Hello World!",
        },
        {
            "name": "/tmp/otherfile.txt",
            "description": "/tmp/otherfile.txt",
            "content": "Welcome to the beginning of the AI adventure!",
        }
    ]
    return context_items

```

```json title="config.json"
{
 "contextProviders": [    
    {
      "name": "http",
      "params": {
        "url": "http://127.0.0.1/retrieve",
        "title": "http",
        "description": "Custom HTTP Context Provider",
        "displayTitle": "Custom"
      }
    }
  ],
}
```
Prompt:
@Custom world

Expected result:
The server should return both entries and pass those entries to the LLM of choice.