### PR TITLE
Fix Jetbrains messaging logic

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
@@ -43,26 +43,11 @@ class IdeProtocolClient(
         )
     }
 
-    private fun send(messageType: String, data: Any?, messageId: String? = null) {
-        val id = messageId ?: uuid()
-        continuePluginService.sendToWebview(messageType, data, id)
-    }
-
     fun handleMessage(msg: String, respond: (Any?) -> Unit) {
         coroutineScope.launch(Dispatchers.IO) {
             val message = Gson().fromJson(msg, Message::class.java)
             val messageType = message.messageType
             val dataElement = message.data
-
-            // A couple oddball messages respond directly to GUI, expect a different message format
-            // e.g. jetbrains/isOSREnabled
-            fun respondToWebview(content: Any) {
-                respond(mutableMapOf(
-                    "done" to true,
-                    "status" to "success",
-                    "content" to content
-                ))
-            }
 
             try {
                 when (messageType) {
@@ -77,12 +62,12 @@ class IdeProtocolClient(
                     "jetbrains/isOSREnabled" -> {
                         val isOSREnabled =
                             ServiceManager.getService(ContinueExtensionSettings::class.java).continueState.enableOSR
-                        respondToWebview(isOSREnabled)
+                            respond(isOSREnabled)
                     }
 
                     "jetbrains/getColors" -> {
                         val colors = GetTheme().getTheme();
-                        respondToWebview(colors)
+                        respond(colors)
                     }
 
                     "jetbrains/onLoad" -> {
@@ -92,7 +77,7 @@ class IdeProtocolClient(
                             "vscMachineId" to getMachineUniqueID(),
                             "vscMediaUrl" to "http://continue",
                         )
-                        respondToWebview(jsonData)
+                        respond(jsonData)
                     }
 
                     "getIdeSettings" -> {
@@ -593,11 +578,11 @@ class IdeProtocolClient(
 
 
     fun sendAcceptRejectDiff(accepted: Boolean, stepIndex: Int) {
-        send("acceptRejectDiff", AcceptRejectDiff(accepted, stepIndex), uuid())
+        continuePluginService.sendToWebview("acceptRejectDiff", AcceptRejectDiff(accepted, stepIndex), uuid())
     }
 
     fun deleteAtIndex(index: Int) {
-        send("deleteAtIndex", DeleteAtIndex(index), uuid())
+        continuePluginService.sendToWebview("deleteAtIndex", DeleteAtIndex(index), uuid())
     }
 
     private fun getModelByRole(

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinueBrowser.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinueBrowser.kt
@@ -55,11 +55,7 @@ class ContinueBrowser(val project: Project, url: String) {
 
             // Webview always expects to receive this format when it initiates
             val respond = fun(data: Any?) {
-                sendToWebview(messageType, mapOf(
-                    "status" to "success",
-                    "content" to data,
-                    "done" to true
-                ), messageId ?: uuid())
+                sendToWebview(messageType, data, messageId ?: uuid())
             }
 
             if (PASS_THROUGH_TO_CORE.contains(messageType)) {
@@ -67,8 +63,16 @@ class ContinueBrowser(val project: Project, url: String) {
                 return@addHandler null
             }
 
+            val respondToWebview = fun(data: Any?) {
+                sendToWebview(messageType, mapOf(
+                    "status" to "success",
+                    "content" to data,
+                    "done" to true
+                ), messageId ?: uuid())
+            }
+
             if (msg != null) {
-                continuePluginService.ideProtocolClient?.handleMessage(msg, respond)
+                continuePluginService.ideProtocolClient?.handleMessage(msg, respondToWebview)
             }
 
             null

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinueBrowser.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinueBrowser.kt
@@ -53,9 +53,13 @@ class ContinueBrowser(val project: Project, url: String) {
                 ContinuePluginService::class.java
             )
 
-
+            // Webview always expects to receive this format when it initiates
             val respond = fun(data: Any?) {
-                sendToWebview(messageType, data, messageId ?: uuid())
+                sendToWebview(messageType, mapOf(
+                    "status" to "success",
+                    "content" to data,
+                    "done" to true
+                ), messageId ?: uuid())
             }
 
             if (PASS_THROUGH_TO_CORE.contains(messageType)) {

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinueBrowser.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinueBrowser.kt
@@ -53,7 +53,6 @@ class ContinueBrowser(val project: Project, url: String) {
                 ContinuePluginService::class.java
             )
 
-            // Webview always expects to receive this format when it initiates
             val respond = fun(data: Any?) {
                 sendToWebview(messageType, data, messageId ?: uuid())
             }
@@ -63,6 +62,8 @@ class ContinueBrowser(val project: Project, url: String) {
                 return@addHandler null
             }
 
+            // If not pass through, then put it in the status/content/done format for webview
+            // Core already sends this format
             val respondToWebview = fun(data: Any?) {
                 sendToWebview(messageType, mapOf(
                     "status" to "success",


### PR DESCRIPTION
## Description
Key insight: when Webview requests, it expects the status/content/done format
So it's never for specific messages, it's just in the response function for handling a message _from_ webview
Also removed confusing `send` function in `IdeProtocolClient`
