### PR TITLE
feat: Add SageMaker Embeddings

### DIFF
--- a/binary/package-lock.json
+++ b/binary/package-lock.json
@@ -74,6 +74,7 @@
         "jsdom": "^24.0.0",
         "launchdarkly-node-client-sdk": "^3.2.0",
         "llm-code-highlighter": "^0.0.14",
+        "lru-cache": "^10.2.2",
         "mac-ca": "^3.1.0",
         "node-fetch": "^3.3.2",
         "node-html-markdown": "^1.3.0",

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -801,6 +801,7 @@ export interface ModelDescription {
 }
 
 export type EmbeddingsProviderName =
+  | "sagemaker"
   | "bedrock"
   | "huggingface-tei"
   | "transformers.js"

--- a/core/indexing/embeddings/SageMakerEmbeddingsProvider.ts
+++ b/core/indexing/embeddings/SageMakerEmbeddingsProvider.ts
@@ -1,0 +1,114 @@
+import {
+    InvokeEndpointCommand,
+    SageMakerRuntimeClient,
+  } from "@aws-sdk/client-sagemaker-runtime";
+  import { fromIni } from "@aws-sdk/credential-providers";
+  
+  import {
+    EmbeddingsProviderName,
+    EmbedOptions,
+    FetchFunction,
+  } from "../../index.js";
+  import BaseEmbeddingsProvider from "./BaseEmbeddingsProvider.js";
+  
+  
+  class SageMakerEmbeddingsProvider extends BaseEmbeddingsProvider {
+    static providerName: EmbeddingsProviderName = "sagemaker";
+  
+    static defaultOptions: Partial<EmbedOptions> | undefined = {
+      region: "us-west-2",
+      maxBatchSize: 1,
+    };
+    profile?: string | undefined;
+  
+    constructor(options: EmbedOptions, fetch: FetchFunction) {
+      super(options, fetch);
+      if (!options.apiBase) {
+        options.apiBase = `https://runtime.sagemaker.${options.region}.amazonaws.com`;
+      }
+  
+      if (options.profile) {
+        this.profile = options.profile;
+      } else {
+        this.profile = "sagemaker";
+      }
+    }
+  
+    async embed(chunks: string[]) {
+      const credentials = await this._getCredentials();
+      const client = new SageMakerRuntimeClient({
+        region: this.options.region,
+        credentials: {
+          accessKeyId: credentials.accessKeyId,
+          secretAccessKey: credentials.secretAccessKey,
+          sessionToken: credentials.sessionToken || "",
+        },
+      });
+  
+      const batchedChunks = this.getBatchedChunks(chunks);
+      return (
+        await Promise.all(
+          batchedChunks.map(async (batch) => {
+            const input = this._generateInvokeModelCommandInput(
+              batch,
+              this.options,
+            );
+            const command = new InvokeEndpointCommand(input);
+            const response = await client.send(command);
+  
+            if (response.Body) {
+              const responseBody = JSON.parse(
+                new TextDecoder().decode(response.Body),
+              );
+              // If the body contains a key called "embedding" or "embeddings", return the value, otherwise return the whole body
+              if (responseBody.embedding) {
+                return responseBody.embedding;
+              } else if (responseBody.embeddings) {
+                return responseBody.embeddings;
+              } else {
+                return responseBody;
+              }
+            }
+          }),
+        )
+      ).flat();
+    }
+    private _generateInvokeModelCommandInput(
+      prompts: string | string[],
+      options: EmbedOptions,
+    ): any {
+      const payload = {
+        inputs: prompts,
+        normalize: true,
+        // ...(options.requestOptions?.extraBodyProperties || {}),
+      };
+  
+      if (options.requestOptions?.extraBodyProperties) {
+        Object.assign(payload, options.requestOptions.extraBodyProperties);
+      }
+  
+      return {
+        EndpointName: this.options.model,
+        Body: JSON.stringify(payload),
+        ContentType: "application/json",
+        CustomAttributes: "accept_eula=false",
+      };
+    }
+  
+    private async _getCredentials() {
+      try {
+        return await fromIni({
+          profile: this.profile,
+          ignoreCache: true,
+        })();
+      } catch (e) {
+        console.warn(
+          `AWS profile with name ${this.profile} not found in ~/.aws/credentials, using default profile`,
+        );
+        return await fromIni()();
+      }
+    }
+  }
+  
+  export default SageMakerEmbeddingsProvider;
+  

--- a/core/indexing/embeddings/index.ts
+++ b/core/indexing/embeddings/index.ts
@@ -1,5 +1,6 @@
 import { EmbeddingsProviderName } from "../../index.js";
 import BaseEmbeddingsProvider from "./BaseEmbeddingsProvider.js";
