### PR TITLE
Respect stream argument for openAI

### DIFF
--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -204,7 +204,6 @@ class OpenAI extends BaseLLM {
       headers: this._getHeaders(),
       body: JSON.stringify({
         ...args,
-        stream: true,
       }),
     });
 


### PR DESCRIPTION
## Description

stream is set inside of convertArgs based off of the config or defaulted to true. By overriding it here, you make it impossible to set it as anything different inside the config.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change. ]
