### PR TITLE
fix: deduplication bug in autocomplete

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/AutocompleteService.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/AutocompleteService.kt
@@ -129,6 +129,13 @@ class AutocompleteService(private val project: Project) {
                 document.getText(com.intellij.openapi.util.TextRange(caretOffset, document.textLength))
             }
 
+            // Determine the index of a newline character within the text following the cursor.
+            val newlineIndex = textAfterCursor.indexOf("\r\n").takeIf { it >= 0 } ?: textAfterCursor.indexOf('\n')
+            // If a newline character is found and the current line is not empty, truncate the text at that point.
+            if (newlineIndex > 0) {
+                textAfterCursor = textAfterCursor.substring(0, newlineIndex)
+            }
+
             val indexOfTextAfterCursorInCompletion = completion.indexOf(textAfterCursor)
             if (indexOfTextAfterCursorInCompletion > 0) {
                 return@runReadAction completion.slice(0..indexOfTextAfterCursorInCompletion - 1)


### PR DESCRIPTION
## Description

This PR addresses a bug in the autocomplete service where suggestions were not properly deduplicated when the cursor was positioned in the middle of a line. The issue arose because `textAfterCursor` could include newline characters, leading to a mismatch when the completion was only one line: 
https://github.com/continuedev/continue/blob/a9845386f054179651bd1e71e768175a3b873c2e/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/AutocompleteService.kt#L126-L132
By detecting and truncating `textAfterCursor` at the first newline, we ensure that the deduplication process correctly recognizes already existing text after the cursor.

## Checklist

- [] The relevant docs, if any, have been updated or created

## Screenshots
Before: 
![image](https://github.com/user-attachments/assets/3e8490b2-e1a9-4c70-bb13-90ed17be761f)
After:
![image](https://github.com/user-attachments/assets/4dee9780-f82a-462c-b773-302c99141a8b)

## Testing

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change. ]
[ For new UI features, ensure that the changes look good across viewport widths, light/dark theme, etc ]
