### PR TITLE
dallin/config json schema validation

### DIFF
--- a/.idea/continue.iml
+++ b/.idea/continue.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/continue-intellij-extension.iml" filepath="$PROJECT_DIR$/.idea/modules/continue-intellij-extension.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/continue.iml" filepath="$PROJECT_DIR$/.idea/continue.iml" />
     </modules>
   </component>
 </project>

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/ConfigRcJsonSchemaProviderFactory copy.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/ConfigRcJsonSchemaProviderFactory copy.kt
@@ -22,7 +22,7 @@ class ConfigJsonSchemaProviderFactory : JsonSchemaProviderFactory {
 
 class ConfigJsonSchemaFileProvider : JsonSchemaFileProvider {
     override fun isAvailable(file: VirtualFile): Boolean {
-        return path.endsWith("/.continue/config.json") || file.name == ".continuerc.json"
+        return file.name == ".continuerc.json"
     }
 
     override fun getName(): String {
@@ -30,13 +30,13 @@ class ConfigJsonSchemaFileProvider : JsonSchemaFileProvider {
     }
 
     override fun getSchemaFile(): VirtualFile? {
-        ContinuePluginStartupActivity::class.java.getClassLoader().getResourceAsStream("config_schema.json")
+        ContinuePluginStartupActivity::class.java.getClassLoader().getResourceAsStream("continue_rc_schema.json")
             .use { `is` ->
                 if (`is` == null) {
-                    throw IOException("Resource not found: config_schema.json")
+                    throw IOException("Resource not found: continue_rc_schema.json")
                 }
                 val content = StreamUtil.readText(`is`, StandardCharsets.UTF_8)
-                val filepath = Paths.get(getContinueGlobalPath(), "config_schema.json").toString()
+                val filepath = Paths.get(getContinueGlobalPath(), "continue_rc_schema.json").toString()
                 File(filepath).writeText(content)
                 return LocalFileSystem.getInstance().findFileByPath(filepath)
             }

--- a/extensions/intellij/src/main/resources/META-INF/plugin.xml
+++ b/extensions/intellij/src/main/resources/META-INF/plugin.xml
@@ -15,6 +15,10 @@
         <ProviderFactory
                 implementation="com.github.continuedev.continueintellijextension.continue.ConfigJsonSchemaProviderFactory"/>
     </extensions>
+        <extensions defaultExtensionNs="JavaScript.JsonSchema">
+        <ProviderFactory
+                implementation="com.github.continuedev.continueintellijextension.continue.ConfigRcJsonSchemaProviderFactory"/>
+    </extensions>
 
     <extensions defaultExtensionNs="com.intellij">
         <editorFactoryListener

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -494,7 +494,7 @@
     },
     "jsonValidation": [
       {
-        "fileMatch": "config.json",
+        "fileMatch": "**/.continue/config.json",
         "url": "./config_schema.json"
       },
       {

--- a/extensions/vscode/scripts/prepackage-cross-platform.js
+++ b/extensions/vscode/scripts/prepackage-cross-platform.js
@@ -85,7 +85,7 @@ function isWin() {
 async function package(target, os, arch, exe) {
   console.log("[info] Packaging extension for target ", target);
 
-  // Copy config_schema.json to config.json in docs and intellij
+  // Copy config_schema to docs and intellij
   copyConfigSchema();
 
   // Install node_modules
@@ -153,10 +153,9 @@ async function package(target, os, arch, exe) {
 
     // onnx runtime bindngs
     `bin/napi-v3/${os}/${arch}/onnxruntime_binding.node`,
-    `bin/napi-v3/${os}/${arch}/${
-      os === "darwin"
-        ? "libonnxruntime.1.14.0.dylib"
-        : os === "linux"
+    `bin/napi-v3/${os}/${arch}/${os === "darwin"
+      ? "libonnxruntime.1.14.0.dylib"
+      : os === "linux"
         ? "libonnxruntime.so.1.14.0"
         : "onnxruntime.dll"
     }`,
@@ -193,17 +192,15 @@ async function package(target, os, arch, exe) {
 
     // out/node_modules (to be accessed by extension.js)
     `out/node_modules/@vscode/ripgrep/bin/rg${exe}`,
-    `out/node_modules/@esbuild/${
-      target === "win32-arm64"
-        ? "esbuild.exe"
-        : target === "win32-x64"
+    `out/node_modules/@esbuild/${target === "win32-arm64"
+      ? "esbuild.exe"
+      : target === "win32-x64"
         ? "win32-x64/esbuild.exe"
         : `${target}/bin/esbuild`
     }`,
-    `out/node_modules/@lancedb/vectordb-${
-      os === "win32"
-        ? "win32-x64-msvc"
-        : `${target}${os === "linux" ? "-gnu" : ""}`
+    `out/node_modules/@lancedb/vectordb-${os === "win32"
+      ? "win32-x64-msvc"
+      : `${target}${os === "linux" ? "-gnu" : ""}`
     }/index.node`,
     `out/node_modules/esbuild/lib/main.js`,
     `out/node_modules/esbuild/bin/esbuild`,

--- a/extensions/vscode/scripts/utils.js
+++ b/extensions/vscode/scripts/utils.js
@@ -11,6 +11,19 @@ const {
 const continueDir = path.join(__dirname, "..", "..", "..");
 
 function copyConfigSchema() {
+  // Modify and copy for .continuerc.json
+  const schema = JSON.parse(fs.readFileSync("config_schema.json", "utf8"));
+  schema.definitions.SerializedContinueConfig.properties.mergeBehavior = {
+    type: "string",
+    enum: ["merge", "overwrite"],
+    default: "merge",
+    title: "Merge behavior",
+    markdownDescription:
+      "If set to 'merge', .continuerc.json will be applied on top of config.json (arrays and objects are merged). If set to 'overwrite', then every top-level property of .continuerc.json will overwrite that property from config.json.",
+  };
+  fs.writeFileSync("continue_rc_schema.json", JSON.stringify(schema, null, 2));
+
+  // Copy config schemas to docs and intellij
   fs.copyFileSync(
     "config_schema.json",
     path.join("..", "..", "docs", "static", "schemas", "config.json"),
@@ -26,17 +39,18 @@ function copyConfigSchema() {
       "config_schema.json",
     ),
   );
-  // Modify and copy for .continuerc.json
-  const schema = JSON.parse(fs.readFileSync("config_schema.json", "utf8"));
-  schema.definitions.SerializedContinueConfig.properties.mergeBehavior = {
-    type: "string",
-    enum: ["merge", "overwrite"],
-    default: "merge",
-    title: "Merge behavior",
-    markdownDescription:
-      "If set to 'merge', .continuerc.json will be applied on top of config.json (arrays and objects are merged). If set to 'overwrite', then every top-level property of .continuerc.json will overwrite that property from config.json.",
-  };
-  fs.writeFileSync("continue_rc_schema.json", JSON.stringify(schema, null, 2));
+  fs.copyFileSync(
+    "continue_rc_schema.json",
+    path.join(
+      "..",
+      "intellij",
+      "src",
+      "main",
+      "resources",
+      "continue_rc_schema.json",
+    ),
+  );
+
 }
 
 function copyTokenizers() {


### PR DESCRIPTION
only uses `config_schema.json` validation for `config.json` files in the `.continue` folder
adds separate check/plugin for `continue_rc_schema.json` json schema validation in intellij
and copying of `continue_rc_schema.json` to intellij resources

Working in VsCode
NOT WORKING IN INTELLIJ - NEED TO FIGURE OUT WHY NOT GETTING SUGGESTIONS IN INTELLIJ
