### PR TITLE
fix: corrected typo in the info Alert paragraph

### DIFF
--- a/gui/src/components/OnboardingCard/components/ProviderAlert.tsx
+++ b/gui/src/components/OnboardingCard/components/ProviderAlert.tsx
@@ -20,7 +20,7 @@ function ProviderAlert() {
     <div className="w-full">
       <Alert type="info">
         <p className="font-semibold text-sm m-0">
-          Prefer to use an different provider like OpenAI?
+          Prefer to use a different provider like OpenAI?
         </p>
         <p className="m-0 mt-1">
           <a


### PR DESCRIPTION
## Description

Changed the article "an" to "a" for grammatical correctness in the sentence "Prefer to use a different provider like OpenAI?"

### Before:
<img width="759" alt="image" src="https://github.com/user-attachments/assets/8048d553-3a9a-420c-b5a7-04a98c1a498b">

### After:

<img width="759" alt="image" src="https://github.com/user-attachments/assets/5f41ee32-0ea2-4c07-853c-7eda0a544e68">
