### PR TITLE
Model Selector - add scrolling for many models

### DIFF
--- a/gui/src/components/modelSelection/ModelSelect.tsx
+++ b/gui/src/components/modelSelection/ModelSelect.tsx
@@ -332,7 +332,9 @@ function ModelSelect() {
           $showabove={showAbove}
           className="z-50 max-w-[90vw]"
         >
-          <div className={`max-h-[${MAX_HEIGHT_PX}px]`}>
+          <div
+            className={`max-h-[${MAX_HEIGHT_PX}px] no-scrollbar overflow-y-scroll`}
+          >
             {sortedOptions.map((option, idx) => (
               <ModelOption
                 option={option}
@@ -345,6 +347,8 @@ function ModelSelect() {
           </div>
 
           <div className="mt-auto">
+            <Divider className="!my-0" />
+
             {selectedProfileId === "local" && (
               <>
                 <StyledListboxOption


### PR DESCRIPTION
## Description
With many models they overflow the `ModelSelect` without being hidden or scrolling. This changes to scroll (seems to already be fixed on platform version)

BEFORE
<img width="358" alt="image" src="https://github.com/user-attachments/assets/d3a1bde8-b0f3-4dee-8a81-54a178550d6e" />

AFTER
<img width="347" alt="image" src="https://github.com/user-attachments/assets/8f2bf06f-28b3-467f-a75f-d4428a7199de" />

