### PR TITLE
Fix disableSessionTitles

### DIFF
--- a/core/config/load.ts
+++ b/core/config/load.ts
@@ -135,11 +135,14 @@ function loadSerializedConfig(
     config.allowAnonymousTelemetry = true;
   }
 
-  if (config.ui?.getChatTitles === undefined) {
-    config.ui = {
-      ...config.ui,
-      getChatTitles: true,
-    };
+  // Deprecated getChatTitles property should be accounted for
+  // This is noted in docs
+  if (
+    config.ui &&
+    "getChatTitles" in config.ui &&
+    config.ui.getChatTitles === false
+  ) {
+    config.disableSessionTitles = true;
   }
 
   if (ideSettings.remoteConfigServerUrl) {

--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -947,7 +947,6 @@ declare global {
     fontSize?: number;
     displayRawMarkdown?: boolean;
     showChatScrollbar?: boolean;
-    getChatTitles?: boolean;
     codeWrap?: boolean;
   }
   

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -986,7 +986,6 @@ export interface ContinueUIConfig {
   fontSize?: number;
   displayRawMarkdown?: boolean;
   showChatScrollbar?: boolean;
-  getChatTitles?: boolean;
   codeWrap?: boolean;
 }
 

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -345,6 +345,8 @@ Example
 
 Prevents generating summary titles for each chat session when set to `true`.
 
+Note that if the deprecated setting `ui.getChatTitles` is set to `false`, it will override this.
+
 ### `ui`
 
 Customizable UI settings to control interface appearance and behavior.

--- a/gui/src/redux/thunks/session.ts
+++ b/gui/src/redux/thunks/session.ts
@@ -166,7 +166,7 @@ export const saveCurrentSession = createAsyncThunk<
     let title = state.session.title;
     if (title === NEW_SESSION_TITLE) {
       if (
-        state.config.config?.ui?.getChatTitles &&
+        !state.config.config?.disableSessionTitles &&
         state.config.defaultModelTitle
       ) {
         let assistantResponse = state.session.history
@@ -190,7 +190,7 @@ export const saveCurrentSession = createAsyncThunk<
           }
         }
       }
-      // Fallbacks if above doesn't work out or getChatTitles = false
+      // Fallbacks if above doesn't work out or session titles disabled
       if (title === NEW_SESSION_TITLE) {
         title = getChatTitleFromMessage(state.session.history[0].message);
       }


### PR DESCRIPTION
## Description
Duplicate config param `ui.getChatTitles` was being used instead of `disableSessionTitles` but wasn't referenced anywhere in the docs. Removed in favor of `disableSessionTitles`

For security if deprecated `ui.getChatTitles` is set to false, it will override this.