### PR TITLE
Fix: Shut down team analytics on config change

### DIFF
--- a/core/config/profile/doLoadConfig.ts
+++ b/core/config/profile/doLoadConfig.ts
@@ -124,12 +124,14 @@ export default async function doLoadConfig(
 
   if (newConfig.analytics) {
     await TeamAnalytics.setup(
-      newConfig.analytics as any, // TODO: Need to get rid of index.d.ts once and for all
+      newConfig.analytics,
       uniqueId,
       ideInfo.extensionVersion,
       controlPlaneClient,
       controlPlaneProxyInfo,
     );
+  } else {
+    await TeamAnalytics.setup(undefined, "NOT_UNIQUE");
   }
 
   newConfig = await injectControlPlaneProxyInfo(

--- a/core/config/profile/doLoadConfig.ts
+++ b/core/config/profile/doLoadConfig.ts
@@ -131,7 +131,7 @@ export default async function doLoadConfig(
       controlPlaneProxyInfo,
     );
   } else {
-    await TeamAnalytics.setup(undefined, "NOT_UNIQUE");
+    await TeamAnalytics.shutdown();
   }
 
   newConfig = await injectControlPlaneProxyInfo(

--- a/core/control-plane/TeamAnalytics.ts
+++ b/core/control-plane/TeamAnalytics.ts
@@ -1,7 +1,5 @@
 import os from "node:os";
 
-import { Analytics } from "@continuedev/config-types";
-
 import ContinueProxyAnalyticsProvider from "./analytics/ContinueProxyAnalyticsProvider.js";
 import {
   ControlPlaneProxyInfo,

--- a/core/control-plane/TeamAnalytics.ts
+++ b/core/control-plane/TeamAnalytics.ts
@@ -10,9 +10,10 @@ import {
 import LogStashAnalyticsProvider from "./analytics/LogStashAnalyticsProvider.js";
 import PostHogAnalyticsProvider from "./analytics/PostHogAnalyticsProvider.js";
 import { ControlPlaneClient } from "./client.js";
+import { AnalyticsConfig } from "../index.js";
 
 function createAnalyticsProvider(
-  config: Analytics,
+  config: AnalyticsConfig,
 ): IAnalyticsProvider | undefined {
   // @ts-ignore
   switch (config.provider) {
@@ -42,7 +43,7 @@ export class TeamAnalytics {
   }
 
   static async setup(
-    config: Analytics,
+    config: AnalyticsConfig,
     uniqueId: string,
     extensionVersion: string,
     controlPlaneClient: ControlPlaneClient,
@@ -52,22 +53,27 @@ export class TeamAnalytics {
     TeamAnalytics.os = os.platform();
     TeamAnalytics.extensionVersion = extensionVersion;
 
-    if (!config) {
-      await TeamAnalytics.provider?.shutdown();
-      TeamAnalytics.provider = undefined;
-    } else {
-      TeamAnalytics.provider = createAnalyticsProvider(config);
-      await TeamAnalytics.provider?.setup(
-        config,
-        uniqueId,
-        controlPlaneProxyInfo,
-      );
+    TeamAnalytics.provider = createAnalyticsProvider(config);
+    await TeamAnalytics.provider?.setup(
+      config,
+      uniqueId,
+      controlPlaneProxyInfo,
+    );
 
-      if (config.provider === "continue-proxy") {
-        (
-          TeamAnalytics.provider as ContinueProxyAnalyticsProvider
-        ).controlPlaneClient = controlPlaneClient;
-      }
+    if (config.provider === "continue-proxy") {
+      (
+        TeamAnalytics.provider as ContinueProxyAnalyticsProvider
+      ).controlPlaneClient = controlPlaneClient;
+    }
+  }
+
+  static async shutdown() {
+    if (TeamAnalytics.provider) {
+      await TeamAnalytics.provider.shutdown();
+      TeamAnalytics.provider = undefined;
+      TeamAnalytics.os = undefined;
+      TeamAnalytics.extensionVersion = undefined;
+      TeamAnalytics.uniqueId = "NOT_UNIQUE";
     }
   }
 }

--- a/core/control-plane/analytics/IAnalyticsProvider.ts
+++ b/core/control-plane/analytics/IAnalyticsProvider.ts
@@ -1,4 +1,4 @@
-import { Analytics } from "@continuedev/config-types";
+import { AnalyticsConfig } from "../..";
 
 export interface AnalyticsMetadata {
   extensionVersion: string;
@@ -13,7 +13,7 @@ export interface ControlPlaneProxyInfo {
 export interface IAnalyticsProvider {
   capture(event: string, properties: { [key: string]: any }): Promise<void>;
   setup(
-    config: Analytics,
+    config: AnalyticsConfig,
     uniqueId: string,
     controlPlaneProxyInfo?: ControlPlaneProxyInfo,
   ): Promise<void>;

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1105,7 +1105,7 @@ export interface ExperimentalConfig {
 }
 
 export interface AnalyticsConfig {
-  type: string;
+  provider: string;
   url?: string;
   clientKey?: string;
 }


### PR DESCRIPTION
## Description
TeamAnalytics was not being un-setup on config change
Added `shutdown` method to `TeamAnalytics`
Moved around types a bit to remove double sources of truth for config `Analytics` type