### PR TITLE
Add Flutter and Dart to pre-indexed docs

### DIFF
--- a/core/indexing/docs/preIndexedDocs.ts
+++ b/core/indexing/docs/preIndexedDocs.ts
@@ -336,6 +336,18 @@ const preIndexedDocs: Record<
     rootUrl: "https://go.dev",
     faviconUrl: "https://go.dev/favicon.ico",
   },
+  "https://api.flutter.dev": {
+    title: "Flutter",
+    startUrl: "https://api.flutter.dev",
+    rootUrl: "https://api.flutter.dev",
+    faviconUrl: "https://api.flutter.dev/flutter/static-assets/favicon.png",
+  },
+  "https://api.dart.dev": {
+    title: "Dart",
+    startUrl: "https://api.dart.dev",
+    rootUrl: "https://api.dart.dev",
+    faviconUrl: "https://api.dart.dev/static-assets/favicon.png",
+  },
 };
 
 export default preIndexedDocs;


### PR DESCRIPTION
## Description

Pre-index docs for Flutter and Dart

## Checklist

- [X] The relevant docs, if any, have been updated or created

## Screenshots

N/A

## Testing

I was able to run my local patch, but I'm not sure if anything else is needed to verify the change.