### PR TITLE
Adding Grok-2 to chat model setup

### DIFF
--- a/docs/docs/chat/model-setup.mdx
+++ b/docs/docs/chat/model-setup.mdx
@@ -99,6 +99,21 @@ If you prefer to use a model from [OpenAI](../customize/model-providers/top-leve
  ]
 ```
 
+### Grok-2 from xAI
+
+If you prefer to use a model from [xAI](../customize/model-providers/top-level/xAI.md), then we recommend Grok-2.
+
+```json title="config.json"
+ "models": [
+   {
+     "title": "Grok-2",
+     "provider": "xAI",
+     "model": "grok-2-latest",
+     "apiKey": "[XAI_API_KEY]"
+   }
+ ]
+```
+
 ### Gemini 1.5 Pro from Google
 
 If you prefer to use a model from [Google](../customize/model-providers/top-level/gemini.md), then we recommend Gemini 1.5 Pro.

--- a/docs/docs/customize/model-types/chat.md
+++ b/docs/docs/customize/model-types/chat.md
@@ -14,6 +14,6 @@ If you have the ability to use any model, we recommend [Claude 3.5 Sonnet](../mo
 Otherwise, some of the next best options are:
 
 - [GPT-4o](../model-providers/top-level/openai.md)
-- [Grok-2](../model-providers//top-level/xAI.md)
+- [Grok-2](../model-providers/top-level/xAI.md)
 - [Gemini 1.5 Pro](../model-providers/top-level/gemini.md)
 - [Llama3.1 405B](../tutorials/llama3.1.md)

--- a/docs/docs/customize/model-types/chat.md
+++ b/docs/docs/customize/model-types/chat.md
@@ -14,5 +14,6 @@ If you have the ability to use any model, we recommend [Claude 3.5 Sonnet](../mo
 Otherwise, some of the next best options are:
 
 - [GPT-4o](../model-providers/top-level/openai.md)
+- [Grok-2](../model-providers//top-level/xAI.md)
 - [Gemini 1.5 Pro](../model-providers/top-level/gemini.md)
 - [Llama3.1 405B](../tutorials/llama3.1.md)

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -16,9 +16,9 @@ Each model has specific configuration options tailored to its provider and funct
 **Properties:**
 
 - `title` (**required**): The title to assign to your model, shown in dropdowns, etc.
-- `provider` (**required**): The provider of the model, which determines the type and interaction method. Options inclued `openai`, `ollama`, etc., see intelliJ suggestions.
+- `provider` (**required**): The provider of the model, which determines the type and interaction method. Options inclued `openai`, `ollama`, `xAI`, etc., see IntelliJ suggestions.
 - `model` (**required**): The name of the model, used for prompt template auto-detection. Use `AUTODETECT` special name to get all available models.
-- `apiKey`: API key required by providers like OpenAI, Anthropic, and Cohere.
+- `apiKey`: API key required by providers like OpenAI, Anthropic, Cohere, and xAI.
 - `apiBase`: The base URL of the LLM API.
 - `contextLength`: Maximum context length of the model, typically in tokens (default: 2048).
 - `maxStopWords`: Maximum number of stop words allowed, to avoid API errors with extensive lists.


### PR DESCRIPTION
## Description

Adding Grok-2 to list of chat models in the Customize -> Model types -> Chat model list and `config.json` reference.

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

