### PR TITLE
replaceSystemMessage model config option

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -43,13 +43,13 @@ export interface IndexingProgressUpdate {
   desc: string;
   shouldClearIndexes?: boolean;
   status:
-    | "loading"
-    | "indexing"
-    | "done"
-    | "failed"
-    | "paused"
-    | "disabled"
-    | "cancelled";
+  | "loading"
+  | "indexing"
+  | "done"
+  | "failed"
+  | "paused"
+  | "disabled"
+  | "cancelled";
   debugInfo?: string;
 }
 
@@ -450,6 +450,7 @@ export interface LLMOptions {
   title?: string;
   uniqueId?: string;
   systemMessage?: string;
+  replaceSystemMessage?: boolean;
   contextLength?: number;
   maxStopWords?: number;
   completionOptions?: CompletionOptions;
@@ -650,10 +651,10 @@ export interface IDE {
   getCurrentFile(): Promise<
     | undefined
     | {
-        isUntitled: boolean;
-        path: string;
-        contents: string;
-      }
+      isUntitled: boolean;
+      path: string;
+      contents: string;
+    }
   >;
 
   getPinnedFiles(): Promise<string[]>;
@@ -832,11 +833,11 @@ export interface CustomCommand {
 export interface Prediction {
   type: "content";
   content:
-    | string
-    | {
-        type: "text";
-        text: string;
-      }[];
+  | string
+  | {
+    type: "text";
+    text: string;
+  }[];
 }
 
 export interface ToolExtras {
@@ -903,6 +904,7 @@ export interface ModelDescription {
   template?: TemplateType;
   completionOptions?: BaseCompletionOptions;
   systemMessage?: string;
+  replaceSystemMessage?: boolean;
   requestOptions?: RequestOptions;
   promptTemplates?: { [key: string]: string };
   capabilities?: ModelCapability;
@@ -1157,9 +1159,9 @@ export interface Config {
   embeddingsProvider?: EmbeddingsProviderDescription | ILLM;
   /** The model that Continue will use for tab autocompletions. */
   tabAutocompleteModel?:
-    | CustomLLM
-    | ModelDescription
-    | (CustomLLM | ModelDescription)[];
+  | CustomLLM
+  | ModelDescription
+  | (CustomLLM | ModelDescription)[];
   /** Options for tab autocomplete */
   tabAutocompleteOptions?: Partial<TabAutocompleteOptions>;
   /** UI styles customization */
@@ -1249,9 +1251,9 @@ export type PackageDetailsSuccess = PackageDetails & {
 export type PackageDocsResult = {
   packageInfo: ParsedPackageInfo;
 } & (
-  | { error: string; details?: never }
-  | { details: PackageDetailsSuccess; error?: never }
-);
+    | { error: string; details?: never }
+    | { details: PackageDetailsSuccess; error?: never }
+  );
 
 export interface TerminalOptions {
   reuseTerminal?: boolean;

--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -173,11 +173,11 @@ export abstract class BaseLLM implements ILLM {
         options.completionOptions?.maxTokens ??
         (llmInfo?.maxCompletionTokens
           ? Math.min(
-              llmInfo.maxCompletionTokens,
-              // Even if the model has a large maxTokens, we don't want to use that every time,
-              // because it takes away from the context length
-              this.contextLength / 4,
-            )
+            llmInfo.maxCompletionTokens,
+            // Even if the model has a large maxTokens, we don't want to use that every time,
+            // because it takes away from the context length
+            this.contextLength / 4,
+          )
           : DEFAULT_MAX_TOKENS),
     };
     this.requestOptions = options.requestOptions;
@@ -261,6 +261,7 @@ export abstract class BaseLLM implements ILLM {
       undefined,
       functions,
       this.systemMessage,
+      this._llmOptions,
     );
   }
 

--- a/core/llm/llms/index.ts
+++ b/core/llm/llms/index.ts
@@ -137,6 +137,7 @@ export async function llmFromDescription(
         cls.defaultOptions?.completionOptions?.maxTokens,
     },
     systemMessage,
+    replaceSystemMessage: desc.replaceSystemMessage ?? false,
     writeLog,
     uniqueId,
   };

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -25,7 +25,8 @@ Each model has specific configuration options tailored to its provider and funct
 - `template`: Chat template to format messages. Auto-detected for most models but can be overridden. See intelliJ suggestions.
 - `promptTemplates`: A mapping of prompt template names (e.g., `edit`) to template strings. [Customization Guide](https://docs.continue.dev/model-setup/configuration#customizing-the-edit-prompt).
 - `completionOptions`: Model-specific completion options, same format as top-level [`completionOptions`](#completionoptions), which they override.
-- `systemMessage`: A system message that will precede responses from the LLM.
+- `systemMessage`: A system message that will precede responses from the LLM. (Note: this property has higher precendence than the root `systemMessage` property)
+- `replaceSystemMessage`: If `true`, replaces the system message with the one specified in the model config's `systemMessage` property or with the root `systemMessage` property. If `false`, appends the `systemMessage` to the default system message, if any exists for the model. (default: `false`)
 - `requestOptions`: Model-specific HTTP request options, same format as top-level [`requestOptions`](#requestoptions), which they override.
 - `apiType`: Specifies the type of API (`openai` or `azure`).
 - `apiVersion`: Azure API version (e.g., `2023-07-01-preview`).
@@ -381,7 +382,7 @@ An optional token that identifies the user, primarily for authenticated services
 
 ### `systemMessage`
 
-Defines a system message that appears before every response from the language model, providing guidance or context.
+Defines a system message that appears before every response from the language model, providing guidance or context. Note: `systemMessage` in the model config takes precedence over this setting.
 
 ### `disableIndexing`
 

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -400,6 +400,11 @@
           "description": "A system message that will always be followed by the LLM",
           "type": "string"
         },
+        "replaceSystemMessage": {
+          "title": "Replace System Message",
+          "description": "If true, the system message will replace the default system message instead of being appended to it",
+          "type": "boolean"
+        },
         "requestOptions": {
           "title": "Request Options",
           "description": "Options for the HTTP request to the LLM.",


### PR DESCRIPTION
## Description

https://github.com/continuedev/continue/issues/3786

A model config option, named "replaceSystemMessage" (self-descriptive), default false.

Behavior:
When true, the model's systemMessage property, or the config's root systemMessage property will replace the default hard-coded system message (Something like "When generating new code:\n\n1. Always produce a single code block.\n2. Never separate the code into multiple code blocks.\n3. Only include the code that is being added.\n4. Replace existing code with a \"lazy\" comment like this ...." and also "When using tools, follow the following guidelines:\n- Avoid calling tools unless they are absolutely necessary...")

Setting false or not setting at all, will keep the current behavior.

Minor change:
The existing behavior, that the model config's systemMessage has higher precedence than the root config's systemMesage, was not documented, I added that to make the information in the documentation more obvious about the new config.

## Checklist

- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing instructions

### Testing replaceSystemMessage = true
1. Create a systemMessage in the default Claude model config.
2. Add replaceSystemMessage true in the model config.
3. Send any message with the model
4. Check the Continue LLM Prompt/Completion on the Output tab.
5. The system message in the sent request should now be the just the one given in the model config.
6. Remove the config and send the message again.
7. The system message should be appended to the default one.
