### PR TITLE
pr_checks: Disable the SSH e2e test when not configured

### DIFF
--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -283,8 +283,11 @@ jobs:
   vscode-get-test-file-matrix:
     runs-on: ubuntu-latest
     needs: [install-root, install-vscode]
+    env:
+      SSH_HOST: ${{ secrets.GH_ACTIONS_SSH_TEST_DNS_NAME }}
     outputs:
       test_file_matrix: ${{ steps.vscode-get-test-file-matrix.outputs.test_file_matrix }}
+      test_file_exclude: ${{ steps.vscode-get-test-file-matrix.outputs.test_file_exclude }}
     steps:
       - uses: actions/checkout@v4
 
@@ -304,10 +307,18 @@ jobs:
           echo "test_file_matrix<<EOF" >> $GITHUB_OUTPUT
           echo "$FILES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+          echo "test_file_exclude<<EOF" >> $GITHUB_OUTPUT
+          if [ "$SSH_HOST" = '' ] ; then
+            echo '[{"test_file": "e2e/_output/tests/SSH.test.js"}]' >> $GITHUB_OUTPUT
+          else
+            echo "[]" >> $GITHUB_OUTPUT
+          fi
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Debug Outputs
         run: |
           echo "Test files: ${{ steps.vscode-get-test-file-matrix.outputs.test_file_matrix }}"
+          echo "Test file excludes: ${{ steps.vscode-get-test-file-matrix.outputs.test_file_exclude }}"
 
   vscode-package-extension:
     runs-on: ubuntu-latest
@@ -389,6 +400,7 @@ jobs:
       fail-fast: false
       matrix:
         test_file: ${{ fromJson(needs.vscode-get-test-file-matrix.outputs.test_file_matrix) }}
+        exclude: ${{ fromJson(needs.vscode-get-test-file-matrix.outputs.test_file_exclude) }}
         command: ["e2e:ci:run", "e2e:ci:run-yaml"]
     steps:
       - uses: actions/checkout@v4
@@ -423,6 +435,7 @@ jobs:
         env:
           SSH_KEY: ${{ secrets.GH_ACTIONS_SSH_TEST_KEY_PEM }}
           SSH_HOST: ${{ secrets.GH_ACTIONS_SSH_TEST_DNS_NAME }}
+        if: ${{ env.SSH_HOST != '' }}
         run: |
           mkdir -p ~/.ssh
           echo "$SSH_KEY" > ~/.ssh/id_rsa


### PR DESCRIPTION
The SSH e2e test requires a host to be running permanently with SSH_HOST/SSH_KEY set as secrets; if these secrets are not set, then exclude it.

This should fix the problem where PR's from external contributors always have the e2e tests fail - even though only a single test requires the SSH setup, the "Set up SSH" step fails on each vscode-e2e-tests job.

It would be nicer to show the test as skipped rather than just excluding it entirely, but I didn't manage to figure out how to do that.
