### PR TITLE
Scroll chat to bottom on session change and load

### DIFF
--- a/gui/src/pages/gui/Chat.tsx
+++ b/gui/src/pages/gui/Chat.tsx
@@ -136,7 +136,6 @@ export function Chat() {
   const { streamResponse } = useChatHandler(dispatch, ideMessenger);
   const onboardingCard = useOnboardingCard();
   const { showTutorialCard, closeTutorialCard } = useTutorialCard();
-  const sessionState = useSelector((state: RootState) => state.state);
   const defaultModel = useSelector(defaultModelSelector);
   const ttsActive = useSelector((state: RootState) => state.state.ttsActive);
   const active = useSelector((state: RootState) => state.state.active);
@@ -148,7 +147,7 @@ export function Chat() {
   const { saveSession, getLastSessionId, loadLastSession } =
     useHistory(dispatch);
 
-  const scrollToBottom = useCallback(() => {
+  const snapToBottom = useCallback(() => {
     if (!topGuiDivRef.current) return;
     const elem = topGuiDivRef.current;
     elem.scrollTop = elem.scrollHeight - elem.clientHeight;
@@ -156,9 +155,26 @@ export function Chat() {
     setIsAtBottom(true);
   }, [topGuiDivRef, setIsAtBottom]);
 
+  const smoothScrollToBottom = useCallback(async () => {
+    if (!topGuiDivRef.current) return;
+    const elem = topGuiDivRef.current
+    elem.scrollTo({
+      top: elem.scrollHeight - elem.clientHeight,
+      behavior: 'smooth'
+    })
+
+    setIsAtBottom(true);
+  }, [topGuiDivRef, setIsAtBottom]);
+
   useEffect(() => {
-    if (active) scrollToBottom();
-  }, [active, scrollToBottom]);
+    if (active) snapToBottom();
+  }, [active, snapToBottom]);
+
+  useEffect(() => {
+    setTimeout(() => {
+      smoothScrollToBottom();
+    }, 250)
+  }, [smoothScrollToBottom, state.sessionId]);
 
   useEffect(() => {
     // Cmd + Backspace to delete current step
@@ -284,8 +300,8 @@ export function Chat() {
       }
     },
     [
-      sessionState.history,
-      sessionState.contextItems,
+      state.history,
+      state.contextItems,
       defaultModel,
       state,
       streamResponse,
@@ -370,11 +386,11 @@ export function Chat() {
                               : true
                             : stepsOpen[index]!
                         }
-                        onToggle={() => {}}
+                        onToggle={() => { }}
                       >
                         <StepContainer
                           index={index}
-                          isLast={index === sessionState.history.length - 1}
+                          isLast={index === state.history.length - 1}
                           isFirst={index === 0}
                           open={
                             typeof stepsOpen[index] === "undefined"
@@ -382,14 +398,14 @@ export function Chat() {
                               : stepsOpen[index]!
                           }
                           key={index}
-                          onUserInput={(input: string) => {}}
+                          onUserInput={(input: string) => { }}
                           item={item}
-                          onReverse={() => {}}
+                          onReverse={() => { }}
                           onRetry={() => {
                             streamResponse(
                               state.history[index - 1].editorState,
                               state.history[index - 1].modifiers ??
-                                defaultInputModifiers,
+                              defaultInputModifiers,
                               ideMessenger,
                               index - 1,
                             );


### PR DESCRIPTION
## Description

Currently when a chat loads it stays at the top, which is pretty much never the desired behavior, you'd want to start where you left off.

Snap scroll isn't bad but there's a few reasons I did the slighly delayed smooth scroll
- In the case of a long chat message, etc. it's nice to have a brief reminder that there _was_ chat history and where it started
- Often snap on load doesn't work because some components take time to render and there's some timing issues, more complicated to check that all children are loaded than to just delay a bit

## Checklist

- [x] The base branch of this PR is `dev`, rather than `main`
- [x] The relevant docs, if any, have been updated or created

## Screenshots

https://www.loom.com/share/d83e76e997104015a8eb07aa0581ed05