### PR TITLE
shorter more descriptive chat titles

### DIFF
--- a/core/util/chatDescriber.ts
+++ b/core/util/chatDescriber.ts
@@ -8,7 +8,7 @@ import type { IMessenger } from "../protocol/messenger";
 export class ChatDescriber {
   static maxTokens = 12;
   static prompt: string | undefined =
-    "Given the following... please reply with a short summary that is 4-8 words in length, you should summarize what the user is asking for OR what the user is trying to accomplish. You should only respond with the summary, no additional text or explanation, you don't need ending punctuation.\n\n";
+    "Given the following... please reply with a title for the chat that is 3-4 words in length, all words used should be directly related to the content of the chat, avoid using verbs unless they are directly related to the content of the chat, no additional text or explanation, you don't need ending punctuation.\n\n";
   static messenger: IMessenger<ToCoreProtocol, FromCoreProtocol>;
 
   static async describe(


### PR DESCRIPTION
## Description

this prompt produces titles which are shorter, more descriptive and less likely to be truncated, this reliably produces more descriptive titles on smaller models, the changes are less pronounced on larger models but still prevents things such as starting with a verb in the present participle ("summarizing", "describing", "discussing")  which don't contribute meaning to the title.


## Screenshots

![image](https://github.com/user-attachments/assets/d2ac6a05-cdbe-46d5-b2a4-ab41ad4561e4)

this shows the old summaries alongside new ones, I think it is pretty easy to tell which is which.

## Testing instructions

tested mainly with llama 3.1 8b and chatgpt 4o
