### PR TITLE
Messaging Audit

### DIFF
--- a/core/context/providers/DocsContextProvider.ts
+++ b/core/context/providers/DocsContextProvider.ts
@@ -92,7 +92,7 @@ class DocsContextProvider extends BaseContextProvider {
       await docsService.isJetBrainsAndPreIndexedDocsProvider();
 
     if (isJetBrainsAndPreIndexedDocsProvider) {
-      await extras.ide.showToast(
+      void extras.ide.showToast(
         "error",
         `${DocsService.preIndexedDocsEmbeddingsProvider.id} is configured as ` +
           "the embeddings provider, but it cannot be used with JetBrains. " +

--- a/core/core.ts
+++ b/core/core.ts
@@ -149,7 +149,7 @@ export class Core {
       void this.ide.getWorkspaceDirs().then(async (dirs) => {
         // Respect pauseCodebaseIndexOnStart user settings
         if (ideSettings.pauseCodebaseIndexOnStart) {
-          await this.messenger.request("indexProgress", {
+          void this.messenger.request("indexProgress", {
             progress: 1,
             desc: "Initial Indexing Skipped",
             status: "paused",

--- a/core/indexing/docs/DocsCrawler.ts
+++ b/core/indexing/docs/DocsCrawler.ts
@@ -79,7 +79,7 @@ class DocsCrawler {
           );
 
         if (didInstall) {
-          await this.ide.showToast(
+          void this.ide.showToast(
             "info",
             `Successfully installed Chromium! Retrying crawl of: ${startUrl.toString()}`,
           );

--- a/core/indexing/docs/DocsService.ts
+++ b/core/indexing/docs/DocsService.ts
@@ -157,7 +157,7 @@ export default class DocsService {
         params: {},
       });
 
-      await this.ide.showToast(
+      void this.ide.showToast(
         "info",
         "Successfuly added docs context provider",
       );
@@ -183,7 +183,7 @@ export default class DocsService {
       while (!(await generator.next()).done) {}
     }
 
-    await this.ide.showToast("info", "Docs indexing completed");
+    void this.ide.showToast("info", "Docs indexing completed");
   }
 
   async list() {
@@ -741,7 +741,7 @@ export default class DocsService {
 
     if (isJetBrainsAndPreIndexedDocsProvider) {
       // A bit noisy for teams users whom have no choice if their admin is the one who didn't setup an embeddingsProvider
-      // this.ide.showToast(
+      // void this.ide.showToast(
       //   "error",
       //   "The 'transformers.js' embeddings provider currently cannot be used to index " +
       //     "documentation in JetBrains. To enable documentation indexing, you can use " +

--- a/core/indexing/docs/crawlers/ChromiumCrawler.ts
+++ b/core/indexing/docs/crawlers/ChromiumCrawler.ts
@@ -242,7 +242,7 @@ export class ChromiumInstaller {
 
       ChromiumCrawler.setUseChromiumForDocsCrawling(false);
 
-      await this.ide.showToast("error", "Failed to install Chromium");
+      void this.ide.showToast("error", "Failed to install Chromium");
 
       return false;
     }

--- a/core/util/tts.ts
+++ b/core/util/tts.ts
@@ -82,10 +82,10 @@ export class TTS {
         return;
     }
 
-    TTS.messenger.request("setTTSActive", true);
+    void TTS.messenger.request("setTTSActive", true);
 
     TTS.handle?.once("exit", () => {
-      TTS.messenger.request("setTTSActive", false);
+      void TTS.messenger.request("setTTSActive", false);
     });
   }
 

--- a/extensions/vscode/src/autocomplete/completionProvider.ts
+++ b/extensions/vscode/src/autocomplete/completionProvider.ts
@@ -41,7 +41,9 @@ export class ContinueCompletionProvider
       showFreeTrialLoginMessage(
         e.message,
         this.configHandler.reloadConfig.bind(this.configHandler),
-        () => this.webviewProtocol.request("openOnboardingCard", undefined),
+        () => {
+          void this.webviewProtocol.request("openOnboardingCard", undefined)
+        },
       );
       return;
     }

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -258,7 +258,7 @@ const commandsMap: (
     const modelTitle =
       getModelByRole(config, "inlineEdit")?.title ?? defaultModelTitle;
 
-    sidebar.webviewProtocol.request("incrementFtc", undefined);
+    void sidebar.webviewProtocol.request("incrementFtc", undefined);
 
     await verticalDiffManager.streamEdit(
       config.experimental?.contextMenuPrompts?.[promptName] ?? fallbackPrompt,
@@ -287,7 +287,7 @@ const commandsMap: (
       verticalDiffManager.clearForFilepath(fullPath, true);
       await diffManager.acceptDiff(fullPath);
 
-      await sidebar.webviewProtocol.request("setEditStatus", {
+      void sidebar.webviewProtocol.request("setEditStatus", {
         status: "done",
       });
     },
@@ -306,7 +306,7 @@ const commandsMap: (
 
       verticalDiffManager.clearForFilepath(fullPath, false);
       await diffManager.rejectDiff(fullPath);
-      await sidebar.webviewProtocol.request("setEditStatus", {
+      void sidebar.webviewProtocol.request("setEditStatus", {
         status: "done",
       });
     },
@@ -387,12 +387,12 @@ const commandsMap: (
         if (historyLength === 0) {
           hideGUI();
         } else {
-          sidebar.webviewProtocol?.request("focusContinueInput", undefined);
+          void sidebar.webviewProtocol?.request("focusContinueInput", undefined);
         }
       } else {
         focusGUI();
         sidebar.webviewProtocol?.request("focusContinueInput", undefined);
-        await addHighlightedCodeToContext(sidebar.webviewProtocol);
+        void addHighlightedCodeToContext(sidebar.webviewProtocol);
       }
     },
     "continue.focusContinueInputWithoutClear": async () => {
@@ -419,7 +419,7 @@ const commandsMap: (
           undefined,
         );
 
-        await addHighlightedCodeToContext(sidebar.webviewProtocol);
+        void addHighlightedCodeToContext(sidebar.webviewProtocol);
       }
     },
     "continue.edit": async () => {
@@ -596,10 +596,10 @@ const commandsMap: (
           prompt: "Enter the Session ID",
         });
       }
-      sidebar.webviewProtocol?.request("focusContinueSessionId", { sessionId });
+      void sidebar.webviewProtocol?.request("focusContinueSessionId", { sessionId });
     },
     "continue.applyCodeFromChat": () => {
-      sidebar.webviewProtocol.request("applyCodeFromChat", undefined);
+      void sidebar.webviewProtocol.request("applyCodeFromChat", undefined);
     },
     "continue.toggleFullScreen": () => {
       focusGUI();

--- a/extensions/vscode/src/diff/vertical/manager.ts
+++ b/extensions/vscode/src/diff/vertical/manager.ts
@@ -218,7 +218,7 @@ export class VerticalDiffManager {
       {
         instant,
         onStatusUpdate: (status, numDiffs) =>
-          this.webviewProtocol.request("updateApplyState", {
+          void this.webviewProtocol.request("updateApplyState", {
             streamId,
             status,
             numDiffs,
@@ -338,7 +338,7 @@ export class VerticalDiffManager {
         input,
         onStatusUpdate: (status, numDiffs) =>
           streamId &&
-          this.webviewProtocol.request("updateApplyState", {
+          void this.webviewProtocol.request("updateApplyState", {
             streamId,
             status,
             numDiffs,

--- a/extensions/vscode/src/extension/VsCodeExtension.ts
+++ b/extensions/vscode/src/extension/VsCodeExtension.ts
@@ -318,14 +318,14 @@ export class VsCodeExtension {
       } else if (e.provider.id === controlPlaneEnv.AUTH_TYPE) {
         const sessionInfo = await getControlPlaneSessionInfo(true);
         this.webviewProtocolPromise.then(async (webviewProtocol) => {
-          webviewProtocol.request("didChangeControlPlaneSessionInfo", {
+          void webviewProtocol.request("didChangeControlPlaneSessionInfo", {
             sessionInfo,
           });
 
           // To make sure continue-proxy models and anything else requiring it get updated access token
           this.configHandler.reloadConfig();
         });
-        this.core.invoke("didChangeControlPlaneSessionInfo", { sessionInfo });
+        void this.core.invoke("didChangeControlPlaneSessionInfo", { sessionInfo });
       }
     });
 
@@ -374,14 +374,14 @@ export class VsCodeExtension {
     );
 
     this.ide.onDidChangeActiveTextEditor((filepath) => {
-      this.core.invoke("didChangeActiveTextEditor", { filepath });
+      void this.core.invoke("didChangeActiveTextEditor", { filepath });
     });
 
     vscode.workspace.onDidChangeConfiguration(async (event) => {
       if (event.affectsConfiguration(EXTENSION_NAME)) {
         const settings = this.ide.getIdeSettingsSync();
         const webviewProtocol = await this.webviewProtocolPromise;
-        webviewProtocol.request("didChangeIdeSettings", {
+        void webviewProtocol.request("didChangeIdeSettings", {
           settings,
         });
       }

--- a/extensions/vscode/src/extension/VsCodeMessenger.ts
+++ b/extensions/vscode/src/extension/VsCodeMessenger.ts
@@ -48,7 +48,7 @@ export class VsCodeMessenger {
       message: Message<FromWebviewProtocol[T][0]>,
     ) => Promise<FromWebviewProtocol[T][1]> | FromWebviewProtocol[T][1],
   ): void {
-    this.webviewProtocol.on(messageType, handler);
+    void this.webviewProtocol.on(messageType, handler);
   }
 
   onCore<T extends keyof ToIdeOrWebviewFromCoreProtocol>(
@@ -153,11 +153,11 @@ export class VsCodeMessenger {
     });
 
     webviewProtocol.on("acceptDiff", async ({ data: { filepath } }) => {
-      await vscode.commands.executeCommand("continue.acceptDiff", filepath);
+      void vscode.commands.executeCommand("continue.acceptDiff", filepath);
     });
 
     webviewProtocol.on("rejectDiff", async ({ data: { filepath } }) => {
-      await vscode.commands.executeCommand("continue.rejectDiff", filepath);
+      void vscode.commands.executeCommand("continue.rejectDiff", filepath);
     });
 
     this.onWebview("applyToFile", async ({ data }) => {
@@ -178,7 +178,7 @@ export class VsCodeMessenger {
           await this.ide.writeFile(fullPath, data.text);
           await this.ide.openFile(fullPath);
 
-          await webviewProtocol.request("updateApplyState", {
+          void webviewProtocol.request("updateApplyState", {
             streamId: data.streamId,
             status: "done",
             numDiffs: 0,
@@ -203,7 +203,7 @@ export class VsCodeMessenger {
         editor.edit((builder) =>
           builder.insert(new vscode.Position(0, 0), data.text),
         );
-        await webviewProtocol.request("updateApplyState", {
+        void webviewProtocol.request("updateApplyState", {
           streamId: data.streamId,
           status: "done",
           numDiffs: 0,
@@ -328,7 +328,7 @@ export class VsCodeMessenger {
         ),
       );
 
-      this.webviewProtocol.request("setEditStatus", {
+      void this.webviewProtocol.request("setEditStatus", {
         status: "accepting",
         fileAfterEdit,
       });

--- a/extensions/vscode/src/quickEdit/QuickEditQuickPick.ts
+++ b/extensions/vscode/src/quickEdit/QuickEditQuickPick.ts
@@ -329,7 +329,7 @@ export class QuickEdit {
       prompt = this.contextProviderStr + prompt;
     }
 
-    this.webviewProtocol.request("incrementFtc", undefined);
+    void this.webviewProtocol.request("incrementFtc", undefined);
 
     await this.verticalDiffManager.streamEdit(
       prompt,

--- a/gui/src/components/OnboardingCard/components/QuickStartSubmitButton.tsx
+++ b/gui/src/components/OnboardingCard/components/QuickStartSubmitButton.tsx
@@ -41,7 +41,7 @@ function QuickstartSubmitButton() {
       force: true,
     });
 
-    if (result.status === "success" && typeof result.content === "string") {
+    if (result.status === "success") {
       onComplete();
     } else {
       ideMessenger.post("showToast", [

--- a/gui/src/components/OnboardingCard/tabs/OnboardingLocalTab.tsx
+++ b/gui/src/components/OnboardingCard/tabs/OnboardingLocalTab.tsx
@@ -57,11 +57,11 @@ function OnboardingLocalTab() {
   useEffect(() => {
     const fetchDownloadedModels = async () => {
       try {
-        const result = (await ideMessenger.request("llm/listModels", {
+        const result = await ideMessenger.request("llm/listModels", {
           title: ONBOARDING_LOCAL_MODEL_TITLE,
-        })) as any;
+        })
 
-        if (result.status === "success" && Array.isArray(result.content)) {
+        if (result.status === "success") {
           setDownloadedOllamaModels(result.content);
           setIsOllamaConnected(true);
         } else {

--- a/gui/src/components/ProfileSwitcher.tsx
+++ b/gui/src/components/ProfileSwitcher.tsx
@@ -193,7 +193,7 @@ function ProfileSwitcher() {
         <StyledListbox
           value={"GPT-4"}
           onChange={(id: string) => {
-            ideMessenger.request("didChangeSelectedProfile", { id });
+            ideMessenger.post("didChangeSelectedProfile", { id });
           }}
         >
           <div className="relative">

--- a/gui/src/components/mainInput/MentionList.tsx
+++ b/gui/src/components/mainInput/MentionList.tsx
@@ -215,7 +215,7 @@ const MentionList = forwardRef((props: MentionListProps, ref) => {
         title: "New .prompt file",
         type: "action",
         action: () => {
-          ideMessenger.request("config/newPromptFile", undefined);
+          ideMessenger.post("config/newPromptFile", undefined);
           const { tr } = props.editor.view.state;
           const text = tr.doc.textBetween(0, tr.selection.from);
           const start = text.lastIndexOf("@");

--- a/gui/src/components/mainInput/TutorialCard.tsx
+++ b/gui/src/components/mainInput/TutorialCard.tsx
@@ -57,7 +57,7 @@ export function TutorialCard({ onClose }: TutorialCardProps) {
               <span
                 className="cursor-pointer underline"
                 onClick={() =>
-                  ideMessenger.request(
+                  ideMessenger.post(
                     "vscode/openMoveRightMarkdown",
                     undefined,
                   )

--- a/gui/src/components/mainInput/getSuggestion.ts
+++ b/gui/src/components/mainInput/getSuggestion.ts
@@ -89,7 +89,7 @@ function getSubActionsForSubmenuItem(
         label: "Open in new tab",
         icon: "trash",
         action: () => {
-          ideMessenger.request("context/removeDocs", { startUrl: item.id });
+          ideMessenger.post("context/removeDocs", { startUrl: item.id });
         },
       },
     ];
@@ -166,7 +166,7 @@ export function getContextProviderDropdownOptions(
         title: "Add more context providers",
         type: "action",
         action: () => {
-          ideMessenger.request(
+          ideMessenger.post(
             "openUrl",
             "https://docs.continue.dev/customization/context-providers#built-in-context-providers",
           );
@@ -196,7 +196,7 @@ export function getSlashCommandDropdownOptions(
       //   id: "createPromptFile",
       //   label: "Create Prompt File",
       //   action: () => {
-      //     ideMessenger.request("config/newPromptFile", undefined);
+      //     ideMessenger.post("config/newPromptFile", undefined);
       //   },
       //   name: "Create Prompt File",
       // },

--- a/gui/src/editorInset/EditorInset.tsx
+++ b/gui/src/editorInset/EditorInset.tsx
@@ -35,7 +35,7 @@ function EditorInset() {
       if (!elementRef.current) return;
 
       console.log("Height: ", elementRef.current.clientHeight);
-      ideMessenger.request("jetbrains/editorInsetHeight", {
+      ideMessenger.post("jetbrains/editorInsetHeight", {
         height: elementRef.current.clientHeight,
       });
     });

--- a/gui/src/hooks/useAuth.tsx
+++ b/gui/src/hooks/useAuth.tsx
@@ -68,7 +68,7 @@ export function useAuth(): {
           confirmText="Yes, log out"
           text={"Are you sure you want to log out of Continue?"}
           onConfirm={() => {
-            ideMessenger.request("logoutOfControlPlane", undefined);
+            ideMessenger.post("logoutOfControlPlane", undefined);
           }}
         />,
       ),

--- a/gui/src/hooks/useCopy.tsx
+++ b/gui/src/hooks/useCopy.tsx
@@ -9,7 +9,7 @@ export default function useCopy(text: string | (() => string)) {
   const copyText = useCallback(() => {
     const textVal = typeof text === "string" ? text : text();
     if (isJetBrains()) {
-      ideMessenger.request("copyText", { text: textVal });
+      ideMessenger.post("copyText", { text: textVal });
     } else {
       navigator.clipboard.writeText(textVal);
     }

--- a/gui/src/hooks/useHistory.tsx
+++ b/gui/src/hooks/useHistory.tsx
@@ -121,9 +121,9 @@ function useHistory(dispatch: Dispatch) {
     if (result.status === "error") {
       throw new Error(result.error);
     }
-    const json = result.content;
-    dispatch(newSession(json));
-    return json;
+    const persistedSessionInfo = result.content;
+    dispatch(newSession(persistedSessionInfo));
+    return persistedSessionInfo;
   }
 
   async function loadLastSession(): Promise<PersistedSessionInfo | undefined> {

--- a/gui/src/hooks/useIsOSREnabled.ts
+++ b/gui/src/hooks/useIsOSREnabled.ts
@@ -13,7 +13,7 @@ export default function useIsOSREnabled() {
 
   useEffect(() => {
     if (isJetBrains()) {
-      ideMessenger.request("jetbrains/isOSREnabled", undefined);
+      ideMessenger.post("jetbrains/isOSREnabled", undefined);
     }
   }, []);
 

--- a/gui/src/hooks/useSetup.ts
+++ b/gui/src/hooks/useSetup.ts
@@ -112,7 +112,7 @@ function useSetup(dispatch: Dispatch<any>) {
   });
 
   const debouncedIndexDocs = debounce(() => {
-    ideMessenger.request("context/indexDocs", { reIndex: false });
+    ideMessenger.post("context/indexDocs", { reIndex: false });
   }, 1000);
 
   useWebviewListener("configUpdate", async () => {

--- a/gui/src/hooks/useSubmenuContextProviders.tsx
+++ b/gui/src/hooks/useSubmenuContextProviders.tsx
@@ -233,12 +233,12 @@ function useSubmenuContextProviders() {
                 storeFields: ["id", "title", "description"],
               });
 
-              const result = (await ideMessenger.request(
+              const result = await ideMessenger.request(
                 "context/loadSubmenuItems",
                 {
                   title: description.title,
                 },
-              )) as WebviewMessengerResult<"context/loadSubmenuItems">;
+              )
 
               if (result.status === "error") {
                 console.error(

--- a/gui/src/pages/edit/EditInputHeader.tsx
+++ b/gui/src/pages/edit/EditInputHeader.tsx
@@ -82,7 +82,7 @@ export function EditInputHeader(editInputHeaderParams: EditInputHeaderParams) {
                     className="h-4 w-4 cursor-pointer px-2"
                     color="red"
                     onClick={() => {
-                      ideMessenger.request("edit/acceptReject", {
+                      ideMessenger.post("edit/acceptReject", {
                         accept: false,
                         onlyFirst: false,
                         filepath: editModeState.highlightedCode.filepath,
@@ -95,7 +95,7 @@ export function EditInputHeader(editInputHeaderParams: EditInputHeaderParams) {
                   <CheckIcon
                     className="h-4 w-4 cursor-pointer px-2 text-green-500"
                     onClick={() => {
-                      ideMessenger.request("edit/acceptReject", {
+                      ideMessenger.post("edit/acceptReject", {
                         accept: true,
                         onlyFirst: false,
                         filepath: editModeState.highlightedCode.filepath,

--- a/gui/src/pages/edit/index.tsx
+++ b/gui/src/pages/edit/index.tsx
@@ -98,7 +98,7 @@ function Edit() {
   // Reusing the applyState logic which was just the fastest way to get this working
   useEffect(() => {
     if (editModeState.editStatus === "done") {
-      ideMessenger.request("edit/escape", undefined);
+      ideMessenger.post("edit/escape", undefined);
       navigate("/");
     }
   }, [editModeState.editStatus]);
@@ -180,7 +180,7 @@ function Edit() {
                   ...contextItems.map((item) => item.content),
                   stripImages(userInstructions),
                 ].join("\n\n");
-                ideMessenger.request("edit/sendPrompt", {
+                ideMessenger.post("edit/sendPrompt", {
                   prompt,
                   range: editModeState.highlightedCode,
                 });


### PR DESCRIPTION
### GUI to IDE/Core
I switched several from `request` to `post` just to be explicit that it won't await

I like this one, I think this should be the go to solution for anything that needs to be triggered by the GUI on startup:
**"onLoad" -> Core sends updates to GUI**

These ones are probably fine since GUI should be locked down and is explicitly a GUI to Core thing

- history/load
- history/delete
- history/save
- history/list

These ones should be removed or refactored to post and then listen for a post from the core rather than locking down the GUI and introducing state race conditions 

- config/getSerializedProfileInfo
- llm/listModels
- getGitHubAuthToken
- update/modelChange
- applyToFile

E.g. apply to file already reacts to apply state updates from core, why is it awaiting this message? onComplete should be triggered in a webview listener based on apply state updates

https://github.com/continuedev/continue/blob/77d0387e4a8cbc59ef9960234fc3a238966cf5db/gui/src/components/markdown/utils/useApplyCodeBlock.ts#L34-L39

### IDE to GUI
No equivalent of "invoke" or "post", so void `request` where relevant

Should add a "post" that doesn't allow awaiting

### IDE to Core
Seems fine, only uses `core.invoke` which has no awaiting. 
I think core.send should be renamed to core.respond since it's unclear that it's responding to a specific message with an id
We should get rid of `ReverseMessageIde`, it's only used for tests and is high maintenance

### Core to IDE

Example here: send is not sending messageId so there's no point in using send, might as well just use request?
https://github.com/continuedev/continue/blob/260c13bd66657b9a058a02de2fc0ed05eb085e16/core/indexing/docs/DocsService.ts

More generally we should make the messaging method naming consistent