### PR TITLE
Fix examples in docs so that base model of Qwen2.5-coder is used for ollama instead of instruct

### DIFF
--- a/core/autocomplete/README.md
+++ b/core/autocomplete/README.md
@@ -7,7 +7,7 @@ Continue now provides support for tab autocomplete in [VS Code](https://marketpl
 We recommend setting up tab-autocomplete with a local Ollama instance. To do this, first download the latest version of Ollama from [here](https://ollama.ai). Then, run the following command to download our recommended model:
 
 ```bash
-ollama run qwen2.5-coder:1.5b
+ollama run qwen2.5-coder:1.5b-base
 ```
 
 Once it has been downloaded, you should begin to see completions in VS Code.
@@ -101,7 +101,7 @@ This object allows you to customize the behavior of tab-autocomplete. The availa
   "tabAutocompleteModel": {
     "title": "Tab Autocomplete Model",
     "provider": "ollama",
-    "model": "qwen2.5-coder:1.5b",
+    "model": "qwen2.5-coder:1.5b-base",
     "apiBase": "https://<my endpoint>"
   },
   "tabAutocompleteOptions": {
@@ -123,9 +123,9 @@ Follow these steps to ensure that everything is set up correctly:
 
 1. Make sure you have the "Enable Tab Autocomplete" setting checked (in VS Code, you can toggle by clicking the "Continue" button in the status bar).
 2. Make sure you have downloaded Ollama.
-3. Run `ollama run qwen2.5-coder:1.5b` to verify that the model is downloaded.
+3. Run `ollama run qwen2.5-coder:1.5b-base` to verify that the model is downloaded.
 4. Make sure that any other completion providers are disabled (e.g. Copilot), as they may interfere.
-5. Make sure that you aren't also using another Ollama model for chat. This will cause Ollama to constantly load and unload the models from memory, resulting in slow responses (or none at all) for both.
+5. If you are using another Ollama model for chat and your resources are limited, this will cause Ollama to constantly load and unload the models from memory, resulting in slow responses (or none at all) for both. A resolution for this could be using the same model for chat and autocomplete.
 6. Check the output of the logs to find any potential errors (cmd/ctrl+shift+p -> "Toggle Developer Tools" -> "Console" tab in VS Code, ~/.continue/logs/core.log in JetBrains).
 7. If you are still having issues, please let us know in our [Discord](https://discord.gg/vapESyrFmJ) and we'll help as soon as possible.
 

--- a/docs/docs/autocomplete/model-setup.md
+++ b/docs/docs/autocomplete/model-setup.md
@@ -31,7 +31,7 @@ For those preferring local execution or self-hosting,`Qwen2.5-Coder 1.5B` offers
 ```json title="config.json""
 {
   "tabAutocompleteModel": {
-    "title": "Qwen2.5-Coder 1.5B Base",
+    "title": "Qwen2.5-Coder 1.5B",
     "model": "qwen2.5-coder:1.5b-base",
     "provider": "ollama"
   }

--- a/docs/docs/autocomplete/model-setup.md
+++ b/docs/docs/autocomplete/model-setup.md
@@ -42,7 +42,7 @@ Have more compute? Use `qwen2.5-coder:7b-base` for potentially higher-quality su
 
 :::note
 
-For LM Studio users, navigate to the "My Models" section, find your desired model, and copy the path (e.g., `Qwen/Qwen2.5-Coder-1.5B-Instruct-GGUF/wen2.5-coder-1.5b-instruct-q4_k_m.gguf`). Use this path as the `model` value in your configuration.
+For LM Studio users, navigate to the "My Models" section, find your desired model, and copy the path (e.g., `Qwen/Qwen2.5-Coder-1.5B-Instruct-GGUF/qwen2.5-coder-1.5b-instruct-q4_k_m.gguf`). Use this path as the `model` value in your configuration.
 
 :::
 

--- a/docs/docs/autocomplete/model-setup.md
+++ b/docs/docs/autocomplete/model-setup.md
@@ -31,14 +31,14 @@ For those preferring local execution or self-hosting,`Qwen2.5-Coder 1.5B` offers
 ```json title="config.json""
 {
   "tabAutocompleteModel": {
-    "title": "Qwen2.5-Coder 1.5B",
-    "model": "qwen2.5-coder:1.5b",
+    "title": "Qwen2.5-Coder 1.5B Base",
+    "model": "qwen2.5-coder:1.5b-base",
     "provider": "ollama"
   }
 }
 ```
 
-Have more compute? Use `qwen2.5-coder:7b` for potentially higher-quality suggestions.
+Have more compute? Use `qwen2.5-coder:7b-base` for potentially higher-quality suggestions.
 
 :::note
 

--- a/docs/docs/customize/deep-dives/autocomplete.md
+++ b/docs/docs/customize/deep-dives/autocomplete.md
@@ -23,7 +23,7 @@ If you want to have the best autocomplete experience, we recommend using Codestr
 If you'd like to run your autocomplete model locally, we recommend using Ollama. To do this, first download the latest version of Ollama from [here](https://ollama.ai). Then, run the following command to download our recommended model:
 
 ```bash
-ollama run qwen2.5-coder:1.5b
+ollama run qwen2.5-coder:1.5b-base
 ```
 
 Once it has been downloaded, you should begin to see completions in VS Code.
@@ -37,7 +37,7 @@ All of the configuration options available for chat models are available to use 
     "tabAutocompleteModel": {
         "title": "Tab Autocomplete Model",
         "provider": "ollama",
-        "model": "qwen2.5-coder:1.5b",
+        "model": "qwen2.5-coder:1.5b-base",
         "apiBase": "https://<my endpoint>"
     },
     ...
@@ -76,7 +76,7 @@ This object allows you to customize the behavior of tab-autocomplete. The availa
   "tabAutocompleteModel": {
     "title": "Tab Autocomplete Model",
     "provider": "ollama",
-    "model": "qwen2.5-coder:1.5b",
+    "model": "qwen2.5-coder:1.5b-base",
     "apiBase": "https://<my endpoint>"
   },
   "tabAutocompleteOptions": {
@@ -99,7 +99,7 @@ Follow these steps to ensure that everything is set up correctly:
 
 1. Make sure you have the "Enable Tab Autocomplete" setting checked (in VS Code, you can toggle by clicking the "Continue" button in the status bar, and in JetBrains by going to Settings -> Tools -> Continue).
 2. Make sure you have downloaded Ollama.
-3. Run `ollama run qwen2.5-coder:1.5b` to verify that the model is downloaded.
+3. Run `ollama run qwen2.5-coder:1.5b-base` to verify that the model is downloaded.
 4. Make sure that any other completion providers are disabled (e.g. Copilot), as they may interfere.
 5. Check the output of the logs to find any potential errors: <kbd>cmd/ctrl</kbd> + <kbd>shift</kbd> + <kbd>P</kbd> -> "Toggle Developer Tools" -> "Console" tab in VS Code, ~/.continue/logs/core.log in JetBrains.
 6. Check VS Code settings to make sure that `"editor.inlineSuggest.enabled"` is set to `true` (use <kbd>cmd/ctrl</kbd> + <kbd>,</kbd> then search for this and check the box)

--- a/docs/docs/customize/model-providers/top-level/ollama.md
+++ b/docs/docs/customize/model-providers/top-level/ollama.md
@@ -23,12 +23,12 @@ We recommend configuring **Llama3.1 8B** as your chat model.
 
 ## Autocomplete model
 
-We recommend configuring **Qwen2.5-Coder 1.5B-base** as your autocomplete model.
+We recommend configuring **Qwen2.5-Coder 1.5B** as your autocomplete model.
 
 ```json title="config.json"
 {
   "tabAutocompleteModel": {
-    "title": "Qwen2.5-Coder 1.5B-base",
+    "title": "Qwen2.5-Coder 1.5B",
     "provider": "ollama",
     "model": "qwen2.5-coder:1.5b-base"
   }

--- a/docs/docs/customize/model-providers/top-level/ollama.md
+++ b/docs/docs/customize/model-providers/top-level/ollama.md
@@ -23,14 +23,14 @@ We recommend configuring **Llama3.1 8B** as your chat model.
 
 ## Autocomplete model
 
-We recommend configuring **Qwen2.5-Coder 1.5B** as your autocomplete model.
+We recommend configuring **Qwen2.5-Coder 1.5B-base** as your autocomplete model.
 
 ```json title="config.json"
 {
   "tabAutocompleteModel": {
-    "title": "Qwen2.5-Coder 1.5B",
+    "title": "Qwen2.5-Coder 1.5B-base",
     "provider": "ollama",
-    "model": "qwen2.5-coder:1.5b"
+    "model": "qwen2.5-coder:1.5b-base"
   }
 }
 ```

--- a/docs/docs/customize/model-types/autocomplete.md
+++ b/docs/docs/customize/model-types/autocomplete.md
@@ -13,4 +13,4 @@ In Continue, these models are used to display inline [Autocomplete](../../autoco
 
 If you have the ability to use any model, we recommend `Codestral` with [Mistral](../model-providers/top-level/mistral.md#autocomplete-model) or [Vertex AI](../model-providers/top-level/vertexai.md#autocomplete-model).
 
-If you want to run a model locally, we recommend `Qwen2.5-Coder 1.5B-base` with [Ollama](../model-providers/top-level/ollama.md#autocomplete-model).
+If you want to run a model locally, we recommend `Qwen2.5-Coder 1.5B` with [Ollama](../model-providers/top-level/ollama.md#autocomplete-model).

--- a/docs/docs/customize/model-types/autocomplete.md
+++ b/docs/docs/customize/model-types/autocomplete.md
@@ -13,4 +13,4 @@ In Continue, these models are used to display inline [Autocomplete](../../autoco
 
 If you have the ability to use any model, we recommend `Codestral` with [Mistral](../model-providers/top-level/mistral.md#autocomplete-model) or [Vertex AI](../model-providers/top-level/vertexai.md#autocomplete-model).
 
-If you want to run a model locally, we recommend `Qwen2.5-Coder 1.5B` with [Ollama](../model-providers/top-level/ollama.md#autocomplete-model).
+If you want to run a model locally, we recommend `Qwen2.5-Coder 1.5B-base` with [Ollama](../model-providers/top-level/ollama.md#autocomplete-model).


### PR DESCRIPTION
## Description

Ollama.com models repository uses the Instruct models as default, but for autocomplete the base models should be used to avoid potentially issues. E.g. in order to use the base model you need to add the -base to the model you want to use.
I saw that the autocomplete model in the onboarding.ts had been fixed in the  PR https://github.com/continuedev/continue/pull/3443
This PR updates the documentation when using the Qwen2.5-coder models for autocomplete with Ollama so that the base model is used instead.

## Checklist

- [X] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots


## Testing instructions
