### PR TITLE
fix: do not filter context providers if not in editMode

### DIFF
--- a/gui/src/components/mainInput/ContinueInputBox.tsx
+++ b/gui/src/components/mainInput/ContinueInputBox.tsx
@@ -93,7 +93,7 @@ function ContinueInputBox(props: ContinueInputBoxProps) {
   const filteredSlashCommands = props.isEditMode ? [] : availableSlashCommands;
   const filteredContextProviders = useMemo(() => {
     if (!props.isEditMode) {
-      availableContextProviders;
+      return availableContextProviders ?? [];
     }
 
     return (


### PR DESCRIPTION
## Description

- editMode context filtering was enabled outside of editMode (missing return in filtering)
- chat was missing some context Providers (folder, open, ...)

## Checklist

n/a

## Screenshots

n/a

## Testing

- chat & edit mode tested. no regression seen
