### PR TITLE
fix java.lang.IndexOutOfBoundsException: Wrong line: -1. Available li…

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/listeners/ContinuePluginSelectionListener.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/listeners/ContinuePluginSelectionListener.kt
@@ -97,9 +97,10 @@ class ContinuePluginSelectionListener(
         val endOffset = model.selectionEnd
         val startLine = document.getLineNumber(startOffset)
         val endLine = document.getLineNumber(endOffset)
-
         val isFullLineSelection = startOffset == document.getLineStartOffset(startLine) &&
-                (endOffset == document.getLineEndOffset(endLine - 1) || endOffset == document.getLineStartOffset(endLine))
+                ((endLine > 0 && endOffset == document.getLineEndOffset(endLine - 1)) || endOffset == document.getLineStartOffset(
+                    endLine
+                ))
 
         val adjustedEndLine = if (isFullLineSelection && endLine > startLine) endLine - 1 else endLine
 


### PR DESCRIPTION
…nes count: 1 #2519

## Description

When the code checks if the selection is a full-line selection (isFullLineSelection), it doesn't account for the case where the selection is on the first line of the code. It attempts to check the previous line, even though there is no code before the first line.

## Checklist

- [X] The base branch of this PR is `dev`, rather than `main`
- [X] The relevant docs, if any, have been updated or created

## Testing

In IntelliJ IDEA, when you select only part of the first line, the issue no longer occurs.
