### PR TITLE
Refresh Index for Files

### DIFF
--- a/core/core.ts
+++ b/core/core.ts
@@ -727,7 +727,7 @@ export class Core {
   }
 
   private indexingCancellationController: AbortController | undefined;
-  private async sendIndexingTelemetry(update: IndexingProgressUpdate) {
+  private async sendIndexingErrorTelemetry(update: IndexingProgressUpdate) {
     console.debug(
       "Indexing failed with error: ",
       update.desc,
@@ -763,11 +763,12 @@ export class Core {
       this.indexingState = updateToSend;
 
       if (update.status === "failed") {
-        void this.sendIndexingTelemetry(update);
+        void this.sendIndexingErrorTelemetry(update);
       }
     }
 
     this.messenger.send("refreshSubmenuItems", undefined);
+    this.indexingCancellationController = undefined;
   }
 
   private async refreshCodebaseIndexFiles(files: string[]) {
@@ -784,7 +785,6 @@ export class Core {
     this.indexingCancellationController = new AbortController();
     for await (const update of (await this.codebaseIndexerPromise).refreshFiles(
       files,
-      this.indexingCancellationController.signal,
     )) {
       let updateToSend = { ...update };
       if (update.status === "failed") {
@@ -797,7 +797,7 @@ export class Core {
       this.indexingState = updateToSend;
 
       if (update.status === "failed") {
-        void this.sendIndexingTelemetry(update);
+        void this.sendIndexingErrorTelemetry(update);
       }
     }
 

--- a/core/indexing/CodebaseIndexer.test.ts
+++ b/core/indexing/CodebaseIndexer.test.ts
@@ -89,9 +89,19 @@ describe("CodebaseIndexer", () => {
     const abortSignal = abortController.signal;
 
     const updates = [];
-    for await (const update of codebaseIndexer.refresh(
+    for await (const update of codebaseIndexer.refreshDirs(
       [TEST_DIR],
       abortSignal,
+    )) {
+      updates.push(update);
+    }
+    return updates;
+  }
+
+  async function refreshIndexFiles(files: string[]) {
+    const updates = [];
+    for await (const update of codebaseIndexer.refreshFiles(
+      files,
     )) {
       updates.push(update);
     }
@@ -156,6 +166,15 @@ describe("CodebaseIndexer", () => {
     expect(indexed.length).toBe(2);
     expect(indexed.some((file) => file.endsWith("test.ts"))).toBe(true);
     expect(indexed.some((file) => file.endsWith("main.py"))).toBe(true);
+  });
+
+  test("should successfuly re-index specific files", async () => {
+    // Could add more specific tests for this but uses similar logic
+    const before = await getAllIndexedFiles();
+    await refreshIndexFiles(before);
+
+    const after = await getAllIndexedFiles();
+    expect(after.length).toBe(before.length);
   });
 
   test("should successfully re-index after adding a file", async () => {

--- a/core/indexing/CodebaseIndexer.ts
+++ b/core/indexing/CodebaseIndexer.ts
@@ -147,7 +147,6 @@ export class CodebaseIndexer {
 
   async *refreshFiles(
     files: string[],
-    abortSignal: AbortSignal,
   ): AsyncGenerator<IndexingProgressUpdate> {
     let progress = 0;
     if (files.length === 0) {
@@ -172,14 +171,6 @@ export class CodebaseIndexer {
 
         if (this.pauseToken.paused) {
           yield* this.yieldUpdateAndPause();
-        }
-        if (abortSignal.aborted) {
-          yield {
-            progress: 1,
-            desc: "Indexing cancelled",
-            status: "disabled",
-          };
-          return;
         }
       }
 

--- a/core/indexing/CodebaseIndexer.ts
+++ b/core/indexing/CodebaseIndexer.ts
@@ -17,6 +17,7 @@ import {
   RefreshIndexResults,
 } from "./types.js";
 import { walkDirAsync } from "./walkDir.js";
+import { getBasename } from "../util/index.js";
 
 export class PauseToken {
   constructor(private _paused: boolean) {}
@@ -144,13 +145,61 @@ export class CodebaseIndexer {
     }
   }
 
-  async *refresh(
-    workspaceDirs: string[],
+  async *refreshFiles(
+    files: string[],
+    abortSignal: AbortSignal,
+  ): AsyncGenerator<IndexingProgressUpdate> {
+    let progress = 0;
+    if (files.length === 0) {
+      yield {
+        progress: 1,
+        desc: "Indexing Complete",
+        status: "done",
+      };
+    }
+
+    const progressPer = 1 / files.length;
+    try {
+      for (const file of files) {
+        yield {
+          progress,
+          desc: `Indexing file ${file}...`,
+          status: "indexing",
+        };
+        await this.refreshFile(file);
+
+        progress += progressPer;
+
+        if (this.pauseToken.paused) {
+          yield* this.yieldUpdateAndPause();
+        }
+        if (abortSignal.aborted) {
+          yield {
+            progress: 1,
+            desc: "Indexing cancelled",
+            status: "disabled",
+          };
+          return;
+        }
+      }
+
+      yield {
+        progress: 1,
+        desc: "Indexing Complete",
+        status: "done",
+      };
+    } catch (err) {
+      yield this.handleErrorAndGetProgressUpdate(err);
+    }
+  }
+
+  async *refreshDirs(
+    dirs: string[],
     abortSignal: AbortSignal,
   ): AsyncGenerator<IndexingProgressUpdate> {
     let progress = 0;
 
-    if (workspaceDirs.length === 0) {
+    if (dirs.length === 0) {
       yield {
         progress,
         desc: "Nothing to index",
@@ -175,11 +224,9 @@ export class CodebaseIndexer {
       };
     }
 
-    let completedDirs = 0;
-
     // Wait until Git Extension has loaded to report progress
     // so we don't appear stuck at 0% while waiting
-    await this.ide.getRepoName(workspaceDirs[0]);
+    await this.ide.getRepoName(dirs[0]);
 
     yield {
       progress,
@@ -188,16 +235,16 @@ export class CodebaseIndexer {
     };
     const beginTime = Date.now();
 
-    for (const directory of workspaceDirs) {
+    for (const directory of dirs) {
       const dirBasename = await this.basename(directory);
       yield {
         progress,
         desc: `Discovering files in ${dirBasename}...`,
         status: "indexing",
       };
-      const workspaceFiles = [];
+      const directoryFiles = [];
       for await (const p of walkDirAsync(directory, this.ide)) {
-        workspaceFiles.push(p);
+        directoryFiles.push(p);
         if (abortSignal.aborted) {
           yield {
             progress: 1,
@@ -218,7 +265,7 @@ export class CodebaseIndexer {
       try {
         for await (const updateDesc of this.indexFiles(
           directory,
-          workspaceFiles,
+          directoryFiles,
           branch,
           repoName,
         )) {
@@ -240,7 +287,7 @@ export class CodebaseIndexer {
             nextLogThreshold += 0.025;
             this.logProgress(
               beginTime,
-              Math.floor(workspaceFiles.length * updateDesc.progress),
+              Math.floor(directoryFiles.length * updateDesc.progress),
               updateDesc.progress,
             );
           }
@@ -347,18 +394,18 @@ export class CodebaseIndexer {
   }
 
   private async *indexFiles(
-    workspaceDir: string,
-    workspaceFiles: string[],
+    directory: string,
+    files: string[],
     branch: string,
     repoName: string | undefined,
   ): AsyncGenerator<IndexingProgressUpdate> {
-    const stats = await this.ide.getLastModified(workspaceFiles);
+    const stats = await this.ide.getLastModified(files);
     const indexesToBuild = await this.getIndexesToBuild();
     let completedIndexCount = 0;
     let progress = 0;
     for (const codebaseIndex of indexesToBuild) {
       const tag: IndexTag = {
-        directory: workspaceDir,
+        directory,
         branch,
         artifactId: codebaseIndex.artifactId,
       };

--- a/core/protocol/core.ts
+++ b/core/protocol/core.ts
@@ -147,6 +147,7 @@ export type ToCoreFromIdeOrWebviewProtocol = {
     undefined | { dirs?: string[]; shouldClearIndexes?: boolean },
     void,
   ];
+  "index/forceReIndexFiles": [undefined | { files?: string[] }, void];
   "index/indexingProgressBarInitialized": [undefined, void];
   completeOnboarding: [
     {

--- a/core/protocol/passThrough.ts
+++ b/core/protocol/passThrough.ts
@@ -41,6 +41,7 @@ export const WEBVIEW_TO_CORE_PASS_THROUGH: (keyof ToCoreFromWebviewProtocol)[] =
     "stats/getTokensPerModel",
     "index/setPaused",
     "index/forceReIndex",
+    "index/forceReIndexFiles",
     "index/indexingProgressBarInitialized",
     "completeOnboarding",
     "addAutocompleteModel",
@@ -60,5 +61,5 @@ export const CORE_TO_WEBVIEW_PASS_THROUGH: (keyof ToWebviewFromCoreProtocol)[] =
     "isContinueInputFocused",
     "didChangeAvailableProfiles",
     "setTTSActive",
-    "getWebviewHistoryLength"
+    "getWebviewHistoryLength",
   ];

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/activities/ContinuePluginStartupActivity.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/activities/ContinuePluginStartupActivity.kt
@@ -169,8 +169,8 @@ class ContinuePluginStartupActivity : StartupActivity, Disposable, DumbAware {
 
                     // Create a data map if there are any paths to re-index
                     if (allPaths.isNotEmpty()) {
-                        val data = mapOf("dirs" to allPaths)
-                        continuePluginService.coreMessenger?.request("index/forceReIndex", data, null) { _ -> }
+                        val data = mapOf("files" to allPaths)
+                        continuePluginService.coreMessenger?.request("index/forceReIndexFiles", data, null) { _ -> }
                     }
                 }
             })

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinueBrowser.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinueBrowser.kt
@@ -58,6 +58,7 @@ class ContinueBrowser(val project: Project, url: String) {
         "stats/getTokensPerModel",
         "index/setPaused",
         "index/forceReIndex",
+        "index/forceReIndexFiles",
         "index/indexingProgressBarInitialized",
         "completeOnboarding",
         "addAutocompleteModel",

--- a/extensions/vscode/src/extension/VsCodeExtension.ts
+++ b/extensions/vscode/src/extension/VsCodeExtension.ts
@@ -309,6 +309,12 @@ export class VsCodeExtension {
       });
     });
 
+    vscode.workspace.onDidCreateFiles(async (event) => {
+      this.core.invoke("index/forceReIndexFiles", {
+        files: event.files.map((file) => file.fsPath),
+      });
+    });
+
     // When GitHub sign-in status changes, reload config
     vscode.authentication.onDidChangeSessions(async (e) => {
       if (e.provider.id === "github") {

--- a/extensions/vscode/src/extension/VsCodeExtension.ts
+++ b/extensions/vscode/src/extension/VsCodeExtension.ts
@@ -297,17 +297,15 @@ export class VsCodeExtension {
         this.core.invoke("index/forceReIndex", undefined);
       } else {
         // Reindex the file
-        this.core.invoke("index/forceReIndex", {
-          dirs: [filepath],
+        this.core.invoke("index/forceReIndexFiles", {
+          files: [filepath],
         });
       }
     });
 
     vscode.workspace.onDidDeleteFiles(async (event) => {
-      this.core.invoke("index/forceReIndex", {
-        dirs: event.files.map((file) =>
-          file.fsPath.split("/").slice(0, -1).join("/"),
-        ),
+      this.core.invoke("index/forceReIndexFiles", {
+        files: event.files.map((file) => file.fsPath),
       });
     });
 


### PR DESCRIPTION
## Description
Fixes problem that files aren't currently being reindexed on save/delete, just throwing an error, and there wasn't an efficient way to reindex them

I did a PR https://github.com/continuedev/continue/pull/2717 a couple weeks back to handle file saves and deletions
Apparently I didn't test it well enough because it keeps throwing errors that it's trying to index a directory

This maxes sense, because the current `index/forceReIndex` only supports directories

The problem with passing directories (e.g. get directory from file name) is that for a specific file you must pass the directory containing that file, which means the entire directory is walked.
E.g. reindexing a file at the root would cause the entire codebase to reindex

Thus, a new `index/forceReIndexFiles` message and indexing function were created

Functionality can be seen here
https://www.loom.com/share/38876683023346239ed3d633857f3ebb