### PR TITLE
fix: Add ContinuePluginDisposable to avoid memory leaks in Jetbrains

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/activities/ContinuePluginDisposable.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/activities/ContinuePluginDisposable.kt
@@ -1,0 +1,32 @@
+package com.github.continuedev.continueintellijextension.activities
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+
+/**
+ * The service is a parent disposable that represents the entire plugin lifecycle
+ * and is intended to be used instead of the project/application as a parent disposable,
+ * ensures that disposables registered using it as parents will be processed when the plugin is unloaded to avoid memory leaks.
+ *
+ * @author lk
+ */
+@Service(Service.Level.APP, Service.Level.PROJECT)
+class ContinuePluginDisposable : Disposable {
+
+    override fun dispose() {
+    }
+
+    companion object {
+
+        fun getInstance(): ContinuePluginDisposable {
+            return ApplicationManager.getApplication().getService(ContinuePluginDisposable::class.java)
+        }
+
+        fun getInstance(project: Project): ContinuePluginDisposable {
+            return project.getService(ContinuePluginDisposable::class.java)
+        }
+
+    }
+}

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/activities/ContinuePluginStartupActivity.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/activities/ContinuePluginStartupActivity.kt
@@ -70,7 +70,7 @@ private fun getTutorialFileName(): String {
     }
 }
 
-class ContinuePluginStartupActivity : StartupActivity, Disposable, DumbAware {
+class ContinuePluginStartupActivity : StartupActivity, DumbAware {
 
     override fun runActivity(project: Project) {
         removeShortcutFromAction(getPlatformSpecificKeyStroke("J"))
@@ -225,14 +225,11 @@ class ContinuePluginStartupActivity : StartupActivity, Disposable, DumbAware {
 
             EditorFactory.getInstance().eventMulticaster.addSelectionListener(
                 listener,
-                this@ContinuePluginStartupActivity
+                ContinuePluginDisposable.getInstance(project)
             )
 
             val coreMessengerManager = CoreMessengerManager(project, ideProtocolClient, coroutineScope)
             continuePluginService.coreMessengerManager = coreMessengerManager
         }
-    }
-
-    override fun dispose() {
     }
 }

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/AutocompleteSpinnerWidgetFactory.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/AutocompleteSpinnerWidgetFactory.kt
@@ -1,5 +1,6 @@
 package com.github.continuedev.continueintellijextension.autocomplete
 
+import com.github.continuedev.continueintellijextension.activities.ContinuePluginDisposable
 import com.github.continuedev.continueintellijextension.services.ContinueExtensionSettings
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.service
@@ -35,7 +36,7 @@ class AutocompleteSpinnerWidget(project: Project) : EditorBasedWidget(project), 
     )
 
     init {
-        Disposer.register(project, this)
+        Disposer.register(ContinuePluginDisposable.getInstance(project), this)
         updateIcon()
     }
 

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
@@ -1,5 +1,6 @@
 package com.github.continuedev.continueintellijextension.`continue`
 
+import com.github.continuedev.continueintellijextension.activities.ContinuePluginDisposable
 import com.github.continuedev.continueintellijextension.auth.AuthListener
 import com.github.continuedev.continueintellijextension.auth.ContinueAuthService
 import com.github.continuedev.continueintellijextension.constants.getConfigJsPath
@@ -132,9 +133,9 @@ class IdeProtocolClient(
         initIdeProtocol()
 
         // Setup config.json / config.ts save listeners
-        VirtualFileManager.getInstance().addAsyncFileListener(AsyncFileSaveListener(this), object : Disposable {
-            override fun dispose() {}
-        })
+        VirtualFileManager.getInstance().addAsyncFileListener(
+            AsyncFileSaveListener(this), ContinuePluginDisposable.getInstance(project)
+        )
 
         val myPluginId = "com.github.continuedev.continueintellijextension"
         val pluginDescriptor =

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinueBrowser.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinueBrowser.kt
@@ -1,5 +1,6 @@
 package com.github.continuedev.continueintellijextension.toolWindow
 
+import com.github.continuedev.continueintellijextension.activities.ContinuePluginDisposable
 import com.github.continuedev.continueintellijextension.activities.showTutorial
 import com.github.continuedev.continueintellijextension.constants.MessageTypes
 import com.github.continuedev.continueintellijextension.constants.getConfigJsonPath
@@ -88,7 +89,7 @@ class ContinueBrowser(val project: Project, url: String) {
 
         registerAppSchemeHandler()
         browser.loadURL(url);
-        Disposer.register(project, browser)
+        Disposer.register(ContinuePluginDisposable.getInstance(project), browser)
 
         // Listen for events sent from browser
         val myJSQueryOpenInBrowser = JBCefJSQuery.create((browser as JBCefBrowserBase?)!!)


### PR DESCRIPTION
## Description

Some components do not have any parent disposable, leading to potential memory leaks,
It should be registered to a parent disposable with the same life cycle as the plugin.