### PR TITLE
default maxStopWords = 16 for DeepInfra

### DIFF
--- a/core/llm/llms/DeepInfra.ts
+++ b/core/llm/llms/DeepInfra.ts
@@ -6,6 +6,7 @@ class DeepInfra extends OpenAI {
   static defaultOptions: Partial<LLMOptions> = {
     apiBase: "https://api.deepinfra.com/v1/openai/",
   };
+  maxStopWords: number | undefined = 16;
 }
 
 export default DeepInfra;


### PR DESCRIPTION
## Description

DeepInfra supports a maximum stop word length of 16, so added this constraint.

## Checklist

- [V] The base branch of this PR is `dev`, rather than `main`
- [V] The relevant docs, if any, have been updated or created

## Screenshots

No visual changes.

## Testing

This is just a parameter change.
