### PR TITLE
Add needs triage label to issues automatically

### DIFF
--- a/.github/workflows/auto-assign.yaml
+++ b/.github/workflows/auto-assign.yaml
@@ -16,3 +16,8 @@ jobs:
           repo-token: ${{ secrets.CI_GITHUB_TOKEN }}
           assignees: sestinj,Patrick-Erichsen
           numOfAssignee: 1
+      - name: Add default labels
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: "needs-triage"


### PR DESCRIPTION
For now, add needs-triage label to new issues by default