### PR TITLE
fix(DocsCrawler): Add response.ok check and improve link splitting

### DIFF
--- a/core/indexing/docs/DocsCrawler.ts
+++ b/core/indexing/docs/DocsCrawler.ts
@@ -261,7 +261,9 @@ class CheerioCrawler {
       console.error(error);
       return { html: "", links: [] };
     }
-
+    if (!response.ok) {
+      return { html: "", links: [] };
+    }
     const html = await response.text();
     let links: string[] = [];
 
@@ -277,7 +279,7 @@ class CheerioCrawler {
         return;
       }
 
-      const parsedUrl = new URL(href, url);
+      const parsedUrl = new URL(href, location);
       if (parsedUrl.hostname === baseUrl.hostname) {
         links.push(parsedUrl.pathname);
       }
@@ -289,14 +291,11 @@ class CheerioCrawler {
         !this.IGNORE_PATHS_ENDING_IN.some((ending) => link.endsWith(ending))
       );
     });
-
     return { html, links };
   }
 
   private splitUrl(url: URL) {
-    const baseUrl = `${url.protocol}//${url.hostname}${
-      url.port ? ":" + url.port : ""
-    }`;
+    const baseUrl = new URL('/', url).href;
     const basePath = url.pathname;
     return { baseUrl, basePath };
   }


### PR DESCRIPTION
## Description

- Added skip for 404 errors in the page parsing logic
- Resolved incorrect handling of relative URLs in link splitting

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

![image](https://github.com/user-attachments/assets/b19de55a-c6a8-455d-8b5c-27331f057e1f)
![image](https://github.com/user-attachments/assets/635b9f68-a517-4d9d-9d8e-415fa6cd2cef)
![image](https://github.com/user-attachments/assets/0b2e5591-73b8-407b-a5d7-36ca0aa0dcf9)


## Testing

I checked several documentation sources for libraries for Python, one of [them](https://docs.telethon.dev/en/stable/index.html)
