### PR TITLE
Add `mirostat_eta` and `mirostat_tau` model parameters supported by Ollama / llama.cpp backend

### DIFF
--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -24,7 +24,7 @@ declare global {
       ) => void;
     }
   }
-  
+
   export interface ChunkWithoutID {
     content: string;
     startLine: number;
@@ -32,13 +32,13 @@ declare global {
     signature?: string;
     otherMetadata?: { [key: string]: any };
   }
-  
+
   export interface Chunk extends ChunkWithoutID {
     digest: string;
     filepath: string;
     index: number; // Index of the chunk in the document at filepath
   }
-  
+
   export interface IndexingProgressUpdate {
     progress: number;
     desc: string;
@@ -53,7 +53,7 @@ declare global {
       | "cancelled";
     debugInfo?: string;
   }
-  
+
   // This is more or less a V2 of IndexingProgressUpdate for docs etc.
   export interface IndexingStatus {
     id: string;
@@ -68,20 +68,20 @@ declare global {
     icon?: string;
     url?: string;
   }
-  
+
   export type PromptTemplateFunction = (
     history: ChatMessage[],
     otherData: Record<string, string>,
   ) => string | ChatMessage[];
-  
+
   export type PromptTemplate = string | PromptTemplateFunction;
-  
+
   export interface ILLM extends LLMOptions {
     get providerName(): string;
-  
+
     uniqueId: string;
     model: string;
-  
+
     title?: string;
     systemMessage?: string;
     contextLength: number;
@@ -95,65 +95,65 @@ declare global {
     apiKey?: string;
     apiBase?: string;
     cacheBehavior?: CacheBehavior;
-  
+
     deployment?: string;
     apiVersion?: string;
     apiType?: string;
     region?: string;
     projectId?: string;
-  
+
     // Embedding options
     embeddingId: string;
     maxEmbeddingChunkSize: number;
     maxEmbeddingBatchSize: number;
-  
+
     complete(
       prompt: string,
       signal: AbortSignal,
       options?: LLMFullCompletionOptions,
     ): Promise<string>;
-  
+
     streamComplete(
       prompt: string,
       signal: AbortSignal,
       options?: LLMFullCompletionOptions,
     ): AsyncGenerator<string, PromptLog>;
-  
+
     streamFim(
       prefix: string,
       suffix: string,
       signal: AbortSignal,
       options?: LLMFullCompletionOptions,
     ): AsyncGenerator<string, PromptLog>;
-  
+
     streamChat(
       messages: ChatMessage[],
       signal: AbortSignal,
       options?: LLMFullCompletionOptions,
     ): AsyncGenerator<ChatMessage, PromptLog>;
-  
+
     chat(
       messages: ChatMessage[],
       signal: AbortSignal,
       options?: LLMFullCompletionOptions,
     ): Promise<ChatMessage>;
-  
+
     embed(chunks: string[]): Promise<number[][]>;
-  
+
     rerank(query: string, chunks: Chunk[]): Promise<number[]>;
-  
+
     countTokens(text: string): number;
-  
+
     supportsImages(): boolean;
-  
+
     supportsCompletions(): boolean;
-  
+
     supportsPrefill(): boolean;
-  
+
     supportsFim(): boolean;
-  
+
     listModels(): Promise<string[]>;
-  
+
     renderPromptTemplate(
       template: PromptTemplate,
       history: ChatMessage[],
@@ -161,9 +161,9 @@ declare global {
       canPutWordsInModelsMouth?: boolean,
     ): string | ChatMessage[];
   }
-  
+
   export type ContextProviderType = "normal" | "query" | "submenu";
-  
+
   export interface ContextProviderDescription {
     title: ContextProviderName;
     displayTitle: string;
@@ -172,9 +172,9 @@ declare global {
     type: ContextProviderType;
     dependsOnIndexing?: boolean;
   }
-  
+
   export type FetchFunction = (url: string | URL, init?: any) => Promise<any>;
-  
+
   export interface ContextProviderExtras {
     config: ContinueConfig;
     fullInput: string;
@@ -185,30 +185,30 @@ declare global {
     selectedCode: RangeInFile[];
     fetch: FetchFunction;
   }
-  
+
   export interface LoadSubmenuItemsArgs {
     config: ContinueConfig;
     ide: IDE;
     fetch: FetchFunction;
   }
-  
+
   export interface CustomContextProvider {
     title: string;
     displayTitle?: string;
     description?: string;
     renderInlineAs?: string;
     type?: ContextProviderType;
-  
+
     getContextItems(
       query: string,
       extras: ContextProviderExtras,
     ): Promise<ContextItem[]>;
-  
+
     loadSubmenuItems?: (
       args: LoadSubmenuItemsArgs,
     ) => Promise<ContextSubmenuItem[]>;
   }
-  
+
   export interface ContextSubmenuItem {
     id: string;
     title: string;
@@ -216,7 +216,7 @@ declare global {
     icon?: string;
     metadata?: any;
   }
-  
+
   export interface SiteIndexingConfig {
     title: string;
     startUrl: string;
@@ -224,93 +224,93 @@ declare global {
     maxDepth?: number;
     faviconUrl?: string;
   }
-  
+
   export interface SiteIndexingConfig {
     startUrl: string;
     rootUrl?: string;
     title: string;
     maxDepth?: number;
   }
-  
+
   export interface IContextProvider {
     get description(): ContextProviderDescription;
-  
+
     getContextItems(
       query: string,
       extras: ContextProviderExtras,
     ): Promise<ContextItem[]>;
-  
+
     loadSubmenuItems(args: LoadSubmenuItemsArgs): Promise<ContextSubmenuItem[]>;
   }
-  
+
   export interface Checkpoint {
     [filepath: string]: string;
   }
-  
+
   export interface Session {
     sessionId: string;
     title: string;
     workspaceDirectory: string;
     history: ChatHistoryItem[];
   }
-  
+
   export interface SessionMetadata {
     sessionId: string;
     title: string;
     dateCreated: string;
     workspaceDirectory: string;
   }
-  
+
   export interface RangeInFile {
     filepath: string;
     range: Range;
   }
-  
+
   export interface Location {
     filepath: string;
     position: Position;
   }
-  
+
   export interface FileWithContents {
     filepath: string;
     contents: string;
   }
-  
+
   export interface Range {
     start: Position;
     end: Position;
   }
-  
+
   export interface Position {
     line: number;
     character: number;
   }
-  
+
   export interface FileEdit {
     filepath: string;
     range: Range;
     replacement: string;
   }
-  
+
   export interface ContinueError {
     title: string;
     message: string;
   }
-  
+
   export interface CompletionOptions extends BaseCompletionOptions {
     model: string;
   }
-  
+
   export type ChatMessageRole = "user" | "assistant" | "system" | "tool";
-  
+
   export interface MessagePart {
     type: "text" | "imageUrl";
     text?: string;
     imageUrl?: { url: string };
   }
-  
+
   export type MessageContent = string | MessagePart[];
-  
+
   export interface ToolCall {
     id: string;
     type: "function";
@@ -319,7 +319,7 @@ declare global {
       arguments: string;
     };
   }
-  
+
   export interface ToolCallDelta {
     id?: string;
     type?: "function";
@@ -328,47 +328,47 @@ declare global {
       arguments?: string;
     };
   }
-  
+
   export interface ToolResultChatMessage {
     role: "tool";
     content: string;
     toolCallId: string;
   }
-  
+
   export interface UserChatMessage {
     role: "user";
     content: MessageContent;
   }
-  
+
   export interface AssistantChatMessage {
     role: "assistant";
     content: MessageContent;
     toolCalls?: ToolCallDelta[];
   }
-  
+
   export interface SystemChatMessage {
     role: "system";
     content: string;
   }
-  
+
   export type ChatMessage =
     | UserChatMessage
     | AssistantChatMessage
     | SystemChatMessage
     | ToolResultChatMessage;
-  
+
   export interface ContextItemId {
     providerTitle: string;
     itemId: string;
   }
-  
+
   export type ContextItemUriTypes = "file" | "url";
-  
+
   export interface ContextItemUri {
     type: ContextItemUriTypes;
     value: string;
   }
-  
+
   export interface ContextItem {
     content: string;
     name: string;
@@ -379,40 +379,40 @@ declare global {
     uri?: ContextItemUri;
     hidden?: boolean;
   }
-  
+
   export interface ContextItemWithId extends ContextItem {
     id: ContextItemId;
   }
-  
+
   export interface InputModifiers {
     useCodebase: boolean;
     noContext: boolean;
   }
-  
+
   export interface SymbolWithRange extends RangeInFile {
     name: string;
     type: Parser.SyntaxNode["type"];
     content: string;
   }
-  
+
   export type FileSymbolMap = Record<string, SymbolWithRange[]>;
-  
+
   export interface PromptLog {
     modelTitle: string;
     completionOptions: CompletionOptions;
     prompt: string;
     completion: string;
   }
-  
+
   type MessageModes = "chat" | "edit";
-  
+
   export type ToolStatus =
     | "generating"
     | "generated"
     | "calling"
     | "done"
     | "canceled";
-  
+
   // Will exist only on "assistant" messages with tool calls
   interface ToolCallState {
     toolCallId: string;
@@ -421,7 +421,7 @@ declare global {
     parsedArgs: any;
     output?: ContextItem[];
   }
-  
+
   export interface ChatHistoryItem {
     message: ChatMessage;
     contextItems: ContextItemWithId[];
@@ -433,17 +433,17 @@ declare global {
     checkpoint?: Checkpoint;
     isBeforeCheckpoint?: boolean;
   }
-  
+
   export interface LLMFullCompletionOptions extends BaseCompletionOptions {
     log?: boolean;
     model?: string;
   }
-  
+
   export type ToastType = "info" | "error" | "warning";
-  
+
   export interface LLMOptions {
     model: string;
-  
+
     title?: string;
     uniqueId?: string;
     systemMessage?: string;
@@ -460,39 +460,39 @@ declare global {
     aiGatewaySlug?: string;
     apiBase?: string;
     cacheBehavior?: CacheBehavior;
-  
+
     useLegacyCompletionsEndpoint?: boolean;
-  
+
     // Embedding options
     embeddingId?: string;
     maxEmbeddingChunkSize?: number;
     maxEmbeddingBatchSize?: number;
-  
+
     // Cloudflare options
     accountId?: string;
-  
+
     // Azure options
     deployment?: string;
     apiVersion?: string;
     apiType?: string;
-  
+
     // AWS options
     profile?: string;
     modelArn?: string;
-  
+
     // AWS and GCP Options
     region?: string;
-  
+
     // GCP Options
     capabilities?: ModelCapability;
-  
+
     // GCP and Watsonx Options
     projectId?: string;
-  
+
     // IBM watsonx Options
     deploymentId?: string;
   }
-  
+
   type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<
     T,
     Exclude<keyof T, Keys>
@@ -500,7 +500,7 @@ declare global {
     {
       [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>;
     }[Keys];
-  
+
   export interface CustomLLMWithOptionals {
     options: LLMOptions;
     streamCompletion?: (
@@ -519,7 +519,7 @@ declare global {
       fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
     ) => Promise<string[]>;
   }
-  
+
   /**
    * The LLM interface requires you to specify either \`streamCompletion\` or \`streamChat\` (or both).
    */
@@ -527,29 +527,29 @@ declare global {
     CustomLLMWithOptionals,
     "streamCompletion" | "streamChat"
   >;
-  
+
   // IDE
-  
+
   export type DiffLineType = "new" | "old" | "same";
-  
+
   export interface DiffLine {
     type: DiffLineType;
     line: string;
   }
-  
+
   export class Problem {
     filepath: string;
     range: Range;
     message: string;
   }
-  
+
   export class Thread {
     name: string;
     id: number;
   }
-  
+
   export type IdeType = "vscode" | "jetbrains";
-  
+
   export interface IdeInfo {
     ideType: IdeType;
     name: string;
@@ -557,23 +557,23 @@ declare global {
     remoteName: string;
     extensionVersion: string;
   }
-  
+
   export interface BranchAndDir {
     branch: string;
     directory: string;
   }
-  
+
   export interface IndexTag extends BranchAndDir {
     artifactId: string;
   }
-  
+
   export enum FileType {
     Unkown = 0,
     File = 1,
     Directory = 2,
     SymbolicLink = 64,
   }
-  
+
   export interface IdeSettings {
     remoteConfigServerUrl: string | undefined;
     remoteConfigSyncPeriod: number;
@@ -582,71 +582,71 @@ declare global {
     pauseCodebaseIndexOnStart: boolean;
     enableDebugLogs: boolean;
   }
-  
+
   export interface IDE {
     getIdeInfo(): Promise<IdeInfo>;
-  
+
     getIdeSettings(): Promise<IdeSettings>;
-  
+
     getDiff(includeUnstaged: boolean): Promise<string[]>;
-  
+
     getClipboardContent(): Promise<{ text: string; copiedAt: string }>;
-  
+
     isTelemetryEnabled(): Promise<boolean>;
-  
+
     getUniqueId(): Promise<string>;
-  
+
     getTerminalContents(): Promise<string>;
-  
+
     getDebugLocals(threadIndex: number): Promise<string>;
-  
+
     getTopLevelCallStackSources(
       threadIndex: number,
       stackDepth: number,
     ): Promise<string[]>;
-  
+
     getAvailableThreads(): Promise<Thread[]>;
-  
+
     listFolders(): Promise<string[]>;
-  
+
     getWorkspaceDirs(): Promise<string[]>;
-  
+
     getWorkspaceConfigs(): Promise<ContinueRcJson[]>;
-  
+
     fileExists(filepath: string): Promise<boolean>;
-  
+
     writeFile(path: string, contents: string): Promise<void>;
-  
+
     showVirtualFile(title: string, contents: string): Promise<void>;
-  
+
     getContinueDir(): Promise<string>;
-  
+
     openFile(path: string): Promise<void>;
-  
+
     openUrl(url: string): Promise<void>;
-  
+
     runCommand(command: string): Promise<void>;
-  
+
     saveFile(filepath: string): Promise<void>;
-  
+
     readFile(filepath: string): Promise<string>;
-  
+
     readRangeInFile(filepath: string, range: Range): Promise<string>;
-  
+
     showLines(
       filepath: string,
       startLine: number,
       endLine: number,
     ): Promise<void>;
-  
+
     showDiff(
       filepath: string,
       newContents: string,
       stepIndex: number,
     ): Promise<void>;
-  
+
     getOpenFiles(): Promise<string[]>;
-  
+
     getCurrentFile(): Promise<
       | undefined
       | {
@@ -655,46 +655,46 @@ declare global {
           contents: string;
         }
     >;
-  
+
     getPinnedFiles(): Promise<string[]>;
-  
+
     getSearchResults(query: string): Promise<string>;
-  
+
     subprocess(command: string, cwd?: string): Promise<[string, string]>;
-  
+
     getProblems(filepath?: string | undefined): Promise<Problem[]>;
-  
+
     getBranch(dir: string): Promise<string>;
-  
+
     getTags(artifactId: string): Promise<IndexTag[]>;
-  
+
     getRepoName(dir: string): Promise<string | undefined>;
-  
+
     showToast(
       type: ToastType,
       message: string,
       ...otherParams: any[]
     ): Promise<any>;
-  
+
     getGitRootPath(dir: string): Promise<string | undefined>;
-  
+
     listDir(dir: string): Promise<[string, FileType][]>;
-  
+
     getLastModified(files: string[]): Promise<{ [path: string]: number }>;
-  
+
     getGitHubAuthToken(args: GetGhTokenArgs): Promise<string | undefined>;
-  
+
     // LSP
     gotoDefinition(location: Location): Promise<RangeInFile[]>;
-  
+
     // Callbacks
     onDidChangeActiveTextEditor(callback: (filepath: string) => void): void;
-  
+
     pathSep(): Promise<string>;
   }
-  
+
   // Slash Commands
-  
+
   export interface ContinueSDK {
     ide: IDE;
     llm: ILLM;
@@ -707,16 +707,16 @@ declare global {
     config: ContinueConfig;
     fetch: FetchFunction;
   }
-  
+
   export interface SlashCommand {
     name: string;
     description: string;
     params?: { [key: string]: any };
     run: (sdk: ContinueSDK) => AsyncGenerator<string | undefined>;
   }
-  
+
   // Config
-  
+
   type StepName =
     | "AnswerQuestionChroma"
     | "GenerateShellCommandStep"
@@ -728,7 +728,7 @@ declare global {
     | "OpenConfigStep"
     | "GenerateShellCommandStep"
     | "DraftIssueStep";
-  
+
   type ContextProviderName =
     | "diff"
     | "github"
@@ -759,7 +759,7 @@ declare global {
     | "repo-map"
     | "url"
     | string;
-  
+
   type TemplateType =
     | "llama2"
     | "alpaca"
@@ -778,7 +778,7 @@ declare global {
     | "gemma"
     | "granite"
     | "llama3";
-  
+
   export interface RequestOptions {
     timeout?: number;
     verifySsl?: boolean;
@@ -789,40 +789,40 @@ declare global {
     noProxy?: string[];
     clientCertificate?: ClientCertificateOptions;
   }
-  
+
   export interface CacheBehavior {
     cacheSystemMessage?: boolean;
     cacheConversation?: boolean;
   }
-  
+
   export interface ClientCertificateOptions {
     cert: string;
     key: string;
     passphrase?: string;
   }
-  
+
   export interface StepWithParams {
     name: StepName;
     params: { [key: string]: any };
   }
-  
+
   export interface ContextProviderWithParams {
     name: ContextProviderName;
     params: { [key: string]: any };
   }
-  
+
   export interface SlashCommandDescription {
     name: string;
     description: string;
     params?: { [key: string]: any };
   }
-  
+
   export interface CustomCommand {
     name: string;
     prompt: string;
     description: string;
   }
-  
+
   interface Prediction {
     type: "content";
     content:
@@ -832,13 +832,13 @@ declare global {
           text: string;
         }[];
   }
-  
+
   export interface ToolExtras {
     ide: IDE;
     llm: ILLM;
     fetch: FetchFunction;
   }
-  
+
   export interface Tool {
     type: "function";
     function: {
@@ -847,13 +847,13 @@ declare global {
       parameters?: Record<string, any>;
       strict?: boolean | null;
     };
-  
+
     displayTitle: string;
     wouldLikeTo: string;
     readonly: boolean;
     uri?: string;
   }
-  
+
   interface BaseCompletionOptions {
     temperature?: number;
     topP?: number;
@@ -862,6 +862,8 @@ declare global {
     presencePenalty?: number;
     frequencyPenalty?: number;
     mirostat?: number;
+    mirostatEta?: number;
+    mirostatTau?: number;
     stop?: string[];
     maxTokens?: number;
     numThreads?: number;
@@ -872,11 +874,11 @@ declare global {
     prediction?: Prediction;
     tools?: Tool[];
   }
-  
+
   export interface ModelCapability {
     uploadImage?: boolean;
   }
-  
+
   export interface ModelDescription {
     title: string;
     provider: string;
@@ -893,7 +895,7 @@ declare global {
     capabilities?: ModelCapability;
     cacheBehavior?: CacheBehavior;
   }
-  
+
   export interface EmbedOptions {
     apiBase?: string;
     apiKey?: string;
@@ -906,23 +908,23 @@ declare global {
     maxBatchSize?: number;
     // AWS options
     profile?: string;
-  
+
     // AWS and GCP Options
     region?: string;
-  
+
     // GCP and Watsonx Options
     projectId?: string;
   }
-  
+
   export interface EmbeddingsProviderDescription extends EmbedOptions {
     provider: string;
   }
-  
+
   export interface RerankerDescription {
     name: string;
     params?: { [key: string]: any };
   }
-  
+
   export interface TabAutocompleteOptions {
     disable: boolean;
     useFileSuffix: boolean;
@@ -942,29 +944,29 @@ declare global {
     useImports?: boolean;
     showWhateverWeHaveAtXMs?: number;
   }
-  
+
   interface StdioOptions {
     type: "stdio";
     command: string;
     args: string[];
   }
-  
+
   interface WebSocketOptions {
     type: "websocket";
     url: string;
   }
-  
+
   interface SSEOptions {
     type: "sse";
     url: string;
   }
-  
+
   type TransportOptions = StdioOptions | WebSocketOptions | SSEOptions;
-  
+
   export interface MCPOptions {
     transport: TransportOptions;
   }
-  
+
   export interface ContinueUIConfig {
     codeBlockToolbarPosition?: "top" | "bottom";
     fontSize?: number;
@@ -973,7 +975,7 @@ declare global {
     getChatTitles?: boolean;
     codeWrap?: boolean;
   }
-  
+
   interface ContextMenuConfig {
     comment?: string;
     docstring?: string;
@@ -981,25 +983,25 @@ declare global {
     optimize?: string;
     fixGrammar?: string;
   }
-  
+
   interface ModelRoles {
     inlineEdit?: string;
     applyCodeBlock?: string;
     repoMapFileSelection?: string;
   }
-  
+
   export type EditStatus =
     | "not-started"
     | "streaming"
     | "accepting"
     | "accepting:full-diff"
     | "done";
-  
+
   export type ApplyStateStatus =
     | "streaming" // Changes are being applied to the file
     | "done" // All changes have been applied, awaiting user to accept/reject
     | "closed"; // All changes have been applied. Note that for new files, we immediately set the status to "closed"
-  
+
   export interface ApplyState {
     streamId: string;
     status?: ApplyStateStatus;
@@ -1007,7 +1009,7 @@ declare global {
     filepath?: string;
     fileContent?: string;
   }
-  
+
   export interface RangeInFileWithContents {
     filepath: string;
     range: {
@@ -1016,9 +1018,9 @@ declare global {
     };
     contents: string;
   }
-  
+
   export type CodeToEdit = RangeInFileWithContents | FileWithContents;
-  
+
   /**
    * Represents the configuration for a quick action in the Code Lens.
    * Quick actions are custom commands that can be added to function and class declarations.
@@ -1028,13 +1030,13 @@ declare global {
      * The title of the quick action that will display in the Code Lens.
      */
     title: string;
-  
+
     /**
      * The prompt that will be sent to the model when the quick action is invoked,
      * with the function or class body concatenated.
      */
     prompt: string;
-  
+
     /**
      * If \`true\`, the result of the quick action will be sent to the chat panel.
      * If \`false\`, the streamed result will be inserted into the document.
@@ -1043,28 +1045,28 @@ declare global {
      */
     sendToChat: boolean;
   }
-  
+
   export type DefaultContextProvider = ContextProviderWithParams & {
     query?: string;
   };
-  
+
   interface ExperimentalConfig {
     contextMenuPrompts?: ContextMenuConfig;
     modelRoles?: ModelRoles;
     defaultContext?: DefaultContextProvider[];
     promptPath?: string;
-  
+
     /**
      * Quick actions are a way to add custom commands to the Code Lens of
      * function and class declarations.
      */
     quickActions?: QuickActionConfig[];
-  
+
     /**
      * Automatically read LLM chat responses aloud using system TTS models
      */
     readResponseTTS?: boolean;
-  
+
     /**
      * If set to true, we will attempt to pull down and install an instance of Chromium
      * that is compatible with the current version of Puppeteer.
@@ -1074,13 +1076,13 @@ declare global {
     useTools?: boolean;
     modelContextProtocolServers?: MCPOptions[];
   }
-  
+
   interface AnalyticsConfig {
     type: string;
     url?: string;
     clientKey?: string;
   }
-  
+
   // config.json
   export interface SerializedContinueConfig {
     env?: string[];
@@ -1104,13 +1106,13 @@ declare global {
     analytics?: AnalyticsConfig;
     docs?: SiteIndexingConfig[];
   }
-  
+
   export type ConfigMergeType = "merge" | "overwrite";
-  
+
   export type ContinueRcJson = Partial<SerializedContinueConfig> & {
     mergeBehavior: ConfigMergeType;
   };
-  
+
   // config.ts - give users simplified interfaces
   export interface Config {
     /** If set to true, Continue will collect anonymous usage data to improve the product. If set to false, we will collect nothing. Read here to learn more: https://docs.continue.dev/telemetry */
@@ -1156,7 +1158,7 @@ declare global {
     /** Analytics configuration */
     analytics?: AnalyticsConfig;
   }
-  
+
   // in the actual Continue source code
   export interface ContinueConfig {
     allowAnonymousTelemetry?: boolean;
@@ -1179,7 +1181,7 @@ declare global {
     docs?: SiteIndexingConfig[];
     tools: Tool[];
   }
-  
+
   export interface BrowserSerializedContinueConfig {
     allowAnonymousTelemetry?: boolean;
     models: ModelDescription[];
@@ -1199,24 +1201,24 @@ declare global {
     docs?: SiteIndexingConfig[];
     tools: Tool[];
   }
-  
+
   // DOCS SUGGESTIONS AND PACKAGE INFO
   export interface FilePathAndName {
     path: string;
     name: string;
   }
-  
+
   export interface PackageFilePathAndName extends FilePathAndName {
     packageRegistry: string; // e.g. npm, pypi
   }
-  
+
   export type ParsedPackageInfo = {
     name: string;
     packageFile: PackageFilePathAndName;
     language: string;
     version: string;
   };
-  
+
   export type PackageDetails = {
     docsLink?: string;
     docsLinkWarning?: string;
@@ -1225,11 +1227,11 @@ declare global {
     repo?: string;
     license?: string;
   };
-  
+
   export type PackageDetailsSuccess = PackageDetails & {
     docsLink: string;
   };
-  
+
   export type PackageDocsResult = {
     packageInfo: ParsedPackageInfo;
   } & (

--- a/core/control-plane/schema.ts
+++ b/core/control-plane/schema.ts
@@ -53,6 +53,8 @@ const modelDescriptionSchema = z.object({
       presencePenalty: z.number().optional(),
       frequencyPenalty: z.number().optional(),
       mirostat: z.number().optional(),
+      mirostatEta: z.number().optional(),
+      mirostatTau: z.number().optional(),
       stop: z.array(z.string()).optional(),
       maxTokens: z.number().optional(),
       numThreads: z.number().optional(),

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -860,6 +860,8 @@ interface BaseCompletionOptions {
   presencePenalty?: number;
   frequencyPenalty?: number;
   mirostat?: number;
+  mirostatEta?: number;
+  mirostatTau?: number;
   stop?: string[];
   maxTokens?: number;
   numThreads?: number;

--- a/core/llm/llms/LlamaCpp.ts
+++ b/core/llm/llms/LlamaCpp.ts
@@ -15,6 +15,8 @@ class LlamaCpp extends BaseLLM {
       presence_penalty: options.presencePenalty,
       min_p: options.minP,
       mirostat: options.mirostat,
+      mirostatEta: options.mirostatEta,
+      mirostatTau: options.mirostatTau,
       stop: options.stop,
       top_k: options.topK,
       top_p: options.topP,

--- a/core/llm/llms/Ollama.ts
+++ b/core/llm/llms/Ollama.ts
@@ -182,6 +182,8 @@ class Ollama extends BaseLLM {
       stop: options.stop,
       num_ctx: this.contextLength,
       mirostat: options.mirostat,
+      mirostat_eta: options.mirostatEta,
+      mirostat_tau: options.mirostatTau,
       num_thread: options.numThreads,
       use_mmap: options.useMmap,
       min_p: options.minP,

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -152,6 +152,8 @@ Parameters that control the behavior of text generation and completion settings.
 - `presencePenalty`: Discourages the model from generating tokens that have already appeared in the output.
 - `frequencePenalty`: Penalizes tokens based on their frequency in the text, reducing repetition.
 - `mirostat`: Enables Mirostat sampling, which controls the perplexity during text generation. Supported by Ollama, LM Studio, and llama.cpp providers (default: `0`, where `0` = disabled, `1` = Mirostat, and `2` = Mirostat 2.0).
+- `mirostatEta`: Influences how quickly the algorithm responds to feedback from the generated text. A lower learning rate will result in slower adjustments, while a higher learning rate will make the algorithm more responsive. (Default: 0.1)
+- `mirostatTau`: Controls the balance between coherence and diversity of the output. A lower value will result in more focused and coherent text. (Default: 5.0)
 - `stop`: An array of stop tokens that, when encountered, will terminate the completion. Allows specifying multiple end conditions.
 - `maxTokens`: The maximum number of tokens to generate in a completion (default: `2048`).
 - `numThreads`: The number of threads used during the generation process. Available only for Ollama as `num_thread`.

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/customize/deep-dives/prompt-files.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/customize/deep-dives/prompt-files.md
@@ -59,6 +59,8 @@ Write unit tests for the above selected code, following each of these instructio
 - `presencePenalty`
 - `frequencyPenalty`
 - `mirostat`
+- `mirostatEta`
+- `mirostatTau`
 - `stop`
 - `maxTokens`
 - `description`

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/reference.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/reference.md
@@ -152,6 +152,8 @@ Parameters that control the behavior of text generation and completion settings.
 - `presencePenalty`: Discourages the model from generating tokens that have already appeared in the output.
 - `frequencePenalty`: Penalizes tokens based on their frequency in the text, reducing repetition.
 - `mirostat`: Enables Mirostat sampling, which controls the perplexity during text generation. Supported by Ollama, LM Studio, and llama.cpp providers (default: `0`, where `0` = disabled, `1` = Mirostat, and `2` = Mirostat 2.0).
+- `mirostatEta`: Influences how quickly the algorithm responds to feedback from the generated text. A lower learning rate will result in slower adjustments, while a higher learning rate will make the algorithm more responsive. (Default: 0.1)
+- `mirostatTau`: Controls the balance between coherence and diversity of the output. A lower value will result in more focused and coherent text. (Default: 5.0)
 - `stop`: An array of stop tokens that, when encountered, will terminate the completion. Allows specifying multiple end conditions.
 - `maxTokens`: The maximum number of tokens to generate in a completion (default: `2048`).
 - `numThreads`: The number of threads used during the generation process. Available only for Ollama as `num_thread`.

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -43,6 +43,16 @@
           "description": "Enable Mirostat sampling, controlling perplexity during text generation (default: 0, 0 = disabled, 1 = Mirostat, 2 = Mirostat 2.0). Only available for Ollama, LM Studio, and llama.cpp providers",
           "type": "number"
         },
+        "mirostatEta": {
+          "title": "Mirostat Eta",
+          "description": "The Mirostat eta value, which controls how quickly the model converges to its optimal perplexity. A higher value means faster convergence but may result in less accurate results. Only enabled when `mirostat` is also enabled. (default: 0.1)",
+          "type": "number"
+        },
+        "mirostatTau": {
+          "title": "Mirostat Tau",
+          "description": "The Mirostat tau value, which controls how quickly the model converges to its optimal perplexity. A higher value means faster convergence but may result in less accurate results. Only enabled when `mirostat` is also enabled. (default: 5.0)",
+          "type": "number"
+        },
         "stop": {
           "title": "Stop",
           "description": "The stop tokens of the completion.",

--- a/packages/config-types/src/index.ts
+++ b/packages/config-types/src/index.ts
@@ -8,6 +8,8 @@ export const completionOptionsSchema = z.object({
   presencePenalty: z.number().optional(),
   frequencyPenalty: z.number().optional(),
   mirostat: z.number().optional(),
+  mirostatEta: z.number().optional(),
+  mirostatTau: z.number().optional(),
   stop: z.array(z.string()).optional(),
   maxTokens: z.number().optional(),
   numThreads: z.number().optional(),


### PR DESCRIPTION
## Description

Added new variables to relevant parts of the code to enable:
- `mirostatEta` and `mirostatTau` can be configured in the appropriate spot in `config.json`
- These variables are now sent to the `_streamComplete` and `_streamChat` functions (and any other data structure that extends `BaseCompletionOptions` and related accessor functions)
- updated documentation

Fixes #3345 

## Checklist

- [x] The relevant docs, if any, have been updated or created

## Screenshots

The schema options are validated and suggested appropriately:
<img width="596" alt="Screenshot 2024-12-13 at 03 38 01" src="https://github.com/user-attachments/assets/6848a8a2-31a8-492d-9e42-9a7e22ddc4ad" />

## Testing

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change. ]
[ For new UI features, ensure that the changes look good across viewport widths, light/dark theme, etc ]
