### PR TITLE
docs: Add explanations for Ollama, Azure OpenAI, Anthropic, and Bedrock providers

### DIFF
--- a/docs/docs/customize/model-providers/top-level/anthropic.md
+++ b/docs/docs/customize/model-providers/top-level/anthropic.md
@@ -3,6 +3,8 @@ title: Anthropic
 slug: ../anthropic
 ---
 
+Anthropic provider offers access to the Claude series of large language models, developed by Anthropic.
+
 :::info
 
 You can get an API key from the [Anthropic console](https://console.anthropic.com/account/keys).

--- a/docs/docs/customize/model-providers/top-level/azure.md
+++ b/docs/docs/customize/model-providers/top-level/azure.md
@@ -3,6 +3,14 @@ title: Azure OpenAI
 slug: ../azure
 ---
 
+Azure OpenAI is a cloud-based service that provides access to OpenAI's large language models including GPT series, integrated with the security and enterprise features of the Microsoft Azure platform. To get started, you have to create an Azure OpenAI resource in [Azure portal](https://portal.azure.com).
+
+:::info
+
+For details on model setup, see [General model configuration](#general-model-configuration).
+
+:::
+
 ## Chat model
 
 We recommend configuring **GPT-4o** as your chat model.

--- a/docs/docs/customize/model-providers/top-level/bedrock.md
+++ b/docs/docs/customize/model-providers/top-level/bedrock.md
@@ -3,6 +3,8 @@ title: Amazon Bedrock
 slug: ../bedrock
 ---
 
+Amazon Bedrock is a fully managed service that provides access to various foundation models from various AI companies through a single API, offering capabilities for building secure and responsible generative AI applications.
+
 ## Chat model
 
 We recommend configuring **Claude 3.5 Sonnet** as your chat model.

--- a/docs/docs/customize/model-providers/top-level/ollama.md
+++ b/docs/docs/customize/model-providers/top-level/ollama.md
@@ -3,6 +3,8 @@ title: Ollama
 slug: ../ollama
 ---
 
+Ollama is an open-source tool that allows users to run large language models (LLMs) locally on their own computers. To use Ollama providers, you need to install Ollama [here](https://ollama.ai/download) and download the model you want to run by `ollama pull` command.
+
 ## Chat model
 
 We recommend configuring **Llama3.1 8B** as your chat model.


### PR DESCRIPTION
## Description

This PR enhances the documentation for several AI providers:

- Ollama: Added brief explanation and prerequisites (installation, model download)
- Azure OpenAI: Included explanation, link to Azure portal, and internal link to configuration details
- Anthropic, Bedrock: Added brief explanation

These additions aim to improve user understanding of each provider and streamline the setup process.

Please review and let me know if any changes are needed.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created


