### PR TITLE
Handle stream errors with messages of format HTTP CODE

### DIFF
--- a/gui/src/pages/gui/StreamError.tsx
+++ b/gui/src/pages/gui/StreamError.tsx
@@ -51,7 +51,8 @@ const StreamErrorDialog = ({ error }: StreamErrorProps) => {
     typeof error["message"] === "string"
   ) {
     message = error["message"];
-    const status = message?.split(" ")[0];
+    const parts = message?.split(" ") ?? [];
+    const status = parts[0] === "HTTP" ? parts[1] : parts[0];
     if (status) {
       const code = Number(status);
       if (!Number.isNaN(statusCode)) {


### PR DESCRIPTION
## Description
Stream error dialog only handled errors with messages _starting_ with a status code
This checks for messages of the form `HTTP 401` and snags the code from the 2nd position if so

Fixes e.g. 401 on OpenAI showing button to visit openai dashboard