### PR TITLE
Fix SonarCube Autocomplete Conflict

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/AutocompleteEditorListener.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/AutocompleteEditorListener.kt
@@ -3,6 +3,7 @@ package com.github.continuedev.continueintellijextension.autocomplete
 import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.components.service
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.EditorKind
 import com.intellij.openapi.editor.event.*
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent
@@ -11,6 +12,10 @@ import com.intellij.openapi.util.TextRange
 
 class AutocompleteCaretListener : CaretListener {
     override fun caretPositionChanged(event: CaretEvent) {
+        if(event.editor.editorKind != EditorKind.MAIN_EDITOR) {
+            return
+        }
+
         val caret = event.caret ?: return
         val offset = caret.offset
         val editor = caret.editor


### PR DESCRIPTION
## Description
SonarCube indexing triggers a caret positioned changed event that was prematurely clearing pending completions and causing a bug where suggestions just moved instead of being accepted
