### PR TITLE
bugfix: get codeblocks for pretoolbar

### DIFF
--- a/gui/src/components/markdown/StyledMarkdownPreview.tsx
+++ b/gui/src/components/markdown/StyledMarkdownPreview.tsx
@@ -136,13 +136,12 @@ function processCodeBlocks(tree: any) {
       node.lang = node.lang.split(".").slice(-1)[0];
     }
 
+    node.data = node.data || {};
+    node.data.hProperties = node.data.hProperties || {};
+    node.data.hProperties.codeBlockContent = node.value;
+    node.data.hProperties.isGeneratingCodeBlock = lastCodeNode === node;
+
     if (node.meta) {
-      node.data = node.data || {};
-      node.data.hProperties = node.data.hProperties || {};
-
-      node.data.hProperties.isGeneratingCodeBlock = lastCodeNode === node;
-      node.data.hProperties.codeBlockContent = node.value;
-
       let meta = node.meta.split(" ");
       node.data.hProperties.filepath = meta[0];
       node.data.hProperties.range = meta[1];


### PR DESCRIPTION
## Description

This fixes a bug that is preventing apply/copy buttons from getting the contents of their respective codeblocks.

## Checklist

- [] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change. ]
[ For new UI features, ensure that the changes look good across viewport widths, light/dark theme, etc ]
