### PR TITLE
Added support for MSSQL to the DatabaseContextProvider

### DIFF
--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -542,6 +542,7 @@ declare global {
     | "folder"
     | "jira"
     | "postgres"
+    | "mssql"
     | "database"
     | "code"
     | "docs"

--- a/docs/docs/customize/context-providers.md
+++ b/docs/docs/customize/context-providers.md
@@ -409,7 +409,8 @@ Reference table schemas from Sqlite, Postgres, MSSQL, and MySQL databases.
               "password": "yourPassword",
               "port": 5432
             }
-          }{
+          },
+          {
             "name": "exampleMssql",
             "connection_type": "mssql",
             "connection": {

--- a/docs/docs/customize/context-providers.md
+++ b/docs/docs/customize/context-providers.md
@@ -390,7 +390,7 @@ By default, the `schema` filter is set to `public`, and the `sampleRows` is set 
 
 ### `@Database`
 
-Reference table schemas from Sqlite, Postgres, and MySQL databases.
+Reference table schemas from Sqlite, Postgres, MSSQL, and MySQL databases.
 
 ```json title="config.json"
 {
@@ -408,6 +408,15 @@ Reference table schemas from Sqlite, Postgres, and MySQL databases.
               "database": "exampleDB",
               "password": "yourPassword",
               "port": 5432
+            }
+          }{
+            "name": "exampleMssql",
+            "connection_type": "mssql",
+            "connection": {
+              "user": "username",
+              "server": "localhost",
+              "database": "exampleDB",
+              "password": "yourPassword"
             }
           },
           {

--- a/docs/static/schemas/config.json
+++ b/docs/static/schemas/config.json
@@ -1737,6 +1737,7 @@
                 "highlights",
                 "outline",
                 "postgres",
+                "mssql",
                 "code",
                 "currentFile",
                 "url",
@@ -1986,7 +1987,7 @@
                         "connection_type": {
                           "type": "string",
                           "description": "The type of database (e.g., 'postgres', 'mysql')",
-                          "enum": ["postgres", "mysql", "sqlite"]
+                          "enum": ["postgres", "mysql", "sqlite", "mssql"]
                         },
                         "connection": {
                           "type": "object",
@@ -2177,6 +2178,65 @@
                 }
               }
             }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "name": {
+                "enum": ["mssql"]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "params": {
+                "properties": {
+                  "server": {
+                    "title": "Host",
+                    "description": "Database host",
+                    "default": "localhost",
+                    "type": "string"
+                  },
+                  "port": {
+                    "title": "Port",
+                    "description": "Database port",
+                    "default": 5432,
+                    "type": "integer"
+                  },
+                  "user": {
+                    "title": "User",
+                    "description": "Database user",
+                    "default": "postgres",
+                    "type": "string"
+                  },
+                  "password": {
+                    "title": "Password",
+                    "description": "Database password",
+                    "type": "string"
+                  },
+                  "database": {
+                    "title": "Database",
+                    "description": "Database name",
+                    "default": "postgres",
+                    "type": "string"
+                  },
+                  "schema": {
+                    "title": "Schema",
+                    "description": "Database schema",
+                    "default": "public",
+                    "type": "string"
+                  },
+                  "sampleRows": {
+                    "title": "Sample Rows",
+                    "description": "Number of rows to sample from the database",
+                    "default": 3,
+                    "type": "integer"
+                  }
+                }
+              }
+            },
+            "required": ["host", "port", "user", "password", "database"]
           }
         },
         {

--- a/docs/static/schemas/config.json
+++ b/docs/static/schemas/config.json
@@ -1737,7 +1737,6 @@
                 "highlights",
                 "outline",
                 "postgres",
-                "mssql",
                 "code",
                 "currentFile",
                 "url",

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -1737,6 +1737,7 @@
                 "highlights",
                 "outline",
                 "postgres",
+                "mssql",
                 "code",
                 "currentFile",
                 "url",
@@ -1986,7 +1987,7 @@
                         "connection_type": {
                           "type": "string",
                           "description": "The type of database (e.g., 'postgres', 'mysql')",
-                          "enum": ["postgres", "mysql", "sqlite"]
+                          "enum": ["postgres", "mysql", "sqlite", "mssql"]
                         },
                         "connection": {
                           "type": "object",
@@ -2177,6 +2178,65 @@
                 }
               }
             }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "name": {
+                "enum": ["mssql"]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "params": {
+                "properties": {
+                  "server": {
+                    "title": "Host",
+                    "description": "Database host",
+                    "default": "localhost",
+                    "type": "string"
+                  },
+                  "port": {
+                    "title": "Port",
+                    "description": "Database port",
+                    "default": 5432,
+                    "type": "integer"
+                  },
+                  "user": {
+                    "title": "User",
+                    "description": "Database user",
+                    "default": "postgres",
+                    "type": "string"
+                  },
+                  "password": {
+                    "title": "Password",
+                    "description": "Database password",
+                    "type": "string"
+                  },
+                  "database": {
+                    "title": "Database",
+                    "description": "Database name",
+                    "default": "postgres",
+                    "type": "string"
+                  },
+                  "schema": {
+                    "title": "Schema",
+                    "description": "Database schema",
+                    "default": "public",
+                    "type": "string"
+                  },
+                  "sampleRows": {
+                    "title": "Sample Rows",
+                    "description": "Number of rows to sample from the database",
+                    "default": 3,
+                    "type": "integer"
+                  }
+                }
+              }
+            },
+            "required": ["host", "port", "user", "password", "database"]
           }
         },
         {

--- a/extensions/vscode/continue_rc_schema.json
+++ b/extensions/vscode/continue_rc_schema.json
@@ -1939,6 +1939,7 @@
                 "highlights",
                 "outline",
                 "postgres",
+                "mssql",
                 "code",
                 "currentFile",
                 "url",
@@ -2234,7 +2235,8 @@
                           "enum": [
                             "postgres",
                             "mysql",
-                            "sqlite"
+                            "sqlite",
+                            "mssql"
                           ]
                         },
                         "connection": {
@@ -2456,6 +2458,73 @@
                 }
               }
             }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "name": {
+                "enum": [
+                  "mssql"
+                ]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "params": {
+                "properties": {
+                  "server": {
+                    "title": "Host",
+                    "description": "Database host",
+                    "default": "localhost",
+                    "type": "string"
+                  },
+                  "port": {
+                    "title": "Port",
+                    "description": "Database port",
+                    "default": 5432,
+                    "type": "integer"
+                  },
+                  "user": {
+                    "title": "User",
+                    "description": "Database user",
+                    "default": "postgres",
+                    "type": "string"
+                  },
+                  "password": {
+                    "title": "Password",
+                    "description": "Database password",
+                    "type": "string"
+                  },
+                  "database": {
+                    "title": "Database",
+                    "description": "Database name",
+                    "default": "postgres",
+                    "type": "string"
+                  },
+                  "schema": {
+                    "title": "Schema",
+                    "description": "Database schema",
+                    "default": "public",
+                    "type": "string"
+                  },
+                  "sampleRows": {
+                    "title": "Sample Rows",
+                    "description": "Number of rows to sample from the database",
+                    "default": 3,
+                    "type": "integer"
+                  }
+                }
+              }
+            },
+            "required": [
+              "host",
+              "port",
+              "user",
+              "password",
+              "database"
+            ]
           }
         },
         {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -563,7 +563,7 @@
     "axios": "^1.2.5",
     "core": "file:../../core",
     "cors": "^2.8.5",
-    "dbinfoz": "^0.11.0",
+    "dbinfoz": "^0.14.0",
     "downshift": "^7.6.0",
     "esbuild": "^0.17.19",
     "express": "^4.18.2",


### PR DESCRIPTION
## Description

I've added support for MSSQL to the DatabaseContextProvider, honestly just a few config tweaks were required.
The package dbinfoz that DatabaseContextProvider relies on has already been updated to support MSSQL.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing

Install SQL Server
Ensure local connectivity to SQL Server
Update continue.dev config for @database context provider and add mssql connection paramaters.
Try out @database with the mssql server