### PR TITLE
feat: focus continue session id command

### DIFF
--- a/core/protocol/ideWebview.ts
+++ b/core/protocol/ideWebview.ts
@@ -66,6 +66,7 @@ export type ToWebviewFromIdeProtocol = ToWebviewFromIdeOrCoreProtocol & {
    * @deprecated Use navigateTo with a path instead.
    */
   viewHistory: [undefined, void];
+  focusContinueSessionId: [{ sessionId: string | undefined }, void];
   newSession: [undefined, void];
   setTheme: [{ theme: any }, void];
   setColors: [{ [key: string]: string }, void];

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -116,6 +116,7 @@
         "dotenv": "^16.4.5",
         "fastest-levenshtein": "^1.0.16",
         "follow-redirects": "^1.15.5",
+        "google-auth-library": "^9.14.2",
         "handlebars": "^4.7.8",
         "http-proxy-agent": "^7.0.1",
         "https-proxy-agent": "^7.0.3",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -280,6 +280,12 @@
         "category": "Continue",
         "title": "Docs Force Re-Index",
         "group": "Continue"
+      },
+      {
+        "command": "continue.focusContinueSessionId",
+        "category": "Continue",
+        "title": "Focus Continue Chat",
+        "group": "Continue"
       }
     ],
     "keybindings": [

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -480,6 +480,14 @@ const commandsMap: (
     "continue.viewHistory": () => {
       sidebar.webviewProtocol?.request("viewHistory", undefined);
     },
+    "continue.focusContinueSessionId": async (sessionId: string | undefined) => {
+      if (!sessionId) {
+        sessionId = await vscode.window.showInputBox({
+          prompt: "Enter the Session ID"
+        });
+      }
+      sidebar.webviewProtocol?.request("focusContinueSessionId", { sessionId });
+    },
     "continue.applyCodeFromChat": () => {
       sidebar.webviewProtocol.request("applyCodeFromChat", undefined);
     },

--- a/gui/src/components/mainInput/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor.tsx
@@ -151,7 +151,7 @@ function TipTapEditor(props: TipTapEditorProps) {
   );
   const useActiveFile = useSelector(selectUseActiveFile);
 
-  const { saveSession } = useHistory(dispatch);
+  const { saveSession, loadSession } = useHistory(dispatch);
 
   const posthog = usePostHog();
   const [isEditorFocused, setIsEditorFocused] = useState(false);
@@ -805,6 +805,17 @@ function TipTapEditor(props: TipTapEditorProps) {
     },
     [editorFocusedRef, props.isMainInput],
     !props.isMainInput,
+  );
+
+  useWebviewListener(
+    "focusContinueSessionId",
+    async (data) => {
+      if (!props.isMainInput) {
+        return;
+      }
+      loadSession(data.sessionId);
+    },
+    [loadSession, props.isMainInput],
   );
 
   const [showDragOverMsg, setShowDragOverMsg] = useState(false);


### PR DESCRIPTION
## Description

Add a command to focus a specific session id in the panelview. 

Context: Would be useful for a getgait.com integration - one cool feature would be to continue (LOL) your collaborators chats. Adding this command in would enable that! 

This would look like a git-blame style annotation into a button that allows you to call this command and pop open a session. 
## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created

## Testing

tested the command out. 