### PR TITLE
Submenu loading items - unselectable Loading item + abort controllers

### DIFF
--- a/gui/src/components/mainInput/MentionList.tsx
+++ b/gui/src/components/mainInput/MentionList.tsx
@@ -155,7 +155,6 @@ const ItemDiv = styled.div`
   text-align: left;
   width: 100%;
   color: ${vscForeground};
-  cursor: pointer;
 
   &.is-selected {
     background-color: ${vscListActiveBackground};
@@ -203,6 +202,9 @@ const MentionList = forwardRef((props: MentionListProps, ref) => {
   const [querySubmenuItem, setQuerySubmenuItem] = useState<
     ComboBoxItem | undefined
   >(undefined);
+  const [loadingSubmenuItem, setLoadingSubmenuItem] = useState<
+    ComboBoxItem | undefined
+  >(undefined);
 
   const [allItems, setAllItems] = useState<ComboBoxItem[]>([]);
 
@@ -245,8 +247,8 @@ const MentionList = forwardRef((props: MentionListProps, ref) => {
         description: "Create a new .prompt file",
       });
     }
-
-    setAllItems(items);
+    setLoadingSubmenuItem(items.find((item) => item.id === "loading"));
+    setAllItems(items.filter((item) => item.id !== "loading"));
   }, [subMenuTitle, props.items, props.editor]);
 
   const queryInputRef = useRef<HTMLTextAreaElement>(null);
@@ -403,78 +405,98 @@ const MentionList = forwardRef((props: MentionListProps, ref) => {
       ) : (
         <>
           {subMenuTitle && <ItemDiv className="mb-2">{subMenuTitle}</ItemDiv>}
-          {allItems.length ? (
-            allItems.map((item, index) => (
-              <ItemDiv
-                as="button"
-                ref={(el) => (itemRefs.current[index] = el)}
-                className={`item ${
-                  index === selectedIndex ? "is-selected" : ""
-                }`}
-                key={index}
-                onClick={() => selectItem(index)}
-                onMouseEnter={() => setSelectedIndex(index)}
-                data-testid="context-provider-dropdown-item"
-              >
-                <span className="flex w-full items-center justify-between">
-                  <div className="flex items-center justify-center">
-                    {showFileIconForItem(item) && (
-                      <FileIcon
-                        height="20px"
-                        width="20px"
-                        filename={item.description}
-                      />
-                    )}
-                    {!showFileIconForItem(item) && (
-                      <>
-                        <DropdownIcon item={item} className="mr-2" />
-                      </>
-                    )}
-                    <span title={item.id}>{item.title}</span>
-                    {"  "}
-                  </div>
-                  <span
-                    style={{
-                      color: lightGray,
-                      float: "right",
-                      textAlign: "right",
-                      opacity: index !== selectedIndex ? 0 : 1,
-                      minWidth: "30px",
-                    }}
-                    className="ml-2 flex items-center overflow-hidden overflow-ellipsis whitespace-nowrap"
-                  >
-                    {item.description}
-                    {item.type === "contextProvider" &&
-                      item.contextProvider?.type === "submenu" && (
-                        <ArrowRightIcon
-                          className="ml-2 flex-shrink-0"
-                          width="1.2em"
-                          height="1.2em"
-                        />
-                      )}
-                    {item.subActions?.map((subAction) => {
-                      const Icon = getIconFromDropdownItem(
-                        subAction.icon,
-                        "action",
-                      );
-                      return (
-                        <HeaderButtonWithToolTip
-                          onClick={(e) => {
-                            subAction.action(item);
-                            e.stopPropagation();
-                            e.preventDefault();
-                            props.onClose();
-                          }}
-                          text={undefined}
-                        >
-                          <Icon width="1.2em" height="1.2em" />
-                        </HeaderButtonWithToolTip>
-                      );
-                    })}
-                  </span>
+          {loadingSubmenuItem && (
+            <ItemDiv>
+              <span className="flex w-full items-center justify-between">
+                <div className="flex items-center justify-center">
+                  <DropdownIcon item={loadingSubmenuItem} className="mr-2" />
+                  <span>{loadingSubmenuItem.title}</span>
+                  {"  "}
+                </div>
+                <span
+                  style={{
+                    color: lightGray,
+                    float: "right",
+                    textAlign: "right",
+                    minWidth: "30px",
+                  }}
+                  className="ml-2 flex items-center overflow-hidden overflow-ellipsis whitespace-nowrap text-xs"
+                >
+                  {loadingSubmenuItem.description}
                 </span>
-              </ItemDiv>
-            ))
+              </span>
+            </ItemDiv>
+          )}
+          {allItems.length ? (
+            allItems.map((item, index) => {
+              const isSelected = index === selectedIndex;
+              return (
+                <ItemDiv
+                  as="button"
+                  ref={(el) => (itemRefs.current[index] = el)}
+                  className={`item cursor-pointer ${isSelected ? "is-selected" : ""}`}
+                  key={index}
+                  onClick={() => selectItem(index)}
+                  onMouseEnter={() => setSelectedIndex(index)}
+                  data-testid="context-provider-dropdown-item"
+                >
+                  <span className="flex w-full items-center justify-between">
+                    <div className="flex items-center justify-center">
+                      {showFileIconForItem(item) ? (
+                        <FileIcon
+                          height="20px"
+                          width="20px"
+                          filename={item.description}
+                        />
+                      ) : (
+                        <DropdownIcon item={item} className="mr-2" />
+                      )}
+                      <span title={item.id}>{item.title}</span>
+                      {"  "}
+                    </div>
+                    <span
+                      style={{
+                        color: lightGray,
+                        float: "right",
+                        textAlign: "right",
+                        opacity: isSelected ? 1 : 0,
+                        minWidth: "30px",
+                      }}
+                      className="ml-2 flex items-center overflow-hidden overflow-ellipsis whitespace-nowrap text-xs"
+                    >
+                      {item.description}
+                      {item.type === "contextProvider" &&
+                        item.contextProvider?.type === "submenu" && (
+                          <ArrowRightIcon
+                            className="ml-2 flex-shrink-0"
+                            width="1.2em"
+                            height="1.2em"
+                          />
+                        )}
+                      {item.subActions?.map((subAction) => {
+                        const Icon = getIconFromDropdownItem(
+                          subAction.icon,
+                          "action",
+                        );
+                        return (
+                          <HeaderButtonWithToolTip
+                            onClick={(e) => {
+                              subAction.action(item);
+                              e.stopPropagation();
+                              e.preventDefault();
+                              props.onClose();
+                            }}
+                            text={undefined}
+                          >
+                            <Icon width="1.2em" height="1.2em" />
+                          </HeaderButtonWithToolTip>
+                        );
+                      })}
+                    </span>
+                  </span>
+                </ItemDiv>
+              );
+            })
           ) : (
             <ItemDiv className="item">No results</ItemDiv>
           )}


### PR DESCRIPTION
## Description
- Makes loading submenu item unselectable - Chose to make fully separate item so that it is never selected or part of selection list
- Adds abort controllers to submenu loaders to prevent loading race conditions (NOTE in the case of a request coming in while the same provider is already loading it does still use the items from the first load it just doesn't set loading false from the first one.