### PR TITLE
log quickEdit to devdata

### DIFF
--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -116,6 +116,7 @@
         "dotenv": "^16.4.5",
         "fastest-levenshtein": "^1.0.16",
         "follow-redirects": "^1.15.5",
+        "google-auth-library": "^9.14.2",
         "handlebars": "^4.7.8",
         "http-proxy-agent": "^7.0.1",
         "https-proxy-agent": "^7.0.3",

--- a/extensions/vscode/src/diff/vertical/handler.ts
+++ b/extensions/vscode/src/diff/vertical/handler.ts
@@ -344,6 +344,7 @@ export class VerticalDiffHandler implements vscode.Disposable {
   }
 
   async run(diffLineGenerator: AsyncGenerator<DiffLine>) {
+    let diffLines = []
     try {
       // As an indicator of loading
       this.updateIndexLineDecorations();
@@ -352,6 +353,7 @@ export class VerticalDiffHandler implements vscode.Disposable {
         if (this.isCancelled) {
           return;
         }
+        diffLines.push(diffLine)
         await this.queueDiffLine(diffLine);
       }
 
@@ -374,6 +376,7 @@ export class VerticalDiffHandler implements vscode.Disposable {
       this.clearForFilepath(this.filepath, false);
       throw e;
     }
+    return diffLines
   }
 
   async acceptRejectBlock(

--- a/extensions/vscode/src/diff/vertical/manager.ts
+++ b/extensions/vscode/src/diff/vertical/manager.ts
@@ -22,6 +22,8 @@ export class VerticalDiffManager {
 
   private userChangeListener: vscode.Disposable | undefined;
 
+  logDiffs: DiffLine[] | undefined;
+
   constructor(
     private readonly configHandler: ConfigHandler,
     private readonly webviewProtocol: VsCodeWebviewProtocol,
@@ -237,8 +239,8 @@ export class VerticalDiffManager {
     );
 
     try {
-      await diffHandler.run(diffStream);
-
+      this.logDiffs = await diffHandler.run(diffStream);
+      
       // enable a listener for user edits to file while diff is open
       this.enableDocumentChangeListener();
     } catch (e) {
@@ -410,7 +412,7 @@ export class VerticalDiffManager {
     );
 
     try {
-      await diffHandler.run(
+      this.logDiffs = await diffHandler.run(
         streamDiffLines(
           prefix,
           rangeContent,

--- a/extensions/vscode/src/quickEdit/QuickEditQuickPick.ts
+++ b/extensions/vscode/src/quickEdit/QuickEditQuickPick.ts
@@ -15,6 +15,7 @@ import { ConfigHandler } from "core/config/ConfigHandler";
 import { getModelByRole } from "core/config/util";
 // @ts-ignore
 import MiniSearch from "minisearch";
+import { logDevData } from "core/util/devdata";
 
 /**
  * Used to track what action to take after a user interacts
@@ -236,7 +237,8 @@ export class QuickEdit {
         default:
           break;
       }
-
+      let model = await this.getCurModelTitle();
+      logDevData('quickEdit', {prompt, path, label, diffs: this.verticalDiffManager.logDiffs, model});
       quickPick.dispose();
     });
   }


### PR DESCRIPTION
## Description

Logged Command-I/QuickEdit changes to devdata

Example log in "quickEdit.jsonl":

{"prompt":"test prompt that should be recorded",
"path":"/Users/kylel1/Documents/GitHub/continue/manual-testing-sandbox/test.js","label":"Accept all (Shift + Cmd + Enter)",
"diffs":[{"type":"new","line":"test() {"},{"type":"new","line":"    console.log(\"test prompt that should be recorded\");"},{"type":"new","line":"    return this;"},{"type":"new","line":"}"}], 
"model":"GPT-3.5-Turbo"}

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Testing

Tested Command-I/QuickEdit, checked .devdata. 