### PR TITLE
fix(jb): prevent white flash on GUI load

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinueBrowser.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinueBrowser.kt
@@ -78,14 +78,6 @@ class ContinueBrowser(val project: Project, url: String, useOsr: Boolean = false
     val browser: JBCefBrowser
 
     init {
-        val osName = System.getProperty("os.name").toLowerCase()
-        val os = when {
-            osName.contains("mac") || osName.contains("darwin") -> "darwin"
-            osName.contains("win") -> "win32"
-            osName.contains("nix") || osName.contains("nux") || osName.contains("aix") -> "linux"
-            else -> "linux"
-        }
-
         this.browser = JBCefBrowser.createBuilder().setOffScreenRendering(true).build()
 
         browser.jbCefClient.setProperty(


### PR DESCRIPTION
## Description

One line fix was setting this: `setOffScreenRendering(true)`

```kotlin
this.browser = JBCefBrowser.createBuilder().setOffScreenRendering(true).build()
```

## Checklist

- [ ] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change. ]
