### PR TITLE
fix: history bug by writing to history after chat completion.

### DIFF
--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -116,6 +116,7 @@
         "dotenv": "^16.4.5",
         "fastest-levenshtein": "^1.0.16",
         "follow-redirects": "^1.15.5",
+        "google-auth-library": "^9.14.2",
         "handlebars": "^4.7.8",
         "http-proxy-agent": "^7.0.1",
         "https-proxy-agent": "^7.0.3",

--- a/gui/src/hooks/useChatHandler.ts
+++ b/gui/src/hooks/useChatHandler.ts
@@ -15,7 +15,7 @@ import { constructMessages } from "core/llm/constructMessages";
 import { stripImages } from "core/llm/images";
 import { getBasename, getRelativePath } from "core/util";
 import { usePostHog } from "posthog-js/react";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSelector } from "react-redux";
 import resolveEditorContent, {
   hasSlashCommandOrContextProvider,
@@ -35,6 +35,7 @@ import {
 } from "../redux/slices/stateSlice";
 import { resetNextCodeBlockToApplyIndex } from "../redux/slices/uiStateSlice";
 import { RootState } from "../redux/store";
+import useHistory from "./useHistory";
 
 function useChatHandler(dispatch: Dispatch, ideMessenger: IIdeMessenger) {
   const posthog = usePostHog();
@@ -55,6 +56,14 @@ function useChatHandler(dispatch: Dispatch, ideMessenger: IIdeMessenger) {
   const history = useSelector((store: RootState) => store.state.history);
   const active = useSelector((store: RootState) => store.state.active);
   const activeRef = useRef(active);
+
+  const {saveSession} = useHistory(dispatch);
+  const [save, triggerSave] = useState(false);
+
+  useEffect(() => {
+    saveSession(false);
+  }, [save]);
+  
 
   useEffect(() => {
     activeRef.current = active;
@@ -309,6 +318,7 @@ function useChatHandler(dispatch: Dispatch, ideMessenger: IIdeMessenger) {
       ]);
     } finally {
       dispatch(setInactive());
+      triggerSave(!save);
     }
   }
 

--- a/gui/src/hooks/useHistory.tsx
+++ b/gui/src/hooks/useHistory.tsx
@@ -48,11 +48,14 @@ function useHistory(dispatch: Dispatch) {
     return result.status === "success" ? result.content : undefined;
   }
 
-  async function saveSession() {
+  async function saveSession(open_new_session = true) {
     if (state.history.length === 0) return;
 
     const stateCopy = { ...state };
-    dispatch(newSession());
+    if (open_new_session){
+      dispatch(newSession());
+      updateLastSessionId(stateCopy.sessionId);
+    }
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     if (
@@ -93,7 +96,6 @@ function useHistory(dispatch: Dispatch) {
       sessionId: stateCopy.sessionId,
       workspaceDirectory: window.workspacePaths?.[0] || "",
     };
-    updateLastSessionId(stateCopy.sessionId);
     return await ideMessenger.request("history/save", sessionInfo);
   }
 


### PR DESCRIPTION
## Description

Fixed bug where last message of history could be lost when switching between chats. 

Step to replicate:
1. create a new chat 
2. send a message
3. go to another chat thru history
4. return to the new chat thru history
5. type another
6. go to history and click on the same new chat

bug - https://www.loom.com/share/e912c87c229d48e59f36d9af26133949
fixed - https://www.loom.com/share/dfda1e458f204b72985c9962af65d86e

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots


## Testing
tried again. 

Using effect might be against best practices! Please let me know what you think is the best way to do this. Calling saveSession directly didn't work in the finally clause - it wouldn't register the new message or dispatched state changes. 

We might want to remove the pattern of calling saveSession to spawn a new session as well. This happens in a few other spots, and is the reason why clicking the "history" button and reselecting the same chat discards the last message. I added an optional parameter here, but it makes sense to just completely replace all other saveSessions with just like a newSession button, now that the latest message is automatically saved. 

