### PR TITLE
close sidebar when opening full screen

### DIFF
--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -810,6 +810,7 @@ const getCommandsMap: (
       );
 
       vscode.commands.executeCommand("workbench.action.copyEditorToNewWindow");
+      vscode.commands.executeCommand("workbench.action.closeAuxiliaryBar");
     },
     "continue.openConfig": () => {
       core.invoke("config/openProfile", {


### PR DESCRIPTION
## Description

the sidebar will now close when the full screen is opened, trying to open it while full screen is up will take you to fullscreen, it will reopen when the fullscreen is closed.

## Testing

tested on vscode
