### PR TITLE
sidebar will always reopen with cmd+L or Open chat

### DIFF
--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -459,10 +459,8 @@ const getCommandsMap: (
       // This is a temporary fix—sidebar.webviewProtocol.request is blocking
       // when the GUI hasn't yet been setup and we should instead be
       // immediately throwing an error, or returning a Result object
-
+      focusGUI();
       if (!sidebar.isReady) {
-        focusGUI();
-
         const isReady = await waitForSidebarReady(sidebar, 5000, 100);
         if (!isReady) {
           return;


### PR DESCRIPTION
## Description

fixes #3367. The sidebar will now alway open regardless of the last page that it was on. 

changing the continueFocusInput command to be more like the navigateTo command may be worth considering, as using cmd+L or open chat quick pick won't take you to the chat page of the sidebar if you're currently on the history page or the more page. This fix works and doesn't have any side effects that I know of, and is important due to #3360 closing the sidebar more frequently.

this code (extensions/vscode/src/commands.ts:475) seems to just stop the process if any page other than the chat page is open.

```
      const isContinueInputFocused = await sidebar.webviewProtocol.request(
        "isContinueInputFocused",
        undefined,
        false,
      );
```

## Testing

tested on vscode
