### PR TITLE
Tweak Granite template and postprocessing

### DIFF
--- a/core/autocomplete/filtering/streamTransforms/lineStream.ts
+++ b/core/autocomplete/filtering/streamTransforms/lineStream.ts
@@ -83,6 +83,7 @@ export const LINES_TO_REMOVE_BEFORE_START = [
   "<COMPLETION>",
   "[CODE]",
   "<START EDITING HERE>",
+  "{{FILL_HERE}}"
 ];
 
 export const ENGLISH_START_PHRASES = [

--- a/core/autocomplete/postprocessing/index.ts
+++ b/core/autocomplete/postprocessing/index.ts
@@ -83,6 +83,24 @@ export function postprocessCompletion({
     }
   }
 
+  if (llm.model.includes("granite")) {
+    // Granite tends to repeat the start of the line in the completion output
+    let prefixEnd = prefix.split("\n").pop();
+    if (prefixEnd) {
+      if (completion.startsWith(prefixEnd)) {
+        completion = completion.slice(prefixEnd.length);
+      } else {
+        const trimmedPrefix = prefixEnd.trim();
+        const lastWord = trimmedPrefix.split(/\s+/).pop();
+        if (lastWord && completion.startsWith(lastWord)) {
+          completion = completion.slice(lastWord.length);
+        } else if (completion.startsWith(trimmedPrefix)) {
+          completion = completion.slice(trimmedPrefix.length);
+        }
+      }
+    }
+  }
+
   // // If completion starts with multiple whitespaces, but the cursor is at the end of the line
   // // then it should probably be on a new line
   // if (
@@ -99,7 +117,6 @@ export function postprocessCompletion({
     prefix.endsWith(" ") &&
     completion.startsWith(" ")
   ) {
-    const test = prefix.split("\n").pop()?.trim() !== "";
     completion = completion.slice(1);
   }
 

--- a/core/autocomplete/templating/AutocompleteTemplate.ts
+++ b/core/autocomplete/templating/AutocompleteTemplate.ts
@@ -376,7 +376,8 @@ export function getTemplateForModel(model: string): AutocompleteTemplate {
   if (
     lowerCaseModel.includes("gpt") ||
     lowerCaseModel.includes("davinci-002") ||
-    lowerCaseModel.includes("claude")
+    lowerCaseModel.includes("claude") ||
+    lowerCaseModel.includes("granite3")
   ) {
     return holeFillerTemplate;
   }

--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -469,7 +469,7 @@ export abstract class BaseLLM implements ILLM {
     );
 
     if (log && this.writeLog) {
-      await this.writeLog(`Completion:\n\n${completion}\n\n`);
+      await this.writeLog(`Completion:\n${completion}\n\n`);
     }
 
     return {
@@ -521,7 +521,7 @@ export abstract class BaseLLM implements ILLM {
       this._logTokensGenerated(completionOptions.model, prompt, completion);
 
       if (log && this.writeLog) {
-        await this.writeLog(`Completion:\n\n${completion}\n\n`);
+        await this.writeLog(`Completion:\n${completion}\n\n`);
       }
     }
 
@@ -562,7 +562,7 @@ export abstract class BaseLLM implements ILLM {
     this._logTokensGenerated(completionOptions.model, prompt, completion);
 
     if (log && this.writeLog) {
-      await this.writeLog(`Completion:\n\n${completion}\n\n`);
+      await this.writeLog(`Completion:\n${completion}\n\n`);
     }
 
     return completion;
@@ -628,7 +628,7 @@ export abstract class BaseLLM implements ILLM {
     this._logTokensGenerated(completionOptions.model, prompt, completion);
 
     if (log && this.writeLog) {
-      await this.writeLog(`Completion:\n\n${completion}\n\n`);
+      await this.writeLog(`Completion:\n${completion}\n\n`);
     }
 
     return {


### PR DESCRIPTION
## Description

This PR aims to improve granite3 models tab completion support. Granite3 is not FIM trained (unlike previous versions), so needs to use the holeFillerTemplate in [AutocompleteTemplate.getTemplateForModel](https://github.com/fbricon/continue/commit/3934e8d81facccc42a44932311a4f36906aec8df#diff-12ca9634605b77255e61137fb07c9cf58462602e3b3a403591be025f7f2df885), instead of the default  stableCodeFimTemplate.
Additionally, we found that smaller variants of granite3 models tend to sometimes return results that do not always satisfy the hole filler prompt instructions, typically repeating existing code in the response. Granite specific post-processing was added to postprocessCompletion to try to mitigate those misbehaviors.

Finally, I chose to remove extra lines prepended to `this.writeLog(`Completion:` statements, as I was having difficulty visually parsing the actual model output. Now we can really tell if extra lines were returned by the model.

## Checklist

- [x] No doc updates needed

## Screenshots

- [x] No visual changes

## Testing
- install granite-dense:2b on ollama: `ollama pull granite-dense:2b`
- configure ~/.continue/config.json with:
```json
"tabAutocompleteModel": {
        "model": "granite3-dense:2b",
        "provider": "ollama",
        "contextLength": 4096,
        "completionOptions": {
            "maxTokens": 2048,
            "temperature": 0,
            "topP": 0.9,
            "topK": 40,
            "presencePenalty": 0,
            "frequencyPenalty": 0.1
        },
        "title": "granite3-dense:2b"
    },
```
- Try auto completing on [manual-testing-sandbox/test.js](https://github.com/continuedev/continue/blob/main/manual-testing-sandbox/test.js). Given:
```javascript
multiply(number) {
    this.res<cursor>
    return this;
  }
```
the model returns:
```javascript
this.res *= number;
```

The end of the prefix is then removed from the completion, so it can be inserted properly 

