### PR TITLE
Remove default chat/autocomplete models

### DIFF
--- a/core/config/default.ts
+++ b/core/config/default.ts
@@ -5,20 +5,6 @@ import {
   SlashCommandDescription,
 } from "../";
 
-export const DEFAULT_CHAT_MODEL_CONFIG: ModelDescription = {
-  model: "claude-3-5-sonnet-latest",
-  provider: "anthropic",
-  apiKey: "",
-  title: "Claude 3.5 Sonnet",
-};
-
-export const DEFAULT_AUTOCOMPLETE_MODEL_CONFIG: ModelDescription = {
-  title: "Codestral",
-  provider: "mistral",
-  model: "codestral-latest",
-  apiKey: "",
-};
-
 export const FREE_TRIAL_MODELS: ModelDescription[] = [
   {
     title: "Claude 3.5 Sonnet (Free Trial)",
@@ -93,15 +79,13 @@ export const defaultSlashCommandsJetBrains = [
 ];
 
 export const defaultConfig: SerializedContinueConfig = {
-  models: [DEFAULT_CHAT_MODEL_CONFIG],
-  tabAutocompleteModel: DEFAULT_AUTOCOMPLETE_MODEL_CONFIG,
+  models: [],
   contextProviders: defaultContextProvidersVsCode,
   slashCommands: defaultSlashCommandsVscode,
 };
 
 export const defaultConfigJetBrains: SerializedContinueConfig = {
-  models: [DEFAULT_CHAT_MODEL_CONFIG],
-  tabAutocompleteModel: DEFAULT_AUTOCOMPLETE_MODEL_CONFIG,
+  models: [],
   contextProviders: defaultContextProvidersJetBrains,
   slashCommands: defaultSlashCommandsJetBrains,
 };

--- a/gui/src/components/OnboardingCard/OnboardingCard.tsx
+++ b/gui/src/components/OnboardingCard/OnboardingCard.tsx
@@ -5,6 +5,7 @@ import styled from "styled-components";
 import { CloseButton, defaultBorderRadius, vscInputBackground } from "../";
 import { getLocalStorage, setLocalStorage } from "../../util/localStorage";
 import { useOnboardingCard } from "./hooks/useOnboardingCard";
+import { useAppSelector } from "../../redux/hooks";
 
 const StyledCard = styled.div`
   margin: auto;
@@ -26,6 +27,7 @@ interface OnboardingCardProps {
 
 export function OnboardingCard({ isDialog }: OnboardingCardProps) {
   const onboardingCard = useOnboardingCard();
+  const config = useAppSelector((store) => store.config.config);
 
   function renderTabContent() {
     switch (onboardingCard.activeTab) {
@@ -53,7 +55,7 @@ export function OnboardingCard({ isDialog }: OnboardingCardProps) {
         activeTab={onboardingCard.activeTab || "Best"}
         onTabClick={onboardingCard.setActiveTab}
       />
-      {!isDialog && (
+      {!isDialog && !!config.models.length && (
         <CloseButton onClick={() => onboardingCard.close()}>
           <XMarkIcon className="mt-1.5 hidden h-5 w-5 hover:brightness-125 sm:flex" />
         </CloseButton>

--- a/gui/src/components/OnboardingCard/components/BestExperienceConfigForm.tsx
+++ b/gui/src/components/OnboardingCard/components/BestExperienceConfigForm.tsx
@@ -1,5 +1,4 @@
 import { CubeIcon } from "@heroicons/react/24/outline";
-import { DEFAULT_CHAT_MODEL_CONFIG } from "core/config/default";
 import { FormEventHandler, useContext, useState } from "react";
 import { useDispatch } from "react-redux";
 import { Button, Input, InputSubtext, lightGray } from "../..";
@@ -57,9 +56,6 @@ function BestExperienceConfigForm({
       apiKey: autocompleteApiKey,
     };
 
-    ideMessenger.post("config/deleteModel", {
-      title: DEFAULT_CHAT_MODEL_CONFIG.title,
-    });
     ideMessenger.post("config/addModel", { model: chatModelConfig });
     ideMessenger.post("config/addModel", {
       model: repoMapConfig,

--- a/gui/src/components/OnboardingCard/platform/PlatformOnboardingCard.tsx
+++ b/gui/src/components/OnboardingCard/platform/PlatformOnboardingCard.tsx
@@ -8,6 +8,7 @@ import { TabTitle } from "../components/OnboardingCardTabs";
 import { useOnboardingCard } from "../hooks";
 import OnboardingLocalTab from "../tabs/OnboardingLocalTab";
 import MainTab from "./tabs/main";
+import { useAppSelector } from "../../../redux/hooks";
 
 const StyledCard = styled.div`
   margin: auto;
@@ -29,6 +30,7 @@ interface OnboardingCardProps {
 
 export function PlatformOnboardingCard({ isDialog }: OnboardingCardProps) {
   const onboardingCard = useOnboardingCard();
+  const config = useAppSelector((store) => store.config.config);
 
   if (getLocalStorage("onboardingStatus") === undefined) {
     setLocalStorage("onboardingStatus", "Started");
@@ -38,7 +40,7 @@ export function PlatformOnboardingCard({ isDialog }: OnboardingCardProps) {
 
   return (
     <StyledCard className="xs:py-4 xs:px-4 relative px-2 py-3">
-      {!isDialog && (
+      {!isDialog && !!config.models.length && (
         <CloseButton onClick={() => onboardingCard.close()}>
           <XMarkIcon className="mt-1.5 hidden h-5 w-5 hover:brightness-125 sm:flex" />
         </CloseButton>


### PR DESCRIPTION
## Description
Decided the UX of having an error pop up if I don't add an API key is worse than no model at all 
But to compromise, hide the close button on onboarding cards if no models