### PR TITLE
Use convertModelName to avoid 422 errors

### DIFF
--- a/core/llm/llms/Scaleway.ts
+++ b/core/llm/llms/Scaleway.ts
@@ -1,6 +1,7 @@
 import OpenAI from "./OpenAI";
 
-import { LLMOptions } from "../../index.js";
+import { LLMOptions, CompletionOptions, ChatMessage } from "../../index.js";
+import { ChatCompletionCreateParams } from "openai/resources/index";
 
 
 class Scaleway extends OpenAI {
@@ -21,6 +22,14 @@ class Scaleway extends OpenAI {
 
   protected _convertModelName(model: string) {
     return Scaleway.MODEL_IDS[model] || this.model;
+  }
+  protected _convertArgs(options: CompletionOptions, messages: ChatMessage[]): ChatCompletionCreateParams {
+    // Convert model name in the options before passing to parent
+    const modifiedOptions = {
+      ...options,
+      model: this._convertModelName(options.model)
+    };
+    return super._convertArgs(modifiedOptions, messages);
   }
 }
 


### PR DESCRIPTION
## Description

Users reported Continue's model strings like `llama3.1-8b` are returning 422 MODEL NOT FOUND errors. 
Implementing _convertArgs and using _convertModelName in our Scaleway class is a fix tested locally.
Unless there's another way for Continue to enforce the model name conversion?

## Checklist

- [X] The relevant docs, if any, have been updated or created

## Testing

This service is free while in beta, get your `SCW_API_KEY` in https://console.scaleway.com/iam/api-keys
