### PR TITLE
fix: add missing eos_token for Qwen2.5 Coder

### DIFF
--- a/core/autocomplete/templates.ts
+++ b/core/autocomplete/templates.ts
@@ -30,6 +30,7 @@ const stableCodeFimTemplate: AutocompleteTemplate = {
   template: "<fim_prefix>{{{prefix}}}<fim_suffix>{{{suffix}}}<fim_middle>",
   completionOptions: {
     stop: [
+      "<|endoftext|>",
       "<fim_prefix>",
       "<fim_suffix>",
       "<fim_middle>",


### PR DESCRIPTION
## Description

Added the missing eos_token `<|endoftext|>` for Qwen2.5 Coder. This oversight was brought to our attention through an issue comment and confirmed via the Hugging Face tokenizer_config.json file. 
(https://huggingface.co/Qwen/Qwen2.5-Coder-7B/blob/main/tokenizer_config.json)

This fix addresses the problem with string/comment creation attempts and should resolve the unexpected behavior in text generation.

closes #2330

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created

## Screenshots

[ No visual changes. ]

## Testing

1. Load the Qwen2.5-Coder-7b model.
2. Attempt to create strings or comments.
3. Verify that the `<|endoftext|>` token is properly recognized as an end-of-sequence marker.
  - <img width="943" alt="image" src="https://github.com/user-attachments/assets/0111185d-6007-4db8-ae47-a14aabe599d3">
  