### PR TITLE
fix: incorrect prefix/suffix range handling in /edit command

### DIFF
--- a/core/commands/slash/edit.ts
+++ b/core/commands/slash/edit.ts
@@ -95,10 +95,10 @@ export async function getPromptParts(
   }
 
   let filePrefix = fullFileContentsList
-    .slice(curStartLine, maxStartLine)
+    .slice(curStartLine, maxStartLine - 1)
     .join("\n");
   let fileSuffix = fullFileContentsList
-    .slice(minEndLine, curEndLine - 1)
+    .slice(minEndLine, curEndLine + 1)
     .join("\n");
 
   if (rif.contents.length > 0) {


### PR DESCRIPTION
maxStartLine should be minus 1
curEndLine should be plus 1

## Description

[ fix the bug that prefix and suffix range error when constructor /edit command prompt ]

## Checklist

- [*] The base branch of this PR is `dev`, rather than `main`
- [*] The relevant docs, if any, have been updated or created

## Screenshots

![image](https://github.com/user-attachments/assets/9a15a3ec-7f1f-413d-b89d-ce5de69f1784)

## Testing

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change. ]
