### PR TITLE
Fix embedding provider not respecting batch size

### DIFF
--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -811,7 +811,7 @@ export abstract class BaseLLM implements ILLM {
                   model: this.model,
                   input: batch,
                 });
-                return result.data.map((batch) => batch.embedding);
+                return result.data.map((chunk) => chunk.embedding);
               }
 
               return await this._embed(batch);

--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -809,12 +809,12 @@ export abstract class BaseLLM implements ILLM {
               if (this.shouldUseOpenAIAdapter("embed") && this.openaiAdapter) {
                 const result = await this.openaiAdapter.embed({
                   model: this.model,
-                  input: chunks,
+                  input: batch,
                 });
-                return result.data.map((chunk) => chunk.embedding);
+                return result.data.map((batch) => batch.embedding);
               }
 
-              return await this._embed(chunks);
+              return await this._embed(batch);
             },
           );
 


### PR DESCRIPTION
## Description

I believe this is a bug. Having this change makes the indexing using gemini model for "embeddingProvider" succeeds

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
