### PR TITLE
fix missing docs subaction item

### DIFF
--- a/gui/src/components/mainInput/MentionList.tsx
+++ b/gui/src/components/mainInput/MentionList.tsx
@@ -81,6 +81,7 @@ const ICONS_FOR_DROPDOWN: { [key: string]: any } = {
   google: GoogleIcon,
   "gitlab-mr": GitlabIcon,
   http: GlobeAltIcon,
+  trash: TrashIcon,
 };
 
 export function getIconFromDropdownItem(
@@ -451,7 +452,10 @@ const MentionList = forwardRef((props: MentionListProps, ref) => {
                         />
                       )}
                     {item.subActions?.map((subAction) => {
-                      const Icon = ICONS_FOR_DROPDOWN[subAction.icon];
+                      const Icon = getIconFromDropdownItem(
+                        subAction.icon,
+                        "action",
+                      );
                       return (
                         <HeaderButtonWithToolTip
                           onClick={(e) => {


### PR DESCRIPTION
On context providers audit PR deleted a trash icon that was used by docs subaction in mention list.
Caused crashes
Re-adding