### PR TITLE
fix: fullscreen bugs

### DIFF
--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -733,7 +733,6 @@ const getCommandsMap: (
         "getCurrentSessionId",
         undefined,
       );
-
       // Check if full screen is already open by checking open tabs
       const fullScreenTab = getFullScreenTab();
 

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -734,18 +734,17 @@ const getCommandsMap: (
         undefined,
       );
 
-      // Clear the sidebar to prevent overwriting changes made in fullscreen 
-      vscode.commands.executeCommand("continue.newSession")
-
       // Check if full screen is already open by checking open tabs
       const fullScreenTab = getFullScreenTab();
 
       if (fullScreenTab && fullScreenPanel) {
         // Full screen open, but not focused - focus it
         fullScreenPanel.reveal();
-        vscode.commands.executeCommand("continue.focusContinueInput");
         return;
       }
+
+      // Clear the sidebar to prevent overwriting changes made in fullscreen 
+      vscode.commands.executeCommand("continue.newSession")
 
       // Full screen not open - open it
       captureCommandTelemetry("openFullScreen");

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -733,6 +733,10 @@ const getCommandsMap: (
         "getCurrentSessionId",
         undefined,
       );
+
+      // Clear the sidebar to prevent overwriting changes made in fullscreen 
+      vscode.commands.executeCommand("continue.newSession")
+
       // Check if full screen is already open by checking open tabs
       const fullScreenTab = getFullScreenTab();
 


### PR DESCRIPTION
## Description
2 unrelated bugs here, I can break this into multiple PRs if that is preferable.

1. opening fullscreen while it is focused clears the chat (vscode commands only work in webviews if they're focused (unsure if this is true for sidebar)).

2. chats made in fullscreen are being overwritten, clearing the sidebar session before opening the fullscreen prevents this.

## Testing instructions

tested locally

Bug repros:

cleared chats when focusing:
1. open a chat in fullscreen.
2. focus said chat (click on it).
3. use some full screen toggle (cmd + k + m), chat will be cleared.

overwritten chats:
1. start a chat in the sidebar.
4. open session in full screen and send followup chat.
5. close fullscreen.
6. open session in history, chats added in fullscreen won't be there.
