### PR TITLE
Fix: getPlatform to return "unknown" when environment isWeb

### DIFF
--- a/extensions/vscode/src/activation/InlineTipManager.ts
+++ b/extensions/vscode/src/activation/InlineTipManager.ts
@@ -16,9 +16,9 @@ const SVG_CONFIG = {
   leftMargin: 40,
   debounceDelay: 500,
   chatLabel: "Chat",
-  chatShortcut: `${getMetaKeyLabel()}L`,
+  chatShortcut: `${getMetaKeyLabel()}+L`,
   editLabel: "Edit",
-  editShortcut: `${getMetaKeyLabel()}I`,
+  editShortcut: `${getMetaKeyLabel()}+I`,
 
   get fontSize() {
     return Math.ceil(
@@ -37,9 +37,6 @@ const SVG_CONFIG = {
   },
   get paddingX() {
     return Math.ceil(this.fontSize * 0.8);
-  },
-  get gap() {
-    return this.fontSize * 2.5;
   },
   get tipWidth() {
     return (
@@ -61,7 +58,7 @@ const SVG_CONFIG = {
     return this.chatLabelX + this.getEstimatedTextWidth(this.chatLabel) + 4;
   },
   get editLabelX() {
-    return this.chatShortcutX + this.gap;
+    return this.chatShortcutX + this.getEstimatedTextWidth(this.chatShortcut) + 4;
   },
   get editShortcutX() {
     return this.editLabelX + this.getEstimatedTextWidth(this.editLabel) + 4;

--- a/extensions/vscode/src/lang-server/codeLens/providers/SuggestionsCodeLensProvider.ts
+++ b/extensions/vscode/src/lang-server/codeLens/providers/SuggestionsCodeLensProvider.ts
@@ -34,7 +34,7 @@ export class SuggestionsCodeLensProvider implements vscode.CodeLensProvider {
       if (codeLenses.length === 2) {
         codeLenses.push(
           new vscode.CodeLens(range, {
-            title: `(${getMetaKeyLabel()}⇧⏎/${getMetaKeyLabel()}⇧⌫ to accept/reject all)`,
+            title: `(${getMetaKeyLabel()}+⇧⏎/${getMetaKeyLabel()}+⇧⌫ to accept/reject all)`,
             command: "",
           }),
         );

--- a/extensions/vscode/src/lang-server/codeLens/providers/VerticalPerLineCodeLensProvider.ts
+++ b/extensions/vscode/src/lang-server/codeLens/providers/VerticalPerLineCodeLensProvider.ts
@@ -1,7 +1,6 @@
 import * as vscode from "vscode";
 
 import { VerticalDiffCodeLens } from "../../../diff/vertical/manager";
-import { getMetaKeyLabel } from "../../../util/util";
 
 export class VerticalDiffCodeLensProvider implements vscode.CodeLensProvider {
   private _eventEmitter: vscode.EventEmitter<void> =

--- a/extensions/vscode/src/util/util.ts
+++ b/extensions/vscode/src/util/util.ts
@@ -72,6 +72,10 @@ export function debounced(delay: number, fn: (...args: any[]) => void) {
 type Platform = "mac" | "linux" | "windows" | "unknown";
 
 export function getPlatform(): Platform {
+  if (vscode.env.uiKind === vscode.UIKind.Web) {
+    return "unknown";
+  }
+
   const platform = os.platform();
   if (platform === "darwin") {
     return "mac";
@@ -87,6 +91,8 @@ export function getPlatform(): Platform {
 export function getAltOrOption() {
   if (getPlatform() === "mac") {
     return "⌥";
+  } else if (getPlatform() === "unknown") {
+    return "Alt/⌥";
   } else {
     return "Alt";
   }
@@ -101,7 +107,7 @@ export function getMetaKeyLabel() {
     case "windows":
       return "^";
     default:
-      return "^";
+      return "^/⌘";
   }
 }
 
@@ -114,7 +120,7 @@ export function getMetaKeyName() {
     case "windows":
       return "Ctrl";
     default:
-      return "Ctrl";
+      return "Ctrl/Cmd";
   }
 }
 


### PR DESCRIPTION
## Description

When running VS Code web users will see wrong shortcuts if the remote system is a Linux box while the user is using a Mac. 

See example: The hint on the right is showing CTRL while the text box on the left is showing the CMD key.
![image](https://github.com/user-attachments/assets/54c50fc8-c463-425e-a2bd-5ccca5aa7caf)

 
When running VS Code remotely it's not possible to determine users platform and `node.os.platform` should not be trusted.

The change explicitly marks platform as `unknown`  if  `vscode.env.uiKind === Web`. This is relevant in remote workspaces such as Coder/Github codespaces/Project IDX etc. 

If the platform is `unknown` show both CMD and CTRL keys.

VS Code extension API does not provide a way to identify the actual users platform.
- See https://github.com/microsoft/vscode/issues/106525 (the api is not provided)
- And https://github.com/microsoft/vscode/issues/10471 (getContext API which would solve this has not been implemented)

I appreciate this solution is not-ideal. Not sure what the proper solution the code probably needs to leverage the `when` [api](https://code.visualstudio.com/api/references/when-clause-contexts). 

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots

Hint SVG formatting is still sane after the changes
![image](https://github.com/user-attachments/assets/f67c5720-e205-41d3-8571-3e843e542eea)
> ^ Platform detected as unknown 

![image](https://github.com/user-attachments/assets/dbfe7b05-f6d4-4f87-8557-63da67a1044b)
> ^ Platform detected as linux 

## Testing instructions

Install continue extension inside github codespaces you will always see linux based shortcuts even when running on a Mac.