### PR TITLE
fix: Looped requests cause page crashes

### DIFF
--- a/core/protocol/ideWebview.ts
+++ b/core/protocol/ideWebview.ts
@@ -92,7 +92,7 @@ export type ToWebviewFromIdeProtocol = ToWebviewFromIdeOrCoreProtocol & {
   setTheme: [{ theme: any }, void];
   setColors: [{ [key: string]: string }, void];
   "jetbrains/editorInsetRefresh": [undefined, void];
-  "jetbrains/isOSREnabled": [boolean, void];
+  "jetbrains/jcefOSREnabled": [boolean, void];
   addApiKey: [undefined, void];
   setupLocalConfig: [undefined, void];
   incrementFtc: [undefined, void];

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
@@ -22,7 +22,6 @@ import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
-import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.WriteCommandAction

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinueBrowser.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinueBrowser.kt
@@ -137,7 +137,7 @@ class ContinueBrowser(val project: Project, url: String) {
                 }
 
                 "jetbrains/isOSREnabled" -> {
-                    sendToWebview( "jetbrains/isOSREnabled", isOSREnabled)
+                    sendToWebview( "jetbrains/jcefOSREnabled", isOSREnabled)
                 }
 
                 "onLoad" -> {

--- a/gui/src/hooks/useIsOSREnabled.ts
+++ b/gui/src/hooks/useIsOSREnabled.ts
@@ -7,7 +7,7 @@ export default function useIsOSREnabled() {
   const [isOSREnabled, setIsOSREnabled] = useState(false);
   const ideMessenger = useContext(IdeMessengerContext);
 
-  useWebviewListener("jetbrains/isOSREnabled", async (isOSREnabled) => {
+  useWebviewListener("jetbrains/jcefOSREnabled", async (isOSREnabled) => {
     setIsOSREnabled(isOSREnabled);
   });
 


### PR DESCRIPTION
## Description

Looped `jetbrains/isOSREnabled` requests cause page crash in JetBrains.