### PR TITLE
Fix activate vscode extension

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,11 +5,11 @@
     {
       "label": "vscode-extension:build",
       "dependsOn": [
-        // To detect compile errors and output extensions.js
+        // To detect compile errors
         "vscode-extension:tsc",
         // To build the React app that is used in the extension
-        "vscode-extension:continue-ui:build",
-        // To bundle the code the same way we do for publishing
+        // "vscode-extension:continue-ui:build",
+        // // To bundle the code the same way we do for publishing
         "vscode-extension:esbuild",
         // Start the React app that is used in the extension
         "gui:dev"
@@ -21,10 +21,7 @@
     },
     {
       "label": "vscode-extension:esbuild",
-      "dependsOn": [
-        "vscode-extension:continue-ui:build",
-        "vscode-extension:tsc"
-      ],
+      "dependsOn": ["vscode-extension:continue-ui:build"],
       "type": "npm",
       "script": "esbuild-watch",
       "path": "extensions/vscode",
@@ -44,7 +41,7 @@
           "background": {
             "activeOnStart": true,
             "beginsPattern": ">",
-            "endsPattern": ">"
+            "endsPattern": "node scripts/esbuild.js --sourcemap --watch"
           }
         }
       ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,7 +8,7 @@
         // To detect compile errors
         "vscode-extension:tsc",
         // To build the React app that is used in the extension
-        // "vscode-extension:continue-ui:build",
+        "vscode-extension:continue-ui:build",
         // // To bundle the code the same way we do for publishing
         "vscode-extension:esbuild",
         // Start the React app that is used in the extension

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "0.9.223",
+  "version": "0.9.224",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "0.9.223",
+      "version": "0.9.224",
       "license": "Apache-2.0",
       "dependencies": {
         "@electron/rebuild": "^3.2.10",


### PR DESCRIPTION
Originally thought it was due to a missing dependsOn, but on second take looks like it was caused by an insufficient endsPattern (something @sestinj @Patrick-Erichsen) mentioned last week but I didn't get at the time

How to know?
vscode-extension:build task alone generates extension.js fine
but Launch "Launch extension" attempts to launch extension host before extension.js has been updated.

Solution:
try a few problem matchers, this one works

note, root issue seems to be that the problem matcher used to be ">" but then an npm script `esbuild-base` was added that caused an addition premature > to be output