### PR TITLE
Explicit end build message

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -41,7 +41,7 @@
           "background": {
             "activeOnStart": true,
             "beginsPattern": ">",
-            "endsPattern": "node scripts/esbuild.js --sourcemap --watch"
+            "endsPattern": "VS Code Extension esbuild complete"
           }
         }
       ]

--- a/extensions/vscode/scripts/esbuild.js
+++ b/extensions/vscode/scripts/esbuild.js
@@ -30,4 +30,5 @@ const esbuildConfig = {
   } else {
     await esbuild.build(esbuildConfig);
   }
+  console.log("VS Code Extension esbuild complete"); // Used in task endpattern to signal completion
 })();


### PR DESCRIPTION
## Description

Somehow the esbuild endsPattern is still occasionally getting prematurely triggered during build tasks.

I believe this is because the extension host sometimes launces between the time the npm script is triggered and esbuild is complete and running watching.

To fix, I added an explicit `endPattern` message.