### PR TITLE
Fix config schema for tab autocomplete models

### DIFF
--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -2684,25 +2684,13 @@
             }
           ]
         },
-        "tabAutocompleteModel": {
-          "title": "Tab Autocomplete Model",
-          "markdownDescription": "The model used for tab autocompletion. If undefined, Continue will default to using starcoder2:3b on a local Ollama instance.\n\n*IMPORTANT*:\n\nIf you use a custom model, ensure that it is one trained for fill-in-the-middle completions. An instruct model is typically not well-suited to autocomplete and you may receive unsatisfactory completions.",
-          "default": {
-            "title": "Tab Autocomplete Model",
-            "provider": "ollama",
-            "model": "deepseek-coder:1.3b-base"
-          },
-          "oneOf": [
-            {
-              "$ref": "#/definitions/ModelDescription"
-            },
-            {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/ModelDescription"
-              }
-            }
-          ]
+        "tabAutocompleteModels": {
+          "title": "Tab Autocomplete Models",
+          "markdownDescription": "The models used for tab autocompletion. If undefined, Continue will default to using starcoder2:3b on a local Ollama instance.\n\n*IMPORTANT*:\n\nIf you use custom models, ensure that they are trained for fill-in-the-middle completions. An instruct model is typically not well-suited to autocomplete and you may receive unsatisfactory completions.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ModelDescription"
+          }
         },
         "tabAutocompleteOptions": {
           "title": "TabAutocompleteOptions",


### PR DESCRIPTION
Old schema used a key which isn't used by Continue, and thus you couldn't specify tab autocomplete model by following schema. This updates it to how it is in the the real