### PR TITLE
Add `showToast` function to Intellij plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,5 @@ Icon?
 .aider*
 
 notes.md
+
+manual-testing-sandbox/Continue/.idea/vcs.xml

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,9 +17,9 @@
     "**/binary": true,
     "binary/": false,
     "**/core/vendor/**": true,
-    "**/gui/dist": true
+    "**/gui/dist": true,
+    "**/extensions/vscode/gui/**": true,
+    "**/extensions/vscode/out/**": true
   },
-  "eslint.workingDirectories": [
-    "./core"
-  ]
+  "eslint.workingDirectories": ["./core"]
 }

--- a/core/indexing/ignore.ts
+++ b/core/indexing/ignore.ts
@@ -68,6 +68,8 @@ export const DEFAULT_IGNORE_FILETYPES = [
   "*.uasset",
   "*.pdb",
   "*.bin",
+  "*.pag",
+  "*.swp",
   // "*.prompt", // can be incredibly confusing for the LLM to have another set of instructions injected into the prompt
 ];
 

--- a/docs/docs/customize/model-providers/top-level/azure.md
+++ b/docs/docs/customize/model-providers/top-level/azure.md
@@ -42,7 +42,7 @@ We recommend configuring **Codestral** as your autocomplete model.
 We recommend configuring **text-embedding-3-large** as your embeddings model.
 
 ```json title="config.json"
-"embeddingsProvider": [{
+"embeddingsProvider": {
     "provider": "azure",
     "model": "text-embedding-3-large",
     "apiBase": "<YOUR_DEPLOYMENT_BASE>",
@@ -50,7 +50,7 @@ We recommend configuring **text-embedding-3-large** as your embeddings model.
     "apiVersion": "<YOUR_API_VERSION>",
     "apiType": "azure",
     "apiKey": "<MY_API_KEY>"
-}]
+}
 ```
 
 ## Reranking model

--- a/docs/docs/customize/model-providers/top-level/gemini.md
+++ b/docs/docs/customize/model-providers/top-level/gemini.md
@@ -38,13 +38,11 @@ We recommend configuring **text-embedding-004** as your embeddings model.
 
 ```json title="config.json"
 {
-  "embeddingsProvider": [
-    {
-      "provider": "gemini",
-      "model": "models/text-embedding-004",
-      "apiKey": "[API_KEY]"
-    }
-  ]
+  "embeddingsProvider": {
+    "provider": "gemini",
+    "model": "models/text-embedding-004",
+    "apiKey": "[API_KEY]"
+  }
 }
 ```
 

--- a/docs/docs/customize/model-providers/top-level/mistral.md
+++ b/docs/docs/customize/model-providers/top-level/mistral.md
@@ -46,14 +46,12 @@ We recommend configuring **Mistral Embed** as your embeddings model.
 
 ```json title="config.json"
 {
-  "embeddingsProvider": [
-    {
-      "provider": "mistral",
-      "model": "mistral-embed",
-      "apiKey": "[API_KEY]",
-      "apiBase": "https://api.mistral.ai/v1"
-    }
-  ]
+  "embeddingsProvider": {
+    "provider": "mistral",
+    "model": "mistral-embed",
+    "apiKey": "[API_KEY]",
+    "apiBase": "https://api.mistral.ai/v1"
+  }
 }
 ```
 

