### PR TITLE
Fix `config.ts` not loading in Jetbrains Editors

### DIFF
--- a/core/config/load.ts
+++ b/core/config/load.ts
@@ -595,7 +595,20 @@ async function loadFullConfigNode(
     try {
       // Try config.ts first
       const configJsPath = getConfigJsPath();
-      const module = await import(configJsPath);
+      let module: any;
+
+      try {
+        module = await import(configJsPath);
+      } catch (e) {
+        console.log(e)
+        console.log("Could not load config.ts as absolute path, retrying as file url ...");
+        try {
+          module = await import(`file://${configJsPath}`);
+        } catch (e) {
+          throw new Error("Could not load config.ts as file url either", { cause: e });
+        }
+      }
+      
       if (typeof require !== "undefined") {
         delete require.cache[require.resolve(configJsPath)];
       }


### PR DESCRIPTION
## Description

Fallback to a `file://` url on windows if we failed to import the `config.ts`. 

This fixes the following error when using Continue with jetbrains editors: 
```
[info] Starting Continue core...
[2024-09-27T09:30:19] [info] Starting Continue core... 
[2024-09-27T09:30:19] Setup 
[2024-09-27T09:30:19] Core started 
[2024-09-27T09:30:20] Error loading config.ts:  Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
[2024-09-27T09:30:21] Indexing: 0.0% complete, elapsed time: 0s, NaN file/sec 
```

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created