### PR TITLE
change: rename locals to debugger (#2503)

### DIFF
--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -531,7 +531,7 @@ declare global {
     | "diff"
     | "github"
     | "terminal"
-    | "locals"
+    | "debugger"
     | "open"
     | "google"
     | "search"

--- a/core/context/providers/DebugLocalsProvider.ts
+++ b/core/context/providers/DebugLocalsProvider.ts
@@ -7,7 +7,7 @@ import {
 } from "../../index.js";
 import { BaseContextProvider } from "../index.js";
 
-class LocalsProvider extends BaseContextProvider {
+class DebugLocalsProvider extends BaseContextProvider {
   static description: ContextProviderDescription = {
     title: "debugger",
     displayTitle: "Debugger",
@@ -60,4 +60,4 @@ class LocalsProvider extends BaseContextProvider {
   }
 }
 
-export default LocalsProvider;
+export default DebugLocalsProvider;

--- a/core/context/providers/DebugLocalsProvider.ts
+++ b/core/context/providers/DebugLocalsProvider.ts
@@ -11,7 +11,7 @@ class DebugLocalsProvider extends BaseContextProvider {
   static description: ContextProviderDescription = {
     title: "debugger",
     displayTitle: "Debugger",
-    description: "Reference the contents of the local variables",
+    description: "Reference the contents of the local variables in the debugger",
     type: "submenu",
     renderInlineAs: "",
   };

--- a/core/context/providers/LocalsProvider.ts
+++ b/core/context/providers/LocalsProvider.ts
@@ -9,8 +9,8 @@ import { BaseContextProvider } from "../index.js";
 
 class LocalsProvider extends BaseContextProvider {
   static description: ContextProviderDescription = {
-    title: "locals",
-    displayTitle: "Locals",
+    title: "debugger",
+    displayTitle: "Debugger",
     description: "Reference the contents of the local variables",
     type: "submenu",
     renderInlineAs: "",
@@ -42,7 +42,7 @@ class LocalsProvider extends BaseContextProvider {
           `This is a paused thread: ${thread?.name}\n` +
           `Current local variable contents: \n${localVariables}.\n` +
           `Current top level call stacks: ${callStackContents}`,
-        name: "Locals",
+        name: "Debugger",
       },
     ];
   }

--- a/core/context/providers/index.ts
+++ b/core/context/providers/index.ts
@@ -13,7 +13,7 @@ import GitLabMergeRequestContextProvider from "./GitLabMergeRequestContextProvid
 import GoogleContextProvider from "./GoogleContextProvider";
 import HttpContextProvider from "./HttpContextProvider";
 import JiraIssuesContextProvider from "./JiraIssuesContextProvider/";
-import LocalsProvider from "./LocalsProvider";
+import DebugLocalsProvider from "./DebugLocalsProvider";
 import OSContextProvider from "./OSContextProvider";
 import OpenFilesContextProvider from "./OpenFilesContextProvider";
 import PostgresContextProvider from "./PostgresContextProvider";
@@ -37,7 +37,7 @@ export const Providers: (typeof BaseContextProvider)[] = [
   GitHubIssuesContextProvider,
   GoogleContextProvider,
   TerminalContextProvider,
-  LocalsProvider,
+  DebugLocalsProvider,
   OpenFilesContextProvider,
   HttpContextProvider,
   SearchContextProvider,

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -563,7 +563,7 @@ type ContextProviderName =
   | "diff"
   | "github"
   | "terminal"
-  | "locals"
+  | "debugger"
   | "open"
   | "google"
   | "search"

--- a/core/test/context/providers/index.skip.ts
+++ b/core/test/context/providers/index.skip.ts
@@ -13,7 +13,7 @@ import { TEST_DIR } from "../../util/testDir";
 const CONTEXT_PROVIDERS_TO_TEST: ContextProviderWithParams[] = [
   { name: "diff", params: {} },
   { name: "currentFile", params: {} },
-  { name: "locals", params: {} },
+  { name: "debugger", params: {} },
   { name: "open", params: {} },
   { name: "os", params: {} },
   { name: "problems", params: {} },

--- a/docs/docs/customize/context-providers.md
+++ b/docs/docs/customize/context-providers.md
@@ -396,7 +396,7 @@ Reference the contents of the local variables in the debugger.
 {
   "contextProviders": [
     {
-      "name": "locals",
+      "name": "debugger",
       "params": {
         "stackDepth": 3
       }

--- a/docs/docs/customize/context-providers.md
+++ b/docs/docs/customize/context-providers.md
@@ -388,7 +388,7 @@ Available connection types:
 - `mysql`
 - `sqlite`
 
-### `@Locals`
+### `@Debugger`
 
 Reference the contents of the local variables in the debugger.
 

--- a/docs/static/schemas/config.json
+++ b/docs/static/schemas/config.json
@@ -1549,7 +1549,7 @@
               "enum": [
                 "diff",
                 "terminal",
-                "locals",
+                "debugger",
                 "open",
                 "google",
                 "search",

--- a/docs/static/schemas/config.json
+++ b/docs/static/schemas/config.json
@@ -1574,7 +1574,7 @@
               "markdownEnumDescriptions": [
                 "Reference the contents of the current changes as given by `git diff`",
                 "Reference the last terminal command",
-                "Reference the contents of the local variables with top n level (defaulting to 3) of call stack for that thread",
+                "Reference the contents of the local variables in the debugger with top n level (defaulting to 3) of call stack for that thread",
                 "Reference the contents of all open or pinned files.",
                 "Enter a search phrase and include the Google search results as context",
                 "Reference the results of a ripgrep search in your codebase",

--- a/extensions/intellij/src/main/resources/config_schema.json
+++ b/extensions/intellij/src/main/resources/config_schema.json
@@ -1549,7 +1549,7 @@
               "enum": [
                 "diff",
                 "terminal",
-                "locals",
+                "debugger",
                 "open",
                 "google",
                 "search",

--- a/extensions/intellij/src/main/resources/config_schema.json
+++ b/extensions/intellij/src/main/resources/config_schema.json
@@ -1574,7 +1574,7 @@
               "markdownEnumDescriptions": [
                 "Reference the contents of the current changes as given by `git diff`",
                 "Reference the last terminal command",
-                "Reference the contents of the local variables with top n level (defaulting to 3) of call stack for that thread",
+                "Reference the contents of the local variables in the debugger with top n level (defaulting to 3) of call stack for that thread",
                 "Reference the contents of all open or pinned files.",
                 "Enter a search phrase and include the Google search results as context",
                 "Reference the results of a ripgrep search in your codebase",

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -1549,7 +1549,7 @@
               "enum": [
                 "diff",
                 "terminal",
-                "locals",
+                "debugger",
                 "open",
                 "google",
                 "search",

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -1574,7 +1574,7 @@
               "markdownEnumDescriptions": [
                 "Reference the contents of the current changes as given by `git diff`",
                 "Reference the last terminal command",
-                "Reference the contents of the local variables with top n level (defaulting to 3) of call stack for that thread",
+                "Reference the contents of the local variables in the debugger with top n level (defaulting to 3) of call stack for that thread",
                 "Reference the contents of all open or pinned files.",
                 "Enter a search phrase and include the Google search results as context",
                 "Reference the results of a ripgrep search in your codebase",

--- a/extensions/vscode/continue_rc_schema.json
+++ b/extensions/vscode/continue_rc_schema.json
@@ -1745,7 +1745,7 @@
               "markdownEnumDescriptions": [
                 "Reference the contents of the current changes as given by `git diff`",
                 "Reference the last terminal command",
-                "Reference the contents of the local variables with top n level (defaulting to 3) of call stack for that thread",
+                "Reference the contents of the local variables in the debugger with top n level (defaulting to 3) of call stack for that thread",
                 "Reference the contents of all open or pinned files.",
                 "Enter a search phrase and include the Google search results as context",
                 "Reference the results of a ripgrep search in your codebase",

--- a/extensions/vscode/continue_rc_schema.json
+++ b/extensions/vscode/continue_rc_schema.json
@@ -1720,7 +1720,7 @@
               "enum": [
                 "diff",
                 "terminal",
-                "locals",
+                "debugger",
                 "open",
                 "google",
                 "search",

--- a/extensions/vscode/src/debug/debug.ts
+++ b/extensions/vscode/src/debug/debug.ts
@@ -13,7 +13,7 @@ export function registerDebugTracker(
     createDebugAdapterTracker(_session: vscode.DebugSession) {
       const updateThreads = async () => {
         webviewProtocol?.request("updateSubmenuItems", {
-          provider: "locals",
+          provider: "debugger",
           submenuItems: (await ide.getAvailableThreads()).map((thread) => ({
             id: `${thread.id}`,
             title: thread.name,


### PR DESCRIPTION
## Description

Change proposed in https://github.com/continuedev/continue/issues/2503#issuecomment-2408144695

Renamed "locals" to "debugger"
Renamed LocalsProvider to DebugLocalsProvided for better clarity
Updated descriptions to specify that "local variables" refers to the debugger

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

![Screenshot 2024-10-12 144848](https://github.com/user-attachments/assets/19401233-4bed-4857-8f81-f9df3181fa50)
![image](https://github.com/user-attachments/assets/b9ebb55d-e2d0-4199-8850-ec1bb98e30cb)


## Testing

Use the debugger context provider as if it were the locals provided
