### PR TITLE
feat: Adding Go to Pre-Indexed Docs

### DIFF
--- a/core/indexing/docs/preIndexedDocs.ts
+++ b/core/indexing/docs/preIndexedDocs.ts
@@ -330,6 +330,12 @@ const preIndexedDocs: Record<
     startUrl: "https://llama-stack.readthedocs.io/",
     rootUrl: "https://llama-stack.readthedocs.io/",
   },
+  "https://go.dev/doc": {
+    title: "Go",
+    startUrl: "https://go.dev/doc",
+    rootUrl: "https://go.dev",
+    faviconUrl: "https://go.dev/favicon.ico",
+  },
 };
 
 export default preIndexedDocs;


### PR DESCRIPTION
## Description

Added Pre-Indexed Documentation for Go (Golang).

## Checklist

- [X] The relevant docs, if any, have been updated or created

## Screenshots

N/A

## Testing

Following the contributor guide, I couldn't find any reference on how to generate pre-indexed docs locally to verify the change.
