### PR TITLE
Fix extra slash in embedding for vertex

### DIFF
--- a/core/llm/llms/VertexAI.ts
+++ b/core/llm/llms/VertexAI.ts
@@ -445,7 +445,7 @@ class VertexAI extends BaseLLM {
     }
 
     const resp = await this.fetch(
-      new URL(this.apiBase + `/publishers/google/models/${this.model}:predict`),
+      new URL(this.apiBase + `publishers/google/models/${this.model}:predict`),
       {
         method: "POST",
         body: JSON.stringify({


### PR DESCRIPTION
## Description

Seems like a bug was introduced when the embeddings were merged into the llm.
https://github.com/continuedev/continue/commit/b14b8c4652c5b132418ad1288444a431e5d81c55#diff-f6056e365b00006d0872276e5078b8e10b940dfeca7f0aa106b1c842e5aa5a14

The embedding class's base url didn't have a slash at the end, while the llm one did. Neither one was 'wrong', but they were different, so when it was merged, it ended up having a // in the url. 

Removing the / before the embedding url fixes this problem.

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
