### PR TITLE
Better fallback fim / autocomplete prompt

### DIFF
--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -476,7 +476,7 @@ export abstract class BaseLLM implements ILLM {
   ): AsyncGenerator<string> {
     const { completionOptions, log } = this._parseCompletionOptions(options);
 
-    const madeUpFimPrompt = `${prefix}<FIM>${suffix}`;
+    const madeUpFimPrompt = `<|fim_prefix|>${prefix}<|fim_suffix|>${suffix}<|fim_middle|>`;
     if (log) {
       if (this.writeLog) {
         await this.writeLog(


### PR DESCRIPTION
## Description

The fallback FIM prompt is useless as is it. This provides a fallback prompt format that is used by some models and somewhat common.
It also happens to be a workaround for issue https://github.com/continuedev/continue/issues/3353
