### PR TITLE
Cache turn-by-turn conversation in Anthropic Claude

### DIFF
--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -343,6 +343,7 @@ declare global {
     watsonxApiVersion?: string;
 
     cacheSystemMessage?: boolean;
+    cacheConversation?: boolean;
   }
   type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<
     T,

--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -47,6 +47,7 @@ declare global {
     llmRequestHook?: (model: string, prompt: string) => any;
     apiKey?: string;
     apiBase?: string;
+    cacheBehavior?: CacheBehavior;
 
     engine?: string;
     apiVersion?: string;
@@ -313,6 +314,7 @@ declare global {
     apiKey?: string;
     aiGatewaySlug?: string;
     apiBase?: string;
+    cacheBehavior?: CacheBehavior;
 
     useLegacyCompletionsEndpoint?: boolean;
 
@@ -341,9 +343,6 @@ declare global {
     watsonxProjectId?: string;
     watsonxStopToken?: string;
     watsonxApiVersion?: string;
-
-    cacheSystemMessage?: boolean;
-    cacheConversation?: boolean;
   }
   type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<
     T,
@@ -688,6 +687,11 @@ declare global {
     clientCertificate?: ClientCertificateOptions;
   }
 
+  export interface CacheBehavior {
+    cacheSystemMessage?: boolean;
+    cacheConversation?: boolean;
+  }
+
   export interface ClientCertificateOptions {
     cert: string;
     key: string;
@@ -750,6 +754,7 @@ declare global {
     requestOptions?: RequestOptions;
     promptTemplates?: { [key: string]: string };
     capabilities?: ModelCapability;
+    cacheBehavior?: CacheBehavior;
   }
 
   export type EmbeddingsProviderName =

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -70,6 +70,7 @@ export interface ILLM extends LLMOptions {
   llmRequestHook?: (model: string, prompt: string) => any;
   apiKey?: string;
   apiBase?: string;
+  cacheBehavior?: CacheBehavior;
 
   engine?: string;
   apiVersion?: string;
@@ -340,6 +341,7 @@ export interface LLMOptions {
   apiKey?: string;
   aiGatewaySlug?: string;
   apiBase?: string;
+  cacheBehavior?: CacheBehavior;
 
   useLegacyCompletionsEndpoint?: boolean;
 
@@ -369,9 +371,6 @@ export interface LLMOptions {
   watsonxStopToken?: string;
   watsonxApiVersion?: string;
   watsonxFullUrl?: string;
-
-  cacheSystemMessage?: boolean;
-  cacheConversation?: boolean;
 }
 type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<
   T,
@@ -728,6 +727,11 @@ export interface RequestOptions {
   clientCertificate?: ClientCertificateOptions;
 }
 
+export interface CacheBehavior {
+  cacheSystemMessage?: boolean;
+  cacheConversation?: boolean;
+}
+
 export interface ClientCertificateOptions {
   cert: string;
   key: string;
@@ -790,6 +794,7 @@ export interface ModelDescription {
   requestOptions?: RequestOptions;
   promptTemplates?: { [key: string]: string };
   capabilities?: ModelCapability;
+  cacheBehavior?: CacheBehavior;
 }
 
 export type EmbeddingsProviderName =

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -371,6 +371,7 @@ export interface LLMOptions {
   watsonxFullUrl?: string;
 
   cacheSystemMessage?: boolean;
+  cacheConversation?: boolean;
 }
 type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<
   T,

--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -121,6 +121,7 @@ export abstract class BaseLLM implements ILLM {
   watsonxFullUrl?: string;
 
   cacheSystemMessage?: boolean;
+  cacheConversation?: boolean;
 
   private _llmOptions: LLMOptions;
 
@@ -194,6 +195,7 @@ export abstract class BaseLLM implements ILLM {
     this.watsonxFullUrl = options.watsonxFullUrl;
 
     this.cacheSystemMessage = options.cacheSystemMessage;
+    this.cacheConversation = options.cacheConversation;
 
     if (this.apiBase && !this.apiBase.endsWith("/")) {
       this.apiBase = `${this.apiBase}/`;

--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -14,6 +14,7 @@ import {
   PromptTemplate,
   RequestOptions,
   TemplateType,
+  CacheBehavior
 } from "../index.js";
 import { logDevData } from "../util/devdata.js";
 import { DevDataSqliteDb } from "../util/devdataSqlite.js";
@@ -102,6 +103,7 @@ export abstract class BaseLLM implements ILLM {
   llmRequestHook?: (model: string, prompt: string) => any;
   apiKey?: string;
   apiBase?: string;
+  cacheBehavior?: CacheBehavior;
   capabilities?: ModelCapability;
 
   engine?: string;
@@ -119,9 +121,6 @@ export abstract class BaseLLM implements ILLM {
   watsonxStopToken?: string;
   watsonxApiVersion?: string;
   watsonxFullUrl?: string;
-
-  cacheSystemMessage?: boolean;
-  cacheConversation?: boolean;
 
   private _llmOptions: LLMOptions;
 
@@ -185,6 +184,7 @@ export abstract class BaseLLM implements ILLM {
     this.apiKey = options.apiKey;
     this.aiGatewaySlug = options.aiGatewaySlug;
     this.apiBase = options.apiBase;
+    this.cacheBehavior = options.cacheBehavior;
 
     // for watsonx only
     this.watsonxUrl = options.watsonxUrl;
@@ -193,9 +193,6 @@ export abstract class BaseLLM implements ILLM {
     this.watsonxStopToken = options.watsonxStopToken;
     this.watsonxApiVersion = options.watsonxApiVersion;
     this.watsonxFullUrl = options.watsonxFullUrl;
-
-    this.cacheSystemMessage = options.cacheSystemMessage;
-    this.cacheConversation = options.cacheConversation;
 
     if (this.apiBase && !this.apiBase.endsWith("/")) {
       this.apiBase = `${this.apiBase}/`;

--- a/core/llm/llms/Anthropic.ts
+++ b/core/llm/llms/Anthropic.ts
@@ -45,7 +45,7 @@ class Anthropic extends BaseLLM {
         // The second-to-last because it retrieves potentially already cached contents,
         // The last one because we want it cached for later retrieval.
         // See: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
-        const addCaching = lastTwoUserMsgIndices.includes(filteredMsgIdx);
+        const addCaching = !!this.cacheConversation && lastTwoUserMsgIndices.includes(filteredMsgIdx);
 
         if (typeof message.content === "string") {
           var chatMessage = {
@@ -126,7 +126,7 @@ class Anthropic extends BaseLLM {
         Accept: "application/json",
         "anthropic-version": "2023-06-01",
         "x-api-key": this.apiKey as string,
-        ...(shouldCacheSystemMessage
+        ...(shouldCacheSystemMessage || !!this.cacheConversation
           ? { "anthropic-beta": "prompt-caching-2024-07-31" }
           : {}),
       },

--- a/core/llm/llms/Anthropic.ts
+++ b/core/llm/llms/Anthropic.ts
@@ -45,7 +45,7 @@ class Anthropic extends BaseLLM {
         // The second-to-last because it retrieves potentially already cached contents,
         // The last one because we want it cached for later retrieval.
         // See: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
-        const addCaching = !!this.cacheConversation && lastTwoUserMsgIndices.includes(filteredMsgIdx);
+        const addCaching = this.cacheBehavior?.cacheConversation && lastTwoUserMsgIndices.includes(filteredMsgIdx);
 
         if (typeof message.content === "string") {
           var chatMessage = {
@@ -98,7 +98,7 @@ class Anthropic extends BaseLLM {
     messages: ChatMessage[],
     options: CompletionOptions,
   ): AsyncGenerator<ChatMessage> {
-    const shouldCacheSystemMessage = !!this.systemMessage && !!this.cacheSystemMessage;
+    const shouldCacheSystemMessage = !!this.systemMessage && this.cacheBehavior?.cacheSystemMessage;
     const systemMessage: string = stripImages(
       messages.filter((m) => m.role === "system")[0]?.content,
     );
@@ -110,7 +110,7 @@ class Anthropic extends BaseLLM {
         Accept: "application/json",
         "anthropic-version": "2023-06-01",
         "x-api-key": this.apiKey as string,
-        ...(shouldCacheSystemMessage || !!this.cacheConversation
+        ...(shouldCacheSystemMessage || this.cacheBehavior?.cacheConversation
           ? { "anthropic-beta": "prompt-caching-2024-07-31" }
           : {}),
       },
@@ -136,7 +136,7 @@ class Anthropic extends BaseLLM {
     }
 
     for await (const value of streamSse(response)) {
-      // if (value.type == "message_start") console.log(value);
+      if (value.type == "message_start") console.log(value);
       if (value.delta?.text) {
         yield { role: "assistant", content: value.delta.text };
       }

--- a/core/llm/llms/Anthropic.ts
+++ b/core/llm/llms/Anthropic.ts
@@ -98,23 +98,7 @@ class Anthropic extends BaseLLM {
     messages: ChatMessage[],
     options: CompletionOptions,
   ): AsyncGenerator<ChatMessage> {
-    const shouldCacheSystemMessage =
-      !!this.cacheSystemMessage;
-
-    const body = JSON.stringify({
-      ...this._convertArgs(options),
-      messages: this._convertMessages(messages),
-      system: shouldCacheSystemMessage
-        ? [
-            {
-              type: "text",
-              text: this.systemMessage,
-              cache_control: { type: "ephemeral" },
-            },
-          ]
-        : this.systemMessage,
-    });
-
+    const shouldCacheSystemMessage = !!this.systemMessage && !!this.cacheSystemMessage;
     const systemMessage: string = stripImages(
       messages.filter((m) => m.role === "system")[0]?.content,
     );

--- a/docs/docs/customize/model-providers/top-level/anthropic.md
+++ b/docs/docs/customize/model-providers/top-level/anthropic.md
@@ -48,16 +48,17 @@ Anthropic currently does not offer any reranking models.
 
 Anthropic supports [prompt caching with Claude](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching).
 
-To enable caching of the system message, update your your model configuration with `"cacheSystemMessage": true`:
-To enable caching of the conversation, update your your model configuration with `"cacheConversation": true`:
+To enable caching of the system message and the turn-by-turn conversation, update your your model configuration as following:
 
 ```json
 {
   "models": [
     {
       // Enable prompt caching
-      "cacheSystemMessage": true,
-      "cacheConversation": true,
+      "cacheBehavior": {
+        "cacheSystemMessage": true,
+        "cacheConversation": true
+      },
       "title": "Anthropic",
       "provider": "anthropic",
       "model": "claude-3-5-sonnet-20240620",

--- a/docs/docs/customize/model-providers/top-level/anthropic.md
+++ b/docs/docs/customize/model-providers/top-level/anthropic.md
@@ -48,7 +48,8 @@ Anthropic currently does not offer any reranking models.
 
 Anthropic supports [prompt caching with Claude](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching).
 
-Currently, we only allow caching of the system message. To enable this feature, update your your model configuration with `"cacheSystemMessage": true`:
+To enable caching of the system message, update your your model configuration with `"cacheSystemMessage": true`:
+To enable caching of the conversation, update your your model configuration with `"cacheConversation": true`:
 
 ```json
 {
@@ -56,6 +57,7 @@ Currently, we only allow caching of the system message. To enable this feature, 
     {
       // Enable prompt caching
       "cacheSystemMessage": true,
+      "cacheConversation": true,
       "title": "Anthropic",
       "provider": "anthropic",
       "model": "claude-3-5-sonnet-20240620",

--- a/docs/static/schemas/config.json
+++ b/docs/static/schemas/config.json
@@ -704,6 +704,9 @@
               "cacheSystemMessage": {
                 "type": "boolean"
               },
+              "cacheConversation": {
+                "type": "boolean"
+              },
               "model": {
                 "anyOf": [
                   {
@@ -799,6 +802,9 @@
           "then": {
             "properties": {
               "cacheSystemMessage": {
+                "type": "boolean"
+              },
+              "cacheConversation": {
                 "type": "boolean"
               },
               "model": {
@@ -1020,6 +1026,9 @@
           "then": {
             "properties": {
               "cacheSystemMessage": {
+                "type": "boolean"
+              },
+              "cacheConversation": {
                 "type": "boolean"
               },
               "model": {

--- a/docs/static/schemas/config.json
+++ b/docs/static/schemas/config.json
@@ -701,11 +701,17 @@
           },
           "then": {
             "properties": {
-              "cacheSystemMessage": {
-                "type": "boolean"
-              },
-              "cacheConversation": {
-                "type": "boolean"
+              "cacheBehavior": {
+                "title": "Caching Behavior",
+                "description": "Options for the prompt caching",
+                "properties": {
+                  "cacheSystemMessage": {
+                    "type": "boolean"
+                  },
+                  "cacheConversation": {
+                    "type": "boolean"
+                  }
+                }
               },
               "model": {
                 "anyOf": [
@@ -801,11 +807,14 @@
           },
           "then": {
             "properties": {
-              "cacheSystemMessage": {
-                "type": "boolean"
-              },
-              "cacheConversation": {
-                "type": "boolean"
+              "cacheBehavior": {
+                "title": "Caching Behavior",
+                "description": "Options for the prompt caching",
+                "properties": {
+                  "cacheSystemMessage": {
+                    "type": "boolean"
+                  }
+                }
               },
               "model": {
                 "enum": [
@@ -1025,11 +1034,17 @@
           },
           "then": {
             "properties": {
-              "cacheSystemMessage": {
-                "type": "boolean"
-              },
-              "cacheConversation": {
-                "type": "boolean"
+              "cacheBehavior": {
+                "title": "Caching Behavior",
+                "description": "Options for the prompt caching",
+                "properties": {
+                  "cacheSystemMessage": {
+                    "type": "boolean"
+                  },
+                  "cacheConversation": {
+                    "type": "boolean"
+                  }
+                }
               },
               "model": {
                 "enum": ["deepseek-chat", "deepseek-coder"]
@@ -1053,6 +1068,7 @@
                   "llama2-70b",
                   "mistral-8x7b",
                   "gemma",
+                  "gemma2",
                   "llama3-8b",
                   "llama3-70b",
                   "llama3.1-8b",
@@ -2121,6 +2137,13 @@
               "description": "The maximum number of tokens that each chunk of a document is allowed to have",
               "type": "integer",
               "minimum": 128,
+              "exclusiveMaximum": 2147483647
+            },
+            "maxBatchSize": {
+              "title": "Maximum Batch Size",
+              "description": "The maximum number of chunks that can be sent to the embeddings provider in a single request",
+              "type": "integer",
+              "minimum": 1,
               "exclusiveMaximum": 2147483647
             },
             "region": {

--- a/extensions/intellij/src/main/resources/config_schema.json
+++ b/extensions/intellij/src/main/resources/config_schema.json
@@ -704,6 +704,9 @@
               "cacheSystemMessage": {
                 "type": "boolean"
               },
+              "cacheConversation": {
+                "type": "boolean"
+              },
               "model": {
                 "anyOf": [
                   {
@@ -799,6 +802,9 @@
           "then": {
             "properties": {
               "cacheSystemMessage": {
+                "type": "boolean"
+              },
+              "cacheConversation": {
                 "type": "boolean"
               },
               "model": {
@@ -1020,6 +1026,9 @@
           "then": {
             "properties": {
               "cacheSystemMessage": {
+                "type": "boolean"
+              },
+              "cacheConversation": {
                 "type": "boolean"
               },
               "model": {

--- a/extensions/intellij/src/main/resources/config_schema.json
+++ b/extensions/intellij/src/main/resources/config_schema.json
@@ -701,11 +701,17 @@
           },
           "then": {
             "properties": {
-              "cacheSystemMessage": {
-                "type": "boolean"
-              },
-              "cacheConversation": {
-                "type": "boolean"
+              "cacheBehavior": {
+                "title": "Caching Behavior",
+                "description": "Options for the prompt caching",
+                "properties": {
+                  "cacheSystemMessage": {
+                    "type": "boolean"
+                  },
+                  "cacheConversation": {
+                    "type": "boolean"
+                  }
+                }
               },
               "model": {
                 "anyOf": [
@@ -801,11 +807,14 @@
           },
           "then": {
             "properties": {
-              "cacheSystemMessage": {
-                "type": "boolean"
-              },
-              "cacheConversation": {
-                "type": "boolean"
+              "cacheBehavior": {
+                "title": "Caching Behavior",
+                "description": "Options for the prompt caching",
+                "properties": {
+                  "cacheSystemMessage": {
+                    "type": "boolean"
+                  }
+                }
               },
               "model": {
                 "enum": [
@@ -1025,11 +1034,17 @@
           },
           "then": {
             "properties": {
-              "cacheSystemMessage": {
-                "type": "boolean"
-              },
-              "cacheConversation": {
-                "type": "boolean"
+              "cacheBehavior": {
+                "title": "Caching Behavior",
+                "description": "Options for the prompt caching",
+                "properties": {
+                  "cacheSystemMessage": {
+                    "type": "boolean"
+                  },
+                  "cacheConversation": {
+                    "type": "boolean"
+                  }
+                }
               },
               "model": {
                 "enum": ["deepseek-chat", "deepseek-coder"]
@@ -2122,6 +2137,13 @@
               "description": "The maximum number of tokens that each chunk of a document is allowed to have",
               "type": "integer",
               "minimum": 128,
+              "exclusiveMaximum": 2147483647
+            },
+            "maxBatchSize": {
+              "title": "Maximum Batch Size",
+              "description": "The maximum number of chunks that can be sent to the embeddings provider in a single request",
+              "type": "integer",
+              "minimum": 1,
               "exclusiveMaximum": 2147483647
             },
             "region": {

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -704,6 +704,9 @@
               "cacheSystemMessage": {
                 "type": "boolean"
               },
+              "cacheConversation": {
+                "type": "boolean"
+              },
               "model": {
                 "anyOf": [
                   {
@@ -799,6 +802,9 @@
           "then": {
             "properties": {
               "cacheSystemMessage": {
+                "type": "boolean"
+              },
+              "cacheConversation": {
                 "type": "boolean"
               },
               "model": {
@@ -1020,6 +1026,9 @@
           "then": {
             "properties": {
               "cacheSystemMessage": {
+                "type": "boolean"
+              },
+              "cacheConversation": {
                 "type": "boolean"
               },
               "model": {

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -701,11 +701,17 @@
           },
           "then": {
             "properties": {
-              "cacheSystemMessage": {
-                "type": "boolean"
-              },
-              "cacheConversation": {
-                "type": "boolean"
+              "cacheBehavior": {
+                "title": "Caching Behavior",
+                "description": "Options for the prompt caching",
+                "properties": {
+                  "cacheSystemMessage": {
+                    "type": "boolean"
+                  },
+                  "cacheConversation": {
+                    "type": "boolean"
+                  }
+                }
               },
               "model": {
                 "anyOf": [
@@ -801,11 +807,14 @@
           },
           "then": {
             "properties": {
-              "cacheSystemMessage": {
-                "type": "boolean"
-              },
-              "cacheConversation": {
-                "type": "boolean"
+              "cacheBehavior": {
+                "title": "Caching Behavior",
+                "description": "Options for the prompt caching",
+                "properties": {
+                  "cacheSystemMessage": {
+                    "type": "boolean"
+                  }
+                }
               },
               "model": {
                 "enum": [
@@ -1025,11 +1034,17 @@
           },
           "then": {
             "properties": {
-              "cacheSystemMessage": {
-                "type": "boolean"
-              },
-              "cacheConversation": {
-                "type": "boolean"
+              "cacheBehavior": {
+                "title": "Caching Behavior",
+                "description": "Options for the prompt caching",
+                "properties": {
+                  "cacheSystemMessage": {
+                    "type": "boolean"
+                  },
+                  "cacheConversation": {
+                    "type": "boolean"
+                  }
+                }
               },
               "model": {
                 "enum": ["deepseek-chat", "deepseek-coder"]

--- a/extensions/vscode/continue_rc_schema.json
+++ b/extensions/vscode/continue_rc_schema.json
@@ -761,6 +761,9 @@
               "cacheSystemMessage": {
                 "type": "boolean"
               },
+              "cacheConversation": {
+                "type": "boolean"
+              },
               "model": {
                 "anyOf": [
                   {
@@ -875,6 +878,9 @@
           "then": {
             "properties": {
               "cacheSystemMessage": {
+                "type": "boolean"
+              },
+              "cacheConversation": {
                 "type": "boolean"
               },
               "model": {
@@ -1118,6 +1124,9 @@
           "then": {
             "properties": {
               "cacheSystemMessage": {
+                "type": "boolean"
+              },
+              "cacheConversation": {
                 "type": "boolean"
               },
               "model": {

--- a/extensions/vscode/continue_rc_schema.json
+++ b/extensions/vscode/continue_rc_schema.json
@@ -758,11 +758,17 @@
           },
           "then": {
             "properties": {
-              "cacheSystemMessage": {
-                "type": "boolean"
-              },
-              "cacheConversation": {
-                "type": "boolean"
+              "cacheBehavior": {
+                "title": "Caching Behavior",
+                "description": "Options for the prompt caching",
+                "properties": {
+                  "cacheSystemMessage": {
+                    "type": "boolean"
+                  },
+                  "cacheConversation": {
+                    "type": "boolean"
+                  }
+                }
               },
               "model": {
                 "anyOf": [
@@ -877,11 +883,14 @@
           },
           "then": {
             "properties": {
-              "cacheSystemMessage": {
-                "type": "boolean"
-              },
-              "cacheConversation": {
-                "type": "boolean"
+              "cacheBehavior": {
+                "title": "Caching Behavior",
+                "description": "Options for the prompt caching",
+                "properties": {
+                  "cacheSystemMessage": {
+                    "type": "boolean"
+                  }
+                }
               },
               "model": {
                 "enum": [
@@ -1123,11 +1132,17 @@
           },
           "then": {
             "properties": {
-              "cacheSystemMessage": {
-                "type": "boolean"
-              },
-              "cacheConversation": {
-                "type": "boolean"
+              "cacheBehavior": {
+                "title": "Caching Behavior",
+                "description": "Options for the prompt caching",
+                "properties": {
+                  "cacheSystemMessage": {
+                    "type": "boolean"
+                  },
+                  "cacheConversation": {
+                    "type": "boolean"
+                  }
+                }
               },
               "model": {
                 "enum": [


### PR DESCRIPTION
## Description

This implements turn-by-turn conversation caching for Claude, in addition to the pre-existing system message caching.
See: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
 
Perhaps we should enable this by default?

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Testing
- Add `"cacheConversation": true` to the anthropic config. Like:
```
{
      "title": "Claude 3.5 Sonnet",
      "provider": "anthropic",
      "model": "claude-3-5-sonnet-20240620",
      "apiKey": "<YOUR_API_KEY>",
      "cacheSystemMessage": true,
      "cacheConversation": true
    }
```

- uncomment the following line in Anthropic.ts: `if (value.type == "message_start") console.log(value);`
- Select the claude model, add at least 1000 tokens context
- When running in the debugger, see in the debug console things like:
```
{input_tokens: 4, cache_creation_input_tokens: 1212, cache_read_input_tokens: 0, output_tokens: 2}
```

then the next request:

```
{input_tokens: 4, cache_creation_input_tokens: 224, cache_read_input_tokens: 1212, output_tokens: 1}
```

Hopefully Anthropic will soon put caching statistics in their api console as well.