+import SageMakerEmbeddingsProvider from "./SageMakerEmbeddingsProvider.js";
 import BedrockEmbeddingsProvider from "./BedrockEmbeddingsProvider.js";
 import CohereEmbeddingsProvider from "./CohereEmbeddingsProvider.js";
 import ContinueProxyEmbeddingsProvider from "./ContinueProxyEmbeddingsProvider.js";
@@ -22,6 +23,7 @@ export const allEmbeddingsProviders: Record<
   EmbeddingsProviderName,
   EmbeddingsProviderConstructor
 > = {
+  sagemaker: SageMakerEmbeddingsProvider,
   bedrock: BedrockEmbeddingsProvider,
   ollama: OllamaEmbeddingsProvider,
   "transformers.js": TransformersJsEmbeddingsProvider,

--- a/docs/docs/customize/model-providers/more/sagemaker.md
+++ b/docs/docs/customize/model-providers/more/sagemaker.md
@@ -1,8 +1,8 @@
 # AWS SageMaker
 
-SageMaker provider support SageMaker endpoint deployed with [LMI](https://docs.djl.ai/docs/serving/serving/docs/lmi/index.html)
+SageMaker can be used for both chat and embedding models. Chat models are supported for endpoints deployed with [LMI](https://docs.djl.ai/docs/serving/serving/docs/lmi/index.html), and embedding models are supported for endpoints deployed with [HuggingFace TEI](https://huggingface.co/blog/sagemaker-huggingface-embedding)
 
-To setup SageMaker, add the following to your `config.json` file:
+To setup SageMaker as a chat model provider, add the following to your `config.json` file:
 
 ```json title="config.json"
 {
@@ -13,7 +13,11 @@ To setup SageMaker, add the following to your `config.json` file:
       "model": "lmi-model-deepseek-coder-xxxxxxx",
       "region": "us-west-2"
     }
-  ]
+  ],
+  "embeddingsProvider": {
+    "provider": "sagemaker",
+    "model": "mxbai-embed-large-v1-endpoint"
+  },
 }
 ```
 

--- a/docs/docs/customize/model-types/embeddings.md
+++ b/docs/docs/customize/model-types/embeddings.md
@@ -69,7 +69,3 @@ See [here](../model-providers/more/cohere.md#embeddings-model) for instructions 
 ### Gemini
 
 See [here](../model-providers/top-level/gemini.md#embeddings-model) for instructions on how to use Gemini for embeddings.
-
-### Amazon
-
-You can use either [Bedrock](../model-providers/top-level/bedrock.md#embeddings-model) or [SageMaker](../model-providers/more/sagemaker.md) for generating embeddings.

--- a/docs/docs/customize/model-types/embeddings.md
+++ b/docs/docs/customize/model-types/embeddings.md
@@ -69,3 +69,7 @@ See [here](../model-providers/more/cohere.md#embeddings-model) for instructions 
 ### Gemini
 
 See [here](../model-providers/top-level/gemini.md#embeddings-model) for instructions on how to use Gemini for embeddings.
+
+### Amazon
+
+You can use either [Bedrock](../model-providers/top-level/bedrock.md#embeddings-model) or [SageMaker](../model-providers/more/sagemaker.md) for generating embeddings.

--- a/docs/static/schemas/config.json
+++ b/docs/static/schemas/config.json
@@ -246,7 +246,24 @@
         "region": {
           "title": "Region",
           "description": "The region where the model is hosted",
-          "type": "string"
+          "anyOf":[
+            {
+              "enum": [
+                "us-east-1",
+                "us-east-2",
+                "us-west-1",
+                "us-west-2",
+                "eu-west-1",
+                "eu-central-1",
+                "ap-southeast-1",
+                "ap-northeast-1",
+                "ap-south-1"
+              ]
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "profile": {
           "title": "Profile",
@@ -2145,7 +2162,8 @@
                 "gemini",
                 "voyage",
                 "nvidia",
-                "bedrock"
+                "bedrock",
+                "sagemaker"
               ]
             },
             "model": {
@@ -2179,7 +2197,24 @@
             "region": {
               "title": "Region",
               "description": "The region where the model is hosted",
-              "type": "string"
+              "anyOf":[
+                {
+                  "enum": [
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
+                    "eu-west-1",
+                    "eu-central-1",
+                    "ap-southeast-1",
+                    "ap-northeast-1",
+                    "ap-south-1"
+                  ]
+                },
+                {
+                  "type": "string"
+                }
+              ]
             },
             "profile": {
               "title": "Profile",
@@ -2200,6 +2235,24 @@
               },
               "then": {
                 "required": ["apiKey"]
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "provider": {
+                    "enum": ["sagemaker"]
+                  }
+                },
+                "required": ["provider"]
+              },
+              "then": {
+                "properties": {
+                  "model": {
+                    "markdownDescription": "SageMaker endpoint name"
+                  }
+                },
+                "required": ["model"]
               }
             }
           ]

--- a/extensions/intellij/src/main/resources/config_schema.json
+++ b/extensions/intellij/src/main/resources/config_schema.json
@@ -246,7 +246,24 @@
         "region": {
           "title": "Region",
           "description": "The region where the model is hosted",
-          "type": "string"
+          "anyOf":[
+            {
+              "enum": [
+                "us-east-1",
+                "us-east-2",
+                "us-west-1",
+                "us-west-2",
+                "eu-west-1",
+                "eu-central-1",
+                "ap-southeast-1",
+                "ap-northeast-1",
+                "ap-south-1"
+              ]
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "profile": {
           "title": "Profile",
@@ -2145,7 +2162,8 @@
                 "gemini",
                 "voyage",
                 "nvidia",
-                "bedrock"
+                "bedrock",
+                "sagemaker"
               ]
             },
             "model": {
@@ -2179,7 +2197,24 @@
             "region": {
               "title": "Region",
               "description": "The region where the model is hosted",
-              "type": "string"
+              "anyOf":[
+                {
+                  "enum": [
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
+                    "eu-west-1",
+                    "eu-central-1",
+                    "ap-southeast-1",
+                    "ap-northeast-1",
+                    "ap-south-1"
+                  ]
+                },
+                {
+                  "type": "string"
+                }
+              ]
             },
             "profile": {
               "title": "Profile",
@@ -2200,6 +2235,24 @@
               },
               "then": {
                 "required": ["apiKey"]
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "provider": {
+                    "enum": ["sagemaker"]
+                  }
+                },
+                "required": ["provider"]
+              },
+              "then": {
+                "properties": {
+                  "model": {
+                    "markdownDescription": "SageMaker endpoint name"
+                  }
+                },
+                "required": ["model"]
               }
             }
           ]

--- a/extensions/intellij/src/main/resources/config_schema.json
+++ b/extensions/intellij/src/main/resources/config_schema.json
@@ -258,7 +258,8 @@
                 "ap-southeast-1",
                 "ap-northeast-1",
                 "ap-south-1"
-              ]
+              ],
+              "type" : "string"
             },
             {
               "type": "string"
@@ -2197,24 +2198,7 @@
             "region": {
               "title": "Region",
               "description": "The region where the model is hosted",
-              "anyOf":[
-                {
-                  "enum": [
-                    "us-east-1",
-                    "us-east-2",
-                    "us-west-1",
-                    "us-west-2",
-                    "eu-west-1",
-                    "eu-central-1",
-                    "ap-southeast-1",
-                    "ap-northeast-1",
-                    "ap-south-1"
-                  ]
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "$ref": "#/definitions/ModelDescription/properties/region"
             },
             "profile": {
               "title": "Profile",

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -246,7 +246,24 @@
         "region": {
           "title": "Region",
           "description": "The region where the model is hosted",
-          "type": "string"
+          "anyOf":[
+            {
+              "enum": [
+                "us-east-1",
+                "us-east-2",
+                "us-west-1",
+                "us-west-2",
+                "eu-west-1",
+                "eu-central-1",
+                "ap-southeast-1",
+                "ap-northeast-1",
+                "ap-south-1"
+              ]
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "profile": {
           "title": "Profile",
@@ -2145,7 +2162,8 @@
                 "gemini",
                 "voyage",
                 "nvidia",
-                "bedrock"
+                "bedrock",
+                "sagemaker"
               ]
             },
             "model": {
@@ -2179,7 +2197,24 @@
             "region": {
               "title": "Region",
               "description": "The region where the model is hosted",
-              "type": "string"
+              "anyOf":[
+                {
+                  "enum": [
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
+                    "eu-west-1",
+                    "eu-central-1",
+                    "ap-southeast-1",
+                    "ap-northeast-1",
+                    "ap-south-1"
+                  ]
+                },
+                {
+                  "type": "string"
+                }
+              ]
             },
             "profile": {
               "title": "Profile",
@@ -2200,6 +2235,24 @@
               },
               "then": {
                 "required": ["apiKey"]
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "provider": {
+                    "enum": ["sagemaker"]
+                  }
+                },
+                "required": ["provider"]
+              },
+              "then": {
+                "properties": {
+                  "model": {
+                    "markdownDescription": "SageMaker endpoint name"
+                  }
+                },
+                "required": ["model"]
               }
             }
           ]

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -258,7 +258,8 @@
                 "ap-southeast-1",
                 "ap-northeast-1",
                 "ap-south-1"
-              ]
+              ],
+              "type" : "string"
             },
             {
               "type": "string"
@@ -2197,24 +2198,7 @@
             "region": {
               "title": "Region",
               "description": "The region where the model is hosted",
-              "anyOf":[
-                {
-                  "enum": [
-                    "us-east-1",
-                    "us-east-2",
-                    "us-west-1",
-                    "us-west-2",
-                    "eu-west-1",
-                    "eu-central-1",
-                    "ap-southeast-1",
-                    "ap-northeast-1",
-                    "ap-south-1"
-                  ]
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "$ref": "#/definitions/ModelDescription/properties/region"
             },
             "profile": {
               "title": "Profile",

--- a/extensions/vscode/continue_rc_schema.json
+++ b/extensions/vscode/continue_rc_schema.json
@@ -249,7 +249,24 @@
         "region": {
           "title": "Region",
           "description": "The region where the model is hosted",
-          "type": "string"
+          "anyOf": [
+            {
+              "enum": [
+                "us-east-1",
+                "us-east-2",
+                "us-west-1",
+                "us-west-2",
+                "eu-west-1",
+                "eu-central-1",
+                "ap-southeast-1",
+                "ap-northeast-1",
+                "ap-south-1"
+              ]
+            },
+            {
+              "type": "string"
+            }
+          ]
         },
         "profile": {
           "title": "Profile",
@@ -2391,7 +2408,8 @@
                 "gemini",
                 "voyage",
                 "nvidia",
-                "bedrock"
+                "bedrock",
+                "sagemaker"
               ]
             },
             "model": {
@@ -2425,7 +2443,24 @@
             "region": {
               "title": "Region",
               "description": "The region where the model is hosted",
-              "type": "string"
+              "anyOf": [
+                {
+                  "enum": [
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
+                    "eu-west-1",
+                    "eu-central-1",
+                    "ap-southeast-1",
+                    "ap-northeast-1",
+                    "ap-south-1"
+                  ]
+                },
+                {
+                  "type": "string"
+                }
+              ]
             },
             "profile": {
               "title": "Profile",
@@ -2456,6 +2491,30 @@
               "then": {
                 "required": [
                   "apiKey"
+                ]
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "provider": {
+                    "enum": [
+                      "sagemaker"
+                    ]
+                  }
+                },
+                "required": [
+                  "provider"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "model": {
+                    "markdownDescription": "SageMaker endpoint name"
+                  }
+                },
+                "required": [
+                  "model"
                 ]
               }
             }

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "0.9.214",
+  "version": "0.9.215",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "0.9.214",
+      "version": "0.9.215",
       "license": "Apache-2.0",
       "dependencies": {
         "@electron/rebuild": "^3.2.10",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "0.9.214",
+  "version": "0.9.215",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION
## Description

This pull request adds SageMaker as an embeddings model provider. The new provider is primarily designed to work with SageMaker endpoints deployed using the Huggingface TEI containers, but can be customized to work with other endpoints too through the use of `requestOptions.extraBodyProperties`. Documentation on how to set up the new provider has been added to both the Embedding Models and Sagemaker Provider pages. The config_schema has been updated for both vscode and intellij to include `sagemaker` as a new provider, as well as providing some default region options for the most commonly used AWS regions.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing

Requires: AWS Sagemaker endpoint deployed with TEI container (example [here](https://www.philschmid.de/sagemaker-train-deploy-embedding-models#4-deploy--test-fine-tuned-embedding-model-on-amazon-sagemaker))
Requires: an AWS profile called "sagemaker" or a default profile with permissions to invoke endpoints

Add the following configuration:
"embeddingsProvider": {
    "provider": "sagemaker",
    "model": "embedding-test-endpoint",
    "maxBatchSize": 12,
    "profile": "default",
    "region": "us-west-2",
    "requestOptions": {
      // this is an example for an endpoint deployed using TEI
      "extraBodyProperties": {
        "parameters": {
          "truncate": true
        }
      }
    }

To learn more about the parameters you can send to TEI backed endpoints, see the API reference [here](https://huggingface.github.io/text-embeddings-inference/#/Text%20Embeddings%20Inference/embed)