### PR TITLE
fix: sanitize lance table names

### DIFF
--- a/core/indexing/docs/DocsService.ts
+++ b/core/indexing/docs/DocsService.ts
@@ -534,8 +534,12 @@ export default class DocsService {
     await table.delete(`title = '${mockRowTitle}'`);
   }
 
-  private removeInvalidLanceTableNameChars(tableName: string) {
-    return tableName.replace(/:/g, "");
+  /**
+   * From Lance: Table names can only contain alphanumeric characters,
+   * underscores, hyphens, and periods
+   */
+  private sanitizeLanceTableName(name: string) {
+    return name.replace(/[^a-zA-Z0-9_.-]/g, "_");
   }
 
   private async getLanceTableNameFromEmbeddingsProvider(
@@ -544,10 +548,10 @@ export default class DocsService {
     const embeddingsProvider = await this.getEmbeddingsProvider(
       isPreIndexedDoc,
     );
-    const embeddingsProviderId = this.removeInvalidLanceTableNameChars(
-      embeddingsProvider.id,
+
+    const tableName = this.sanitizeLanceTableName(
+      `${DocsService.lanceTableName}${embeddingsProvider.id}`,
     );
-    const tableName = `${DocsService.lanceTableName}${embeddingsProviderId}`;
 
     return tableName;
   }

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/InlineEditAction.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/InlineEditAction.kt
@@ -599,26 +599,23 @@ class TransparentArrowButtonUI : BasicComboBoxUI() {
         val defaultBackground = globalScheme.defaultBackground
         comboBox.background = defaultBackground
 
-        // Modify the ComboBoxModel to include the down symbol
-        val originalModel = comboBox.model
-        comboBox.model = object : ComboBoxModel<Any> {
-            override fun getSize(): Int = originalModel.size
-            override fun getElementAt(index: Int): Any? = originalModel.getElementAt(index)
-            override fun setSelectedItem(anItem: Any?) {
-                originalModel.selectedItem = anItem
-            }
-
-            override fun getSelectedItem(): Any? {
-                val item = originalModel.selectedItem
-                return if (item is String) "$item ▾" else item
-            }
-
-            override fun addListDataListener(l: ListDataListener?) {
-                originalModel.addListDataListener(l)
-            }
-
-            override fun removeListDataListener(l: ListDataListener?) {
-                originalModel.removeListDataListener(l)
+        // Custom renderer to add the down caret symbol
+        comboBox.renderer = object : DefaultListCellRenderer() {
+            override fun getListCellRendererComponent(
+                list: JList<*>?,
+                value: Any?,
+                index: Int,
+                isSelected: Boolean,
+                cellHasFocus: Boolean
+            ): Component {
+                val component = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus)
+                if (component is JLabel && index == -1) {  // -1 indicates it's the selected item in the ComboBox
+                    text = "$text ▾"
+                }
+                foreground = Color(156, 163, 175) // text-gray-400
+                background = comboBox.background
+                isOpaque = false
+                return component
             }
         }
     }


### PR DESCRIPTION
## Description

Fixes issues with Lance table names containing invalid chars, e.g. `Error: Invalid table name ("docsGeminiEmbeddingsProvidermodels/text-embedding-004"): Table names can only contain alphanumeric characters, underscores, hyphens, and periods
`

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change. ]
