### PR TITLE
fix: Add context/getSymbolsForFiles endpoint in JetBrains and handle …

### DIFF
--- a/core/util/treeSitter.ts
+++ b/core/util/treeSitter.ts
@@ -290,7 +290,12 @@ export async function getSymbolsForManyFiles(
   const filesAndSymbols = await Promise.all(
     uris.map(async (uri): Promise<[string, SymbolWithRange[]]> => {
       const contents = await ide.readFile(uri);
-      const symbols = await getSymbolsForFile(uri, contents);
+      let symbols = undefined;
+      try {
+        symbols = await getSymbolsForFile(uri, contents);
+      } catch (e) {
+        console.error(`Failed to get symbols for ${uri}:`, e);
+      }
       return [uri, symbols ?? []];
     }),
   );

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinueBrowser.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinueBrowser.kt
@@ -66,6 +66,7 @@ class ContinueBrowser(val project: Project, url: String) {
         "config/listProfiles",
         "profiles/switch",
         "didChangeSelectedProfile",
+        "context/getSymbolsForFiles",
     )
 
     private fun registerAppSchemeHandler() {


### PR DESCRIPTION

## Description

1. Add `context/getSymbolsForFiles` endpoint in JetBrains to support forwarding requests.
2. Handle parsing exceptions to avoid no response results.