### PR TITLE
copy prompt logs button

### DIFF
--- a/gui/src/components/gui/StepContainer.tsx
+++ b/gui/src/components/gui/StepContainer.tsx
@@ -17,6 +17,7 @@ import { RootState } from "../../redux/store";
 import { getFontSize } from "../../util";
 import ButtonWithTooltip from "../ButtonWithTooltip";
 import { CopyButton } from "../markdown/CopyButton";
+import { CopyChatHistoryItemButton } from "../markdown/CopyPromptLogsButton";
 import StyledMarkdownPreview from "../markdown/StyledMarkdownPreview";
 
 interface StepContainerProps {
@@ -117,9 +118,16 @@ function StepContainer(props: StepContainerProps) {
             </ButtonWithTooltip>
           )}
 
+          <CopyChatHistoryItemButton
+            tabIndex={-1}
+            chatHistoryItem={props.item}
+            logsIconClassName="h-3.5 w-3.5 text-gray-500"
+            checkIconClassName="h-3.5 w-3.5 text-green-400"
+          />
+
           {props.index !== 1 && (
             <ButtonWithTooltip
-              text="Delete"
+              text={"Delete"}
               tabIndex={-1}
               onClick={props.onDelete}
             >
@@ -131,6 +139,7 @@ function StepContainer(props: StepContainerProps) {
             tabIndex={-1}
             text={stripImages(props.item.message.content)}
             clipboardIconClassName="h-3.5 w-3.5 text-gray-500"
+            checkIconClassName="h-3.5 w-3.5 text-green-400"
           />
 
           <ButtonWithTooltip

--- a/gui/src/components/markdown/CopyPromptLogsButton/format.ts
+++ b/gui/src/components/markdown/CopyPromptLogsButton/format.ts
@@ -1,0 +1,78 @@
+import { ChatHistoryItem } from "core";
+import { stripImages } from "core/llm/images";
+
+
+const sectionBreak = "=".repeat(80)
+const subSectionBreak = "*".repeat(80)
+const sectionHeader = (title: string) => sectionBreak + "\n" + title + "\n" + sectionBreak + "\n";
+
+export function formattedChatHistoryItem(item: ChatHistoryItem): string {
+    // Header 
+    let header = sectionHeader("CHAT INTERACTION LOG")
+
+    // Context Items
+    let context = "\n" + sectionHeader("CONTEXT");
+    if (item.modifiers) {
+        context += `Modifiers:\nUse Codebase: ${item.modifiers.useCodebase}\nNo Context: ${item.modifiers.noContext}\n\n`;
+        context += subSectionBreak + "\n"
+    }
+    if (item.contextItems.length > 0) {
+        item.contextItems.forEach((contextItem, index) => {
+            if (index !== 0) context += subSectionBreak + "\n"
+            context += `Name: ${contextItem.name}\n`;
+            context += `Description: ${contextItem.description}\n`;
+            context += contextItem.editing ? `Editing: ${contextItem.editing}\n` : "";
+            context += contextItem.editable ? `Editable: ${contextItem.editable}\n` : "";
+            context += contextItem.icon ? `Icon: ${contextItem.icon}\n` : "";
+            context += contextItem.uri ? `URI: ${JSON.stringify(contextItem.uri)}\n` : "";
+            context += contextItem.content ? `Content:\n\n${contextItem.content}` : "";
+        });
+    } else {
+        context += "No context items";
+    };
+
+    // For now seems redundant with prompts and completions
+    // // Messages
+    // let messages = "\n" + sectionHeader("MESSAGES");
+    // const { role, content } = item.message;
+    // messages += `${role.toUpperCase()}:\n`;
+    // if (typeof content === "string") {
+    //     messages += `${stripImages(content)}\n`;
+    // } else {
+    //     content.forEach(part => {
+    //         if (part.type === "text") {
+    //             messages += `${part.text}\n`;
+    //         } else if (part.type === "imageUrl" && part.imageUrl) {
+    //             messages += `Image URL: ${part.imageUrl.url}\n`;
+    //         }
+    //     });
+    // }
+
+    let promptsAndCompletions = "\n\n" + sectionHeader("PROMPTS AND COMPLETIONS");
+
+
+    if (item.promptLogs && item.promptLogs.length > 0) {
+        item.promptLogs.forEach((promptLog, index) => {
+            if (index !== 0) promptsAndCompletions += subSectionBreak + "\n";
+
+            // Model info and completion options
+            promptsAndCompletions += `Model Title: ${promptLog.modelTitle}\n`;
+            promptsAndCompletions += `Model: ${promptLog.completionOptions.model}\n`;
+
+            for (const [key, value] of Object.entries(promptLog.completionOptions)) {
+                if (value !== undefined && key !== "model") {
+                    promptsAndCompletions += `${key}: ${value}\n`;
+                }
+            }
+            promptsAndCompletions += `Prompt:\n\n${promptLog.prompt}`;
+            promptsAndCompletions += `\nCompletion:\n\n${promptLog.completion}\n`;
+        })
+
+    } else {
+        promptsAndCompletions += "No prompts/completions"
+    }
+
+    // Combine all parts
+    const formattedLog = header + context + promptsAndCompletions;
+    return formattedLog;
+}

--- a/gui/src/components/markdown/CopyPromptLogsButton/index.tsx
+++ b/gui/src/components/markdown/CopyPromptLogsButton/index.tsx
@@ -1,0 +1,55 @@
+import { CheckIcon, QueueListIcon } from "@heroicons/react/24/outline";
+import { useContext, useMemo, useState } from "react";
+import { IdeMessengerContext } from "../../../context/IdeMessenger";
+import { isJetBrains } from "../../../util";
+import ButtonWithTooltip from "../../ButtonWithTooltip";
+import { ChatHistoryItem } from "core";
+import { formattedChatHistoryItem } from "./format";
+
+interface CopyChatHistoryItemButtonProps {
+  chatHistoryItem: ChatHistoryItem;
+  tabIndex?: number;
+  checkIconClassName?: string;
+  logsIconClassName?: string;
+}
+
+export function CopyChatHistoryItemButton({
+  chatHistoryItem,
+  tabIndex,
+  checkIconClassName = "h-4 w-4 text-green-400",
+  logsIconClassName = "h-4 w-4 text-gray-400",
+}: CopyChatHistoryItemButtonProps) {
+  const [copied, setCopied] = useState<boolean>(false);
+
+  const ideMessenger = useContext(IdeMessengerContext);
+
+  const textVal = useMemo(() => {
+    return formattedChatHistoryItem(chatHistoryItem)
+  }, [chatHistoryItem])
+
+  return (
+    <>
+      <ButtonWithTooltip
+        tabIndex={tabIndex}
+        text={copied ? "Copied!" : "Copy Logs"}
+        onClick={(e) => {
+          // const textVal = typeof text === "string" ? text : text();
+          if (isJetBrains()) {
+            ideMessenger.request("copyText", { text: textVal });
+          } else {
+            navigator.clipboard.writeText(textVal);
+          }
+
+          setCopied(true);
+          setTimeout(() => setCopied(false), 2000);
+        }}
+      >
+        {copied ? (
+          <CheckIcon className={checkIconClassName} />
+        ) : (
+          <QueueListIcon className={logsIconClassName} />
+        )}
+      </ButtonWithTooltip>
+    </>
+  );
+}

--- a/gui/src/components/markdown/CopyPromptLogsButton/index.tsx
+++ b/gui/src/components/markdown/CopyPromptLogsButton/index.tsx
@@ -5,6 +5,7 @@ import { isJetBrains } from "../../../util";
 import ButtonWithTooltip from "../../ButtonWithTooltip";
 import { ChatHistoryItem } from "core";
 import { formattedChatHistoryItem } from "./format";
+import { usePostHog } from "posthog-js/react";
 
 interface CopyChatHistoryItemButtonProps {
   chatHistoryItem: ChatHistoryItem;
@@ -20,6 +21,7 @@ export function CopyChatHistoryItemButton({
   logsIconClassName = "h-4 w-4 text-gray-400",
 }: CopyChatHistoryItemButtonProps) {
   const [copied, setCopied] = useState<boolean>(false);
+  const posthog = usePostHog()
 
   const ideMessenger = useContext(IdeMessengerContext);
 
@@ -42,6 +44,8 @@ export function CopyChatHistoryItemButton({
 
           setCopied(true);
           setTimeout(() => setCopied(false), 2000);
+
+          posthog?.capture('clicked_copy_chat_history_logs')
         }}
       >
         {copied ? (


### PR DESCRIPTION
Adds a small button for people to be able to copy logs for the current chat history item

<img width="503" alt="image" src="https://github.com/user-attachments/assets/5dfb7ef6-ee53-4799-a739-c1b87a3d41f0">

Copies context, prompts and completions, llm info, etc. to the clipboard