### PR TITLE
config file uri bug

### DIFF
--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -15,7 +15,6 @@ import { GlobalContext } from "../util/GlobalContext.js";
 import { getConfigJsonPath } from "../util/paths.js";
 
 import { ConfigResult } from "@continuedev/config-yaml";
-import { pathToFileURL } from "url";
 import { controlPlaneEnv } from "../control-plane/env.js";
 import { usePlatform } from "../control-plane/flags.js";
 import {
@@ -29,6 +28,7 @@ import {
   ProfileDescription,
   ProfileLifecycleManager,
 } from "./ProfileLifecycleManager.js";
+import { localPathToUri } from "../util/pathToUri.js";
 
 export type { ProfileDescription };
 
@@ -95,7 +95,7 @@ export class ConfigHandler {
   async openConfigProfile(profileId?: string) {
     let openProfileId = profileId || this.selectedProfileId;
     if (openProfileId === "local") {
-      await this.ide.openFile(pathToFileURL(getConfigJsonPath()).toString());
+      await this.ide.openFile(localPathToUri(getConfigJsonPath()));
     } else {
       await this.ide.openUrl(`${controlPlaneEnv.APP_URL}${openProfileId}`);
     }

--- a/core/config/load.ts
+++ b/core/config/load.ts
@@ -73,6 +73,7 @@ import {
 import { getSystemPromptDotFile } from "./getSystemPromptDotFile";
 // import { isSupportedLanceDbCpuTarget } from "./util";
 import { validateConfig } from "./validation.js";
+import { localPathToUri } from "../util/pathToUri";
 
 function resolveSerializedConfig(filepath: string): SerializedContinueConfig {
   let content = fs.readFileSync(filepath, "utf8");
@@ -813,7 +814,7 @@ async function loadFullConfigNode(
           "Could not load config.ts as absolute path, retrying as file url ...",
         );
         try {
-          module = await import(`file://${configJsPath}`);
+          module = await import(localPathToUri(configJsPath));
         } catch (e) {
           throw new Error("Could not load config.ts as file url either", {
             cause: e,

--- a/core/indexing/CodebaseIndexer.test.ts
+++ b/core/indexing/CodebaseIndexer.test.ts
@@ -14,12 +14,12 @@ import {
 } from "../test/testDir.js";
 import { getIndexSqlitePath } from "../util/paths.js";
 
-import { pathToFileURL } from "node:url";
 import { CodebaseIndexer, PauseToken } from "./CodebaseIndexer.js";
 import { getComputeDeleteAddRemove } from "./refreshIndex.js";
 import { TestCodebaseIndex } from "./TestCodebaseIndex.js";
 import { CodebaseIndex } from "./types.js";
 import { walkDir } from "./walkDir.js";
+import { localPathToUri } from "../util/pathToUri.js";
 
 jest.useFakeTimers();
 
@@ -159,7 +159,7 @@ describe("CodebaseIndexer", () => {
 
   test("should have created index folder with all necessary files", async () => {
     const exists = await testIde.fileExists(
-      pathToFileURL(getIndexSqlitePath()).toString(),
+      localPathToUri(getIndexSqlitePath()),
     );
     expect(exists).toBe(true);
   });

--- a/core/promptFiles/v2/getPromptFiles.ts
+++ b/core/promptFiles/v2/getPromptFiles.ts
@@ -16,11 +16,11 @@ export async function getPromptFilesFromDir(
       return [];
     }
 
-    const paths = await walkDir(dir, ide, { ignoreFiles: [] });
-    const promptFilePaths = paths.filter((p) => p.endsWith(".prompt"));
-    const results = promptFilePaths.map(async (path) => {
-      const content = await ide.readFile(path); // make a try catch
-      return { path, content };
+    const uris = await walkDir(dir, ide, { ignoreFiles: [] });
+    const promptFilePaths = uris.filter((p) => p.endsWith(".prompt"));
+    const results = promptFilePaths.map(async (uri) => {
+      const content = await ide.readFile(uri); // make a try catch
+      return { path: uri, content };
     });
     return Promise.all(results);
   } catch (e) {

--- a/core/util/pathToUri.ts
+++ b/core/util/pathToUri.ts
@@ -4,7 +4,7 @@ import * as URI from "uri-js";
 
 // CAN ONLY BE USED IN CORE
 
-// Converts a local path to a file:// URI
+// Converts a local path to a file:/// URI
 export function localPathToUri(path: string) {
   const url = pathToFileURL(path);
   return URI.normalize(url.toString());


### PR DESCRIPTION
Fix two-slash explicit file URI that was causing the first segment of a path to be interpreted as the authority component

E.g. `C:/users/bob` -> `file://c:/users/bob` : c: is an authority component rather than part of the path like it should be.