### PR TITLE
Fix: RecentlyEditedTracker tries to read invalid uri 

### DIFF
--- a/extensions/vscode/src/autocomplete/recentlyEdited.ts
+++ b/extensions/vscode/src/autocomplete/recentlyEdited.ts
@@ -51,32 +51,42 @@ export class RecentlyEditedTracker {
       let range = this.recentlyEditedRanges[i];
       if (range.range.intersection(editedRange.range)) {
         const union = range.range.union(editedRange.range);
-        const contents = await this._getContentsForRange({
-          ...range,
-          range: union,
-        });
-        range = {
-          ...range,
-          range: union,
-          lines: contents.split("\n"),
-          symbols: getSymbolsForSnippet(contents),
-        };
-        return;
+        try {
+          const contents = await this._getContentsForRange({
+            ...range,
+            range: union,
+          });
+          range = {
+            ...range,
+            range: union,
+            lines: contents.split("\n"),
+            symbols: getSymbolsForSnippet(contents),
+          };
+          return;
+        } catch (error) {
+          console.debug('insertRange: Failed to get contents for: ' + range.uri, error);
+        }
       }
     }
 
     // Otherwise, just add the new and maintain max size
-    const contents = await this._getContentsForRange(editedRange);
-    const newLength = this.recentlyEditedRanges.unshift({
-      ...editedRange,
-      lines: contents.split("\n"),
-      symbols: getSymbolsForSnippet(contents),
-    });
-    if (newLength >= RecentlyEditedTracker.maxRecentlyEditedRanges) {
-      this.recentlyEditedRanges = this.recentlyEditedRanges.slice(
-        0,
-        RecentlyEditedTracker.maxRecentlyEditedRanges,
-      );
+    try {
+      const contents = await this._getContentsForRange(editedRange);
+      const newLength = this.recentlyEditedRanges.unshift({
+        ...editedRange,
+        lines: contents.split("\n"),
+        symbols: getSymbolsForSnippet(contents),
+      });
+      if (newLength >= RecentlyEditedTracker.maxRecentlyEditedRanges) {
+        this.recentlyEditedRanges = this.recentlyEditedRanges.slice(
+          0,
+          RecentlyEditedTracker.maxRecentlyEditedRanges,
+        );
+      }
+    } catch (error) {
+      console.error('Failed to get contents for new range: ' + editedRange.uri, error);
+      // Skip adding the new range if we can't get its contents
+      return;
     }
   }
 


### PR DESCRIPTION
## Description

RecentlyEditedTracked throwed unhandled promise rejection errors due to trying to read file with uri like "output:extension-output-Continue.continue-%231-Continue - LLM Prompt/Completion"

## Testing instructions

In Host:
1. Set up autocompletion
2. Open the Output bottom panel
3. Write something to trigger autocompletion
4. Rightclick on the Output panel and choose clear output
5. Write again something to trigger autocompletion
In main:
6. Check debug console

Before fix, there were unhandled promise rejection errors.
