### PR TITLE
gui: add keyboard shortcut for toggling autocomplete in sidebar

### DIFF
--- a/gui/src/pages/More/KeyboardShortcuts.tsx
+++ b/gui/src/pages/More/KeyboardShortcuts.tsx
@@ -141,6 +141,11 @@ const vscodeShortcuts: KeyboardShortcutProps[] = [
     windows: "⌃ '",
     description: "Toggle Selected Model",
   },
+  {
+    mac: "⌘ K ⌘ A",
+    windows: "⌃ K ⌃ A",
+    description: "Toggle Autocomplete Enabled",
+  },
 ];
 
 const jetbrainsShortcuts: KeyboardShortcutProps[] = [


### PR DESCRIPTION
## Description

I have added a keyboard shortcut for controlling the Autocomplete feature to the continue/gui/src/pages/More/KeyboardShortcuts.tsx file.
Initially, I planned to develop this feature myself, but upon discovering that it already existed, I decided to add the shortcut not only to the official documentation but also to the 'Keyboard Shortcuts' section in the Continue sidebar.
I believe this will make it easier for more users to utilize the feature.

## Checklist

- [X] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created

## Screenshots

![image1](https://github.com/user-attachments/assets/02c9a58a-43fc-45a8-8fc3-3826d605dac5)

## Testing

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change. ]
