### PR TITLE
refactor : declare and initialize class property

### DIFF
--- a/core/autocomplete/cache.ts
+++ b/core/autocomplete/cache.ts
@@ -8,11 +8,7 @@ export class AutocompleteLruCache {
   private static capacity = 1000;
   private mutex = new Mutex();
 
-  db: DatabaseConnection;
-
-  constructor(db: DatabaseConnection) {
-    this.db = db;
-  }
+  constructor(public db: DatabaseConnection) {}
 
   static async get(): Promise<AutocompleteLruCache> {
     const db = await open({

--- a/core/autocomplete/cache.ts
+++ b/core/autocomplete/cache.ts
@@ -8,7 +8,7 @@ export class AutocompleteLruCache {
   private static capacity = 1000;
   private mutex = new Mutex();
 
-  constructor(public db: DatabaseConnection) {}
+  constructor(private db: DatabaseConnection) {}
 
   static async get(): Promise<AutocompleteLruCache> {
     const db = await open({

--- a/core/context/providers/CustomContextProvider.ts
+++ b/core/context/providers/CustomContextProvider.ts
@@ -8,10 +8,7 @@ import type {
 } from "../../";
 
 class CustomContextProviderClass implements IContextProvider {
-  custom: CustomContextProvider;
-  constructor(custom: CustomContextProvider) {
-    this.custom = custom;
-  }
+  constructor(public custom: CustomContextProvider) {}
 
   get description(): ContextProviderDescription {
     return {

--- a/core/context/providers/CustomContextProvider.ts
+++ b/core/context/providers/CustomContextProvider.ts
@@ -8,7 +8,7 @@ import type {
 } from "../../";
 
 class CustomContextProviderClass implements IContextProvider {
-  constructor(public custom: CustomContextProvider) {}
+  constructor(private custom: CustomContextProvider) {}
 
   get description(): ContextProviderDescription {
     return {

--- a/core/indexing/chunk/ChunkCodebaseIndex.ts
+++ b/core/indexing/chunk/ChunkCodebaseIndex.ts
@@ -23,9 +23,7 @@ export class ChunkCodebaseIndex implements CodebaseIndex {
     private readonly pathSep: string,
     private readonly continueServerClient: IContinueServerClient,
     private readonly maxChunkSize: number,
-  ) {
-    this.readFile = readFile;
-  }
+  ) {}
 
   async *update(
     tag: IndexTag,

--- a/core/indexing/refreshIndex.ts
+++ b/core/indexing/refreshIndex.ts
@@ -416,11 +416,9 @@ export async function getComputeDeleteAddRemove(
 
 export class GlobalCacheCodeBaseIndex implements CodebaseIndex {
   relativeExpectedTime: number = 1;
-  private db: DatabaseConnection;
 
-  constructor(db: DatabaseConnection) {
-    this.db = db;
-  }
+  constructor(private db: DatabaseConnection) {}
+
   artifactId = "globalCache";
 
   static async create(): Promise<GlobalCacheCodeBaseIndex> {

--- a/core/indexing/walkDir.ts
+++ b/core/indexing/walkDir.ts
@@ -38,15 +38,13 @@ type IgnoreContext = {
 };
 
 class DFSWalker {
-  private readonly path: string;
-  private readonly ide: IDE;
-  private readonly options: WalkerOptions;
   private readonly ignoreFileNames: Set<string>;
 
-  constructor(path: string, ide: IDE, options: WalkerOptions) {
-    this.path = path;
-    this.ide = ide;
-    this.options = options;
+  constructor(
+    private readonly path: string,
+    private readonly ide: IDE,
+    private readonly options: WalkerOptions,
+  ) {
     this.ignoreFileNames = new Set<string>(options.ignoreFiles);
   }
 
@@ -128,10 +126,7 @@ class DFSWalker {
       ignore: ignore().add(patterns),
       dirname: curDir.walkableEntry.relPath,
     };
-    return [
-      ...curDir.ignoreContexts,
-      newIgnoreContext
-    ];
+    return [...curDir.ignoreContexts, newIgnoreContext];
   }
 
   private async loadIgnoreFiles(entries: WalkableEntry[]): Promise<string[]> {
@@ -147,7 +142,10 @@ class DFSWalker {
     return this.ignoreFileNames.has(p);
   }
 
-  private shouldInclude(walkableEntry: WalkableEntry, ignoreContexts: IgnoreContext[]) {
+  private shouldInclude(
+    walkableEntry: WalkableEntry,
+    ignoreContexts: IgnoreContext[],
+  ) {
     if (this.entryIsSymlink(walkableEntry.entry)) {
       // If called from the root, a symlink either links to a real file in this repository,
       // and therefore will be walked OR it linksto something outside of the repository and

--- a/core/util/generateRepoMap.ts
+++ b/core/util/generateRepoMap.ts
@@ -12,9 +12,6 @@ export interface RepoMapOptions {
 }
 
 class RepoMapGenerator {
-  private llm: ILLM;
-  private ide: IDE;
-  private options: RepoMapOptions;
   private maxRepoMapTokens: number;
 
   private repoMapPath: string = getRepoMapFilePath();
@@ -32,10 +29,11 @@ class RepoMapGenerator {
     "this map contains the name of the file, and the signature for any " +
     "classes, methods, or functions in the file.\n\n";
 
-  constructor(llm: ILLM, ide: IDE, options: RepoMapOptions) {
-    this.llm = llm;
-    this.ide = ide;
-    this.options = options;
+  constructor(
+    private llm: ILLM,
+    private ide: IDE,
+    private options: RepoMapOptions,
+  ) {
     this.maxRepoMapTokens =
       llm.contextLength * this.REPO_MAX_CONTEXT_LENGTH_RATIO;
   }

--- a/extensions/vscode/src/diff/vertical/decorations.ts
+++ b/extensions/vscode/src/diff/vertical/decorations.ts
@@ -36,16 +36,10 @@ export const belowIndexDecorationType =
   });
 
 export class DecorationTypeRangeManager {
-  private decorationType: vscode.TextEditorDecorationType;
-  private editor: vscode.TextEditor;
-
   constructor(
-    decorationType: vscode.TextEditorDecorationType,
-    editor: vscode.TextEditor,
-  ) {
-    this.decorationType = decorationType;
-    this.editor = editor;
-  }
+    private decorationType: vscode.TextEditorDecorationType,
+    private editor: vscode.TextEditor,
+  ) {}
 
   private ranges: vscode.Range[] = [];
 

--- a/extensions/vscode/src/diff/vertical/handler.ts
+++ b/extensions/vscode/src/diff/vertical/handler.ts
@@ -17,9 +17,6 @@ export interface VerticalDiffHandlerOptions {
 }
 
 export class VerticalDiffHandler implements vscode.Disposable {
-  private editor: vscode.TextEditor;
-  private startLine: number;
-  private endLine: number;
   private currentLineIndex: number;
   private cancelled = false;
 
@@ -31,12 +28,10 @@ export class VerticalDiffHandler implements vscode.Disposable {
 
   private newLinesAdded = 0;
 
-  public options: VerticalDiffHandlerOptions;
-
   constructor(
-    startLine: number,
-    endLine: number,
-    editor: vscode.TextEditor,
+    private startLine: number,
+    private endLine: number,
+    private editor: vscode.TextEditor,
     private readonly editorToVerticalDiffCodeLens: Map<
       string,
       VerticalDiffCodeLens[]
@@ -46,18 +41,15 @@ export class VerticalDiffHandler implements vscode.Disposable {
       accept: boolean,
     ) => void,
     private readonly refreshCodeLens: () => void,
-    options: VerticalDiffHandlerOptions,
+    public options: VerticalDiffHandlerOptions,
   ) {
     this.currentLineIndex = startLine;
-    this.startLine = startLine;
-    this.endLine = endLine;
-    this.editor = editor;
-    this.options = options;
 
     this.redDecorationManager = new DecorationTypeRangeManager(
       redDecorationType,
       this.editor,
     );
+
     this.greenDecorationManager = new DecorationTypeRangeManager(
       greenDecorationType,
       this.editor,

--- a/extensions/vscode/src/lang-server/codeLens/providers/DiffViewerCodeLensProvider.ts
+++ b/extensions/vscode/src/lang-server/codeLens/providers/DiffViewerCodeLensProvider.ts
@@ -4,11 +4,7 @@ import { DiffManager, DIFF_DIRECTORY } from "../../../diff/horizontal";
 import { getMetaKeyLabel } from "../../../util/util";
 
 export class DiffViewerCodeLensProvider implements vscode.CodeLensProvider {
-  diffManager: DiffManager;
-
-  constructor(diffManager: DiffManager) {
-    this.diffManager = diffManager;
-  }
+  constructor(public diffManager: DiffManager) {}
 
   public provideCodeLenses(
     document: vscode.TextDocument,

--- a/extensions/vscode/src/lang-server/codeLens/providers/DiffViewerCodeLensProvider.ts
+++ b/extensions/vscode/src/lang-server/codeLens/providers/DiffViewerCodeLensProvider.ts
@@ -4,7 +4,7 @@ import { DiffManager, DIFF_DIRECTORY } from "../../../diff/horizontal";
 import { getMetaKeyLabel } from "../../../util/util";
 
 export class DiffViewerCodeLensProvider implements vscode.CodeLensProvider {
-  constructor(public diffManager: DiffManager) {}
+  constructor(private diffManager: DiffManager) {}
 
   public provideCodeLenses(
     document: vscode.TextDocument,

--- a/extensions/vscode/src/lang-server/codeLens/providers/QuickActionsCodeLensProvider.ts
+++ b/extensions/vscode/src/lang-server/codeLens/providers/QuickActionsCodeLensProvider.ts
@@ -62,13 +62,7 @@ export class QuickActionsCodeLensProvider implements vscode.CodeLensProvider {
     vscode.SymbolKind.Constructor,
   ];
 
-  customQuickActionsConfig?: QuickActionConfig[];
-
-  constructor(customQuickActionsConfigs?: QuickActionConfig[]) {
-    if (customQuickActionsConfigs) {
-      this.customQuickActionsConfig = customQuickActionsConfigs;
-    }
-  }
+  constructor(public customQuickActionsConfigs?: QuickActionConfig[]) {}
 
   getCustomCommands(
     range: vscode.Range,
@@ -145,8 +139,8 @@ export class QuickActionsCodeLensProvider implements vscode.CodeLensProvider {
     const symbols = await this.getTopLevelAndChildrenSymbols(document.uri);
 
     return symbols.flatMap(({ range }) => {
-      const commands: vscode.Command[] = !!this.customQuickActionsConfig
-        ? this.getCustomCommands(range, this.customQuickActionsConfig)
+      const commands: vscode.Command[] = !!this.customQuickActionsConfigs
+        ? this.getCustomCommands(range, this.customQuickActionsConfigs)
         : this.getDefaultCommand(range);
 
       return commands.map((command) => new vscode.CodeLens(range, command));

--- a/extensions/vscode/src/lang-server/codeLens/providers/QuickActionsCodeLensProvider.ts
+++ b/extensions/vscode/src/lang-server/codeLens/providers/QuickActionsCodeLensProvider.ts
@@ -62,7 +62,7 @@ export class QuickActionsCodeLensProvider implements vscode.CodeLensProvider {
     vscode.SymbolKind.Constructor,
   ];
 
-  constructor(public customQuickActionsConfigs?: QuickActionConfig[]) {}
+  constructor(private customQuickActionsConfigs?: QuickActionConfig[]) {}
 
   getCustomCommands(
     range: vscode.Range,

--- a/extensions/vscode/src/terminal/terminalEmulator.ts
+++ b/extensions/vscode/src/terminal/terminalEmulator.ts
@@ -129,7 +129,6 @@ export class CapturedTerminal {
   private readonly writeEmitter: vscode.EventEmitter<string>;
 
   private splitByCommandsBuffer = "";
-  private readonly onCommandOutput: ((output: string) => void) | undefined;
 
   splitByCommandsListener(data: string) {
     // Split the output by commands so it can be sent to Continue Server
@@ -164,10 +163,8 @@ export class CapturedTerminal {
 
   constructor(
     options: { name: string } & Partial<vscode.ExtensionTerminalOptions>,
-    onCommandOutput?: (output: string) => void,
+    private readonly onCommandOutput?: (output: string) => void,
   ) {
-    this.onCommandOutput = onCommandOutput;
-
     // this.shellCmd = "bash"; // getDefaultShell();
     this.shellCmd = getDefaultShell();
 

--- a/extensions/vscode/src/util/loadAutocompleteModel.ts
+++ b/extensions/vscode/src/util/loadAutocompleteModel.ts
@@ -13,11 +13,7 @@ export class TabAutocompleteModel {
   private shownOllamaWarning = false;
   private shownDeepseekWarning = false;
 
-  private configHandler: ConfigHandler;
-
-  constructor(configHandler: ConfigHandler) {
-    this.configHandler = configHandler;
-  }
+  constructor(private configHandler: ConfigHandler) {}
 
   clearLlm() {
     this._llm = undefined;

--- a/packages/openai-adapters/src/apis/AzureOpenAI.ts
+++ b/packages/openai-adapters/src/apis/AzureOpenAI.ts
@@ -31,10 +31,8 @@ const MS_TOKEN = 30;
 
 export class AzureOpenAIApi implements BaseLlmApi {
   private client: OpenAIClient;
-  private config: LlmApiConfig;
 
-  constructor(config: LlmApiConfig) {
-    this.config = config;
+  constructor(private config: LlmApiConfig) {
     let proxyOptions;
     const PROXY = HTTPS_PROXY ?? HTTP_PROXY;
     if (PROXY) {


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

Typescript class grammar allows the constructor to declare and initialize properties at the same time.

I applied it to continue in this PR

And I want to ask you one thing.

If you look at the second commit of this PR, there are properties that have public access designators. Shouldn't these properties be designated as private access designators?

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change. ]
