### PR TITLE
Passs through configError message

### DIFF
--- a/core/protocol/passThrough.ts
+++ b/core/protocol/passThrough.ts
@@ -66,6 +66,7 @@ export const WEBVIEW_TO_CORE_PASS_THROUGH: (keyof ToCoreFromWebviewProtocol)[] =
 export const CORE_TO_WEBVIEW_PASS_THROUGH: (keyof ToWebviewFromCoreProtocol)[] =
   [
     "configUpdate",
+    "configError",
     "getDefaultModelTitle",
     "indexProgress", // Codebase
     "indexing/statusUpdate", // Docs, etc.

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/MessageTypes.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/MessageTypes.kt
@@ -53,6 +53,7 @@ class MessageTypes {
         // Note: If updating these values, make a corresponding update in
         // core/protocol/passThrough.ts
         val PASS_THROUGH_TO_WEBVIEW = listOf(
+            "configError",
             "configUpdate",
             "getDefaultModelTitle",
             "indexProgress", // Codebase


### PR DESCRIPTION
Pass through Config Error message
Note, won't work for jetbrains because logic to send config error is in vscode extension specifically. Have made note of this