### PR TITLE
fix: 'inferenceConfig.stopSequences' failed to satisfy constraint: Me…

### DIFF
--- a/core/llm/llms/Bedrock.ts
+++ b/core/llm/llms/Bedrock.ts
@@ -112,7 +112,7 @@ class Bedrock extends BaseLLM {
         temperature: options.temperature,
         topP: options.topP,
         // TODO: The current approach selects the first 4 items from the list to comply with Bedrock's requirement
-        // of having at least 4 stop sequences, as per the AWS documentation:
+        // of having at most 4 stop sequences, as per the AWS documentation:
         // https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_InferenceConfiguration.html
         // However, it might be better to implement a strategy that dynamically selects the most appropriate stop sequences
         // based on the context.

--- a/core/llm/llms/Bedrock.ts
+++ b/core/llm/llms/Bedrock.ts
@@ -111,7 +111,15 @@ class Bedrock extends BaseLLM {
         maxTokens: options.maxTokens,
         temperature: options.temperature,
         topP: options.topP,
-        stopSequences: options.stop?.filter((stop) => stop.trim() !== ""),
+        // TODO: The current approach selects the first 4 items from the list to comply with Bedrock's requirement
+        // of having at least 4 stop sequences, as per the AWS documentation:
+        // https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_InferenceConfiguration.html
+        // However, it might be better to implement a strategy that dynamically selects the most appropriate stop sequences
+        // based on the context.
+        // TODO: Additionally, consider implementing a global exception handler for the provider to give users clearer feedback.
+        // For example, differentiate between client-side errors (4XX status codes) and server-side issues (5XX status codes),
+        // providing meaningful error messages to improve the user experience.
+        stopSequences: options.stop?.filter((stop) => stop.trim() !== "").slice(0, 4),
       },
     };
   }

--- a/core/llm/llms/Bedrock.ts
+++ b/core/llm/llms/Bedrock.ts
@@ -116,7 +116,7 @@ class Bedrock extends BaseLLM {
         // https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_InferenceConfiguration.html
         // However, it might be better to implement a strategy that dynamically selects the most appropriate stop sequences
         // based on the context.
-        // TODO: Additionally, consider implementing a global exception handler for the provider to give users clearer feedback.
+        // TODO: Additionally, consider implementing a global exception handler for the providers to give users clearer feedback.
         // For example, differentiate between client-side errors (4XX status codes) and server-side issues (5XX status codes),
         // providing meaningful error messages to improve the user experience.
         stopSequences: options.stop?.filter((stop) => stop.trim() !== "").slice(0, 4),


### PR DESCRIPTION
…mber must have length less than or equal to 4 #2538

## Description

According to AWS Bedrock's requirements, we need to define at least four stop sequences, as outlined in the AWS documentation: [API Inference Configuration](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_InferenceConfiguration.html). As a result, I have limited the stop sequences to a maximum of four.

## Checklist

- [X] The base branch of this PR is `dev`, rather than `main`
- [X] The relevant docs, if any, have been updated or created

## Testing

Auto-completion for Bedrock is working.
