### PR TITLE
Submit dependency graph to make Dependabot aware of the Gradle project (Intellij extension)

### DIFF
--- a/.github/workflows/submit-github-dependency-graph.yml
+++ b/.github/workflows/submit-github-dependency-graph.yml
@@ -1,0 +1,25 @@
+name: Submit Gradle Dependency Graph For Dependabot
+
+on:
+  push:
+    branches: ['main']
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v4
+    - name: Setup Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: 17
+    - name: Generate and submit dependency graph
+      uses: gradle/actions/dependency-submission@v4
+      with:
+        # The gradle project is not in the root of the repository.
+        build-root-directory: extensions/intellij


### PR DESCRIPTION
### Enable Dependabot for the Gradle project

Add a workflow for submitting a dependency graph generated from the gradle project located in [extensions/intellij](https://github.com/continuedev/continue/tree/main/extensions/intellij), as described here:
[The dependency-submission action
](https://github.com/gradle/actions/blob/main/docs/dependency-submission.md
)
## Description

The added workflow is copied from the example in the documentation + a slight  modification for pointing out the correct Gradle build root.

The official Gradle project is also using this mechanism enabling Dependabot use the Gradle dependency graph:
https://github.com/gradle/gradle/blob/master/.github/workflows/submit-github-dependency-graph.yml

## Checklist

- No updates

## Screenshots

- No changes
## Testing

- Not tested
