### PR TITLE
Use meta keys and improve formatting on quickpick items

### DIFF
--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -31,6 +31,7 @@ import EditDecorationManager from "./quickEdit/EditDecorationManager";
 import { QuickEdit, QuickEditShowParams } from "./quickEdit/QuickEditQuickPick";
 import { Battery } from "./util/battery";
 import { VsCodeIde } from "./VsCodeIde";
+import { getMetaKeyLabel } from "./util/util";
 
 import type { VsCodeWebviewProtocol } from "./webviewProtocol";
 
@@ -902,15 +903,18 @@ const getCommandsMap: (
             ? StatusBarStatus.Enabled
             : StatusBarStatus.Disabled;
       }
+
       quickPick.items = [
         {
           label: "$(question) Open help center",
         },
         {
-          label: "$(comment) Open chat (Cmd+L)",
+          label: "$(comment) Open chat",
+          description: getMetaKeyLabel() + " + L",
         },
         {
-          label: "$(screen-full) Open full screen chat (Cmd+K Cmd+M)",
+          label: "$(screen-full) Open full screen chat",
+          description: getMetaKeyLabel() + " + K, " + getMetaKeyLabel() + " + M",
         },
         {
           label: quickPickStatusText(targetStatus),

--- a/extensions/vscode/src/util/util.ts
+++ b/extensions/vscode/src/util/util.ts
@@ -99,9 +99,9 @@ export function getMetaKeyLabel() {
       return "⌘";
     case "linux":
     case "windows":
-      return "^";
+      return "Ctrl";
     default:
-      return "^";
+      return "Ctrl";
   }
 }
 


### PR DESCRIPTION
## Description

Fixed `quickpick` shortcuts for Windows/Mac.  Used `description` for better appearance.

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots
Windows before:
![image](https://github.com/user-attachments/assets/a69872ad-2359-4bec-ad34-d896393b7bc0)

Windows After:
![image](https://github.com/user-attachments/assets/5e79c8ae-c8c6-4a43-8898-8ef3e7a9e686)



Mac before:
<img width="872" alt="Screenshot 2025-02-03 at 2 21 15 PM" src="https://github.com/user-attachments/assets/43cb7080-11c0-4821-9a75-5e870f113c04" />

Mac after:
<img width="872" alt="Screenshot 2025-02-03 at 2 16 50 PM" src="https://github.com/user-attachments/assets/8c977453-7fbd-4c23-9dc1-706603407748" />


## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
