### PR TITLE
Fix false positives when checking if a file is in a workspace

### DIFF
--- a/core/autocomplete/completionProvider.ts
+++ b/core/autocomplete/completionProvider.ts
@@ -268,7 +268,10 @@ export class CompletionProvider {
         const workspaceDirs = await this.ide.getWorkspaceDirs();
         let filepath = input.filepath;
         for (const workspaceDir of workspaceDirs) {
-          if (filepath.startsWith(workspaceDir)) {
+          const relativePath = path.relative(workspaceDir, filepath);
+          const relativePathBase = relativePath.split(path.sep).at(0);
+          const isInWorkspace = !path.isAbsolute(relativePath) && relativePathBase !== "..";
+          if (isInWorkspace) {
             filepath = path.relative(workspaceDir, filepath);
             break;
           }


### PR DESCRIPTION
## Description

Depending on the workspace layout, I would sometimes get this error toast from Continue:

![VS Code error toast with the following message: path should be a `path.relative()`d string, but got "..\foo-bar\test3.js"](https://github.com/user-attachments/assets/7439b854-875e-4ded-ab31-58199efeb05e)

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

N/A

## Testing

This fixes a bug when a directory in a workspace has a path that overlaps with another directory in a workspace. In this case, `path.relative()` would return a path containing `..` components. The fix was to tweak the logic to detect if a path is contained within another path to make it more robust ([this Stack Overflow answer](https://stackoverflow.com/a/45242825) gives some helpful context, although I went with a different solution because I believe that answer _also_ has a bug if one of the paths has a name starting with `..`, such as `..foo`)

Anyway, here's how I reproduced this issue:

2. Create an empty directory called `foo`
3. Create another directory next to it called `foo-bar`
4. Open `foo` in VS Code
5. In the Command Palette, run "Workspaces: Add Folder to Workspace...", then add `foo-bar` to the workspace
6. Create a file under `foo-bar`, then edit it with inline completions enabled

On both the latest release (v0.8.54) and pre-release (v0.9.217) versions of the Continue VS Code extension, this reliably triggers an error for me. With this PR, the error goes away and completions work as expected.

