### PR TITLE
feat: Add "numHistory" parameter to completionOptions

### DIFF
--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -729,6 +729,7 @@ declare global {
     keepAlive?: number;
     raw?: boolean;
     stream?: boolean;
+    numHistory?: number;
   }
 
   export interface ModelCapability {

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -769,6 +769,7 @@ interface BaseCompletionOptions {
   keepAlive?: number;
   raw?: boolean;
   stream?: boolean;
+  numHistory?: number;
 }
 
 export interface ModelCapability {

--- a/core/llm/countTokens.ts
+++ b/core/llm/countTokens.ts
@@ -330,6 +330,7 @@ function compileChatMessages(
   prompt: string | undefined = undefined,
   functions: any[] | undefined = undefined,
   systemMessage: string | undefined = undefined,
+  numHistory: number | undefined = undefined,
 ): ChatMessage[] {
   const msgsCopy = msgs
     ? msgs
@@ -392,9 +393,12 @@ function compileChatMessages(
     }
   }
 
+  const recentMsgs =
+    numHistory && numHistory > 0 ? msgsCopy.slice(-numHistory) : msgsCopy;
+
   const history = pruneChatHistory(
     modelName,
-    msgsCopy,
+    recentMsgs,
     contextLength,
     functionTokens + maxTokens + TOKEN_BUFFER_FOR_SAFETY,
   );

--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -235,6 +235,7 @@ export abstract class BaseLLM implements ILLM {
       undefined,
       functions,
       this.systemMessage,
+      options.numHistory,
     );
   }
 

--- a/docs/static/schemas/config.json
+++ b/docs/static/schemas/config.json
@@ -65,6 +65,11 @@
           "title": "Ollama keep_alive",
           "description": "The number of seconds after no requests are made to unload the model from memory. Defaults to 60*30 = 30min",
           "type": "integer"
+        },
+        "numHistory": {
+          "title": "Number of conversation history",
+          "description": "The number of previous conversations to include in the current context. Adjusting this parameter helps manage the amount of retained conversational context to either provide more relevant responses or to reduce memory usage.",
+          "type": "integer"
         }
       }
     },
@@ -310,7 +315,8 @@
             "presencePenalty": null,
             "frequencyPenalty": null,
             "stop": null,
-            "maxTokens": 600
+            "maxTokens": 600,
+            "numHistory": null
           },
           "allOf": [
             {
@@ -2007,7 +2013,8 @@
             "presencePenalty": null,
             "frequencyPenalty": null,
             "stop": null,
-            "maxTokens": 600
+            "maxTokens": 600,
+            "numHistory": null
           },
           "allOf": [
             {

--- a/extensions/intellij/src/main/resources/config_schema.json
+++ b/extensions/intellij/src/main/resources/config_schema.json
@@ -65,6 +65,11 @@
           "title": "Ollama keep_alive",
           "description": "The number of seconds after no requests are made to unload the model from memory. Defaults to 60*30 = 30min",
           "type": "integer"
+        },
+        "numHistory": {
+          "title": "Number of conversation history",
+          "description": "The number of previous conversations to include in the current context. Adjusting this parameter helps manage the amount of retained conversational context to either provide more relevant responses or to reduce memory usage.",
+          "type": "integer"
         }
       }
     },
@@ -310,7 +315,8 @@
             "presencePenalty": null,
             "frequencyPenalty": null,
             "stop": null,
-            "maxTokens": 600
+            "maxTokens": 600,
+            "numHistory": null
           },
           "allOf": [
             {
@@ -2008,7 +2014,8 @@
             "presencePenalty": null,
             "frequencyPenalty": null,
             "stop": null,
-            "maxTokens": 600
+            "maxTokens": 600,
+            "numHistory": null
           },
           "allOf": [
             {

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -65,6 +65,11 @@
           "title": "Ollama keep_alive",
           "description": "The number of seconds after no requests are made to unload the model from memory. Defaults to 60*30 = 30min",
           "type": "integer"
+        },
+        "numHistory": {
+          "title": "Number of conversation history",
+          "description": "The number of previous conversations to include in the current context. Adjusting this parameter helps manage the amount of retained conversational context to either provide more relevant responses or to reduce memory usage.",
+          "type": "integer"
         }
       }
     },
@@ -310,7 +315,8 @@
             "presencePenalty": null,
             "frequencyPenalty": null,
             "stop": null,
-            "maxTokens": 600
+            "maxTokens": 600,
+            "numHistory": null
           },
           "allOf": [
             {
@@ -2008,7 +2014,8 @@
             "presencePenalty": null,
             "frequencyPenalty": null,
             "stop": null,
-            "maxTokens": 600
+            "maxTokens": 600,
+            "numHistory": null
           },
           "allOf": [
             {

--- a/extensions/vscode/continue_rc_schema.json
+++ b/extensions/vscode/continue_rc_schema.json
@@ -65,6 +65,11 @@
           "title": "Ollama keep_alive",
           "description": "The number of seconds after no requests are made to unload the model from memory. Defaults to 60*30 = 30min",
           "type": "integer"
+        },
+        "numHistory": {
+          "title": "Number of conversation history",
+          "description": "The number of previous conversations to include in the current context. Adjusting this parameter helps manage the amount of retained conversational context to either provide more relevant responses or to reduce memory usage.",
+          "type": "integer"
         }
       }
     },
@@ -313,7 +318,8 @@
             "presencePenalty": null,
             "frequencyPenalty": null,
             "stop": null,
-            "maxTokens": 600
+            "maxTokens": 600,
+            "numHistory": null
           },
           "allOf": [
             {
@@ -2249,7 +2255,8 @@
             "presencePenalty": null,
             "frequencyPenalty": null,
             "stop": null,
-            "maxTokens": 600
+            "maxTokens": 600,
+            "numHistory": null
           },
           "allOf": [
             {


### PR DESCRIPTION
## Description

This pull request introduces a new parameter, numHistory, in the completionOptions. The purpose of this parameter is to specify the number of recent messages to include in the input context when generating completions.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Testing

1.Add the following configuration in config.json:
`{
  "completionOptions": { "numHistory": 3 }
}`
2.During interactions, the llm's input context consists of only the most recent 3 messages, as specified by the numHistory parameter.