### PR TITLE
Esbuild visualizer

### DIFF
--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "0.9.241",
+  "version": "0.9.242",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "0.9.241",
+      "version": "0.9.242",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/fetch": "^1.0.3",
@@ -77,6 +77,7 @@
         "cargo-cp-artifact": "^0.1",
         "chai": "^4.5.0",
         "esbuild": "0.17.19",
+        "esbuild-visualizer": "^0.6.0",
         "eslint": "^8.28.0",
         "glob": "^8.0.3",
         "json-schema-to-typescript": "^12.0.0",
@@ -102,9 +103,9 @@
         "@aws-sdk/client-sagemaker-runtime": "^3.621.0",
         "@aws-sdk/credential-providers": "^3.620.1",
         "@continuedev/config-types": "^1.0.13",
-        "@continuedev/fetch": "^1.0.3",
+        "@continuedev/fetch": "^1.0.4",
         "@continuedev/llm-info": "^1.0.2",
-        "@continuedev/openai-adapters": "../packages/openai-adapters",
+        "@continuedev/openai-adapters": "^1.0.10",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@mozilla/readability": "^0.5.0",
         "@octokit/rest": "^20.0.2",
@@ -5348,6 +5349,23 @@
         "@esbuild/win32-arm64": "0.17.19",
         "@esbuild/win32-ia32": "0.17.19",
         "@esbuild/win32-x64": "0.17.19"
+      }
+    },
+    "node_modules/esbuild-visualizer": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/esbuild-visualizer/-/esbuild-visualizer-0.6.0.tgz",
+      "integrity": "sha512-oNK3JAhC7+re93VTtUdWJKTDVnA2qXPAjCAoaw9OxEFUXztszw3kcaK46u1U790T8FdUBAWv6F9Xt59P8nJCVA==",
+      "dev": true,
+      "dependencies": {
+        "open": "^8.4.0",
+        "picomatch": "^2.3.1",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "esbuild-visualizer": "dist/bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/escalade": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -651,6 +651,7 @@
     "cargo-cp-artifact": "^0.1",
     "chai": "^4.5.0",
     "esbuild": "0.17.19",
+    "esbuild-visualizer": "^0.6.0",
     "eslint": "^8.28.0",
     "glob": "^8.0.3",
     "json-schema-to-typescript": "^12.0.0",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -602,6 +602,7 @@
     "vscode:prepublish": "npm run esbuild-base -- --minify",
     "esbuild": "npm run esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
+    "esbuild:visualize": "esbuild-visualizer --metadata ./build/meta.json --filename ./build/stats.html --open",
     "tsc": "tsc -p ./",
     "tsc:check": "tsc -p ./ --noEmit",
     "tsc-watch": "tsc -watch -p ./",

--- a/extensions/vscode/scripts/esbuild.js
+++ b/extensions/vscode/scripts/esbuild.js
@@ -20,6 +20,7 @@ const esbuildConfig = {
   inject: ["./scripts/importMetaUrl.js"],
   define: { "import.meta.url": "importMetaUrl" },
   supported: { "dynamic-import": false },
+  metafile: true,
   plugins: [
     {
       name: "on-end-plugin",
@@ -29,6 +30,15 @@ const esbuildConfig = {
             console.error("Build failed with errors:", result.errors);
             throw new Error(result.errors);
           } else {
+            try {
+              const fs = require("fs");
+              fs.writeFileSync(
+                "./build/meta.json",
+                JSON.stringify(result.metafile, null, 2),
+              );
+            } catch (e) {
+              console.error("Failed to write esbuild meta file", e);
+            }
             console.log("VS Code Extension esbuild complete"); // used verbatim in vscode tasks to detect completion
           }
         });


### PR DESCRIPTION
NOTE branches off open PR https://github.com/continuedev/continue/pull/3268

```sh
npm run esbuild:visualize
```

From `extensions/vscode` generates e.g.:

![image](https://github.com/user-attachments/assets/3c37a918-fdf2-4731-a2a5-569cad75b9cd)
