### PR TITLE
fix getTheme to respect preferred mode

### DIFF
--- a/extensions/vscode/src/ContinueGUIWebviewViewProvider.ts
+++ b/extensions/vscode/src/ContinueGUIWebviewViewProvider.ts
@@ -168,7 +168,15 @@ export class ContinueGUIWebviewViewProvider
 
     const currentTheme = getTheme();
     vscode.workspace.onDidChangeConfiguration((e) => {
-      if (e.affectsConfiguration("workbench.colorTheme")) {
+      if (
+        e.affectsConfiguration("workbench.colorTheme") ||
+        e.affectsConfiguration("window.autoDetectColorScheme") ||
+        e.affectsConfiguration("window.autoDetectHighContrast") ||
+        e.affectsConfiguration("workbench.preferredDarkColorTheme") ||
+        e.affectsConfiguration("workbench.preferredLightColorTheme") ||
+        e.affectsConfiguration("workbench.preferredHighContrastColorTheme") ||
+        e.affectsConfiguration("workbench.preferredHighContrastLightColorTheme")
+      ) {
         // Send new theme to GUI to update embedded Monaco themes
         this.webviewProtocol?.request("setTheme", { theme: getTheme() });
       }
@@ -188,7 +196,7 @@ export class ContinueGUIWebviewViewProvider
       </head>
       <body>
         <div id="root"></div>
-        
+
         ${
           inDevelopmentMode
             ? `<script type="module">

--- a/extensions/vscode/src/util/getTheme.ts
+++ b/extensions/vscode/src/util/getTheme.ts
@@ -70,7 +70,7 @@ export function getTheme() {
         break;
       case vscode.ColorThemeKind.HighContrastLight:
         colorTheme = workbenchConfig.get<string>(
-          "workbench.preferredHighContrastColorTheme",
+          "workbench.preferredHighContrastLightColorTheme",
         );
         break;
       default:

--- a/extensions/vscode/src/util/getTheme.ts
+++ b/extensions/vscode/src/util/getTheme.ts
@@ -36,9 +36,55 @@ function parseThemeString(themeString: string | undefined): any {
 
 export function getTheme() {
   let currentTheme = undefined;
-  const colorTheme =
-    vscode.workspace.getConfiguration("workbench").get<string>("colorTheme") ||
-    "Default Dark Modern";
+  // Get color theme from settings
+  // use user settings if available
+  // otherwise use default
+  let colorTheme: string | undefined = undefined;
+
+  // Get color theme from settings
+  const workbenchConfig = vscode.workspace.getConfiguration();
+  const autoDetectColorScheme = workbenchConfig.get<boolean>(
+    "window.autoDetectColorScheme",
+  );
+  const autoDetectHighContrast = workbenchConfig.get<boolean>(
+    "window.autoDetectHighContrast",
+  );
+  const activeColorTheme = vscode.window.activeColorTheme.kind;
+
+  if (autoDetectHighContrast || autoDetectColorScheme) {
+    switch (activeColorTheme) {
+      case vscode.ColorThemeKind.Dark:
+        colorTheme = workbenchConfig.get<string>(
+          "workbench.preferredDarkColorTheme",
+        );
+        break;
+      case vscode.ColorThemeKind.Light:
+        colorTheme = workbenchConfig.get<string>(
+          "workbench.preferredLightColorTheme",
+        );
+        break;
+      case vscode.ColorThemeKind.HighContrast:
+        colorTheme = workbenchConfig.get<string>(
+          "workbench.preferredHighContrastColorTheme",
+        );
+        break;
+      case vscode.ColorThemeKind.HighContrastLight:
+        colorTheme = workbenchConfig.get<string>(
+          "workbench.preferredHighContrastColorTheme",
+        );
+        break;
+      default:
+        console.log("unknown color theme kind", activeColorTheme);
+        colorTheme = workbenchConfig.get<string>("workbench.colorTheme");
+        break;
+    }
+  }
+
+  if (!colorTheme) {
+    colorTheme =
+      workbenchConfig.get<string>("workbench.colorTheme") ??
+      "Default Dark Modern";
+  }
 
   try {
     // Pass color theme to webview for syntax highlighting
@@ -85,7 +131,8 @@ export function getTheme() {
     converted.base = (
       ["vs", "hc-black"].includes(converted.base)
         ? converted.base
-        : colorTheme.includes("Light")
+        : activeColorTheme === vscode.ColorThemeKind.Light ||
+            activeColorTheme === vscode.ColorThemeKind.HighContrastLight
           ? "vs"
           : "vs-dark"
     ) as any;


### PR DESCRIPTION
previously the getTheme function would only inspect the workbench.colorTheme. This would not work for users who use window.autoDetectColorScheme. Now, we inspect this value before deciding which color theme to use.

Shuold fix https://github.com/continuedev/continue/issues/1458