### PR TITLE
optimize remote config url

### DIFF
--- a/core/continueServer/stubs/client.ts
+++ b/core/continueServer/stubs/client.ts
@@ -15,7 +15,7 @@ export class ContinueServerClient implements IContinueServerClient {
       this.url =
         typeof serverUrl !== "string" || serverUrl === ""
           ? undefined
-          : new URL(serverUrl);
+          : new URL(serverUrl.endsWith("/") ? serverUrl : `${serverUrl}/`);
     } catch (e) {
       console.warn("Invalid Continue server url", e);
       this.url = undefined;


### PR DESCRIPTION
When user add remote config url like: `http://host/foo`, the config sync request will be parsed as `http://host/sync`, not expected `http://host/foo/sync`.

Of course we can update the remote config url to `http://host/foo/` to resolve this problem, but the configuration is error prone, so I optimized the logic to prevent this case.
