### PR TITLE
Updated Running Doc Server section in CONTRIBUTE.md, fix for npm start in windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,12 +68,18 @@ You can run the documentation server locally using either of the following metho
 
 #### Method 1: NPM Script
 
-1. Open your terminal and navigate to the root directory of the project.
+1. Open your terminal and navigate to the `docs` subdirectory of the project.  The `docusaurus.config.js` file you'll see there is a sign you're in the right place.
 
-2. Run the following command to start the documentation server:
+2. Run the following command to install the necessary dependencies for the documentation server:
 
    ```bash
-   npm run start --prefix docs
+   npm install
+   ```
+
+3. Run the following command to start the documentation server:
+
+   ```bash
+   npm run start
    ```
 
 #### Method 2: VS Code Task

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "nodemon --watch sidebars.js --watch docusaurus.config.js --exec 'docusaurus start'",
+    "start": "nodemon --watch sidebars.js --watch docusaurus.config.js --exec \"docusaurus start\"",
     "build": "docusaurus build",
     "build:netlify": "docusaurus build --out-dir build/docs",
     "swizzle": "docusaurus swizzle",


### PR DESCRIPTION
## Description

### CONTRIBUTING.md
- _changed 'navigate to project root directory' to 'navigate to docs subdirectory'_

It seems like the process has changed, since you can't run npm from the root directory, there's no package.json there.  So I updated the instructions to start from the 'doc' subdir.

- _Added 'npm install' to instructions_

This is required for new installs, right?

### package.json 
- _Changed npm start script to use double quotes for Windows compatibility_
 
'nodemon' has some limitations using --exec on windows.  Double quotes are required for Windows users.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Testing

- Viewed CONTRIBUTING doc in browser on my fork.
- Tested 'npm run start' in Windows 11 and MacOS Sonoma environments.

Follow the instructions in the updated doc to test:

1. Open your terminal and navigate to the `docs` subdirectory of the project.  The `docusaurus.config.js` file you'll see there is a sign you're in the right place.

2. Run the following command to install the necessary dependencies for the documentation server:

   ```bash
   npm install
   ```

3. Run the following command to start the documentation server:

   ```bash
   npm run start
   ```