### PR TITLE
refactor: Prevent Unrecognized DOM Prop Warning for showAbove in Mode…

### DIFF
--- a/gui/src/components/modelSelection/ModelSelect.tsx
+++ b/gui/src/components/modelSelection/ModelSelect.tsx
@@ -220,7 +220,7 @@ function ModelSelect() {
     (state: RootState) => state.state.config.models,
   );
   const ideMessenger = useContext(IdeMessengerContext);
-  const [showAbove, setshowAbove] = useState(false);
+  const [showAbove, setShowAbove] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const [options, setOptions] = useState<Option[]>([]);
   const [sortedOptions, setSortedOptions] = useState<Option[]>([]);
@@ -281,7 +281,7 @@ function ModelSelect() {
     const spaceAbove = rect.top;
     const dropdownHeight = MAX_HEIGHT_PX;
 
-    setshowAbove(spaceBelow < dropdownHeight && spaceAbove > spaceBelow);
+    setShowAbove(spaceBelow < dropdownHeight && spaceAbove > spaceBelow);
   }
 
   function onClickAddModel(e) {

--- a/gui/src/components/modelSelection/ModelSelect.tsx
+++ b/gui/src/components/modelSelection/ModelSelect.tsx
@@ -220,7 +220,7 @@ function ModelSelect() {
     (state: RootState) => state.state.config.models,
   );
   const ideMessenger = useContext(IdeMessengerContext);
-  const [$showabove, set$showabove] = useState(false);
+  const [showAbove, setshowAbove] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const [options, setOptions] = useState<Option[]>([]);
   const [sortedOptions, setSortedOptions] = useState<Option[]>([]);
@@ -281,7 +281,7 @@ function ModelSelect() {
     const spaceAbove = rect.top;
     const dropdownHeight = MAX_HEIGHT_PX;
 
-    set$showabove(spaceBelow < dropdownHeight && spaceAbove > spaceBelow);
+    setshowAbove(spaceBelow < dropdownHeight && spaceAbove > spaceBelow);
   }
 
   function onClickAddModel(e) {
@@ -330,7 +330,7 @@ function ModelSelect() {
           </div>
         </StyledListboxButton>
         <StyledListboxOptions
-          $showabove={$showabove}
+          $showabove={showAbove}
           className="z-50 max-w-[90vw]"
         >
           <div className={`max-h-[${MAX_HEIGHT_PX}px]`}>

--- a/gui/src/components/modelSelection/ModelSelect.tsx
+++ b/gui/src/components/modelSelection/ModelSelect.tsx
@@ -61,7 +61,7 @@ const StyledListboxButton = styled(Listbox.Button)`
   }
 `;
 
-const StyledListboxOptions = styled(Listbox.Options)<{ showAbove: boolean }>`
+const StyledListboxOptions = styled(Listbox.Options)<{ $showabove: boolean }>`
   margin-top: 4px;
   position: absolute;
   list-style: none;
@@ -81,7 +81,7 @@ const StyledListboxOptions = styled(Listbox.Options)<{ showAbove: boolean }>`
 
   scrollbar-width: none;
 
-  ${(props) => (props.showAbove ? "bottom: 100%;" : "top: 100%;")}
+  ${(props) => (props.$showabove ? "bottom: 100%;" : "top: 100%;")}
 `;
 
 const StyledListboxOption = styled(Listbox.Option)<{ isDisabled?: boolean }>`
@@ -220,7 +220,7 @@ function ModelSelect() {
     (state: RootState) => state.state.config.models,
   );
   const ideMessenger = useContext(IdeMessengerContext);
-  const [showAbove, setShowAbove] = useState(false);
+  const [$showabove, set$showabove] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const [options, setOptions] = useState<Option[]>([]);
   const [sortedOptions, setSortedOptions] = useState<Option[]>([]);
@@ -281,7 +281,7 @@ function ModelSelect() {
     const spaceAbove = rect.top;
     const dropdownHeight = MAX_HEIGHT_PX;
 
-    setShowAbove(spaceBelow < dropdownHeight && spaceAbove > spaceBelow);
+    set$showabove(spaceBelow < dropdownHeight && spaceAbove > spaceBelow);
   }
 
   function onClickAddModel(e) {
@@ -330,7 +330,7 @@ function ModelSelect() {
           </div>
         </StyledListboxButton>
         <StyledListboxOptions
-          showAbove={showAbove}
+          $showabove={$showabove}
           className="z-50 max-w-[90vw]"
         >
           <div className={`max-h-[${MAX_HEIGHT_PX}px]`}>


### PR DESCRIPTION
## Description
- When the `showAbove` prop is provided by the parent component, it is inadvertently passed to a DOM element, causing the following warning in the console:
![Warning Screenshot](https://github.com/user-attachments/assets/ee624b81-f6ad-4f45-8689-0e09776b0353)

**Replaced all occurrences of `showAbove` with `$showabove` in `ModelSelect.tsx`.**  
This change prevents the prop from being passed down to the DOM, thereby eliminating the console warning.

- This solution leverages **styled-components** props, which allows props prefixed with `$` to be used only in styled components and not passed to the underlying DOM elements. 
- By adhering to this pattern, we ensure that the component follows React's best practices by not passing unrecognized props to the DOM, thereby reducing console clutter.
[Refer to styled-components documentation](https://styled-components.com/docs/api#transient-props)

This is my first time contributing to Continue, so please let me know if there is anything wrong or need to modify.

## Checklist
- [x] The base branch of this PR is `dev`, rather than `main`.
- [x] The relevant documentation, if any, has been updated or created.
