### PR TITLE
VeniceAI is compatible with the OpenAI API

### DIFF
--- a/docs/docs/customize/model-providers/top-level/openai.md
+++ b/docs/docs/customize/model-providers/top-level/openai.md
@@ -64,6 +64,7 @@ OpenAI compatible servers
 - [TensorRT-LLM](https://github.com/NVIDIA/trt-llm-as-openai-windows?tab=readme-ov-file#examples)
 - [vLLM](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html)
 - [BerriAI/litellm](https://github.com/BerriAI/litellm)
+- [VeniceAI](https://docs.venice.ai/api-reference/endpoint/chat/completions)
 
 OpenAI compatible APIs
 


### PR DESCRIPTION
## Description

This is a one-line documentation change to add Venice AI to the list of OpenAI compatible APIs on the following _Continue_ documentation page: https://docs.continue.dev/customize/model-providers/openai#openai-compatible-servers--apis 

## Checklist

- [x] The relevant docs, if any, have been updated or created

---

VeniceAI can be used in Chat, if you add the following to your _continue_ `config.js`:

```
    {
      "title": "Qwen2-72b (Venice.ai)",
      "provider": "openai",
      "model": "dolphin-2.9.2-qwen2-72b",
      "apiKey": "<REDACTED>",
      "apiBase": "https://api.venice.ai/api/v1",
      "useLegacyCompletionsEndpoint": false
    }
```

Why should we add Venice?

For me, Venice is interesting because you can use the API without needing a Debit card or Credit card. Instead you can stake a crypto token called `VVV` and get a API key. This opens up interesting possibilities for autonomous Agents to gain access to AI models without being gate-kept by a Bank. Obviously AI Agents can't KYC, and all Banks need KYC. Venice side-steps this issue - it allows Bankless access to AI, which is incredibly exciting.