### PR TITLE
fix: snippets in fim prefix

### DIFF
--- a/core/autocomplete/CompletionProvider.ts
+++ b/core/autocomplete/CompletionProvider.ts
@@ -6,7 +6,7 @@ import { DEFAULT_AUTOCOMPLETE_OPTS } from "../util/parameters.js";
 
 import { shouldCompleteMultiline } from "./classification/shouldCompleteMultiline.js";
 import { AutocompleteLanguageInfo } from "./constants/AutocompleteLanguageInfo.js";
-import { constructAutocompletePrompt } from "./constructPrompt.js";
+import { aggregateSnippets } from "./aggregateSnippets";
 // @prettier-ignore
 
 import { ContextRetrievalService } from "./context/ContextRetrievalService.js";
@@ -176,12 +176,13 @@ export class CompletionProvider {
       // or they might separately track recently edited ranges)
       const extraSnippets = await this._getExtraSnippets(helper);
 
-      let snippets = await constructAutocompletePrompt(
+      let snippets = await aggregateSnippets(
         helper,
         extraSnippets,
         this.contextRetrievalService,
       );
 
+      debugger;
       const { prompt, prefix, suffix, completionOptions } = renderPrompt(
         snippets,
         await this.ide.getWorkspaceDirs(),

--- a/core/autocomplete/aggregateSnippets.ts
+++ b/core/autocomplete/aggregateSnippets.ts
@@ -44,7 +44,7 @@ function getRangeOfPrefixAndSuffixWithBuffer(
   return prefixSuffixRangeWithBuffer;
 }
 
-export async function constructAutocompletePrompt(
+export async function aggregateSnippets(
   helper: HelperVars,
   extraSnippets: AutocompleteSnippet[],
   contextRetrievalService: ContextRetrievalService,


### PR DESCRIPTION
## Description

Snippets weren't being appended to FIM prefix. This is now corrected.

## Checklist

- [] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change. ]
[ For new UI features, ensure that the changes look good across viewport widths, light/dark theme, etc ]
