### PR TITLE
o1 preview fix - mark as chat only

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -664,6 +664,8 @@ export type ModelName =
   | "gpt-4-turbo"
   | "gpt-4-turbo-preview"
   | "gpt-4-vision-preview"
+  | "o1-preview"
+  | "o1-mini"
   // Mistral
   | "codestral-latest"
   | "open-mistral-7b"

--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -37,6 +37,8 @@ const CHAT_ONLY_MODELS = [
   "gpt-4-0125-preview",
   "gpt-4-1106-preview",
   "gpt-4o-mini",
+  "o1-preview",
+  "o1-mini",
 ];
 
 class OpenAI extends BaseLLM {
@@ -111,9 +113,9 @@ class OpenAI extends BaseLLM {
           : url.host === "api.deepseek.com"
             ? options.stop?.slice(0, 16)
             : url.port === "1337" ||
-                url.host === "api.openai.com" ||
-                url.host === "api.groq.com" ||
-                this.apiType === "azure"
+              url.host === "api.openai.com" ||
+              url.host === "api.groq.com" ||
+              this.apiType === "azure"
               ? options.stop?.slice(0, 4)
               : options.stop,
     };


### PR DESCRIPTION
## Description

Added o1-preview to `CHAT_ONLY_MODELS` to prevent legacy chat endpoint usage

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

Not tested