### PR TITLE
fix: handle RangeError during didChangeActiveTextEditor

### DIFF
--- a/core/core.ts
+++ b/core/core.ts
@@ -775,8 +775,16 @@ export class Core {
       const ignoreInstance = ignore().add(defaultIgnoreFile);
       let rootDirectory = await this.ide.getWorkspaceDirs();
       const relativeFilePath = path.relative(rootDirectory[0], filepath);
-      if (!ignoreInstance.ignores(relativeFilePath)) {
-        recentlyEditedFilesCache.set(filepath, filepath);
+      try {
+        if (!ignoreInstance.ignores(relativeFilePath)) {
+          recentlyEditedFilesCache.set(filepath, filepath);
+        }
+      } catch (e) {
+        if (e instanceof RangeError) {
+          // do nothing, this can happen when editing a file outside the workspace such as `../extensions/.continue-debug/config.json`
+        } else {
+          console.debug("unhandled ignores error", relativeFilePath, e);
+        }
       }
     });
 


### PR DESCRIPTION
## Description

This can happen when path.relative returns something like `../foo`.

## Checklist

- [] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change. ]
[ For new UI features, ensure that the changes look good across viewport widths, light/dark theme, etc ]
