### PR TITLE
Fix an edge case when stop token is not filtered out in completion response.

### DIFF
--- a/core/autocomplete/filtering/streamTransforms/charStream.test.ts
+++ b/core/autocomplete/filtering/streamTransforms/charStream.test.ts
@@ -157,4 +157,20 @@ describe("stopAtStopTokens", () => {
 
     expect(output.join("")).toBe("Hello world!");
   });
+
+  it("should handle stop token when remaining buffer is smaller than maximum stop token length", async () => {
+    const mockStream = createMockStream(["Hello world!STOP"]);
+    const stopTokens: string[] = [
+      "STOP",
+      "STOP_TOKEN_THAT_IS_LARGER_THAN_BUFFER",
+    ];
+    const result = stopAtStopTokens(mockStream, stopTokens);
+
+    const output = [];
+    for await (const char of result) {
+      output.push(char);
+    }
+
+    expect(output.join("")).toBe("Hello world!");
+  });
 });

--- a/core/autocomplete/filtering/streamTransforms/charStream.ts
+++ b/core/autocomplete/filtering/streamTransforms/charStream.ts
@@ -70,7 +70,8 @@ export async function* noFirstCharNewline(stream: AsyncGenerator<string>) {
  * 2. Otherwise, buffers incoming chunks and checks for stop tokens.
  * 3. Yields characters one by one if no stop token is found at the start of the buffer.
  * 4. Stops yielding and returns if a stop token is encountered.
- * 5. After the stream ends, yields any remaining buffered characters.
+ * 5. After the stream ends, filters encountered stop tokens in remaining buffer.
+ * 6. Yields any remaining buffered characters.
  */
 export async function* stopAtStopTokens(
   stream: AsyncGenerator<string>,
@@ -106,6 +107,10 @@ export async function* stopAtStopTokens(
       }
     }
   }
+  // Filter out the possible stop tokens from remaining buffer
+  stopTokens.forEach((token) => {
+    buffer = buffer.replace(token, "");
+  });
 
   // Yield any remaining characters in the buffer
   for (const char of buffer) {


### PR DESCRIPTION
## Description
We recently started using Qwen2.5-Coder-7B-Instruct for code completion.
In most cases the response from LLM is quite long, and selected/trimmed completion won't contain "<im_end|>" token.
But in some cases, when completion is short, or LLM does not add extra data (such as examples, comments, etc..) which are usually filtered out, plugin would not filter out <|im_end|"> at the end of the completion.
For example:
For code
```
const notificationSlice = createSlice({
})
```
the suggestion from LLM would be something like
```
const notificationSlice({
...lots of react-redux code...
})
// Export actions
const {...} = notificationSlice
....
export default notificationSlice<|im_end|>
```
and the completion returned to IDE would end up as
```
const notificationSlice({
...lots of react-redux code...
})
```

But for code
```
const log = (x) => {

}
```

the suggestion completion from LLM and returned to IDE would be the same
`console.log(x);<|im_end|>`

After investigation, I found out it occurs when remaining buffer here (https://github.com/continuedev/continue/blob/main/core/autocomplete/filtering/streamTransforms/charStream.ts#L110)
contains stop token, it's not getting filtered out. So, the naive fix was added.

## Testing
Added a test that covers that case. Problem is I can't figure out how to run the suite. Maybe will try that tomorrow.

Thank you for your work, extensions is amazing.
