### PR TITLE
Remove duplicate jetbrains streaming errors

### DIFF
--- a/binary/src/IpcMessenger.ts
+++ b/binary/src/IpcMessenger.ts
@@ -75,7 +75,7 @@ class IPCMessengerBase<
 
           console.warn(`Error running handler for "${msg.messageType}": `, e);
           this._onErrorHandlers.forEach((handler) => {
-            handler(e);
+            handler(msg, e);
           });
         }
       });
@@ -112,9 +112,9 @@ class IPCMessengerBase<
     lines.forEach((line) => this._handleLine(line));
   }
 
-  private _onErrorHandlers: ((error: Error) => void)[] = [];
+  private _onErrorHandlers: ((message: Message, error: Error) => void)[] = [];
 
-  onError(handler: (error: Error) => void) {
+  onError(handler: (message: Message, error: Error) => void) {
     this._onErrorHandlers.push(handler);
   }
 
@@ -217,7 +217,7 @@ export class CoreBinaryMessenger<
   extends IPCMessengerBase<ToProtocol, FromProtocol>
   implements IMessenger<ToProtocol, FromProtocol>
 {
-  private errorHandler: (error: Error) => void = () => {};
+  private errorHandler: (message: Message, error: Error) => void = () => {};
   private messageHandlers: Map<
     keyof ToProtocol,
     (message: Message<any>) => Promise<any> | any

--- a/binary/src/TcpMessenger.ts
+++ b/binary/src/TcpMessenger.ts
@@ -41,9 +41,9 @@ export class TcpMessenger<
     });
   }
 
-  private _onErrorHandlers: ((error: Error) => void)[] = [];
+  private _onErrorHandlers: ((message: Message, error: Error) => void)[] = [];
 
-  onError(handler: (error: Error) => void) {
+  onError(handler: (message: Message, error: Error) => void) {
     this._onErrorHandlers.push(handler);
   }
 
@@ -111,7 +111,7 @@ export class TcpMessenger<
 
           console.warn(`Error running handler for "${msg.messageType}": `, e);
           this._onErrorHandlers.forEach((handler) => {
-            handler(e);
+            handler(msg, e);
           });
         }
       });

--- a/core/core.ts
+++ b/core/core.ts
@@ -208,13 +208,23 @@ export class Core {
 
     // Note, VsCode's in-process messenger doesn't do anything with this
     // It will only show for jetbrains
-    this.messenger.onError((err) => {
-      console.error(err);
+    this.messenger.onError((message, err) => {
       void Telemetry.capture("core_messenger_error", {
         message: err.message,
         stack: err.stack,
       });
-      void this.ide.showToast("error", err.message);
+
+      // Again, specifically for jetbrains to prevent duplicate error messages
+      // The same logic can currently be found in the webview protocol
+      // bc streaming errors are handled in the GUI
+      if (
+        ["llm/streamChat", "chatDescriber/describe"].includes(
+          message.messageType,
+        )
+      ) {
+      } else {
+        void this.ide.showToast("error", err.message);
+      }
     });
 
     on("update/selectTabAutocompleteModel", async (msg) => {

--- a/core/core.ts
+++ b/core/core.ts
@@ -57,7 +57,6 @@ import type { FromCoreProtocol, ToCoreProtocol } from "./protocol";
 import type { IMessenger, Message } from "./protocol/messenger";
 
 export class Core {
-  // implements IMessenger<ToCoreProtocol, FromCoreProtocol>
   configHandler: ConfigHandler;
   codebaseIndexerPromise: Promise<CodebaseIndexer>;
   completionProvider: CompletionProvider;

--- a/core/core.ts
+++ b/core/core.ts
@@ -222,6 +222,7 @@ export class Core {
           message.messageType,
         )
       ) {
+        return;
       } else {
         void this.ide.showToast("error", err.message);
       }

--- a/core/protocol/messenger/index.ts
+++ b/core/protocol/messenger/index.ts
@@ -21,7 +21,7 @@ export interface IMessenger<
   ToProtocol extends IProtocol,
   FromProtocol extends IProtocol,
 > {
-  onError(handler: (error: Error) => void): void;
+  onError(handler: (message: Message, error: Error) => void): void;
   send<T extends keyof FromProtocol>(
     messageType: T,
     data: FromProtocol[T][0],
@@ -64,9 +64,9 @@ export class InProcessMessenger<
     (message: Message) => any
   >();
 
-  protected _onErrorHandlers: ((error: Error) => void)[] = [];
+  protected _onErrorHandlers: ((message: Message, error: Error) => void)[] = [];
 
-  onError(handler: (error: Error) => void) {
+  onError(handler: (message: Message, error: Error) => void) {
     this._onErrorHandlers.push(handler);
   }
 

--- a/extensions/vscode/src/webviewProtocol.ts
+++ b/extensions/vscode/src/webviewProtocol.ts
@@ -10,7 +10,8 @@ import { IMessenger } from "../../../core/protocol/messenger";
 import { showFreeTrialLoginMessage } from "./util/messages";
 
 export class VsCodeWebviewProtocol
-  implements IMessenger<FromWebviewProtocol, ToWebviewProtocol> {
+  implements IMessenger<FromWebviewProtocol, ToWebviewProtocol>
+{
   listeners = new Map<
     keyof FromWebviewProtocol,
     ((message: Message) => any)[]
@@ -114,8 +115,7 @@ export class VsCodeWebviewProtocol
             message = message.split("\n").filter((l: string) => l !== "")[1];
             try {
               message = JSON.parse(message).message;
-            } catch {
-            }
+            } catch {}
             if (message.includes("exceeded")) {
               message +=
                 " To keep using Continue, you can set up a local model or use your own API key.";
@@ -152,8 +152,7 @@ export class VsCodeWebviewProtocol
     this._webviewListener = this._webview.onDidReceiveMessage(handleMessage);
   }
 
-  constructor(private readonly reloadConfig: () => void) {
-  }
+  constructor(private readonly reloadConfig: () => void) {}
 
   invoke<T extends keyof FromWebviewProtocol>(
     messageType: T,
@@ -163,7 +162,7 @@ export class VsCodeWebviewProtocol
     throw new Error("Method not implemented.");
   }
 
-  onError(handler: (error: Error) => void): void {
+  onError(handler: (message: Message, error: Error) => void): void {
     throw new Error("Method not implemented.");
   }
 


### PR DESCRIPTION
## Description
Jetbrains ide error messages from core come from the `messenger.onError` handler added in `core` (this doesn't apply to vs code because the error handling isn't implemented for the `InProcessMessenger`. Filtered out errors that occur on streaming messages.

To detect message type also rearranged messenger error handlers a bit to pass message on error.
