### PR TITLE
vscode: Ensure extension.js is rebuilt when deleted

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -28,6 +28,9 @@
         "vscode-extension:continue-ui:build",
         // // To bundle the code the same way we do for publishing
         "vscode-extension:esbuild",
+        // To ensure extension.js is regenerated even if
+        // vscode-extension:esbuild was already running in background
+        "vscode-extension:esbuild-notify",
         // Start the React app that is used in the extension
         "gui:dev"
       ],
@@ -35,6 +38,13 @@
         "kind": "build",
         "isDefault": true
       }
+    },
+    {
+      "label": "vscode-extension:esbuild-notify",
+      "dependsOn": ["vscode-extension:esbuild"],
+      "type": "npm",
+      "script": "esbuild-notify",
+      "path": "extensions/vscode"
     },
     {
       "label": "vscode-extension:esbuild",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -602,6 +602,7 @@
     "vscode:prepublish": "npm run esbuild-base -- --minify",
     "esbuild": "npm run esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
+    "esbuild-notify": "npm run esbuild-base -- --sourcemap --notify",
     "esbuild:visualize": "esbuild-visualizer --metadata ./build/meta.json --filename ./build/stats.html --open",
     "tsc": "tsc -p ./",
     "tsc:check": "tsc -p ./ --noEmit",


### PR DESCRIPTION
Right now, the vscode-extension:continue-ui:build task deletes extension.js as part of its prepackage.js script.

This wouldn't normally be a problem, because extension.js is generated by the vscode-extension:esbuild, and
vscode-extension:continue-ui:build is a dependency of vscode-extension:esbuild, implying it should always get run first.

But, vscode-extension:esbuild is a background task, that stays running after it's been started once. Future calls to run that task become no ops, because it's already active. This means running

vscode-extension:esbuild ->
  vscode-extension:continue-ui:build ->
    vscode-extension:esbuild

will lead to the last vscode-extension:esbuild not regenerating extension.js.

In order to resolve that problem, this commit adds a new foreground task into the build pipeline:

  vscode-extension:touch-source

that tickles the source so the running background
vscode-extension:esbuild task will "wake up" and regenerate extension.js