### PR TITLE
fix: add missing eos_token for Qwen2.5 Coder

### DIFF
--- a/core/autocomplete/templates.ts
+++ b/core/autocomplete/templates.ts
@@ -47,6 +47,7 @@ const qwenCoderFimTemplate: AutocompleteTemplate = {
     "<|fim_prefix|>{{{prefix}}}<|fim_suffix|>{{{suffix}}}<|fim_middle|>",
   completionOptions: {
     stop: [
+      "<|endoftext|>",
       "<|fim_prefix|>",
       "<|fim_middle|>",
       "<|fim_suffix|>",


### PR DESCRIPTION
## Description

Added the missing stop_sequence `<|endoftext|>`(eos_token) for Qwen2.5 Coder. 

Caught the issue thanks to a comment and verified with the Hugging Face tokenizer_config.json file.
(https://huggingface.co/Qwen/Qwen2.5-Coder-7B/blob/main/tokenizer_config.json)

closes #2330

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

[ No visual changes. ]

## Testing

1. Load the Qwen2.5-Coder-7b model.
2. Attempt to create strings or comments.
3. Verify that the `<|endoftext|>` token is properly recognized as an end-of-sequence marker.
  - <img width="943" alt="image" src="https://github.com/user-attachments/assets/0111185d-6007-4db8-ae47-a14aabe599d3">
  