### PR TITLE
Cancel stale completion requests as you type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,7 +142,7 @@ codeql
 .tiktoken_cache
 
 
-# IntelliJ Plugin 
+# IntelliJ Plugin
 **/**/.gradle
 **/**/.qodana
 **/**/build
@@ -169,3 +169,5 @@ extensions/intellij/.idea/**
 
 extensions/intellij/bin
 extensions/.continue-debug/
+
+*.vsix

--- a/core/autocomplete/CompletionProvider.ts
+++ b/core/autocomplete/CompletionProvider.ts
@@ -29,6 +29,7 @@ const autocompleteCache = AutocompleteLruCache.get();
 const ERRORS_TO_IGNORE = [
   // From Ollama
   "unexpected server status",
+  "operation was aborted"
 ];
 
 export type GetLspDefinitionsFunction = (

--- a/core/autocomplete/generation/CompletionStreamer.ts
+++ b/core/autocomplete/generation/CompletionStreamer.ts
@@ -25,10 +25,10 @@ export class CompletionStreamer {
     // Try to reuse pending requests if what the user typed matches start of completion
     const generator = this.generatorReuseManager.getGenerator(
       prefix,
-      () =>
+      (abortSignal: AbortSignal) =>
         llm.supportsFim()
-          ? llm.streamFim(prefix, suffix, completionOptions)
-          : llm.streamComplete(prompt, {
+          ? llm.streamFim(prefix, suffix, abortSignal, completionOptions)
+          : llm.streamComplete(prompt, abortSignal, {
               ...completionOptions,
               raw: true,
             }),

--- a/core/autocomplete/generation/GeneratorReuseManager.test.ts
+++ b/core/autocomplete/generation/GeneratorReuseManager.test.ts
@@ -4,7 +4,7 @@ import { GeneratorReuseManager } from "./GeneratorReuseManager";
 function createMockGenerator(
   data: string[],
   delay: number = 0,
-): () => AsyncGenerator<string> {
+): (abortSignal: AbortSignal) => AsyncGenerator<string> {
   const mockGenerator = async function* () {
     for (const chunk of data) {
       yield chunk;

--- a/core/autocomplete/generation/ListenableGenerator.ts
+++ b/core/autocomplete/generation/ListenableGenerator.ts
@@ -3,16 +3,20 @@ export class ListenableGenerator<T> {
   private _buffer: T[] = [];
   private _listeners: Set<(value: T) => void> = new Set();
   private _isEnded = false;
+  private _abortController: AbortController
 
   constructor(
     source: AsyncGenerator<T>,
     private readonly onError: (e: any) => void,
+    abortController: AbortController
   ) {
     this._source = source;
+    this._abortController = abortController;
     this._start();
   }
 
   public cancel() {
+    this._abortController.abort();
     this._isEnded = true;
   }
 

--- a/core/commands/index.ts
+++ b/core/commands/index.ts
@@ -58,7 +58,7 @@ export function slashFromCustomCommand(
         }
       }
 
-      for await (const chunk of llm.streamChat(messages)) {
+      for await (const chunk of llm.streamChat(messages, new AbortController().signal)) {
         yield stripImages(chunk.content);
       }
     },

--- a/core/commands/slash/cmd.ts
+++ b/core/commands/slash/cmd.ts
@@ -24,7 +24,9 @@ const GenerateTerminalCommand: SlashCommand = {
 
 "${input}"
 
-Please write a shell command that will do what the user requested. Your output should consist of only the command itself, without any explanation or example output. Do not use any newlines. Only output the command that when inserted into the terminal will do precisely what was requested. Here is the command:`);
+Please write a shell command that will do what the user requested. Your output should consist of only the command itself, without any explanation or example output. Do not use any newlines. Only output the command that when inserted into the terminal will do precisely what was requested. Here is the command:`,
+        new AbortController().signal
+      );
 
     const lines = streamLines(gen);
     let cmd = "";

--- a/core/commands/slash/commit.ts
+++ b/core/commands/slash/commit.ts
@@ -16,7 +16,7 @@ const CommitMessageCommand: SlashCommand = {
     const prompt = `${diff}\n\nGenerate a commit message for the above set of changes. First, give a single sentence, no more than 80 characters. Then, after 2 line breaks, give a list of no more than 5 short bullet points, each no more than 40 characters. Output nothing except for the commit message, and don't surround it in quotes.`;
     for await (const chunk of llm.streamChat([
       { role: "user", content: prompt },
-    ])) {
+    ], new AbortController().signal)) {
       yield stripImages(chunk.content);
     }
   },

--- a/core/commands/slash/draftIssue.ts
+++ b/core/commands/slash/draftIssue.ts
@@ -30,7 +30,7 @@ const DraftIssueCommand: SlashCommand = {
       return;
     }
     let title = await llm.complete(
-      `Generate a title for the GitHub issue requested in this user input: '${input}'. Use no more than 20 words and output nothing other than the title. Do not surround it with quotes. The title is: `,
+      `Generate a title for the GitHub issue requested in this user input: '${input}'. Use no more than 20 words and output nothing other than the title. Do not surround it with quotes. The title is: `, new AbortController().signal,
       { maxTokens: 20 },
     );
 
@@ -43,7 +43,7 @@ const DraftIssueCommand: SlashCommand = {
       { role: "user", content: PROMPT(input, title) },
     ];
 
-    for await (const chunk of llm.streamChat(messages)) {
+    for await (const chunk of llm.streamChat(messages, new AbortController().signal)) {
       body += chunk.content;
       yield stripImages(chunk.content);
     }

--- a/core/commands/slash/edit.ts
+++ b/core/commands/slash/edit.ts
@@ -478,7 +478,7 @@ const EditSlashCommand: SlashCommand = {
         messages = rendered;
       }
 
-      const completion = llm.streamComplete(rendered as string, {
+      const completion = llm.streamComplete(rendered as string,  new AbortController().signal, {
         maxTokens: Math.min(maxTokens, Math.floor(llm.contextLength / 2), 4096),
         raw: true,
       });
@@ -494,7 +494,7 @@ const EditSlashCommand: SlashCommand = {
       );
     } else {
       async function* gen() {
-        for await (const chunk of llm.streamChat(messages, {
+        for await (const chunk of llm.streamChat(messages,  new AbortController().signal,{
           temperature: 0.5, // TODO
           maxTokens: Math.min(
             maxTokens,
@@ -609,7 +609,7 @@ ${lines.join("\n")}
 
 Please briefly explain the changes made to the code above. Give no more than 2-3 sentences, and use markdown bullet points:`;
 
-      for await (const update of llm.streamComplete(prompt)) {
+      for await (const update of llm.streamComplete(prompt, new AbortController().signal)) {
         yield update;
       }
     }

--- a/core/commands/slash/multifileEdit.ts
+++ b/core/commands/slash/multifileEdit.ts
@@ -39,7 +39,7 @@ const MultiFileEditSlashCommand: SlashCommand = {
 
     const content = createPrompt(filesToEditStr, additionalContextStr, input);
 
-    for await (const chunk of llm.streamChat([{ role: "user", content }])) {
+    for await (const chunk of llm.streamChat([{ role: "user", content }], new AbortController().signal)) {
       yield stripImages(chunk.content);
     }
   },

--- a/core/commands/slash/onboard.ts
+++ b/core/commands/slash/onboard.ts
@@ -47,7 +47,7 @@ const OnboardSlashCommand: SlashCommand = {
 
     for await (const chunk of llm.streamChat([
       { role: "user", content: prompt },
-    ])) {
+    ], new AbortController().signal)) {
       yield stripImages(chunk.content);
     }
   },
@@ -134,7 +134,7 @@ function createOnboardingPrompt(context: string): string {
     Your response should be structured, clear, and focused on giving the new developer both a detailed understanding of individual components and a high-level overview of the project as a whole.
 
     Here is an example of a valid response:
-    
+
     ## Important folders
 
     ### /folder1

--- a/core/commands/slash/review.ts
+++ b/core/commands/slash/review.ts
@@ -45,7 +45,7 @@ const ReviewMessageCommand: SlashCommand = {
 
     for await (const chunk of llm.streamChat([
       { role: "user", content: content },
-    ])) {
+    ], new AbortController().signal)) {
       yield stripImages(chunk.content);
     }
   },

--- a/core/config/promptFile.ts
+++ b/core/config/promptFile.ts
@@ -125,7 +125,7 @@ export function slashCommandFromPromptFile(
         systemMessage,
       );
 
-      for await (const chunk of context.llm.streamChat(messages)) {
+      for await (const chunk of context.llm.streamChat(messages, new AbortController().signal)) {
         yield stripImages(chunk.content);
       }
 

--- a/core/context/rerankers/llm.ts
+++ b/core/context/rerankers/llm.ts
@@ -6,7 +6,7 @@ const RERANK_PROMPT = (
   documentId: string,
   document: string,
 ) => `You are an expert software developer responsible for helping detect whether the retrieved snippet of code is relevant to the query. For a given input, you need to output a single word: "Yes" or "No" indicating the retrieved snippet is relevant to the query.
-  
+
   Query: Where is the FastAPI server?
   Snippet:
   \`\`\`/Users/andrew/Desktop/server/main.py
@@ -17,7 +17,7 @@ const RERANK_PROMPT = (
       return {{"Hello": "World"}}
   \`\`\`
   Relevant: Yes
-  
+
   Query: Where in the documentation does it talk about the UI?
   Snippet:
   \`\`\`/Users/andrew/Projects/bubble_sort/src/lib.rs
@@ -32,13 +32,13 @@ const RERANK_PROMPT = (
   }}
   \`\`\`
   Relevant: No
-  
+
   Query: ${query}
   Snippet:
   \`\`\`${documentId}
   ${document}
   \`\`\`
-  Relevant: 
+  Relevant:
   `;
 
 export class LLMReranker implements Reranker {
@@ -49,6 +49,7 @@ export class LLMReranker implements Reranker {
   async scoreChunk(chunk: Chunk, query: string): Promise<number> {
     const completion = await this.llm.complete(
       RERANK_PROMPT(query, getBasename(chunk.filepath), chunk.content),
+      new AbortController().signal,
       {
         maxTokens: 1,
         model:

--- a/core/context/retrieval/repoMapRequest.ts
+++ b/core/context/retrieval/repoMapRequest.ts
@@ -61,7 +61,7 @@ This is the question that you should select relevant files for: "${input}"`;
     const response = await llm.chat([
       { role: "user", content: prompt },
       { role: "assistant", content: "<reasoning>" },
-    ]);
+    ], new AbortController().signal);
     const content = stripImages(response.content);
     console.debug("Repo map retrieval response: ", content);
 

--- a/core/core.ts
+++ b/core/core.ts
@@ -387,6 +387,7 @@ export class Core {
       const model = await configHandler.llmFromTitle(msg.data.title);
       const gen = model.streamChat(
         msg.data.messages,
+        new AbortController().signal,
         msg.data.completionOptions,
       );
       let next = await gen.next();
@@ -428,6 +429,7 @@ export class Core {
       const model = await configHandler.llmFromTitle(msg.data.title);
       const gen = model.streamComplete(
         msg.data.prompt,
+        new AbortController().signal,
         msg.data.completionOptions,
       );
       let next = await gen.next();
@@ -460,6 +462,7 @@ export class Core {
       const model = await this.configHandler.llmFromTitle(msg.data.title);
       const completion = await model.complete(
         msg.data.prompt,
+        new AbortController().signal,
         msg.data.completionOptions,
       );
       return completion;

--- a/core/edit/lazy/replace.ts
+++ b/core/edit/lazy/replace.ts
@@ -86,7 +86,7 @@ export async function* getReplacementWithLlm(
   const completion = await llm.streamChat([
     { role: "user", content: userPrompt },
     { role: "assistant", content: assistantPrompt },
-  ]);
+  ], new AbortController().signal);
 
   let lines = streamLines(completion);
   lines = filterLeadingNewline(lines);

--- a/core/edit/lazy/streamLazyApply.ts
+++ b/core/edit/lazy/streamLazyApply.ts
@@ -23,7 +23,7 @@ export async function* streamLazyApply(
   }
 
   const promptMessages = promptFactory(oldCode, filename, newCode);
-  const lazyCompletion = llm.streamChat(promptMessages);
+  const lazyCompletion = llm.streamChat(promptMessages, new AbortController().signal);
 
   // Do find and replace over the lazy edit response
   async function* replacementFunction(

--- a/core/edit/streamDiffLines.ts
+++ b/core/edit/streamDiffLines.ts
@@ -96,8 +96,8 @@ export async function* streamDiffLines(
 
   const completion =
     typeof prompt === "string"
-      ? llm.streamComplete(prompt, { raw: true, prediction })
-      : llm.streamChat(prompt, {
+      ? llm.streamComplete(prompt,  new AbortController().signal, { raw: true, prediction })
+      : llm.streamChat(prompt,  new AbortController().signal, {
           prediction,
         });
 

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -78,26 +78,34 @@ export interface ILLM extends LLMOptions {
   region?: string;
   projectId?: string;
 
-  complete(prompt: string, options?: LLMFullCompletionOptions): Promise<string>;
+  complete(
+    prompt: string,
+    signal: AbortSignal,
+    options?: LLMFullCompletionOptions
+  ): Promise<string>;
 
   streamComplete(
     prompt: string,
+    signal: AbortSignal,
     options?: LLMFullCompletionOptions,
   ): AsyncGenerator<string, PromptLog>;
 
   streamFim(
     prefix: string,
     suffix: string,
+    signal: AbortSignal,
     options?: LLMFullCompletionOptions,
   ): AsyncGenerator<string, PromptLog>;
 
   streamChat(
     messages: ChatMessage[],
+    signal: AbortSignal,
     options?: LLMFullCompletionOptions,
   ): AsyncGenerator<ChatMessage, PromptLog>;
 
   chat(
     messages: ChatMessage[],
+    signal: AbortSignal,
     options?: LLMFullCompletionOptions,
   ): Promise<ChatMessage>;
 
@@ -388,11 +396,13 @@ export interface CustomLLMWithOptionals {
   options: LLMOptions;
   streamCompletion?: (
     prompt: string,
+    signal: AbortSignal,
     options: CompletionOptions,
     fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
   ) => AsyncGenerator<string>;
   streamChat?: (
     messages: ChatMessage[],
+    signal: AbortSignal,
     options: CompletionOptions,
     fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
   ) => AsyncGenerator<string>;

--- a/core/llm/llms/Anthropic.ts
+++ b/core/llm/llms/Anthropic.ts
@@ -95,16 +95,18 @@ class Anthropic extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<string> {
     const messages = [{ role: "user" as const, content: prompt }];
-    for await (const update of this._streamChat(messages, options)) {
+    for await (const update of this._streamChat(messages, signal, options)) {
       yield stripImages(update.content);
     }
   }
 
   protected async *_streamChat(
     messages: ChatMessage[],
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<ChatMessage> {
     const shouldCacheSystemMessage =
@@ -137,6 +139,7 @@ class Anthropic extends BaseLLM {
             ]
           : systemMessage,
       }),
+      signal
     });
 
     if (options.stream === false) {

--- a/core/llm/llms/Asksage.ts
+++ b/core/llm/llms/Asksage.ts
@@ -98,6 +98,7 @@ class Asksage extends BaseLLM {
 
   protected async _complete(
     prompt: string,
+    signal: AbortSignal,
     options: CompletionOptions
   ): Promise<string> {
     if (typeof prompt !== "string" || prompt.trim() === "") {
@@ -126,14 +127,16 @@ class Asksage extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
+    signal: AbortSignal,
     options: CompletionOptions
   ): AsyncGenerator<string> {
-    const completion = await this._complete(prompt, options);
+    const completion = await this._complete(prompt, signal, options);
     yield completion;
   }
 
   protected async *_streamChat(
     messages: ChatMessage[],
+    signal: AbortSignal,
     options: CompletionOptions
   ): AsyncGenerator<ChatMessage> {
     const args = this._convertArgs(options, messages);
@@ -142,6 +145,7 @@ class Asksage extends BaseLLM {
       method: "POST",
       headers: this._getHeaders(),
       body: JSON.stringify(args),
+      signal
     });
 
     if (!response.ok) {

--- a/core/llm/llms/Bedrock.ts
+++ b/core/llm/llms/Bedrock.ts
@@ -37,16 +37,18 @@ class Bedrock extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<string> {
     const messages = [{ role: "user" as const, content: prompt }];
-    for await (const update of this._streamChat(messages, options)) {
+    for await (const update of this._streamChat(messages, signal, options)) {
       yield stripImages(update.content);
     }
   }
 
   protected async *_streamChat(
     messages: ChatMessage[],
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<ChatMessage> {
     const credentials = await this._getCredentials();
@@ -84,7 +86,7 @@ class Bedrock extends BaseLLM {
 
     const input = this._generateConverseInput(messages, options);
     const command = new ConverseStreamCommand(input);
-    const response = await client.send(command);
+    const response = await client.send(command, { abortSignal: signal});
 
     if (response.stream) {
       for await (const chunk of response.stream) {

--- a/core/llm/llms/BedrockImport.ts
+++ b/core/llm/llms/BedrockImport.ts
@@ -37,6 +37,7 @@ class BedrockImport extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<string> {
     const credentials = await this._getCredentials();
@@ -51,7 +52,7 @@ class BedrockImport extends BaseLLM {
 
     const input = this._generateInvokeModelCommandInput(prompt, options);
     const command = new InvokeModelWithResponseStreamCommand(input);
-    const response = await client.send(command);
+    const response = await client.send(command, {abortSignal: signal});
 
     if (response.body) {
       for await (const item of response.body) {

--- a/core/llm/llms/Cloudflare.ts
+++ b/core/llm/llms/Cloudflare.ts
@@ -16,6 +16,7 @@ export default class Cloudflare extends BaseLLM {
 
   protected async *_streamChat(
     messages: ChatMessage[],
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<ChatMessage, any, unknown> {
     const headers = {
@@ -35,6 +36,7 @@ export default class Cloudflare extends BaseLLM {
         model: this.model,
         ...this._convertArgs(options),
       }),
+      signal
     });
 
     for await (const value of streamSse(resp)) {
@@ -46,10 +48,12 @@ export default class Cloudflare extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<string> {
     for await (const chunk of this._streamChat(
       [{ role: "user", content: prompt }],
+      signal,
       options,
     )) {
       yield stripImages(chunk.content);

--- a/core/llm/llms/Cohere.ts
+++ b/core/llm/llms/Cohere.ts
@@ -46,16 +46,18 @@ class Cohere extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<string> {
     const messages = [{ role: "user" as const, content: prompt }];
-    for await (const update of this._streamChat(messages, options)) {
+    for await (const update of this._streamChat(messages, signal, options)) {
       yield stripImages(update.content);
     }
   }
 
   protected async *_streamChat(
     messages: ChatMessage[],
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<ChatMessage> {
     const headers = {
@@ -73,6 +75,7 @@ class Cohere extends BaseLLM {
         chat_history: this._convertMessages(messages),
         preamble: this.systemMessage,
       }),
+      signal
     });
 
     if (options.stream === false) {

--- a/core/llm/llms/CustomLLM.ts
+++ b/core/llm/llms/CustomLLM.ts
@@ -13,12 +13,14 @@ class CustomLLMClass extends BaseLLM {
 
   private customStreamCompletion?: (
     prompt: string,
+    signal: AbortSignal,
     options: CompletionOptions,
     fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
   ) => AsyncGenerator<string>;
 
   private customStreamChat?: (
     messages: ChatMessage[],
+    signal: AbortSignal,
     options: CompletionOptions,
     fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
   ) => AsyncGenerator<string>;
@@ -31,18 +33,20 @@ class CustomLLMClass extends BaseLLM {
 
   protected async *_streamChat(
     messages: ChatMessage[],
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<ChatMessage> {
     if (this.customStreamChat) {
       for await (const content of this.customStreamChat(
         messages,
+        signal,
         options,
         (...args) => this.fetch(...args),
       )) {
         yield { role: "assistant", content };
       }
     } else {
-      for await (const update of super._streamChat(messages, options)) {
+      for await (const update of super._streamChat(messages, signal, options)) {
         yield update;
       }
     }
@@ -50,11 +54,13 @@ class CustomLLMClass extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<string> {
     if (this.customStreamCompletion) {
       for await (const content of this.customStreamCompletion(
         prompt,
+        signal,
         options,
         (...args) => this.fetch(...args),
       )) {
@@ -63,6 +69,7 @@ class CustomLLMClass extends BaseLLM {
     } else if (this.customStreamChat) {
       for await (const content of this.customStreamChat(
         [{ role: "user", content: prompt }],
+        signal,
         options,
         (...args) => this.fetch(...args),
       )) {

--- a/core/llm/llms/Deepseek.ts
+++ b/core/llm/llms/Deepseek.ts
@@ -23,6 +23,7 @@ class Deepseek extends OpenAI {
   async *_streamFim(
     prefix: string,
     suffix: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<string> {
     const endpoint = new URL("beta/completions", this.apiBase);
@@ -45,6 +46,7 @@ class Deepseek extends OpenAI {
         Accept: "application/json",
         Authorization: `Bearer ${this.apiKey}`,
       },
+      signal
     });
     for await (const chunk of streamSse(resp)) {
       yield chunk.choices[0].text;

--- a/core/llm/llms/Flowise.ts
+++ b/core/llm/llms/Flowise.ts
@@ -121,16 +121,18 @@ class Flowise extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<string> {
     const message: ChatMessage = { role: "user", content: prompt };
-    for await (const chunk of this._streamChat([message], options)) {
+    for await (const chunk of this._streamChat([message], signal, options)) {
       yield stripImages(chunk.content);
     }
   }
 
   protected async *_streamChat(
     messages: ChatMessage[],
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<ChatMessage> {
     const requestBody = this._getRequestBody(messages, options);
@@ -139,6 +141,7 @@ class Flowise extends BaseLLM {
       method: "POST",
       headers: this._getHeaders(),
       body: JSON.stringify({ ...requestBody, socketIOClientId: socket.id }),
+      signal
     }).then((res) => res.json());
 
     while (await socketInfo.hasNextToken()) {

--- a/core/llm/llms/FreeTrial.ts
+++ b/core/llm/llms/FreeTrial.ts
@@ -60,6 +60,7 @@ class FreeTrial extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<string> {
     const args = this._convertArgs(this.collectArgs(options));
@@ -73,6 +74,7 @@ class FreeTrial extends BaseLLM {
         prompt,
         ...args,
       }),
+      signal
     });
 
     let completion = "";
@@ -103,6 +105,7 @@ class FreeTrial extends BaseLLM {
 
   protected async *_streamChat(
     messages: ChatMessage[],
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<ChatMessage> {
     const args = this._convertArgs(this.collectArgs(options));
@@ -120,6 +123,7 @@ class FreeTrial extends BaseLLM {
         messages: messages.map(this._convertMessage),
         ...args,
       }),
+      signal
     });
 
     let completion = "";
@@ -140,6 +144,7 @@ class FreeTrial extends BaseLLM {
   async *_streamFim(
     prefix: string,
     suffix: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<string> {
     const args = this._convertArgs(this.collectArgs(options));
@@ -153,6 +158,7 @@ class FreeTrial extends BaseLLM {
           suffix,
           ...args,
         }),
+        signal
       });
 
       let completion = "";

--- a/core/llm/llms/HuggingFaceInferenceAPI.ts
+++ b/core/llm/llms/HuggingFaceInferenceAPI.ts
@@ -16,6 +16,7 @@ class HuggingFaceInferenceAPI extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<string> {
     if (!this.apiBase) {
@@ -36,6 +37,7 @@ class HuggingFaceInferenceAPI extends BaseLLM {
         stream: true,
         parameters: this._convertArgs(options),
       }),
+      signal
     });
 
     async function* stream() {

--- a/core/llm/llms/HuggingFaceTGI.ts
+++ b/core/llm/llms/HuggingFaceTGI.ts
@@ -48,6 +48,7 @@ class HuggingFaceTGI extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<string> {
     const args = this._convertArgs(options, prompt);
@@ -60,6 +61,7 @@ class HuggingFaceTGI extends BaseLLM {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({ inputs: prompt, parameters: args }),
+        signal
       },
     );
 

--- a/core/llm/llms/LlamaCpp.ts
+++ b/core/llm/llms/LlamaCpp.ts
@@ -26,6 +26,7 @@ class LlamaCpp extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<string> {
     const headers = {
@@ -42,6 +43,7 @@ class LlamaCpp extends BaseLLM {
         stream: true,
         ...this._convertArgs(options, prompt),
       }),
+      signal
     });
 
     for await (const value of streamSse(resp)) {

--- a/core/llm/llms/Mock.ts
+++ b/core/llm/llms/Mock.ts
@@ -7,6 +7,7 @@ class Mock extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<string> {
     yield this.completion;
@@ -14,6 +15,7 @@ class Mock extends BaseLLM {
 
   protected async *_streamChat(
     messages: ChatMessage[],
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<ChatMessage> {
     for (const char of this.completion) {

--- a/core/llm/llms/Moonshot.ts
+++ b/core/llm/llms/Moonshot.ts
@@ -23,6 +23,7 @@ class Moonshot extends OpenAI {
   async *_streamFim(
     prefix: string,
     suffix: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<string> {
     const endpoint = new URL("v1/chat/completions", this.apiBase);
@@ -49,6 +50,7 @@ class Moonshot extends OpenAI {
         Accept: "application/json",
         Authorization: `Bearer ${this.apiKey}`,
       },
+      signal
     });
     for await (const chunk of streamSse(resp)) {
       yield chunk.choices[0].delta.content;

--- a/core/llm/llms/Ollama.ts
+++ b/core/llm/llms/Ollama.ts
@@ -30,7 +30,7 @@ interface ModelFileParams {
   min_p?: number;
   // deprecated?
   num_thread?: number;
-  use_mmap?: boolean;	
+  use_mmap?: boolean;
   num_gqa?: number;
   num_gpu?: number;
 }
@@ -77,7 +77,6 @@ class Ollama extends BaseLLM {
     if (options.model === "AUTODETECT") {
       return;
     }
-
     this.fetch(this.getEndpoint("api/show"), {
       method: "POST",
       headers: {
@@ -262,6 +261,7 @@ class Ollama extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<string> {
     const response = await this.fetch(this.getEndpoint("api/generate"), {
@@ -271,6 +271,7 @@ class Ollama extends BaseLLM {
         Authorization: `Bearer ${this.apiKey}`,
       },
       body: JSON.stringify(this._getGenerateOptions(options, prompt)),
+      signal
     });
 
     let buffer = "";
@@ -301,6 +302,7 @@ class Ollama extends BaseLLM {
 
   protected async *_streamChat(
     messages: ChatMessage[],
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<ChatMessage> {
     const response = await this.fetch(this.getEndpoint("api/chat"), {
@@ -310,6 +312,7 @@ class Ollama extends BaseLLM {
         Authorization: `Bearer ${this.apiKey}`,
       },
       body: JSON.stringify(this._getChatOptions(options, messages)),
+      signal
     });
 
     let buffer = "";
@@ -348,8 +351,10 @@ class Ollama extends BaseLLM {
   protected async *_streamFim(
     prefix: string,
     suffix: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<string> {
+
     const response = await this.fetch(this.getEndpoint("api/generate"), {
       method: "POST",
       headers: {
@@ -357,6 +362,7 @@ class Ollama extends BaseLLM {
         Authorization: `Bearer ${this.apiKey}`,
       },
       body: JSON.stringify(this._getGenerateOptions(options, prefix, suffix)),
+      signal
     });
 
     let buffer = "";

--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -166,11 +166,13 @@ class OpenAI extends BaseLLM {
 
   protected async _complete(
     prompt: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): Promise<string> {
     let completion = "";
     for await (const chunk of this._streamChat(
       [{ role: "user", content: prompt }],
+      signal,
       options,
     )) {
       completion += chunk.content;
@@ -199,10 +201,12 @@ class OpenAI extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<string> {
     for await (const chunk of this._streamChat(
       [{ role: "user", content: prompt }],
+      signal,
       options,
     )) {
       yield stripImages(chunk.content);
@@ -211,6 +215,7 @@ class OpenAI extends BaseLLM {
 
   protected async *_legacystreamComplete(
     prompt: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<string> {
     const args: any = this._convertArgs(options, []);
@@ -224,6 +229,7 @@ class OpenAI extends BaseLLM {
         ...args,
         stream: true,
       }),
+      signal
     });
 
     for await (const value of streamSse(response)) {
@@ -235,6 +241,7 @@ class OpenAI extends BaseLLM {
 
   protected async *_streamChat(
     messages: ChatMessage[],
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<ChatMessage> {
     if (
@@ -246,6 +253,7 @@ class OpenAI extends BaseLLM {
     ) {
       for await (const content of this._legacystreamComplete(
         stripImages(messages[messages.length - 1]?.content || ""),
+        signal,
         options,
       )) {
         yield {
@@ -266,6 +274,7 @@ class OpenAI extends BaseLLM {
       method: "POST",
       headers: this._getHeaders(),
       body: JSON.stringify(body),
+      signal
     });
 
     // Handle non-streaming response
@@ -285,6 +294,7 @@ class OpenAI extends BaseLLM {
   protected async *_streamFim(
     prefix: string,
     suffix: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<string> {
     const endpoint = new URL("fim/completions", this.apiBase);
@@ -308,6 +318,7 @@ class OpenAI extends BaseLLM {
         "x-api-key": this.apiKey ?? "",
         Authorization: `Bearer ${this.apiKey}`,
       },
+      signal
     });
     for await (const chunk of streamSse(resp)) {
       yield chunk.choices[0].delta.content;

--- a/core/llm/llms/Replicate.ts
+++ b/core/llm/llms/Replicate.ts
@@ -41,11 +41,13 @@ class Replicate extends BaseLLM {
   private _convertArgs(
     options: CompletionOptions,
     prompt: string,
-  ): [`${string}/${string}:${string}`, { input: any }] {
+    signal: AbortSignal
+  ): [`${string}/${string}:${string}`, { input: any, signal: AbortSignal }] {
     return [
       Replicate.MODEL_IDS[options.model] || (options.model as any),
       {
         input: { prompt, message: prompt },
+        signal
       },
     ];
   }
@@ -57,9 +59,10 @@ class Replicate extends BaseLLM {
 
   protected async _complete(
     prompt: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): Promise<string> {
-    const [model, args] = this._convertArgs(options, prompt);
+    const [model, args] = this._convertArgs(options, prompt, signal);
     const response = await this._replicate.run(model, args);
 
     return (response as any)[0];
@@ -67,9 +70,10 @@ class Replicate extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<string> {
-    const [model, args] = this._convertArgs(options, prompt);
+    const [model, args] = this._convertArgs(options, prompt, signal);
     for await (const event of this._replicate.stream(model, args)) {
       if (event.event === "output") {
         yield event.data;

--- a/core/llm/llms/SageMaker.ts
+++ b/core/llm/llms/SageMaker.ts
@@ -32,6 +32,7 @@ class SageMaker extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<string> {
     const credentials = await this._getCredentials();
@@ -45,7 +46,7 @@ class SageMaker extends BaseLLM {
     });
     const toolkit = new CompletionAPIToolkit(this);
     const command = toolkit.generateCommand([], prompt, options);
-    const response = await client.send(command);
+    const response = await client.send(command, { abortSignal: signal });
     if (response.Body) {
       let buffer = "";
       for await (const rawValue of response.Body) {
@@ -82,6 +83,7 @@ class SageMaker extends BaseLLM {
 
   protected async *_streamChat(
     messages: ChatMessage[],
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<ChatMessage> {
     const credentials = await this._getCredentials();
@@ -96,7 +98,7 @@ class SageMaker extends BaseLLM {
     const toolkit = new MessageAPIToolkit(this);
 
     const command = toolkit.generateCommand(messages, "", options);
-    const response = await client.send(command);
+    const response = await client.send(command, { abortSignal: signal });
     if (response.Body) {
       let buffer = "";
       for await (const rawValue of response.Body) {

--- a/core/llm/llms/Together.ts
+++ b/core/llm/llms/Together.ts
@@ -41,9 +41,10 @@ class Together extends OpenAI {
 
   protected async *_streamComplete(
     prompt: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<string> {
-    for await (const chunk of this._legacystreamComplete(prompt, options)) {
+    for await (const chunk of this._legacystreamComplete(prompt,signal, options)) {
       yield chunk;
     }
   }

--- a/core/llm/llms/WatsonX.ts
+++ b/core/llm/llms/WatsonX.ts
@@ -140,11 +140,13 @@ class WatsonX extends BaseLLM {
 
   protected async _complete(
     prompt: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): Promise<string> {
     let completion = "";
     for await (const chunk of this._streamChat(
       [{ role: "user", content: prompt }],
+      signal,
       options,
     )) {
       completion += chunk.content;
@@ -155,10 +157,12 @@ class WatsonX extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<string> {
     for await (const chunk of this._streamChat(
       [{ role: "user", content: prompt }],
+      signal,
       options,
     )) {
       yield stripImages(chunk.content);
@@ -167,6 +171,7 @@ class WatsonX extends BaseLLM {
 
   protected async *_streamChat(
     messages: ChatMessage[],
+    signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<ChatMessage> {
     var now = new Date().getTime() / 1000;
@@ -219,6 +224,7 @@ class WatsonX extends BaseLLM {
       method: "POST",
       headers: headers,
       body: JSON.stringify(payload),
+      signal
     });
 
     if (!response.ok || response.body === null) {

--- a/core/promptFiles/v1/slashCommandFromPromptFile.ts
+++ b/core/promptFiles/v1/slashCommandFromPromptFile.ts
@@ -90,7 +90,7 @@ export function slashCommandFromPromptFile(
         systemMessage,
       );
 
-      for await (const chunk of context.llm.streamChat(messages)) {
+      for await (const chunk of context.llm.streamChat(messages, new AbortController().signal)) {
         yield stripImages(chunk.content);
       }
     },

--- a/core/util/chatDescriber.ts
+++ b/core/util/chatDescriber.ts
@@ -52,6 +52,7 @@ export class ChatDescriber {
           content: ChatDescriber.prompt + message,
         },
       ],
+      new AbortController().signal,
       completionOptions,
     );
 


### PR DESCRIPTION
## Description

On VS Code, while editing a file, on every keystroke, Continue sends an http request to the provider. When running against ollama 0.4.x, it quickly becomes unresponsive (see https://github.com/continuedev/continue/issues/2838#issuecomment-2474492124). VS Code provides a cancellation token but it's unused when it comes to querying servers.

This PR ensures the AbortSignal bound to VS Code's cancellation token is used in all fetch queries. In effect, this means that on each character you type actually cancel the previous completion requests to the servers.

I'm not too sure how to handle requests not bound to a CancellationToken so I just created new AbortController().signal everywhere. This leads to more changes than I'd like but I think it makes the API more consistent across the board. But feel free to disagree/point me to better approaches.

~~This is still WIP as I need to fix an issue where all aborted signal spew stacktraces in the console.~~ fixed

While the implementation might be debatable, I'm convinced the overall strategy is sound (cancel stale requests as you type). It feels the overall type completion is snappier (using ollama), but I'm sure other providers would also benefit from it. 

Looking for feedback @sestinj


## Checklist

- [x] No doc change needed

## Screenshots

- [x] No UI changes

## Testing
- install ollama 0.4.1 and pull granite-code:3b
- configure granite-code:3b for autocompletion
>     "tabAutocompleteModel": {
>       "model": "granite-code:3b",
>         "provider": "ollama",
>         "contextLength": 128000,
>         "completionOptions": {
>             "maxTokens": 4000,
>             "temperature": 0.1,
>             "topP": 0.9,
>             "topK": 40,
>             "presencePenalty": 0,
>             "frequencyPenalty": 0.1
>         },
>         "title": "granite-code:3b"
>     },