### PR TITLE
Typo in Cohere JSON Config settings (the page itself not reranking)

### DIFF
--- a/docs/docs/customize/model-providers/more/cohere.md
+++ b/docs/docs/customize/model-providers/more/cohere.md
@@ -46,7 +46,7 @@ We recommend configuring **rerank-english-v3.0** as your reranking model.
 ```json title="config.json"
 {
   "reranker": {
-    "provider": "cohere",
+    "name": "cohere",
     "params": {
       "model": "rerank-english-v3.0",
       "apiKey": "<COHERE_API_KEY>"


### PR DESCRIPTION
for reranking,
json is expecting name not provider

## Description

[ What changed? Feel free to be brief. ]

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
