### PR TITLE
Fix editor to limit textarea to 15 

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor.tsx
@@ -464,7 +464,7 @@ function TipTapEditor(props: TipTapEditorProps) {
     ],
     editorProps: {
       attributes: {
-        class: "outline-none -mt-1 overflow-hidden",
+        class: "outline-none -mt-1 overflow-y-auto resize-none h-[calc(1.5rem*15)] leading-6",
         style: `font-size: ${getFontSize()}px;`,
       },
     },


### PR DESCRIPTION
## Description
- Fixes #2696 
- Modified the `TipTapEditor` component to limit the visible lines to 15, implementing scroll behavior for additional content.
- As soon as the user enters more than 15 lines, the scroll bar would appear which will improve the readability

## Checklist

- [X] The base branch of this PR is `dev`, rather than `main`
- [X] The relevant docs, if any, have been updated or created

## Screenshots
- below is the ss that shows the appearance of the scroll bar as soon as the content exceeds 15 lines 
![Screenshot (371)](https://github.com/user-attachments/assets/0e5b0afa-3741-46b0-b180-321f279c76b7)


## Testing

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change. ]
[ For new UI features, ensure that the changes look good across viewport widths, light/dark theme, etc ]
