### PR TITLE
ConfigHandler: make updateIdeSettings work (better)

### DIFF
--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -51,7 +51,6 @@ export class ConfigHandler {
     // Set local profile as default
     const localProfileLoader = new LocalProfileLoader(
       ide,
-      ideSettingsPromise,
       controlPlaneClient,
       writeLog,
     );
@@ -111,7 +110,6 @@ export class ConfigHandler {
             workspace.name,
             this.controlPlaneClient,
             this.ide,
-            this.ideSettingsPromise,
             this.writeLog,
             this.reloadConfig.bind(this),
           );
@@ -210,7 +208,7 @@ export class ConfigHandler {
     // TODO: this isn't right, there are two different senses in which you want to "reload"
 
     const { config, errors, configLoadInterrupted } =
-      await this.currentProfile.reloadConfig();
+      await this.currentProfile.reloadConfig(this.ideSettingsPromise);
 
     if (config) {
       this.inactiveProfiles.forEach((profile) => profile.clearConfig());
@@ -224,6 +222,7 @@ export class ConfigHandler {
     ConfigResult<BrowserSerializedContinueConfig>
   > {
     return this.currentProfile.getSerializedConfig(
+      this.ideSettingsPromise,
       this.additionalContextProviders,
     );
   }
@@ -233,7 +232,8 @@ export class ConfigHandler {
   }
 
   async loadConfig(): Promise<ConfigResult<ContinueConfig>> {
-    return await this.currentProfile.loadConfig(
+    return this.currentProfile.loadConfig(
+      this.ideSettingsPromise,
       this.additionalContextProviders,
     );
   }

--- a/core/config/profile/ControlPlaneProfileLoader.ts
+++ b/core/config/profile/ControlPlaneProfileLoader.ts
@@ -25,7 +25,6 @@ export default class ControlPlaneProfileLoader implements IProfileLoader {
     private workspaceTitle: string,
     private readonly controlPlaneClient: ControlPlaneClient,
     private readonly ide: IDE,
-    private ideSettingsPromise: Promise<IdeSettings>,
     private writeLog: (message: string) => Promise<void>,
     private readonly onReload: () => void,
   ) {
@@ -39,7 +38,7 @@ export default class ControlPlaneProfileLoader implements IProfileLoader {
     }, ControlPlaneProfileLoader.RELOAD_INTERVAL);
   }
 
-  async doLoadConfig(): Promise<ConfigResult<ContinueConfig>> {
+  async doLoadConfig(ideSettingsPromise: Promise<IdeSettings>): Promise<ConfigResult<ContinueConfig>> {
     const settings =
       this.workspaceSettings ??
       ((await this.controlPlaneClient.getSettingsForWorkspace(
@@ -49,7 +48,7 @@ export default class ControlPlaneProfileLoader implements IProfileLoader {
 
     const results = await doLoadConfig(
       this.ide,
-      this.ideSettingsPromise,
+      ideSettingsPromise,
       this.controlPlaneClient,
       this.writeLog,
       serializedConfig,

--- a/core/config/profile/IProfileLoader.ts
+++ b/core/config/profile/IProfileLoader.ts
@@ -1,12 +1,15 @@
 // ProfileHandlers manage the loading of a config, allowing us to abstract over different ways of getting to a ContinueConfig
 
-import { ContinueConfig } from "../../index.js";
+import {
+  ContinueConfig,
+  IdeSettings,
+} from "../../index.js";
 import { ConfigResult } from "../load.js";
 
 // After we have the ContinueConfig, the ConfigHandler takes care of everything else (loading models, lifecycle, etc.)
 export interface IProfileLoader {
   profileTitle: string;
   profileId: string;
-  doLoadConfig(): Promise<ConfigResult<ContinueConfig>>;
+  doLoadConfig(ideSettingsPromise: Promise<IdeSettings>): Promise<ConfigResult<ContinueConfig>>;
   setIsActive(isActive: boolean): void;
 }

--- a/core/config/profile/LocalProfileLoader.ts
+++ b/core/config/profile/LocalProfileLoader.ts
@@ -12,15 +12,14 @@ export default class LocalProfileLoader implements IProfileLoader {
 
   constructor(
     private ide: IDE,
-    private ideSettingsPromise: Promise<IdeSettings>,
     private controlPlaneClient: ControlPlaneClient,
     private writeLog: (message: string) => Promise<void>,
   ) {}
 
-  async doLoadConfig(): Promise<ConfigResult<ContinueConfig>> {
+  async doLoadConfig(ideSettingsPromise: Promise<IdeSettings>): Promise<ConfigResult<ContinueConfig>> {
     return doLoadConfig(
       this.ide,
-      this.ideSettingsPromise,
+      ideSettingsPromise,
       this.controlPlaneClient,
       this.writeLog,
       undefined,


### PR DESCRIPTION
## Description

`ConfigHandler.updateIdeSettings()` was largely ineffective because the `ideSettingsPromise` was stored in the ProfileLoader object, so updating to a new `ideSettingsPromise` resulted in the config being reloaded with the old settings. Fix this by passing the `ideSettingsPromise` as a parameter to `IProfileLoader.doLoadConfig()`.

I came up with this while working on a larger change (for automatic model selection), so I don't have a great example of when this would matter, but it does seem like this would affect the use of `ideSettings.userToken` in `core/llm/llms/index.ts` - 

```ts
  if (desc.provider === "continue-proxy") {
    options.apiKey = ideSettings.userToken;
    if (ideSettings.remoteConfigServerUrl) {
      options.apiBase = new URL(
        "/proxy/v1",
        ideSettings.remoteConfigServerUrl,
      ).toString();
    }
  }
```

This patch does not fix the case where changing the settings affects what profiles (changes to `ideSettings.remoteConfigServerUrl`)

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created
