### PR TITLE
feat(JB): scroll to top of file on full file edit

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/listeners/ContinuePluginSelectionListener.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/listeners/ContinuePluginSelectionListener.kt
@@ -110,6 +110,19 @@ class ContinuePluginSelectionListener(
             ApplicationManager.getApplication().invokeLater {
                 val document = editor.document
                 val (startLine, endLine, isFullLineSelection) = getSelectionInfo(model, document)
+
+                // Check if entire file is selected
+                val isEntireFileSelected = model.selectionStart == 0 &&
+                        model.selectionEnd == document.textLength
+
+                // Scroll to top if entire file selected so that the user can see the input
+                if (isEntireFileSelected) {
+                    editor.scrollingModel.scrollTo(
+                        LogicalPosition(0, 0),
+                        com.intellij.openapi.editor.ScrollType.CENTER
+                    )
+                }
+
                 val selectionTopY = calculateSelectionTopY(editor, startLine, endLine, isFullLineSelection)
                 val tooltipX = calculateTooltipX(editor, document, startLine, endLine, isFullLineSelection)
 


### PR DESCRIPTION
## Description

Scrolls to the top of the file if a user selects the entire file when performing an inline edit.

Addresses https://discord.com/channels/1108621136150929458/1325945346819489984
