### PR TITLE
docs: add information of keyboard shortcuts for toggling autocomplete

### DIFF
--- a/docs/docs/customize/deep-dives/autocomplete.md
+++ b/docs/docs/customize/deep-dives/autocomplete.md
@@ -137,6 +137,8 @@ Click the "Continue" button in the status panel at the bottom right of the scree
 
 Alternatively, open VS Code settings, search for "Continue" and uncheck the box for "Enable Tab Autocomplete".
 
+You can also use the default shortcut to disable autocomplete directly: press `ctrl/cmd + K`, `ctrl/cmd + A`. This will turn off autocomplete without navigating through settings.
+
 #### JetBrains
 
 Open Settings -> Tools -> Continue and uncheck the box for "Enable Tab Autocomplete".


### PR DESCRIPTION
## Description

I have added a section to the official documentation under `Customize/Deepdives/Autocomplete`, specifically in the 'How to turn off autocomplete' part, as it was missing information on how to enable/disable autocomplete using keyboard shortcuts.
Initially, I was going to develop a feature to control autocomplete with a shortcut, but I discovered that this functionality already exists.
I believe adding this information to the documentation will help more users utilize the feature more easily.

## Checklist

- [X] The base branch of this PR is `dev`, rather than `main`
- [X] The relevant docs, if any, have been updated or created

## Screenshots
![image](https://github.com/user-attachments/assets/416ba48e-c643-4b5f-838d-ed473be3807a)

## Testing

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change. ]
