### PR TITLE
Add Scaleway as OpenAI-compatible LLM and Embeddings provider

### DIFF
--- a/core/llm/autodetect.ts
+++ b/core/llm/autodetect.ts
@@ -65,6 +65,7 @@ const PROVIDER_SUPPORTS_IMAGES: string[] = [
   "openrouter",
   "vertexai",
   "azure",
+  "scaleway",
 ];
 
 const MODEL_SUPPORTS_IMAGES: string[] = [

--- a/core/llm/llms/Scaleway.ts
+++ b/core/llm/llms/Scaleway.ts
@@ -1,0 +1,27 @@
+import OpenAI from "./OpenAI";
+
+import { LLMOptions } from "../../index.js";
+
+
+class Scaleway extends OpenAI {
+  static providerName = "scaleway";
+  static defaultOptions: Partial<LLMOptions> = {
+    apiBase: "https://api.scaleway.ai/v1/",
+    model: "qwen2.5-coder-32b-instruct",
+    useLegacyCompletionsEndpoint: false,
+  };
+
+  private static MODEL_IDS: { [name: string]: string } = {
+    "llama3.1-8b": "llama-3.1-8b-instruct",
+    "llama3.1-70b": "llama-3.1-70b-instruct",
+    "mistral-nemo": "mistral-nemo-instruct-2407",
+    "qwen2.5-coder-32b": "qwen2.5-coder-32b-instruct",
+    "pixtral": "pixtral-12b-2409",
+  };
+
+  protected _convertModelName(model: string) {
+    return Scaleway.MODEL_IDS[model] || this.model;
+  }
+}
+
+export default Scaleway;

--- a/core/llm/llms/index.ts
+++ b/core/llm/llms/index.ts
@@ -42,6 +42,7 @@ import OpenRouter from "./OpenRouter";
 import Replicate from "./Replicate";
 import SageMaker from "./SageMaker";
 import SambaNova from "./SambaNova";
+import Scaleway from "./Scaleway";
 import ContinueProxy from "./stubs/ContinueProxy";
 import TextGenWebUI from "./TextGenWebUI";
 import Together from "./Together";

--- a/docs/docs/customize/model-providers/more/scaleway.md
+++ b/docs/docs/customize/model-providers/more/scaleway.md
@@ -1,0 +1,49 @@
+---
+title: Scaleway
+---
+
+:::info
+
+Scaleway Generative APIs give you instant access to leading AI models hosted in European data centers, ideal for developers requiring low latency, full data privacy, and compliance with EU AI Act.
+You can generate your API key in [Scaleway's console](https://console.scaleway.com/generative-api/models).
+Read the [quickstart documentation here](https://www.scaleway.com/en/docs/ai-data/generative-apis/quickstart/).
+
+:::
+
+## Chat model
+
+We recommend configuring **Qwen2.5-Coder-32B-Instruct** as your chat model.
+[Click here](https://www.scaleway.com/en/docs/ai-data/generative-apis/reference-content/supported-models/) to see the list of available chat models.
+
+```json title="config.json"
+{
+  "models": [
+    {
+      "title": "Qwen2.5-Coder-32B-Instruct",
+      "provider": "scaleway",
+      "model": "qwen2.5-coder-32b-instruct",
+      "apiKey": "[API_KEY]"
+    }
+  ]
+}
+```
+
+## Autocomplete model
+
+Scaleway currently does not offer any autocomplete models.
+
+[Click here](../../model-types/autocomplete.md) to see a list of autocomplete model providers.
+
+## Embeddings model
+
+We recommend configuring **BGE-Multilingual-Gemma2** as your embeddings model.
+
+```json title="config.json"
+{
+  "embeddingsProvider": {
+    "provider": "scaleway",
+    "model": "bge-multilingual-gemma2",
+    "apiKey": "[API_KEY]"
+  }
+}
+```

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -208,7 +208,8 @@
             "kindo",
             "moonshot",
             "siliconflow",
-            "function-network"
+            "function-network",
+            "scaleway"
           ],
           "markdownEnumDescriptions": [
             "### OpenAI\nUse gpt-4, gpt-3.5-turbo, or any other OpenAI model. See [here](https://openai.com/product#made-for-developers) to obtain an API key.\n\n> [Reference](https://docs.continue.dev/reference/Model%20Providers/openai)",
@@ -248,7 +249,8 @@
             "### Secure AI management software that helps enterprises adopt and manage AI across their workforce. To get started, obtain an API key from [the Kindo console](https://app.kindo.ai/settings/api), and see the [website](https://app.kindo.ai//)",
             "### Moonshot\nTo get started with Moonshot AI, obtain your API key from [Moonshot AI](https://platform.moonshot.cn/). Moonshot AI provides high-quality large language models with competitive pricing.\n> [Reference](https://platform.moonshot.cn/docs/api)",
             "### SiliconFlow\nTo get started with SiliconFlow, obtain your API key from [SiliconCloud](https://cloud.siliconflow.cn/account/ak). SiliconCloud provides cost-effective GenAI services based on excellent open source basic models.\n> [Models](https://siliconflow.cn/zh-cn/models)",
-            "### Function Network offers private, affordable user-owned AI\nTo get started with Function Network, obtain your API key from [Function Network](https://www.function.network/join-waitlist). Function Network provides a variety of models for chat, completion, and embeddings."
+            "### Function Network offers private, affordable user-owned AI\nTo get started with Function Network, obtain your API key from [Function Network](https://www.function.network/join-waitlist). Function Network provides a variety of models for chat, completion, and embeddings.",
+            "### Scaleway\n Generative APIs are serverless endpoints for the most popular AI models.\nHosted in European data centers and priced competitively per million tokens used, models served by Scaleway are ideal for users requiring low latency, full data privacy, and 100% compliance with EU AI Act. To get access to the Scaleway Generative APIs, read the [Quickstart guide](https://www.scaleway.com/en/docs/ai-data/generative-apis/quickstart/) and get a [valid API key](https://www.scaleway.com/en/docs/identity-and-access-management/iam/how-to/create-api-keys/)."
           ],
           "type": "string"
         },
@@ -476,7 +478,8 @@
                   "sambanova",
                   "nebius",
                   "xAI",
-                  "kindo"
+                  "kindo",
+                  "scaleway"
                 ]
               }
             },
