### PR TITLE
fix(vscode): specify name and icon for gui view

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -580,7 +580,8 @@
         {
           "type": "webview",
           "id": "continue.continueGUIView",
-          "name": "",
+          "name": "Continue",
+          "icon": "media/sidebar-icon.png",
           "visibility": "visible"
         }
       ]
@@ -702,6 +703,7 @@
     "ncp": "^2.0.0",
     "node-fetch": "^3.3.2",
     "node-machine-id": "^1.1.12",
+    "partial-json": "^0.1.7",
     "posthog-node": "^3.6.3",
     "react-markdown": "^8.0.7",
     "react-redux": "^8.0.5",
@@ -718,6 +720,7 @@
     "vectordb": "^0.4.20",
     "vscode-languageclient": "^8.0.2",
     "ws": "^8.13.0",
-    "yarn": "^1.22.21"
+    "yarn": "^1.22.21",
+    "zod": "^3.24.1"
   }
 }

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -703,7 +703,6 @@
     "ncp": "^2.0.0",
     "node-fetch": "^3.3.2",
     "node-machine-id": "^1.1.12",
-    "partial-json": "^0.1.7",
     "posthog-node": "^3.6.3",
     "react-markdown": "^8.0.7",
     "react-redux": "^8.0.5",
@@ -720,7 +719,6 @@
     "vectordb": "^0.4.20",
     "vscode-languageclient": "^8.0.2",
     "ws": "^8.13.0",
-    "yarn": "^1.22.21",
-    "zod": "^3.24.1"
+    "yarn": "^1.22.21"
   }
 }


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

Specified name and icon for GUI view. Closes #3963

It also makes sense to change the name of `sidebar-icon.png` to things like `ui-icon.png`, since it's not only used in sidebar.

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Testing instructions

Unfortunately I don't know how to test an extension locally.
