### PR TITLE
Submenu Context Provider fixes

### DIFF
--- a/core/context/providers/DebugLocalsProvider.ts
+++ b/core/context/providers/DebugLocalsProvider.ts
@@ -11,7 +11,7 @@ class DebugLocalsProvider extends BaseContextProvider {
   static description: ContextProviderDescription = {
     title: "debugger",
     displayTitle: "Debugger",
-    description: "Reference the contents of the local variables in the debugger",
+    description: "Local variables",
     type: "submenu",
     renderInlineAs: "",
   };

--- a/core/core.ts
+++ b/core/core.ts
@@ -299,7 +299,6 @@ export class Core {
     });
 
     on("context/loadSubmenuItems", async (msg) => {
-      console.log("Load SUMBENU ITEMS", msg);
       const config = await this.config();
       if (!config) {
         return [];

--- a/core/core.ts
+++ b/core/core.ts
@@ -384,9 +384,12 @@ export class Core {
     });
 
     on("clipboardCache/add", (msg) => {
-      console.log("ADD TO CLIPBOARD", msg);
-      clipboardCache.add(uuidv4(), msg.data.content);
-      this.messenger.send("refreshSubmenuItems", undefined);
+      const added = clipboardCache.add(uuidv4(), msg.data.content);
+      if (added) {
+        this.messenger.send("refreshSubmenuItems", {
+          providers: ["clipboard"],
+        });
+      }
     });
 
     async function* llmStreamChat(
@@ -948,7 +951,9 @@ export class Core {
       }
     }
 
-    this.messenger.send("refreshSubmenuItems", undefined);
+    this.messenger.send("refreshSubmenuItems", {
+      providers: "dependsOnIndexing",
+    });
     this.indexingCancellationController = undefined;
   }
 
@@ -979,7 +984,9 @@ export class Core {
       }
     }
 
-    this.messenger.send("refreshSubmenuItems", undefined);
+    this.messenger.send("refreshSubmenuItems", {
+      providers: "dependsOnIndexing",
+    });
   }
 
   // private

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -216,6 +216,10 @@ export interface ContextSubmenuItem {
   metadata?: any;
 }
 
