### PR TITLE
Add chat shortcut to quick picks

### DIFF
--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -642,6 +642,12 @@ const commandsMap: (
       }
       quickPick.items = [
         {
+          label: "$(comment) Open chat (Cmd+L)",
+        },
+        {
+          label: "$(screen-full) Open full screen chat (Cmd+K Cmd+M)",
+        },
+        {
           label: quickPickStatusText(targetStatus),
         },
         {
@@ -685,6 +691,13 @@ const commandsMap: (
           configHandler.reloadConfig();
         } else if (selectedOption === "$(feedback) Give feedback") {
           vscode.commands.executeCommand("continue.giveAutocompleteFeedback");
+        } else if (selectedOption === "$(comment) Open chat (Cmd+L)") {
+          vscode.commands.executeCommand("continue.focusContinueInput");
+        } else if (
+          selectedOption ===
+          "$(screen-full) Open full screen chat (Cmd+K Cmd+M)"
+        ) {
+          vscode.commands.executeCommand("continue.toggleFullScreen");
         }
         quickPick.dispose();
       });


### PR DESCRIPTION
## Description

Added chat shortcuts to quick actions menu.

## Checklist

- [ x] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created (N/A)

## Screenshots

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/d4e5a368-f1e0-47e2-ab1f-bf9adf472dbc">

## Testing

1. Click "continue" button in the lower right corner
2. Click either "Open chat" or "Open full screen chat"
