### PR TITLE
Only save in chat mode, handle chat describer errors

### DIFF
--- a/gui/src/redux/thunks/session.ts
+++ b/gui/src/redux/thunks/session.ts
@@ -174,15 +174,19 @@ export const saveCurrentSession = createAsyncThunk<
           ?.message?.content?.toString();
 
         if (assistantResponse) {
-          const result = await extra.ideMessenger.request(
-            "chatDescriber/describe",
-            {
-              text: assistantResponse,
-              selectedModelTitle: state.config.defaultModelTitle,
-            },
-          );
-          if (result.status === "success" && result.content) {
-            title = result.content;
+          try {
+            const result = await extra.ideMessenger.request(
+              "chatDescriber/describe",
+              {
+                text: assistantResponse,
+                selectedModelTitle: state.config.defaultModelTitle,
+              },
+            );
+            if (result.status === "success" && result.content) {
+              title = result.content;
+            }
+          } catch (e) {
+            console.error("Error generating chat title", e);
           }
         }
       }

--- a/gui/src/redux/thunks/streamThunkWrapper.ts
+++ b/gui/src/redux/thunks/streamThunkWrapper.ts
@@ -7,7 +7,7 @@ export const streamThunkWrapper = createAsyncThunk<
   void,
   () => Promise<void>,
   ThunkApiType
->("chat/streamWrapper", async (runStream, { dispatch, extra }) => {
+>("chat/streamWrapper", async (runStream, { dispatch, extra, getState }) => {
   try {
     await runStream();
   } catch (e: any) {
@@ -16,10 +16,13 @@ export const streamThunkWrapper = createAsyncThunk<
     dispatch(clearLastEmptyResponse());
   } finally {
     dispatch(setInactive());
-    await dispatch(
-      saveCurrentSession({
-        openNewSession: false,
-      }),
-    );
+    const state = getState();
+    if (state.session.mode === "chat") {
+      await dispatch(
+        saveCurrentSession({
+          openNewSession: false,
+        }),
+      );
+    }
   }
 });


### PR DESCRIPTION
- Don't save on stream end in edit mode
- Handle chat/chatdescriber errors - shouldn't prevent from saving session

Future: update session before and after chat describer so there's not a delay?