### PR TITLE
Fix Max Stop Words not being set for openai and watsonx models

### DIFF
--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -42,8 +42,6 @@ const CHAT_ONLY_MODELS = [
 class OpenAI extends BaseLLM {
   public useLegacyCompletionsEndpoint: boolean | undefined = undefined;
 
-  maxStopWords: number | undefined = undefined;
-
   constructor(options: LLMOptions) {
     super(options);
     this.useLegacyCompletionsEndpoint = options.useLegacyCompletionsEndpoint;

--- a/core/llm/llms/WatsonX.ts
+++ b/core/llm/llms/WatsonX.ts
@@ -14,7 +14,6 @@ const watsonxConfig = {
   },
 };
 class WatsonX extends BaseLLM {
-  maxStopWords: number | undefined = undefined;
 
   constructor(options: LLMOptions) {
     super(options);


### PR DESCRIPTION
## Description

A model i'm using with continue requires under 6 stop words. I tried setting maxStopWords, realized it did not work and looked on github for issues. I found #2538. 

After doing some debugging, I realized that maxStopWords was set during the super constructor, but blank in the child classes constructor.

This was because of the class level setting of maxStopWords = undefined. Removing that, it correctly accesses this.maxStopWords during _convertArgs()

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing

- Use a openAi model
- Set maxStopWords
- Verify stopWords is under the limit specified
