### PR TITLE
display error in voyage to user, dont rerank empty chunks, make sort

### DIFF
--- a/core/context/rerankers/voyage.ts
+++ b/core/context/rerankers/voyage.ts
@@ -27,8 +27,16 @@ export class VoyageReranker implements Reranker {
         model: this.params.model ?? "rerank-2",
       }),
     });
-    const data: any = await resp.json();
-    const results = data.data.sort((a: any, b: any) => a.index - b.index);
-    return results.map((result: any) => result.relevance_score);
+
+    if (resp.status !== 200) {
+      throw new Error(
+        `VoyageReranker API error ${resp.status}: ${await resp.text()}`,
+      );
+    }
+
+    const data: { data: Array<{ index: number; relevance_score: number }> } =
+      await resp.json();
+    const results = data.data.sort((a, b) => a.index - b.index);
+    return results.map((result) => result.relevance_score);
   }
 }


### PR DESCRIPTION
Fixes #2511 

## Description

Empty chunks were making the voyager reranker explode. I apparently have some of those (?) so I'm filtering them out now before we compute the scores (or indices will get thrown off).

I also saw a silly O(N^2) so fixed that, and added better error checking to the reranker. Remember to check for errors!

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

N/A

## Testing

Built and tested on my machine -- was failing, now working