### PR TITLE
OpenAI Prediction

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -794,6 +794,7 @@ interface BaseCompletionOptions {
   keepAlive?: number;
   raw?: boolean;
   stream?: boolean;
+  predictionContent?: string;
 }
 
 export interface ModelCapability {

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -780,6 +780,14 @@ export interface CustomCommand {
   description: string;
 }
 
+interface Prediction {
+  type: "content"
+  content: string | {
+    type: "text"
+    text: string
+  }[]
+}
+
 interface BaseCompletionOptions {
   temperature?: number;
   topP?: number;
@@ -794,7 +802,7 @@ interface BaseCompletionOptions {
   keepAlive?: number;
   raw?: boolean;
   stream?: boolean;
-  predictionContent?: string;
+  prediction?: Prediction;
 }
 
 export interface ModelCapability {

--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -142,7 +142,7 @@ class OpenAI extends BaseLLM {
       );
     }
 
-    if (options.predictionContent && this.supportsPrediction(options.model)) {
+    if (options.prediction && this.supportsPrediction(options.model)) {
       if (finalOptions.presence_penalty) { // prediction doesn't support > 0
         finalOptions.presence_penalty = undefined;
       }
@@ -151,10 +151,7 @@ class OpenAI extends BaseLLM {
       }
       finalOptions.max_completion_tokens = undefined;
 
-      finalOptions.prediction = {
-        "type": "content",
-        "content": options.predictionContent
-      };
+      finalOptions.prediction = options.prediction;
     }
 
     return finalOptions;

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -65,57 +65,6 @@
           "title": "Ollama keep_alive",
           "description": "The number of seconds after no requests are made to unload the model from memory. Defaults to 60*30 = 30min",
           "type": "integer"
-        },
-        "prediction": {
-          "title": "Prediction",
-          "description": "(gpt-4o/gpt-4o-mini only) Prediction output which can greatly improve response times when large parts of the model response are known ahead of time. This is most common when you are regenerating a file with only minor changes to most of the content.",
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "content"
-              ],
-              "description": "Currently only 'content' type supported"
-            },
-            "content": {
-              "description": "Predicted output (usually contents of a file)",
-              "anyOf": [
-                {
-                  "type": "string",
-                  "description": "Predicted output (usually contents of a file)"
-                },
-                {
-                  "type": "array",
-                  "description": "Array of predicted output text items (usually pieces of a file)",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "text"
-                        ],
-                        "description": "Currently only 'text' supported"
-                      },
-                      "text": {
-                        "type": "string",
-                        "description": "Predicted output item text"
-                      }
-                    },
-                    "required": [
-                      "type",
-                      "text"
-                    ]
-                  }
-                }
-              ]
-            }
-          },
-          "required": [
-            "type",
-            "content"
-          ]
         }
       }
     },

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -66,10 +66,56 @@
           "description": "The number of seconds after no requests are made to unload the model from memory. Defaults to 60*30 = 30min",
           "type": "integer"
         },
-        "predictionContent": {
+        "prediction": {
           "title": "Prediction",
           "description": "(gpt-4o/gpt-4o-mini only) Prediction output which can greatly improve response times when large parts of the model response are known ahead of time. This is most common when you are regenerating a file with only minor changes to most of the content.",
-          "type": "string"
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "content"
+              ],
+              "description": "Currently only 'content' type supported"
+            },
+            "content": {
+              "description": "Predicted output (usually contents of a file)",
+              "anyOf": [
+                {
+                  "type": "string",
+                  "description": "Predicted output (usually contents of a file)"
+                },
+                {
+                  "type": "array",
+                  "description": "Array of predicted output text items (usually pieces of a file)",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "text"
+                        ],
+                        "description": "Currently only 'text' supported"
+                      },
+                      "text": {
+                        "type": "string",
+                        "description": "Predicted output item text"
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "text"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          "required": [
+            "type",
+            "content"
+          ]
         }
       }
     },

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -65,6 +65,11 @@
           "title": "Ollama keep_alive",
           "description": "The number of seconds after no requests are made to unload the model from memory. Defaults to 60*30 = 30min",
           "type": "integer"
+        },
+        "predictionContent": {
+          "title": "Prediction",
+          "description": "(gpt-4o/gpt-4o-mini only) Prediction output which can greatly improve response times when large parts of the model response are known ahead of time. This is most common when you are regenerating a file with only minor changes to most of the content.",
+          "type": "string"
         }
       }
     },


### PR DESCRIPTION
## Description

In the first commit, I added `predictionContent` property to the completion options, that would only support a string, keep it simple, and could be deprecated for `prediction` later.

Then I decided there _might_ be a use case for the array of text items prediction format, so I decided to do the full implementation in the second commit.

Also, ended up removing the config_schema definition. It's misleading because in practice no one would ever declare `prediction` in their config. In the future, if `prediction` became widespread, could add more on the same level as `prompt`, where instead of being passed as `options`, it's a separate function parameter

Because of this, I chose to not add `prediction` to the docs config reference.

See https://platform.openai.com/docs/api-reference/chat/create#chat-create-prediction

Let me know your thoughts on this

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Usage
```
// First check model is openai compatible
if(provider instanceof OpenAI){
options = {
   ...options,
prediction: {
    type: "content",
    content: "file string"
    }
}
```

Could add this to base llm instead but openai specific for now