### PR TITLE
change qwen2.5-coder:1.5b-base to qwen2.5-coder:1.5b

### DIFF
--- a/docs/docs/autocomplete/model-setup.md
+++ b/docs/docs/autocomplete/model-setup.md
@@ -36,13 +36,13 @@ For those preferring local execution or self-hosting,`Qwen2.5-Coder 1.5B` offers
 {
   "tabAutocompleteModel": {
     "title": "Qwen2.5-Coder 1.5B",
-    "model": "qwen2.5-coder:1.5b-base",
+    "model": "qwen2.5-coder:1.5b",
     "provider": "ollama"
   }
 }
 ```
 
-Have more compute? Use `qwen2.5-coder:7b-base` for potentially higher-quality suggestions.
+Have more compute? Use `qwen2.5-coder:7b` for potentially higher-quality suggestions.
 
 :::note
 
@@ -57,7 +57,7 @@ When using a remote instance you need to set the `"apiBase"` value in the config
 {
   "tabAutocompleteModel": {
     "title": "Qwen2.5-Coder 1.5B",
-    "model": "qwen2.5-coder:1.5b-base",
+    "model": "qwen2.5-coder:1.5b",
     "provider": "ollama"
     "apiBase": "http://<my endpoint>:11434"
   }


### PR DESCRIPTION
## Description

Changed qwen2.5-coder:1.5b-base to qwen2.5-coder:1.5b
Tried qwen2.5-coder:1.5b-base, it returns weird results in russian...
official Qwen models are hosted here: https://ollama.com/library/qwen2.5-coder:1.5b
as you can see there is no '-base' models

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
