### PR TITLE
fix: log llm completition in edit command

### DIFF
--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -501,15 +501,20 @@ export abstract class BaseLLM implements ILLM {
     }
 
     let completion = "";
-    for await (const chunk of this._streamComplete(prompt, completionOptions)) {
-      completion += chunk;
-      yield chunk;
-    }
+    try {
+      for await (const chunk of this._streamComplete(
+        prompt,
+        completionOptions,
+      )) {
+        completion += chunk;
+        yield chunk;
+      }
+    } finally {
+      this._logTokensGenerated(completionOptions.model, prompt, completion);
 
-    this._logTokensGenerated(completionOptions.model, prompt, completion);
-
-    if (log && this.writeLog) {
-      await this.writeLog(`Completion:\n\n${completion}\n\n`);
+      if (log && this.writeLog) {
+        await this.writeLog(`Completion:\n\n${completion}\n\n`);
+      }
     }
 
     return {


### PR DESCRIPTION
## Description

currently the llm answer is not logged because the for loop never ends, it break from the caller.
wrapping with a finally block to log it anyway

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created
