### PR TITLE
Enable history titles by default

### DIFF
--- a/core/config/load.ts
+++ b/core/config/load.ts
@@ -1,16 +1,9 @@
+import { execSync } from "child_process";
 import * as JSONC from "comment-json";
 import * as fs from "fs";
+import os from "os";
 import path from "path";
 import * as tar from "tar";
-import {
-  slashCommandFromDescription,
-  slashFromCustomCommand,
-} from "../commands/index.js";
-import CustomContextProviderClass from "../context/providers/CustomContextProvider";
-import FileContextProvider from "../context/providers/FileContextProvider";
-import { contextProviderClassFromName } from "../context/providers/index";
-import { AllRerankers } from "../context/rerankers/index";
-import { LLMReranker } from "../context/rerankers/llm";
 import {
   BrowserSerializedContinueConfig,
   Config,
@@ -30,18 +23,25 @@ import {
   SerializedContinueConfig,
   SlashCommand,
 } from "..";
-import TransformersJsEmbeddingsProvider from "../indexing/embeddings/TransformersJsEmbeddingsProvider";
-import { allEmbeddingsProviders } from "../indexing/embeddings";
-import { BaseLLM } from "../llm";
-import CustomLLMClass from "../llm/llms/CustomLLM";
-import FreeTrial from "../llm/llms/FreeTrial";
-import { llmFromDescription } from "../llm/llms";
-import os from "os";
-import { execSync } from "child_process";
+import {
+  slashCommandFromDescription,
+  slashFromCustomCommand,
+} from "../commands/index.js";
 import CodebaseContextProvider from "../context/providers/CodebaseContextProvider";
 import ContinueProxyContextProvider from "../context/providers/ContinueProxyContextProvider";
-import { fetchwithRequestOptions } from "../util/fetchWithOptions";
+import CustomContextProviderClass from "../context/providers/CustomContextProvider";
+import FileContextProvider from "../context/providers/FileContextProvider";
+import { contextProviderClassFromName } from "../context/providers/index";
+import { AllRerankers } from "../context/rerankers/index";
+import { LLMReranker } from "../context/rerankers/llm";
+import { allEmbeddingsProviders } from "../indexing/embeddings";
+import TransformersJsEmbeddingsProvider from "../indexing/embeddings/TransformersJsEmbeddingsProvider";
+import { BaseLLM } from "../llm";
+import { llmFromDescription } from "../llm/llms";
+import CustomLLMClass from "../llm/llms/CustomLLM";
+import FreeTrial from "../llm/llms/FreeTrial";
 import { copyOf } from "../util";
+import { fetchwithRequestOptions } from "../util/fetchWithOptions";
 import mergeJson from "../util/merge";
 import {
   DEFAULT_CONFIG_TS_CONTENTS,
@@ -65,7 +65,7 @@ import {
   getPromptFiles,
   slashCommandFromPromptFile,
 } from "./promptFile.js";
-import { validateConfig, ConfigValidationError } from "./validation.js";
+import { ConfigValidationError, validateConfig } from "./validation.js";
 
 import { GlobalContext } from "../util/GlobalContext";
 
@@ -134,8 +134,11 @@ function loadSerializedConfig(
     config.allowAnonymousTelemetry = true;
   }
 
-  if (config.getChatTitles === undefined) {
-    config.getChatTitles = true;
+  if (config.ui?.getChatTitles === undefined) {
+    config.ui = {
+      ...config.ui,
+      getChatTitles: true,
+    };
   }
 
   if (ideSettings.remoteConfigServerUrl) {
@@ -515,7 +518,6 @@ function finalToBrowserConfig(
     embeddingsProvider: final.embeddingsProvider?.id,
     ui: final.ui,
     experimental: final.experimental,
-    getChatTitles: final.getChatTitles,
   };
 }
 

--- a/core/config/load.ts
+++ b/core/config/load.ts
@@ -134,6 +134,10 @@ function loadSerializedConfig(
     config.allowAnonymousTelemetry = true;
   }
 
+  if (config.getChatTitles === undefined) {
+    config.getChatTitles = true;
+  }
+
   if (ideSettings.remoteConfigServerUrl) {
     try {
       const remoteConfigJson = resolveSerializedConfig(
@@ -511,6 +515,7 @@ function finalToBrowserConfig(
     embeddingsProvider: final.embeddingsProvider?.id,
     ui: final.ui,
     experimental: final.experimental,
+    getChatTitles: final.getChatTitles,
   };
 }
 

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -979,11 +979,6 @@ interface ExperimentalConfig {
   readResponseTTS?: boolean;
 
   /**
-   * Prompt the user's LLM for a title given the current chat content
-   */
-  getChatTitles?: boolean;
-
-  /**
    * If set to true, we will attempt to pull down and install an instance of Chromium
    * that is compatible with the current version of Puppeteer.
    * This is needed to crawl a large number of documentation sites that are dynamically rendered.
@@ -1019,6 +1014,7 @@ export interface SerializedContinueConfig {
   experimental?: ExperimentalConfig;
   analytics?: AnalyticsConfig;
   docs?: SiteIndexingConfig[];
+  getChatTitles?: boolean;
 }
 
 export type ConfigMergeType = "merge" | "overwrite";
@@ -1093,6 +1089,7 @@ export interface ContinueConfig {
   experimental?: ExperimentalConfig;
   analytics?: AnalyticsConfig;
   docs?: SiteIndexingConfig[];
+  getChatTitles?: boolean;
 }
 
 export interface BrowserSerializedContinueConfig {
@@ -1111,4 +1108,5 @@ export interface BrowserSerializedContinueConfig {
   reranker?: RerankerDescription;
   experimental?: ExperimentalConfig;
   analytics?: AnalyticsConfig;
+  getChatTitles?: boolean;
 }

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -916,6 +916,7 @@ export interface ContinueUIConfig {
   fontSize?: number;
   displayRawMarkdown?: boolean;
   showChatScrollbar?: boolean;
+  getChatTitles?: boolean;
 }
 
 interface ContextMenuConfig {
@@ -1014,7 +1015,6 @@ export interface SerializedContinueConfig {
   experimental?: ExperimentalConfig;
   analytics?: AnalyticsConfig;
   docs?: SiteIndexingConfig[];
-  getChatTitles?: boolean;
 }
 
 export type ConfigMergeType = "merge" | "overwrite";
@@ -1089,7 +1089,6 @@ export interface ContinueConfig {
   experimental?: ExperimentalConfig;
   analytics?: AnalyticsConfig;
   docs?: SiteIndexingConfig[];
-  getChatTitles?: boolean;
 }
 
 export interface BrowserSerializedContinueConfig {
@@ -1108,5 +1107,4 @@ export interface BrowserSerializedContinueConfig {
   reranker?: RerankerDescription;
   experimental?: ExperimentalConfig;
   analytics?: AnalyticsConfig;
-  getChatTitles?: boolean;
 }

--- a/core/util/chatDescriber.ts
+++ b/core/util/chatDescriber.ts
@@ -40,7 +40,7 @@ export class ChatDescriber {
       return;
     }
 
-    completionOptions.maxTokens = 24;
+    completionOptions.maxTokens = 6;
 
     // Prompt the user's current LLM for the title
     const titleResponse = await model.chat(

--- a/gui/src/hooks/useHistory.tsx
+++ b/gui/src/hooks/useHistory.tsx
@@ -2,14 +2,14 @@ import { Dispatch } from "@reduxjs/toolkit";
 import { PersistedSessionInfo, SessionInfo } from "core";
 
 import { stripImages } from "core/llm/images";
-import { useCallback, useContext, useEffect } from "react";
+import { useCallback, useContext } from "react";
 import { useSelector } from "react-redux";
 import { IdeMessengerContext } from "../context/IdeMessenger";
+import { useLastSessionContext } from "../context/LastSessionContext";
 import { defaultModelSelector } from "../redux/selectors/modelSelectors";
 import { newSession } from "../redux/slices/stateSlice";
 import { RootState } from "../redux/store";
 import { getLocalStorage, setLocalStorage } from "../util/localStorage";
-import { useLastSessionContext } from "../context/LastSessionContext";
 
 const MAX_TITLE_LENGTH = 100;
 
@@ -50,17 +50,17 @@ function useHistory(dispatch: Dispatch) {
     return result.status === "success" ? result.content : undefined;
   }
 
-  async function saveSession(open_new_session = true) {
+  async function saveSession(openNewSession: boolean = true) {
     if (state.history.length === 0) return;
 
     const stateCopy = { ...state };
-    if (open_new_session) {
+    if (openNewSession) {
       dispatch(newSession());
       updateLastSessionId(stateCopy.sessionId);
     }
     await new Promise((resolve) => setTimeout(resolve, 10));
 
-    if (state.config?.getChatTitles && stateCopy.title === "New Session") {
+    if (state.config?.ui?.getChatTitles && stateCopy.title === "New Session") {
       try {
         // Check if we have first assistant response
         let assistantResponse = stateCopy.history

--- a/gui/src/hooks/useHistory.tsx
+++ b/gui/src/hooks/useHistory.tsx
@@ -54,16 +54,13 @@ function useHistory(dispatch: Dispatch) {
     if (state.history.length === 0) return;
 
     const stateCopy = { ...state };
-    if (open_new_session){
+    if (open_new_session) {
       dispatch(newSession());
       updateLastSessionId(stateCopy.sessionId);
     }
     await new Promise((resolve) => setTimeout(resolve, 10));
 
-    if (
-      state.config?.experimental?.getChatTitles &&
-      stateCopy.title === "New Session"
-    ) {
+    if (state.config?.getChatTitles && stateCopy.title === "New Session") {
       try {
         // Check if we have first assistant response
         let assistantResponse = stateCopy.history
@@ -89,8 +86,8 @@ function useHistory(dispatch: Dispatch) {
             MAX_TITLE_LENGTH,
           )
         : stateCopy.title?.length > 0
-        ? stateCopy.title
-        : (await getSession(stateCopy.sessionId)).title; // to ensure titles are synced with updates from history page.
+          ? stateCopy.title
+          : (await getSession(stateCopy.sessionId)).title; // to ensure titles are synced with updates from history page.
 
     const sessionInfo: PersistedSessionInfo = {
       history: stateCopy.history,


### PR DESCRIPTION
## Description

History title generation is enabled by default. Reduced the number of tokens.

## Checklist

- [ ] ~~The base branch of this PR is `dev`, rather than `main`~~ The base is `nate/autcomplete-testing` because I used this ticket to test the autocomplete changes in real life scenarios
- [ ] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change. ]
[ For new UI features, ensure that the changes look good across viewport widths, light/dark theme, etc ]
