### PR TITLE
feat: ollama emedding provider: respect maxBatchSize configuration option

### DIFF
--- a/core/indexing/embeddings/OllamaEmbeddingsProvider.ts
+++ b/core/indexing/embeddings/OllamaEmbeddingsProvider.ts
@@ -8,12 +8,12 @@ import BaseEmbeddingsProvider, {
   IBaseEmbeddingsProvider,
 } from "./BaseEmbeddingsProvider.js";
 
-async function embedOne(
-  chunk: string,
+async function embedOneBatch(
+  chunks: string[],
   options: EmbedOptions,
   customFetch: FetchFunction,
 ) {
-  const embedding = await withExponentialBackoff<number[]>(async () => {
+  const embedding = await withExponentialBackoff<number[][]>(async () => {
     let apiBase = options.apiBase!;
 
     if (!apiBase.endsWith("/")) {
@@ -24,7 +24,7 @@ async function embedOne(
       method: "POST",
       body: JSON.stringify({
         model: options.model,
-        input: chunk,
+        input: chunks,
       }),
       headers: {
         "Content-Type": "application/json",
@@ -37,7 +37,7 @@ async function embedOne(
     }
 
     const data = await resp.json();
-    const embedding = data.embeddings[0];
+    const embedding: number[][] = data.embeddings;
 
     if (!embedding || embedding.length === 0) {
       throw new Error("Ollama generated empty embedding");
@@ -53,12 +53,15 @@ class OllamaEmbeddingsProvider extends BaseEmbeddingsProvider {
   static defaultOptions: IBaseEmbeddingsProvider["defaultOptions"] = {
     apiBase: "http://localhost:11434/",
     model: "nomic-embed-text",
+    maxBatchSize: 64,
   };
 
   async embed(chunks: string[]) {
-    const results: any = [];
-    for (const chunk of chunks) {
-      results.push(await embedOne(chunk, this.options, this.fetch));
+    const batchedChunks = this.getBatchedChunks(chunks);
+    var results: number[][] = [];
+
+    for (const batch of batchedChunks) {
+      results.push(...await embedOneBatch(batch, this.options, this.fetch));
     }
     return results;
   }


### PR DESCRIPTION
## Description

Currently, the `ollama` embedding provider loops through one chunk at a time which can take quite some time on large codebases (sometimes it feels like it never completes!)

This PR adds support to the embedding provider to use the base class's `getBatchedChunks` function in order to take advantage of the fact that ollama [can accept multiple strings to embed at once](https://github.com/ollama/ollama/blob/main/docs/api.md#request-multiple-input).

I set the default maxBatchSize for this provider to a lower amount than the cloud provider's just out of abundance of caution - let me know if we should lower it/raise it further.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

n/a

## Testing

1. Configure ollama as your embedding provider as normal
2. Debug extension, set breakpoint [here](https://github.com/continuedev/continue/blob/ollama_respect_max_chunk_size/core/indexing/embeddings/OllamaEmbeddingsProvider.ts#L64-L65)
3. Re-index codebase
4. Observe that we are passing an array of chunks of size `maxBatchSize` (default 64) rather than just one by one.