+export interface ContextSubmenuItemWithProvider extends ContextSubmenuItem {
+  providerTitle: string;
+}
+
 export interface SiteIndexingConfig {
   title: string;
   startUrl: string;

--- a/core/indexing/docs/DocsService.ts
+++ b/core/indexing/docs/DocsService.ts
@@ -580,9 +580,9 @@ export default class DocsService {
 
       void this.ide.showToast("info", `Successfully indexed ${startUrl}`);
 
-      if (this.messenger) {
-        this.messenger.send("refreshSubmenuItems", undefined);
-      }
+      this.messenger?.send("refreshSubmenuItems", {
+        providers: ["docs"],
+      });
     } catch (e) {
       console.error("Error indexing docs", e);
       this.handleStatusUpdate({
@@ -1055,6 +1055,8 @@ export default class DocsService {
     this.abort(startUrl);
     await this.deleteIndexes(startUrl);
     this.deleteFromConfig(startUrl);
-    this.messenger?.send("refreshSubmenuItems", undefined);
+    this.messenger?.send("refreshSubmenuItems", {
+      providers: ["docs"],
+    });
   }
 }

--- a/core/protocol/ideWebview.ts
+++ b/core/protocol/ideWebview.ts
@@ -62,10 +62,6 @@ export type ToIdeFromWebviewProtocol = ToIdeFromWebviewOrCoreProtocol & {
 export type ToWebviewFromIdeProtocol = ToWebviewFromIdeOrCoreProtocol & {
   setInactive: [undefined, void];
   submitMessage: [{ message: any }, void]; // any -> JSONContent from TipTap
-  updateSubmenuItems: [
-    { provider: string; submenuItems: ContextSubmenuItem[] },
-    void,
-  ];
   newSessionWithPrompt: [{ prompt: string }, void];
   userInput: [{ input: string }, void];
   focusContinueInput: [undefined, void];

--- a/core/protocol/webview.ts
+++ b/core/protocol/webview.ts
@@ -4,6 +4,8 @@ import { ConfigValidationError } from "../config/validation.js";
 import type {
   BrowserSerializedContinueConfig,
   ContextItemWithId,
+  ContextProviderName,
+  ContextSubmenuItem,
   IndexingProgressUpdate,
   IndexingStatus,
   PackageDocsResult,
@@ -21,7 +23,12 @@ export type ToWebviewFromIdeOrCoreProtocol = {
   getDefaultModelTitle: [undefined, string];
   indexProgress: [IndexingProgressUpdate, void]; // Codebase
   "indexing/statusUpdate": [IndexingStatus, void]; // Docs, etc.
-  refreshSubmenuItems: [undefined, void];
+  refreshSubmenuItems: [
+    {
+      providers: "all" | "dependsOnIndexing" | ContextProviderName[];
+    },
+    void,
+  ];
   isContinueInputFocused: [undefined, boolean];
   addContextItem: [
     {

--- a/core/util/clipboardCache.ts
+++ b/core/util/clipboardCache.ts
@@ -8,10 +8,28 @@ class ClipboardCache {
     this.order = [];
   }
 
-  add(id: string, content: string): void {
+  /*
+  Returns true if added, false if not.
+  */
+  add(id: string, content: string): boolean {
     if (!content) {
-      return;
+      return false;
     }
+
+    // Check if the content already exists in the cache
+    for (const [existingId, existingContent] of this.cache.entries()) {
+      if (existingContent === content) {
+        // Remove the existing entry with the same content
+        this.cache.delete(existingId);
+        const index = this.order.indexOf(existingId);
+        if (index > -1) {
+          this.order.splice(index, 1);
+        }
+        return false;
+      }
+    }
+
+    // Remove the oldest entry if the cache exceeds the maximum size
     if (this.order.length >= this.maxSize) {
       const oldest = this.order.pop();
       if (oldest) {
@@ -19,14 +37,13 @@ class ClipboardCache {
       }
     }
 
+    // Add the new entry to the cache and update the order
     this.cache.set(id, content);
     this.order.unshift(id);
+    return true;
   }
 
-  getNItems(count: number): {
-    id: string;
-    content: string;
-  }[] {
+  getNItems(count: number): { id: string; content: string }[] {
     return this.order.slice(0, count).map((id) => ({
       id,
       content: this.cache.get(id) || "",

--- a/extensions/vscode/src/debug/debug.ts
+++ b/extensions/vscode/src/debug/debug.ts
@@ -13,13 +13,8 @@ export function registerDebugTracker(
   vscode.debug.registerDebugAdapterTrackerFactory("*", {
     createDebugAdapterTracker(_session: vscode.DebugSession) {
       const updateThreads = async () => {
-        webviewProtocol?.request("updateSubmenuItems", {
-          provider: "debugger",
-          submenuItems: (await ide.getAvailableThreads()).map((thread) => ({
-            id: `${thread.id}`,
-            title: thread.name,
-            description: `${thread.id}`,
-          })),
+        webviewProtocol?.request("refreshSubmenuItems", {
+          providers: ["debugger"],
         });
       };
 
@@ -33,30 +28,34 @@ export function registerDebugTracker(
             switch (message.event) {
               case "continued":
               case "stopped":
-                if (typeof message.body.threadId !== "undefined")
-                  {threadStopped.set(
+                if (typeof message.body.threadId !== "undefined") {
+                  threadStopped.set(
                     Number(message.body.threadId),
                     message.event === "stopped",
-                  );}
+                  );
+                }
 
-                if (message.body.allThreadsStopped)
-                  {threadStopped.forEach((_, key) =>
+                if (message.body.allThreadsStopped) {
+                  threadStopped.forEach((_, key) =>
                     threadStopped.set(key, true),
-                  );}
+                  );
+                }
 
-                if (message.body.allThreadsContinued)
-                  {threadStopped.forEach((_, key) =>
+                if (message.body.allThreadsContinued) {
+                  threadStopped.forEach((_, key) =>
                     threadStopped.set(key, false),
-                  );}
+                  );
+                }
 
                 updateThreads();
                 break;
 
               case "thread":
-                if (message.body.reason === "exited")
-                  {threadStopped.delete(Number(message.body.threadId));}
-                else if (message.body.reason === "started")
-                  {threadStopped.set(Number(message.body.threadId), false);}
+                if (message.body.reason === "exited") {
+                  threadStopped.delete(Number(message.body.threadId));
+                } else if (message.body.reason === "started") {
+                  threadStopped.set(Number(message.body.threadId), false);
+                }
                 // somehow the threadId does not respect the specification in my vscodium (debugging C++)
                 // expecting a number but got a string instead
                 break;

--- a/gui/src/components/CodeToEditCard/AddFileCombobox.tsx
+++ b/gui/src/components/CodeToEditCard/AddFileCombobox.tsx
@@ -1,11 +1,9 @@
 import { useState, useEffect, useRef } from "react";
-import {
-  ContextSubmenuItemWithProvider,
-  useSubmenuContextProviders,
-} from "../../context/SubmenuContextProviders";
+import { useSubmenuContextProviders } from "../../context/SubmenuContextProviders";
 import { Combobox } from "@headlessui/react";
 import FileIcon from "../FileIcon";
 import { useAppSelector } from "../../redux/hooks";
+import { ContextSubmenuItemWithProvider } from "core";
 
 export interface AddFileComboboxProps {
   onSelect: (filepaths: string[]) => void | Promise<void>;

--- a/gui/src/components/mainInput/getSuggestion.ts
+++ b/gui/src/components/mainInput/getSuggestion.ts
@@ -1,5 +1,9 @@
 import { Editor, ReactRenderer } from "@tiptap/react";
-import { ContextProviderDescription, ContextSubmenuItem } from "core";
+import {
+  ContextProviderDescription,
+  ContextSubmenuItem,
+  ContextSubmenuItemWithProvider,
+} from "core";
 import { MutableRefObject } from "react";
 import tippy from "tippy.js";
 import { IIdeMessenger } from "../../context/IdeMessenger";
@@ -112,7 +116,7 @@ export function getContextProviderDropdownOptions(
     (
       providerTitle: string | undefined,
       query: string,
-    ) => (ContextSubmenuItem & { providerTitle: string })[]
+    ) => ContextSubmenuItemWithProvider[]
   >,
   enterSubmenu: (editor: Editor, providerId: string) => void,
   onClose: () => void,
@@ -137,7 +141,7 @@ export function getContextProviderDropdownOptions(
       });
     }
 
-    const mainResults: any[] =
+    const contextProviderMatches: ComboBoxItem[] =
       availableContextProvidersRef.current
         ?.filter(
           (provider) =>
@@ -156,21 +160,8 @@ export function getContextProviderDropdownOptions(
         }))
         .sort((c, _) => (c.id === "file" ? -1 : 1)) || [];
 
-    if (mainResults.length === 0) {
-      const results = getSubmenuContextItemsRef.current(undefined, query);
-      return results.map((result) => {
-        return {
-          ...result,
-          label: result.title,
-          type: result.providerTitle as ComboBoxItemType,
-          query: result.id,
-          icon: result.icon,
-        };
-      });
-    } else if (
-      mainResults.length === availableContextProvidersRef.current.length
-    ) {
-      mainResults.push({
+    if (contextProviderMatches.length) {
+      contextProviderMatches.push({
         title: "Add more context providers",
         type: "action",
         action: () => {
@@ -181,8 +172,20 @@ export function getContextProviderDropdownOptions(
         },
         description: "",
       });
+      return contextProviderMatches;
     }
-    return mainResults;
+
+    // No provider matches -> search all providers
+    const results = getSubmenuContextItemsRef.current(undefined, query);
+    return results.map((result) => {
+      return {
+        ...result,
+        label: result.title,
+        type: result.providerTitle as ComboBoxItemType,
+        query: result.id,
+        icon: result.icon,
+      };
+    });
   };
 
   return getSuggestion(items, enterSubmenu, onClose, onOpen);

--- a/gui/src/context/SubmenuContextProviders.tsx
+++ b/gui/src/context/SubmenuContextProviders.tsx
@@ -1,4 +1,9 @@
-import { ContextSubmenuItem } from "core";
+import {
+  ContextProviderDescription,
+  ContextProviderName,
+  ContextSubmenuItem,
+  ContextSubmenuItemWithProvider,
+} from "core";
 import { createContext } from "react";
 import { deduplicateArray } from "core/util";
 import MiniSearch, { SearchResult } from "minisearch";
@@ -11,13 +16,14 @@ import {
   useState,
 } from "react";
 import { IdeMessengerContext } from "./IdeMessenger";
-import { selectContextProviderDescriptions } from "../redux/selectors";
+import { selectSubmenuContextProviders } from "../redux/selectors";
 import { useWebviewListener } from "../hooks/useWebviewListener";
 import { useAppSelector } from "../redux/hooks";
 import {
   getShortestUniqueRelativeUriPaths,
   getUriPathBasename,
 } from "core/util/uri";
+import { truncate } from "fs";
 
 const MINISEARCH_OPTIONS = {
   prefix: true,
@@ -26,142 +32,92 @@ const MINISEARCH_OPTIONS = {
 
 const MAX_LENGTH = 70;
 
-export interface ContextSubmenuItemWithProvider extends ContextSubmenuItem {
-  providerTitle: string;
-}
-
 interface SubtextContextProvidersContextType {
   getSubmenuContextItems: (
     providerTitle: string | undefined,
     query: string,
-  ) => (ContextSubmenuItem & { providerTitle: string })[];
-  addItem: (providerTitle: string, item: ContextSubmenuItem) => void;
+  ) => ContextSubmenuItemWithProvider[];
+  initialLoadComplete: boolean;
 }
 
 const initialContextProviders: SubtextContextProvidersContextType = {
   getSubmenuContextItems: () => [],
-  addItem: () => {},
+  initialLoadComplete: false,
 };
 
 const SubmenuContextProvidersContext =
   createContext<SubtextContextProvidersContextType>(initialContextProviders);
 
-function isOpenFilesChanged(
-  newFiles: { id: string }[],
-  oldFiles: { id: string }[],
-) {
-  if (newFiles.length > oldFiles.length) {
-    return true;
-  }
-  for (let i = 0; i < newFiles.length; ++i) {
-    if (newFiles[i].id !== oldFiles[i].id) return true;
-  }
-  return false;
-}
+/*
 
+*/
 export const SubmenuContextProvidersProvider = ({
   children,
 }: {
   children: React.ReactNode;
 }) => {
-  const [minisearches, setMinisearches] = useState<{
-    [id: string]: MiniSearch;
-  }>({});
-  const [fallbackResults, setFallbackResults] = useState<{
-    [id: string]: ContextSubmenuItem[];
-  }>({});
-
-  const contextProviderDescriptions = useAppSelector(
-    selectContextProviderDescriptions,
-  );
+  const ideMessenger = useContext(IdeMessengerContext);
+  const submenuContextProviders = useAppSelector(selectSubmenuContextProviders);
   const disableIndexing = useAppSelector(
     (store) => store.config.config.disableIndexing,
   );
 
-  const [initialLoadComplete, setInitialLoadComplete] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const [autoLoadTriggered, setAutoLoadTriggered] = useState(false);
+  const [minisearches, setMinisearches] = useState<{
+    [id: string]: MiniSearch<ContextSubmenuItemWithProvider>;
+  }>({});
+  const [fallbackResults, setFallbackResults] = useState<{
+    [id: string]: ContextSubmenuItemWithProvider[];
+  }>({});
 
-  const ideMessenger = useContext(IdeMessengerContext);
-
-  const getOpenFilesItems = useCallback(async () => {
-    const openFiles = await ideMessenger.ide.getOpenFiles();
-    const workspaceDirs = await ideMessenger.ide.getWorkspaceDirs();
-    const withUniquePaths = getShortestUniqueRelativeUriPaths(
-      openFiles,
-      workspaceDirs,
-    );
-
-    return withUniquePaths.map((file) => ({
-      id: file.uri,
-      title: getUriPathBasename(file.uri),
-      description: file.uniquePath,
-      providerTitle: "file",
-    }));
-  }, [ideMessenger]);
-
-  useWebviewListener("refreshSubmenuItems", async () => {
-    if (!isLoading) {
-      setInitialLoadComplete(false);
-      setAutoLoadTriggered((prev) => !prev); // Toggle to trigger effect
-    }
-  });
-
-  useWebviewListener("updateSubmenuItems", async (data) => {
-    const minisearch = new MiniSearch<ContextSubmenuItem>({
-      fields: ["title", "description"],
-      storeFields: ["id", "title", "description"],
-    });
-
-    minisearch.addAll(data.submenuItems);
-
-    setMinisearches((prev) => ({ ...prev, [data.provider]: minisearch }));
-
-    if (data.provider === "file") {
-      const openFiles = await getOpenFilesItems();
-      setFallbackResults((prev) => ({
-        ...prev,
-        file: [
-          ...openFiles,
-          ...data.submenuItems.slice(0, MAX_LENGTH - openFiles.length),
-        ],
-      }));
-    } else {
-      setFallbackResults((prev) => ({
-        ...prev,
-        [data.provider]: data.submenuItems.slice(0, MAX_LENGTH),
-      }));
-    }
-  });
-
-  const addItem = useCallback(
-    (providerTitle: string, item: ContextSubmenuItem) => {
-      if (!minisearches[providerTitle]) {
-        return;
-      }
-      minisearches[providerTitle].add(item);
-    },
-    [minisearches],
-  );
-
-  const lastOpenFilesRef = useRef<
-    Awaited<ReturnType<typeof getOpenFilesItems>>
-  >([]);
+  // Update open files for file provider on an interval
+  const lastOpenFilesRef = useRef<ContextSubmenuItemWithProvider[]>([]);
   useEffect(() => {
+    function hasOpenFilesChanged(
+      newFiles: ContextSubmenuItemWithProvider[],
+      oldFiles: ContextSubmenuItemWithProvider[],
+    ) {
+      const newIds = new Set(newFiles.map((f) => f.id));
+      const oldIds = new Set(oldFiles.map((f) => f.id));
+
+      if (newIds.size !== oldIds.size) return true;
+
+      for (const id of newIds) {
+        if (!oldIds.has(id)) return true;
+      }
+
+      for (const id of oldIds) {
+        if (!newIds.has(id)) return true;
+      }
+      return false;
+    }
+
     let isMounted = true;
     const refreshOpenFiles = async () => {
       if (!isMounted) return;
-      const openFiles = await getOpenFilesItems();
-      if (isOpenFilesChanged(openFiles, lastOpenFilesRef.current)) {
+
+      const openFiles = await ideMessenger.ide.getOpenFiles();
+      const workspaceDirs = await ideMessenger.ide.getWorkspaceDirs();
+      const withUniquePaths = getShortestUniqueRelativeUriPaths(
+        openFiles,
+        workspaceDirs,
+      );
+      const openFileItems = withUniquePaths.map((file) => ({
+        id: file.uri,
+        title: getUriPathBasename(file.uri),
+        description: file.uniquePath,
+        providerTitle: "file",
+      }));
+
+      if (hasOpenFilesChanged(openFileItems, lastOpenFilesRef.current)) {
         setFallbackResults((prev) => ({
           ...prev,
           file: deduplicateArray(
-            [...openFiles, ...(Array.isArray(prev.file) ? prev.file : [])],
+            [...openFileItems, ...(prev.file ?? [])],
             (a, b) => a.id === b.id,
           ),
         }));
-        lastOpenFilesRef.current = openFiles;
       }
+      lastOpenFilesRef.current = openFileItems;
     };
 
     const interval = setInterval(refreshOpenFiles, 2000);
@@ -172,117 +128,121 @@ export const SubmenuContextProvidersProvider = ({
       isMounted = false;
       clearInterval(interval);
     };
-  }, [getOpenFilesItems]);
+  }, [ideMessenger]);
 
-  const getSubmenuSearchResults = useMemo(
-    () =>
-      (providerTitle: string | undefined, query: string): SearchResult[] => {
+  const [initialLoadComplete, setInitialLoadComplete] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const getSubmenuContextItems = useCallback(
+    (
+      providerTitle: string | undefined,
+      query: string,
+      limit: number = MAX_LENGTH,
+    ): ContextSubmenuItemWithProvider[] => {
+      try {
+        // 1. Search using minisearch
+        let searchResults: (SearchResult & ContextSubmenuItemWithProvider)[] =
+          [];
+
         if (providerTitle === undefined) {
-          // Return search combined from all providers
-          const results = Object.keys(minisearches).map((providerTitle) => {
-            const results = minisearches[providerTitle].search(
-              query,
-              MINISEARCH_OPTIONS,
-            );
-            return results.map((result) => {
-              return { ...result, providerTitle };
-            });
-          });
-
-          return results.flat().sort((a, b) => b.score - a.score);
-        }
-        if (!minisearches[providerTitle]) {
-          return [];
-        }
-
-        const results = minisearches[providerTitle]
-          .search(query, MINISEARCH_OPTIONS)
-          .map((result) => {
-            return { ...result, providerTitle };
-          });
-
-        return results;
-      },
-    [minisearches],
-  );
-
-  const getSubmenuContextItems = useMemo(
-    () =>
-      (
-        providerTitle: string | undefined,
-        query: string,
-        limit: number = MAX_LENGTH,
-      ): (ContextSubmenuItem & { providerTitle: string })[] => {
-        try {
-          const results = getSubmenuSearchResults(providerTitle, query);
-          if (results.length === 0) {
-            const fallbackItems = (
-              providerTitle ? (fallbackResults[providerTitle] ?? []) : []
-            )
-              .slice(0, limit)
+          // Include results from all providers
+          searchResults = Object.keys(minisearches).flatMap((providerTitle) =>
+            minisearches[providerTitle]
+              .search(query, MINISEARCH_OPTIONS)
               .map((result) => {
                 return {
                   ...result,
-                  providerTitle: providerTitle || "unknown",
+                  providerTitle,
+                  title: result.title,
+                  description: result.description,
+                };
+              }),
+          );
+        } else {
+          // Only include results from the specified provider
+          if (minisearches[providerTitle]) {
+            searchResults = minisearches[providerTitle]
+              .search(query, MINISEARCH_OPTIONS)
+              .map((result) => {
+                return {
+                  ...result,
+                  providerTitle,
+                  title: result.title,
+                  description: result.description,
                 };
               });
-
-            if (fallbackItems.length === 0 && !initialLoadComplete) {
-              return [
-                {
-                  id: "loading",
-                  title: "Loading...",
-                  description: "Please wait while items are being loaded",
-                  providerTitle: providerTitle || "unknown",
-                },
-              ];
-            }
-
-            return fallbackItems;
           }
-          const limitedResults = results.slice(0, limit).map((result) => {
-            return {
-              id: result.id,
-              title: result.title,
-              description: result.description,
-              providerTitle: result.providerTitle,
-            };
-          });
-          return limitedResults;
-        } catch (error) {
-          console.error("Error in getSubmenuContextItems:", error);
-          return [];
         }
-      },
-    [fallbackResults, getSubmenuSearchResults, initialLoadComplete],
+        searchResults.sort((a, b) => b.score - a.score);
+
+        // 2. Add fallback results if no search results
+        if (searchResults.length === 0) {
+          const fallbackItems = (
+            providerTitle ? (fallbackResults[providerTitle] ?? []) : []
+          )
+            .slice(0, limit)
+            .map((result) => {
+              return {
+                ...result,
+                providerTitle: providerTitle || "unknown",
+              };
+            });
+
+          if (fallbackItems.length === 0 && !initialLoadComplete) {
+            return [
+              {
+                id: "loading",
+                title: "Loading...",
+                description: "Please wait while items are being loaded",
+                providerTitle: providerTitle || "unknown",
+              },
+            ];
+          }
+
+          return fallbackItems;
+        }
+        const limitedResults = searchResults.slice(0, limit).map((result) => {
+          return {
+            id: result.id,
+            title: result.title,
+            description: result.description,
+            providerTitle: result.providerTitle,
+          };
+        });
+        return limitedResults;
+      } catch (error) {
+        console.error("Error in getSubmenuContextItems:", error);
+        return [];
+      }
+    },
+    [fallbackResults, minisearches, initialLoadComplete],
   );
 
-  useEffect(() => {
-    if (contextProviderDescriptions.length === 0 || isLoading) {
-      return;
-    }
-    setIsLoading(true);
+  const loadSubmenuItems = useCallback(
+    async (providers: "dependsOnIndexing" | "all" | ContextProviderName[]) => {
+      setIsLoading(true);
 
-    const loadSubmenuItems = async () => {
-      try {
-        await Promise.all(
-          contextProviderDescriptions.map(async (description) => {
-            const shouldSkipProvider =
-              description.dependsOnIndexing && disableIndexing;
-
-            if (shouldSkipProvider) {
-              console.debug(
-                `Skipping ${description.title} provider due to disabled indexing`,
-              );
-              return;
-            }
-
+      await Promise.allSettled(
+        submenuContextProviders.map(
+          async (description: ContextProviderDescription) => {
             try {
-              const minisearch = new MiniSearch<ContextSubmenuItem>({
-                fields: ["title", "description"],
-                storeFields: ["id", "title", "description"],
-              });
+              const refreshProvider =
+                providers === "all"
+                  ? true
+                  : providers === "dependsOnIndexing"
+                    ? description.dependsOnIndexing
+                    : providers.includes(description.title);
 
+              if (!refreshProvider) {
+                return;
+              }
+
+              if (description.dependsOnIndexing && disableIndexing) {
+                console.debug(
+                  `Skipping ${description.title} provider due to disabled indexing`,
+                );
+                return;
+              }
               const result = await ideMessenger.request(
                 "context/loadSubmenuItems",
                 {
@@ -291,61 +251,88 @@ export const SubmenuContextProvidersProvider = ({
               );
 
               if (result.status === "error") {
-                console.error(
-                  `Error loading items for ${description.title}:`,
-                  result.error,
-                );
-                return;
+                throw new Error(result.error);
               }
-              const items = result.content;
+              const submenuItems = result.content;
+              const providerTitle = description.title;
 
-              minisearch.addAll(items);
+              const itemsWithProvider = submenuItems.map((item) => ({
+                ...item,
+                providerTitle,
+              }));
+
+              const minisearch = new MiniSearch<ContextSubmenuItemWithProvider>(
+                {
+                  fields: ["title", "description"],
+                  storeFields: ["id", "title", "description", "providerTitle"],
+                },
+              );
+
+              minisearch.addAll(
+                submenuItems.map((item) => ({ ...item, providerTitle })),
+              );
 
               setMinisearches((prev) => ({
                 ...prev,
-                [description.title]: minisearch,
+                [providerTitle]: minisearch,
               }));
 
-              if (description.title === "file") {
-                const openFiles = await getOpenFilesItems();
+              if (providerTitle === "file") {
                 setFallbackResults((prev) => ({
                   ...prev,
-                  file: [
-                    ...openFiles,
-                    ...items.slice(0, MAX_LENGTH - openFiles.length),
-                  ],
+                  file: deduplicateArray(
+                    [...lastOpenFilesRef.current, ...(prev.file ?? [])],
+                    (a, b) => a.id === b.id,
+                  ),
                 }));
               } else {
                 setFallbackResults((prev) => ({
                   ...prev,
-                  [description.title]: items.slice(0, MAX_LENGTH),
+                  [providerTitle]: itemsWithProvider,
                 }));
               }
             } catch (error) {
-              console.error(`Error processing ${description.title}:`, error);
+              console.error(
+                `Error loading items for ${description.title}:`,
+                error,
+              );
               console.error(
                 "Error details:",
                 JSON.stringify(error, Object.getOwnPropertyNames(error)),
               );
             }
-          }),
-        );
-      } catch (error) {
-        console.error("Error in loadSubmenuItems:", error);
-      } finally {
-        setInitialLoadComplete(true);
-        setIsLoading(false);
-      }
-    };
+          },
+        ),
+      );
+      setInitialLoadComplete(true);
+      setIsLoading(false);
+    },
+    [submenuContextProviders, disableIndexing],
+  );
 
-    loadSubmenuItems();
-  }, [contextProviderDescriptions, autoLoadTriggered]);
+  useWebviewListener(
+    "refreshSubmenuItems",
+    async (data) => {
+      if (isLoading) {
+        return;
+      }
+      if (data.providers === "all") {
+        setInitialLoadComplete(false);
+      }
+      await loadSubmenuItems(data.providers);
+    },
+    [isLoading, loadSubmenuItems],
+  );
+
+  useEffect(() => {
+    void loadSubmenuItems("all");
+  }, []);
 
   return (
     <SubmenuContextProvidersContext.Provider
       value={{
         getSubmenuContextItems,
-        addItem,
+        initialLoadComplete,
       }}
     >
       {children}

--- a/gui/src/context/SubmenuContextProviders.tsx
+++ b/gui/src/context/SubmenuContextProviders.tsx
@@ -1,20 +1,12 @@
 import {
   ContextProviderDescription,
   ContextProviderName,
-  ContextSubmenuItem,
   ContextSubmenuItemWithProvider,
 } from "core";
 import { createContext } from "react";
 import { deduplicateArray } from "core/util";
 import MiniSearch, { SearchResult } from "minisearch";
-import {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { IdeMessengerContext } from "./IdeMessenger";
 import { selectSubmenuContextProviders } from "../redux/selectors";
 import { useWebviewListener } from "../hooks/useWebviewListener";
@@ -23,7 +15,6 @@ import {
   getShortestUniqueRelativeUriPaths,
   getUriPathBasename,
 } from "core/util/uri";
-import { truncate } from "fs";
 
 const MINISEARCH_OPTIONS = {
   prefix: true,
@@ -48,9 +39,6 @@ const initialContextProviders: SubtextContextProvidersContextType = {
 const SubmenuContextProvidersContext =
   createContext<SubtextContextProvidersContextType>(initialContextProviders);
 
-/*
-
-*/
 export const SubmenuContextProvidersProvider = ({
   children,
 }: {

--- a/gui/src/redux/selectors/index.ts
+++ b/gui/src/redux/selectors/index.ts
@@ -24,7 +24,7 @@ export const selectSlashCommands = createSelector(
   },
 );
 
-export const selectContextProviderDescriptions = createSelector(
+export const selectSubmenuContextProviders = createSelector(
   [(state: RootState) => state.config.config.contextProviders],
   (providers) => {
     return providers?.filter((desc) => desc.type === "submenu") || [];


### PR DESCRIPTION
Improve/fix logic for several things around loading submenu items
- Fix debugger provider and remove the "updateSubmenuItems" message
- Change "refreshSubmenuItems" message to accept specific providers (or `dependsOnIndexing` or `all`)
- Fix submenu logic causing it to load open files too frequently
- Fix clipboard cache containing duplicate items
- Fix logic checking if open files have changed