### PR TITLE
fix: Clipboard is not available in chat window

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor.tsx
@@ -598,7 +598,7 @@ function TipTapEditor(props: TipTapEditorProps) {
 
     if (isOSREnabled) {
       handleJetBrainsOSRMetaKeyIssues(e, editor);
-    } else {
+    } else if (!isJetBrains()){
       await handleVSCMetaKeyIssues(e, editor);
     }
   };


### PR DESCRIPTION
## Description

Currently the clipboard is not working in the chat window. Maybe enabling OSR will make it work, but this doesn't seem like a good solution.

When OSR is not enabled, `navigator.clipboard.readText()` is used to handle paste requests. 
However, in JetBrains, JCEF browser is used, which is a Chromium-based browser. It seems that it is not friendly enough to support `navigator.clipboard.readText()`. 
I found that when the permission status is **PROMPT**, it doesn't give any response, and it keeps hanging without resolving the Promise, so the clipboard is invalid.

This change is very small, just don't use `navigator.clipboard.readText()` in JCEF, keep it original, which can fix the bug about the clipboard.


There are also similar issues about the invalid clipboard of JCEF browser, e.g. https://bugs.chromium.org/p/chromium/issues/detail?id=1425583