### PR TITLE
refactor: Improve the diff block logic for inline chat

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/EditorComponentInlaysManager.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/EditorComponentInlaysManager.kt
@@ -51,7 +51,7 @@ class EditorComponentInlaysManager(val editor: EditorImpl, private val onlyOneIn
         }
 
         val wrappedComponent = ComponentWrapper(component)
-        val offset = editor.document.getLineEndOffset(lineIndex)
+        val offset = editor.document.getLineStartOffset(lineIndex)
 
         return EditorEmbeddedComponentManager.getInstance()
             .addComponent(
@@ -59,7 +59,7 @@ class EditorComponentInlaysManager(val editor: EditorImpl, private val onlyOneIn
                 EditorEmbeddedComponentManager.Properties(
                     EditorEmbeddedComponentManager.ResizePolicy.none(),
                     null,
-                    true,
+                    !editor.inlayModel.getBlockElementsInRange(offset,offset).isEmpty(),
                     showAbove,
                     0,
                     offset

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/VerticalDiffBlock.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/VerticalDiffBlock.kt
@@ -59,11 +59,12 @@ class VerticalDiffBlock(
 
     fun deleteLineAt(line: Int) {
         val startOffset = editor.document.getLineStartOffset(line)
-        val endOffset = editor.document.getLineEndOffset(line) + 1
+        val endOffset = min(editor.document.getLineEndOffset(line) + 1, editor.document.textLength)
         val deletedText = editor.document.getText(TextRange(startOffset, endOffset))
 
         deletedLines.add(deletedText.trimEnd())
 
+        // Unable to ensure that text length has not changed, so we need to get it again
         editor.document.deleteString(startOffset, min(endOffset, editor.document.textLength))
     }
 


### PR DESCRIPTION
## Description

1. When the type of the first diff line is `old`, the inlay box is removed.
2. When the type of the first diff line is `new`, it is displayed above the inlay box.
3. Fixed `IndexOutOfBoundsException` when deleting the last row.

## Screenshots

![bug1](https://github.com/user-attachments/assets/17d2e273-f297-41ee-a35b-7b1b693752ac)

![bug2](https://github.com/user-attachments/assets/d38b9266-15b5-483a-86ad-f15bc465bd44)

## Testing

![fix1](https://github.com/user-attachments/assets/dd5df971-ad83-4fb3-944a-ffdd68c2b71b)
![fix2](https://github.com/user-attachments/assets/59c3e39c-caa5-442e-9951-fa5ee0c42816)

