### PR TITLE
🌟 `bug(scripts): ./install-dependencies.sh: line 12: pushd: core: No such file or directory

### DIFF
--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -5,6 +5,9 @@
 # - Debug -> Extension
 set -e
 
+# Change to the root directory
+cd "$(dirname "$0")/.."
+
 echo "Installing root-level dependencies..."
 npm install
 


### PR DESCRIPTION
Introduce SiliconFlowReranker to the rerankers list, extending support for additional reranking models.

## Description

~/workspace/js/continue/scripts siliconflow*
» ./install-dependencies.sh
Installing root-level dependencies...

up to date, audited 225 packages in 959ms

94 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
Installing Core extension dependencies...
./install-dependencies.sh: line 12: pushd: core: No such file or directory

## Checklist

- [] The relevant docs, if any, have been updated or created

## Screenshots

![image](https://github.com/user-attachments/assets/847cf897-926c-4e62-b623-078c0ea294df)
## Testing
→ ./scripts/install-dependencies.sh
Installing root-level dependencies...

up to date, audited 225 packages in 1s

94 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
Installing Core extension dependencies...
~/workspace/js/continue/core ~/workspace/js/continue
npm warn deprecated @npmcli/move-file@1.1.2: This functionality has been moved to @npmcli/fs
npm warn deprecated npmlog@6.0.2: This package is no longer supported.
npm warn deprecated har-validator@5.1.5: this library is no longer supported
npm warn deprecated abab@2.0.6: Use your platform's native atob() and btoa() methods instead
npm warn deprecated are-we-there-yet@3.0.1: This package is no longer supported.
npm warn deprecated domexception@4.0.0: Use your platform's native DOMException instead
npm warn deprecated gauge@4.0.4: This package is no longer supported.
npm warn deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm warn deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
npm warn deprecated gauge@5.0.2: This package is no longer supported.

added 1221 packages, and audited 1222 packages in 12s

