### PR TITLE
docs: corrected link to @docs context providers

### DIFF
--- a/docs/docs/customize/deep-dives/docs.md
+++ b/docs/docs/customize/deep-dives/docs.md
@@ -6,7 +6,7 @@ toc_max_heading_level: 5
 
 # @Docs
 
-The [`@Docs` context provider](http://localhost:3000/customization/context-providers#documentation) allows you to interact with your documentation directly within Continue. This feature enables you to index any static site or GitHub markdown pages, making it easier to access and utilize your documentation while coding.
+The [`@Docs` context provider](customize/context-providers.md#docs) allows you to interact with your documentation directly within Continue. This feature enables you to index any static site or GitHub markdown pages, making it easier to access and utilize your documentation while coding.
 
 ## Enabling the `@Docs` context provider
 


### PR DESCRIPTION
## Description

Fixes a broken link in the documentation.
"@Docs context provider" was a link to localhost:3000 and the wrong page

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