@@ -1262,6 +1265,38 @@
                   "TeleAI/TeleMM",
                   "deepseek-ai/DeepSeek-V2.5"
                 ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "provider": {
+                "enum": ["scaleway"]
+              }
+            },
+            "required": ["provider"]
+          },
+          "then": {
+            "properties": {
+              "model": {
+                "anyOf": [
+                  {
+                    "enum": [
+                      "llama-3.1-8b-instruct",
+                      "llama-3.1-70b-instruct",
+                      "mistral-nemo-instruct-2407",
+                      "qwen2.5-coder-32b-instruct",
+                      "pixtral-12b-2409"
+                    ]
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "markdownDescription": "Select a pre-defined option, or find the exact model string from Scaleway [here](https://www.scaleway.com/en/docs/ai-data/generative-apis/reference-content/supported-models/).",
+                "x-intellij-html-description": "Select a pre-defined option, or find the exact model string from Scaleway <a href='https://www.scaleway.com/en/docs/ai-data/generative-apis/reference-content/supported-models/'>here</a>."
               }
             }
           }
@@ -2533,7 +2568,8 @@
                 "watsonx",
                 "lmstudio",
                 "siliconflow",
-                "function-network"
+                "function-network",
+                "scaleway"
               ]
             },
             "model": {

--- a/packages/openai-adapters/README.md
+++ b/packages/openai-adapters/README.md
@@ -53,6 +53,7 @@ They are concerned with:
 - [ ] Replicate
 - [ ] SageMaker
 - [x] SambaNova
+- [x] Scaleway
 - [ ] Silicon Flow
 - [x] TextGen Web UI
 - [x] Together

--- a/packages/openai-adapters/src/index.ts
+++ b/packages/openai-adapters/src/index.ts
@@ -67,6 +67,8 @@ export function constructLlmApi(config: LLMConfig): BaseLlmApi | undefined {
       return openAICompatible("http://localhost:10000", config);
     case "nvidia":
       return openAICompatible("https://integrate.api.nvidia.com/v1/", config);
+    case "scaleway":
+        return openAICompatible("https://api.scaleway.ai/v1/", config);      
     case "fireworks":
       return openAICompatible("https://api.fireworks.ai/inference/v1/", config);
     case "together":

--- a/packages/openai-adapters/test/main.test.ts
+++ b/packages/openai-adapters/test/main.test.ts
@@ -279,6 +279,12 @@ const COMPLETION_TESTS: ({ chatOnly?: boolean } & LlmApiConfig)[] = [
     apiKey: process.env.NEBIUS_API_KEY!,
     chatOnly: true,
   },
+  {
+    provider: "scaleway",
+    model: "llama3.1-8b",
+    apiKey: process.env.SCALEWAY_API_KEY!,
+    chatOnly: true,
+  },  
 ];
 
 const FIM_TESTS: LlmApiConfig[] = [
@@ -322,6 +328,11 @@ const EMBEDDINGS_TESTS: LlmApiConfig[] = [
     model: "BAAI/bge-en-icl",
     apiKey: process.env.NEBIUS_API_KEY!,
   },
+  {
+    provider: "scaleway",
+    model: "bge-multilingual-gemma2",
+    apiKey: process.env.SCALEWAY_API_KEY!,
+  },  
 ];
 
 const RERANK_TESTS: LlmApiConfig[] = [


### PR DESCRIPTION
## Description

Added Scaleway LLM and embedding provider.

## Checklist

- [X] The relevant docs, if any, have been updated or created

## Screenshots

No visual changes

## Testing

User Scaleway provider with an [API key](https://www.scaleway.com/en/docs/ai-data/generative-apis/quickstart/)
