### PR TITLE
Improve Autocomplete Filtering

### DIFF
--- a/core/autocomplete/filtering/streamTransforms/StreamTransformPipeline.ts
+++ b/core/autocomplete/filtering/streamTransforms/StreamTransformPipeline.ts
@@ -2,7 +2,7 @@ import { streamLines } from "../../../diff/util";
 import { DEFAULT_AUTOCOMPLETE_OPTS } from "../../../util/parameters";
 import { HelperVars } from "../../util/HelperVars";
 
-import { stopAtStopTokens } from "./charStream";
+import { stopAtStartOf, stopAtStopTokens } from "./charStream";
 import {
   avoidEmptyComments,
   avoidPathLine,
@@ -28,6 +28,7 @@ export class StreamTransformPipeline {
     let charGenerator = generator;
 
     charGenerator = stopAtStopTokens(generator, stopTokens);
+    charGenerator = stopAtStartOf(charGenerator, suffix);
     for (const charFilter of helper.lang.charFilters ?? []) {
       charGenerator = charFilter({
         chars: charGenerator,

--- a/core/autocomplete/filtering/streamTransforms/charStream.test.ts
+++ b/core/autocomplete/filtering/streamTransforms/charStream.test.ts
@@ -1,12 +1,20 @@
-import { stopAtStopTokens } from "./charStream";
+import { stopAtStartOf, stopAtStopTokens } from "./charStream";
+
+async function* createMockStream(chunks: string[]): AsyncGenerator<string> {
+  for (const chunk of chunks) {
+    yield chunk;
+  }
+}
+
+async function streamToString(stream: AsyncGenerator<string>): Promise<string> {
+  let result = "";
+  for await (const chunk of stream) {
+    result += chunk;
+  }
+  return result;
+}
 
 describe("stopAtStopTokens", () => {
-  async function* createMockStream(chunks: string[]): AsyncGenerator<string> {
-    for (const chunk of chunks) {
-      yield chunk;
-    }
-  }
-
   it("should yield characters until a stop token is encountered", async () => {
     const mockStream = createMockStream(["Hello", " world", "! Stop", "here"]);
     const stopTokens = ["Stop"];
@@ -30,12 +38,7 @@ describe("stopAtStopTokens", () => {
     const stopTokens = ["END", "STOP", "HALT"];
     const result = stopAtStopTokens(mockStream, stopTokens);
 
-    const output = [];
-    for await (const char of result) {
-      output.push(char);
-    }
-
-    expect(output.join("")).toBe("This is a test. ");
+    expect(await streamToString(result)).toBe("This is a test. ");
   });
 
   it("should handle stop tokens split across chunks", async () => {
@@ -67,12 +70,7 @@ describe("stopAtStopTokens", () => {
     const stopTokens = ["END"];
     const result = stopAtStopTokens(mockStream, stopTokens);
 
-    const output = [];
-    for await (const char of result) {
-      output.push(char);
-    }
-
-    expect(output.join("")).toBe("This is a complete stream");
+    expect(await streamToString(result)).toBe("This is a complete stream");
   });
 
   it("should handle empty chunks", async () => {
@@ -80,12 +78,7 @@ describe("stopAtStopTokens", () => {
     const stopTokens = ["STOP"];
     const result = stopAtStopTokens(mockStream, stopTokens);
 
-    const output = [];
-    for await (const char of result) {
-      output.push(char);
-    }
-
-    expect(output.join("")).toBe("Hello world! ");
+    expect(await streamToString(result)).toBe("Hello world! ");
   });
 
   it("should handle stop token at the beginning of the stream", async () => {
@@ -106,12 +99,7 @@ describe("stopAtStopTokens", () => {
     const stopTokens = ["STOP"];
     const result = stopAtStopTokens(mockStream, stopTokens);
 
-    const output = [];
-    for await (const char of result) {
-      output.push(char);
-    }
-
-    expect(output.join("")).toBe("Hello world");
+    expect(await streamToString(result)).toBe("Hello world");
   });
 
   it("should handle multiple stop tokens of different lengths", async () => {
@@ -124,12 +112,7 @@ describe("stopAtStopTokens", () => {
     const stopTokens = ["STOP", "END", "HALT"];
     const result = stopAtStopTokens(mockStream, stopTokens);
 
-    const output = [];
-    for await (const char of result) {
-      output.push(char);
-    }
-
-    expect(output.join("")).toBe("This is a test with multiple ");
+    expect(await streamToString(result)).toBe("This is a test with multiple ");
   });
 
   it("should handle an empty stream", async () => {
@@ -137,12 +120,7 @@ describe("stopAtStopTokens", () => {
     const stopTokens = ["STOP"];
     const result = stopAtStopTokens(mockStream, stopTokens);
 
-    const output = [];
-    for await (const char of result) {
-      output.push(char);
-    }
-
-    expect(output.join("")).toBe("");
+    expect(await streamToString(result)).toBe("");
   });
 
   it("should handle an empty stop tokens array", async () => {
@@ -166,11 +144,105 @@ describe("stopAtStopTokens", () => {
     ];
     const result = stopAtStopTokens(mockStream, stopTokens);
 
-    const output = [];
-    for await (const char of result) {
-      output.push(char);
-    }
+    expect(await streamToString(result)).toBe("Hello world!");
+  });
+});
 
-    expect(output.join("")).toBe("Hello world!");
+describe("stopAtStartOf", () => {
+  const sampleCode = `      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: \`Bearer \${this.workOsAccessToken}\`,
+        },
+      },
+    );
+    const data = await response.json();
+    return data.items;
+  }
+
+  async getContextItems(
+    query: string,
+    extras: ContextProviderExtras,
+  ): Promise<ContextItem[]> {
+    const response = await extras.fetch(
+      new URL(
+        \`/proxy/context/\${this.options.id}/retrieve\`,
+        controlPlaneEnv.CONTROL_PLANE_URL,
+      ),
+`;
+  /* Some LLMs, such as Codestral, repeat the suffix of the query. To test our filtering, we cut the sample code at random positions, remove a part of the input
+and construct a response, containing the removed part and the suffix. The goal of the stopAtStartOf() method is to detect the start of the suffix in the response */
+  it("should stop if the start of the suffix is reached", async () => {
+    const removeLength = 10;
+    for (let i = 0; i < sampleCode.length - removeLength - 20; i++) {
+      const removed = sampleCode.slice(i, i + removeLength);
+      const suffix = sampleCode.slice(i + removeLength);
+      const response = removed + suffix;
+
+      // split the response but keep spaces
+      const mockStream = createMockStream(response.split(/(?! )/g));
+      const result = stopAtStartOf(mockStream, suffix);
+
+      const resultStr = await streamToString(result);
+      if (resultStr !== removed) {
+        throw new Error(
+          `i=${i} result:\n${resultStr}\n\nremoved:\n${removed}\n\nsuffix:\n${suffix}`,
+        );
+      }
+    }
+  });
+  it("should stop if the start of the suffix is reached, even if the suffix has a prefix", async () => {
+    const removeLength = 10;
+    for (let i = 0; i < sampleCode.length - removeLength - 20; i++) {
+      const removed = sampleCode.slice(i, i + removeLength);
+      let suffix = sampleCode.slice(i + removeLength);
+      const response = removed + suffix;
+      // add a prefix to the suffix
+      suffix = "strange words;\n which start the suffix#" + suffix;
+
+      // split the response but keep spaces
+      const mockStream = createMockStream(response.split(/(?! )/g));
+      const result = stopAtStartOf(mockStream, suffix);
+
+      const resultStr = await streamToString(result);
+      if (resultStr !== removed) {
+        throw new Error(
+          `i=${i} result:\n${resultStr}\n\nremoved:\n${removed}\n\nsuffix:\n${suffix}`,
+        );
+      }
+    }
+  });
+
+  it("should work with a real example", async () => {
+    let suffix = `
+
+  subtract(number) {
+    this.result -= number;
+    return this;
+  }
+
+  multiply(number) {
+    this.result *= number;
+    return this;
+  }
+
+  divide(number) {`;
+    const response = `    this.result -= number;
+    return this;
+  }
+  // Add the multiply method
+  multiply(number) {
+    this.result *= number;
+    return this;
+  }
+  // Add the divide method
+  divide(number) {`;
+    // split the response but keep spaces
+    const mockStream = createMockStream([response]);
+    const result = stopAtStartOf(mockStream, suffix);
+
+    const resultStr = await streamToString(result);
+    expect(resultStr).toBe(``);
   });
 });

--- a/core/autocomplete/filtering/streamTransforms/lineStream.test.ts
+++ b/core/autocomplete/filtering/streamTransforms/lineStream.test.ts
@@ -98,7 +98,7 @@ describe("lineStream", () => {
 
   describe("stopAtSimilarLine", () => {
     it("should stop at the exact same line", async () => {
-      const lineToTest = "const x = 6;";
+      const lineToTest = "const x = 6";
       const linesGenerator = await getLineGenerator([
         "console.log();",
         "const y = () => {};",
@@ -116,7 +116,7 @@ describe("lineStream", () => {
       expect(mockFullStop).toHaveBeenCalledTimes(1);
     });
 
-    it.only("should stop at a similar line", async () => {
+    it("should stop at a similar line", async () => {
       const lineToTest = "const x = 6;";
       const linesGenerator = await getLineGenerator([
         "console.log();",


### PR DESCRIPTION
## Description

Often continue with Codestral would propose autocompletions which just reproduce what is already below the autocomplete position in the editor (suffix). This PR tries to address this by stopping when a part of the suffix is encountered

## Checklist

- [x] The relevant docs, if any, have been updated or created

## Screenshots

na

## Testing

Added unit tests, cleaned up some existing tests and reenabled tests in `lineStream.test.ts`
