### PR TITLE
Added support for MSSQL to the DatabaseContextProvider

### DIFF
--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -542,6 +542,7 @@ declare global {
     | "folder"
     | "jira"
     | "postgres"
+    | "mssql"
     | "database"
     | "code"
     | "docs"

--- a/docs/docs/customize/context-providers.md
+++ b/docs/docs/customize/context-providers.md
@@ -346,7 +346,7 @@ By default, the `schema` filter is set to `public`, and the `sampleRows` is set 
 
 ### `@Database`
 
-Reference table schemas from Sqlite, Postgres, and MySQL databases.
+Reference table schemas from Sqlite, Postgres, MSSQL, and MySQL databases.
 
 ```json title="config.json"
 {
@@ -364,6 +364,15 @@ Reference table schemas from Sqlite, Postgres, and MySQL databases.
               "database": "exampleDB",
               "password": "yourPassword",
               "port": 5432
+            }
+          }{
+            "name": "exampleMssql",
+            "connection_type": "mssql",
+            "connection": {
+              "user": "username",
+              "server": "localhost",
+              "database": "exampleDB",
+              "password": "yourPassword"
             }
           },
           {

--- a/docs/static/schemas/config.json
+++ b/docs/static/schemas/config.json
@@ -1547,6 +1547,7 @@
                 "highlights",
                 "outline",
                 "postgres",
+                "mssql",
                 "code",
                 "currentFile",
                 "url",
@@ -1710,7 +1711,7 @@
                         "connection_type": {
                           "type": "string",
                           "description": "The type of database (e.g., 'postgres', 'mysql')",
-                          "enum": ["postgres", "mysql", "sqlite"]
+                          "enum": ["postgres", "mysql", "sqlite", "mssql"]
                         },
                         "connection": {
                           "type": "object",
@@ -1896,6 +1897,65 @@
                 }
               }
             }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "name": {
+                "enum": ["mssql"]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "params": {
+                "properties": {
+                  "server": {
+                    "title": "Host",
+                    "description": "Database host",
+                    "default": "localhost",
+                    "type": "string"
+                  },
+                  "port": {
+                    "title": "Port",
+                    "description": "Database port",
+                    "default": 5432,
+                    "type": "integer"
+                  },
+                  "user": {
+                    "title": "User",
+                    "description": "Database user",
+                    "default": "postgres",
+                    "type": "string"
+                  },
+                  "password": {
+                    "title": "Password",
+                    "description": "Database password",
+                    "type": "string"
+                  },
+                  "database": {
+                    "title": "Database",
+                    "description": "Database name",
+                    "default": "postgres",
+                    "type": "string"
+                  },
+                  "schema": {
+                    "title": "Schema",
+                    "description": "Database schema",
+                    "default": "public",
+                    "type": "string"
+                  },
+                  "sampleRows": {
+                    "title": "Sample Rows",
+                    "description": "Number of rows to sample from the database",
+                    "default": 3,
+                    "type": "integer"
+                  }
+                }
+              }
+            },
+            "required": ["host", "port", "user", "password", "database"]
           }
         },
         {

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -1547,6 +1547,7 @@
                 "highlights",
                 "outline",
                 "postgres",
+                "mssql",
                 "code",
                 "currentFile",
                 "url",
@@ -1710,7 +1711,7 @@
                         "connection_type": {
                           "type": "string",
                           "description": "The type of database (e.g., 'postgres', 'mysql')",
-                          "enum": ["postgres", "mysql", "sqlite"]
+                          "enum": ["postgres", "mysql", "sqlite", "mssql"]
                         },
                         "connection": {
                           "type": "object",
@@ -1896,6 +1897,65 @@
                 }
               }
             }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "name": {
+                "enum": ["mssql"]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "params": {
+                "properties": {
+                  "server": {
+                    "title": "Host",
+                    "description": "Database host",
+                    "default": "localhost",
+                    "type": "string"
+                  },
+                  "port": {
+                    "title": "Port",
+                    "description": "Database port",
+                    "default": 5432,
+                    "type": "integer"
+                  },
+                  "user": {
+                    "title": "User",
+                    "description": "Database user",
+                    "default": "postgres",
+                    "type": "string"
+                  },
+                  "password": {
+                    "title": "Password",
+                    "description": "Database password",
+                    "type": "string"
+                  },
+                  "database": {
+                    "title": "Database",
+                    "description": "Database name",
+                    "default": "postgres",
+                    "type": "string"
+                  },
+                  "schema": {
+                    "title": "Schema",
+                    "description": "Database schema",
+                    "default": "public",
+                    "type": "string"
+                  },
+                  "sampleRows": {
+                    "title": "Sample Rows",
+                    "description": "Number of rows to sample from the database",
+                    "default": 3,
+                    "type": "integer"
+                  }
+                }
+              }
+            },
+            "required": ["host", "port", "user", "password", "database"]
           }
         },
         {

--- a/extensions/vscode/continue_rc_schema.json
+++ b/extensions/vscode/continue_rc_schema.json
@@ -1718,6 +1718,7 @@
                 "highlights",
                 "outline",
                 "postgres",
+                "mssql",
                 "code",
                 "currentFile",
                 "url",
@@ -1907,7 +1908,8 @@
                           "enum": [
                             "postgres",
                             "mysql",
-                            "sqlite"
+                            "sqlite",
+                            "mssql"
                           ]
                         },
                         "connection": {
@@ -2124,6 +2126,73 @@
                 }
               }
             }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "name": {
+                "enum": [
+                  "mssql"
+                ]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "params": {
+                "properties": {
+                  "server": {
+                    "title": "Host",
+                    "description": "Database host",
+                    "default": "localhost",
+                    "type": "string"
+                  },
+                  "port": {
+                    "title": "Port",
+                    "description": "Database port",
+                    "default": 5432,
+                    "type": "integer"
+                  },
+                  "user": {
+                    "title": "User",
+                    "description": "Database user",
+                    "default": "postgres",
+                    "type": "string"
+                  },
+                  "password": {
+                    "title": "Password",
+                    "description": "Database password",
+                    "type": "string"
+                  },
+                  "database": {
+                    "title": "Database",
+                    "description": "Database name",
+                    "default": "postgres",
+                    "type": "string"
+                  },
+                  "schema": {
+                    "title": "Schema",
+                    "description": "Database schema",
+                    "default": "public",
+                    "type": "string"
+                  },
+                  "sampleRows": {
+                    "title": "Sample Rows",
+                    "description": "Number of rows to sample from the database",
+                    "default": 3,
+                    "type": "integer"
+                  }
+                }
+              }
+            },
+            "required": [
+              "host",
+              "port",
+              "user",
+              "password",
+              "database"
+            ]
           }
         },
         {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "0.8.54",
+  "version": "0.8.56",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"
@@ -551,7 +551,7 @@
     "axios": "^1.2.5",
     "core": "file:../../core",
     "cors": "^2.8.5",
-    "dbinfoz": "^0.11.0",
+    "dbinfoz": "^0.14.0",
     "downshift": "^7.6.0",
     "esbuild": "^0.17.19",
     "express": "^4.18.2",


### PR DESCRIPTION
## Description

I've added support for MSSQL to the DatabaseContextProvider, honestly just a few config tweaks were required.
The package dbinfoz that DatabaseContextProvider relies on has already been updated to support MSSQL.

## Checklist

- [ ] The base branch of this PR is `dev`, rather than `main` <- Oops...
- [x] The relevant docs, if any, have been updated or created

## Screenshots

pending

## Testing

Install SQL Server
Ensure local connectivity to SQL Server
Update continue.dev config for @Database context provider and add mssql connection paramaters.
Try out @Database with the mssql server
