### PR TITLE
Refactor reloadConfig method to reference additional context providers

### DIFF
--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -365,11 +365,11 @@ export class ConfigHandler {
     this.updateListeners.push(listener);
   }
 
-  async reloadConfig(additionalContextProviders: IContextProvider[] = []) {
+  async reloadConfig() {
     // TODO: this isn't right, there are two different senses in which you want to "reload"
 
     const { config, errors, configLoadInterrupted } =
-      await this.currentProfile.reloadConfig(additionalContextProviders);
+      await this.currentProfile.reloadConfig(this.additionalContextProviders);
 
     if (config) {
       this.inactiveProfiles.forEach((profile) => profile.clearConfig());
@@ -419,6 +419,6 @@ export class ConfigHandler {
 
   registerCustomContextProvider(contextProvider: IContextProvider) {
     this.additionalContextProviders.push(contextProvider);
-    void this.reloadConfig(this.additionalContextProviders);
+    void this.reloadConfig();
   }
 }


### PR DESCRIPTION

## Description

#3845 fixed the issue with the custom context provider registration API. However, manually saving the `config.json` file triggered a config reload, causing the context providers to be overwritten. This PR ensures that the config is reloaded with the additional context providers that are supplied through the VSCode API

Code simplification:

* [`core/config/ConfigHandler.ts`](diffhunk://#diff-dcb88fe77b65db9e319e7648f22f31c5a1ff12241ab25c6f97b1fbef96241e4fL368-R372): Modified the `reloadConfig` method to remove the `additionalContextProviders` parameter and use the class member `this.additionalContextProviders` instead.
* [`core/config/ConfigHandler.ts`](diffhunk://#diff-dcb88fe77b65db9e319e7648f22f31c5a1ff12241ab25c6f97b1fbef96241e4fL422-R422): Updated the `registerCustomContextProvider` method to call `reloadConfig` without passing `additionalContextProviders` as a parameter.


## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
