### PR TITLE
Bugapalooza part 1

### DIFF
--- a/gui/src/components/PageHeader.tsx
+++ b/gui/src/components/PageHeader.tsx
@@ -7,7 +7,7 @@ export interface PageHeaderProps {
 
 export default function PageHeader({ onClick, title }: PageHeaderProps) {
   return (
-    <div className="bg-vsc-background sticky top-0 m-0 flex items-center border-0 border-b border-solid border-b-zinc-700 bg-inherit p-0">
+    <div className="bg-vsc-background sticky top-0 z-20 m-0 flex items-center border-0 border-b border-solid border-b-zinc-700 bg-inherit p-0">
       <div
         className="cursor-pointer transition-colors duration-200 hover:text-zinc-100"
         onClick={onClick}

--- a/gui/src/components/indexing/DocsIndexingStatus.tsx
+++ b/gui/src/components/indexing/DocsIndexingStatus.tsx
@@ -5,9 +5,9 @@ import {
   ArrowPathIcon,
   ArrowTopRightOnSquareIcon,
   CheckCircleIcon,
+  ExclamationTriangleIcon,
   PauseCircleIcon,
   TrashIcon,
-  XMarkIcon,
 } from "@heroicons/react/24/outline";
 import { useAppDispatch, useAppSelector } from "../../redux/hooks";
 import { updateIndexingStatus } from "../../redux/slices/indexingSlice";
@@ -24,7 +24,7 @@ const STATUS_TO_ICON: Record<IndexingStatus["status"], any> = {
   complete: CheckCircleIcon,
   aborted: null,
   pending: null,
-  failed: XMarkIcon, // Since we show an error message below
+  failed: ExclamationTriangleIcon, // Since we show an error message below
 };
 
 function DocsIndexingStatus({ docConfig }: IndexingStatusViewerProps) {

--- a/gui/src/components/indexing/DocsIndexingStatuses.tsx
+++ b/gui/src/components/indexing/DocsIndexingStatuses.tsx
@@ -16,8 +16,7 @@ function DocsIndexingStatuses() {
         <h3 className="mb-1 mt-0 text-xl">@docs indexes</h3>
         {configDocs.length ? (
           <SecondaryButton
-            className="border-vsc-foreground text-vsc-foreground enabled:hover:bg-vsc-background m-2 rounded border bg-inherit px-3 py-2 enabled:hover:cursor-pointer enabled:hover:opacity-90 disabled:text-gray-500"
-            type="submit"
+            className="flex h-7 flex-col items-center justify-center"
             onClick={() => {
               dispatch(setShowDialog(true));
               dispatch(setDialogMessage(<AddDocsDialog />));
@@ -32,10 +31,11 @@ function DocsIndexingStatuses() {
           ? "Manage your documentation sources"
           : "No docs yet"}
       </span>
-      <div className="flex max-h-[170px] flex-col gap-1 overflow-x-hidden overflow-y-scroll pr-2">
+      <div className="flex max-h-[170px] flex-col gap-1 overflow-y-auto overflow-x-hidden pr-2">
         <div>
           {configDocs.length === 0 && (
             <SecondaryButton
+              className="flex h-7 flex-col items-center justify-center"
               onClick={() => {
                 dispatch(setShowDialog(true));
                 dispatch(setDialogMessage(<AddDocsDialog />));

--- a/gui/src/components/mainInput/resolveInput.ts
+++ b/gui/src/components/mainInput/resolveInput.ts
@@ -117,7 +117,6 @@ async function resolveEditorContent({
   }
 
   const shouldGatherContext = modifiers.useCodebase || slashCommand;
-
   if (shouldGatherContext) {
     dispatch(setIsGatheringContext(true));
   }
@@ -192,7 +191,6 @@ async function resolveEditorContent({
       parts = [{ type: "text", text: lastPart }];
     }
   }
-
   if (shouldGatherContext) {
     dispatch(setIsGatheringContext(true));
   }

--- a/gui/src/components/markdown/FilenameLink.tsx
+++ b/gui/src/components/markdown/FilenameLink.tsx
@@ -27,6 +27,7 @@ function FilenameLink({ rif }: FilenameLinkProps) {
     <>
       <span
         data-tooltip-id={id}
+        data-tooltip-delay-show={500}
         className="mx-[0.1em] mb-[0.15em] inline-flex cursor-pointer items-center gap-0.5 rounded-md pr-[0.2em] align-middle hover:ring-1"
         onClick={onClick}
       >

--- a/gui/src/pages/gui/Chat.tsx
+++ b/gui/src/pages/gui/Chat.tsx
@@ -233,8 +233,8 @@ export function Chat() {
     (
       editorState: JSONContent,
       modifiers: InputModifiers,
-      editor: Editor,
       index?: number,
+      editorToClearOnSend?: Editor,
     ) => {
       if (defaultModel?.provider === "free-trial") {
         const u = getLocalStorage("ftc");
@@ -268,7 +268,9 @@ export function Chat() {
         streamResponseThunk({ editorState, modifiers, promptPreamble, index }),
       );
 
-      editor.commands.clearContent(true);
+      if (editorToClearOnSend) {
+        editorToClearOnSend.commands.clearContent();
+      }
 
       // Increment localstorage counter for popup
       const currentCount = getLocalStorage("mainTextEntryCounter");
@@ -381,8 +383,8 @@ export function Chat() {
                   {isInEditMode && index === 0 && <CodeToEditCard />}
                   <ContinueInputBox
                     isEditMode={isInEditMode}
-                    onEnter={(editorState, modifiers, editor) =>
-                      sendInput(editorState, modifiers, editor, index)
+                    onEnter={(editorState, modifiers) =>
+                      sendInput(editorState, modifiers, index)
                     }
                     isLastUserInput={isLastUserInput(index)}
                     isMainInput={false}
@@ -487,7 +489,9 @@ export function Chat() {
             isMainInput
             isEditMode={isInEditMode}
             isLastUserInput={false}
-            onEnter={sendInput}
+            onEnter={(editorState, modifiers, editor) =>
+              sendInput(editorState, modifiers, undefined, editor)
+            }
           />
         )}
 


### PR DESCRIPTION
Bugs squashed:
- Transparent page header on chat/more pages
- Make filename link hover delay same as symbol links
- More page docs slimmer "Add" buttons, more clear error icon (Exclamation triangle)
- Fix editor flashing blank: only clear editor on submission if it's the main editor