### PR TITLE
fix issue: every accepted attribute in the file ~/.continue/dev_data/…

### DIFF
--- a/core/autocomplete/util/AutocompleteLoggingService.ts
+++ b/core/autocomplete/util/AutocompleteLoggingService.ts
@@ -37,6 +37,7 @@ export class AutocompleteLoggingService {
 
     if (this._outcomes.has(completionId)) {
       const outcome = this._outcomes.get(completionId)!;
+      outcome.accepted = true;
       this.logAutocompleteOutcome(outcome);
       this._outcomes.delete(completionId);
       return outcome;
@@ -94,7 +95,6 @@ export class AutocompleteLoggingService {
   }
 
   private logAutocompleteOutcome(outcome: AutocompleteOutcome) {
-    outcome.accepted = true;
     logDevData("autocomplete", outcome);
     const { prompt, completion, prefix, suffix, ...restOfOutcome } = outcome;
     void Telemetry.capture(


### PR DESCRIPTION
## Description

fix issue: every accepted attribute in the file ~/.continue/dev_data/autocomplete.jsonl is true

## Checklist

- [] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing

Accept an autocomplete suggestion and reject an autocomplete suggestion, then watch the file autocomplete.json. The value of accepted attribute is 'right'.
