### PR TITLE
 feat(jb): install esbuild on the fly

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,1 @@
-Continue IntelliJ Extension
+continue-intellij-extension

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,7 +29,6 @@
       "name": "Core Binary",
       "skipFiles": ["<node_internals>/**"],
       "program": "${workspaceFolder}/binary/out/index.js",
-      // "preLaunchTask": "binary:esbuild",
       "outFiles": ["${workspaceFolder}/binary/out/**/*.js"],
       "sourceMaps": true,
       "smartStep": true,

--- a/binary/.idea/vcs.xml
+++ b/binary/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/binary/build.js
+++ b/binary/build.js
@@ -276,6 +276,7 @@ async function installNodeModuleInTempDirAndCopyToCurrent(packageName, toCopy) {
       `node_modules/${targetToLanceDb[target]}/index.node`,
       `${targetDir}/index.node`,
     );
+  }
 
   const pathsToVerify = [];
   for (target of targets) {

--- a/binary/build.js
+++ b/binary/build.js
@@ -270,34 +270,12 @@ async function installNodeModuleInTempDirAndCopyToCurrent(packageName, toCopy) {
 
     fs.unlinkSync(`${targetDir}/build.tar.gz`);
 
-    // Download and unzip prebuilt esbuild binary for the target
-    console.log(`[info] Downloading esbuild for ${target}...`);
-    // Version is pinned to 0.19.11 in package.json to make sure that they match
-    execCmdSync(
-      `curl -o ${targetDir}/esbuild.tgz https://registry.npmjs.org/@esbuild/${target}/-/${target}-0.19.11.tgz`,
-    );
-    execCmdSync(`tar -xzvf ${targetDir}/esbuild.tgz -C ${targetDir}`);
-    if (target.startsWith("win32")) {
-      fs.cpSync(`${targetDir}/package/esbuild.exe`, `${targetDir}/esbuild.exe`);
-    } else {
-      fs.cpSync(`${targetDir}/package/bin/esbuild`, `${targetDir}/esbuild`);
-    }
-    fs.rmSync(`${targetDir}/esbuild.tgz`);
-    fs.rmSync(`${targetDir}/package`, {
-      force: true,
-      recursive: true,
-    });
-
     // copy @lancedb to bin folders
     console.log("[info] Copying @lancedb files to bin");
     fs.copyFileSync(
       `node_modules/${targetToLanceDb[target]}/index.node`,
       `${targetDir}/index.node`,
     );
-  }
-  // execCmdSync(
-  //   `npx pkg out/index.js --target node18-darwin-arm64 --no-bytecode --public-packages "*" --public -o bin/pkg`
-  // );
 
   const pathsToVerify = [];
   for (target of targets) {
@@ -305,7 +283,6 @@ async function installNodeModuleInTempDirAndCopyToCurrent(packageName, toCopy) {
     const targetDir = `bin/${target}`;
     pathsToVerify.push(
       `${targetDir}/continue-binary${exe}`,
-      `${targetDir}/esbuild${exe}`,
       `${targetDir}/index.node`, // @lancedb
       "package.json", // Informs of where to look for node_sqlite3.node https://www.npmjs.com/package/bindings#:~:text=The%20searching%20for,file%20is%20found
       `${targetDir}/build/Release/node_sqlite3.node`,

--- a/binary/package.json
+++ b/binary/package.json
@@ -23,7 +23,6 @@
   "scripts": {
     "test": "jest",
     "build": "node build.js",
-    "build:old": "ncc build src/index.ts -o out && pkg .",
     "build:dev": "tsc",
     "esbuild": "node build.js --esbuild-only"
   },

--- a/core/config/load.ts
+++ b/core/config/load.ts
@@ -551,7 +551,7 @@ async function promptEsbuildInstallation(ide: IDE): Promise<boolean> {
 /**
  * The download logic is adapted from here: https://esbuild.github.io/getting-started/#download-a-build
  */
-async function downloadAndInstallEsbuild() {
+async function downloadAndInstallEsbuild(ide: IDE) {
   const esbuildPath = getEsbuildBinaryPath();
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "esbuild-"));
 
@@ -606,6 +606,11 @@ async function downloadAndInstallEsbuild() {
     // Clean up
     fs.unlinkSync(tgzPath);
     fs.rmSync(tempDir, { recursive: true });
+
+    await ide.showToast(
+      "info",
+      `'esbuild' successfully installed to ${esbuildPath}`,
+    );
   } catch (error) {
     console.error("Error downloading or saving esbuild binary:", error);
     throw error;

--- a/core/config/load.ts
+++ b/core/config/load.ts
@@ -500,6 +500,8 @@ function escapeSpacesInPath(p: string): string {
 }
 
 async function handleEsbuildInstallation(ide: IDE, ideType: IdeType) {
+  // JetBrains is currently the only IDE that we've reached the plugin size limit and
+  // therefore need to install esbuild manually to reduce the size
   if (ideType !== "jetbrains") {
     return;
   }

--- a/core/config/load.ts
+++ b/core/config/load.ts
@@ -556,27 +556,10 @@ async function downloadAndInstallEsbuild(ide: IDE) {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "esbuild-"));
 
   try {
-    const platform = `${os.platform()} ${os.arch()}`;
+    const target = `${os.platform()}-${os.arch()}`;
     const version = "0.19.11";
+    const url = `https://registry.npmjs.org/@esbuild/${target}/-/${target}-${version}.tgz`;
     const tgzPath = path.join(tempDir, `esbuild-${version}.tgz`);
-
-    let url;
-    switch (platform) {
-      case "darwin arm64":
-        url = `https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-${version}.tgz`;
-        break;
-      case "darwin x64":
-        url = `https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-${version}.tgz`;
-        break;
-      case "linux arm64":
-        url = `https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-${version}.tgz`;
-        break;
-      case "linux x64":
-        url = `https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-${version}.tgz`;
-        break;
-      default:
-        throw new Error(`Unsupported platform: ${platform}`);
-    }
 
     console.debug(`Downloading esbuild from: ${url}`);
     execSync(`curl -fo "${tgzPath}" "${url}"`);

--- a/core/config/load.ts
+++ b/core/config/load.ts
@@ -496,35 +496,6 @@ function finalToBrowserConfig(
   };
 }
 
-function getTarget() {
-  const os =
-    {
-      aix: "linux",
-      darwin: "darwin",
-      freebsd: "linux",
-      linux: "linux",
-      openbsd: "linux",
-      sunos: "linux",
-      win32: "win32",
-    }[process.platform as string] ?? "linux";
-  const arch = {
-    arm: "arm64",
-    arm64: "arm64",
-    ia32: "x64",
-    loong64: "arm64",
-    mips: "arm64",
-    mipsel: "arm64",
-    ppc: "x64",
-    ppc64: "x64",
-    riscv64: "arm64",
-    s390: "x64",
-    s390x: "x64",
-    x64: "x64",
-  }[process.arch];
-
-  return `${os}-${arch}`;
-}
-
 function escapeSpacesInPath(p: string): string {
   return p.replace(/ /g, "\\ ");
 }
@@ -534,10 +505,11 @@ async function handleEsbuildInstallation(ide: IDE, ideType: IdeType) {
     return;
   }
 
-  const globalContext = new GlobalContext();
-  if (globalContext.get("hasReceivedConfigTsNoticeJetBrains")) {
-    return;
-  }
+  // TODO: Uncomment
+  // const globalContext = new GlobalContext();
+  // if (globalContext.get("hasReceivedConfigTsNoticeJetBrains")) {
+  //   return;
+  // }
 
   const esbuildPath = getEsbuildBinaryPath();
 
@@ -556,11 +528,13 @@ async function handleEsbuildInstallation(ide: IDE, ideType: IdeType) {
 
 async function promptEsbuildInstallation(ide: IDE): Promise<boolean> {
   const actionMsg = "Install esbuild";
+
   const res = await ide.showToast(
-    "info",
+    "warning",
     "You're using a custom 'config.ts' file, which requires 'esbuild' to be installed. Would you like to install it now?",
     actionMsg,
   );
+
   return res === actionMsg;
 }
 
@@ -630,6 +604,8 @@ function readConfigJs(): string | undefined {
 }
 
 async function buildConfigTs(ide: IDE, ideType: IdeType) {
+  // TODO: Remove
+  await ide.showToast("info", "test toast");
   const configTsPath = getConfigTsPath();
 
   if (!fs.existsSync(configTsPath)) {

--- a/core/config/load.ts
+++ b/core/config/load.ts
@@ -530,16 +530,14 @@ function escapeSpacesInPath(p: string): string {
 }
 
 async function handleEsbuildInstallation(ide: IDE, ideType: IdeType) {
-  // TODO: Uncomment
-  // if (ideType !== "jetbrains") {
-  //   return;
-  // }
+  if (ideType !== "jetbrains") {
+    return;
+  }
 
-  // TODO: Uncomment
-  // const globalContext = new GlobalContext();
-  // if (globalContext.get("hasReceivedConfigTsNoticeJetBrains")) {
-  //   return;
-  // }
+  const globalContext = new GlobalContext();
+  if (globalContext.get("hasReceivedConfigTsNoticeJetBrains")) {
+    return;
+  }
 
   const esbuildPath = getEsbuildBinaryPath();
 
@@ -550,9 +548,7 @@ async function handleEsbuildInstallation(ide: IDE, ideType: IdeType) {
   console.debug("No esbuild binary detected");
 
   const shouldInstall = await promptEsbuildInstallation(ide);
-  debugger;
 
-  // TODO: Debug toast
   if (shouldInstall || true) {
     await downloadAndInstallEsbuild(ide, esbuildPath);
   }
@@ -634,13 +630,6 @@ function readConfigJs(): string | undefined {
 }
 
 async function buildConfigTs(ide: IDE, ideType: IdeType) {
-  // TODO: Remove
-  await ide.showToast(
-    "info",
-    "You're using a custom 'config.ts' file, which requires 'esbuild' to be installed. Would you like to install it now?",
-    "YES",
-  );
-
   const configTsPath = getConfigTsPath();
 
   if (!fs.existsSync(configTsPath)) {

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -58,6 +58,7 @@
         "sqlite": "^5.1.1",
         "sqlite3": "^5.1.7",
         "system-ca": "^1.0.3",
+        "tar": "^7.4.3",
         "tree-sitter-wasms": "^0.1.11",
         "uuid": "^9.0.1",
         "vectordb": "^0.4.20",
@@ -3305,6 +3306,114 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA=="
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -4015,6 +4124,15 @@
       "integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
       "dependencies": {
         "@octokit/openapi-types": "^22.2.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -6170,6 +6288,32 @@
         "node": ">=10"
       }
     },
+    "node_modules/cacache/node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cacache/node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cacache/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -7053,6 +7197,11 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
@@ -8066,6 +8215,32 @@
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/forever-agent": {
@@ -9281,6 +9456,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jest": {
@@ -11040,6 +11229,38 @@
         "node": ">= 10.12.0"
       }
     },
+    "node_modules/node-gyp/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/node-gyp/node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-gyp/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "optional": true
+    },
     "node_modules/node-html-markdown": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/node-html-markdown/-/node-html-markdown-1.3.0.tgz",
@@ -11552,6 +11773,11 @@
         "node": ">= 14"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="
+    },
     "node_modules/pad-left": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pad-left/-/pad-left-2.1.0.tgz",
@@ -11654,6 +11880,29 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -13120,6 +13369,14 @@
         }
       }
     },
+    "node_modules/sqlite3/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/sqlite3/node_modules/node-addon-api": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
@@ -13127,6 +13384,27 @@
       "engines": {
         "node": "^16 || ^18 || >= 20"
       }
+    },
+    "node_modules/sqlite3/node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sqlite3/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/sqlstring": {
       "version": "2.3.3",
@@ -13253,6 +13531,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.trim": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
@@ -13300,6 +13592,18 @@
       }
     },
     "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -13420,19 +13724,19 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
+      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
       "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.0.1",
+        "mkdirp": "^3.0.1",
+        "yallist": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/tar-fs": {
@@ -13458,18 +13762,88 @@
         "streamx": "^2.15.0"
       }
     },
-    "node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+    "node_modules/tar/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/tar/node_modules/minizlib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
+      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
+      "dependencies": {
+        "minipass": "^7.0.4",
+        "rimraf": "^5.0.5"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/tar/node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tar/node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/tar/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -14259,6 +14633,23 @@
       "integrity": "sha512-LhUrk4tbxJRDQmRrrFWA9EnboXI79fe0ZNTy3u8m+dqPN1EkVSIsQYAB8OF/fkyhG8Rtup+c/bzj/+bzbG8fqg=="
     },
     "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",

--- a/core/package.json
+++ b/core/package.json
@@ -88,6 +88,7 @@
     "sqlite": "^5.1.1",
     "sqlite3": "^5.1.7",
     "system-ca": "^1.0.3",
+    "tar": "^7.4.3",
     "tree-sitter-wasms": "^0.1.11",
     "uuid": "^9.0.1",
     "vectordb": "^0.4.20",

--- a/core/util/GlobalContext.ts
+++ b/core/util/GlobalContext.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
-import { getGlobalContextFilePath } from "./paths.js";
-import { EmbeddingsProvider } from "../index.js";
+import { getGlobalContextFilePath } from "./paths";
+import { EmbeddingsProvider } from "../";
 
 export type GlobalContextType = {
   indexingPaused: boolean;
@@ -13,7 +13,7 @@ export type GlobalContextType = {
    * For VS Code users, it is unnecessary since we use transformers.js by default.
    */
   curEmbeddingsProviderId: EmbeddingsProvider["id"];
-  hasReceivedConfigTsNoticeJetBrains: boolean;
+  hasDismissedConfigTsNoticeJetBrains: boolean;
 };
 
 /**

--- a/core/util/GlobalContext.ts
+++ b/core/util/GlobalContext.ts
@@ -13,6 +13,7 @@ export type GlobalContextType = {
    * For VS Code users, it is unnecessary since we use transformers.js by default.
    */
   curEmbeddingsProviderId: EmbeddingsProvider["id"];
+  hasReceivedConfigTsNoticeJetBrains: boolean;
 };
 
 /**

--- a/core/util/paths.ts
+++ b/core/util/paths.ts
@@ -12,6 +12,10 @@ dotenv.config();
 const CONTINUE_GLOBAL_DIR =
   process.env.CONTINUE_GLOBAL_DIR ?? path.join(os.homedir(), ".continue");
 
+export const DEFAULT_CONFIG_TS_CONTENTS = `export function modifyConfig(config: Config): Config {
+  return config;
+}`;
+
 export function getChromiumPath(): string {
   return path.join(getContinueUtilsPath(), ".chromium-browser-snapshots");
 }
@@ -80,12 +84,7 @@ export function getConfigJsonPath(ideType: IdeType = "vscode"): string {
 export function getConfigTsPath(): string {
   const p = path.join(getContinueGlobalPath(), "config.ts");
   if (!fs.existsSync(p)) {
-    fs.writeFileSync(
-      p,
-      `export function modifyConfig(config: Config): Config {
-  return config;
-}`,
-    );
+    fs.writeFileSync(p, DEFAULT_CONFIG_TS_CONTENTS);
   }
 
   const typesPath = path.join(getContinueGlobalPath(), "types");
@@ -344,4 +343,8 @@ export function readAllGlobalPromptFiles(
 
 export function getRepoMapFilePath(): string {
   return path.join(getContinueUtilsPath(), "repo_map.txt");
+}
+
+export function getEsbuildBinaryPath(): string {
+  return path.join(getContinueUtilsPath(), "esbuild");
 }

--- a/extensions/intellij/build.gradle.kts
+++ b/extensions/intellij/build.gradle.kts
@@ -29,13 +29,13 @@ dependencies {
         exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
     }
     implementation("org.jetbrains.kotlin:kotlin-stdlib:1.4.32")
-    implementation("io.ktor:ktor-server-core:2.3.7"){
+    implementation("io.ktor:ktor-server-core:2.3.7") {
         exclude(group = "org.slf4j", module = "slf4j-api")
     }
     implementation("io.ktor:ktor-server-netty:2.3.7") {
         exclude(group = "org.slf4j", module = "slf4j-api")
     }
-    implementation("io.ktor:ktor-server-cors:2.3.7"){
+    implementation("io.ktor:ktor-server-cors:2.3.7") {
         exclude(group = "org.slf4j", module = "slf4j-api")
     }
     implementation("com.posthog.java:posthog:1.+")
@@ -106,26 +106,13 @@ tasks {
             val start = "<!-- Plugin description -->"
             val end = "<!-- Plugin description end -->"
 
-            with (it.lines()) {
+            with(it.lines()) {
                 if (!containsAll(listOf(start, end))) {
                     throw GradleException("Plugin description section not found in README.md:\n$start ... $end")
                 }
                 subList(indexOf(start) + 1, indexOf(end)).joinToString("\n").let(::markdownToHTML)
             }
         }
-//
-//        val changelog = project.changelog // local variable for configuration cache compatibility
-//        // Get the latest available change notes from the changelog file
-//        changeNotes = properties("pluginVersion").map { pluginVersion ->
-//            with(changelog) {
-//                renderItem(
-//                    (getOrNull(pluginVersion) ?: getUnreleased())
-//                        .withHeader(false)
-//                        .withEmptySections(false),
-//                    Changelog.OutputType.HTML,
-//                )
-//            }
-//        }
     }
 
     // Configure UI tests plugin

--- a/extensions/intellij/gradle.properties
+++ b/extensions/intellij/gradle.properties
@@ -9,7 +9,7 @@ pluginSinceBuild=223
 #pluginUntilBuild = 232.*
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType=IC
-platformVersion=2023.2
+platformVersion=2022.3.3
 #platformVersion = LATEST-EAP-SNAPSHOT
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/activities/ContinuePluginStartupActivity.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/activities/ContinuePluginStartupActivity.kt
@@ -96,8 +96,6 @@ class ContinuePluginStartupActivity : StartupActivity, Disposable, DumbAware {
             ContinuePluginService::class.java
         )
 
-        val defaultStrategy = DefaultTextSelectionStrategy()
-
         coroutineScope.launch {
             val settings =
                 ServiceManager.getService(ContinueExtensionSettings::class.java)
@@ -111,7 +109,6 @@ class ContinuePluginStartupActivity : StartupActivity, Disposable, DumbAware {
 
             val ideProtocolClient = IdeProtocolClient(
                 continuePluginService,
-                defaultStrategy,
                 coroutineScope,
                 project.basePath,
                 project

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/MessageTypes.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/MessageTypes.kt
@@ -8,7 +8,7 @@ class MessageTypes {
             "command/run",
             "streamDiffLines"
         )
-        
+
         val ideMessageTypes = listOf(
             "readRangeInFile",
             "isTelemetryEnabled",
@@ -53,7 +53,7 @@ class MessageTypes {
             "showToast",
         )
 
-        val PASS_THROUGH_TO_WEBVIEW = listOf<String>(
+        val PASS_THROUGH_TO_WEBVIEW = listOf(
             "configUpdate",
             "getDefaultModelTitle",
             "indexProgress",

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessenger.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessenger.kt
@@ -28,7 +28,7 @@ class CoreMessenger(
     private val gson = Gson()
     private val responseListeners = mutableMapOf<String, (Any?) -> Unit>()
     private val ideProtocolClient = ideProtocolClient
-    private val useTcp: Boolean = false
+    private val useTcp: Boolean = true // TODO: Revert
 
     private fun write(message: String) {
         try {
@@ -98,7 +98,7 @@ class CoreMessenger(
             val continuePluginService = project.service<ContinuePluginService>()
             continuePluginService.sendToWebview(messageType, responseMap["data"], messageType)
         }
-        
+
         // Responses for messageId
         responseListeners[messageId]?.let { listener ->
             listener(data)

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessenger.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessenger.kt
@@ -28,7 +28,7 @@ class CoreMessenger(
     private val gson = Gson()
     private val responseListeners = mutableMapOf<String, (Any?) -> Unit>()
     private val ideProtocolClient = ideProtocolClient
-    private val useTcp: Boolean = false // TODO: Set to `false`
+    private val useTcp: Boolean = false
     private fun write(message: String) {
         try {
             writer?.write(message + "\r\n")

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessenger.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessenger.kt
@@ -28,8 +28,7 @@ class CoreMessenger(
     private val gson = Gson()
     private val responseListeners = mutableMapOf<String, (Any?) -> Unit>()
     private val ideProtocolClient = ideProtocolClient
-    private val useTcp: Boolean = true // TODO: Revert
-
+    private val useTcp: Boolean = false
     private fun write(message: String) {
         try {
             writer?.write(message + "\r\n")

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessenger.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessenger.kt
@@ -28,7 +28,7 @@ class CoreMessenger(
     private val gson = Gson()
     private val responseListeners = mutableMapOf<String, (Any?) -> Unit>()
     private val ideProtocolClient = ideProtocolClient
-    private val useTcp: Boolean = false
+    private val useTcp: Boolean = false // TODO: Set to `false`
     private fun write(message: String) {
         try {
             writer?.write(message + "\r\n")

--- a/extensions/intellij/src/main/resources/META-INF/plugin.xml
+++ b/extensions/intellij/src/main/resources/META-INF/plugin.xml
@@ -29,6 +29,8 @@
         <statusBarWidgetFactory
                 implementation="com.github.continuedev.continueintellijextension.autocomplete.AutocompleteSpinnerWidgetFactory"
                 id="AutocompleteSpinnerWidget"/>
+        <notificationGroup id="Continue"
+                           displayType="BALLOON"/>
     </extensions>
 
     <resource-bundle>messages.MyBundle</resource-bundle>
@@ -163,6 +165,4 @@
             <keyboard-shortcut first-keystroke="alt meta RIGHT" keymap="Mac OS X"/>
         </action>
     </actions>
-
-
 </idea-plugin>

--- a/scripts/util/index.js
+++ b/scripts/util/index.js
@@ -1,5 +1,4 @@
 const fs = require("fs");
-const os = require("os");
 const { execSync } = require("child_process");
 
 function execCmdSync(cmd) {
@@ -91,7 +90,9 @@ function validateFilesPresent(pathsToVerify) {
 
   if (missingFiles.length > 0 || emptyFiles.length > 0) {
     throw new Error(
-      `The following files were missing:\n- ${missingFiles.join("\n- ")}\n\nThe following files were empty:\n- ${emptyFiles.join("\n- ")}`,
+      `The following files were missing:\n- ${missingFiles.join(
+        "\n- ",
+      )}\n\nThe following files were empty:\n- ${emptyFiles.join("\n- ")}`,
     );
   } else {
     console.log("All paths exist");


### PR DESCRIPTION
## Description

This PR removes esbuild from our build and instead downloads it on the fly when we detect a user is using config.ts. The purpose of this is to reduce our build size. esbuild is ~10mb, so this removes ~50mb from the build across our 5 arches.
## Checklist

- [ ] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change. ]
