### PR TITLE
Support remote access toolwindow

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -15,6 +15,8 @@ declare global {
     };
     colorThemeName?: string;
     workspacePaths?: string[];
+    project:string,
+    embeddedSocketInfo?: IEmbeddedSocketManager;
     postIntellijMessage?: (
       messageType: string,
       data: any,
@@ -22,7 +24,17 @@ declare global {
     ) => void;
   }
 }
-
+export interface IEmbeddedSocketManager {
+  socket: WebSocket,
+  authed: boolean;
+  isConnected: boolean;
+  error?: Error;
+  internal?: {
+    timeout?: NodeJS.Timeout;
+  };
+  project:string?,
+  serverToken:string
+}
 export interface ChunkWithoutID {
   content: string;
   startLine: number;

--- a/extensions/intellij/build.gradle.kts
+++ b/extensions/intellij/build.gradle.kts
@@ -38,6 +38,15 @@ dependencies {
     implementation("io.ktor:ktor-server-cors:2.3.7"){
         exclude(group = "org.slf4j", module = "slf4j-api")
     }
+    implementation("io.ktor:ktor-server-websockets:2.3.7"){
+        exclude(group = "org.slf4j", module = "slf4j-api")
+    }
+    implementation("io.ktor:ktor-server-webjars:2.3.7"){
+        exclude(group = "org.slf4j", module = "slf4j-api")
+    }
+//    implementation("io.ktor:ktor-server-auth:2.3.7"){
+//        exclude(group = "org.slf4j", module = "slf4j-api")
+//    }
     implementation("com.posthog.java:posthog:1.+")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0")
 //    implementation("com.jetbrains.jsonSchema")

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
@@ -149,7 +149,7 @@ fun getMachineUniqueID(): String {
     return "No MAC Address Found"
 }
 
-private fun readConfigJson(): Map<String, Any> {
+fun readConfigJson(): Map<String, Any> {
     val gson = GsonBuilder().setPrettyPrinting().create()
     val configJsonPath = getConfigJsonPath()
     val reader = FileReader(configJsonPath)

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinueBrowser.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinueBrowser.kt
@@ -6,21 +6,45 @@ import com.github.continuedev.continueintellijextension.`continue`.*
 import com.github.continuedev.continueintellijextension.factories.CustomSchemeHandlerFactory
 import com.github.continuedev.continueintellijextension.services.ContinuePluginService
 import com.google.gson.Gson
+import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
-import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.intellij.ui.jcef.*
-import kotlinx.coroutines.*
+import io.ktor.http.*
+import io.ktor.http.content.*
+import io.ktor.server.application.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import io.ktor.server.plugins.cors.routing.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.webjars.*
+import io.ktor.server.websocket.*
+import io.ktor.util.cio.*
+import io.ktor.util.date.*
+import io.ktor.utils.io.*
+import io.ktor.utils.io.jvm.javaio.*
+import io.ktor.websocket.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import org.cef.CefApp
 import org.cef.browser.CefBrowser
 import org.cef.handler.CefLoadHandlerAdapter
+import org.webjars.MultipleMatchesException
+import java.io.InputStream
+import java.time.Duration
+import java.util.*
 
-class ContinueBrowser(val project: Project, url: String, useOsr: Boolean = false) {
+class ContinueBrowser(val project: Project, url: String, useOsr: Boolean = false,
+                      splitMode: Boolean = false, staticResHost: String) {
     private val coroutineScope = CoroutineScope(
-        SupervisorJob() + Dispatchers.Default
+            SupervisorJob() + Dispatchers.Default
     )
     private val heightChangeListeners = mutableListOf<(Int) -> Unit>()
     fun onHeightChange(listener: (Int) -> Unit) {
@@ -28,43 +52,43 @@ class ContinueBrowser(val project: Project, url: String, useOsr: Boolean = false
     }
 
     private val PASS_THROUGH_TO_CORE = listOf(
-        "update/modelChange",
-        "ping",
-        "abort",
-        "history/list",
-        "history/delete",
-        "history/load",
-        "history/save",
-        "devdata/log",
-        "config/addOpenAiKey",
-        "config/addModel",
-        "config/ideSettingsUpdate",
-        "config/getSerializedProfileInfo",
-        "config/deleteModel",
-        "config/newPromptFile",
-        "config/reload",
-        "context/getContextItems",
-        "context/loadSubmenuItems",
-        "context/addDocs",
-        "autocomplete/complete",
-        "autocomplete/cancel",
-        "autocomplete/accept",
-        "command/run",
-        "llm/complete",
-        "llm/streamComplete",
-        "llm/streamChat",
-        "llm/listModels",
-        "streamDiffLines",
-        "stats/getTokensPerDay",
-        "stats/getTokensPerModel",
-        "index/setPaused",
-        "index/forceReIndex",
-        "index/indexingProgressBarInitialized",
-        "completeOnboarding",
-        "addAutocompleteModel",
-        "config/listProfiles",
-        "profiles/switch",
-        "didChangeSelectedProfile",
+            "update/modelChange",
+            "ping",
+            "abort",
+            "history/list",
+            "history/delete",
+            "history/load",
+            "history/save",
+            "devdata/log",
+            "config/addOpenAiKey",
+            "config/addModel",
+            "config/ideSettingsUpdate",
+            "config/getSerializedProfileInfo",
+            "config/deleteModel",
+            "config/newPromptFile",
+            "config/reload",
+            "context/getContextItems",
+            "context/loadSubmenuItems",
+            "context/addDocs",
+            "autocomplete/complete",
+            "autocomplete/cancel",
+            "autocomplete/accept",
+            "command/run",
+            "llm/complete",
+            "llm/streamComplete",
+            "llm/streamChat",
+            "llm/listModels",
+            "streamDiffLines",
+            "stats/getTokensPerDay",
+            "stats/getTokensPerModel",
+            "index/setPaused",
+            "index/forceReIndex",
+            "index/indexingProgressBarInitialized",
+            "completeOnboarding",
+            "addAutocompleteModel",
+            "config/listProfiles",
+            "profiles/switch",
+            "didChangeSelectedProfile",
     )
 
     private fun registerAppSchemeHandler() {
@@ -75,157 +99,314 @@ class ContinueBrowser(val project: Project, url: String, useOsr: Boolean = false
         )
     }
 
-    val browser: JBCefBrowser
+    val splitMode: Boolean
+    val staticResHost: String
+    var browser: JBCefBrowser? = null
+    val activeSessions = Collections.synchronizedSet<DefaultWebSocketSession?>(LinkedHashSet())
+
     init {
-        val osName = System.getProperty("os.name").toLowerCase()
-        val os = when {
-            osName.contains("mac") || osName.contains("darwin") -> "darwin"
-            osName.contains("win") -> "win32"
-            osName.contains("nix") || osName.contains("nux") || osName.contains("aix") -> "linux"
-            else -> "linux"
+        println("init Continue Browser splitMode:$splitMode")
+        this.splitMode = splitMode
+        this.staticResHost = staticResHost
+        // Listen for events sent from browser
+        if (splitMode) {
+            // Ensure the server is started
+            embeddedServer
+            // Dynamically add WebSocket route for this project
+            addProjectWebSocket(project, defaultWebsocketHandler(project))
+            Disposer.register(project) { removeProjectWebSocket(project) }
+        } else {
+            this.browser = JBCefBrowser.createBuilder().setOffScreenRendering(useOsr).build()
+            browser?.jbCefClient?.setProperty(
+                    JBCefClient.Properties.JS_QUERY_POOL_SIZE,
+                    JS_QUERY_POOL_SIZE
+            )
+            registerAppSchemeHandler()
+            browser?.loadURL(url);
+            Disposer.register(project, browser!!)
+            val myJSQueryOpenInBrowser = JBCefJSQuery.create((browser as JBCefBrowserBase?)!!)
+            myJSQueryOpenInBrowser.addHandler { msg: String? ->
+                if (handleMsg(msg)) {
+                    return@addHandler null
+                }
+                null
+            }
+            // Listen for the page load event
+            browser?.jbCefClient?.addLoadHandler(object : CefLoadHandlerAdapter() {
+                override fun onLoadingStateChange(
+                        browser: CefBrowser?,
+                        isLoading: Boolean,
+                        canGoBack: Boolean,
+                        canGoForward: Boolean
+                ) {
+                    if (!isLoading) {
+                        // The page has finished loading
+                        executeJavaScript(browser, myJSQueryOpenInBrowser)
+                    }
+                }
+            }, browser!!.cefBrowser)
+        }
+    }
+
+    companion object EmbeddedServer {
+        private var routing: Routing? = null
+        var serverHost: String? = null
+        var serverPort: String? = null
+        val embeddedServer: ApplicationEngine by lazy {
+            println("starting embedded server with port:$serverPort, token:$serverToken")
+            embeddedServer(Netty, host = serverHost!!, port = Integer.parseInt(serverPort!!)) {
+                install(CORS) {
+//                    allowHost("localhost:5173", schemes = listOf("http", "https","ws","wss"))
+//                    allowHeader(HttpHeaders.ContentType)
+                    anyHost()
+
+                }
+                install(customWebJars)
+//                install(Authentication) {
+//                    bearer("auth-bearer") {
+//                        realm = "continue"
+//                        authenticate { tokenCred ->
+//                            if (tokenCred.token == serverToken) {
+//                                UserIdPrincipal("continue")
+//                            } else {
+//                                null
+//                            }
+//                        }
+//                    }
+//                }
+                install(WebSockets) {
+                    pingPeriod = Duration.ofSeconds(15)
+                    timeout = Duration.ofSeconds(15)
+                    maxFrameSize = Long.MAX_VALUE
+                    masking = false
+                }
+                routing = install(Routing) {
+                    webSocket("/projects") {
+                        println("list all projects");
+//                        send(Frame.Text("list all projects"))
+                        var authed = false
+                        for (frame in incoming) {
+                            try {
+                                frame as? Frame.Text ?: continue
+                                val receivedText = frame.readText()
+                                authed = authedFilter(authed, receivedText) { msg ->
+                                    when (msg) {
+                                        "list" -> {
+                                            val projectPathPrefix = routing?.children?.firstOrNull { it.toString() == "/project" }
+                                            val result = projectPathPrefix?.children?.joinToString(",") { it.selector.toString() }
+                                                    ?: ""
+                                            send(Frame.Text("[$result]"))
+                                        }
+
+                                        else -> {
+                                            send(Frame.Text("unsupport operation"))
+                                        }
+                                    }
+                                }
+                            } catch (e: Exception) {
+                                println("list all projects error: $e");
+                            }
+                        }
+                    }
+                }
+            }.start()
         }
 
-        this.browser = JBCefBrowser.createBuilder().setOffScreenRendering(os == "linux" || useOsr).build()
-        browser.jbCefClient.setProperty(
-                JBCefClient.Properties.JS_QUERY_POOL_SIZE,
-                JS_QUERY_POOL_SIZE
+
+        var serverToken: String? = null
+        suspend fun DefaultWebSocketServerSession.authedFilter(authed: Boolean, receivedText: String, msgHandler: suspend (String) -> Unit): Boolean {
+            var result = authed
+            if (receivedText == "auth") {
+                val status = if (authed) "succ" else "failed"
+                send(Frame.Text("auth $status"))
+            } else if (receivedText == serverToken) {
+                result = true
+                println("auth succ by $receivedText")
+                send(Frame.Text("auth succ"))
+            } else if (authed) {
+                msgHandler(receivedText)
+            } else {
+                println("auth failed, token:$receivedText, correct: $serverToken")
+                send(Frame.Text("auth failed|$receivedText"))
+            }
+            return result
+        }
+    }
+
+    fun addProjectWebSocket(project: Project, handler: suspend DefaultWebSocketServerSession.() -> Unit) {
+        val path = "/project/${project.name}"
+        val routeExists = routing?.children?.firstOrNull { it.selector.toString() == path }
+        if (routeExists != null) {
+            println("dynamic routing $path already exists, route:$routeExists")
+            return
+        }
+        routing?.webSocket(path, handler = handler)
+        println("dynamic routing $path register succ")
+    }
+
+    fun removeProjectWebSocket(project: Project) {
+        val path = "/project/${project.name}"
+        // 查找对应的路由
+        val routeExists = routing?.children?.firstOrNull { it.selector.toString() == path }
+        // 如果找到了对应的路由，则从父节点移除它
+        if (routeExists == null) {
+            println("dynamic routing $path not found")
+        }
+        (routing?.children as MutableList<Route>).remove(routeExists)
+        println("dynamic routing $path removed successfully")
+    }
+
+    private fun defaultWebsocketHandler(project: Project): suspend DefaultWebSocketServerSession.() -> Unit = {
+        val local = this.call.request.local
+        var authed = false
+        println("new connection, project:${project.name}, remoteHost: ${local.remoteHost}")
+        for (frame in incoming) {
+            try {
+                frame as? Frame.Text ?: continue
+                val receivedText = frame.readText()
+                println("received from webview, project:${project.name}, data:$receivedText")
+                authed = authedFilter(authed, receivedText) { msg ->
+                    handleMsg(msg)
+                }
+                if(authed){
+                    activeSessions.add(this)
+                }
+            } catch (e: Exception) {
+                val msg = "received from webview error, project:${project.name},  e:$e"
+                println(msg)
+                send(Frame.Text(msg))
+            }
+        }
+        println("connection lost, project:${project.name}, ${local.remoteHost}")
+        activeSessions.remove(this)
+    }
+
+    /**
+     * @return needTransfer2Core
+     */
+    private fun handleMsg(msg: String?): Boolean {
+        val parser = JsonParser()
+        val json: JsonObject = parser.parse(msg).asJsonObject
+        val messageType = json.get("messageType").asString
+        val data = json.get("data")
+        val messageId = json.get("messageId")?.asString
+
+        val continuePluginService = ServiceManager.getService(
+                project,
+                ContinuePluginService::class.java
         )
-        registerAppSchemeHandler()
-        browser.loadURL(url);
-        Disposer.register(project, browser)
 
-        // Listen for events sent from browser
-        val myJSQueryOpenInBrowser = JBCefJSQuery.create((browser as JBCefBrowserBase?)!!)
-        myJSQueryOpenInBrowser.addHandler { msg: String? ->
-            val parser = JsonParser()
-            val json: JsonObject = parser.parse(msg).asJsonObject
-            val messageType = json.get("messageType").asString
-            val data = json.get("data")
-            val messageId = json.get("messageId")?.asString
+        val ide = continuePluginService.ideProtocolClient;
 
-            val continuePluginService = ServiceManager.getService(
-                    project,
-                    ContinuePluginService::class.java
-            )
-
-            val ide = continuePluginService.ideProtocolClient;
-
-            val respond = fun(data: Any?) {
-                // This matches the way that we expect receive messages in IdeMessenger.ts (gui)
-                // and the way they are sent in VS Code (webviewProtocol.ts)
-                var result: Map<String, Any?>? = null
-                if (MessageTypes.generatorTypes.contains(messageType)) {
-                    result = data as? Map<String, Any?>
-                } else {
-                    result = mutableMapOf(
+        val respond = fun(data: Any?) {
+            // This matches the way that we expect receive messages in IdeMessenger.ts (gui)
+            // and the way they are sent in VS Code (webviewProtocol.ts)
+            var result: Map<String, Any?>? = null
+            if (MessageTypes.generatorTypes.contains(messageType)) {
+                result = data as? Map<String, Any?>
+            } else {
+                result = mutableMapOf(
                         "status" to "success",
                         "done" to false,
                         "content" to data
-                    )
-                }
-
-                sendToWebview(messageType, result, messageId ?: uuid())
+                )
             }
 
-            if (PASS_THROUGH_TO_CORE.contains(messageType)) {
-                continuePluginService.coreMessenger?.request(messageType, data, messageId, respond)
-                return@addHandler null
-            }
-
-            when (messageType) {
-                "jetbrains/editorInsetHeight" -> {
-                    val height = data.asJsonObject.get("height").asInt
-                    heightChangeListeners.forEach { it(height) }
-                }
-                "onLoad" -> {
-                    coroutineScope.launch {
-                        // Set the colors to match Intellij theme
-                        val colors = GetTheme().getTheme();
-                        sendToWebview("setColors", colors)
-
-                        val jsonData = mutableMapOf(
-                                "windowId" to continuePluginService.windowId,
-                                "workspacePaths" to continuePluginService.workspacePaths,
-                                "vscMachineId" to getMachineUniqueID(),
-                                "vscMediaUrl" to "http://continue",
-                        )
-                        respond(jsonData)
-                    }
-
-                }
-                "showLines" -> {
-                    val data = data.asJsonObject
-                    ide?.setFileOpen(data.get("filepath").asString)
-                    ide?.highlightCode(RangeInFile(
-                            data.get("filepath").asString,
-                            Range(Position(
-                                    data.get("start").asInt,
-                                    0
-                            ), Position(
-                                    data.get("end").asInt,
-                                    0
-                            )),
-
-                            ),"#00ff0022")
-                }
-                "showTutorial" -> {
-                    showTutorial(project)
-                }
-                "showVirtualFile" -> {
-                    val data = data.asJsonObject
-                    ide?.showVirtualFile(data.get("name").asString, data.get("content").asString)
-                }
-                "showFile" -> {
-                    val data = data.asJsonObject
-                    ide?.setFileOpen(data.get("filepath").asString)
-                }
-                "reloadWindow" -> {}
-                "openConfigJson" -> {
-                    ide?.setFileOpen(getConfigJsonPath())
-                }
-                "readRangeInFile" -> {
-                    val data = data.asJsonObject
-                    ide?.readRangeInFile(RangeInFile(
-                            data.get("filepath").asString,
-                            Range(Position(
-                                    data.get("start").asInt,
-                                    0
-                            ), Position(
-                                    data.get("end").asInt + 1,
-                                    0
-                            )),
-                    ))
-                }
-                "focusEditor" -> {}
-
-                // IDE //
-                else -> {
-                    if (msg != null) {
-                        ide?.handleMessage(msg, respond)
-                    }
-                }
-            }
-
-
-            null
+            sendToWebview(messageType, result, messageId ?: uuid())
         }
 
-        // Listen for the page load event
-        browser.jbCefClient.addLoadHandler(object : CefLoadHandlerAdapter() {
-            override fun onLoadingStateChange(
-                    browser: CefBrowser?,
-                    isLoading: Boolean,
-                    canGoBack: Boolean,
-                    canGoForward: Boolean
-            ) {
-                if (!isLoading) {
-                    // The page has finished loading
-                    executeJavaScript(browser, myJSQueryOpenInBrowser)
+        if (PASS_THROUGH_TO_CORE.contains(messageType)) {
+            continuePluginService.coreMessenger?.request(messageType, data, messageId, respond)
+            return true
+        }
+        handleIdeActionMsg(messageType, data ?: JsonObject(), continuePluginService, respond, ide, msg)
+        return false
+    }
+
+    private fun handleIdeActionMsg(messageType: String?, data: JsonElement, continuePluginService: ContinuePluginService, respond: (Any?) -> Unit, ide: IdeProtocolClient?, msg: String?) {
+        when (messageType) {
+            "jetbrains/editorInsetHeight" -> {
+                val height = data.asJsonObject.get("height").asInt
+                heightChangeListeners.forEach { it(height) }
+            }
+
+            "onLoad" -> {
+                coroutineScope.launch {
+                    // Set the colors to match Intellij theme
+                    val colors = GetTheme().getTheme();
+                    sendToWebview("setColors", colors)
+
+                    val jsonData = mutableMapOf(
+                            "windowId" to continuePluginService.windowId,
+                            "workspacePaths" to continuePluginService.workspacePaths,
+                            "vscMachineId" to getMachineUniqueID(),
+                            "vscMediaUrl" to  "http://$staticResHost",
+                    )
+                    respond(jsonData)
+                }
+
+            }
+
+            "showLines" -> {
+                val data = data.asJsonObject
+                ide?.setFileOpen(data.get("filepath").asString)
+                ide?.highlightCode(RangeInFile(
+                        data.get("filepath").asString,
+                        Range(Position(
+                                data.get("start").asInt,
+                                0
+                        ), Position(
+                                data.get("end").asInt,
+                                0
+                        )),
+
+                        ), "#00ff0022")
+            }
+
+            "showTutorial" -> {
+                showTutorial(project)
+            }
+
+            "showVirtualFile" -> {
+                val data = data.asJsonObject
+                ide?.showVirtualFile(data.get("name").asString, data.get("content").asString)
+            }
+
+            "showFile" -> {
+                val data = data.asJsonObject
+                ide?.setFileOpen(data.get("filepath").asString)
+            }
+
+            "reloadWindow" -> {}
+            "openConfigJson" -> {
+                ide?.setFileOpen(getConfigJsonPath())
+            }
+
+            "readRangeInFile" -> {
+                val data = data.asJsonObject
+                ide?.readRangeInFile(RangeInFile(
+                        data.get("filepath").asString,
+                        Range(Position(
+                                data.get("start").asInt,
+                                0
+                        ), Position(
+                                data.get("end").asInt + 1,
+                                0
+                        )),
+                ))
+            }
+
+            "focusEditor" -> {}
+
+            // IDE //
+            else -> {
+                if (msg != null) {
+                    ide?.handleMessage(msg, respond)
                 }
             }
-        }, browser.cefBrowser)
-
+        }
     }
+
     fun executeJavaScript(browser: CefBrowser?, myJSQueryOpenInBrowser: JBCefJSQuery) {
         // Execute JavaScript - you might want to handle potential exceptions here
         val script = """window.postIntellijMessage = function(messageType, data, messageId) {
@@ -248,10 +429,22 @@ class ContinueBrowser(val project: Project, url: String, useOsr: Boolean = false
                         "data" to data
                 )
         )
+        if (this.splitMode) {
+            coroutineScope.launch {
+                val emptySessions = activeSessions.isEmpty()
+                if (!emptySessions) {
+                    println("send to webview, project:${project.name}, data:$jsonData")
+                    activeSessions.forEach {
+                        it?.send(Frame.Text(jsonData))
+                    }
+                }
+            }
+            return
+        }
         val jsCode = buildJavaScript(jsonData)
 
         try {
-            this.browser.executeJavaScriptAsync(jsCode)
+            this.browser?.executeJavaScriptAsync(jsCode)
         } catch (error: IllegalStateException) {
             println("Webview not initialized yet $error")
         }
@@ -259,5 +452,46 @@ class ContinueBrowser(val project: Project, url: String, useOsr: Boolean = false
 
     private fun buildJavaScript(jsonData: String): String {
         return """window.postMessage($jsonData, "*");"""
+    }
+}
+
+class InputStreamContent(
+        val input: InputStream,
+        override val contentType: ContentType,
+        lastModified: GMTDate
+) : OutgoingContent.ReadChannelContent() {
+    init {
+        versions += LastModifiedVersion(lastModified)
+    }
+
+    override fun readFrom(): ByteReadChannel = input.toByteReadChannel(pool = KtorDefaultPool)
+}
+
+val customWebJars: ApplicationPlugin<WebjarsConfig> = createApplicationPlugin("Webjars", ::WebjarsConfig) {
+//    val webjarsPrefix = pluginConfig.path
+//    require(webjarsPrefix.startsWith("/"))
+//    require(webjarsPrefix.endsWith("/"))
+    val lastModified = GMTDate()
+    onCall { call ->
+        if (call.response.isCommitted) return@onCall
+        val originPath = call.request.path()
+        var fullPath = originPath
+        if (fullPath == "/") {
+            fullPath += "/index.html"
+        }
+        if (call.request.httpMethod == HttpMethod.Get) {
+//            (fullPath.startsWith("/asset") || fullPath == "/index.html")
+            val resourcePath = "webview$fullPath";
+            println("webJars: originPath:$originPath, resourcePath:$resourcePath")
+            try {
+                val stream = WebjarsConfig::class.java.classLoader.getResourceAsStream(resourcePath)
+                        ?: return@onCall
+                val content = InputStreamContent(stream, ContentType.defaultForFilePath(fullPath), lastModified)
+                call.respond(content)
+            } catch (multipleFiles: MultipleMatchesException) {
+                call.respond(HttpStatusCode.InternalServerError)
+            } catch (_: IllegalArgumentException) {
+            }
+        }
     }
 }

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinuePluginToolWindowFactory.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinuePluginToolWindowFactory.kt
@@ -1,7 +1,8 @@
 package com.github.continuedev.continueintellijextension.toolWindow
 
+import com.github.continuedev.continueintellijextension.`continue`.readConfigJson
 import com.github.continuedev.continueintellijextension.services.ContinuePluginService
-import com.intellij.collaboration.async.disposingScope
+import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.components.ServiceManager
@@ -9,14 +10,34 @@ import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.ui.components.JBTextArea
+import com.intellij.ui.components.panels.VerticalBox
 import com.intellij.ui.content.ContentFactory
-import javax.swing.*
+import org.apache.commons.lang3.RandomStringUtils
+import java.awt.BorderLayout
+import javax.swing.JButton
+import javax.swing.JComponent
+import javax.swing.JPanel
 
 const val JS_QUERY_POOL_SIZE = "200"
 
 class ContinuePluginToolWindowFactory : ToolWindowFactory, DumbAware {
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
-        val continueToolWindow = ContinuePluginWindow(toolWindow, project)
+        val readConfigJson = readConfigJson()
+        val serverHost: String = readConfigJson.getOrDefault("serverHost", "127.0.0.1") as String
+        val serverPort: String = readConfigJson.getOrDefault("serverPort", "8080") as String
+        val serverToken = readConfigJson.getOrDefault("serverToken", RandomStringUtils.randomAlphabetic(16)) as String
+        val externalHostPort = readConfigJson.getOrDefault("serverExternalHostPort", "$serverHost:$serverPort") as String
+        val splitMode = readConfigJson.getOrDefault("splitMode", false) as Boolean
+        val osName = System.getProperty("os.name").toLowerCase()
+        val os = when {
+            osName.contains("mac") || osName.contains("darwin") -> "darwin"
+            osName.contains("win") -> "win32"
+            osName.contains("nix") || osName.contains("nux") || osName.contains("aix") -> "linux"
+            else -> "linux"
+        }
+        val useOsr = readConfigJson.getOrDefault("useOsr", os == "linux") as Boolean
+        val continueToolWindow = ContinuePluginWindow(toolWindow, project, splitMode, useOsr, serverHost, serverPort, serverToken, externalHostPort)
         val content = ContentFactory.getInstance().createContent(continueToolWindow.content, null, false)
         toolWindow.contentManager.addContent(content)
         val titleActions = mutableListOf<AnAction>()
@@ -41,19 +62,49 @@ class ContinuePluginToolWindowFactory : ToolWindowFactory, DumbAware {
     override fun shouldBeAvailable(project: Project) = true
 
 
-    class ContinuePluginWindow(toolWindow: ToolWindow, project: Project) {
+    class ContinuePluginWindow(toolWindow: ToolWindow, project: Project, splitMode: Boolean, useOsr: Boolean,
+                               serverHost: String, serverPort: String, serverToken: String, externalHostPort: String) {
+        val host: String
+        var url: String
+        val urlPanel: JPanel = JPanel(BorderLayout())
 
         init {
             System.setProperty("ide.browser.jcef.jsQueryPoolSize", JS_QUERY_POOL_SIZE)
             System.setProperty("ide.browser.jcef.contextMenu.devTools.enabled", "true")
+            this.host = if (splitMode) externalHostPort else "continue"
+            url = "http://$host/index.html"
+            if (splitMode) {
+                url += "?splitMode=true&currentProject=${project.name}&serverToken=${serverToken}"
+                val debugMode = false
+                if (debugMode) {
+                    url += "&debugWsHost=${host}"
+                }
+                val vbox = VerticalBox()
+
+                val urlText = JBTextArea(url)
+                urlText.lineWrap = true
+                vbox.add(urlText)
+
+                val openBtn = JButton("Open")
+                openBtn.addActionListener {
+                    BrowserUtil.browse(url)
+                }
+                vbox.add(openBtn)
+
+                urlPanel.add(vbox)
+                //init embedded server params
+                ContinueBrowser.serverHost = serverHost
+                ContinueBrowser.serverPort = serverPort
+                ContinueBrowser.serverToken = serverToken
+            }
         }
 
         val browser: ContinueBrowser by lazy {
-            val url = "http://continue/index.html";
+            println("ContinuePluginWindow splitMode $splitMode")
             // Use to get hot-reloading in local development
             // val url = "http://localhost:5173/jetbrains_index.html";
 
-            val browser = ContinueBrowser(project, url)
+            val browser = ContinueBrowser(project, url, useOsr = useOsr, splitMode = splitMode, staticResHost = host)
             val continuePluginService = ServiceManager.getService(
                     project,
                     ContinuePluginService::class.java
@@ -61,8 +112,9 @@ class ContinuePluginToolWindowFactory : ToolWindowFactory, DumbAware {
             continuePluginService.continuePluginWindow = this
             browser
         }
-
         val content: JComponent
-            get() = browser.browser.component
+            get() = browser.browser?.component ?: urlPanel
     }
+
+
 }

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -2552,6 +2552,36 @@
               }
             }
           }
+        },
+        "useOsr":{
+          "title": "useOsr",
+          "type": "boolean",
+          "markdownDescription": "Force change toolwindow Jcef Osr mode, default enabled if os is Linux"
+        },
+        "splitMode":{
+          "title": "splitMode",
+          "type": "boolean",
+          "markdownDescription": "Split toolwindow content to external browser, default is false"
+        },
+        "serverHost":{
+          "title": "serverHost",
+          "type": "string",
+          "markdownDescription": "Effective when splitMode = true, embedded server listen address, default is 127.0.0.1"
+        },
+        "serverPort":{
+          "title": "serverPort",
+          "type": "string",
+          "markdownDescription": "Effective when splitMode = true, embedded server listen address, default is 8080"
+        },
+        "serverToken":{
+          "title": "serverToken",
+          "type": "string",
+          "markdownDescription": "Effective when splitMode = true, embedded server websocket auth token, default is random"
+        },
+        "serverExternalHostPort":{
+          "title": "serverExternalHostPort",
+          "type": "string",
+          "markdownDescription": "Effective when splitMode = true, embedded server access address, default is serverHost:serverPort, useful when port mapping exists"
         }
       }
     }

--- a/gui/src/context/IdeMessenger.ts
+++ b/gui/src/context/IdeMessenger.ts
@@ -1,4 +1,4 @@
-import { ChatMessage, IDE, LLMFullCompletionOptions, PromptLog } from "core";
+import { ChatMessage, IDE, LLMFullCompletionOptions, PromptLog, IEmbeddedSocketManager } from "core";
 import type { FromWebviewProtocol, ToWebviewProtocol } from "core/protocol";
 import { WebviewMessengerResult } from "core/protocol/util";
 import { MessageIde } from "core/util/messageIde";
@@ -6,8 +6,7 @@ import { Message } from "core/util/messenger";
 import { createContext } from "react";
 import { v4 as uuidv4 } from "uuid";
 import "vscode-webview";
-import { isJetBrains } from "../util";
-
+import { isJetBrains, inSplitMode, getCurrentProject, getServerToken, getOverrideWsHost } from "../util";
 interface vscode {
   postMessage(message: any): vscode;
 }
@@ -61,20 +60,142 @@ export class IdeMessenger implements IIdeMessenger {
         }
         return result.content;
       },
-      () => {},
+      () => { },
     );
   }
 
+  private embeddedSocketUrl(project: String) {
+    const overrideWsHost = getOverrideWsHost()
+    var host = location.host
+    if (overrideWsHost && overrideWsHost.length > 0) {
+      host = overrideWsHost
+    }
+    return `ws://${host}/project/${project}`
+  }
+
+  private _initWs(wsUrl: string, project: string, serverToken: string): Promise<{ socketInfo: IEmbeddedSocketManager }> {
+    return new Promise((res, rej) => {
+      const timeout = 5000;
+      const socket = new WebSocket(wsUrl)
+      const socketInfo: IEmbeddedSocketManager = {
+        socket: socket,
+        project: project,
+        serverToken: serverToken,
+        authed: false,
+        isConnected: false,
+        internal: {
+        },
+      }
+      const resetTimeout = () => {
+        clearTimeout(socketInfo.internal.timeout);
+        socketInfo.internal.timeout = setTimeout(() => {
+          socketInfo.error = new Error("Timeout occurred");
+          rej(`Timeout trying to connect to socket: ${wsUrl}`);
+        }, timeout);
+      };
+      resetTimeout();
+      socket.onopen = () => {
+        socketInfo.isConnected = true;
+        resetTimeout();
+        res({ socketInfo });
+      }
+      socket.onerror = (e) => {
+        clearTimeout(socketInfo.internal.timeout);
+        if (e instanceof ErrorEvent) {
+          console.log(e.message) // and now TS can found the `message` property.
+          socketInfo.error = Error(e.message);
+          rej(`Error trying to connect to socket: ${wsUrl}, msg = ${e.message}}`);
+        }
+      }
+      socket.onclose = () => {
+        clearTimeout(socketInfo.internal.timeout);
+      }
+      socket.onclose = () => {
+        clearTimeout(socketInfo.internal.timeout);
+        socketInfo.socket = null
+        socketInfo.isConnected = false;
+        socketInfo.authed = false;
+      }
+      // Log incoming messages to the console.
+      socket.onmessage = (event) => {
+        const data = event.data
+        console.log('received: %s', event.data);
+        if (data.startsWith("auth failed|")) {
+          const retry = data.replace("auth failed|", "")
+          socket.send(serverToken)
+          socket.send(retry)
+        } else if (data == "auth succ" || data == "auth failed") {
+        } else {
+          window.postMessage(JSON.parse(data), "*")
+        }
+      };
+    });
+  }
+  private async reconnectWsAsync(project: string, token: string) {
+    try {
+      const wsUrl = this.embeddedSocketUrl(project)
+      const { socketInfo } = await this._initWs(wsUrl, project, token);
+      window.embeddedSocketInfo = socketInfo
+    } catch (e) {
+      console.log("init ws error:", e)
+    }
+  }
+  private splitModeIdeaMsgHandler(messageType: string, data: any, messageId: string) {
+    const msg = JSON.stringify({ messageType, data, messageId });
+    console.log("splitModeIdeaMsgHandler msg:", msg);
+    const socketInfo = window.embeddedSocketInfo
+    const socket = socketInfo.socket
+    socket.send(msg)
+  }
+  public ensureSocketConnected() {
+    const currentProject = getCurrentProject();
+    if (currentProject == null) {
+      console.log("not ready, currentProject is empty");
+      return
+    }
+    const serverToken = getServerToken()
+    if (serverToken == null) {
+      console.log("not ready, serverToken is empty");
+      return
+    }
+    const socketInfo = window.embeddedSocketInfo
+    if (socketInfo == null) {
+      console.log("not ready, embeddedSocketInfo is empty");
+      this.reconnectWsAsync(currentProject, serverToken)
+      return
+    }
+    const socket = socketInfo.socket
+    if (!socketInfo.isConnected) {
+      console.log("not ready, isConnected is false");
+      this.reconnectWsAsync(currentProject, serverToken)
+      return
+    }
+    if (currentProject != socketInfo.project) {
+      console.log(`current project changed, currentProject:${socketInfo.project}, oldProject: ${socketInfo.project}`);
+      window.location.reload()
+      return
+    }
+    if (!socketInfo.authed) {
+      console.log("not ready, authed is false");
+      socket.send(serverToken)
+      //no return, avoid loss msg befor auth succ
+    }
+  }
   private _postToIde(messageType: string, data: any, messageId?: string) {
     if (typeof vscode === "undefined") {
       if (isJetBrains()) {
         if (window.postIntellijMessage === undefined) {
-          console.log(
-            "Unable to send message: postIntellijMessage is undefined. ",
-            messageType,
-            data,
-          );
-          throw new Error("postIntellijMessage is undefined");
+          if (inSplitMode()) {
+            this.ensureSocketConnected()
+            window.postIntellijMessage = this.splitModeIdeaMsgHandler
+          } else {
+            console.log(
+              "Unable to send message: postIntellijMessage is undefined. ",
+              messageType,
+              data,
+            );
+            throw new Error("postIntellijMessage is undefined");
+          }
         }
         messageId = messageId ?? uuidv4();
         window.postIntellijMessage?.(messageType, data, messageId);

--- a/gui/src/context/IdeMessenger.ts
+++ b/gui/src/context/IdeMessenger.ts
@@ -109,9 +109,6 @@ export class IdeMessenger implements IIdeMessenger {
       }
       socket.onclose = () => {
         clearTimeout(socketInfo.internal.timeout);
-      }
-      socket.onclose = () => {
-        clearTimeout(socketInfo.internal.timeout);
         socketInfo.socket = null
         socketInfo.isConnected = false;
         socketInfo.authed = false;
@@ -124,7 +121,10 @@ export class IdeMessenger implements IIdeMessenger {
           const retry = data.replace("auth failed|", "")
           socket.send(serverToken)
           socket.send(retry)
-        } else if (data == "auth succ" || data == "auth failed") {
+        } else if (data == "auth failed") {
+          // status query response ,ignore it
+        } else if (data == "auth succ") {
+          socketInfo.authed = true
         } else {
           window.postMessage(JSON.parse(data), "*")
         }

--- a/gui/src/pages/gui.tsx
+++ b/gui/src/pages/gui.tsx
@@ -57,7 +57,12 @@ import {
   getFontSize,
   getMetaKeyLabel,
   isJetBrains,
+  setJetBrains,
   isMetaEquivalentKeyPressed,
+  setSplitMode,
+  setCurrentProject,
+  setServerToken,
+  setOverrideWsHost
 } from "../util";
 import { FREE_TRIAL_LIMIT_REQUESTS } from "../util/freeTrial";
 import { getLocalStorage, setLocalStorage } from "../util/localStorage";
@@ -162,7 +167,21 @@ function GUI() {
   const state = useSelector((state: RootState) => state.state);
   const { saveSession, getLastSessionId, loadLastSession } =
     useHistory(dispatch);
-
+  const searchParams = new URLSearchParams(window.location.search);
+  const splitModePram = searchParams.get("splitMode");
+  const splitMode = splitModePram == "true" || splitModePram == '1';
+  if (splitMode) {
+    setJetBrains();
+    const currentProject = searchParams.get("currentProject");
+    setCurrentProject(currentProject)
+    const serverToken = searchParams.get("serverToken");
+    setServerToken(serverToken)
+    const debugWsHost = searchParams.get("debugWsHost");
+    if (debugWsHost && debugWsHost.length > 0) {
+      setOverrideWsHost(debugWsHost)
+    }
+  }
+  setSplitMode(splitMode);
   useEffect(() => {
     if (!active || !topGuiDivRef.current) return;
 

--- a/gui/src/util/index.ts
+++ b/gui/src/util/index.ts
@@ -1,7 +1,43 @@
 import _ from "lodash";
-import { getLocalStorage } from "./localStorage";
+import { getLocalStorage, setLocalStorage } from "./localStorage";
 
 type Platform = "mac" | "linux" | "windows" | "unknown";
+export function getOverrideWsHost(): string {
+  return getLocalStorage("overrideWsHost")
+}
+
+export function setOverrideWsHost(value: string): string {
+  setLocalStorage("overrideWsHost", value)
+  return getOverrideWsHost()
+}
+
+export function inSplitMode(): boolean {
+  return getLocalStorage("inSplitMode") || false
+}
+
+export function setSplitMode(value: boolean): boolean {
+  setLocalStorage("inSplitMode", value)
+  console.log("inSplitMode", value)
+  return inSplitMode()
+}
+
+export function getCurrentProject(): string {
+  return getLocalStorage("currentProject")
+}
+
+export function setCurrentProject(project: string): string {
+  setLocalStorage("currentProject", project)
+  return getCurrentProject()
+}
+
+export function getServerToken(): string {
+  return getLocalStorage("serverToken")
+}
+
+export function setServerToken(token: string): string {
+  setLocalStorage("serverToken", token)
+  return getServerToken()
+}
 
 export function getPlatform(): Platform {
   const platform = window.navigator.platform.toUpperCase();
@@ -61,6 +97,10 @@ export function getFontSize(): number {
 
 export function isJetBrains() {
   return getLocalStorage("ide") === "jetbrains";
+}
+
+export function setJetBrains() {
+  return setLocalStorage("ide", "jetbrains");
 }
 
 export function isWebEnvironment(): boolean {

--- a/gui/src/util/localStorage.ts
+++ b/gui/src/util/localStorage.ts
@@ -8,6 +8,10 @@ type LocalStorageTypes = {
   mainTextEntryCounter: number;
   ide: "vscode" | "jetbrains";
   ftc: number;
+  overrideWsHost: string;
+  inSplitMode: boolean;
+  currentProject: string;
+  serverToken: string;
   fontSize: number;
   lastSessionId: string | undefined;
   inputHistory: JSONContent[];


### PR DESCRIPTION
For intellij idea 
1.Some headless env use jcef runtime need extra effort, or impossiable.
2.For some remote env screen size too small to use continue.

So i changed tool window factory logic, use embedded ktor websever for remote access. When splitMode enabled jcef will not load instead of ktor server, it can be access from remote or out of jetbrains ide.

## Description
1.support force config osr enabled when using jcef
2.support ktor embedded websocket and webjar server for headless or remote enc, also support port mapping config

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots
![image](https://github.com/user-attachments/assets/effd6edd-f818-4dfe-9b0c-8b2579c90c6e)

## Testing
1. change `config.json` for enabled splitMode
```
  "splitMode": true,
  "serverHost": "127.0.0.1",
  "serverPort": "2333",
  "serverToken": "123456"
  "serverExternalHostPort":"reverse-proxy.xxx:port"//optional
```
2. continue gui canbe access from 127.0.0.1:2333 out of ide env