### PR TITLE
Fixes issue 2313 - Fix Open Files Context Provider for WSL and SSH

### DIFF
--- a/extensions/vscode/src/util/ideUtils.ts
+++ b/extensions/vscode/src/util/ideUtils.ts
@@ -233,7 +233,7 @@ export class VsCodeIdeUtils {
   // In some cases vscode.window.visibleTextEditors can return non-code editors
   // e.g. terminal editors in side-by-side mode
   private documentIsCode(uri: vscode.Uri) {
-    return uri.scheme === "file";
+    return uri.scheme === "file" || uri.scheme === "vscode-remote";
   }
 
   getOpenFiles(): string[] {
@@ -246,7 +246,7 @@ export class VsCodeIdeUtils {
       .flat()
       .filter(Boolean) // filter out undefined values
       .filter((uri) => this.documentIsCode(uri)) // Filter out undesired documents
-      .map((uri) => uriFromFilePath(uri.fsPath).fsPath);
+      .map((uri) => uri.fsPath);
   }
 
   getVisibleFiles(): string[] {


### PR DESCRIPTION
## Description

Remote SSH and WSL files are represented with a uri scheme of `vscode-remote`. There is a check in the `openFiles` method of the ideUtils class that checks to see if the current uri is of a schema `file`, if it's not it get's filtered out.

This breaks the OpenFilesContextProvider for the `vscode-remote` schemes.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created

## Screenshots

Before fix
https://github.com/user-attachments/assets/9c13b347-3440-4d88-a6f2-869254173189

After Fix
https://github.com/user-attachments/assets/4dbfead7-ca5c-4c4c-8a24-5512b41cfbc6

