### PR TITLE
Remove getIdeSnippets()

### DIFF
--- a/core/autocomplete/CompletionProvider.ts
+++ b/core/autocomplete/CompletionProvider.ts
@@ -3,7 +3,7 @@ import { TRIAL_FIM_MODEL } from "../config/onboarding.js";
 import { IDE, ILLM } from "../index.js";
 import OpenAI from "../llm/llms/OpenAI.js";
 import { DEFAULT_AUTOCOMPLETE_OPTS } from "../util/parameters.js";
-import { EXPERIMENTS, PosthogFeatureFlag, Telemetry } from "../util/posthog.js";
+import { PosthogFeatureFlag, Telemetry } from "../util/posthog.js";
 
 import { shouldCompleteMultiline } from "./classification/shouldCompleteMultiline.js";
 import { ContextRetrievalService } from "./context/ContextRetrievalService.js";
@@ -15,7 +15,6 @@ import { postprocessCompletion } from "./postprocessing/index.js";
 import { shouldPrefilter } from "./prefiltering/index.js";
 import { getAllSnippets } from "./snippets/index.js";
 import { renderPrompt } from "./templating/index.js";
-import { GetLspDefinitionsFunction } from "./types.js";
 import { AutocompleteDebouncer } from "./util/AutocompleteDebouncer.js";
 import { AutocompleteLoggingService } from "./util/AutocompleteLoggingService.js";
 import AutocompleteLruCache from "./util/AutocompleteLruCache.js";
@@ -46,7 +45,6 @@ export class CompletionProvider {
     private readonly ide: IDE,
     private readonly _injectedGetLlm: () => Promise<ILLM | undefined>,
     private readonly _onError: (e: any) => void,
-    private readonly getDefinitionsFromLsp: GetLspDefinitionsFunction,
   ) {
     this.completionStreamer = new CompletionStreamer(this.onError.bind(this));
     this.contextRetrievalService = new ContextRetrievalService(this.ide);
@@ -171,7 +169,6 @@ export class CompletionProvider {
         getAllSnippets({
           helper,
           ide: this.ide,
-          getDefinitionsFromLsp: this.getDefinitionsFromLsp,
           contextRetrievalService: this.contextRetrievalService,
         }),
         this.ide.getWorkspaceDirs(),

--- a/core/autocomplete/filtering/test/util.ts
+++ b/core/autocomplete/filtering/test/util.ts
@@ -48,7 +48,6 @@ export async function testAutocompleteFiltering(
     ide,
     async () => llm,
     () => {},
-    async () => [],
   );
 
   const line = prefix.split("\n").length - 1;

--- a/core/autocomplete/types.ts
+++ b/core/autocomplete/types.ts
@@ -1,6 +1,4 @@
-import { IDE, RangeInFileWithContents } from "../index";
-import { AutocompleteLanguageInfo } from "./constants/AutocompleteLanguageInfo";
-import { AutocompleteCodeSnippet } from "./snippets/types";
+import { RangeInFileWithContents } from "../index";
 
 /**
  * @deprecated This type should be removed in the future or renamed.
@@ -10,11 +8,3 @@ import { AutocompleteCodeSnippet } from "./snippets/types";
 export type AutocompleteSnippetDeprecated = RangeInFileWithContents & {
   score?: number;
 };
-
-export type GetLspDefinitionsFunction = (
-  filepath: string,
-  contents: string,
-  cursorIndex: number,
-  ide: IDE,
-  lang: AutocompleteLanguageInfo,
-) => Promise<AutocompleteCodeSnippet[]>;

--- a/core/core.ts
+++ b/core/core.ts
@@ -183,7 +183,6 @@ export class Core {
       ide,
       getLlm,
       (e) => {},
-      (..._) => Promise.resolve([]),
     );
 
     const on = this.messenger.on.bind(this.messenger);


### PR DESCRIPTION
## Description

The auto completion had dead code for getting snippets from the IDE via LSP, which the LSP does not support. I removed the code.

## Checklist

- [x] The relevant docs, if any, have been updated or created

## Screenshots

na

## Testing

na
