### PR TITLE
Docs: Specify apiBase for ollama

### DIFF
--- a/docs/docs/chat/model-setup.mdx
+++ b/docs/docs/chat/model-setup.mdx
@@ -129,7 +129,8 @@ If your local machine can run an 8B parameter model, then we recommend running L
                 {
                     "title": "Llama 3.1 8B",
                     "provider": "ollama",
-                    "model": "llama3.1:8b"
+                    "model": "llama3.1:8b",
+                    "apiBase": "http://localhost:11434"
                 }
             ]
         ```
@@ -158,7 +159,8 @@ If your local machine can run a 16B parameter model, then we recommend running D
                 {
                     "title": "DeepSeek Coder 2 16B",
                     "provider": "ollama",
-                    "model": "deepseek-coder-v2:16b"
+                    "model": "deepseek-coder-v2:16b",
+                    "apiBase": "http://localhost:11434"
                 }
             ]
         ```


### PR DESCRIPTION
## Description

Updated the documentation to clarify how to specify the Ollama API base, as many users run Ollama on machines other than their localhost—a scenario that appears to be quite common.

As requested in #2895 

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

