### PR TITLE
Fix apply button loading previous session

### DIFF
--- a/gui/src/components/Layout.tsx
+++ b/gui/src/components/Layout.tsx
@@ -11,6 +11,7 @@ import {
   updateApplyState,
   setMode,
   newSession,
+  selectIsInEditMode,
 } from "../redux/slices/sessionSlice";
 import { getFontSize, isMetaEquivalentKeyPressed } from "../util";
 import { ROUTES } from "../util/navigation";
@@ -221,7 +222,11 @@ const Layout = () => {
     [],
   );
 
+  const isInEditMode = useAppSelector(selectIsInEditMode);
   useWebviewListener("exitEditMode", async () => {
+    if (!isInEditMode) {
+      return;
+    }
     dispatch(
       loadLastSession({
         saveCurrentSession: false,

--- a/gui/src/components/markdown/StepContainerPreToolbar/StepContainerPreToolbar.tsx
+++ b/gui/src/components/markdown/StepContainerPreToolbar/StepContainerPreToolbar.tsx
@@ -99,16 +99,6 @@ export default function StepContainerPreToolbar(
       ideMessenger.ide,
     );
 
-    // Sometimes the model will decide to only output the base name
-    // in which case we shouldn't create a new file if it matches the current file
-    const exists = await ideMessenger.ide.fileExists(fileUri);
-    if (!exists) {
-      const activeFile = await ideMessenger.ide.getCurrentFile();
-      if (activeFile && activeFile.path.endsWith(props.relativeFilepath)) {
-        fileUri = activeFile.path;
-      }
-    }
-
     ideMessenger.post("applyToFile", {
       streamId: streamIdRef.current,
       filepath: fileUri,


### PR DESCRIPTION
## Description
- Fixes the `exitEditMode` applying when in chat mode
- Moves relative path -> URI infer logic that accounts for current file match (as a last resort) to the util so that it's used for all infers
