### PR TITLE
Preserve punctuation autocomplete

### DIFF
--- a/core/autocomplete/completionProvider.ts
+++ b/core/autocomplete/completionProvider.ts
@@ -28,7 +28,7 @@ import {
   constructAutocompletePrompt,
   languageForFilepath,
 } from "./constructPrompt.js";
-import { isOnlyPunctuationAndWhitespace } from "./filter.js";
+import { isOnlyWhitespace } from "./filter.js";
 import { AutocompleteLanguageInfo } from "./languages.js";
 import { postprocessCompletion } from "./postprocessing.js";
 import { AutocompleteSnippet } from "./ranking.js";
@@ -355,8 +355,12 @@ export class CompletionProvider {
         return undefined;
       }
 
-      // Filter out unwanted results
-      if (isOnlyPunctuationAndWhitespace(outcome.completion)) {
+      /**
+       * This check is most likely not needed because we do trim the LLM output
+       * elsewhere in the code. That said, I'm not yet confident enough to
+       * remove this.
+       */
+      if (isOnlyWhitespace(outcome.completion)) {
         return undefined;
       }
 

--- a/core/autocomplete/filter.ts
+++ b/core/autocomplete/filter.ts
@@ -1,4 +1,4 @@
-export function isOnlyPunctuationAndWhitespace(completion: string): boolean {
-  const punctuationAndWhitespaceRegex = /^[^\w\d\}\)\]]+$/;
-  return punctuationAndWhitespaceRegex.test(completion);
+export function isOnlyWhitespace(completion: string): boolean {
+  const whitespaceRegex = /^[\s]+$/;
+  return whitespaceRegex.test(completion);
 }

--- a/manual-testing-sandbox/Button.tsx
+++ b/manual-testing-sandbox/Button.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+export const Button = ({
+  onClick,
+  children,
+}: {
+  children: React.ReactNode;
+  onClick: () => void;
+}) => {
+  return (
+    <button className="btn btn-primary" onClick={onClick}>
+      {children}
+    </button>
+  );
+};


### PR DESCRIPTION
## Description

We are returning autocomplete suggestions even if they're punctuation only.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change. ]
