### PR TITLE
Replace tab-autocomplete untrained model error with warning

### DIFF
--- a/extensions/vscode/src/quickEdit/QuickEditQuickPick.ts
+++ b/extensions/vscode/src/quickEdit/QuickEditQuickPick.ts
@@ -319,9 +319,8 @@ export class QuickEdit {
 
     return isSelectionEmpty
       ? `Edit ${fileName}`
-      : `Edit ${fileName}:${start.line}${
-          end.line > start.line ? `-${end.line}` : ""
-        }`;
+      : `Edit ${fileName}:${start.line}${end.line > start.line ? `-${end.line}` : ""
+      }`;
   };
 
   private async _streamEditWithInputAndContext(
@@ -385,7 +384,7 @@ export class QuickEdit {
     const modelTitle = await this.getCurModelTitle();
 
     if (!modelTitle) {
-      this.ide.showToast("info", "Please configure a model to use Quick Edit");
+      this.ide.showToast("error", "Please configure a model to use Quick Edit");
       return { label: undefined, value: undefined };
     }
 


### PR DESCRIPTION
## Description

Untrained autocomplete model was shown as error. 
Disabling extension notifications didn't prevent this.
Changing it to warning (showToast("warning", ...))

## Checklist

- [x ] The base branch of this PR is `dev`, rather than `main`
- [ x] The relevant docs, if any, have been updated or created

See [issue 2437](https://github.com/continuedev/continue/issues/2437)
