### PR TITLE
fix `renderInlineAs` not working in `HttpContextProvider`

### DIFF
--- a/core/context/providers/HttpContextProvider.ts
+++ b/core/context/providers/HttpContextProvider.ts
@@ -22,6 +22,9 @@ class HttpContextProvider extends BaseContextProvider {
         this.options.description ||
         "Retrieve a context item from a custom server",
       type: "normal",
+      renderInlineAs:
+        this.options.renderInlineAs ||
+        HttpContextProvider.description.renderInlineAs,
     };
   }
 


### PR DESCRIPTION
fix `renderInlineAs` not working in `HttpContextProvider`