### PR TITLE
FilenameLink: match exact basename

### DIFF
--- a/gui/src/components/markdown/StyledMarkdownPreview.tsx
+++ b/gui/src/components/markdown/StyledMarkdownPreview.tsx
@@ -296,14 +296,16 @@ const StyledMarkdownPreview = memo(function StyledMarkdownPreview(
         code: ({ node, ...codeProps }) => {
           const content = getCodeChildrenContent(codeProps.children);
 
-          if (content && previousFileContextItemsRef.current) {
+          if (content) {
             // Insert file links for matching previous context items
-            const ctxItem = previousFileContextItemsRef.current.find((item) =>
-              item.uri!.value!.includes(content),
-            );
-            if (ctxItem) {
-              const rif = ctxItemToRifWithContents(ctxItem);
-              return <FilenameLink rif={rif} />;
+            if (previousFileContextItemsRef.current?.length) {
+              const ctxItem = previousFileContextItemsRef.current.find((item) =>
+                item.uri!.value!.endsWith(content),
+              );
+              if (ctxItem) {
+                const rif = ctxItemToRifWithContents(ctxItem);
+                return <FilenameLink rif={rif} />;
+              }
             }
 
             // Insert symbols for exact matches

--- a/gui/src/components/markdown/StyledMarkdownPreview.tsx
+++ b/gui/src/components/markdown/StyledMarkdownPreview.tsx
@@ -298,10 +298,16 @@ const StyledMarkdownPreview = memo(function StyledMarkdownPreview(
 
           if (content) {
             // Insert file links for matching previous context items
-            if (previousFileContextItemsRef.current?.length) {
-              const ctxItem = previousFileContextItemsRef.current.find((item) =>
-                item.uri!.value!.endsWith(content),
+            // With some reasonable limitations on what might be a filename
+            if (
+              previousFileContextItemsRef.current?.length &&
+              content.includes(".") &&
+              content.length > 2
+            ) {
+              const ctxItem = previousFileContextItemsRef.current.find(
+                (item) => item.uri!.value!.split("/").pop() === content, // Exact match for last segment of URI
               );
+
               if (ctxItem) {
                 const rif = ctxItemToRifWithContents(ctxItem);
                 return <FilenameLink rif={rif} />;


### PR DESCRIPTION
Solving this issue:
https://github.com/continuedev/continue/issues/3503

Filename link was comparing using `.includes(value in backticks)`, which caused e.g. `a` to match e.g. `migrations.ts`

Changed to checking exact match for URI basename, which seems pretty effective.