### PR TITLE
feat: use lazy edit sys msg for `gpt-4o` and `mistral-large` families

### DIFF
--- a/core/llm/constructMessages.ts
+++ b/core/llm/constructMessages.ts
@@ -1,6 +1,9 @@
 import { ChatHistoryItem, ChatMessage, MessagePart } from "../index.js";
 import { normalizeToMessageParts } from "../util/messageContent.js";
+
 import { modelSupportsTools } from "./autodetect.js";
+
+const CUSTOM_SYS_MSG_MODEL_FAMILIES = ["sonnet", "gpt-4o", "mistral-large"];
 
 const SYSTEM_MESSAGE = `When generating new code:
 
@@ -64,7 +67,7 @@ const TOOL_USE_RULES = `When using tools, follow the following guidelines:
 - Avoid calling tools unless they are absolutely necessary. For example, if you are asked a simple programming question you do not need web search. As another example, if the user asks you to explain something about code, do not create a new file.`;
 
 function constructSystemPrompt(model: string): string | null {
-  if (model.includes("sonnet")) {
+  if (CUSTOM_SYS_MSG_MODEL_FAMILIES.some((family) => model.includes(family))) {
     return SYSTEM_MESSAGE + "\n\n" + TOOL_USE_RULES;
   }
   if (modelSupportsTools(model)) {


### PR DESCRIPTION
This PR adds `mistral-large` and `gpt-4o` to the list of model families  use our custom system message that encourages "lazy" outputs.