### PR TITLE
Remove the extra "+" sign from the IDEA shortcut

### DIFF
--- a/docs/docs/getting-started/install.md
+++ b/docs/docs/getting-started/install.md
@@ -18,7 +18,7 @@ If you have any problems, see the [troubleshooting guide](troubleshooting.md) or
 
 ## JetBrains
 
-1. Open your JetBrains IDE and open **Settings** using <kbd>Ctrl</kbd> + <kbd>+Alt</kbd> + <kbd>S</kbd>
+1. Open your JetBrains IDE and open **Settings** using <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>S</kbd>
 2. Select **Plugins** on the sidebar and search for "Continue" in the marketplace
 3. Click `Install`, which will cause the Continue logo to show up on the right toolbar
 


### PR DESCRIPTION
## Description

Remove the extra "+" sign from the IDEA shortcut for open IDE Settings.

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

N/A

## Testing instructions

N/A
