### PR TITLE
fix: add hover effect and restrict clickable area for the history and more back buttons

### DIFF
--- a/gui/src/pages/More/More.tsx
+++ b/gui/src/pages/More/More.tsx
@@ -26,14 +26,15 @@ function MorePage() {
   return (
     <div className="overflow-y-scroll">
       <div
-        onClick={() => navigate("/")}
-        className="sticky top-0 m-0 flex cursor-pointer items-center border-0 border-b border-solid border-b-zinc-700 bg-inherit p-0"
+        className="sticky top-0 m-0 flex items-center border-0 border-b border-solid border-b-zinc-700 bg-inherit p-0"
         style={{
           backgroundColor: vscBackground,
         }}
       >
-        <ArrowLeftIcon className="ml-3 inline-block h-3 w-3 cursor-pointer" />
-        <span className="m-2 inline-block text-base font-bold">Chat</span>
+        <div className="cursor-pointer hover:text-zinc-100 transition-colors duration-200" onClick={() => navigate("/")}>
+          <ArrowLeftIcon className="ml-3 inline-block h-3 w-3" />
+          <span className="m-2 inline-block text-base font-bold">Chat</span>
+        </div>
       </div>
 
       <div className="gap-2 divide-x-0 divide-y-2 divide-solid divide-zinc-700 px-4">

--- a/gui/src/pages/history/HistoryHeader.tsx
+++ b/gui/src/pages/history/HistoryHeader.tsx
@@ -19,13 +19,14 @@ export const HistoryHeader = () => {
           borderBottom: `0.5px solid ${lightGray}`,
         }}
       >
-        <ArrowLeftIcon
-          width="1.2em"
-          height="1.2em"
-          onClick={() => navigate("/")}
-          className="ml-4 inline-block cursor-pointer"
-        />
-        <span className="m-2 inline-block text-base font-bold">Chat</span>
+        <div className="flex items-center cursor-pointer hover:text-zinc-100 transition-colors duration-200" onClick={() => navigate("/")}> 
+          <ArrowLeftIcon
+            width="1.2em"
+            height="1.2em"
+            className="ml-4 inline-block"
+          />
+          <span className="m-2 inline-block text-base font-bold">Chat</span>
+        </div>
       </div>
       {/* {workspacePaths && workspacePaths.length > 0 && (
       <CheckDiv


### PR DESCRIPTION
## Description

This PR fixes the back arrow button interaction by adding a hover effect and restricting the clickable area to only the arrow icon and text on the history and more pages.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change. ]