--- a/docs/docs/customize/model-providers/top-level/openai.md
+++ b/docs/docs/customize/model-providers/top-level/openai.md
@@ -38,13 +38,11 @@ We recommend configuring **text-embedding-3-large** as your embeddings model.
 
 ```json title="config.json"
 {
-  "embeddingsProvider": [
-    {
-      "provider": "openai",
-      "model": "text-embedding-3-large",
-      "apiKey": "[API_KEY]"
-    }
-  ]
+  "embeddingsProvider": {
+    "provider": "openai",
+    "model": "text-embedding-3-large",
+    "apiKey": "[API_KEY]"
+  }
 }
 ```
 

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -20,6 +20,6 @@ keywords:
 **Continue is the leading open-source AI code assistant inside of [VS Code](https://marketplace.visualstudio.com/items?itemName=Continue.continue) and [JetBrains](https://plugins.jetbrains.com/plugin/22707-continue-extension)**
 
 - [Chat](chat/how-to-use-it.md) to understand and iterate on code in the sidebar
-- [Autocomplete](autocomplete/how-to-use-it.md) to recieve inline code suggestions as you type
+- [Autocomplete](autocomplete/how-to-use-it.md) to receive inline code suggestions as you type
 - [Edit](edit/how-to-use-it.md) to modify code without leaving your current file
 - [Actions](actions/how-to-use-it.md) to establish shortcuts for common use cases

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessenger.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessenger.kt
@@ -15,7 +15,13 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.attribute.PosixFilePermission
 
-class CoreMessenger(private val project: Project, esbuildPath: String, continueCorePath: String, ideProtocolClient: IdeProtocolClient, private val coroutineScope: CoroutineScope) {
+class CoreMessenger(
+    private val project: Project,
+    esbuildPath: String,
+    continueCorePath: String,
+    ideProtocolClient: IdeProtocolClient,
+    private val coroutineScope: CoroutineScope
+) {
     private var writer: Writer? = null
     private var reader: BufferedReader? = null
     private var process: Process? = null
@@ -42,11 +48,13 @@ class CoreMessenger(private val project: Project, esbuildPath: String, continueC
 
     fun request(messageType: String, data: Any?, messageId: String?, onResponse: (Any?) -> Unit) {
         val id = messageId ?: uuid()
-        val message = gson.toJson(mapOf(
+        val message = gson.toJson(
+            mapOf(
                 "messageId" to id,
                 "messageType" to messageType,
                 "data" to data
-        ))
+            )
+        )
         responseListeners[id] = onResponse
         write(message)
     }
@@ -60,11 +68,13 @@ class CoreMessenger(private val project: Project, esbuildPath: String, continueC
         // IDE listeners
         if (MessageTypes.ideMessageTypes.contains(messageType)) {
             ideProtocolClient.handleMessage(json) { data ->
-                val message = gson.toJson(mapOf(
+                val message = gson.toJson(
+                    mapOf(
                         "messageId" to messageId,
                         "messageType" to messageType,
                         "data" to data
-                ))
+                    )
+                )
                 write(message)
             };
         }
@@ -76,11 +86,13 @@ class CoreMessenger(private val project: Project, esbuildPath: String, continueC
             if (messageType == "getDefaultModelTitle") {
                 val continueSettingsService = service<ContinueExtensionSettings>()
                 val defaultModelTitle = continueSettingsService.continueState.lastSelectedInlineEditModel;
-                val message = gson.toJson(mapOf(
+                val message = gson.toJson(
+                    mapOf(
                         "messageId" to messageId,
                         "messageType" to messageType,
                         "data" to defaultModelTitle
-                ))
+                    )
+                )
                 write(message)
             }
             val continuePluginService = project.service<ContinuePluginService>()
@@ -94,7 +106,8 @@ class CoreMessenger(private val project: Project, esbuildPath: String, continueC
                 val done = (data as Map<String, Boolean?>)["done"]
                 if (done == true) {
                     responseListeners.remove(messageId)
-                } else {}
+                } else {
+                }
             } else {
                 responseListeners.remove(messageId)
             }
@@ -106,10 +119,10 @@ class CoreMessenger(private val project: Project, esbuildPath: String, continueC
         val osName = System.getProperty("os.name").toLowerCase()
         if (osName.contains("mac") || osName.contains("darwin")) {
             ProcessBuilder(
-                    "xattr",
-                    "-dr",
-                    "com.apple.quarantine",
-                    destination
+                "xattr",
+                "-dr",
+                "com.apple.quarantine",
+                destination
             ).start()
             setFilePermissions(destination, "rwxr-xr-x")
         } else if (osName.contains("nix") || osName.contains("nux") || osName.contains("mac")) {
@@ -177,7 +190,7 @@ class CoreMessenger(private val project: Project, esbuildPath: String, continueC
 
             // Start the subprocess
             val processBuilder = ProcessBuilder(continueCorePath)
-                    .directory(File(continueCorePath).parentFile)
+                .directory(File(continueCorePath).parentFile)
             process = processBuilder.start()
 
             val outputStream = process!!.outputStream
@@ -200,14 +213,16 @@ class CoreMessenger(private val project: Project, esbuildPath: String, continueC
 
                 println("Core process exited with output: $err")
                 CoroutineScope(Dispatchers.Main).launch {
-                    ideProtocolClient.showMessage("Core process exited with output: $err")
+                    ideProtocolClient.showToast("error", "Core process exited with output: $err")
                 }
 
                 // Log the cause of the failure
                 val telemetryService = service<TelemetryService>()
-                telemetryService.capture("jetbrains_core_exit", mapOf(
-                    "error" to err
-                ))
+                telemetryService.capture(
+                    "jetbrains_core_exit", mapOf(
+                        "error" to err
+                    )
+                )
 
                 // Clean up all resources
                 writer?.close()

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
@@ -157,8 +157,8 @@ private fun readConfigJson(): Map<String, Any> {
     val configJsonPath = getConfigJsonPath()
     val reader = FileReader(configJsonPath)
     val config: Map<String, Any> = gson.fromJson(
-            reader,
-            object : TypeToken<Map<String, Any>>() {}.type
+        reader,
+        object : TypeToken<Map<String, Any>>() {}.type
     )
     reader.close()
     return config
@@ -170,9 +170,13 @@ class AsyncFileSaveListener : AsyncFileListener {
     constructor(ideProtocolClient: IdeProtocolClient) {
         this.ideProtocolClient = ideProtocolClient
     }
+
     override fun prepareChange(events: MutableList<out VFileEvent>): AsyncFileListener.ChangeApplier? {
         for (event in events) {
-            if (event.path.endsWith(".continue/config.json") || event.path.endsWith(".continue/config.ts") || event.path.endsWith(".continue\\config.json") || event.path.endsWith(".continue\\config.ts") || event.path.endsWith(".continuerc.json")) {
+            if (event.path.endsWith(".continue/config.json") || event.path.endsWith(".continue/config.ts") || event.path.endsWith(
+                    ".continue\\config.json"
+                ) || event.path.endsWith(".continue\\config.ts") || event.path.endsWith(".continuerc.json")
+            ) {
                 return object : AsyncFileListener.ChangeApplier {
                     override fun afterVfsChange() {
                         val config = readConfigJson()
@@ -186,13 +190,13 @@ class AsyncFileSaveListener : AsyncFileListener {
 
 }
 
-class IdeProtocolClient (
+class IdeProtocolClient(
     private val continuePluginService: ContinuePluginService,
     private val textSelectionStrategy: TextSelectionStrategy,
     private val coroutineScope: CoroutineScope,
     private val workspacePath: String?,
     private val project: Project
-): DumbAware {
+) : DumbAware {
     val diffManager = DiffManager(project)
     private val CONTINUE_NOTIFICATION_GROUP = NotificationGroup("Continue", NotificationDisplayType.BALLOON, true)
     private val ripgrep: String
@@ -206,7 +210,8 @@ class IdeProtocolClient (
         })
 
         val myPluginId = "com.github.continuedev.continueintellijextension"
-        val pluginDescriptor = PluginManager.getPlugin(PluginId.getId(myPluginId)) ?: throw Exception("Plugin not found")
+        val pluginDescriptor =
+            PluginManager.getPlugin(PluginId.getId(myPluginId)) ?: throw Exception("Plugin not found")
 
         val pluginPath = pluginDescriptor.pluginPath
         val osName = System.getProperty("os.name").toLowerCase()
@@ -217,7 +222,8 @@ class IdeProtocolClient (
             else -> "linux"
         }
 
-        ripgrep = Paths.get(pluginPath.toString(), "ripgrep", "bin", "rg" + (if (os == "win32") ".exe" else "")).toString()
+        ripgrep =
+            Paths.get(pluginPath.toString(), "ripgrep", "bin", "rg" + (if (os == "win32") ".exe" else "")).toString()
     }
 
     private fun send(messageType: String, data: Any?, messageId: String? = null) {
@@ -228,8 +234,8 @@ class IdeProtocolClient (
     fun handleMessage(text: String, respond: (Any?) -> Unit) {
         coroutineScope.launch(Dispatchers.IO) {
             val parsedMessage: Map<String, Any> = Gson().fromJson(
-                    text,
-                    object : TypeToken<Map<String, Any>>() {}.type
+                text,
+                object : TypeToken<Map<String, Any>>() {}.type
             )
             val messageType = parsedMessage["messageType"] as? String
             if (messageType == null) {
@@ -243,16 +249,20 @@ class IdeProtocolClient (
                     "uniqueId" -> respond(
                         mapOf("uniqueId" to uniqueId())
                     )
+
                     "getIdeSettings" -> {
                         val settings =
-                                ServiceManager.getService(ContinueExtensionSettings::class.java)
-                        respond(mapOf(
-                            "remoteConfigServerUrl" to settings.continueState.remoteConfigServerUrl,
-                            "remoteConfigSyncPeriod" to settings.continueState.remoteConfigSyncPeriod,
-                            "userToken" to settings.continueState.userToken,
-                            "enableControlServerBeta" to settings.continueState.enableContinueTeamsBeta
-                        ))
+                            ServiceManager.getService(ContinueExtensionSettings::class.java)
+                        respond(
+                            mapOf(
+                                "remoteConfigServerUrl" to settings.continueState.remoteConfigServerUrl,
+                                "remoteConfigSyncPeriod" to settings.continueState.remoteConfigSyncPeriod,
+                                "userToken" to settings.continueState.userToken,
+                                "enableControlServerBeta" to settings.continueState.enableContinueTeamsBeta
+                            )
+                        )
                     }
+
                     "getControlPlaneSessionInfo" -> {
                         val silent = (data as? Map<String, Any>)?.get("silent") as? Boolean ?: false
 
@@ -265,12 +275,15 @@ class IdeProtocolClient (
                             respond(null)
                         }
                     }
+
                     "logoutOfControlPlane" -> {
                         val authService = service<ContinueAuthService>()
                         authService.signOut()
-                        ApplicationManager.getApplication().messageBus.syncPublisher(AuthListener.TOPIC).handleUpdatedSessionInfo(null)
+                        ApplicationManager.getApplication().messageBus.syncPublisher(AuthListener.TOPIC)
+                            .handleUpdatedSessionInfo(null)
                         respond(null)
                     }
+
                     "getIdeInfo" -> {
                         val applicationInfo = ApplicationInfo.getInstance()
                         val ideName: String = applicationInfo.fullApplicationName
@@ -287,13 +300,15 @@ class IdeProtocolClient (
                         val plugin = PluginManagerCore.getPlugin(PluginId.getId(pluginId))
                         val extensionVersion = plugin?.version ?: "Unknown"
 
-                        respond(mapOf(
-                            "ideType" to "jetbrains",
-                            "name" to ideName,
-                            "version" to ideVersion,
-                            "remoteName" to remoteName,
-                            "extensionVersion" to extensionVersion
-                        ))
+                        respond(
+                            mapOf(
+                                "ideType" to "jetbrains",
+                                "name" to ideName,
+                                "version" to ideVersion,
+                                "remoteName" to remoteName,
+                                "extensionVersion" to extensionVersion
+                            )
+                        )
                     }
 
                     "getUniqueId" -> {
@@ -311,9 +326,9 @@ class IdeProtocolClient (
                     "showDiff" -> {
                         val data = data as Map<String, Any>
                         diffManager.showDiff(
-                                data["filepath"] as String,
-                                data["newContents"] as String,
-                                (data["stepIndex"] as Double).toInt()
+                            data["filepath"] as String,
+                            data["newContents"] as String,
+                            (data["stepIndex"] as Double).toInt()
                         )
                         respond(null)
                     }
@@ -337,7 +352,8 @@ class IdeProtocolClient (
                         val endLine = end["line"] as Int
                         val endCharacter = end["character"] as Int
 
-                        val firstLine = fullContents.split("\n")[startLine].slice(startCharacter until fullContents.split("\n")[startLine].length)
+                        val firstLine =
+                            fullContents.split("\n")[startLine].slice(startCharacter until fullContents.split("\n")[startLine].length)
                         val lastLine = fullContents.split("\n")[endLine].slice(0 until endCharacter)
                         val between = fullContents.split("\n").slice(startLine + 1 until endLine).joinToString("\n")
 
@@ -395,6 +411,7 @@ class IdeProtocolClient (
                         saveFile((data as Map<String, String>)["filepath"] ?: throw Exception("No filepath provided"))
                         respond(null)
                     }
+
                     "showVirtualFile" -> {
                         val data = data as Map<String, Any>
                         showVirtualFile(
@@ -405,15 +422,11 @@ class IdeProtocolClient (
                     }
 
                     "connected" -> {}
-                    "showMessage" -> {
-                        showMessage(data as String)
-                        respond(null)
-                    }
                     "setFileOpen" -> {
                         val data = data as Map<String, Any>
                         setFileOpen(
-                                data["filepath"] as String,
-                                data["open"] as Boolean
+                            data["filepath"] as String,
+                            data["open"] as Boolean
                         )
                         respond(null)
                     }
@@ -424,14 +437,14 @@ class IdeProtocolClient (
                         val startLine = (data["startLine"] as Double).toInt()
                         val endLine = (data["endLine"] as Double).toInt()
                         highlightCode(
-                                RangeInFile(
-                                        filepath,
-                                        Range(
-                                                Position(startLine, 0),
-                                                Position(endLine, 0)
-                                        )
-                                ),
-                                data["color"] as String?
+                            RangeInFile(
+                                filepath,
+                                Range(
+                                    Position(startLine, 0),
+                                    Position(endLine, 0)
+                                )
+                            ),
+                            data["color"] as String?
                         )
                         respond(null)
                     }
@@ -442,7 +455,7 @@ class IdeProtocolClient (
                         val json = gson.toJson(data["rangeInFile"])
                         val type = object : TypeToken<RangeInFile>() {}.type
                         val rangeInFile =
-                                gson.fromJson<RangeInFile>(json, type)
+                            gson.fromJson<RangeInFile>(json, type)
                         highlightCode(rangeInFile, data["color"] as String)
                         respond(null)
                     }
@@ -460,6 +473,7 @@ class IdeProtocolClient (
                         }.toMap()
                         respond(pathToLastModified)
                     }
+
                     "listDir" -> {
                         val data = data as Map<String, Any>
                         val dir = data["dir"] as String
@@ -469,6 +483,7 @@ class IdeProtocolClient (
                         } ?: emptyList()
                         respond(files)
                     }
+
                     "getGitRootPath" -> {
                         val data = data as Map<String, Any>
                         val directory = data["dir"] as String
@@ -482,12 +497,14 @@ class IdeProtocolClient (
 
                         respond(output)
                     }
+
                     "getBranch" -> {
                         // Get the current branch name
                         val dir = (data as Map<String, Any>)["dir"] as String
                         val branch = getBranch(dir)
                         respond(branch)
                     }
+
                     "getRepoName" -> {
                         // Get the current repository name
                         val dir = (data as Map<String, Any>)["dir"] as String
@@ -526,6 +543,7 @@ class IdeProtocolClient (
 
                         respond(output.toString());
                     }
+
                     "getProblems" -> {
                         // Get currently active editor
                         var editor: Editor? = null
@@ -574,53 +592,58 @@ class IdeProtocolClient (
 //                        }
 //                        respond(problems)
                     }
+
                     "getConfigJsUrl" -> {
                         // Calculate a data URL for the config.js file
                         val configJsPath = getConfigJsPath()
                         val configJsContents = File(configJsPath).readText()
-                        val configJsDataUrl = "data:text/javascript;base64,${Base64.getEncoder().encodeToString(configJsContents.toByteArray())}"
+                        val configJsDataUrl = "data:text/javascript;base64,${
+                            Base64.getEncoder().encodeToString(configJsContents.toByteArray())
+                        }"
                         respond(configJsDataUrl)
                     }
+
                     "writeFile" -> {
                         val msg = data as Map<String, String>;
                         val file = File(msg["path"])
                         file.writeText(msg["contents"] as String)
                         respond(null);
                     }
+
                     "fileExists" -> {
                         val msg = data as Map<String, String>;
                         val file = File(msg["filepath"])
                         respond(file.exists())
                     }
+
                     "getContinueDir" -> {
                         respond(getContinueGlobalPath())
                     }
+
                     "openFile" -> {
                         setFileOpen((data as Map<String, Any>)["path"] as String)
                         respond(null)
                     }
+
                     "runCommand" -> {
                         respond(null)
                         // Running commands not yet supported in JetBrains
                     }
+
                     "showToast" -> {
                         val data = data as ArrayList<String>
-                        val toast_type =  data[0]
+                        val toast_type = data[0]
                         val message = data[1]
                         showToast(toast_type, message)
-                        respond(null)
-                    }
-                    "errorPopup" -> {
-                        val data = data as Map<String, Any>
-                        val message = data["message"] as String
-                        showMessage(message)
                         respond(null)
                     }
 
                     "listFolders" -> {
                         val workspacePath = workspacePath ?: return@launch
                         val workspaceDir = File(workspacePath)
-                        val folders = workspaceDir.listFiles { file -> file.isDirectory }?.map { file -> file.absolutePath } ?: emptyList()
+                        val folders =
+                            workspaceDir.listFiles { file -> file.isDirectory }?.map { file -> file.absolutePath }
+                                ?: emptyList()
                         respond(folders)
                     }
 
@@ -634,16 +657,19 @@ class IdeProtocolClient (
                         val openFiles = visibleFiles()
                         respond(openFiles)
                     }
+
                     "getCurrentFile" -> {
                         val currentFile = currentFile()
                         respond(currentFile)
                     }
+
                     "getPinnedFiles" -> {
                         ApplicationManager.getApplication().invokeLater {
                             val pinnedFiles = pinnedFiles()
                             respond(pinnedFiles)
                         }
                     }
+
                     "insertAtCursor" -> {
                         val msg = data as Map<String, String>;
                         val text = msg["text"] as String
@@ -660,8 +686,10 @@ class IdeProtocolClient (
                             }
                         }
                     }
+
                     "applyToFile" -> {
                     }
+
                     "getGitHubAuthToken" -> {
                         val continueSettingsService = service<ContinueExtensionSettings>()
                         val ghAuthToken = continueSettingsService.continueState.ghAuthToken;
@@ -674,26 +702,30 @@ class IdeProtocolClient (
                             respond(ghAuthToken)
                         }
                     }
+
                     "setGitHubAuthToken" -> {
                         val continueSettingsService = service<ContinueExtensionSettings>()
                         val data = data as Map<String, String>
                         continueSettingsService.continueState.ghAuthToken = data["token"]
                         respond(null)
                     }
+
                     "openUrl" -> {
                         val url = data as String
                         java.awt.Desktop.getDesktop().browse(java.net.URI(url))
                         respond(null)
                     }
+
                     "pathSep" -> {
                         respond(File.separator)
                     }
+
                     else -> {
                         println("Unknown messageType: $messageType")
                     }
                 }
             } catch (error: Exception) {
-                showMessage("Error handling message of type $messageType: $error")
+                showToast("error", "Error handling message of type $messageType: $error")
             }
         }
     }
@@ -707,8 +739,8 @@ class IdeProtocolClient (
         val configJsonPath = getConfigJsonPath()
         val reader = FileReader(configJsonPath)
         val config: MutableMap<String, Any> = gson.fromJson(
-                reader,
-                object : TypeToken<Map<String, Any>>() {}.type
+            reader,
+            object : TypeToken<Map<String, Any>>() {}.type
         )
         reader.close()
 
@@ -829,7 +861,8 @@ class IdeProtocolClient (
         val result = ApplicationManager.getApplication().runReadAction<RangeInFileWithContents?> {
             // Get the editor instance for the currently active editor window
             val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return@runReadAction null
-            val virtualFile = editor.let { FileDocumentManager.getInstance().getFile(it.document) } ?: return@runReadAction null
+            val virtualFile =
+                editor.let { FileDocumentManager.getInstance().getFile(it.document) } ?: return@runReadAction null
 
             // Get the selection range and content
             val selectionModel: SelectionModel = editor.selectionModel
@@ -849,10 +882,12 @@ class IdeProtocolClient (
             val startChar = startOffset - document.getLineStartOffset(startLine)
             val endChar = endOffset - document.getLineStartOffset(endLine)
 
-            return@runReadAction RangeInFileWithContents(virtualFile.path, Range(
+            return@runReadAction RangeInFileWithContents(
+                virtualFile.path, Range(
                     Position(startLine, startChar),
                     Position(endLine, endChar)
-            ), selectedText)
+                ), selectedText
+            )
         }
 
         return result
@@ -867,8 +902,8 @@ class IdeProtocolClient (
 //        ))
 
         continuePluginService.sendToWebview(
-"highlightedCode",
-           mapOf(
+            "highlightedCode",
+            mapOf(
                 "rangeInFileWithContents" to rif,
                 "edit" to edit
             )
@@ -888,29 +923,30 @@ class IdeProtocolClient (
     }
 
     private val DEFAULT_IGNORE_DIRS = listOf(
-            ".git",
-            ".vscode",
-            ".idea",
-            ".vs",
-            "venv",
-            ".venv",
-            "env",
-            ".env",
-            "node_modules",
-            "dist",
-            "build",
-            "target",
-            "out",
-            "bin",
-            ".pytest_cache",
-            ".vscode-test",
-            ".continue",
-            "__pycache__",
-            "site-packages",
-            ".gradle",
-            ".cache",
-            "gems",
+        ".git",
+        ".vscode",
+        ".idea",
+        ".vs",
+        "venv",
+        ".venv",
+        "env",
+        ".env",
+        "node_modules",
+        "dist",
+        "build",
+        "target",
+        "out",
+        "bin",
+        ".pytest_cache",
+        ".vscode-test",
+        ".continue",
+        "__pycache__",
+        "site-packages",
+        ".gradle",
+        ".cache",
+        "gems",
     )
+
     private fun shouldIgnoreDirectory(name: String): Boolean {
         val components = File(name).path.split(File.separator)
         return DEFAULT_IGNORE_DIRS.any { dir ->
@@ -987,7 +1023,7 @@ class IdeProtocolClient (
         return virtualFile?.path
     }
 
-    private fun showToast(type: String, content:String) {
+    fun showToast(type: String, content: String) {
         val notificationType = when (type.uppercase()) {
             "ERROR" -> NotificationType.ERROR
             "WARNING" -> NotificationType.WARNING
@@ -995,24 +1031,8 @@ class IdeProtocolClient (
         }
 
         CONTINUE_NOTIFICATION_GROUP.createNotification(content, notificationType)
-        .notify(project);
+            .notify(project);
     }
-
-suspend fun showMessage(msg: String) {
-    withContext(Dispatchers.Main) {
-        val statusBar = WindowManager.getInstance().getStatusBar(project)
-
-        JBPopupFactory.getInstance()
-            .createHtmlTextBalloonBuilder(msg, MessageType.INFO, null)
-            .setFadeoutTime(10000)
-            .setHideOnAction(false)
-            .createBalloon()
-            .show(
-                RelativePoint.getSouthEastOf(statusBar.component),
-                Balloon.Position.atRight
-            )
-    }
-}
 
     fun highlightCode(rangeInFile: RangeInFile, color: String?) {
         val file =

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/InlineEditAction.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/InlineEditAction.kt
@@ -45,7 +45,7 @@ fun makeTextArea(): JTextArea {
         isOpaque = false
         background = GetTheme().getSecondaryDark()
         maximumSize = Dimension(400, Short.MAX_VALUE.toInt())
-        margin = JBUI.insets(6, 4, 4, 4) // Reduced from 8 to 4
+        margin = JBUI.insets(6, 4, 0, 4)
         font = UIUtil.getFontWithFallback("Arial", Font.PLAIN, MAIN_FONT_SIZE)
         // Set a preferred size with a taller height
         preferredSize = Dimension(400, 75)  // Added this line
@@ -55,7 +55,7 @@ fun makeTextArea(): JTextArea {
 }
 
 fun makePanel(project: Project, customPanelRef: Ref<CustomPanel>, textArea: JTextArea, inlayRef: Ref<Disposable>, comboBoxRef: Ref<JComboBox<String>>, leftInset: Int, modelTitles: List<String>, onEnter: () -> Unit, onCancel: () -> Unit, onAccept: () -> Unit, onReject: () -> Unit): JPanel {
-    val topPanel = ShadowPanel(MigLayout("wrap 1, insets 2 ${leftInset + 4}  8 2, gap 0!")).apply {
+    val topPanel = ShadowPanel(MigLayout("wrap 1, insets 2 ${leftInset} 2 2, gap 0!")).apply {
         val globalScheme = EditorColorsManager.getInstance().globalScheme
         val defaultBackground = globalScheme.defaultBackground
 //            background = defaultBackground
@@ -63,7 +63,7 @@ fun makePanel(project: Project, customPanelRef: Ref<CustomPanel>, textArea: JTex
         isOpaque = false
     }
 
-    val panel = CustomPanel(MigLayout("wrap 1, insets 4 10 0 2, gap 0!, fillx"), project, modelTitles, comboBoxRef, onEnter, onCancel, onAccept, onReject).apply {
+    val panel = CustomPanel(MigLayout("wrap 1, insets 4 10 0 2, gap 0!, fillx"), project, modelTitles, comboBoxRef, onEnter, onCancel, onAccept, onReject, textArea).apply {
         val globalScheme = EditorColorsManager.getInstance().globalScheme
         val defaultBackground = globalScheme.defaultBackground
         background = defaultBackground
@@ -197,6 +197,15 @@ fun openInlineEdit(project: Project?, editor: Editor) {
         }
     })
 
+    // Listen for key typed events after diff streaming is finished
+    textArea.addKeyListener(object : KeyAdapter() {
+        override fun keyTyped(e: KeyEvent) {
+            if (customPanelRef.get().isFinished) {
+                customPanelRef.get().setup()
+            }
+        }
+    })
+
     // Listen for changes to textarea line count
     textArea.document.addDocumentListener(object : DocumentListener {
         private var lastNumLines: Int = 0
@@ -252,7 +261,8 @@ class CustomPanel(
     private val onEnter: () -> Unit,
     private val onCancel: () -> Unit,
     private val onAccept: () -> Unit,
-    private val onReject: () -> Unit
+    private val onReject: () -> Unit,
+    private val textArea: JTextArea
 ) : JPanel(layout) {
     private val shadowSize = 5
     private val cornerRadius = 8
@@ -262,18 +272,31 @@ class CustomPanel(
     private val triangleSize = 6
     private val rightMargin = 3.0
     private val closeButton: JComponent = createCloseButton()
+    private val originalTextColor: Color = textArea.foreground
+    private val greyTextColor: Color = Color(128, 128, 128, 200)
+    public var isFinished = false
 
     init {
         isOpaque = false
-        add(closeButton, "pos 100% 0 -3 3, w 20!, h 20!")
+        add(closeButton, "pos 100%-25 0 -3 3, w 20!, h 20!")
     }
 
     private fun createCloseButton(): JComponent {
         return CustomButton("X") { onCancel() }.apply {
-            foreground = Color(128, 128, 128, 200)
+            foreground = Color(128, 128, 128, 128)
             background = Color(0, 0, 0, 0)
-            font = UIUtil.getFontWithFallback("Arial", Font.BOLD, 12)
+            font = UIUtil.getFontWithFallback("Arial", Font.BOLD, 10)
             border = EmptyBorder(2, 6, 2, 6)
+            toolTipText = "`esc` to cancel"
+
+            addMouseListener(object : MouseAdapter() {
+                override fun mouseEntered(e: MouseEvent) {
+                    foreground = Color(128, 128, 128, 255)
+                }
+                override fun mouseExited(e: MouseEvent) {
+                    foreground = Color(128, 128, 128, 128)
+                }
+            })
         }
     }
 
@@ -307,8 +330,9 @@ class CustomPanel(
         comboBoxRef.set(dropdown)
 
         val rightButton = CustomButton("↵ Enter") { onEnter() }.apply {
-            background = JBColor(0x999998.toInt(), 0x999998.toInt())
-            foreground = JBColor(0xffffffff.toInt(), 0xffffffff.toInt())
+            background = JBColor(0x33999998.toInt(), 0x33999998.toInt())
+            foreground = Color.WHITE
+            border = EmptyBorder(2, 6, 2, 6)
         }
 
         val rightPanel = JPanel(MigLayout("insets 0, fillx")).apply {
@@ -318,7 +342,7 @@ class CustomPanel(
             add(rightButton, "align right")
         }
 
-        border = EmptyBorder(0, 0, 18, 12) // Increased bottom padding from 4 to 8
+        border = EmptyBorder(0, 0, 20, 16)
 
         add(dropdown, "align left")
         add(rightPanel, "align right, split 2")
@@ -341,17 +365,20 @@ class CustomPanel(
     }
 
     private val subPanelC: JPanel = JPanel(MigLayout("insets 0, fillx")).apply {
-        val leftLabel = JLabel("Enter follow-up instructions").apply {
+        val leftLabel = JLabel("Type to re-prompt").apply {
             foreground = Color(128, 128, 128, 200)
             font = UIUtil.getFontWithFallback("Arial", Font.PLAIN, 11)
+            border = EmptyBorder(0, 4, 0, 0)
         }
 
-        val leftButton = CustomButton("${getAltKeyLabel()}⇧N") { onReject() }.apply {
-            background = Color(255, 0, 0, 64)
+        val leftButton = CustomButton("Reject (${getAltKeyLabel()}⇧N)") { onReject() }.apply {
+            background = Color(239, 68, 68) // text-red-500
+            foreground = Color.WHITE
         }
 
-        val rightButton = CustomButton("${getAltKeyLabel()}⇧Y") { onAccept() }.apply {
-            background = Color(0, 255, 0, 64)
+        val rightButton = CustomButton("Accept (${getAltKeyLabel()}⇧Y)") { onAccept() }.apply {
+            background = Color(34, 197, 94)  // text-green-500
+            foreground = Color.WHITE
         }
 
         val rightPanel = JPanel(MigLayout("insets 0, fillx")).apply {
@@ -363,15 +390,19 @@ class CustomPanel(
 
         add(leftLabel, "align left")
         add(rightPanel, "align right")
-        border = EmptyBorder(4, 8, 4, 8)
+        // Add right and bottom insets
+        border = BorderFactory.createEmptyBorder(0, 0, 20, 16)
         isOpaque = false
     }
 
     fun setup() {
-//        add(subPanelB, "grow, gap 0!")
         remove(subPanelB)
         remove(subPanelC)
         add(subPanelA, "grow, gap 0!")
+        isFinished = false
+        revalidate()
+        repaint()
+        textArea.foreground = originalTextColor
     }
 
     fun enter() {
@@ -387,6 +418,8 @@ class CustomPanel(
         add(subPanelC, "grow, gap 0!")
         revalidate()
         repaint()
+        isFinished = true
+        textArea.foreground = greyTextColor
     }
 
     override fun paintComponent(g: Graphics) {
@@ -507,37 +540,56 @@ class TransparentArrowButtonUI : BasicComboBoxUI() {
         override fun paintComponent(g: Graphics) {
             val g2 = g as Graphics2D
             g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
-            g2.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE)
-
-            val size = 4 // Smaller size
+            val size = 6
             val x = (width - size) / 2
-            val y = (height - size) / 2
-
-            val path = Path2D.Double()
-            path.moveTo(x.toDouble(), y.toDouble())
-            path.lineTo((x + size).toDouble(), y.toDouble())
-            path.lineTo((x + size / 2.0), (y + size).toDouble())
-            path.closePath()
-
-            g2.color = Color(128, 128, 128, 200) // Light gray, semi-transparent
-            g2.fill(path)
-        }
-
-        override fun getPreferredSize(): Dimension {
-            return Dimension(12, 12) // Smaller button size
+            val y = (height - size / 2) / 2
+            val triangle = Polygon(
+                intArrayOf(x, x + size, x + size / 2),
+                intArrayOf(y, y, (y + size / 1.16).toInt()),
+                3
+            )
+            g2.color = Color.GRAY
+            g2.fill(triangle)
         }
     }.apply {
+        border = EmptyBorder(0, 0, 0, 0)
         isOpaque = false
-        isFocusable = false
-        isBorderPainted = false
-        isContentAreaFilled = false
+    }
+
+    override fun getInsets(): Insets {
+        return JBUI.insets(0, 6, 0, 0)
     }
 
     override fun installUI(c: JComponent?) {
         super.installUI(c)
-        comboBox.border = EmptyBorder(2, 0, 2, 0)
         comboBox.isOpaque = false
-        comboBox.background = Color(0, 0, 0, 0) // Fully transparent background
+        val globalScheme = EditorColorsManager.getInstance().globalScheme
+        val defaultBackground = globalScheme.defaultBackground
+        comboBox.background = defaultBackground
     }
+
+    override fun paintCurrentValueBackground(g: Graphics, bounds: Rectangle, hasFocus: Boolean) {
+
+    // Do nothing to prevent painting the background
+}
+
+override fun paintCurrentValue(g: Graphics, bounds: Rectangle, hasFocus: Boolean) {
+    val renderer = comboBox.renderer
+    val item = comboBox.selectedItem
+
+    if (item != null) {
+        val c = renderer.getListCellRendererComponent(listBox, item, -1, false, false)
+        c.font = comboBox.font
+        c.foreground = comboBox.foreground
+        c.background = comboBox.background
+
+        if (c is JComponent) {
+            c.isOpaque = false
+        }
+
+        val currentValuePane = currentValuePane
+        currentValuePane.paintComponent(g, c, comboBox, bounds.x, bounds.y, bounds.width, bounds.height, true)
+    }
+}
 }
 

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/InlineEditAction.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/InlineEditAction.kt
@@ -45,25 +45,43 @@ fun makeTextArea(): JTextArea {
         isOpaque = false
         background = GetTheme().getSecondaryDark()
         maximumSize = Dimension(400, Short.MAX_VALUE.toInt())
-        margin = JBUI.insets(6, 4, 0, 4)
+        margin = JBUI.insets(6, 4, 6, 4)
         font = UIUtil.getFontWithFallback("Arial", Font.PLAIN, MAIN_FONT_SIZE)
-        // Set a preferred size with a taller height
-        preferredSize = Dimension(400, 75)  // Added this line
+        preferredSize = Dimension(400, 75)
     }
     textArea.putClientProperty(UIUtil.HIDE_EDITOR_FROM_DATA_CONTEXT_PROPERTY, true)
     return textArea
 }
 
-fun makePanel(project: Project, customPanelRef: Ref<CustomPanel>, textArea: JTextArea, inlayRef: Ref<Disposable>, comboBoxRef: Ref<JComboBox<String>>, leftInset: Int, modelTitles: List<String>, onEnter: () -> Unit, onCancel: () -> Unit, onAccept: () -> Unit, onReject: () -> Unit): JPanel {
+fun makePanel(
+    project: Project,
+    customPanelRef: Ref<CustomPanel>,
+    textArea: JTextArea,
+    inlayRef: Ref<Disposable>,
+    comboBoxRef: Ref<JComboBox<String>>,
+    leftInset: Int,
+    modelTitles: List<String>,
+    onEnter: () -> Unit,
+    onCancel: () -> Unit,
+    onAccept: () -> Unit,
+    onReject: () -> Unit
+): JPanel {
     val topPanel = ShadowPanel(MigLayout("wrap 1, insets 2 ${leftInset} 2 2, gap 0!")).apply {
-        val globalScheme = EditorColorsManager.getInstance().globalScheme
-        val defaultBackground = globalScheme.defaultBackground
-//            background = defaultBackground
-        background =  JBColor(0x20888888.toInt(), 0x20888888.toInt())
+        background = JBColor(0x20888888.toInt(), 0x20888888.toInt())
         isOpaque = false
     }
 
-    val panel = CustomPanel(MigLayout("wrap 1, insets 4 10 0 2, gap 0!, fillx"), project, modelTitles, comboBoxRef, onEnter, onCancel, onAccept, onReject, textArea).apply {
+    val panel = CustomPanel(
+        MigLayout("wrap 1, insets 4 10 0 2, gap 0!, fillx"),
+        project,
+        modelTitles,
+        comboBoxRef,
+        onEnter,
+        onCancel,
+        onAccept,
+        onReject,
+        textArea
+    ).apply {
         val globalScheme = EditorColorsManager.getInstance().globalScheme
         val defaultBackground = globalScheme.defaultBackground
         background = defaultBackground
@@ -92,9 +110,9 @@ fun openInlineEdit(project: Project?, editor: Editor) {
     if (project == null) return
 
     // Don't open in terminal
-     if (EditorUtils().isTerminal(editor)) {
-            return
-     }
+    if (EditorUtils().isTerminal(editor)) {
+        return
+    }
 
     val manager = EditorComponentInlaysManager.from(editor)
 
@@ -135,7 +153,8 @@ fun openInlineEdit(project: Project?, editor: Editor) {
     val lineEnd = editor.document.getLineEndOffset(indentationLineNum)
     val text = editor.document.getText(TextRange(lineStart, lineEnd))
     val indentation = text.takeWhile { it == ' ' }.length
-    val charWidth = editor.contentComponent.getFontMetrics(editor.colorsScheme.getFont(EditorFontType.PLAIN)).charWidth(' ')
+    val charWidth =
+        editor.contentComponent.getFontMetrics(editor.colorsScheme.getFont(EditorFontType.PLAIN)).charWidth(' ')
     val leftInset = indentation * charWidth * 2 / 3
 
     val inlayRef = Ref<Disposable>()
@@ -162,16 +181,17 @@ fun openInlineEdit(project: Project?, editor: Editor) {
         diffStreamHandler.run(textArea.text, prefix, highlighted, suffix, comboBoxRef.get().selectedItem as String)
     }
 
-    val panel = makePanel(project, customPanelRef, textArea, inlayRef, comboBoxRef, leftInset, modelTitles, {onEnter()}, {
-        diffStreamService.reject(editor)
-        selectionModel.setSelection(start, end)
-    }, {
-        diffStreamService.accept(editor)
-        inlayRef.get().dispose()
-    }, {
-        diffStreamService.reject(editor)
-        inlayRef.get().dispose()
-    })
+    val panel =
+        makePanel(project, customPanelRef, textArea, inlayRef, comboBoxRef, leftInset, modelTitles, { onEnter() }, {
+            diffStreamService.reject(editor)
+            selectionModel.setSelection(start, end)
+        }, {
+            diffStreamService.accept(editor)
+            inlayRef.get().dispose()
+        }, {
+            diffStreamService.reject(editor)
+            inlayRef.get().dispose()
+        })
     val inlay = manager.insertAfter(lineNumber, panel)
     panel.revalidate()
     inlayRef.set(inlay)
@@ -216,6 +236,7 @@ fun openInlineEdit(project: Project?, editor: Editor) {
                 viewport?.dispatchEvent(ComponentEvent(viewport, ComponentEvent.COMPONENT_RESIZED))
             }
         }
+
         override fun insertUpdate(e: DocumentEvent?) {
             updateSize()
         }
@@ -293,6 +314,7 @@ class CustomPanel(
                 override fun mouseEntered(e: MouseEvent) {
                     foreground = Color(128, 128, 128, 255)
                 }
+
                 override fun mouseExited(e: MouseEvent) {
                     foreground = Color(128, 128, 128, 128)
                 }
@@ -329,7 +351,7 @@ class CustomPanel(
 
         comboBoxRef.set(dropdown)
 
-        val rightButton = CustomButton("↵ Enter") { onEnter() }.apply {
+        val rightButton = CustomButton("⏎  Enter") { onEnter() }.apply {
             background = JBColor(0x33999998.toInt(), 0x33999998.toInt())
             foreground = Color.WHITE
             border = EmptyBorder(2, 6, 2, 6)
@@ -359,14 +381,12 @@ class CustomPanel(
         }
 
         add(progressBar, BorderLayout.CENTER)
-
-        // Add right and bottom insets
         border = BorderFactory.createEmptyBorder(0, 0, 20, 16)
     }
 
     private val subPanelC: JPanel = JPanel(MigLayout("insets 0, fillx")).apply {
         val leftLabel = JLabel("Type to re-prompt").apply {
-            foreground = Color(128, 128, 128, 200)
+            foreground = Color(156, 163, 175) // text-gray-400
             font = UIUtil.getFontWithFallback("Arial", Font.PLAIN, 11)
             border = EmptyBorder(0, 4, 0, 0)
         }
@@ -390,7 +410,6 @@ class CustomPanel(
 
         add(leftLabel, "align left")
         add(rightPanel, "align right")
-        // Add right and bottom insets
         border = BorderFactory.createEmptyBorder(0, 0, 20, 16)
         isOpaque = false
     }
@@ -436,16 +455,33 @@ class CustomPanel(
         shape.moveTo(borderThickness / 2.0, cornerRadius.toDouble())
         shape.quadTo(borderThickness / 2.0, borderThickness / 2.0, cornerRadius.toDouble(), borderThickness / 2.0)
         shape.lineTo(w - cornerRadius.toDouble() - rightMargin, borderThickness / 2.0)
-        shape.quadTo(w - borderThickness / 2.0 - rightMargin, borderThickness / 2.0, w - borderThickness / 2.0 - rightMargin, cornerRadius.toDouble())
+        shape.quadTo(
+            w - borderThickness / 2.0 - rightMargin,
+            borderThickness / 2.0,
+            w - borderThickness / 2.0 - rightMargin,
+            cornerRadius.toDouble()
+        )
         shape.lineTo(w - borderThickness / 2.0 - rightMargin, h - cornerRadius - triangleSize.toDouble())
-        shape.quadTo(w - borderThickness / 2.0 - rightMargin, h - triangleSize.toDouble(), w - cornerRadius.toDouble() - rightMargin, h - triangleSize.toDouble())
+        shape.quadTo(
+            w - borderThickness / 2.0 - rightMargin,
+            h - triangleSize.toDouble(),
+            w - cornerRadius.toDouble() - rightMargin,
+            h - triangleSize.toDouble()
+        )
         shape.lineTo(triangleSize.toDouble(), h - triangleSize.toDouble())
         shape.lineTo(borderThickness / 2.0, h.toDouble())
         shape.lineTo(borderThickness / 2.0, cornerRadius.toDouble())
 
         // Draw shadow
         g2.color = shadowColor
-        g2.fill(shape.createTransformedShape(AffineTransform.getTranslateInstance(shadowSize.toDouble(), shadowSize.toDouble())))
+        g2.fill(
+            shape.createTransformedShape(
+                AffineTransform.getTranslateInstance(
+                    shadowSize.toDouble(),
+                    shadowSize.toDouble()
+                )
+            )
+        )
 
         // Draw main shape
         g2.color = background
@@ -484,13 +520,21 @@ class CustomButton(text: String, onClick: () -> Unit) : JLabel(text, CENTER) {
         font = UIUtil.getFontWithFallback("Arial", Font.PLAIN, 11)
         border = EmptyBorder(2, 4, 2, 4)
     }
+
     override fun paintComponent(g: Graphics) {
         val g2 = g as Graphics2D
         g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
 
         val cornerRadius = 8
         val rect = Rectangle(0, 0, width, height)
-        val roundRect = RoundRectangle2D.Float(rect.x.toFloat(), rect.y.toFloat(), rect.width.toFloat(), rect.height.toFloat(), cornerRadius.toFloat(), cornerRadius.toFloat())
+        val roundRect = RoundRectangle2D.Float(
+            rect.x.toFloat(),
+            rect.y.toFloat(),
+            rect.width.toFloat(),
+            rect.height.toFloat(),
+            cornerRadius.toFloat(),
+            cornerRadius.toFloat()
+        )
         if (isHovered) {
             g2.color = background.brighter()
         } else {
@@ -498,8 +542,10 @@ class CustomButton(text: String, onClick: () -> Unit) : JLabel(text, CENTER) {
         }
         g2.fill(roundRect)
         g2.color = foreground
-        g2.drawString(text, (width / 2 - g.fontMetrics.stringWidth(text) / 2).toFloat(),
-                (height / 2 + g.fontMetrics.ascent / 2).toFloat())
+        g2.drawString(
+            text, (width / 2 - g.fontMetrics.stringWidth(text) / 2).toFloat(),
+            (height / 2 + g.fontMetrics.ascent / 2).toFloat()
+        )
     }
 }
 
@@ -570,26 +616,26 @@ class TransparentArrowButtonUI : BasicComboBoxUI() {
 
     override fun paintCurrentValueBackground(g: Graphics, bounds: Rectangle, hasFocus: Boolean) {
 
-    // Do nothing to prevent painting the background
-}
-
-override fun paintCurrentValue(g: Graphics, bounds: Rectangle, hasFocus: Boolean) {
-    val renderer = comboBox.renderer
-    val item = comboBox.selectedItem
-
-    if (item != null) {
-        val c = renderer.getListCellRendererComponent(listBox, item, -1, false, false)
-        c.font = comboBox.font
-        c.foreground = comboBox.foreground
-        c.background = comboBox.background
-
-        if (c is JComponent) {
-            c.isOpaque = false
-        }
-
-        val currentValuePane = currentValuePane
-        currentValuePane.paintComponent(g, c, comboBox, bounds.x, bounds.y, bounds.width, bounds.height, true)
+        // Do nothing to prevent painting the background
     }
-}
+
+    override fun paintCurrentValue(g: Graphics, bounds: Rectangle, hasFocus: Boolean) {
+        val renderer = comboBox.renderer
+        val item = comboBox.selectedItem
+
+        if (item != null) {
+            val c = renderer.getListCellRendererComponent(listBox, item, -1, false, false)
+            c.font = comboBox.font
+            c.foreground = Color(156, 163, 175) // text-gray-400
+            c.background = comboBox.background
+
+            if (c is JComponent) {
+                c.isOpaque = false
+            }
+
+            val currentValuePane = currentValuePane
+            currentValuePane.paintComponent(g, c, comboBox, bounds.x, bounds.y, bounds.width, bounds.height, true)
+        }
+    }
 }
 

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/MessageTypes.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/MessageTypes.kt
@@ -38,7 +38,6 @@ class MessageTypes {
             "getTags",
             "getIdeInfo",
             "getIdeSettings",
-            "errorPopup",
             "getRepoName",
             "listDir",
             "getGitRootPath",

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/MessageTypes.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/MessageTypes.kt
@@ -50,7 +50,8 @@ class MessageTypes {
             "pathSep",
             "getControlPlaneSessionInfo",
             "logoutOfControlPlane",
-            "getTerminalContents"
+            "getTerminalContents",
+            "showToast"
         )
 
         val PASS_THROUGH_TO_WEBVIEW = listOf<String>(


### PR DESCRIPTION
## Description

Implements the [`showToast`](https://github.com/continuedev/continue/blob/dev/core/index.d.ts#L508-L512) function of the IDE interface for the Intellij plugin.

This allows custom context providers to send messages directly to the IDE.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots
![grafik](https://github.com/user-attachments/assets/3e323c81-99e3-4098-8739-ddcf5fedb347)

![grafik](https://github.com/user-attachments/assets/0f63c498-ace1-4ead-a3c6-b5d985d3e291)

