### PR TITLE
gui: create an `xxs` breakpoint and remap existing breakpoints

### DIFF
--- a/docs/static/schemas/config.json
+++ b/docs/static/schemas/config.json
@@ -1044,6 +1044,7 @@
                   "llama2-70b",
                   "mistral-8x7b",
                   "gemma",
+                  "gemma2",
                   "llama3-8b",
                   "llama3-70b",
                   "llama3.1-8b",
@@ -2112,6 +2113,13 @@
               "description": "The maximum number of tokens that each chunk of a document is allowed to have",
               "type": "integer",
               "minimum": 128,
+              "exclusiveMaximum": 2147483647
+            },
+            "maxBatchSize": {
+              "title": "Maximum Batch Size",
+              "description": "The maximum number of chunks that can be sent to the embeddings provider in a single request",
+              "type": "integer",
+              "minimum": 1,
               "exclusiveMaximum": 2147483647
             },
             "region": {

--- a/extensions/intellij/src/main/resources/config_schema.json
+++ b/extensions/intellij/src/main/resources/config_schema.json
@@ -2115,6 +2115,13 @@
               "minimum": 128,
               "exclusiveMaximum": 2147483647
             },
+            "maxBatchSize": {
+              "title": "Maximum Batch Size",
+              "description": "The maximum number of chunks that can be sent to the embeddings provider in a single request",
+              "type": "integer",
+              "minimum": 1,
+              "exclusiveMaximum": 2147483647
+            },
             "region": {
               "title": "Region",
               "description": "The region where the model is hosted",

--- a/extensions/vscode/continue_rc_schema.json
+++ b/extensions/vscode/continue_rc_schema.json
@@ -2356,6 +2356,13 @@
               "minimum": 128,
               "exclusiveMaximum": 2147483647
             },
