### PR TITLE
Update mcp tool URI to handle multiple tools

### DIFF
--- a/core/context/mcp/index.ts
+++ b/core/context/mcp/index.ts
@@ -24,7 +24,7 @@ export class MCPManagerSingleton {
 
   createConnection(id: string, options: MCPOptions): MCPConnection | undefined {
     if (!this.connections.has(id)) {
-      const connection = new MCPConnection(options);
+      const connection = new MCPConnection(id, options);
       this.connections.set(id, connection);
       return connection;
     } else {
@@ -49,8 +49,10 @@ export class MCPManagerSingleton {
 class MCPConnection {
   public client: Client;
   private transport: Transport;
+  private id: string;
 
-  constructor(private readonly options: MCPOptions) {
+  constructor(id: string, private readonly options: MCPOptions) {
+    this.id = id;
     this.transport = this.constructTransport(options);
 
     this.client = new Client(
@@ -171,7 +173,7 @@ class MCPConnection {
         readonly: false,
         type: "function",
         wouldLikeTo: `use the ${tool.name} tool`,
-        uri: `mcp://${tool.name}`,
+        uri: `mcp://${this.id}/${tool.name}`,
       }));
 
       config.tools = [...config.tools, ...continueTools];

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1055,7 +1055,7 @@ export interface ExperimentalConfig {
    */
   useChromiumForDocsCrawling?: boolean;
   useTools?: boolean;
-  modelContextProtocolServers?: MCPOptions[];
+  modelContextProtocolServers?: TransportOptions[];
 }
 
 export interface AnalyticsConfig {

--- a/core/tools/callTool.ts
+++ b/core/tools/callTool.ts
@@ -44,7 +44,7 @@ export function decodeMCPToolUri(uri: string): [string, string] | null {
   if (url.protocol !== "mcp:") {
     return null;
   }
-  return [decodeURIComponent(url.hostname), decodeURIComponent(url.pathname)];
+  return [decodeURIComponent(url.hostname), decodeURIComponent(url.pathname.substring(1))];
 }
 
 async function callToolFromUri(


### PR DESCRIPTION
## Description

Update mcp tool URI to handle multiple tools. 

## changes made

- update type of `config.experimental.modelContextProtocolServers` to `TransportOptions[]`
- update MCP server parsing logic
- add MCP server id as the hostname in  mcp uri (`MCPConnection.modifyConfig`)
    - `mcp://{MCPID}/{TOOL_NAME}`

## Checklist

- [ ] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing instructions

make sure to change `modelContextProtocolServer` -> `modelContextProtocolServers` in your config.json
example config:
```
"experimental": {
    "useTools": true,
    "modelContextProtocolServers": {
      "filesystem": {
        "type": "stdio",
        "command": "node",
        "args": [
          "/Users/adamshedivy/.nvm/versions/node/v22.6.0/lib/node_modules/@modelcontextprotocol/server-filesystem/dist/index.js",
          "/Users/adamshedivy/Documents/test"
        ]
      },
      "db2i": {
        "type": "stdio",
        "command": "uv",
        "args": [
          "--directory",
          "/Users/adamshedivy/Documents/anthro/db2i-mcp-server",
          "run",
          "db2i-mcp-server"
        ]
      }
    }
  }

```
Note that `db2i` is a custom MCP server. 

Here is an example of calling 2 tools from different MCP servers:
![image](https://github.com/user-attachments/assets/4fc1fb85-9aa7-4a27-bd87-17a2f4f1d87a)


