### PR TITLE
polishing after reference docs addition

### DIFF
--- a/docs/docs/customize/deep-dives/autocomplete.md
+++ b/docs/docs/customize/deep-dives/autocomplete.md
@@ -44,7 +44,7 @@ All of the configuration options available for chat models are available to use 
 }
 ```
 
-If you aren't yet familiar with the available options, you can find the full reference [here](./ways-to-configure.md).
+If you aren't yet familiar with the available options, you can find the full reference [here](./configuration.md).
 
 ## Configuration Options
 

--- a/docs/docs/customize/deep-dives/configuration.md
+++ b/docs/docs/customize/deep-dives/configuration.md
@@ -1,9 +1,9 @@
 ---
-description: Ways to configure
+description: Configuration
 keywords: [config, settings, customize]
 ---
 
-# Ways to configure
+# Configuration
 
 Continue can be deeply customized. User-level configuration is stored and can be edited in your home directory in [`config.json`](#configjson):
 

--- a/docs/docs/customize/overview.md
+++ b/docs/docs/customize/overview.md
@@ -8,13 +8,13 @@ Continue can be deeply customized. This is primarily accomplished by editing a l
 
 ## Getting started
 
-To open `config.json`, click the "gear" icon in the bottom right corner of the Continue Chat sidebar. When editing this file, you can see the available options suggested as you type, or you can check the [full reference](./deep-dives/ways-to-configure.md).
+To open `config.json`, click the "gear" icon in the bottom right corner of the Continue Chat sidebar. When editing this file, you can see the available options suggested as you type, or you can check the [full reference](./deep-dives/configuration.md).
 
 When you save `config.json`, Continue will automatically refresh to take into account your changes.
 
 ## Per-workspace configuration
 
-If you'd like to scope certain settings to a particular workspace, you can add a `.continuerc.json` to the root of your project. It has the same [definition](./deep-dives/ways-to-configure.md) as `config.json`, and will automatically be applied on top of the local config.json.
+If you'd like to scope certain settings to a particular workspace, you can add a `.continuerc.json` to the root of your project. It has the same [definition](./deep-dives/configuration.md) as `config.json`, and will automatically be applied on top of the local config.json.
 
 ## Programmatic configuration
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -81,7 +81,7 @@ const config = {
             type: "docSidebar",
             sidebarId: "docsSidebar",
             position: "left",
-            label: "Docs",
+            label: "User Guide",
             href: "/",
           },
           {

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -132,6 +132,11 @@ const sidebars = {
       ],
     },
     "customize/changelog",
+    {
+      type: "link",
+      label: "Reference",
+      href: "/reference",
+    },
   ],
 };
 


### PR DESCRIPTION
## Description

- `Docs` label to `User Guide` label
- Added `Reference` to bottom of `Customize` page
-`Ways to configure` --> `Configuration`
