### PR TITLE
Separate Docs EmbeddingProviderId migration 

### DIFF
--- a/core/indexing/docs/DocsService.ts
+++ b/core/indexing/docs/DocsService.ts
@@ -743,10 +743,17 @@ export default class DocsService {
   }
 
   async getFavicon(startUrl: string) {
+    if (!this.config.embeddingsProvider) {
+      console.warn(
+        "Attempting to get favicon without embeddings provider specified",
+      );
+      return;
+    }
     const db = await this.getOrCreateSqliteDb();
     const result = await db.get(
-      `SELECT favicon FROM ${DocsService.sqlitebTableName} WHERE startUrl = ?`,
+      `SELECT favicon FROM ${DocsService.sqlitebTableName} WHERE startUrl = ? AND embeddingsProviderId = ?`,
       startUrl,
+      this.config.embeddingsProvider.embeddingId,
     );
 
     if (!result) {
@@ -1011,10 +1018,18 @@ export default class DocsService {
   }
 
   private async deleteMetadataFromSqlite(startUrl: string) {
+    if (!this.config.embeddingsProvider) {
+      console.warn(
+        `Attempting to delete metadata for ${startUrl} without embeddings provider specified`,
+      );
+      return;
+    }
     const db = await this.getOrCreateSqliteDb();
+
     await db.run(
-      `DELETE FROM ${DocsService.sqlitebTableName} WHERE startUrl = ?`,
+      `DELETE FROM ${DocsService.sqlitebTableName} WHERE startUrl = ? AND embeddingsProviderId = ?`,
       startUrl,
+      this.config.embeddingsProvider.embeddingId,
     );
   }
 

--- a/core/indexing/docs/migrations.ts
+++ b/core/indexing/docs/migrations.ts
@@ -53,14 +53,6 @@ export async function runSqliteMigrations(db: Database) {
             );
           }
 
-          const hasEmbeddingsProviderColumn = pragma.some(
-            (pragma) => pragma.name === "embeddingsProviderId",
-          );
-          if (!hasEmbeddingsProviderColumn) {
-            // gotta just delete in this case since old docs will be unusable anyway
-            await db.exec(`DROP TABLE ${DocsService.sqlitebTableName};`);
-          }
-
           const needsToUpdateConfig = !hasFaviconCol || hasBaseUrlCol;
           if (needsToUpdateConfig) {
             const sqliteDocs = await db.all<

--- a/core/indexing/docs/migrations.ts
+++ b/core/indexing/docs/migrations.ts
@@ -27,7 +27,7 @@ export async function runLanceMigrations(table: Table) {
 
 export async function runSqliteMigrations(db: Database) {
   await new Promise((resolve) => {
-    await migrate(
+    void migrate(
       "sqlite_modify_docs_columns_and_copy_to_config",
       async () => {
         try {
@@ -52,7 +52,7 @@ export async function runSqliteMigrations(db: Database) {
               `ALTER TABLE ${DocsService.sqlitebTableName} RENAME COLUMN baseUrl TO startUrl;`,
             );
           }
-          
+
           const hasEmbeddingsProviderColumn = pragma.some(
             (pragma) => pragma.name === "embeddingsProviderId",
           );
@@ -77,7 +77,10 @@ export async function runSqliteMigrations(db: Database) {
       },
       () => resolve(undefined),
     );
-    await migrate(
+  });
+
+  await new Promise((resolve) => {
+    void migrate(
       "sqlite_delete_docs_with_no_embeddingsProviderId",
       async () => {
         try {


### PR DESCRIPTION
Originally added the check for embeddingsProviderId to the first migration
Now moved to new migration so that it will trigger properly for existing users