### PR TITLE
fix: listDir

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IntelliJIde.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IntelliJIde.kt
@@ -513,7 +513,7 @@ class IntelliJIDE(
 
     override suspend fun listDir(dir: String): List<List<Any>> {
         val files = File(URI(dir)).listFiles()?.map {
-            listOf(it.name, if (it.isDirectory) FileType.DIRECTORY else FileType.FILE)
+            listOf(it.name, if (it.isDirectory) FileType.DIRECTORY.value else FileType.FILE.value)
         } ?: emptyList()
 
         return files


### PR DESCRIPTION
## Description

DFSWalker.entryIsDirectory() only accept a number as FileType
fix the listDir on IntelliJIde.kt

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
