### PR TITLE
Fixes #2692 - add support for multiple modules in jetbrains for git diff context provider

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
@@ -447,22 +447,26 @@ class IdeProtocolClient(
                     }
 
                     "getDiff" -> {
-                        val builder = ProcessBuilder("git", "diff")
-                        builder.directory(File(workspacePath ?: "."))
-                        val process = builder.start()
-
-                        val reader = BufferedReader(InputStreamReader(process.inputStream))
+                        val workspaceDirs = workspaceDirectories()
                         val output = StringBuilder()
-                        var line: String? = reader.readLine()
-                        while (line != null) {
-                            output.append(line)
-                            output.append("\n")
-                            line = reader.readLine()
+
+                        for (workspaceDir in workspaceDirs) {
+                            val builder = ProcessBuilder("git", "diff")
+                            builder.directory(File(workspaceDir))
+                            val process = builder.start()
+
+                            val reader = BufferedReader(InputStreamReader(process.inputStream))
+                            var line: String? = reader.readLine()
+                            while (line != null) {
+                                output.append(line)
+                                output.append("\n")
+                                line = reader.readLine()
+                            }
+
+                            process.waitFor()
                         }
 
-                        process.waitFor()
-
-                        respond(output.toString());
+                        respond(output.toString())
                     }
 
                     "getProblems" -> {


### PR DESCRIPTION
## Description

add support for multiple modules in jetbrains for git diff context provider

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Testing

In a jetbrains workspace that contains multiple modules or micro-services, make changes in more than 1 repository. Use the `@Git Diff` context provider in a chat window and ensure the diff for each repository is included in the context.
