### PR TITLE
bugfix(GUI): broken Chinese input w/ codeblock

### DIFF
--- a/gui/src/components/mainInput/CodeBlockComponent.tsx
+++ b/gui/src/components/mainInput/CodeBlockComponent.tsx
@@ -1,4 +1,4 @@
-import { NodeViewWrapper } from "@tiptap/react";
+import { NodeViewWrapper, NodeViewWrapperProps } from "@tiptap/react";
 import { ContextItemWithId } from "core";
 import { vscBadgeBackground } from "..";
 import CodeSnippetPreview from "../markdown/CodeSnippetPreview";
@@ -13,8 +13,15 @@ export const CodeBlockComponent = (props: any) => {
   // const isFirstContextItem = item.id === contextItems[0]?.id;
   const isFirstContextItem = false; // TODO: fix this, decided not worth the insane renders for now
 
+  // Not setting this as a "p" will cause issues with foreign keyboards
+  // See https://github.com/continuedev/continue/issues/3199
+  const nodeViewWrapperTag: NodeViewWrapperProps["as"] = "p";
+
   return (
-    <NodeViewWrapper className="code-block-with-content" as="div">
+    <NodeViewWrapper
+      className="code-block-with-content"
+      as={nodeViewWrapperTag}
+    >
       <CodeSnippetPreview
         borderColor={
           isFirstContextItem


### PR DESCRIPTION
## Description

See https://github.com/continuedev/continue/issues/3199

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