+            "maxBatchSize": {
+              "title": "Maximum Batch Size",
+              "description": "The maximum number of chunks that can be sent to the embeddings provider in a single request",
+              "type": "integer",
+              "minimum": 1,
+              "exclusiveMaximum": 2147483647
+            },
             "region": {
               "title": "Region",
               "description": "The region where the model is hosted",

--- a/gui/src/components/OnboardingCard/OnboardingCard.tsx
+++ b/gui/src/components/OnboardingCard/OnboardingCard.tsx
@@ -9,7 +9,6 @@ import { useOnboardingCard } from "./hooks/useOnboardingCard";
 const StyledCard = styled.div`
   margin: auto;
   border-radius: ${defaultBorderRadius};
-  padding: 1rem 1.5rem;
   background-color: ${vscInputBackground};
   box-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1),
     0 8px 10px -6px rgb(0 0 0 / 0.1);
@@ -43,13 +42,13 @@ export function OnboardingCard(props: OnboardingCardProps) {
   }
 
   return (
-    <StyledCard className="relative">
+    <StyledCard className="relative px-2 py-3 xs:py-4 xs:px-4">
       <OnboardingCardTabs
         activeTab={onboardingCard.activeTab}
         onTabClick={onboardingCard.setActiveTab}
       />
       <CloseButton onClick={onboardingCard.close}>
-        <XMarkIcon className="h-5 w-5" />
+        <XMarkIcon className="h-5 w-5 hidden sm:flex" />
       </CloseButton>
       <div className="content py-4">{renderTabContent()}</div>
     </StyledCard>

--- a/gui/src/components/OnboardingCard/components/BestExperienceConfigForm.tsx
+++ b/gui/src/components/OnboardingCard/components/BestExperienceConfigForm.tsx
@@ -65,13 +65,13 @@ function BestExperienceConfigForm({
           <div className="text-lg font-bold mb-1 flex flex-row justify-between gap-4">
             <label className="text-lg font-bold">Chat model</label>
             <div
-              className="flex items-center text-xs font-semibold justify-end"
+              className="flex items-center text-xs font-semibold justify-end hidden sm:flex"
               style={{ color: lightGray }}
             >
               <CubeIcon className="w-4 h-4 mr-1 flex-shrink-0" />
               <span className="italic text-right inline">
                 {chatModel.title}{" "}
-                <span className="max-xs:hidden">by Anthropic</span>
+                <span className="hidden md:inline">by Anthropic</span>
               </span>
             </div>
           </div>
@@ -99,13 +99,13 @@ function BestExperienceConfigForm({
           <div className="text-lg font-bold mb-1 flex flex-row justify-between gap-4">
             <label className="text-lg font-bold">Autocomplete model</label>
             <div
-              className="flex items-center text-xs font-semibold"
+              className="flex items-center text-xs font-semibold  hidden sm:flex"
               style={{ color: lightGray }}
             >
               <CubeIcon className="w-4 h-4 mr-1 flex-shrink-0  inline" />
               <span className="italic text-right">
                 {autocompleteModel.title}{" "}
-                <span className="max-xs:hidden">by Mistral</span>
+                <span className="hidden md:inline">by Mistral</span>
               </span>
             </div>
           </div>
@@ -129,7 +129,7 @@ function BestExperienceConfigForm({
           </div>
         </div>
 
-        <div className="mt-2 w-full">
+        <div className="w-full">
           <Button className="w-full" type="submit" disabled={!chatApiKey}>
             Connect
           </Button>

--- a/gui/src/components/OnboardingCard/components/OllamaCompletedStep.tsx
+++ b/gui/src/components/OnboardingCard/components/OllamaCompletedStep.tsx
@@ -7,7 +7,7 @@ interface OllamaCompletedStepProps {
 function OllamaCompletedStep({ text }: OllamaCompletedStepProps) {
   return (
     <div className="flex justify-between items-center">
-      <p className="text-sm w-3/4 font-mono">{text}</p>
+      <p className="text-sm w-3/4 font-mono truncate mr-1">{text}</p>
       <CheckCircleIcon width={24} height={24} className="text-emerald-600" />
     </div>
   );

--- a/gui/src/components/OnboardingCard/components/OllamaModelDownload.tsx
+++ b/gui/src/components/OnboardingCard/components/OllamaModelDownload.tsx
@@ -35,7 +35,7 @@ function OllamaModelDownload({
       ) : (
         <>
           <StyledActionButton data-tooltip-id={id} onClick={onClick}>
-            <p className="font-mono">{command}</p>
+            <p className="font-mono truncate">{command}</p>
             <CommandLineIcon width={24} height={24} />
           </StyledActionButton>
           {tooltipPortalDiv &&

--- a/gui/src/components/OnboardingCard/components/OllamaStatus.tsx
+++ b/gui/src/components/OnboardingCard/components/OllamaStatus.tsx
@@ -35,14 +35,14 @@ export function OllamaStatus({ isOllamaConnected }: OllamaStatusProps) {
     case OllamaConnectionStatuses.WaitingToDownload:
       return (
         <StyledActionButton onClick={onClickDownload}>
-          <p className="underline text-sm">{downloadUrl}</p>
+          <p className="underline text-sm truncate mr-1">{downloadUrl}</p>
           <ArrowTopRightOnSquareIcon width={24} height={24} />
         </StyledActionButton>
       );
     case OllamaConnectionStatuses.Downloading:
       return (
         <div className="flex justify-between items-center">
-          <p className="text-sm w-3/4 font-mono">
+          <p className="text-sm w-3/4 font-mono truncate mr-1">
             Checking for connection to Ollama at http://localhost:11434
           </p>
           <ArrowPathIcon className="h-4 w-4 animate-spin-slow mr-1" />

--- a/gui/src/components/OnboardingCard/components/OnboardingCardTabs.tsx
+++ b/gui/src/components/OnboardingCard/components/OnboardingCardTabs.tsx
@@ -9,23 +9,39 @@ interface OnboardingCardTabsProps {
 
 export type TabTitle = "Quickstart" | "Best" | "Local";
 
-export const TabTitles: { [k in TabTitle]: { xs: string; default: string } } = {
+export const TabTitles: { [k in TabTitle]: { md: string; default: string } } = {
   Quickstart: {
-    xs: "Quickstart",
+    md: "Quickstart",
     default: "Quickstart",
   },
   Best: {
-    xs: "Best",
+    md: "Best",
     default: "Best experience",
   },
   Local: {
-    xs: "Local",
+    md: "Local",
     default: "Local with Ollama",
   },
 };
 
+const StyledSelect = styled.select`
+  width: 100%;
+  padding: 0.5rem;
+  background-color: transparent;
+  color: ${vscForeground};
+  border: none;
+  border-bottom: 1px solid ${vscForeground};
+  border-radius: 0;
+  font-size: 1rem;
+  cursor: pointer;
+  display: block;
+
+  &:focus {
+    outline: none;
+  }
+`;
+
 const TabButton = styled.button<{ isActive: boolean }>`
-  padding: 1rem 1rem 0.5rem 1rem;
   margin-bottom: -1px;
   focus: outline-none;
   background: transparent;
@@ -54,23 +70,48 @@ export function OnboardingCardTabs({
   onTabClick,
 }: OnboardingCardTabsProps) {
   return (
-    <TabList>
-      {Object.entries(TabTitles).map(([tabType, titles]) => {
-        if (hasPassedFTL() && tabType === "Quickstart") {
-          return undefined;
-        }
+    <div>
+      <div className="hidden xs:block">
+        <TabList>
+          {Object.entries(TabTitles).map(([tabType, titles]) => {
+            if (hasPassedFTL() && tabType === "Quickstart") {
+              return undefined;
+            }
 
-        return (
-          <TabButton
-            key={tabType}
-            isActive={activeTab === tabType}
-            onClick={() => onTabClick(tabType as TabTitle)}
-          >
-            <p className="hidden xs:block m-0 font-medium">{titles.default}</p>
-            <p className="block xs:hidden m-0 font-medium">{titles.xs}</p>
-          </TabButton>
-        );
-      })}
-    </TabList>
+            return (
+              <TabButton
+                className="px-6 py-2 xs:py-2 xs:px-3 sm:px-5"
+                key={tabType}
+                isActive={activeTab === tabType}
+                onClick={() => onTabClick(tabType as TabTitle)}
+              >
+                <p className="hidden md:block m-0 font-medium">
+                  {titles.default}
+                </p>
+                <p className="block md:hidden m-0 font-medium">{titles.md}</p>
+              </TabButton>
+            );
+          })}
+        </TabList>
+      </div>
+      <div className="block xs:hidden">
+        <StyledSelect
+          value={activeTab}
+          onChange={(e) => onTabClick(e.target.value as TabTitle)}
+        >
+          {Object.entries(TabTitles).map(([tabType, titles]) => {
+            if (hasPassedFTL() && tabType === "Quickstart") {
+              return null;
+            }
+
+            return (
+              <option key={tabType} value={tabType}>
+                {titles.md}
+              </option>
+            );
+          })}
+        </StyledSelect>
+      </div>
+    </div>
   );
 }

--- a/gui/src/components/OnboardingCard/components/ProviderAlert.tsx
+++ b/gui/src/components/OnboardingCard/components/ProviderAlert.tsx
@@ -17,7 +17,7 @@ function ProviderAlert() {
   }
 
   return (
-    <div>
+    <div className="w-full">
       <Alert type="info">
         <p className="font-semibold text-sm m-0">
           Prefer to use an different provider like OpenAI?

--- a/gui/src/components/OnboardingCard/tabs/OnboardingBestTab.tsx
+++ b/gui/src/components/OnboardingCard/tabs/OnboardingBestTab.tsx
@@ -7,7 +7,9 @@ function OnboardingBestTab() {
 
   return (
     <div className="flex flex-col gap-8">
-      <ProviderAlert />
+      <div className="hidden xs:flex w-full">
+        <ProviderAlert />
+      </div>
       <BestExperienceConfigForm onComplete={submitOnboarding} />
     </div>
   );

--- a/gui/src/components/OnboardingCard/tabs/OnboardingQuickstartTab.tsx
+++ b/gui/src/components/OnboardingCard/tabs/OnboardingQuickstartTab.tsx
@@ -3,18 +3,18 @@ import QuickStartSubmitButton from "../components/QuickStartSubmitButton";
 
 function OnboardingQuickstartTab() {
   return (
-    <div className="flex justify-center items-center">
-      <div className="flex flex-col items-center justify-center w-3/4 text-center">
-        <div className="mr-5">
+    <div className="flex justify-center items-center w-full h-full">
+      <div className="flex flex-col items-center justify-center w-full max-w-full px-4 xs:px-0 text-center">
+        <div className="hidden xs:flex">
           <ContinueLogo height={75} />
         </div>
 
-        <p className="text-sm">
+        <p className="text-sm w-full xs:w-3/4">
           Quickly get up and running using our API keys. After this trial, we'll
           help you set up your own models.
         </p>
 
-        <p className="text-sm">
+        <p className="text-sm w-full xs:w-3/4">
           To prevent abuse, we'll ask you to sign in to GitHub.
         </p>
 

--- a/gui/src/components/gui/StepContainer.tsx
+++ b/gui/src/components/gui/StepContainer.tsx
@@ -124,14 +124,14 @@ function StepContainer(props: StepContainerProps) {
         {(props.isLast || isHovered || typeof feedback !== "undefined") &&
           !active && (
             <div
-              className="flex items-center gap-1 absolute -bottom-2 right-2"
+              className="flex items-center gap-1 absolute -bottom-2 right-2 hidden xs:flex"
               style={{
                 color: lightGray,
                 fontSize: getFontSize() - 3,
               }}
             >
               {props.modelTitle && (
-                <>
+                <div className="hidden sm:flex">
                   <div className="flex items-center">{props.modelTitle}</div>
                   <div
                     className="ml-2 mr-1"
@@ -141,7 +141,7 @@ function StepContainer(props: StepContainerProps) {
                       backgroundColor: lightGray,
                     }}
                   ></div>
-                </>
+                </div>
               )}
 
               {truncatedEarly && (

--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -28,7 +28,6 @@ import ModelSelect from "../modelSelection/ModelSelect";
 
 const StyledDiv = styled.div<{ isHidden: boolean }>`
   padding: 4px 0;
-  display: flex;
   justify-content: space-between;
   gap: 1px;
   background-color: ${vscInputBackground};
@@ -110,6 +109,7 @@ function InputToolbar(props: InputToolbarProps) {
         isHidden={props.hidden}
         onClick={props.onClick}
         id="input-toolbar"
+        className="hidden xs:flex"
       >
         <span className="flex gap-2 items-center whitespace-nowrap">
           <ModelSelect />

--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -207,17 +207,19 @@ function InputToolbar(props: InputToolbarProps) {
               {getMetaKeyLabel()} ⏎ Use @codebase
             </StyledSpan>
           )}
-          <EnterButton
-            offFocus={props.usingCodebase}
-            onClick={(e) => {
-              props.onEnter({
-                useCodebase: isMetaEquivalentKeyPressed(e),
-                noContext: useActiveFile ? e.altKey : !e.altKey,
-              });
-            }}
-          >
-            ⏎ Enter
-          </EnterButton>
+          <div className="hidden xs:flex">
+            <EnterButton
+              offFocus={props.usingCodebase}
+              onClick={(e) => {
+                props.onEnter({
+                  useCodebase: isMetaEquivalentKeyPressed(e),
+                  noContext: useActiveFile ? e.altKey : !e.altKey,
+                });
+              }}
+            >
+              ⏎ Enter
+            </EnterButton>
+          </div>
         </span>
       </StyledDiv>
     </>

--- a/gui/src/components/mainInput/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor.tsx
@@ -894,6 +894,7 @@ function TipTapEditor(props: TipTapEditorProps) {
           });
         }}
       />
+
       {showDragOverMsg &&
         modelSupportsImages(
           defaultModel.provider,

--- a/gui/src/components/markdown/CodeBlockToolbar.tsx
+++ b/gui/src/components/markdown/CodeBlockToolbar.tsx
@@ -28,6 +28,7 @@ import FileIcon from "../FileIcon";
 import ButtonWithTooltip from "../ButtonWithTooltip";
 import { CopyButton as CopyButtonHeader } from "./CopyButton";
 import { ToolbarButtonWithTooltip } from "./ToolbarButtonWithTooltip";
+import { getBasename } from "core/util";
 
 const ToolbarDiv = styled.div`
   display: flex;
@@ -217,11 +218,15 @@ function CodeBlockToolBar(props: CodeBlockToolBarProps) {
   return (
     <ToolbarDiv>
       <div
-        className="flex items-center cursor-pointer py-0.5 px-0.5"
+        className="flex items-center cursor-pointer py-0.5 px-0.5 max-w-[50%]"
         onClick={onClickHeader}
       >
         <FileIcon filename={props.filepath} height="18px" width="18px" />
-        <span className="hover:brightness-125 ml-1">{props.filepath}</span>{" "}
+        <div className="ml-1 truncate">
+          <span className="hover:brightness-125 truncate inline-block w-full">
+            {getBasename(props.filepath)}
+          </span>
+        </div>
       </div>
 
       <div className="flex items-center gap-1">
@@ -233,12 +238,12 @@ function CodeBlockToolBar(props: CodeBlockToolBarProps) {
             {isCopied ? (
               <>
                 <CheckIcon className="w-3 h-3 text-green-500 hover:brightness-125" />
-                <span>Copied</span>
+                <span className="hidden sm:inline">Copied</span>
               </>
             ) : (
               <>
                 <ClipboardIcon className="w-3 h-3 hover:brightness-125" />
-                <span>Copy</span>
+                <span className="hidden xs:inline">Copy</span>
               </>
             )}
           </div>
@@ -256,7 +261,7 @@ function CodeBlockToolBar(props: CodeBlockToolBarProps) {
                   style={{ color: lightGray }}
                 >
                   <PlayIcon className="w-3 h-3" />
-                  <span>Apply</span>
+                  <span className="hidden xs:inline">Apply</span>
                 </div>
               </ToolbarButton>
             ) : (

--- a/gui/src/components/modelSelection/ModelSelect.tsx
+++ b/gui/src/components/modelSelection/ModelSelect.tsx
@@ -304,67 +304,65 @@ function ModelSelect() {
   }
 
   return (
-    <div className="hidden xs:flex">
-      <Listbox
-        onChange={async (val: string) => {
-          if (val === defaultModel?.title) return;
-          dispatch(setDefaultModel({ title: val }));
-          await ideMessenger.request("update/modelChange", val);
-        }}
-      >
-        <div className="relative">
-          <StyledListboxButton
-            ref={buttonRef}
-            className="h-[18px] overflow-hidden"
-            style={{ padding: 0 }}
-            onClick={calculatePosition}
-          >
-            <span className="hover:underline">
-              {modelSelectTitle(defaultModel) || "Select model"}{" "}
-              <ChevronDownIcon className="h-2.5 w-2.5" aria-hidden="true" />
+    <Listbox
+      onChange={async (val: string) => {
+        if (val === defaultModel?.title) return;
+        dispatch(setDefaultModel({ title: val }));
+        await ideMessenger.request("update/modelChange", val);
+      }}
+    >
+      <div className="relative">
+        <StyledListboxButton
+          ref={buttonRef}
+          className="h-[18px] overflow-hidden"
+          style={{ padding: 0 }}
+          onClick={calculatePosition}
+        >
+          <span className="hover:underline">
+            {modelSelectTitle(defaultModel) || "Select model"}{" "}
+            <ChevronDownIcon className="h-2.5 w-2.5" aria-hidden="true" />
+          </span>
+        </StyledListboxButton>
+        <StyledListboxOptions showAbove={showAbove} className="z-50">
+          <div className={`max-h-[${MAX_HEIGHT_PX}px]`}>
+            {sortedOptions.map((option, idx) => (
+              <ModelOption
+                option={option}
+                idx={idx}
+                key={idx}
+                showDelete={options.length > 1}
+                showMissingApiKeyMsg={option.apiKey === ""}
+              />
+            ))}
+          </div>
+
+          <div className="mt-auto">
+            {selectedProfileId === "local" && (
+              <>
+                {options.length > 0 && <Divider className="!my-0" />}
+
+                <StyledListboxOption
+                  key={options.length}
+                  onClick={onClickAddModel}
+                  value={"addModel" as any}
+                >
+                  <div className="flex items-center py-0.5">
+                    <PlusIcon className="w-4 h-4 mr-2" />
+                    Add Chat model
+                  </div>
+                </StyledListboxOption>
+              </>
+            )}
+
+            <Divider className="!my-0" />
+
+            <span className="block px-3 py-3" style={{ color: lightGray }}>
+              <code>{getMetaKeyLabel()} + '</code> to toggle
             </span>
-          </StyledListboxButton>
-          <StyledListboxOptions showAbove={showAbove} className="z-50">
-            <div className={`max-h-[${MAX_HEIGHT_PX}px]`}>
-              {sortedOptions.map((option, idx) => (
-                <ModelOption
-                  option={option}
-                  idx={idx}
-                  key={idx}
-                  showDelete={options.length > 1}
-                  showMissingApiKeyMsg={option.apiKey === ""}
-                />
-              ))}
-            </div>
-
-            <div className="mt-auto">
-              {selectedProfileId === "local" && (
-                <>
-                  {options.length > 0 && <Divider className="!my-0" />}
-
-                  <StyledListboxOption
-                    key={options.length}
-                    onClick={onClickAddModel}
-                    value={"addModel" as any}
-                  >
-                    <div className="flex items-center py-0.5">
-                      <PlusIcon className="w-4 h-4 mr-2" />
-                      Add Chat model
-                    </div>
-                  </StyledListboxOption>
-                </>
-              )}
-
-              <Divider className="!my-0" />
-
-              <span className="block px-3 py-3" style={{ color: lightGray }}>
-                <code>{getMetaKeyLabel()} + '</code> to toggle
-              </span>
-            </div>
-          </StyledListboxOptions>
-        </div>
-      </Listbox>
-    </div>
+          </div>
+        </StyledListboxOptions>
+      </div>
+    </Listbox>
   );
 }
 

--- a/gui/src/components/modelSelection/ModelSelect.tsx
+++ b/gui/src/components/modelSelection/ModelSelect.tsx
@@ -304,65 +304,67 @@ function ModelSelect() {
   }
 
   return (
-    <Listbox
-      onChange={async (val: string) => {
-        if (val === defaultModel?.title) return;
-        dispatch(setDefaultModel({ title: val }));
-        await ideMessenger.request("update/modelChange", val);
-      }}
-    >
-      <div className="relative">
-        <StyledListboxButton
-          ref={buttonRef}
-          className="h-[18px] overflow-hidden"
-          style={{ padding: 0 }}
-          onClick={calculatePosition}
-        >
-          <span className="hover:underline">
-            {modelSelectTitle(defaultModel) || "Select model"}{" "}
-            <ChevronDownIcon className="h-2.5 w-2.5" aria-hidden="true" />
-          </span>
-        </StyledListboxButton>
-        <StyledListboxOptions showAbove={showAbove} className="z-50">
-          <div className={`max-h-[${MAX_HEIGHT_PX}px]`}>
-            {sortedOptions.map((option, idx) => (
-              <ModelOption
-                option={option}
-                idx={idx}
-                key={idx}
-                showDelete={options.length > 1}
-                showMissingApiKeyMsg={option.apiKey === ""}
-              />
-            ))}
-          </div>
-
-          <div className="mt-auto">
-            {selectedProfileId === "local" && (
-              <>
-                {options.length > 0 && <Divider className="!my-0" />}
-
-                <StyledListboxOption
-                  key={options.length}
-                  onClick={onClickAddModel}
-                  value={"addModel" as any}
-                >
-                  <div className="flex items-center py-0.5">
-                    <PlusIcon className="w-4 h-4 mr-2" />
-                    Add Chat model
-                  </div>
-                </StyledListboxOption>
-              </>
-            )}
-
-            <Divider className="!my-0" />
-
-            <span className="block px-3 py-3" style={{ color: lightGray }}>
-              <code>{getMetaKeyLabel()} + '</code> to toggle
+    <div className="hidden xs:flex">
+      <Listbox
+        onChange={async (val: string) => {
+          if (val === defaultModel?.title) return;
+          dispatch(setDefaultModel({ title: val }));
+          await ideMessenger.request("update/modelChange", val);
+        }}
+      >
+        <div className="relative">
+          <StyledListboxButton
+            ref={buttonRef}
+            className="h-[18px] overflow-hidden"
+            style={{ padding: 0 }}
+            onClick={calculatePosition}
+          >
+            <span className="hover:underline">
+              {modelSelectTitle(defaultModel) || "Select model"}{" "}
+              <ChevronDownIcon className="h-2.5 w-2.5" aria-hidden="true" />
             </span>
-          </div>
-        </StyledListboxOptions>
-      </div>
-    </Listbox>
+          </StyledListboxButton>
+          <StyledListboxOptions showAbove={showAbove} className="z-50">
+            <div className={`max-h-[${MAX_HEIGHT_PX}px]`}>
+              {sortedOptions.map((option, idx) => (
+                <ModelOption
+                  option={option}
+                  idx={idx}
+                  key={idx}
+                  showDelete={options.length > 1}
+                  showMissingApiKeyMsg={option.apiKey === ""}
+                />
+              ))}
+            </div>
+
+            <div className="mt-auto">
+              {selectedProfileId === "local" && (
+                <>
+                  {options.length > 0 && <Divider className="!my-0" />}
+
+                  <StyledListboxOption
+                    key={options.length}
+                    onClick={onClickAddModel}
+                    value={"addModel" as any}
+                  >
+                    <div className="flex items-center py-0.5">
+                      <PlusIcon className="w-4 h-4 mr-2" />
+                      Add Chat model
+                    </div>
+                  </StyledListboxOption>
+                </>
+              )}
+
+              <Divider className="!my-0" />
+
+              <span className="block px-3 py-3" style={{ color: lightGray }}>
+                <code>{getMetaKeyLabel()} + '</code> to toggle
+              </span>
+            </div>
+          </StyledListboxOptions>
+        </div>
+      </Listbox>
+    </div>
   );
 }
 

--- a/gui/tailwind.config.cjs
+++ b/gui/tailwind.config.cjs
@@ -9,8 +9,13 @@ module.exports = {
   ],
   theme: {
     screens: {
-      xs: "425px",
-      ...defaultTheme.screens,
+      xxs: "170px", // Smallest width for Primary Sidebar in VS Code
+      xs: "250px", // Default sidebar width in VS Code
+      sm: "320px",
+      md: "480px",
+      lg: "640px", // Tailwind's default 'sm'
+      xl: "768px", // Tailwind's default 'md'
+      "2xl": "1024px", // Tailwind's default 'lg'
     },
     extend: {
       animation: {


### PR DESCRIPTION
## Description

Remaps the tailwind breakpoints to better suit the smaller/more granular widths of an IDE extension. Updates the onboarding card and input to better utilize these new breakpoints.

## Checklist

- [ ] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created

## Screenshots
![new-breakpoints](https://github.com/user-attachments/assets/b7a4b2de-19a3-4410-8e71-2547db362cd3)

## Testing

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change. ]
