### PR TITLE
Include signatures by default in repo map context provider

### DIFF
--- a/core/context/providers/RepoMapContextProvider.ts
+++ b/core/context/providers/RepoMapContextProvider.ts
@@ -41,7 +41,7 @@ class RepoMapContextProvider extends BaseContextProvider {
           // Doesn't ALWAYS depend on indexing, so not setting dependsOnIndexing = true, just checking for it
           includeSignatures: extras.config.disableIndexing
             ? false
-            : (this.options?.includeSignatures ?? false),
+            : (this.options?.includeSignatures ?? true),
         }),
       },
     ];

--- a/docs/docs/customize/context-providers.md
+++ b/docs/docs/customize/context-providers.md
@@ -261,9 +261,9 @@ Uses the top _n_ levels (defaulting to 3) of the call stack for that thread.
 
 ### `@Repository Map`
 
-Reference the outline of your codebase.
+Reference the outline of your codebase. By default, signatures are included along with file in the repo map.
 
-`includeSignatures` params can be used to include signatures for all files in the repo. Use with caution as will increase context size significantly. `includeSignatures` will not work if indexing is disabled.
+`includeSignatures` params can be set to false to exclude signatures. This could be necessary for large codebases and/or to reduce context size significantly. Signatures will not be included if indexing is disabled.
 
 ```json title="config.json"
 {
@@ -271,7 +271,7 @@ Reference the outline of your codebase.
     {
       "name": "repo-map",
       "params": {
-        "includeSignatures": false
+        "includeSignatures": false // default true
       }
     }
   ]


### PR DESCRIPTION
Without signatures the repo map and tree context providers are identical
Include signatures by default