### PR TITLE
Fix direct webview -> ide Jetbrains specific messages

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
@@ -54,6 +54,16 @@ class IdeProtocolClient(
             val messageType = message.messageType
             val dataElement = message.data
 
+            // A couple oddball messages respond directly to GUI, expect a different message format
+            // e.g. jetbrains/isOSREnabled
+            fun respondToWebview(content: Any) {
+                respond(mutableMapOf(
+                    "done" to true,
+                    "status" to "success",
+                    "content" to content
+                ))
+            }
+
             try {
                 when (messageType) {
                     "showTutorial" -> {
@@ -63,12 +73,12 @@ class IdeProtocolClient(
                     "jetbrains/isOSREnabled" -> {
                         val isOSREnabled =
                             ServiceManager.getService(ContinueExtensionSettings::class.java).continueState.enableOSR
-                        respond(isOSREnabled)
+                        respondToWebview(isOSREnabled)
                     }
 
                     "jetbrains/getColors" -> {
                         val colors = GetTheme().getTheme();
-                        respond(colors)
+                        respondToWebview(colors)
                     }
 
                     "jetbrains/onLoad" -> {
@@ -78,7 +88,7 @@ class IdeProtocolClient(
                             "vscMachineId" to getMachineUniqueID(),
                             "vscMediaUrl" to "http://continue",
                         )
-                        respond(jsonData)
+                        respondToWebview(jsonData)
                     }
 
                     "getIdeSettings" -> {


### PR DESCRIPTION
## Description

for "jetbrains/..." messages, webview now expects `result.content`, but was receiving everything flat on `result`.