### PR TITLE
Custom OSR context menu

### DIFF
--- a/gui/src/components/Layout.tsx
+++ b/gui/src/components/Layout.tsx
@@ -23,6 +23,7 @@ import { AuthProvider } from "../context/Auth";
 import { exitEditMode } from "../redux/thunks";
 import { loadLastSession, saveCurrentSession } from "../redux/thunks/session";
 import { incrementFreeTrialCount } from "../util/freeTrial";
+import OSRContextMenu from "./OSRContextMenu";
 
 const LayoutTopDiv = styled(CustomScrollbarDiv)`
   height: 100%;
@@ -261,6 +262,7 @@ const Layout = () => {
   return (
     <AuthProvider>
       <LayoutTopDiv>
+        <OSRContextMenu />
         <div
           style={{
             scrollbarGutter: "stable both-edges",

--- a/gui/src/components/OSRContextMenu.tsx
+++ b/gui/src/components/OSRContextMenu.tsx
@@ -1,34 +1,112 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 import useIsOSREnabled from "../hooks/useIsOSREnabled";
 import { IdeMessengerContext } from "../context/IdeMessenger";
+
+interface Position {
+  top?: number;
+  left?: number;
+  bottom?: number;
+  right?: number;
+}
 
 const OSRContextMenu = () => {
   const ideMessenger = useContext(IdeMessengerContext);
 
-  const [position, setPosition] = useState<{
-    top?: number;
-    left?: number;
-    bottom?: number;
-    right?: number;
-  } | null>(null);
+  const [position, setPosition] = useState<Position | null>(null);
+  const [canCopy, setCanCopy] = useState(false);
+  const [canCut, setCanCut] = useState(false);
+  const [canPaste, setCanPaste] = useState(false);
+
   const menuRef = React.useRef<HTMLDivElement>(null);
+  const selectedTextRef = useRef<string | null>(null);
+  const selectedRangeRef = useRef<Range | null>(null);
+
+  function onMenuItemClick(
+    event: React.MouseEvent<HTMLDivElement, MouseEvent>,
+  ) {
+    event.preventDefault();
+
+    // restore selection
+    if (selectedRangeRef.current) {
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(selectedRangeRef.current);
+    }
+
+    // Hide menu
+    setPosition(null);
+  }
 
   const isOSREnabled = useIsOSREnabled();
   useEffect(() => {
-    function leaveWindowHandler(event: MouseEvent) {
+    function leaveWindowHandler() {
       setPosition(null);
     }
     function contextMenuHandler(event: MouseEvent) {
       event.preventDefault();
     }
-    function rightClickHandler(event: MouseEvent) {
+    function clickHandler(event: MouseEvent) {
+      // If clicked outside of menu, close menu
       if (!menuRef.current?.contains(event.target as Node)) {
         setPosition(null);
       }
+
       if (event.button === 2) {
+        // Prevent default context menu
         event.preventDefault();
 
-        // always open towards inside of window from click
+        selectedRangeRef.current = null;
+        selectedTextRef.current = null;
+
+        const selection = window.getSelection();
+        let isClickWithinSelection = false;
+        if (selection && selection.rangeCount > 0) {
+          const range = selection.getRangeAt(0);
+          const selectedText = range.toString();
+          selectedRangeRef.current = range.cloneRange();
+
+          if (selectedText.length > 0) {
+            if (selectedText) {
+              selectedTextRef.current = selectedText;
+              const rects = range.getClientRects();
+              for (let i = 0; i < rects.length; i++) {
+                const rect = rects[i];
+                if (
+                  event.clientX >= rect.left &&
+                  event.clientX <= rect.right &&
+                  event.clientY >= rect.top &&
+                  event.clientY <= rect.bottom
+                ) {
+                  isClickWithinSelection = true;
+                  break;
+                }
+              }
+            }
+          }
+        }
+
+        // Check if right clicked on editable content (allows paste/cut)
+        let isEditable = false;
+        if (
+          event.target &&
+          "isContentEditable" in event.target &&
+          typeof event.target.isContentEditable === "boolean"
+        ) {
+          isEditable = event.target.isContentEditable;
+        }
+
+        setCanCopy(!!selectedTextRef.current && isClickWithinSelection);
+        setCanCut(
+          !!(isEditable && selectedTextRef.current && isClickWithinSelection),
+        );
+
+        // TODO only can paste if there is text in clipboard?
+        setCanPaste(isEditable);
+        //   navigator.clipboard.readText().then((text) => {
+        //     setCanPaste(text || null);
+        //   });
+
+        // Open towards inside of window from click
         const toRight = event.clientX > window.innerWidth / 2;
         const toBottom = event.clientY > window.innerHeight / 2;
         if (toRight) {
@@ -59,39 +137,81 @@ const OSRContextMenu = () => {
       }
     }
 
+    setPosition(null);
     if (isOSREnabled) {
       document.addEventListener("mouseleave", leaveWindowHandler);
       document.addEventListener("contextmenu", contextMenuHandler);
-      document.addEventListener("mousedown", rightClickHandler);
+      document.addEventListener("mousedown", clickHandler);
     }
 
     return () => {
       document.removeEventListener("mouseleave", leaveWindowHandler);
       document.removeEventListener("contextmenu", contextMenuHandler);
-      document.removeEventListener("mousedown", rightClickHandler);
+      document.removeEventListener("mousedown", clickHandler);
     };
-  }, [isOSREnabled, menuRef]);
+  }, [isOSREnabled]);
 
   if (!position) {
     return null;
   }
   return (
     <div
-      className="bg-vsc-editor-background absolute overflow-hidden rounded-md border border-solid border-gray-500"
+      className="bg-vsc-editor-background absolute flex flex-col gap-1.5 overflow-hidden rounded-md border border-solid border-gray-500 px-3 py-1.5"
       style={{
         ...position,
-        zIndex: 1000,
+        zIndex: 9999,
       }}
       ref={menuRef}
     >
+      {canCopy && (
+        <div
+          className="cursor-pointer hover:opacity-90"
+          onClick={(e) => {
+            onMenuItemClick(e);
+            document.execCommand("copy");
+          }}
+        >
+          Copy
+        </div>
+      )}
+      {canCut && (
+        <div
+          className="cursor-pointer hover:opacity-90"
+          onClick={(e) => {
+            onMenuItemClick(e);
+            document.execCommand("cut");
+          }}
+        >
+          Cut
+        </div>
+      )}
+      {/* PASTING is currently broken, can't get the clipboard text */}
+      {/* {canPaste && (
+        <div
+          className="cursor-pointer hover:opacity-90"
+          onClick={async (e) => {
+            onMenuItemClick(e);
+            const clipboardText = await navigator.clipboard.readText();
+            // const out = await navigator.clipboard.read();
+            if (clipboardText) {
+              selectedRangeRef.current?.deleteContents();
+              selectedRangeRef.current?.insertNode(
+                document.createTextNode(clipboardText),
+              );
+            }
+          }}
+        >
+          Paste
+        </div>
+      )} */}
       <div
-        className="cursor-pointer px-2 py-1 hover:opacity-90"
+        className="cursor-pointer hover:opacity-90"
         onClick={(e) => {
-          e.stopPropagation();
+          onMenuItemClick(e);
           ideMessenger.post("toggleDevTools", undefined);
         }}
       >
-        Toggle Dev Tools
+        Open Dev Tools
       </div>
     </div>
   );

--- a/gui/src/components/OSRContextMenu.tsx
+++ b/gui/src/components/OSRContextMenu.tsx
@@ -1,0 +1,100 @@
+import React, { useContext, useEffect, useState } from "react";
+import useIsOSREnabled from "../hooks/useIsOSREnabled";
+import { IdeMessengerContext } from "../context/IdeMessenger";
+
+const OSRContextMenu = () => {
+  const ideMessenger = useContext(IdeMessengerContext);
+
+  const [position, setPosition] = useState<{
+    top?: number;
+    left?: number;
+    bottom?: number;
+    right?: number;
+  } | null>(null);
+  const menuRef = React.useRef<HTMLDivElement>(null);
+
+  const isOSREnabled = useIsOSREnabled();
+  useEffect(() => {
+    function leaveWindowHandler(event: MouseEvent) {
+      setPosition(null);
+    }
+    function contextMenuHandler(event: MouseEvent) {
+      event.preventDefault();
+    }
+    function rightClickHandler(event: MouseEvent) {
+      if (!menuRef.current?.contains(event.target as Node)) {
+        setPosition(null);
+      }
+      if (event.button === 2) {
+        event.preventDefault();
+
+        // always open towards inside of window from click
+        const toRight = event.clientX > window.innerWidth / 2;
+        const toBottom = event.clientY > window.innerHeight / 2;
+        if (toRight) {
+          if (toBottom) {
+            setPosition({
+              bottom: window.innerHeight - event.clientY,
+              right: window.innerWidth - event.clientX,
+            });
+          } else {
+            setPosition({
+              top: event.clientY,
+              right: window.innerWidth - event.clientX,
+            });
+          }
+        } else {
+          if (toBottom) {
+            setPosition({
+              bottom: window.innerHeight - event.clientY,
+              left: event.clientX,
+            });
+          } else {
+            setPosition({
+              top: event.clientY,
+              left: event.clientX,
+            });
+          }
+        }
+      }
+    }
+
+    if (isOSREnabled) {
+      document.addEventListener("mouseleave", leaveWindowHandler);
+      document.addEventListener("contextmenu", contextMenuHandler);
+      document.addEventListener("mousedown", rightClickHandler);
+    }
+
+    return () => {
+      document.removeEventListener("mouseleave", leaveWindowHandler);
+      document.removeEventListener("contextmenu", contextMenuHandler);
+      document.removeEventListener("mousedown", rightClickHandler);
+    };
+  }, [isOSREnabled, menuRef]);
+
+  if (!position) {
+    return null;
+  }
+  return (
+    <div
+      className="bg-vsc-editor-background absolute overflow-hidden rounded-md border border-solid border-gray-500"
+      style={{
+        ...position,
+        zIndex: 1000,
+      }}
+      ref={menuRef}
+    >
+      <div
+        className="cursor-pointer px-2 py-1 hover:opacity-90"
+        onClick={(e) => {
+          e.stopPropagation();
+          ideMessenger.post("toggleDevTools", undefined);
+        }}
+      >
+        Toggle Dev Tools
+      </div>
+    </div>
+  );
+};
+
+export default OSRContextMenu;

--- a/gui/src/components/OSRContextMenu.tsx
+++ b/gui/src/components/OSRContextMenu.tsx
@@ -12,6 +12,7 @@ interface Position {
 
 const OSRContextMenu = () => {
   const ideMessenger = useContext(IdeMessengerContext);
+  const isOSREnabled = useIsOSREnabled();
   const platform = useRef(getPlatform());
 
   const [position, setPosition] = useState<Position | null>(null);
@@ -39,12 +40,7 @@ const OSRContextMenu = () => {
     setPosition(null);
   }
 
-  const isOSREnabled = useIsOSREnabled();
   useEffect(() => {
-    if (platform.current === "mac") {
-      return;
-    }
-
     function leaveWindowHandler() {
       setPosition(null);
     }
@@ -144,16 +140,16 @@ const OSRContextMenu = () => {
     }
 
     setPosition(null);
-    if (isOSREnabled) {
+    if (isOSREnabled && platform.current !== "mac") {
+      document.addEventListener("mousedown", clickHandler);
       document.addEventListener("mouseleave", leaveWindowHandler);
       document.addEventListener("contextmenu", contextMenuHandler);
-      document.addEventListener("mousedown", clickHandler);
     }
 
     return () => {
+      document.removeEventListener("mousedown", clickHandler);
       document.removeEventListener("mouseleave", leaveWindowHandler);
       document.removeEventListener("contextmenu", contextMenuHandler);
-      document.removeEventListener("mousedown", clickHandler);
     };
   }, [isOSREnabled]);
 

--- a/gui/src/components/OSRContextMenu.tsx
+++ b/gui/src/components/OSRContextMenu.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useEffect, useRef, useState } from "react";
 import useIsOSREnabled from "../hooks/useIsOSREnabled";
 import { IdeMessengerContext } from "../context/IdeMessenger";
+import { getPlatform } from "../util";
 
 interface Position {
   top?: number;
@@ -11,6 +12,7 @@ interface Position {
 
 const OSRContextMenu = () => {
   const ideMessenger = useContext(IdeMessengerContext);
+  const platform = useRef(getPlatform());
 
   const [position, setPosition] = useState<Position | null>(null);
   const [canCopy, setCanCopy] = useState(false);
@@ -39,6 +41,10 @@ const OSRContextMenu = () => {
 
   const isOSREnabled = useIsOSREnabled();
   useEffect(() => {
+    if (platform.current === "mac") {
+      return;
+    }
+
     function leaveWindowHandler() {
       setPosition(null);
     }
@@ -151,7 +157,7 @@ const OSRContextMenu = () => {
     };
   }, [isOSREnabled]);
 
-  if (!position) {
+  if (platform.current === "mac" || !isOSREnabled || !position) {
     return null;
   }
   return (

--- a/gui/src/components/mainInput/handleMetaKeyIssues.ts
+++ b/gui/src/components/mainInput/handleMetaKeyIssues.ts
@@ -3,7 +3,6 @@ import { KeyboardEvent } from "react";
 import { getPlatform, isWebEnvironment } from "../../util";
 
 const isWebEnv = isWebEnvironment();
-const platform = getPlatform();
 
 /**
  * This handles various keypress issues when OSR is enabled
@@ -14,6 +13,7 @@ export const handleJetBrainsOSRMetaKeyIssues = (
 ) => {
   const selection = window.getSelection();
   const alter = e.shiftKey ? "extend" : "move";
+  const platform = getPlatform();
 
   const handlers: Record<string, () => void> = {
     Backspace: () => handleJetBrainsMetaBackspace(editor),
@@ -108,6 +108,7 @@ export const handleJetBrainsMetaBackspace = (editor: Editor) => {
     }
 
     // For Linux/Windows, only delete the word to the left of the cursor
+    const platform = getPlatform();
     if (platform !== "mac") {
       deleteSingleWord(editor);
       break;


### PR DESCRIPTION
## Description
With OSR enabled:
- on mac context menu frequently opens way far from click
- on other platforms it doesn't open at all

This adds a custom context menu with similar options at the correct location
![image](https://github.com/user-attachments/assets/a5ea0755-8a99-4248-b4b2-a29dd3017644)

Note, this will not have "Paste" as an option, but better than no context menu at all
Because of that, I've decided to not use this for mac right now, which means will still show in the wrong place sometimes for mac