### PR TITLE
1.Add a timestamp attribute to the file autocomplete.jsonl. 2.Fix the…

### DIFF
--- a/core/autocomplete/completionProvider.ts
+++ b/core/autocomplete/completionProvider.ts
@@ -89,6 +89,7 @@ export interface AutocompleteOutcome extends TabAutocompleteOptions {
   gitRepo?: string;
   completionId: string;
   uniqueId: string;
+  timestamp: number;
 }
 
 const autocompleteCache = AutocompleteLruCache.get();
@@ -367,6 +368,12 @@ export class CompletionProvider {
           (await this.autocompleteCache).put(outcome.prefix, completionToCache);
         }
       }, 100);
+
+      // When using the JetBrains extension, Mark as displayed
+      const ideType = (await this.ide.getIdeInfo()).ideType;
+      if (ideType === "jetbrains") {
+        this.markDisplayed(input.completionId, outcome);
+      }
 
       return outcome;
     } catch (e: any) {
@@ -759,6 +766,7 @@ export class CompletionProvider {
     }
 
     const time = Date.now() - startTime;
+    const timestamp = Date.now();
     return {
       time,
       completion,
@@ -773,6 +781,7 @@ export class CompletionProvider {
       completionId: input.completionId,
       gitRepo: await this.ide.getRepoName(input.filepath),
       uniqueId: await this.ide.getUniqueId(),
+      timestamp: timestamp,
       ...options,
     };
   }

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/AutocompleteService.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/AutocompleteService.kt
@@ -192,10 +192,9 @@ class AutocompleteService(private val project: Project) {
 
         editor.caretModel.moveToOffset(offset + text.length)
 
-
         project.service<ContinuePluginService>().coreMessenger?.request(
             "autocomplete/accept",
-            completion.completionId,
+            hashMapOf("completionId" to completion.completionId),
             null,
             ({})
         )


### PR DESCRIPTION
## Description

1. Add a timestamp attribute to the file autocomplete.jsonl. 
2. Fix the issue where JetBranins doesn't write to autocomplete.jsonl.

## Checklist

- [ ] The base branch of this PR is `dev`, rather than `main`
- [ ] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing

1. After the autocompleted content is displayed in the JetBrains IDE, you will see the content in the file /continue/dev_data/autocomplete.jsonl.

2. After the autocompleted content is displayed in JetBrains or VSCode, you will see the content in the file /continue/dev_data/autocomplete.jsonl with the timestamp attribute.
