### PR TITLE
fix order of providers in config schema

### DIFF
--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -207,8 +207,8 @@
             "xAI",
             "kindo",
             "moonshot",
-            "function-network",
-            "siliconflow"
+            "siliconflow",
+            "function-network"
           ],
           "markdownEnumDescriptions": [
             "### OpenAI\nUse gpt-4, gpt-3.5-turbo, or any other OpenAI model. See [here](https://openai.com/product#made-for-developers) to obtain an API key.\n\n> [Reference](https://docs.continue.dev/reference/Model%20Providers/openai)",


### PR DESCRIPTION
## Description

`function-network` & `siliconflow` had their markdown descriptions mixed up.

https://github.com/continuedev/continue/tree/main/extensions/vscode/config_schema.json#L249-L251

<img width="338" alt="Screenshot 2024-11-30 at 09 23 56" src="https://github.com/user-attachments/assets/c21e7f0c-f8a1-4af4-9927-61fabbd966b1">

## Checklist

- [] The relevant docs, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change. ]
[ For new UI features, ensure that the changes look good across viewport widths, light/dark theme, etc ]
