### PR TITLE
Submenu loading logic fix

### DIFF
--- a/gui/src/context/SubmenuContextProviders.tsx
+++ b/gui/src/context/SubmenuContextProviders.tsx
@@ -117,7 +117,7 @@ export const SubmenuContextProvidersProvider = ({
     };
   }, [ideMessenger]);
 
-  const providersLoading = useRef(new Map<string, boolean>()).current;
+  const providersLoading = useRef(new Set<string>()).current;
 
   const getSubmenuContextItems = useCallback(
     (
@@ -192,7 +192,7 @@ export const SubmenuContextProvidersProvider = ({
               }
             } else {
               // Otherwise just check if the provider is loading
-              if (providersLoading.get(providerTitle)) {
+              if (providersLoading.has(providerTitle)) {
                 return loadingFiller;
               }
             }
@@ -223,10 +223,10 @@ export const SubmenuContextProvidersProvider = ({
         submenuContextProviders.map(
           async (description: ContextProviderDescription) => {
             try {
-              if (providersLoading.get(description.title)) {
+              if (providersLoading.has(description.title)) {
                 return;
               }
-              providersLoading.set(description.title, true);
+              providersLoading.add(description.title);
 
               const refreshProvider =
                 providers === "all"
@@ -303,7 +303,7 @@ export const SubmenuContextProvidersProvider = ({
                 JSON.stringify(error, Object.getOwnPropertyNames(error)),
               );
             } finally {
-              providersLoading.set(description.title, false);
+              providersLoading.delete(description.title);
             }
           },
         ),

--- a/gui/src/context/SubmenuContextProviders.tsx
+++ b/gui/src/context/SubmenuContextProviders.tsx
@@ -15,7 +15,6 @@ import {
   getShortestUniqueRelativeUriPaths,
   getUriPathBasename,
 } from "core/util/uri";
-import { providers } from "../pages/AddNewModel/configs/providers";
 
 const MINISEARCH_OPTIONS = {
   prefix: true,
@@ -309,7 +308,7 @@ export const SubmenuContextProvidersProvider = ({
         ),
       );
     },
-    [submenuContextProviders, disableIndexing],
+    [submenuContextProviders, disableIndexing, providersLoading],
   );
 
   useWebviewListener(

--- a/gui/src/context/SubmenuContextProviders.tsx
+++ b/gui/src/context/SubmenuContextProviders.tsx
@@ -317,7 +317,7 @@ export const SubmenuContextProvidersProvider = ({
 
   useEffect(() => {
     void loadSubmenuItems("all");
-  }, []);
+  }, [loadSubmenuItems]);
 
   return (
     <SubmenuContextProvidersContext.Provider

--- a/gui/src/context/SubmenuContextProviders.tsx
+++ b/gui/src/context/SubmenuContextProviders.tsx
@@ -126,6 +126,7 @@ export const SubmenuContextProvidersProvider = ({
     ): ContextSubmenuItemWithProvider[] => {
       try {
         // 1. Search using minisearch
+        debugger;
         let searchResults: (SearchResult & ContextSubmenuItemWithProvider)[] =
           [];
 
@@ -310,14 +311,22 @@ export const SubmenuContextProvidersProvider = ({
   useWebviewListener(
     "refreshSubmenuItems",
     async (data) => {
-      await loadSubmenuItems(data.providers);
+      loadSubmenuItems(data.providers);
     },
     [loadSubmenuItems],
   );
 
+  // Reload all submenu items on the initial config load
+  // TODO - could refresh on any change
+  const initialLoad = useRef(false);
+  const config = useAppSelector((store) => store.config.config);
   useEffect(() => {
+    if (!config?.contextProviders?.length || initialLoad.current) {
+      return;
+    }
     void loadSubmenuItems("all");
-  }, [loadSubmenuItems]);
+    initialLoad.current = true;
+  }, [loadSubmenuItems, config, initialLoad]);
 
   return (
     <SubmenuContextProvidersContext.Provider

--- a/gui/src/context/SubmenuContextProviders.tsx
+++ b/gui/src/context/SubmenuContextProviders.tsx
@@ -126,7 +126,6 @@ export const SubmenuContextProvidersProvider = ({
     ): ContextSubmenuItemWithProvider[] => {
       try {
         // 1. Search using minisearch
-        debugger;
         let searchResults: (SearchResult & ContextSubmenuItemWithProvider)[] =
           [];
 


### PR DESCRIPTION
This PR fixes three submenu loading issues:
- race condition on `isLoading` logic: When I added ability to refresh specific submenu providers, I didn't update the `isLoading` logic properly. This uses a set with provider names rather than overarching isLoading
- Removes unnecessary waiting till all providers are done loading to move on logic
- Config trigger - initial load fixed - was trying to load submenu items before config existed. I think this started happening when we removed config from the persist gate