### PR TITLE
Open local config: use file URL

### DIFF
--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -25,6 +25,7 @@ import {
   ProfileDescription,
   ProfileLifecycleManager,
 } from "./ProfileLifecycleManager.js";
+import { pathToFileURL } from "url";
 
 export type { ProfileDescription };
 
@@ -88,7 +89,7 @@ export class ConfigHandler {
   async openConfigProfile(profileId?: string) {
     let openProfileId = profileId || this.selectedProfileId;
     if (openProfileId === "local") {
-      await this.ide.openFile(getConfigJsonPath());
+      await this.ide.openFile(pathToFileURL(getConfigJsonPath()).toString());
     } else {
       await this.ide.openUrl(
         "https://app.continue.dev/",

--- a/core/tools/implementations/createNewFile.ts
+++ b/core/tools/implementations/createNewFile.ts
@@ -3,13 +3,13 @@ import { inferResolvedUriFromRelativePath } from "../../util/ideUtils";
 import { ToolImpl } from ".";
 
 export const createNewFileImpl: ToolImpl = async (args, extras) => {
-  const resolvedFilepath = await inferResolvedUriFromRelativePath(
+  const resolvedFileUri = await inferResolvedUriFromRelativePath(
     args.filepath,
     extras.ide,
   );
-  if (resolvedFilepath) {
-    await extras.ide.writeFile(resolvedFilepath, args.contents);
-    await extras.ide.openFile(resolvedFilepath);
+  if (resolvedFileUri) {
+    await extras.ide.writeFile(resolvedFileUri, args.contents);
+    await extras.ide.openFile(resolvedFileUri);
   }
   return [];
 };


### PR DESCRIPTION
was attempting to open a path with `ide.openFile` rather than a URI