### PR TITLE
bugfix(JB): handle disposed editor tooltips

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/listeners/ContinuePluginSelectionListener.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/listeners/ContinuePluginSelectionListener.kt
@@ -28,6 +28,10 @@ class ContinuePluginSelectionListener(
     private var lastActiveEditor: Editor? = null
 
     override fun selectionChanged(e: SelectionEvent) {
+        if (e.editor.isDisposed || e.editor.project?.isDisposed == true) {
+            return
+        }
+
         debouncer.debounce { handleSelection(e) }
     }
 


### PR DESCRIPTION
## Description

Resolves the following error log output that I was getting when closing a project in JetBrains:

```log
com.intellij.serviceContainer.AlreadyDisposedException: Container is already disposed

	at com.intellij.serviceContainer.ComponentManagerImplKt.throwAlreadyDisposedIfNotUnderIndicatorOrJob(ComponentManagerImpl.kt:1672)

	at com.intellij.serviceContainer.ComponentManagerImplKt.access$throwAlreadyDisposedIfNotUnderIndicatorOrJob(ComponentManagerImpl.kt:1)

	at com.intellij.serviceContainer.ComponentManagerImpl.doGetService(ComponentManagerImpl.kt:716)

	at com.intellij.serviceContainer.ComponentManagerImpl.getService(ComponentManagerImpl.kt:690)

	at com.intellij.openapi.fileEditor.FileEditorManager.getInstance(FileEditorManager.java:33)

	at com.github.continuedev.continueintellijextension.listeners.ContinuePluginSelectionListener.isFileEditor(ContinuePluginSelectionListener.kt:81)

	at com.github.continuedev.continueintellijextension.listeners.ContinuePluginSelectionListener.handleSelection$lambda$2(ContinuePluginSelectionListener.kt:48)

	at com.intellij.util.concurrency.ContextRunnable.run(ContextRunnable.java:27)

	at com.intellij.openapi.application.TransactionGuardImpl.runWithWritingAllowed(TransactionGuardImpl.java:229)

	at com.intellij.openapi.application.TransactionGuardImpl.access$100(TransactionGuardImpl.java:22)

	at com.intellij.openapi.application.TransactionGuardImpl$1.run(TransactionGuardImpl.java:191)

	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runIntendedWriteActionOnCurrentThread$lambda$1(AnyThreadWriteThreadingSupport.kt:184)

	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:84)

	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runIntendedWriteActionOnCurrentThread(AnyThreadWriteThreadingSupport.kt:183)

	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:836)

	at com.intellij.openapi.application.impl.ApplicationImpl$2.run(ApplicationImpl.java:424)

	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWithImplicitRead(AnyThreadWriteThreadingSupport.kt:122)

	at com.intellij.openapi.application.impl.ApplicationImpl.runWithImplicitRead(ApplicationImpl.java:1162)

	at com.intellij.openapi.application.impl.FlushQueue.doRun(FlushQueue.java:78)

	at com.intellij.openapi.application.impl.FlushQueue.runNextEvent(FlushQueue.java:119)

	at com.intellij.openapi.application.impl.FlushQueue.flushNow(FlushQueue.java:41)

	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)

	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:781)

	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:728)

	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:722)

	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)

	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:87)

	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:750)

	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.kt:696)

	at com.intellij.ide.IdeEventQueue._dispatchEvent$lambda$16(IdeEventQueue.kt:590)

	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWithoutImplicitRead(AnyThreadWriteThreadingSupport.kt:117)

	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.kt:590)

	at com.intellij.ide.IdeEventQueue.access$_dispatchEvent(IdeEventQueue.kt:73)

	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1$1.compute(IdeEventQueue.kt:357)

	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1$1.compute(IdeEventQueue.kt:356)

	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:843)

	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.invoke(IdeEventQueue.kt:356)

	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.invoke(IdeEventQueue.kt:351)

	at com.intellij.ide.IdeEventQueueKt$performActivity$runnableWithWIL$1.invoke$lambda$0(IdeEventQueue.kt:1035)

	at com.intellij.openapi.application.WriteIntentReadAction.lambda$run$0(WriteIntentReadAction.java:24)

	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:84)

	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteIntentReadAction(ApplicationImpl.java:910)

	at com.intellij.openapi.application.WriteIntentReadAction.compute(WriteIntentReadAction.java:55)

	at com.intellij.openapi.application.WriteIntentReadAction.run(WriteIntentReadAction.java:23)

	at com.intellij.ide.IdeEventQueueKt$performActivity$runnableWithWIL$1.invoke(IdeEventQueue.kt:1035)

	at com.intellij.ide.IdeEventQueueKt$performActivity$runnableWithWIL$1.invoke(IdeEventQueue.kt:1035)

	at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$1(IdeEventQueue.kt:1036)

	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:106)

	at com.intellij.ide.IdeEventQueueKt.performActivity(IdeEventQueue.kt:1036)

	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$10(IdeEventQueue.kt:351)

	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.kt:397)

	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)

	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)

	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)

	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)

	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)

	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)

Caused by: com.intellij.platform.instanceContainer.internal.ContainerDisposedException: Container 'ProjectImpl@420129891 services' was disposed

	at com.intellij.platform.instanceContainer.internal.InstanceContainerImpl.state(InstanceContainerImpl.kt:60)

	at com.intellij.platform.instanceContainer.internal.InstanceContainerImpl.state(InstanceContainerImpl.kt:40)

	at com.intellij.platform.instanceContainer.internal.InstanceContainerImpl.getInstanceHolder(InstanceContainerImpl.kt:277)

	at com.intellij.serviceContainer.ComponentManagerImpl.doGetService(ComponentManagerImpl.kt:712)

	... 54 more

Caused by: com.intellij.platform.instanceContainer.internal.DisposalTrace

	at com.intellij.platform.instanceContainer.internal.InstanceContainerImpl.dispose(InstanceContainerImpl.kt:266)

	at com.intellij.serviceContainer.ComponentManagerImpl.dispose(ComponentManagerImpl.kt:1164)

	at com.intellij.openapi.project.impl.ProjectImpl.dispose(ProjectImpl.kt:321)

	at com.intellij.openapi.util.ObjectTree.runWithTrace(ObjectTree.java:131)

	at com.intellij.openapi.util.ObjectTree.executeAll(ObjectTree.java:163)

	at com.intellij.openapi.util.Disposer.dispose(Disposer.java:205)

	at com.intellij.openapi.util.Disposer.dispose(Disposer.java:193)

	at com.intellij.openapi.project.impl.ProjectManagerImpl.closeProject$lambda$15(ProjectManagerImpl.kt:423)

	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteAction$lambda$4(AnyThreadWriteThreadingSupport.kt:318)

	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteAction(AnyThreadWriteThreadingSupport.kt:328)

	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteAction(AnyThreadWriteThreadingSupport.kt:318)

	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteAction(ApplicationImpl.java:890)

	at com.intellij.openapi.project.impl.ProjectManagerImpl.closeProject(ProjectManagerImpl.kt:406)

	at com.intellij.openapi.project.impl.ProjectManagerImpl.closeProject$default(ProjectManagerImpl.kt:328)

	at com.intellij.openapi.project.impl.ProjectManagerImpl$closeAndDisposeKeepingFrame$2$1.invoke(ProjectManagerImpl.kt:981)

	at com.intellij.openapi.project.impl.ProjectManagerImpl$closeAndDisposeKeepingFrame$2$1.invoke(ProjectManagerImpl.kt:979)

	at com.intellij.openapi.progress.CoroutinesKt.blockingContextInner(coroutines.kt:339)

	at com.intellij.openapi.progress.CoroutinesKt$blockingContext$2.invokeSuspend(coroutines.kt:232)

	at com.intellij.openapi.progress.CoroutinesKt$blockingContext$2.invoke(coroutines.kt)

	at com.intellij.openapi.progress.CoroutinesKt$blockingContext$2.invoke(coroutines.kt)

	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:62)

	at kotlinx.coroutines.CoroutineScopeKt.coroutineScope(CoroutineScope.kt:261)

	at com.intellij.openapi.progress.CoroutinesKt.blockingContext(coroutines.kt:231)

	at com.intellij.openapi.project.impl.ProjectManagerImpl$closeAndDisposeKeepingFrame$2.invokeSuspend(ProjectManagerImpl.kt:979)

	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)

	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)

	at com.intellij.openapi.application.impl.DispatchedRunnable.run(DispatchedRunnable.kt:44)

	at com.intellij.openapi.application.TransactionGuardImpl.runWithWritingAllowed(TransactionGuardImpl.java:229)

	at com.intellij.openapi.application.TransactionGuardImpl.access$100(TransactionGuardImpl.java:22)

	at com.intellij.openapi.application.TransactionGuardImpl$2.run(TransactionGuardImpl.java:211)

	... 41 more
```