### PR TITLE
bugfix(jb): dont override `esc` key globally

### DIFF
--- a/extensions/intellij/.run/Run_Continue.xml
+++ b/extensions/intellij/.run/Run_Continue.xml
@@ -1,8 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Run Continue" type="CompoundRunConfigurationType">
-    <toRun name="Run Extension" type="GradleRunConfiguration" />
-    <toRun name="GUI: Start Dev Server" type="js.build_tools.npm" />
-    <toRun name="Tail Dev Logs" type="ShConfigurationType" />
-    <method v="2" />
-  </configuration>
-</component>

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/CancelAutocompleteAction.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/CancelAutocompleteAction.kt
@@ -1,21 +1,30 @@
 package com.github.continuedev.continueintellijextension.autocomplete
 
-import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.service
-import com.intellij.openapi.editor.Caret
 import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.editor.actionSystem.EditorAction
-import com.intellij.openapi.editor.actionSystem.EditorActionHandler
+import com.intellij.openapi.project.Project
 
-class CancelAutocompleteAction : EditorAction(object : EditorActionHandler() {
-    override fun doExecute(editor: Editor, caret: Caret?, dataContext: DataContext?) {
-        ApplicationManager.getApplication().runWriteAction {
-            editor.project?.service<AutocompleteService>()?.clearCompletions(editor)
+class CancelAutocompleteAction : AnAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+        if (isInvokedInEditor(e)) {
+            val editor = e.getRequiredData(CommonDataKeys.EDITOR)
+            ApplicationManager.getApplication().runWriteAction {
+                editor.project?.service<AutocompleteService>()?.clearCompletions(editor)
+            }
         }
     }
 
-    override fun isEnabledForCaret(editor: Editor, caret: Caret, dataContext: DataContext?): Boolean {
-        return true
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabledAndVisible = isInvokedInEditor(e)
     }
-}) {}
+
+    private fun isInvokedInEditor(e: AnActionEvent): Boolean {
+        val project: Project? = e.project
+        val editor: Editor? = e.getData(CommonDataKeys.EDITOR)
+        return project != null && editor != null && editor.contentComponent.hasFocus()
+    }
+}

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/InlineEditAction.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/InlineEditAction.kt
@@ -191,7 +191,9 @@ fun openInlineEdit(project: Project?, editor: Editor) {
             editor,
             startLineNumber,
             endLineNumber,
-            { inlayRef.get().dispose() },
+            {
+                inlayRef.get()?.dispose()
+            },
             {
                 textArea.document.insertString(textArea.caretPosition, ", ", null)
                 textArea.requestFocus()


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

## Checklist

- [ ] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change. ]
