### PR TITLE
full screen now opens the current session

### DIFF
--- a/core/protocol/passThrough.ts
+++ b/core/protocol/passThrough.ts
@@ -73,6 +73,7 @@ export const CORE_TO_WEBVIEW_PASS_THROUGH: (keyof ToWebviewFromCoreProtocol)[] =
     "didChangeAvailableProfiles",
     "setTTSActive",
     "getWebviewHistoryLength",
+    "getCurrentSessionId",
     "signInToControlPlane",
     "openDialogMessage",
     "docs/suggestions",

--- a/core/protocol/webview.ts
+++ b/core/protocol/webview.ts
@@ -24,6 +24,7 @@ export type ToWebviewFromIdeOrCoreProtocol = {
   ];
   setTTSActive: [boolean, void];
   getWebviewHistoryLength: [undefined, number];
+  getCurrentSessionId: [undefined, string];
   signInToControlPlane: [undefined, void];
   openDialogMessage: ["account", void];
   "docs/suggestions": [PackageDocsResult[], void];

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -754,9 +754,10 @@ const getCommandsMap: (
     "continue.applyCodeFromChat": () => {
       void sidebar.webviewProtocol.request("applyCodeFromChat", undefined);
     },
-    "continue.toggleFullScreen": () => {
+    "continue.toggleFullScreen": async () => {
       focusGUI();
 
+      const sessionId = await sidebar.webviewProtocol.request("getCurrentSessionId", undefined);
       // Check if full screen is already open by checking open tabs
       const fullScreenTab = getFullScreenTab();
 
@@ -777,6 +778,7 @@ const getCommandsMap: (
         vscode.ViewColumn.One,
         {
           retainContextWhenHidden: true,
+          enableScripts: true,
         },
       );
       fullScreenPanel = panel;
@@ -789,6 +791,13 @@ const getCommandsMap: (
         undefined,
         true,
       );
+      
+      panel.onDidChangeViewState(() => {
+        vscode.commands.executeCommand("continue.newSession");
+        if(sessionId){
+          vscode.commands.executeCommand("continue.focusContinueSessionId", sessionId);
+        }
+      });
 
       // When panel closes, reset the webview and focus
       panel.onDidDispose(

--- a/gui/src/hooks/useSetup.ts
+++ b/gui/src/hooks/useSetup.ts
@@ -137,6 +137,14 @@ function useSetup() {
     [history],
   );
 
+  useWebviewListener(
+    "getCurrentSessionId",
+    async () => {
+      return sessionId
+    },
+    [sessionId],
+  );
+
   useWebviewListener("setInactive", async () => {
     dispatch(setInactive());
   });


### PR DESCRIPTION
## Description

clicking on the full screen button will either open the current session or a new one (the old behavior of the last thing that was on the fullscreen window showing up felt weird).

this also helps address an issue where chats are getting duplicated in history due to old chats getting pulled up when the html renders and then resaved under a new session id.


## Screenshots


https://github.com/user-attachments/assets/bf228655-5b90-4e77-a5cd-5aad084a20bd



## Testing

tested on vscode
