### PR TITLE
feat : disable the enter button of chat input while ai answers

### DIFF
--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -60,6 +60,9 @@ const EnterButton = styled.button`
   border-radius: ${defaultBorderRadius};
   color: ${vscForeground};
   cursor: pointer;
+  :disabled {
+    cursor: wait;
+  }
 `;
 
 interface InputToolbarProps {

--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -52,7 +52,7 @@ const HoverItem = styled.span<{ isActive?: boolean }>`
   transition: color 200ms, background-color 200ms, box-shadow 200ms;
 `;
 
-const EnterButton = styled.div`
+const EnterButton = styled.button`
   padding: 2px 4px;
   display: flex;
   align-items: center;
@@ -70,6 +70,7 @@ interface InputToolbarProps {
   onImageFileSelected?: (file: File) => void;
   hidden?: boolean;
   activeKey: string | null;
+  disabled?: boolean;
 }
 
 function InputToolbar(props: InputToolbarProps) {
@@ -168,6 +169,7 @@ function InputToolbar(props: InputToolbarProps) {
                 noContext: useActiveFile ? e.altKey : !e.altKey,
               });
             }}
+            disabled={props.disabled}
           >
             <span className="hidden md:inline">⏎ Enter</span>
             <span className="md:hidden">⏎</span>

--- a/gui/src/components/mainInput/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor.tsx
@@ -606,6 +606,10 @@ function TipTapEditor(props: TipTapEditorProps) {
 
   const onEnterRef = useUpdatingRef(
     (modifiers: InputModifiers) => {
+      if (active) {
+        return;
+      }
+
       const json = editor.getJSON();
 
       // Don't do anything if input box is empty

--- a/gui/src/components/mainInput/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor.tsx
@@ -502,6 +502,7 @@ function TipTapEditor(props: TipTapEditorProps) {
         }
       }
     },
+    editable: !active,
   });
 
   const [shouldHideToolbar, setShouldHideToolbar] = useState(false);

--- a/gui/src/components/mainInput/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor.tsx
@@ -915,6 +915,7 @@ function TipTapEditor(props: TipTapEditorProps) {
             });
           });
         }}
+        disabled={active}
       />
 
       {showDragOverMsg &&


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

related #1042

As can be seen in the above issue, there was a problem that the answer became strange when you asked a question to ai and pressed the enter button again when ai answered. 

To solve this problem

1. the enter button was deactivated while ai was answering
2. early return onEnter callback while ai was answering
3. deactivate main-input-editor while ai was answering

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

While ai was answering, I enabled the disabled property on the Enter button

![button diabled while chatting](https://github.com/user-attachments/assets/2ab9c1d1-681f-484d-ac7d-7437057e792e)

## Testing

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change. ]
