### PR TITLE
Fix comment parsing to handle end of line inline comments

### DIFF
--- a/extensions/vscode/src/util/getTheme.ts
+++ b/extensions/vscode/src/util/getTheme.ts
@@ -11,12 +11,39 @@ import * as vscode from "vscode";
 /**
  * Strip comments from theme
  */
+
+function stripInLineComment(line: string): string {
+  let inString = false;
+  let pCh = '';
+
+  for (let i = 0; i < line.length-1; i++) {
+    const ch = line[i];
+    const nCh = line[i + 1];
+
+    // If we're not in a string and we see '//' this is a comment.
+    if (!inString && ch === '/' && nCh === '/') {
+      // Stop processing this line from here.
+      return line.substring(0, i);
+    }
+
+    // Toggle inString state if we see a double quote not escaped by a backslash.
+    if (ch === '"' && pCh !== '\\') {
+      inString = !inString;
+    }
+
+    pCh = ch;
+  }
+
+  return line;
+}
+
 function parseThemeString(themeString: string | undefined): any {
   themeString = themeString
     ?.split("\n")
     .filter((line) => {
       return !line.trim().startsWith("//");
     })
+    .map(stripInLineComment)
     .join("\n");
   return JSON.parse(themeString ?? "{}");
 }


### PR DESCRIPTION
## Description

Add support to handle comments that are at the end of a line of json because M$FT is just that way. The implementation is a bit naive and expanded for readability.  Also, I'm not exactly a javascript / typescript programmer. There is likely a better way to implement this but it does fix the issue.

## Checklist

N/A

## Screenshots

N/A

## Testing

Checked with vs2019A_dark.json from the vscode-csharp extension that was breaking the previous code.