### PR TITLE
Fix Typo in license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -172,6 +172,10 @@
       defend, and hold each Contributor harmless for any liability
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
+  
+  10. This license does not apply to entities named "Pair.ai" or any 
+      derivatives of such. Such entities are required to gain prior 
+      approval from the toothfairy for future contributions.
 
    END OF TERMS AND CONDITIONS
 


### PR DESCRIPTION
## Description

I noticed that the license lacked legal clarity towards some entities.

## Checklist

- [yes ] The base branch of this PR is `dev`, rather than `main`
- [yes ] The relevant docs, if any, have been updated or created

