### PR TITLE
Flow AbortSignal from IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,7 +142,7 @@ codeql
 .tiktoken_cache
 
 
-# IntelliJ Plugin
+# IntelliJ Plugin 
 **/**/.gradle
 **/**/.qodana
 **/**/build
@@ -169,5 +169,3 @@ extensions/intellij/.idea/**
 
 extensions/intellij/bin
 extensions/.continue-debug/
-
-*.vsix

--- a/core/autocomplete/CompletionProvider.ts
+++ b/core/autocomplete/CompletionProvider.ts
@@ -29,7 +29,6 @@ const autocompleteCache = AutocompleteLruCache.get();
 const ERRORS_TO_IGNORE = [
   // From Ollama
   "unexpected server status",
-  "operation was aborted",
 ];
 
 export type GetLspDefinitionsFunction = (

--- a/core/autocomplete/generation/CompletionStreamer.ts
+++ b/core/autocomplete/generation/CompletionStreamer.ts
@@ -25,13 +25,13 @@ export class CompletionStreamer {
     // Try to reuse pending requests if what the user typed matches start of completion
     const generator = this.generatorReuseManager.getGenerator(
       prefix,
-      (abortSignal: AbortSignal) =>
+      () =>
         llm.supportsFim()
-          ? llm.streamFim(prefix, suffix, abortSignal, completionOptions)
-          : llm.streamComplete(prompt, abortSignal, {
-              ...completionOptions,
-              raw: true,
-            }),
+          ? llm.streamFim(prefix, suffix, completionOptions, token)
+          : llm.streamComplete(prompt, {
+            ...completionOptions,
+            raw: true,
+          }, token),
       multiline,
     );
 
@@ -52,14 +52,14 @@ export class CompletionStreamer {
     const initialGenerator = generatorWithCancellation();
     const transformedGenerator = helper.options.transform
       ? this.streamTransformPipeline.transform(
-          initialGenerator,
-          prefix,
-          suffix,
-          multiline,
-          completionOptions?.stop || [],
-          fullStop,
-          helper,
-        )
+        initialGenerator,
+        prefix,
+        suffix,
+        multiline,
+        completionOptions?.stop || [],
+        fullStop,
+        helper,
+      )
       : initialGenerator;
 
     for await (const update of transformedGenerator) {

--- a/core/autocomplete/generation/CompletionStreamer.ts
+++ b/core/autocomplete/generation/CompletionStreamer.ts
@@ -25,13 +25,13 @@ export class CompletionStreamer {
     // Try to reuse pending requests if what the user typed matches start of completion
     const generator = this.generatorReuseManager.getGenerator(
       prefix,
-      () =>
+      (generatorToken) =>
         llm.supportsFim()
-          ? llm.streamFim(prefix, suffix, completionOptions, token)
+          ? llm.streamFim(prefix, suffix, completionOptions, generatorToken)
           : llm.streamComplete(prompt, {
             ...completionOptions,
             raw: true,
-          }, token),
+          }, generatorToken),
       multiline,
     );
 

--- a/core/autocomplete/generation/GeneratorReuseManager.test.ts
+++ b/core/autocomplete/generation/GeneratorReuseManager.test.ts
@@ -4,7 +4,7 @@ import { GeneratorReuseManager } from "./GeneratorReuseManager";
 function createMockGenerator(
   data: string[],
   delay: number = 0,
-): (abortSignal: AbortSignal) => AsyncGenerator<string> {
+): () => AsyncGenerator<string> {
   const mockGenerator = async function* () {
     for (const chunk of data) {
       yield chunk;

--- a/core/autocomplete/generation/ListenableGenerator.ts
+++ b/core/autocomplete/generation/ListenableGenerator.ts
@@ -3,20 +3,16 @@ export class ListenableGenerator<T> {
   private _buffer: T[] = [];
   private _listeners: Set<(value: T) => void> = new Set();
   private _isEnded = false;
-  private _abortController: AbortController
 
   constructor(
     source: AsyncGenerator<T>,
     private readonly onError: (e: any) => void,
-    abortController: AbortController
   ) {
     this._source = source;
-    this._abortController = abortController;
     this._start();
   }
 
   public cancel() {
-    this._abortController.abort();
     this._isEnded = true;
   }
 

--- a/core/commands/index.ts
+++ b/core/commands/index.ts
@@ -58,7 +58,7 @@ export function slashFromCustomCommand(
         }
       }
 
-      for await (const chunk of llm.streamChat(messages, new AbortController().signal)) {
+      for await (const chunk of llm.streamChat(messages)) {
         yield stripImages(chunk.content);
       }
     },

--- a/core/commands/slash/cmd.ts
+++ b/core/commands/slash/cmd.ts
@@ -24,9 +24,7 @@ const GenerateTerminalCommand: SlashCommand = {
 
 "${input}"
 
-Please write a shell command that will do what the user requested. Your output should consist of only the command itself, without any explanation or example output. Do not use any newlines. Only output the command that when inserted into the terminal will do precisely what was requested. Here is the command:`,
-        new AbortController().signal
-      );
+Please write a shell command that will do what the user requested. Your output should consist of only the command itself, without any explanation or example output. Do not use any newlines. Only output the command that when inserted into the terminal will do precisely what was requested. Here is the command:`);
 
     const lines = streamLines(gen);
     let cmd = "";

--- a/core/commands/slash/commit.ts
+++ b/core/commands/slash/commit.ts
@@ -16,7 +16,7 @@ const CommitMessageCommand: SlashCommand = {
     const prompt = `${diff}\n\nGenerate a commit message for the above set of changes. First, give a single sentence, no more than 80 characters. Then, after 2 line breaks, give a list of no more than 5 short bullet points, each no more than 40 characters. Output nothing except for the commit message, and don't surround it in quotes.`;
     for await (const chunk of llm.streamChat([
       { role: "user", content: prompt },
-    ], new AbortController().signal)) {
+    ])) {
       yield stripImages(chunk.content);
     }
   },

--- a/core/commands/slash/draftIssue.ts
+++ b/core/commands/slash/draftIssue.ts
@@ -30,7 +30,7 @@ const DraftIssueCommand: SlashCommand = {
       return;
     }
     let title = await llm.complete(
-      `Generate a title for the GitHub issue requested in this user input: '${input}'. Use no more than 20 words and output nothing other than the title. Do not surround it with quotes. The title is: `, new AbortController().signal,
+      `Generate a title for the GitHub issue requested in this user input: '${input}'. Use no more than 20 words and output nothing other than the title. Do not surround it with quotes. The title is: `,
       { maxTokens: 20 },
     );
 
@@ -43,7 +43,7 @@ const DraftIssueCommand: SlashCommand = {
       { role: "user", content: PROMPT(input, title) },
     ];
 
-    for await (const chunk of llm.streamChat(messages, new AbortController().signal)) {
+    for await (const chunk of llm.streamChat(messages)) {
       body += chunk.content;
       yield stripImages(chunk.content);
     }

--- a/core/commands/slash/edit.ts
+++ b/core/commands/slash/edit.ts
@@ -480,18 +480,10 @@ const EditSlashCommand: SlashCommand = {
         messages = rendered;
       }
 
-      const completion = llm.streamComplete(
-        rendered as string,
-        new AbortController().signal,
-        {
-          maxTokens: Math.min(
-            maxTokens,
-            Math.floor(llm.contextLength / 2),
-            4096,
-          ),
-          raw: true,
-        },
-      );
+      const completion = llm.streamComplete(rendered as string, {
+        maxTokens: Math.min(maxTokens, Math.floor(llm.contextLength / 2), 4096),
+        raw: true,
+      });
       let lineStream = streamLines(completion);
 
       lineStream = filterEnglishLinesAtStart(lineStream);
@@ -504,18 +496,14 @@ const EditSlashCommand: SlashCommand = {
       );
     } else {
       async function* gen() {
-        for await (const chunk of llm.streamChat(
-          messages,
-          new AbortController().signal,
-          {
-            temperature: 0.5, // TODO
-            maxTokens: Math.min(
-              maxTokens,
-              Math.floor(llm.contextLength / 2),
-              4096,
-            ),
-          },
-        )) {
+        for await (const chunk of llm.streamChat(messages, {
+          temperature: 0.5, // TODO
+          maxTokens: Math.min(
+            maxTokens,
+            Math.floor(llm.contextLength / 2),
+            4096,
+          ),
+        })) {
           yield stripImages(chunk.content);
         }
       }
@@ -623,10 +611,7 @@ ${lines.join("\n")}
 
 Please briefly explain the changes made to the code above. Give no more than 2-3 sentences, and use markdown bullet points:`;
 
-      for await (const update of llm.streamComplete(
-        prompt,
-        new AbortController().signal,
-      )) {
+      for await (const update of llm.streamComplete(prompt)) {
         yield update;
       }
     }

--- a/core/commands/slash/onboard.ts
+++ b/core/commands/slash/onboard.ts
@@ -47,7 +47,7 @@ const OnboardSlashCommand: SlashCommand = {
 
     for await (const chunk of llm.streamChat([
       { role: "user", content: prompt },
-    ], new AbortController().signal)) {
+    ])) {
       yield stripImages(chunk.content);
     }
   },
@@ -134,7 +134,7 @@ function createOnboardingPrompt(context: string): string {
     Your response should be structured, clear, and focused on giving the new developer both a detailed understanding of individual components and a high-level overview of the project as a whole.
 
     Here is an example of a valid response:
-
+    
     ## Important folders
 
     ### /folder1

--- a/core/commands/slash/review.ts
+++ b/core/commands/slash/review.ts
@@ -45,7 +45,7 @@ const ReviewMessageCommand: SlashCommand = {
 
     for await (const chunk of llm.streamChat([
       { role: "user", content: content },
-    ], new AbortController().signal)) {
+    ])) {
       yield stripImages(chunk.content);
     }
   },

--- a/core/config/promptFile.ts
+++ b/core/config/promptFile.ts
@@ -125,7 +125,7 @@ export function slashCommandFromPromptFile(
         systemMessage,
       );
 
-      for await (const chunk of context.llm.streamChat(messages, new AbortController().signal)) {
+      for await (const chunk of context.llm.streamChat(messages)) {
         yield stripImages(chunk.content);
       }
 

--- a/core/context/rerankers/llm.ts
+++ b/core/context/rerankers/llm.ts
@@ -6,7 +6,7 @@ const RERANK_PROMPT = (
   documentId: string,
   document: string,
 ) => `You are an expert software developer responsible for helping detect whether the retrieved snippet of code is relevant to the query. For a given input, you need to output a single word: "Yes" or "No" indicating the retrieved snippet is relevant to the query.
-
+  
   Query: Where is the FastAPI server?
   Snippet:
   \`\`\`/Users/andrew/Desktop/server/main.py
@@ -17,7 +17,7 @@ const RERANK_PROMPT = (
       return {{"Hello": "World"}}
   \`\`\`
   Relevant: Yes
-
+  
   Query: Where in the documentation does it talk about the UI?
   Snippet:
   \`\`\`/Users/andrew/Projects/bubble_sort/src/lib.rs
@@ -32,13 +32,13 @@ const RERANK_PROMPT = (
   }}
   \`\`\`
   Relevant: No
-
+  
   Query: ${query}
   Snippet:
   \`\`\`${documentId}
   ${document}
   \`\`\`
-  Relevant:
+  Relevant: 
   `;
 
 export class LLMReranker implements Reranker {
@@ -49,7 +49,6 @@ export class LLMReranker implements Reranker {
   async scoreChunk(chunk: Chunk, query: string): Promise<number> {
     const completion = await this.llm.complete(
       RERANK_PROMPT(query, getBasename(chunk.filepath), chunk.content),
-      new AbortController().signal,
       {
         maxTokens: 1,
         model:

--- a/core/context/retrieval/repoMapRequest.ts
+++ b/core/context/retrieval/repoMapRequest.ts
@@ -61,7 +61,7 @@ This is the question that you should select relevant files for: "${input}"`;
     const response = await llm.chat([
       { role: "user", content: prompt },
       { role: "assistant", content: "<reasoning>" },
-    ], new AbortController().signal);
+    ]);
     const content = stripImages(response.content);
     console.debug("Repo map retrieval response: ", content);
 

--- a/core/core.ts
+++ b/core/core.ts
@@ -387,7 +387,6 @@ export class Core {
       const model = await configHandler.llmFromTitle(msg.data.title);
       const gen = model.streamChat(
         msg.data.messages,
-        new AbortController().signal,
         msg.data.completionOptions,
       );
       let next = await gen.next();
@@ -429,7 +428,6 @@ export class Core {
       const model = await configHandler.llmFromTitle(msg.data.title);
       const gen = model.streamComplete(
         msg.data.prompt,
-        new AbortController().signal,
         msg.data.completionOptions,
       );
       let next = await gen.next();
@@ -462,7 +460,6 @@ export class Core {
       const model = await this.configHandler.llmFromTitle(msg.data.title);
       const completion = await model.complete(
         msg.data.prompt,
-        new AbortController().signal,
         msg.data.completionOptions,
       );
       return completion;

--- a/core/edit/lazy/replace.ts
+++ b/core/edit/lazy/replace.ts
@@ -86,7 +86,7 @@ export async function* getReplacementWithLlm(
   const completion = await llm.streamChat([
     { role: "user", content: userPrompt },
     { role: "assistant", content: assistantPrompt },
-  ], new AbortController().signal);
+  ]);
 
   let lines = streamLines(completion);
   lines = filterLeadingNewline(lines);

--- a/core/edit/lazy/streamLazyApply.ts
+++ b/core/edit/lazy/streamLazyApply.ts
@@ -23,7 +23,7 @@ export async function* streamLazyApply(
   }
 
   const promptMessages = promptFactory(oldCode, filename, newCode);
-  const lazyCompletion = llm.streamChat(promptMessages, new AbortController().signal);
+  const lazyCompletion = llm.streamChat(promptMessages);
 
   // Do find and replace over the lazy edit response
   async function* replacementFunction(

--- a/core/edit/streamDiffLines.ts
+++ b/core/edit/streamDiffLines.ts
@@ -96,8 +96,8 @@ export async function* streamDiffLines(
 
   const completion =
     typeof prompt === "string"
-      ? llm.streamComplete(prompt,  new AbortController().signal, { raw: true, prediction })
-      : llm.streamChat(prompt,  new AbortController().signal, {
+      ? llm.streamComplete(prompt, { raw: true, prediction })
+      : llm.streamChat(prompt, {
           prediction,
         });
 

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -105,33 +105,33 @@ export interface ILLM extends LLMOptions {
 
   complete(
     prompt: string,
-    signal: AbortSignal,
     options?: LLMFullCompletionOptions,
+    token?: AbortSignal
   ): Promise<string>;
 
   streamComplete(
     prompt: string,
-    signal: AbortSignal,
     options?: LLMFullCompletionOptions,
+    token?: AbortSignal
   ): AsyncGenerator<string, PromptLog>;
 
   streamFim(
     prefix: string,
     suffix: string,
-    signal: AbortSignal,
     options?: LLMFullCompletionOptions,
+    token?: AbortSignal
   ): AsyncGenerator<string, PromptLog>;
 
   streamChat(
     messages: ChatMessage[],
-    signal: AbortSignal,
     options?: LLMFullCompletionOptions,
+    token?: AbortSignal
   ): AsyncGenerator<ChatMessage, PromptLog>;
 
   chat(
     messages: ChatMessage[],
-    signal: AbortSignal,
     options?: LLMFullCompletionOptions,
+    token?: AbortSignal
   ): Promise<ChatMessage>;
 
   countTokens(text: string): number;
@@ -427,13 +427,11 @@ export interface CustomLLMWithOptionals {
   options: LLMOptions;
   streamCompletion?: (
     prompt: string,
-    signal: AbortSignal,
     options: CompletionOptions,
     fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
   ) => AsyncGenerator<string>;
   streamChat?: (
     messages: ChatMessage[],
-    signal: AbortSignal,
     options: CompletionOptions,
     fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
   ) => AsyncGenerator<string>;
@@ -545,10 +543,10 @@ export interface IDE {
   getCurrentFile(): Promise<
     | undefined
     | {
-        isUntitled: boolean;
-        path: string;
-        contents: string;
-      }
+      isUntitled: boolean;
+      path: string;
+      contents: string;
+    }
   >;
   getPinnedFiles(): Promise<string[]>;
   getSearchResults(query: string): Promise<string>;
@@ -851,11 +849,11 @@ export interface CustomCommand {
 interface Prediction {
   type: "content";
   content:
-    | string
-    | {
-        type: "text";
-        text: string;
-      }[];
+  | string
+  | {
+    type: "text";
+    text: string;
+  }[];
 }
 
 interface BaseCompletionOptions {
@@ -1167,9 +1165,9 @@ export interface Config {
   embeddingsProvider?: EmbeddingsProviderDescription | EmbeddingsProvider;
   /** The model that Continue will use for tab autocompletions. */
   tabAutocompleteModel?:
