### PR TITLE
docs: add BerriAI/litellm to the openai compatible server list

### DIFF
--- a/docs/docs/customize/model-providers/top-level/openai.md
+++ b/docs/docs/customize/model-providers/top-level/openai.md
@@ -63,6 +63,7 @@ OpenAI compatible servers
 - [llama-cpp-python](https://github.com/abetlen/llama-cpp-python#web-server)
 - [TensorRT-LLM](https://github.com/NVIDIA/trt-llm-as-openai-windows?tab=readme-ov-file#examples)
 - [vLLM](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html)
+- [BerriAI/litellm](https://github.com/BerriAI/litellm)
 
 OpenAI compatible APIs
 


### PR DESCRIPTION
## Description

Added BerriAI/litellm to the openai compatible server list in the docs


## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

- N/A

## Testing

- N/A
