### PR TITLE
feat: add API key support for TEI reranker

### DIFF
--- a/core/context/rerankers/tei.ts
+++ b/core/context/rerankers/tei.ts
@@ -15,6 +15,7 @@ export class HuggingFaceTEIReranker implements Reranker {
       apiBase?: string;
       truncate?: boolean;
       truncation_direction?: string;
+      apiKey?: string;
     },
   ) {}
 
@@ -24,9 +25,17 @@ export class HuggingFaceTEIReranker implements Reranker {
       apiBase += "/";
     }
 
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+
+    if (this.params.apiKey) {
+      headers["Authorization"] = `Bearer ${this.params.apiKey}`;
+    }
+
     const resp = await fetch(new URL("rerank", apiBase), {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers,
       body: JSON.stringify({
         query: query,
         return_text: false,

--- a/docs/docs/customize/model-types/reranking.md
+++ b/docs/docs/customize/model-types/reranking.md
@@ -72,6 +72,7 @@ The `"modelTitle"` field must match one of the models in your "models" array in 
     "name": "huggingface-tei",
     "params": {
       "apiBase": "http://localhost:8080",
+      "apiKey": "<TEI_API_KEY>",
       "truncate": true,
       "truncation_direction": "Right"
     }

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -2637,6 +2637,9 @@
                         "type": "string",
                         "default": "http://localhost:8080"
                       },
+                      "apiKey": {
+                        "type": "string"
+                      },
                       "truncate": {
                         "type": "boolean",
                         "description": "Whether to truncate long sequences to the maximum allowed context length.",


### PR DESCRIPTION
fixes: #2741

## Description

This change adds API key support for the TEI reranker. Here are the key changes:

1. In the reranker implementation:
```typescript:core/context/rerankers/tei.ts
export class HuggingFaceTEIReranker implements Reranker {
  // ... existing code ...

  // Add apiKey to params
  constructor(
    private params: {
      apiBase?: string;
      truncate?: boolean;
      truncation_direction?: string;
      apiKey?: string;  // New parameter
    },
  ) {}

  async rerank(query: string, documents: Document[]): Promise<Document[]> {
    // ... existing code ...

    const headers: Record<string, string> = {
      "Content-Type": "application/json",
    };

    if (this.params.apiKey) {
      headers["Authorization"] = `Bearer ${this.params.apiKey}`;
    }

    const resp = await fetch(new URL("rerank", apiBase), {
      method: "POST",
      headers,  // Updated headers object
      // ... rest of existing code ...
    });
    // ... existing code ...
  }
}
```

2. The schema files and documentation have been updated to include the new `apiKey` parameter in the configuration options for the TEI reranker.

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing

The changes allow users to authenticate with the TEI API by providing an API key in their configuration. The key is sent in the Authorization header using Bearer token authentication.
