### PR TITLE
Fix: Add Bearer auth header when fetching ollama models

### DIFF
--- a/core/llm/llms/Ollama.ts
+++ b/core/llm/llms/Ollama.ts
@@ -139,12 +139,17 @@ class Ollama extends BaseLLM {
     if (options.model === "AUTODETECT") {
       return;
     }
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+  
+    if (this.apiKey) {
+      headers.Authorization = `Bearer ${this.apiKey}`;
+    }
+
     this.fetch(this.getEndpoint("api/show"), {
       method: "POST",
-      headers: {
-        Authorization: `Bearer ${this.apiKey}`,
-        "Content-Type": "application/json",
-      },
+      headers: headers,
       body: JSON.stringify({ name: this._getModel() }),
     })
       .then(async (response) => {
@@ -323,12 +328,16 @@ class Ollama extends BaseLLM {
     signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<string> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+  
+    if (this.apiKey) {
+      headers.Authorization = `Bearer ${this.apiKey}`;
+    }
     const response = await this.fetch(this.getEndpoint("api/generate"), {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${this.apiKey}`,
-      },
+      headers: headers,
       body: JSON.stringify(this._getGenerateOptions(options, prompt)),
       signal,
     });
@@ -384,13 +393,16 @@ class Ollama extends BaseLLM {
       }));
       chatOptions.stream = false; // Cannot set stream = true for tools calls
     }
-
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+  
+    if (this.apiKey) {
+      headers.Authorization = `Bearer ${this.apiKey}`;
+    }
     const response = await this.fetch(this.getEndpoint("api/chat"), {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${this.apiKey}`,
-      },
+      headers: headers,
       body: JSON.stringify(chatOptions),
       signal,
     });
@@ -467,12 +479,16 @@ class Ollama extends BaseLLM {
     signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<string> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+  
+    if (this.apiKey) {
+      headers.Authorization = `Bearer ${this.apiKey}`;
+    }
     const response = await this.fetch(this.getEndpoint("api/generate"), {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${this.apiKey}`,
-      },
+      headers: headers,
       body: JSON.stringify(this._getGenerateOptions(options, prefix, suffix)),
       signal,
     });
@@ -504,15 +520,19 @@ class Ollama extends BaseLLM {
   }
 
   async listModels(): Promise<string[]> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+  
+    if (this.apiKey) {
+      headers.Authorization = `Bearer ${this.apiKey}`;
+    }
     const response = await this.fetch(
       // localhost was causing fetch failed in pkg binary only for this Ollama endpoint
       this.getEndpoint("api/tags"),
       {
         method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${this.apiKey}`,
-        },
+        headers: headers,
       },
     );
     const data = await response.json();
@@ -526,16 +546,20 @@ class Ollama extends BaseLLM {
   }
 
   protected async _embed(chunks: string[]): Promise<number[][]> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+  
+    if (this.apiKey) {
+      headers.Authorization = `Bearer ${this.apiKey}`;
+    }
     const resp = await this.fetch(new URL("api/embed", this.apiBase), {
       method: "POST",
       body: JSON.stringify({
         model: this.model,
         input: chunks,
       }),
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${this.apiKey}`,
-      },
+      headers: headers
     });
 
     if (!resp.ok) {

--- a/core/llm/llms/Ollama.ts
+++ b/core/llm/llms/Ollama.ts
@@ -509,6 +509,10 @@ class Ollama extends BaseLLM {
       this.getEndpoint("api/tags"),
       {
         method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.apiKey}`,
+        },
       },
     );
     const data = await response.json();


### PR DESCRIPTION
## Description

While ollama llm supports bearer auth, for some reason for fetching the models there is no auth header being added which causes forbidden error when trying to use continue.dev with remote ollama installation which expects token for authentication.
