### PR TITLE
Ensure don't go over sqlite max like pattern length

### DIFF
--- a/core/autocomplete/cache.ts
+++ b/core/autocomplete/cache.ts
@@ -1,16 +1,8 @@
 import { Mutex } from "async-mutex";
 import { open } from "sqlite";
 import sqlite3 from "sqlite3";
-import { DatabaseConnection } from "../indexing/refreshIndex.js";
+import { DatabaseConnection, truncateSqliteLikePattern } from "../indexing/refreshIndex.js";
 import { getTabAutocompleteCacheSqlitePath } from "../util/paths.js";
-
-const SQLITE_MAX_LIKE_PATTERN_LENGTH = 50000;
-
-function truncateToBytes(input: string, maxBytes: number): string {
-  let bytes = 0;
-  return input.split("").filter(char => (bytes += new TextEncoder().encode(char).length) <= maxBytes).join("");
-}
-
 
 export class AutocompleteLruCache {
   private static capacity = 1000;
@@ -43,10 +35,9 @@ export class AutocompleteLruCache {
     // If the query is "co" and we have "c" -> "ontinue" in the cache,
     // we should return "ntinue" as the completion.
     // Have to make sure we take the key with shortest length
-    const truncatedPrefix = truncateToBytes(prefix, SQLITE_MAX_LIKE_PATTERN_LENGTH);
     const result = await this.db.get(
       "SELECT key, value FROM cache WHERE ? LIKE key || '%' ORDER BY LENGTH(key) DESC LIMIT 1",
-      truncatedPrefix,
+      truncateSqliteLikePattern(prefix),
     );
 
     // Validate that the cached compeltion is a valid completion for the prefix

--- a/core/indexing/CodeSnippetsIndex.ts
+++ b/core/indexing/CodeSnippetsIndex.ts
@@ -14,7 +14,7 @@ import {
   getParserForFile,
   getQueryForFile,
 } from "../util/treeSitter";
-import { DatabaseConnection, SqliteDb, tagToString } from "./refreshIndex";
+import { DatabaseConnection, SqliteDb, tagToString, truncateSqliteLikePattern } from "./refreshIndex";
 import {
   IndexResultType,
   MarkCompleteCallback,
@@ -28,7 +28,7 @@ export class CodeSnippetsCodebaseIndex implements CodebaseIndex {
   relativeExpectedTime: number = 1;
   artifactId = "codeSnippets";
 
-  constructor(private readonly ide: IDE) {}
+  constructor(private readonly ide: IDE) { }
 
   private static async _createTables(db: DatabaseConnection) {
     await db.exec(`CREATE TABLE IF NOT EXISTS code_snippets (
@@ -383,7 +383,7 @@ export class CodeSnippetsCodebaseIndex implements CodebaseIndex {
     const db = await SqliteDb.get();
     await CodeSnippetsCodebaseIndex._createTables(db);
 
-    const likePatterns = workspaceDirs.map((dir) => `${dir}%`);
+    const likePatterns = workspaceDirs.map((dir) => truncateSqliteLikePattern(`${dir}%`));
     const placeholders = likePatterns.map(() => "?").join(" OR path LIKE ");
 
     const query = `

--- a/core/indexing/refreshIndex.test.ts
+++ b/core/indexing/refreshIndex.test.ts
@@ -1,0 +1,34 @@
+import { truncateToLastNBytes } from "./refreshIndex";
+
+describe("truncateToLastNBytes", () => {
+  it("should return full string if maxBytes greater than string byte length", () => {
+    const input = "Hello World";
+    const result = truncateToLastNBytes(input, 100);
+    expect(result).toBe("Hello World");
+  });
+
+  it("should truncate ASCII string correctly", () => {
+    const input = "Hello World";
+    const result = truncateToLastNBytes(input, 5);
+    expect(result).toBe("World");
+  });
+
+  it("should handle empty string", () => {
+    const input = "";
+    const result = truncateToLastNBytes(input, 5);
+    expect(result).toBe("");
+  });
+
+  it("should handle UTF-8 characters correctly", () => {
+    const input = "👋 Hello";
+    // 👋 is 4 bytes, space is 1 byte
+    const result = truncateToLastNBytes(input, 5);
+    expect(result).toBe("Hello");
+  });
+
+  it("should handle maxBytes of 0", () => {
+    const input = "Hello World";
+    const result = truncateToLastNBytes(input, 0);
+    expect(result).toBe("");
+  });
+});

--- a/core/indexing/refreshIndex.ts
+++ b/core/indexing/refreshIndex.ts
@@ -472,11 +472,21 @@ export class GlobalCacheCodeBaseIndex implements CodebaseIndex {
 
 const SQLITE_MAX_LIKE_PATTERN_LENGTH = 50000;
 
-function truncateToBytes(input: string, maxBytes: number): string {
+function truncateFirstNBytes(input: string, maxBytes: number): string {
   let bytes = 0;
-  return input.split("").filter(char => (bytes += new TextEncoder().encode(char).length) <= maxBytes).join("");
+  let startIndex = 0;
+
+  for (let i = 0; i < input.length; i++) {
+    bytes += new TextEncoder().encode(input[i]).length;
+    if (bytes > maxBytes) {
+      startIndex = i;
+      break;
+    }
+  }
+
+  return input.substring(startIndex);
 }
 
 export function truncateSqliteLikePattern(input: string) {
-  return truncateToBytes(input, SQLITE_MAX_LIKE_PATTERN_LENGTH);
+  return truncateFirstNBytes(input, SQLITE_MAX_LIKE_PATTERN_LENGTH);
 }

--- a/core/indexing/refreshIndex.ts
+++ b/core/indexing/refreshIndex.ts
@@ -406,7 +406,7 @@ export async function getComputeDeleteAddRemove(
       for await (const _ of globalCacheIndex.update(
         tag,
         results,
-        async () => { },
+        async () => {},
         repoName,
       )) {
       }
@@ -417,7 +417,7 @@ export async function getComputeDeleteAddRemove(
 export class GlobalCacheCodeBaseIndex implements CodebaseIndex {
   relativeExpectedTime: number = 1;
 
-  constructor(private db: DatabaseConnection) { }
+  constructor(private db: DatabaseConnection) {}
 
   artifactId = "globalCache";
 
@@ -472,21 +472,21 @@ export class GlobalCacheCodeBaseIndex implements CodebaseIndex {
 
 const SQLITE_MAX_LIKE_PATTERN_LENGTH = 50000;
 
-function truncateFirstNBytes(input: string, maxBytes: number): string {
+export function truncateToLastNBytes(input: string, maxBytes: number): string {
   let bytes = 0;
   let startIndex = 0;
 
-  for (let i = 0; i < input.length; i++) {
+  for (let i = input.length - 1; i >= 0; i--) {
     bytes += new TextEncoder().encode(input[i]).length;
     if (bytes > maxBytes) {
-      startIndex = i;
+      startIndex = i + 1;
       break;
     }
   }
 
-  return input.substring(startIndex);
+  return input.substring(startIndex, input.length);
 }
 
 export function truncateSqliteLikePattern(input: string) {
-  return truncateFirstNBytes(input, SQLITE_MAX_LIKE_PATTERN_LENGTH);
+  return truncateToLastNBytes(input, SQLITE_MAX_LIKE_PATTERN_LENGTH);
 }

--- a/core/indexing/refreshIndex.ts
+++ b/core/indexing/refreshIndex.ts
@@ -406,7 +406,7 @@ export async function getComputeDeleteAddRemove(
       for await (const _ of globalCacheIndex.update(
         tag,
         results,
-        async () => {},
+        async () => { },
         repoName,
       )) {
       }
@@ -417,7 +417,7 @@ export async function getComputeDeleteAddRemove(
 export class GlobalCacheCodeBaseIndex implements CodebaseIndex {
   relativeExpectedTime: number = 1;
 
-  constructor(private db: DatabaseConnection) {}
+  constructor(private db: DatabaseConnection) { }
 
   artifactId = "globalCache";
 
@@ -468,4 +468,15 @@ export class GlobalCacheCodeBaseIndex implements CodebaseIndex {
       tag.artifactId,
     );
   }
+}
+
+const SQLITE_MAX_LIKE_PATTERN_LENGTH = 50000;
+
+function truncateToBytes(input: string, maxBytes: number): string {
+  let bytes = 0;
+  return input.split("").filter(char => (bytes += new TextEncoder().encode(char).length) <= maxBytes).join("");
+}
+
+export function truncateSqliteLikePattern(input: string) {
+  return truncateToBytes(input, SQLITE_MAX_LIKE_PATTERN_LENGTH);
 }


### PR DESCRIPTION
## Description

Truncate LIKE comparison pattern in autocomplete LRU cache

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

See discussion in 
https://github.com/continuedev/continue/issues/2688