-    | CustomLLM
-    | ModelDescription
-    | (CustomLLM | ModelDescription)[];
+  | CustomLLM
+  | ModelDescription
+  | (CustomLLM | ModelDescription)[];
   /** Options for tab autocomplete */
   tabAutocompleteOptions?: Partial<TabAutocompleteOptions>;
   /** UI styles customization */

--- a/core/llm/llms/Asksage.ts
+++ b/core/llm/llms/Asksage.ts
@@ -98,8 +98,8 @@ class Asksage extends BaseLLM {
 
   protected async _complete(
     prompt: string,
-    signal: AbortSignal,
-    options: CompletionOptions
+    options: CompletionOptions,
+    token?: AbortSignal
   ): Promise<string> {
     if (typeof prompt !== "string" || prompt.trim() === "") {
       throw new Error("Prompt must be a non-empty string.");
@@ -113,6 +113,7 @@ class Asksage extends BaseLLM {
       method: "POST",
       headers: this._getHeaders(),
       body: JSON.stringify(args),
+      signal: token
     });
 
     if (!response.ok) {
@@ -127,17 +128,17 @@ class Asksage extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
-    signal: AbortSignal,
-    options: CompletionOptions
+    options: CompletionOptions,
+    token?: AbortSignal
   ): AsyncGenerator<string> {
-    const completion = await this._complete(prompt, signal, options);
+    const completion = await this._complete(prompt, options, token);
     yield completion;
   }
 
   protected async *_streamChat(
     messages: ChatMessage[],
-    signal: AbortSignal,
-    options: CompletionOptions
+    options: CompletionOptions,
+    token?: AbortSignal
   ): AsyncGenerator<ChatMessage> {
     const args = this._convertArgs(options, messages);
 
@@ -145,7 +146,7 @@ class Asksage extends BaseLLM {
       method: "POST",
       headers: this._getHeaders(),
       body: JSON.stringify(args),
-      signal
+      signal: token
     });
 
     if (!response.ok) {

--- a/core/llm/llms/Bedrock.ts
+++ b/core/llm/llms/Bedrock.ts
@@ -42,19 +42,19 @@ class Bedrock extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
-    signal: AbortSignal,
     options: CompletionOptions,
+    token?: AbortSignal
   ): AsyncGenerator<string> {
     const messages = [{ role: "user" as const, content: prompt }];
-    for await (const update of this._streamChat(messages, signal, options)) {
+    for await (const update of this._streamChat(messages, options, token)) {
       yield stripImages(update.content);
     }
   }
 
   protected async *_streamChat(
     messages: ChatMessage[],
-    signal: AbortSignal,
     options: CompletionOptions,
+    token?: AbortSignal | null
   ): AsyncGenerator<ChatMessage> {
     const credentials = await this._getCredentials();
 
@@ -91,7 +91,7 @@ class Bedrock extends BaseLLM {
 
     const input = this._generateConverseInput(messages, options);
     const command = new ConverseStreamCommand(input);
-    const response = await client.send(command, { abortSignal: signal});
+    const response = await client.send(command, { abortSignal: token ? token : undefined });
 
     if (response.stream) {
       for await (const chunk of response.stream) {

--- a/core/llm/llms/BedrockImport.ts
+++ b/core/llm/llms/BedrockImport.ts
@@ -37,8 +37,8 @@ class BedrockImport extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
-    signal: AbortSignal,
     options: CompletionOptions,
+    token?: AbortSignal
   ): AsyncGenerator<string> {
     const credentials = await this._getCredentials();
     const client = new BedrockRuntimeClient({
@@ -52,7 +52,7 @@ class BedrockImport extends BaseLLM {
 
     const input = this._generateInvokeModelCommandInput(prompt, options);
     const command = new InvokeModelWithResponseStreamCommand(input);
-    const response = await client.send(command, {abortSignal: signal});
+    const response = await client.send(command, { abortSignal: token });
 
     if (response.body) {
       for await (const item of response.body) {
@@ -83,10 +83,10 @@ class BedrockImport extends BaseLLM {
   private async _getCredentials() {
     try {
       return await
-      fromIni({
-        profile: this.profile,
-        ignoreCache: true
-      })();
+        fromIni({
+          profile: this.profile,
+          ignoreCache: true
+        })();
     } catch (e) {
       console.warn(
         `AWS profile with name ${this.profile} not found in ~/.aws/credentials, using default profile`,

--- a/core/llm/llms/Deepseek.ts
+++ b/core/llm/llms/Deepseek.ts
@@ -20,11 +20,11 @@ class Deepseek extends OpenAI {
     return true;
   }
 
-  async *_streamFim(
+  protected async *_streamFim(
     prefix: string,
     suffix: string,
-    signal: AbortSignal,
     options: CompletionOptions,
+    token?: AbortSignal
   ): AsyncGenerator<string> {
     const endpoint = new URL("beta/completions", this.apiBase);
     const resp = await this.fetch(endpoint, {
@@ -46,9 +46,8 @@ class Deepseek extends OpenAI {
         Accept: "application/json",
         Authorization: `Bearer ${this.apiKey}`,
       },
-      signal
     });
-    for await (const chunk of streamSse(resp)) {
+    for await (const chunk of streamSse(resp, token ? token : null)) {
       yield chunk.choices[0].text;
     }
   }

--- a/core/llm/llms/FreeTrial.ts
+++ b/core/llm/llms/FreeTrial.ts
@@ -60,8 +60,8 @@ class FreeTrial extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
-    signal: AbortSignal,
     options: CompletionOptions,
+    token?: AbortSignal
   ): AsyncGenerator<string> {
     const args = this._convertArgs(this.collectArgs(options));
 
@@ -74,11 +74,11 @@ class FreeTrial extends BaseLLM {
         prompt,
         ...args,
       }),
-      signal
+      signal: token
     });
 
     let completion = "";
-    for await (const value of streamResponse(response)) {
+    for await (const value of streamResponse(response, token ? token : null)) {
       yield value;
       completion += value;
     }
@@ -105,8 +105,8 @@ class FreeTrial extends BaseLLM {
 
   protected async *_streamChat(
     messages: ChatMessage[],
-    signal: AbortSignal,
     options: CompletionOptions,
+    token?: AbortSignal
   ): AsyncGenerator<ChatMessage> {
     const args = this._convertArgs(this.collectArgs(options));
 
@@ -123,11 +123,10 @@ class FreeTrial extends BaseLLM {
         messages: messages.map(this._convertMessage),
         ...args,
       }),
-      signal
     });
 
     let completion = "";
-    for await (const chunk of streamResponse(response)) {
+    for await (const chunk of streamResponse(response, token ? token : null)) {
       yield {
         role: "assistant",
         content: chunk,
@@ -144,8 +143,8 @@ class FreeTrial extends BaseLLM {
   async *_streamFim(
     prefix: string,
     suffix: string,
-    signal: AbortSignal,
     options: CompletionOptions,
+    token?: AbortSignal
   ): AsyncGenerator<string> {
     const args = this._convertArgs(this.collectArgs(options));
 
@@ -158,11 +157,11 @@ class FreeTrial extends BaseLLM {
           suffix,
           ...args,
         }),
-        signal
+        signal: token
       });
 
       let completion = "";
-      for await (const value of streamResponse(resp)) {
+      for await (const value of streamResponse(resp, token ? token : null)) {
         yield value;
         completion += value;
       }

--- a/core/llm/llms/HuggingFaceInferenceAPI.ts
+++ b/core/llm/llms/HuggingFaceInferenceAPI.ts
@@ -16,8 +16,8 @@ class HuggingFaceInferenceAPI extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
-    signal: AbortSignal,
     options: CompletionOptions,
+    token?: AbortSignal
   ): AsyncGenerator<string> {
     if (!this.apiBase) {
       throw new Error(
@@ -37,11 +37,11 @@ class HuggingFaceInferenceAPI extends BaseLLM {
         stream: true,
         parameters: this._convertArgs(options),
       }),
-      signal
+      signal: token
     });
 
     async function* stream() {
-      for await (const chunk of streamSse(response)) {
+      for await (const chunk of streamSse(response, token ? token : null)) {
         const text = chunk?.token?.text ?? "";
         if (text.endsWith("</s>")) {
           yield text.slice(0, -5);

--- a/core/llm/llms/HuggingFaceTGI.ts
+++ b/core/llm/llms/HuggingFaceTGI.ts
@@ -48,8 +48,8 @@ class HuggingFaceTGI extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
-    signal: AbortSignal,
     options: CompletionOptions,
+    token?: AbortSignal
   ): AsyncGenerator<string> {
     const args = this._convertArgs(options, prompt);
 
@@ -61,11 +61,11 @@ class HuggingFaceTGI extends BaseLLM {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({ inputs: prompt, parameters: args }),
-        signal
+        signal: token
       },
     );
 
-    for await (const value of streamSse(response)) {
+    for await (const value of streamSse(response, token ? token : null)) {
       yield value.token.text;
     }
   }

--- a/core/llm/llms/LlamaCpp.ts
+++ b/core/llm/llms/LlamaCpp.ts
@@ -26,8 +26,8 @@ class LlamaCpp extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
-    signal: AbortSignal,
     options: CompletionOptions,
+    token?: AbortSignal
   ): AsyncGenerator<string> {
     const headers = {
       "Content-Type": "application/json",
@@ -43,10 +43,10 @@ class LlamaCpp extends BaseLLM {
         stream: true,
         ...this._convertArgs(options, prompt),
       }),
-      signal
+      signal: token
     });
 
-    for await (const value of streamSse(resp)) {
+    for await (const value of streamSse(resp, token ? token : null)) {
       if (value.content) {
         yield value.content;
       }

--- a/core/llm/llms/Mock.ts
+++ b/core/llm/llms/Mock.ts
@@ -7,16 +7,16 @@ class Mock extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
-    signal: AbortSignal,
     options: CompletionOptions,
+    token?: AbortSignal
   ): AsyncGenerator<string> {
     yield this.completion;
   }
 
   protected async *_streamChat(
     messages: ChatMessage[],
-    signal: AbortSignal,
     options: CompletionOptions,
+    token?: AbortSignal
   ): AsyncGenerator<ChatMessage> {
     for (const char of this.completion) {
       yield {

--- a/core/llm/llms/Moonshot.ts
+++ b/core/llm/llms/Moonshot.ts
@@ -23,8 +23,8 @@ class Moonshot extends OpenAI {
   async *_streamFim(
     prefix: string,
     suffix: string,
-    signal: AbortSignal,
     options: CompletionOptions,
+    token?: AbortSignal
   ): AsyncGenerator<string> {
     const endpoint = new URL("v1/chat/completions", this.apiBase);
     const resp = await this.fetch(endpoint, {
@@ -50,9 +50,9 @@ class Moonshot extends OpenAI {
         Accept: "application/json",
         Authorization: `Bearer ${this.apiKey}`,
       },
-      signal
+      signal: token
     });
-    for await (const chunk of streamSse(resp)) {
+    for await (const chunk of streamSse(resp, token ? token : null)) {
       yield chunk.choices[0].delta.content;
     }
   }

--- a/core/llm/llms/Ollama.ts
+++ b/core/llm/llms/Ollama.ts
@@ -77,6 +77,7 @@ class Ollama extends BaseLLM {
     if (options.model === "AUTODETECT") {
       return;
     }
+
     this.fetch(this.getEndpoint("api/show"), {
       method: "POST",
       headers: {
@@ -261,8 +262,8 @@ class Ollama extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
-    signal: AbortSignal,
     options: CompletionOptions,
+    token?: AbortSignal
   ): AsyncGenerator<string> {
     const response = await this.fetch(this.getEndpoint("api/generate"), {
       method: "POST",
@@ -271,11 +272,11 @@ class Ollama extends BaseLLM {
         Authorization: `Bearer ${this.apiKey}`,
       },
       body: JSON.stringify(this._getGenerateOptions(options, prompt)),
-      signal
+      signal: token
     });
 
     let buffer = "";
-    for await (const value of streamResponse(response)) {
+    for await (const value of streamResponse(response, token ? token : null)) {
       // Append the received chunk to the buffer
       buffer += value;
       // Split the buffer into individual JSON chunks
@@ -302,8 +303,8 @@ class Ollama extends BaseLLM {
 
   protected async *_streamChat(
     messages: ChatMessage[],
-    signal: AbortSignal,
     options: CompletionOptions,
+    token?: AbortSignal
   ): AsyncGenerator<ChatMessage> {
     const response = await this.fetch(this.getEndpoint("api/chat"), {
       method: "POST",
@@ -312,11 +313,11 @@ class Ollama extends BaseLLM {
         Authorization: `Bearer ${this.apiKey}`,
       },
       body: JSON.stringify(this._getChatOptions(options, messages)),
-      signal
+      signal: token
     });
 
     let buffer = "";
-    for await (const value of streamResponse(response)) {
+    for await (const value of streamResponse(response, token ? token : null)) {
       // Append the received chunk to the buffer
       buffer += value;
       // Split the buffer into individual JSON chunks
@@ -351,10 +352,9 @@ class Ollama extends BaseLLM {
   protected async *_streamFim(
     prefix: string,
     suffix: string,
-    signal: AbortSignal,
     options: CompletionOptions,
+    token?: AbortSignal
   ): AsyncGenerator<string> {
-
     const response = await this.fetch(this.getEndpoint("api/generate"), {
       method: "POST",
       headers: {
@@ -362,11 +362,11 @@ class Ollama extends BaseLLM {
         Authorization: `Bearer ${this.apiKey}`,
       },
       body: JSON.stringify(this._getGenerateOptions(options, prefix, suffix)),
-      signal
+      signal: token
     });
 
     let buffer = "";
-    for await (const value of streamResponse(response)) {
+    for await (const value of streamResponse(response, token ? token : null)) {
       // Append the received chunk to the buffer
       buffer += value;
       // Split the buffer into individual JSON chunks

--- a/core/llm/llms/Replicate.ts
+++ b/core/llm/llms/Replicate.ts
@@ -7,33 +7,33 @@ class Replicate extends BaseLLM {
   private static MODEL_IDS: {
     [name: string]: `${string}/${string}:${string}`;
   } = {
-    "codellama-7b":
-      "meta/codellama-7b-instruct:aac3ab196f8a75729aab9368cd45ea6ad3fc793b6cda93b1ded17299df369332",
-    "codellama-13b":
-      "meta/codellama-13b-instruct:a5e2d67630195a09b96932f5fa541fe64069c97d40cd0b69cdd91919987d0e7f",
-    "codellama-34b":
-      "meta/codellama-34b-instruct:eeb928567781f4e90d2aba57a51baef235de53f907c214a4ab42adabf5bb9736",
-    "codellama-70b":
-      "meta/codellama-70b-instruct:a279116fe47a0f65701a8817188601e2fe8f4b9e04a518789655ea7b995851bf",
-    "llama2-7b": "meta/llama-2-7b-chat" as any,
-    "llama2-13b": "meta/llama-2-13b-chat" as any,
-    "llama3-8b": "meta/meta-llama-3-8b-instruct" as any,
-    "llama3-70b": "meta/meta-llama-3-70b-instruct" as any,
-    "llama3.1-8b": "meta/meta-llama-3.1-8b-instruct" as any,
-    "llama3.1-70b": "meta/meta-llama-3.1-70b-instruct" as any,
-    "llama3.1-405b": "meta/meta-llama-3.1-405b-instruct" as any,
-    "zephyr-7b":
-      "nateraw/zephyr-7b-beta:b79f33de5c6c4e34087d44eaea4a9d98ce5d3f3a09522f7328eea0685003a931",
-    "mistral-7b":
-      "mistralai/mistral-7b-instruct-v0.1:83b6a56e7c828e667f21fd596c338fd4f0039b46bcfa18d973e8e70e455fda70",
-    "mistral-8x7b": "mistralai/mixtral-8x7b-instruct-v0.1" as any,
-    "wizardcoder-34b":
-      "andreasjansson/wizardcoder-python-34b-v1-gguf:67eed332a5389263b8ede41be3ee7dc119fa984e2bde287814c4abed19a45e54",
-    "neural-chat-7b":
-      "tomasmcm/neural-chat-7b-v3-1:acb450496b49e19a1e410b50c574a34acacd54820bc36c19cbfe05148de2ba57",
-    "deepseek-7b": "kcaverly/deepseek-coder-33b-instruct-gguf" as any,
-    "phind-codellama-34b": "kcaverly/phind-codellama-34b-v2-gguf" as any,
-  };
+      "codellama-7b":
+        "meta/codellama-7b-instruct:aac3ab196f8a75729aab9368cd45ea6ad3fc793b6cda93b1ded17299df369332",
+      "codellama-13b":
+        "meta/codellama-13b-instruct:a5e2d67630195a09b96932f5fa541fe64069c97d40cd0b69cdd91919987d0e7f",
+      "codellama-34b":
+        "meta/codellama-34b-instruct:eeb928567781f4e90d2aba57a51baef235de53f907c214a4ab42adabf5bb9736",
+      "codellama-70b":
+        "meta/codellama-70b-instruct:a279116fe47a0f65701a8817188601e2fe8f4b9e04a518789655ea7b995851bf",
+      "llama2-7b": "meta/llama-2-7b-chat" as any,
+      "llama2-13b": "meta/llama-2-13b-chat" as any,
+      "llama3-8b": "meta/meta-llama-3-8b-instruct" as any,
+      "llama3-70b": "meta/meta-llama-3-70b-instruct" as any,
+      "llama3.1-8b": "meta/meta-llama-3.1-8b-instruct" as any,
+      "llama3.1-70b": "meta/meta-llama-3.1-70b-instruct" as any,
+      "llama3.1-405b": "meta/meta-llama-3.1-405b-instruct" as any,
+      "zephyr-7b":
+        "nateraw/zephyr-7b-beta:b79f33de5c6c4e34087d44eaea4a9d98ce5d3f3a09522f7328eea0685003a931",
+      "mistral-7b":
+        "mistralai/mistral-7b-instruct-v0.1:83b6a56e7c828e667f21fd596c338fd4f0039b46bcfa18d973e8e70e455fda70",
+      "mistral-8x7b": "mistralai/mixtral-8x7b-instruct-v0.1" as any,
+      "wizardcoder-34b":
+        "andreasjansson/wizardcoder-python-34b-v1-gguf:67eed332a5389263b8ede41be3ee7dc119fa984e2bde287814c4abed19a45e54",
+      "neural-chat-7b":
+        "tomasmcm/neural-chat-7b-v3-1:acb450496b49e19a1e410b50c574a34acacd54820bc36c19cbfe05148de2ba57",
+      "deepseek-7b": "kcaverly/deepseek-coder-33b-instruct-gguf" as any,
+      "phind-codellama-34b": "kcaverly/phind-codellama-34b-v2-gguf" as any,
+    };
 
   static providerName: ModelProvider = "replicate";
   private _replicate: ReplicateClient;
@@ -41,13 +41,13 @@ class Replicate extends BaseLLM {
   private _convertArgs(
     options: CompletionOptions,
     prompt: string,
-    signal: AbortSignal
-  ): [`${string}/${string}:${string}`, { input: any, signal: AbortSignal }] {
+    token?: AbortSignal
+  ): [`${string}/${string}:${string}`, { input: any, signal: AbortSignal | undefined }] {
     return [
       Replicate.MODEL_IDS[options.model] || (options.model as any),
       {
         input: { prompt, message: prompt },
-        signal
+        signal: token
       },
     ];
   }
@@ -59,21 +59,21 @@ class Replicate extends BaseLLM {
 
   protected async _complete(
     prompt: string,
-    signal: AbortSignal,
     options: CompletionOptions,
+    token?: AbortSignal
   ): Promise<string> {
-    const [model, args] = this._convertArgs(options, prompt, signal);
-    const response = await this._replicate.run(model, args);
+    const [model, args] = this._convertArgs(options, prompt, token);
+    const response = await this._replicate.run(model, { ...args, signal: token });
 
     return (response as any)[0];
   }
 
   protected async *_streamComplete(
     prompt: string,
-    signal: AbortSignal,
     options: CompletionOptions,
+    token?: AbortSignal
   ): AsyncGenerator<string> {
-    const [model, args] = this._convertArgs(options, prompt, signal);
+    const [model, args] = this._convertArgs(options, prompt, token);
     for await (const event of this._replicate.stream(model, args)) {
       if (event.event === "output") {
         yield event.data;

--- a/core/llm/llms/SageMaker.ts
+++ b/core/llm/llms/SageMaker.ts
@@ -32,8 +32,8 @@ class SageMaker extends BaseLLM {
 
   protected async *_streamComplete(
     prompt: string,
-    signal: AbortSignal,
     options: CompletionOptions,
+    token?: AbortSignal
   ): AsyncGenerator<string> {
     const credentials = await this._getCredentials();
     const client = new SageMakerRuntimeClient({
@@ -46,7 +46,7 @@ class SageMaker extends BaseLLM {
     });
     const toolkit = new CompletionAPIToolkit(this);
     const command = toolkit.generateCommand([], prompt, options);
-    const response = await client.send(command, { abortSignal: signal });
+    const response = await client.send(command, { abortSignal: token });
     if (response.Body) {
       let buffer = "";
       for await (const rawValue of response.Body) {
@@ -83,8 +83,8 @@ class SageMaker extends BaseLLM {
 
   protected async *_streamChat(
     messages: ChatMessage[],
-    signal: AbortSignal,
     options: CompletionOptions,
+    token?: AbortSignal
   ): AsyncGenerator<ChatMessage> {
     const credentials = await this._getCredentials();
     const client = new SageMakerRuntimeClient({
@@ -98,7 +98,7 @@ class SageMaker extends BaseLLM {
     const toolkit = new MessageAPIToolkit(this);
 
     const command = toolkit.generateCommand(messages, "", options);
-    const response = await client.send(command, { abortSignal: signal });
+    const response = await client.send(command, { abortSignal: token });
     if (response.Body) {
       let buffer = "";
       for await (const rawValue of response.Body) {

--- a/core/llm/llms/Together.ts
+++ b/core/llm/llms/Together.ts
@@ -41,10 +41,10 @@ class Together extends OpenAI {
 
   protected async *_streamComplete(
     prompt: string,
-    signal: AbortSignal,
     options: CompletionOptions,
+    token?: AbortSignal
   ): AsyncGenerator<string> {
-    for await (const chunk of this._legacystreamComplete(prompt,signal, options)) {
+    for await (const chunk of this._legacystreamComplete(prompt, options, token)) {
       yield chunk;
     }
   }

--- a/core/llm/stream.ts
+++ b/core/llm/stream.ts
@@ -4,7 +4,7 @@ async function* toAsyncIterable(nodeReadable: NodeJS.ReadableStream): AsyncGener
   }
 }
 
-export async function* streamResponse(response: Response): AsyncGenerator<string> {
+export async function* streamResponse(response: Response, token: AbortSignal | null): AsyncGenerator<string> {
   if (response.status !== 200) {
     throw new Error(await response.text());
   }
@@ -63,9 +63,9 @@ function parseSseLine(line: string): { done: boolean; data: any } {
   return { done: false, data: undefined };
 }
 
-export async function* streamSse(response: Response): AsyncGenerator<any> {
+export async function* streamSse(response: Response, token: AbortSignal | null): AsyncGenerator<any> {
   let buffer = "";
-  for await (const value of streamResponse(response)) {
+  for await (const value of streamResponse(response, token)) {
     buffer += value;
 
     let position: number;
@@ -91,9 +91,9 @@ export async function* streamSse(response: Response): AsyncGenerator<any> {
   }
 }
 
-export async function* streamJSON(response: Response): AsyncGenerator<any> {
+export async function* streamJSON(response: Response, token: AbortSignal | null): AsyncGenerator<any> {
   let buffer = "";
-  for await (const value of streamResponse(response)) {
+  for await (const value of streamResponse(response, token)) {
     buffer += value;
 
     let position;

--- a/core/promptFiles/v1/slashCommandFromPromptFile.ts
+++ b/core/promptFiles/v1/slashCommandFromPromptFile.ts
@@ -90,7 +90,7 @@ export function slashCommandFromPromptFile(
         systemMessage,
       );
 
-      for await (const chunk of context.llm.streamChat(messages, new AbortController().signal)) {
+      for await (const chunk of context.llm.streamChat(messages)) {
         yield stripImages(chunk.content);
       }
     },

--- a/core/util/chatDescriber.ts
+++ b/core/util/chatDescriber.ts
@@ -52,7 +52,6 @@ export class ChatDescriber {
           content: ChatDescriber.prompt + message,
         },
       ],
-      new AbortController().signal,
       completionOptions,
     );
 

--- a/core/util/fetchWithOptions.ts
+++ b/core/util/fetchWithOptions.ts
@@ -45,7 +45,7 @@ export function fetchwithRequestOptions(
 
   const timeout = (requestOptions?.timeout ?? TIMEOUT) * 1000; // measured in ms
 
-  const agentOptions: {[key: string]: any} = {
+  const agentOptions: { [key: string]: any } = {
     ca,
     rejectUnauthorized: requestOptions?.verifySsl,
     timeout,
@@ -55,10 +55,10 @@ export function fetchwithRequestOptions(
   };
 
   // Handle ClientCertificateOptions
-  if (requestOptions?.clientCertificate){
-    agentOptions.cert = fs.readFileSync(requestOptions.clientCertificate.cert,"utf8");
-    agentOptions.key = fs.readFileSync(requestOptions.clientCertificate.key,"utf8");
-    if(requestOptions.clientCertificate.passphrase){
+  if (requestOptions?.clientCertificate) {
+    agentOptions.cert = fs.readFileSync(requestOptions.clientCertificate.cert, "utf8");
+    agentOptions.key = fs.readFileSync(requestOptions.clientCertificate.key, "utf8");
+    if (requestOptions.clientCertificate.passphrase) {
       agentOptions.passphrase = requestOptions.clientCertificate.passphrase;
     }
   }


### PR DESCRIPTION
## Description

#2935 had some `AbortController`s with no way to call `abort()` on it. This PR fixes that and only adds AbortSignal where it makes sense. For future proofing, AbortSignal is also passed down to `core/llm/stream.ts` functions.

The abort error that shows up in debug console is also removed.

## Testing

- Tested with `ollama serve`. No requests are left open. Cached completions still work. No regressions are detected so far with manual testing.