### PR TITLE
Fix contradictory instruction in .continuerules docs

### DIFF
--- a/docs/docs/customize/deep-dives/rules.md
+++ b/docs/docs/customize/deep-dives/rules.md
@@ -12,7 +12,7 @@ You can create a project-specific system message by adding a `.continuerules` fi
 - If you want concise answers:
 
 ```title=.continuerules
-Please provide concise answers. Do explain obvious concepts. You can assume that I am knowledgable about most programming topics.
+Please provide concise answers. Don't explain obvious concepts. You can assume that I am knowledgable about most programming topics.
 ```
 
 - If you want to ensure certain practices are followed, for example in React:


### PR DESCRIPTION
## Description

'Do explain obvious concepts' contradicts the rest of the example.

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

