### PR TITLE
Handle 5xx errors more gracefully in Chat #2495 #2557

### DIFF
--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -624,6 +624,7 @@ export abstract class BaseLLM implements ILLM {
         if (error.message.includes("HTTP 500 Internal Server Error")) {
           yield { role: "system", content: `Something went wrong with the provider's server, and we were unable to retrieve the result (${error.message}).`};
         }
+        throw error;
       }
     }
 


### PR DESCRIPTION
## Description

Make it clear that the error is on the provider’s side, not Continue’s, and ensure the chat history is preserved.

<img width="392" alt="image" src="https://github.com/user-attachments/assets/d7e3b229-f89f-4fd8-9a3b-7e44fb4403ca">

## Checklist

- [X] The base branch of this PR is `dev`, rather than `main`
- [X] The relevant docs, if any, have been updated or created