### PR TITLE
fix: Properly ignore ignored folders when generating /onboard context

### DIFF
--- a/core/commands/slash/onboard.ts
+++ b/core/commands/slash/onboard.ts
@@ -73,7 +73,10 @@ async function getEntriesFilteredByIgnore(dir: string, ide: IDE) {
     ig = ig.add(igPatterns);
   }
 
-  const filteredEntries = entries.filter((entry) => !ig.ignores(entry.name));
+  const filteredEntries = entries.filter((entry) => {
+    const name = entry.isDirectory() ? `${entry.name}/` : entry.name;
+    return !ig.ignores(name);
+  });
 
   return filteredEntries;
 }
@@ -117,7 +120,7 @@ async function gatherProjectContext(
 
 function createOnboardingPrompt(context: string): string {
   return `
-    As a helpful AI assistant, your task is to onboard a new developer to this project. 
+    As a helpful AI assistant, your task is to onboard a new developer to this project.
     Use the following context about the project structure, READMEs, and dependency files to create a comprehensive overview:
 
     ${context}

--- a/core/indexing/ignore.ts
+++ b/core/indexing/ignore.ts
@@ -102,6 +102,7 @@ export const DEFAULT_IGNORE_DIRS = [
   "__pycache__/",
   "site-packages/",
   ".gradle/",
+  ".mvn/",
   ".cache/",
   "gems/",
   "vendor/",


### PR DESCRIPTION
- **fix: Properly ignore ignored folders when generating /onboard context**
- **fix: add .mvn/ to list of default ignored folders**

Fixes #3293