### PR TITLE
Global .continueignore

### DIFF
--- a/core/indexing/ignore.ts
+++ b/core/indexing/ignore.ts
@@ -1,4 +1,7 @@
 import ignore from "ignore";
+import path from "path";
+import os from "os";
+import fs from "fs";
 
 export const DEFAULT_IGNORE_FILETYPES = [
   "*.DS_Store",
@@ -114,3 +117,18 @@ export function gitIgArrayFromFile(file: string) {
     .map((l) => l.trim()) // Remove whitespace
     .filter((l) => !/^#|^$/.test(l)); // Remove empty lines
 }
+
+export const GLOBAL_CONTINUEIGNORE_PATH = path.join(os.homedir(), ".continue", ".continueignore");
+
+export const getGlobalContinueIgArray = () => {
+  try {
+    const contents = fs.readFileSync(GLOBAL_CONTINUEIGNORE_PATH, "utf8");
+    return gitIgArrayFromFile(contents);
+  } catch (error) {
+    // If the file doesn't exist, that's okay
+    if (error instanceof Error && ("code" in error) && error.code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+};

--- a/core/indexing/walkDir.ts
+++ b/core/indexing/walkDir.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_IGNORE_FILETYPES,
   defaultIgnoreDir,
   defaultIgnoreFile,
+  getGlobalContinueIgArray,
   gitIgArrayFromFile,
 } from "./ignore.js";
 
@@ -85,6 +86,7 @@ class DFSWalker {
   }
 
   private newRootWalkContext(): WalkContext {
+    const globalIgnoreFile = getGlobalContinueIgArray();
     return {
       walkableEntry: {
         relPath: "",
@@ -94,7 +96,7 @@ class DFSWalker {
       },
       ignoreContexts: [
         {
-          ignore: ignore().add(defaultIgnoreDir).add(defaultIgnoreFile),
+          ignore: ignore().add(defaultIgnoreDir).add(defaultIgnoreFile).add(globalIgnoreFile),
           dirname: "",
         },
       ],

--- a/docs/docs/customize/deep-dives/codebase.md
+++ b/docs/docs/customize/deep-dives/codebase.md
@@ -67,6 +67,8 @@ Whether to use re-ranking, which will allow initial selection of `nRetrieve` res
 
 Continue respects `.gitignore` files in order to determine which files should not be indexed. If you'd like to exclude additional files, you can add them to a `.continueignore` file, which follows the exact same rules as `.gitignore`.
 
+Continue also supports a **global** `.continueignore` file that will be respected for all workspaces, which can be created at `~/.continue/.continueignore`.
+
 If you want to see exactly what files Continue has indexed, the metadata is stored in `~/.continue/index/index.sqlite`. You can use a tool like [DB Browser for SQLite](https://sqlitebrowser.org/) to view the `tag_catalog` table within this file.
 
 If you need to force a refresh of the index, reload the VS Code window with `cmd/ctrl + shift + p` + "Reload Window".

--- a/sync/src/sync/merkle.rs
+++ b/sync/src/sync/merkle.rs
@@ -422,8 +422,7 @@ const GLOBAL_IGNORE_PATTERNS: &[&str] = &[
 fn global_ignore_path() -> PathBuf {
     let mut path = get_my_home().unwrap().unwrap();
     path.push(".continue");
-    path.push("index");
-    path.push(".globalcontinueignore");
+    path.push(".continueignore");
     path
 }
 


### PR DESCRIPTION
## Description

Add support for a global `~/.continue/.continueignore` file and a note in the associate deep dive docs.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Testing

1. Add breakpoint after `newRootWalkContext` creation 
2. Launch extension on dev and check `root.ignoreContexts[0].ignore._rules.map(r => r.regex).join('\n')` values at breakpoint
3. Add `~/.continue/.continueignore` with contents "*.ts"
4. Relaunch, see new `.ts` rule added!
