### PR TITLE
[#2791] - Proposal for addin use_mmap parameter

### DIFF
--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -730,6 +730,7 @@ declare global {
     stop?: string[];
     maxTokens?: number;
     numThreads?: number;
+    useMmap?: boolean;
     keepAlive?: number;
     raw?: boolean;
     stream?: boolean;

--- a/core/control-plane/schema.ts
+++ b/core/control-plane/schema.ts
@@ -54,6 +54,7 @@ const modelDescriptionSchema = z.object({
       stop: z.array(z.string()).optional(),
       maxTokens: z.number().optional(),
       numThreads: z.number().optional(),
+      useMmap: z.boolean().optional(),
       keepAlive: z.number().optional(),
       raw: z.boolean().optional(),
       stream: z.boolean().optional(),

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -788,6 +788,7 @@ interface BaseCompletionOptions {
   stop?: string[];
   maxTokens?: number;
   numThreads?: number;
+  useMmap?: boolean;
   keepAlive?: number;
   raw?: boolean;
   stream?: boolean;

--- a/core/llm/llms/Ollama.ts
+++ b/core/llm/llms/Ollama.ts
@@ -30,6 +30,7 @@ interface ModelFileParams {
   min_p?: number;
   // deprecated?
   num_thread?: number;
+  use_mmap?: boolean;	
   num_gqa?: number;
   num_gpu?: number;
 }
@@ -191,6 +192,7 @@ class Ollama extends BaseLLM {
       num_ctx: this.contextLength,
       mirostat: options.mirostat,
       num_thread: options.numThreads,
+      use_mmap: options.useMmap,
       min_p: options.minP,
     };
   }

--- a/docs/docs/customize/model-providers/more/msty.md
+++ b/docs/docs/customize/model-providers/more/msty.md
@@ -24,6 +24,7 @@ In addition to the model type, you can also configure some of the parameters tha
 - top_k: options.topK - This parameter limits the number of unique tokens to consider when generating the next token in the sequence. Higher values increase the variety of generated sequences, while lower values lead to more focused outputs.
 - num_predict: options.maxTokens - This determines the maximum number of tokens (words or characters) to generate for the given input prompt.
 - num_thread: options.numThreads - This is the multi-threading configuration option that controls how many threads the model uses for parallel processing. Higher values may lead to faster generation times but could also increase memory usage and complexity. Set this to one or two lower than the number of threads your CPU can handle to leave some for your GUI when running the model locally.
+- use_mmap: options.useMmap - For Ollama, this parameter allows the model to be mapped into memory. If disabled can enhance response time on low end devices but will slow down the stream.
 
 ## Authentication
 

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -158,6 +158,7 @@ Parameters that control the behavior of text generation and completion settings.
 - `maxTokens`: The maximum number of tokens to generate in a completion (default: `2048`).
 - `numThreads`: The number of threads used during the generation process. Available only for Ollama as `num_thread`.
 - `keepAlive`: For Ollama, this parameter sets the number of seconds to keep the model loaded after the last request, unloading it from memory if inactive (default: `1800` seconds, or 30 minutes).
+- `useMmap`: For Ollama, this parameter allows the model to be mapped into memory. If disabled can enhance response time on low end devices but will slow down the stream.
 
 Example
 

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -61,6 +61,11 @@
           "description": "The number of threads used in the generation process. Only available for Ollama (this is the num_thread parameter)",
           "type": "integer"
         },
+        "useMmap": {
+          "title": "Use Memory Map",
+          "description": "Allows the model to be mapped into memory. If disabled can enhance response time on low end devices. Only available for Ollama (this is the use_mmap parameter)",
+          "type": "boolean"
+        },
         "keepAlive": {
           "title": "Ollama keep_alive",
           "description": "The number of seconds after no requests are made to unload the model from memory. Defaults to 60*30 = 30min",

--- a/packages/config-types/src/index.ts
+++ b/packages/config-types/src/index.ts
@@ -11,6 +11,7 @@ export const completionOptionsSchema = z.object({
   stop: z.array(z.string()).optional(),
   maxTokens: z.number().optional(),
   numThreads: z.number().optional(),
+  useMmap: z.boolean().optional(),
   keepAlive: z.number().optional(),
   raw: z.boolean().optional(),
   stream: z.boolean().optional(),


### PR DESCRIPTION
## Description

[#2791] - Proposal for addin use_mmap parameter

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing
When adding the useMmap variablet o false

```json
    {
      "title": "Llama 3.2 3.2B",
      "model": "llama3.2:latest",
      "provider": "ollama",
      "apiBase": "https://aserver",
      "completionOptions": {
        "useMmap": false
      }
    },
```

You should see in Ollama the new request using the `--no-mmap` modifier.

![image](https://github.com/user-attachments/assets/72cd9ec1-88d3-4f14-b7b9-045ec81048b5)
