### PR TITLE
fix - resolve TypeError for http-slash-command

### DIFF
--- a/core/commands/slash/http.ts
+++ b/core/commands/slash/http.ts
@@ -1,5 +1,6 @@
 import { SlashCommand } from "../../index.js";
 import { removeQuotesAndEscapes } from "../../util/index.js";
+import { streamResponse } from "../../llm/stream.js";
 
 const HttpSlashCommand: SlashCommand = {
   name: "http",
@@ -23,14 +24,8 @@ const HttpSlashCommand: SlashCommand = {
     if (response.body === null) {
       throw new Error("Response body is null");
     }
-    const reader = response.body.getReader();
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) {
-        break;
-      }
-      const decoded = new TextDecoder("utf-8").decode(value);
-      yield decoded;
+    for await (const chunk of streamResponse(response)) {
+      yield chunk;
     }
   },
 };


### PR DESCRIPTION
## Description

Fixing the issue when triggering the [http-slash-command](https://docs.continue.dev/customize/slash-commands#http):

`TypeError: response.body.getReader is not a function`

Following @tomasz-stefaniak suggestion: https://discord.com/channels/1108621136150929458/1326174510352957512

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots

-

## Testing instructions

### 1] Add the http slash command to config.json

```
  "slashCommands": [
    {
      "name": "http",
      "description": "My http",
      "params": {
        "url": "http://127.0.0.1:5000"
      }
    }
]
```

### 2] Run a local http server, with streaming

#### Example with `flask`

```
from flask import Flask, Response, request
import time

app = Flask(__name__)

@app.route("/", methods=["POST"])
def stream_response():
    # Validate input (optional)
    data = request.get_json()
    if not data or "input" not in data:
        return Response("Invalid input", status=400)

    # Generator to stream responses
    def generate():
        for i in range(10):
            yield f"data: Message {i}\n\n"  # Format for Server-Sent Events (SSE)
            time.sleep(0.5)

    return Response(generate(), content_type="text/event-stream")

if __name__ == "__main__":
    app.run(port=5000, debug=True)
```


#### Example with `fastapi`

Create `app.py`

```
import asyncio

from fastapi import FastAPI
from fastapi.responses import StreamingResponse

app = FastAPI()


@app.post("/")
async def stream_response():
    async def generate():
        for i in range(10):
            yield f"Message {i}\n"
            await asyncio.sleep(0.5)
    return StreamingResponse(generate(), media_type="text/plain")
```

Run with `uvicorn app:app --host 127.0.0.1 --port 5000`

#### 3] Run the slash command in the continue chat panel