### PR TITLE
document defaults and missing config flag

### DIFF
--- a/docs/docs/customize/deep-dives/autocomplete.md
+++ b/docs/docs/customize/deep-dives/autocomplete.md
@@ -58,16 +58,17 @@ This is just another object like the ones in the `"models"` array of `config.jso
 
 This object allows you to customize the behavior of tab-autocomplete. The available options are shown below, and you can find their default values [here](https://github.com/continuedev/continue/blob/fbeb2e4fe15d4b434a30a136f74b672485c852d9/core/util/parameters.ts).
 
-- `disable`: Disable autocomplete (can also be done from IDE settings)
+- `disable`: Disable autocomplete (can also be done from IDE settings) (default: `false`)
 - `template`: An optional template string to be used for autocomplete. It will be rendered with the Mustache templating language, and is passed the 'prefix' and 'suffix' variables. (String)
-- `useFileSuffix`: Determines whether to use the file suffix in the prompt. (Boolean)
-- `maxPromptTokens`: The maximum number of prompt tokens to use. A smaller number will yield faster completions, but less context. (Number)
-- `prefixPercentage`: The percentage of the input that should be dedicated to the prefix. (Number)
-- `maxSuffixPercentage`: The maximum percentage of the prompt that can be dedicated to the suffix. (Number)
-- `debounceDelay`: The delay in milliseconds before triggering autocomplete after a keystroke. (Number)
-- `multilineCompletions`: Whether to enable multiline completions ("always", "never", or "auto"). Defaults to "auto".
-- `useCache`: Whether to cache and reuse completions when the prompt is the same as a previous one. May be useful to disable for testing purposes.
-- `disableInFiles`: A list of glob patterns for files in which you want to disable tab autocomplete.
+- `useFileSuffix`: Determines whether to use the file suffix in the prompt. (Boolean) (default: `true`)
+- `maxPromptTokens`: The maximum number of prompt tokens to use. A smaller number will yield faster completions, but less context. (Number) (default: `1024`)
+- `prefixPercentage`: The percentage of the input that should be dedicated to the prefix. (Number) (default: `0.3`)
+- `maxSuffixPercentage`: The maximum percentage of the prompt that can be dedicated to the suffix. (Number) (default: `0.2`)
+- `debounceDelay`: The delay in milliseconds before triggering autocomplete after a keystroke. (Number) (default: `350`)
+- `multilineCompletions`: Whether to enable multiline completions ("always", "never", or "auto"). Defaults to "auto". (default: `auto`)
+- `useCache`: Whether to cache and reuse completions when the prompt is the same as a previous one. May be useful to disable for testing purposes. (default: `true`)
+- `disableInFiles`: A list of glob patterns for files in which you want to disable tab autocomplete. (default: `[]`)
+- `onlyMyCode`: If `true`, only includes code within the repository (default: `true`).
 
 ### Full example
 

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -83,16 +83,16 @@ Specifies options for tab autocompletion behavior.
 **Properties:**
 
 - `disable`: If `true`, disables tab autocomplete (default: `false`).
-- `useFileSuffix`: If `true`, includes file suffix in the prompt.
-- `maxPromptTokens`: Maximum number of tokens for the prompt.
-- `debounceDelay`: Delay (in ms) before triggering autocomplete.
-- `maxSuffixPercentage`: Maximum percentage of prompt for suffix.
-- `prefixPercentage`: Percentage of input for prefix.
+- `useFileSuffix`: If `true`, includes file suffix in the prompt (default: `true`).
+- `maxPromptTokens`: Maximum number of tokens for the prompt (default: `1024`).
+- `debounceDelay`: Delay (in ms) before triggering autocomplete (default: `350`).
+- `maxSuffixPercentage`: Maximum percentage of prompt for suffix (default: `0.2`).
+- `prefixPercentage`: Percentage of input for prefix (default: `0.3`).
 - `template`: Template string for autocomplete, using Mustache templating. You can use the `{{{ prefix }}}`, `{{{ suffix }}}`, `{{{ filename }}}`, `{{{ reponame }}}`, and `{{{ language }}}` variables.
-- `multilineCompletions`: Controls multiline completions (`"always"`, `"never"`, or `"auto"`).
-- `useCache`: If `true`, caches completions.
-- `onlyMyCode`: If `true`, only includes code within the repository.
-- `disableInFiles`: Array of glob patterns for files where autocomplete is disabled.
+- `multilineCompletions`: Controls multiline completions (`"always"`, `"never"`, or `"auto"`) (default: `auto`).
+- `useCache`: If `true`, caches completions (default: `true`).
+- `onlyMyCode`: If `true`, only includes code within the repository (default: `true`).
+- `disableInFiles`: Array of glob patterns for files where autocomplete is disabled (default: `[]`).
 
 Example
 

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/reference.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/reference.md
@@ -83,16 +83,16 @@ Specifies options for tab autocompletion behavior.
 **Properties:**
 
 - `disable`: If `true`, disables tab autocomplete (default: `false`).
-- `useFileSuffix`: If `true`, includes file suffix in the prompt.
-- `maxPromptTokens`: Maximum number of tokens for the prompt.
-- `debounceDelay`: Delay (in ms) before triggering autocomplete.
-- `maxSuffixPercentage`: Maximum percentage of prompt for suffix.
-- `prefixPercentage`: Percentage of input for prefix.
+- `useFileSuffix`: If `true`, includes file suffix in the prompt (default: `true`).
+- `maxPromptTokens`: Maximum number of tokens for the prompt (default: `1024`).
+- `debounceDelay`: Delay (in ms) before triggering autocomplete (default: `350`).
+- `maxSuffixPercentage`: Maximum percentage of prompt for suffix (default: `0.2`).
+- `prefixPercentage`: Percentage of input for prefix (default: `0.3`).
 - `template`: Template string for autocomplete, using Mustache templating.
-- `multilineCompletions`: Controls multiline completions (`"always"`, `"never"`, or `"auto"`).
-- `useCache`: If `true`, caches completions.
-- `onlyMyCode`: If `true`, only includes code within the repository.
-- `disableInFiles`: Array of glob patterns for files where autocomplete is disabled.
+- `multilineCompletions`: Controls multiline completions (`"always"`, `"never"`, or `"auto"`) (default: `auto`).
+- `useCache`: If `true`, caches completions (default: `true`).
+- `onlyMyCode`: If `true`, only includes code within the repository (default: `true`).
+- `disableInFiles`: Array of glob patterns for files where autocomplete is disabled (default: `[]`).
 
 Example
 


### PR DESCRIPTION
## Description

When setting things up, I had to dig in the code to determine what the default was for the autocomplete option of `debounceDelay`. To help others who are in this situation, I've updated the relevant documentation to include the defaults for all of the options under auto completion. All of these changes are adding `(default <default>)` to the end of each documentation line.

This PR also adds `onlyMyCode` to the autocomplete MD, as it seems to have been missing originally.

## Checklist

- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

n/a

## Testing instructions

n/a
