### PR TITLE
[JetBrain IDE] Fix `continue-binary` process does not properly exit

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/activities/ContinuePluginStartupActivity.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/activities/ContinuePluginStartupActivity.kt
@@ -71,7 +71,6 @@ private fun getTutorialFileName(): String {
 }
 
 class ContinuePluginStartupActivity : StartupActivity, Disposable, DumbAware {
-    private val coroutineScope = CoroutineScope(Dispatchers.IO)
 
     override fun runActivity(project: Project) {
         removeShortcutFromAction(getPlatformSpecificKeyStroke("J"))
@@ -110,6 +109,7 @@ class ContinuePluginStartupActivity : StartupActivity, Disposable, DumbAware {
     }
 
     private fun initializePlugin(project: Project) {
+        val coroutineScope = CoroutineScope(Dispatchers.IO)
         val continuePluginService = ServiceManager.getService(
             project,
             ContinuePluginService::class.java
@@ -234,7 +234,5 @@ class ContinuePluginStartupActivity : StartupActivity, Disposable, DumbAware {
     }
 
     override fun dispose() {
-        // Cleanup resources here
-        coroutineScope.cancel()
     }
 }

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessenger.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessenger.kt
@@ -19,7 +19,7 @@ class CoreMessenger(
     private val project: Project,
     continueCorePath: String,
     private val ideProtocolClient: IdeProtocolClient,
-    coroutineScope: CoroutineScope
+    val coroutineScope: CoroutineScope
 ) {
   private var writer: Writer? = null
   private var reader: BufferedReader? = null
@@ -230,6 +230,13 @@ class CoreMessenger(
           }
         }
       }
+    }
+  }
+
+  fun killSubProcess() {
+    process?.isAlive?.let {
+      exitCallbacks.clear()
+      process?.destroy()
     }
   }
 }

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/services/ContinuePluginService.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/services/ContinuePluginService.kt
@@ -34,6 +34,10 @@ class ContinuePluginService(project: Project) : Disposable, DumbAware {
 
     override fun dispose() {
         coroutineScope.cancel()
+        coreMessenger?.coroutineScope?.let {
+            it.cancel()
+            coreMessenger?.killSubProcess()
+        }
     }
 
     fun sendToWebview(


### PR DESCRIPTION
Fix: https://github.com/continuedev/continue/issues/2896

ContinuePluginStartupActivity's life cycle is IDE instance level, its `dispose` will not be called when a project is closed.