### PR TITLE
Show IDE completions side-by-side

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/actions/ContinueActionPromote.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/actions/ContinueActionPromote.kt
@@ -1,0 +1,25 @@
+package com.github.continuedev.continueintellijextension.actions
+
+import com.github.continuedev.continueintellijextension.autocomplete.AcceptAutocompleteAction
+import com.github.continuedev.continueintellijextension.services.ContinueExtensionSettings
+import com.intellij.openapi.actionSystem.ActionPromoter
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.components.ServiceManager
+import org.jetbrains.annotations.NotNull
+
+class ContinueActionPromote : ActionPromoter {
+
+    override fun promote(@NotNull actions: List<AnAction>, @NotNull context: DataContext): List<AnAction>? {
+
+        if (actions.none { it is AcceptAutocompleteAction }) {
+            return null
+        } else {
+            val settings = ServiceManager.getService(ContinueExtensionSettings::class.java)
+            if (!settings.continueState.showIDECompletionSideBySide) {
+                return null;
+            }
+            return actions.filterIsInstance<AcceptAutocompleteAction>()
+        }
+    }
+}

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/services/ContinueExtensionSettingsService.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/services/ContinueExtensionSettingsService.kt
@@ -32,6 +32,7 @@ class ContinueSettingsComponent : DumbAware {
     val enableContinueTeamsBeta: JCheckBox = JCheckBox("Enable Continue for Teams Beta")
     val enableOSR: JCheckBox = JCheckBox("Enable Off-Screen Rendering")
     val displayEditorTooltip: JCheckBox = JCheckBox("Display Editor Tooltip")
+    val showIDECompletionSideBySide: JCheckBox = JCheckBox("Show IDE completions side-by-side")
 
     init {
         val constraints = GridBagConstraints()
@@ -62,6 +63,8 @@ class ContinueSettingsComponent : DumbAware {
         panel.add(enableOSR, constraints)
         constraints.gridy++
         panel.add(displayEditorTooltip, constraints)
+        constraints.gridy++
+        panel.add(showIDECompletionSideBySide, constraints)
         constraints.gridy++
 
         // Add a "filler" component that takes up all remaining vertical space
@@ -94,6 +97,7 @@ open class ContinueExtensionSettings : PersistentStateComponent<ContinueExtensio
         var enableContinueTeamsBeta: Boolean = false
         var enableOSR: Boolean = shouldRenderOffScreen()
         var displayEditorTooltip: Boolean = true
+        var showIDECompletionSideBySide: Boolean = false
     }
 
     var continueState: ContinueState = ContinueState()
@@ -206,7 +210,8 @@ class ContinueExtensionConfigurable : Configurable {
                     mySettingsComponent?.enableTabAutocomplete?.isSelected != settings.continueState.enableTabAutocomplete ||
                     mySettingsComponent?.enableContinueTeamsBeta?.isSelected != settings.continueState.enableContinueTeamsBeta ||
                     mySettingsComponent?.enableOSR?.isSelected != settings.continueState.enableOSR ||
-                    mySettingsComponent?.displayEditorTooltip?.isSelected != settings.continueState.displayEditorTooltip
+                    mySettingsComponent?.displayEditorTooltip?.isSelected != settings.continueState.displayEditorTooltip ||
+                    mySettingsComponent?.showIDECompletionSideBySide?.isSelected != settings.continueState.showIDECompletionSideBySide
         return modified
     }
 
@@ -220,6 +225,8 @@ class ContinueExtensionConfigurable : Configurable {
             mySettingsComponent?.enableContinueTeamsBeta?.isSelected ?: false
         settings.continueState.enableOSR = mySettingsComponent?.enableOSR?.isSelected ?: true
         settings.continueState.displayEditorTooltip = mySettingsComponent?.displayEditorTooltip?.isSelected ?: true
+        settings.continueState.showIDECompletionSideBySide =
+            mySettingsComponent?.showIDECompletionSideBySide?.isSelected ?: false
 
         ApplicationManager.getApplication().messageBus.syncPublisher(SettingsListener.TOPIC)
             .settingsUpdated(settings.continueState)
@@ -235,6 +242,8 @@ class ContinueExtensionConfigurable : Configurable {
         mySettingsComponent?.enableContinueTeamsBeta?.isSelected = settings.continueState.enableContinueTeamsBeta
         mySettingsComponent?.enableOSR?.isSelected = settings.continueState.enableOSR
         mySettingsComponent?.displayEditorTooltip?.isSelected = settings.continueState.displayEditorTooltip
+        mySettingsComponent?.showIDECompletionSideBySide?.isSelected =
+            settings.continueState.showIDECompletionSideBySide
 
         ContinueExtensionSettings.instance.addRemoteSyncJob()
     }

--- a/extensions/intellij/src/main/resources/META-INF/plugin.xml
+++ b/extensions/intellij/src/main/resources/META-INF/plugin.xml
@@ -15,7 +15,7 @@
         <ProviderFactory
                 implementation="com.github.continuedev.continueintellijextension.continue.ConfigJsonSchemaProviderFactory"/>
     </extensions>
-        <extensions defaultExtensionNs="JavaScript.JsonSchema">
+    <extensions defaultExtensionNs="JavaScript.JsonSchema">
         <ProviderFactory
                 implementation="com.github.continuedev.continueintellijextension.continue.ConfigRcJsonSchemaProviderFactory"/>
     </extensions>
@@ -38,6 +38,8 @@
                 id="AutocompleteSpinnerWidget"/>
         <notificationGroup id="Continue"
                            displayType="BALLOON"/>
+        <actionPromoter order="last"
+                        implementation="com.github.continuedev.continueintellijextension.actions.ContinueActionPromote"/>
     </extensions>
 
     <resource-bundle>messages.MyBundle</resource-bundle>


### PR DESCRIPTION


## Description

Add an option to allow auto-completion and IDEA’s built-in completion to work simultaneously. For #2518 

## Checklist


## Screenshots

See the video below


## Testing

When the option is enabled, IDE built-in completion and auto-completion work simultaneously, with Tab prioritizing auto-completion.

https://github.com/user-attachments/assets/9fe746b6-2c45-4a57-a597-fd76e4ec1596


