### PR TITLE
3832: DeepSeek-R1 reasoning display can be toggled

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -425,6 +425,11 @@ interface ToolCallState {
   output?: ContextItem[];
 }
 
+interface Reasoning {
+  active: boolean;
+  text: string;
+}
+
 export interface ChatHistoryItem {
   message: ChatMessage;
   contextItems: ContextItemWithId[];
@@ -435,6 +440,7 @@ export interface ChatHistoryItem {
   isGatheringContext?: boolean;
   checkpoint?: Checkpoint;
   isBeforeCheckpoint?: boolean;
+  reasoning?: Reasoning;
 }
 
 export interface LLMFullCompletionOptions extends BaseCompletionOptions {

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "0.9.254",
+  "version": "0.9.255",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "0.9.254",
+      "version": "0.9.255",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/fetch": "^1.0.3",

--- a/gui/src/components/StepContainer/Reasoning.tsx
+++ b/gui/src/components/StepContainer/Reasoning.tsx
@@ -1,0 +1,64 @@
+import { ChatHistoryItem } from "core";
+import { stripImages } from "core/util/messageContent";
+import { useState } from "react";
+import styled from "styled-components";
+import { defaultBorderRadius, lightGray, vscBackground, vscQuickInputBackground, } from "..";
+import { getFontSize } from "../../util";
+import StyledMarkdownPreview from "../markdown/StyledMarkdownPreview";
+
+interface ReasoningProps {
+  item: ChatHistoryItem;
+  index: number;
+  isLast: boolean;
+}
+
+const SpoilerButton = styled.div`
+  background-color: ${vscBackground};
+  width: fit-content;
+  font-size: ${getFontSize() - 2}px;
+  border: 0.5px solid ${lightGray};
+  border-radius: ${defaultBorderRadius};
+  padding: 4px 8px;
+  color: ${lightGray};
+  cursor: pointer;
+  box-shadow:
+    0 4px 6px rgba(0, 0, 0, 0.1),
+    0 1px 3px rgba(0, 0, 0, 0.08);
+  transition: box-shadow 0.3s ease;
+
+  &:hover {
+    box-shadow:
+      0 6px 8px rgba(0, 0, 0, 0.15),
+      0 3px 6px rgba(0, 0, 0, 0.1);
+  }
+`;
+
+const ContentDiv = styled.div<{ fontSize?: number }>`
+  margin: 4px;
+  padding: 4px;
+  font-size: ${getFontSize()}px;
+  overflow: hidden;
+  border-left: 4px solid ${lightGray};
+  border-radius: ${defaultBorderRadius};
+  background-color: ${vscQuickInputBackground};
+`;
+
+export default function Reasoning(props: ReasoningProps) {
+  const [open, setOpen] = useState(false);
+
+  if (!props.item.reasoning?.text) {
+    return null;
+  }
+
+  return <>
+    <SpoilerButton onClick={() => setOpen(!open)}> {open ? "Hide reasoning" : "Show reasoning"}</SpoilerButton>
+    {open && (<ContentDiv>
+      <StyledMarkdownPreview
+        isRenderingInStepContainer
+        source={stripImages(props.item.reasoning.text)}
+        itemIndex={props.index}
+        useParentBackgroundColor
+      />
+    </ContentDiv>)}
+  </>
+}

--- a/gui/src/components/StepContainer/StepContainer.tsx
+++ b/gui/src/components/StepContainer/StepContainer.tsx
@@ -11,6 +11,7 @@ import { getFontSize } from "../../util";
 import StyledMarkdownPreview from "../markdown/StyledMarkdownPreview";
 import ResponseActions from "./ResponseActions";
 import ThinkingIndicator from "./ThinkingIndicator";
+import Reasoning from "./Reasoning";
 
 interface StepContainerProps {
   item: ChatHistoryItem;
@@ -90,11 +91,15 @@ export default function StepContainer(props: StepContainerProps) {
             {renderChatMessage(props.item.message)}
           </pre>
         ) : (
-          <StyledMarkdownPreview
-            isRenderingInStepContainer
-            source={stripImages(props.item.message.content)}
-            itemIndex={props.index}
-          />
+          <>
+            <Reasoning {...props}/>
+
+            <StyledMarkdownPreview
+              isRenderingInStepContainer
+              source={stripImages(props.item.message.content)}
+              itemIndex={props.index}
+            />
+          </>
         )}
         {props.isLast && <ThinkingIndicator historyItem={props.item} />}
       </ContentDiv>

--- a/gui/src/components/markdown/StyledMarkdownPreview.tsx
+++ b/gui/src/components/markdown/StyledMarkdownPreview.tsx
@@ -34,6 +34,7 @@ import { remarkTables } from "./utils/remarkTables";
 const StyledMarkdown = styled.div<{
   fontSize?: number;
   whiteSpace: string;
+  bgColor: string;
 }>`
   pre {
     white-space: ${(props) => props.whiteSpace};
@@ -63,7 +64,7 @@ const StyledMarkdown = styled.div<{
     color: #f78383;
   }
 
-  background-color: ${vscBackground};
+  background-color: ${(props) => props.bgColor};
   font-family:
     var(--vscode-font-family),
     system-ui,
@@ -104,6 +105,7 @@ interface StyledMarkdownPreviewProps {
   isRenderingInStepContainer?: boolean; // Currently only used to control the rendering of codeblocks
   scrollLocked?: boolean;
   itemIndex?: number;
+  useParentBackgroundColor?: boolean;
 }
 
 const HLJS_LANGUAGE_CLASSNAME_PREFIX = "language-";
@@ -332,7 +334,11 @@ const StyledMarkdownPreview = memo(function StyledMarkdownPreview(
   const uiConfig = useAppSelector(selectUIConfig);
   const codeWrapState = uiConfig?.codeWrap ? "pre-wrap" : "pre";
   return (
-    <StyledMarkdown fontSize={getFontSize()} whiteSpace={codeWrapState}>
+    <StyledMarkdown
+      fontSize={getFontSize()}
+      whiteSpace={codeWrapState}
+      bgColor={props.useParentBackgroundColor ? "" : vscBackground}
+    >
       {reactContent}
     </StyledMarkdown>
   );

--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -362,9 +362,24 @@ export const sessionSlice = createSlice({
           } else {
             // Add to the existing message
             if (message.content) {
-              // Note this only works because new message above
-              // was already rendered from parts to string
-              lastMessage.content += renderChatMessage(message);
+              const messageContent = renderChatMessage(message);
+              if (messageContent.includes("<think>")) {
+                lastItem.reasoning = {
+                  active: true,
+                  text: messageContent.replace("<think>", "").trim(),
+                }
+              } else if (lastItem.reasoning?.active && messageContent.includes("</think>")) {
+                const [reasoningEnd, answerStart] = messageContent.split("</think>");
+                lastItem.reasoning.text += reasoningEnd.trimEnd();
+                lastItem.reasoning.active = false;
+                lastMessage.content += answerStart.trimStart();
+              } else if (lastItem.reasoning?.active) {
+                lastItem.reasoning.text += messageContent;
+              } else {
+                // Note this only works because new message above
+                // was already rendered from parts to string
+                lastMessage.content += messageContent;
+              }
             } else if (
               message.role === "assistant" &&
               message.toolCalls?.[0] &&


### PR DESCRIPTION
## Related Issue

https://github.com/continuedev/continue/issues/3832

## Description

For DeepSeek-R1: Fixed missing first paragraph of reasoning. Added a spoiler to toggle visibility of reasoning tokens.

## Screenshots

<img width="1727" alt="Screenshot 2025-01-24 at 22 35 18" src="https://github.com/user-attachments/assets/4aea5b59-b28b-4ec9-890f-3248e55a4b2f" />
<img width="1728" alt="Screenshot 2025-01-24 at 22 35 40" src="https://github.com/user-attachments/assets/ff1d9b9f-2b0d-4b78-80e8-cb9c309edb6f" />


## Testing instructions

tested on model:

```json
{
  "title": "deepseek-r1:14b (local)",
  "model": "deepseek-r1:14b",
  "provider": "ollama",
  "apiBase": "http://localhost:11434"
}
```
