### PR TITLE
Azure OpenAI and OpenAI use the same models so we can simply inherit

### DIFF
--- a/packages/llm-info/src/providers/azure.ts
+++ b/packages/llm-info/src/providers/azure.ts
@@ -1,21 +1,9 @@
 import { ModelProvider } from "../types.js";
+import { OpenAi } from "./openai.js";  
 
 export const Azure: ModelProvider = {
+  ...OpenAi,  // inherit models from OpenAI
   id: "azure",
   displayName: "Azure",
   extraParameters: [],
-  models: [
-    {
-      model: "gpt-4o",
-      displayName: "GPT-4o",
-      contextLength: 128_000,
-      recommendedFor: ["chat"],
-    },
-    {
-      model: "gpt-4o-mini",
-      displayName: "GPT-4o Mini",
-      contextLength: 128_000,
-      recommendedFor: ["chat"],
-    },
-  ],
 };


### PR DESCRIPTION
## Description

Azure OpenAI and OpenAI use the same models so we can simply inherit

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing instructions

Instead of having only gpt-4o and gpt-4o-mini available as models we now have all openai models available when using azure.