### PR TITLE
Don't retry failed docs with identical config

### DIFF
--- a/core/indexing/docs/DocsService.ts
+++ b/core/indexing/docs/DocsService.ts
@@ -431,6 +431,12 @@ export default class DocsService {
         console.log(
           `Not reattempting to index ${siteIndexingConfig.startUrl}, has already failed with same config`,
         );
+        this.handleStatusUpdate({
+          ...fixedStatus,
+          description: "Failed",
+          status: "failed",
+          progress: 1,
+        });
         return;
       }
     }

--- a/core/indexing/docs/DocsService.ts
+++ b/core/indexing/docs/DocsService.ts
@@ -420,6 +420,16 @@ export default class DocsService {
       }
     }
 
+    const markFailedInGlobalContext = () => {
+      const globalContext = new GlobalContext();
+      const failedDocs = globalContext.get("failedDocs") ?? [];
+      const newFailedDocs = failedDocs.filter(
+        (d) => !this.siteIndexingConfigsAreEqual(siteIndexingConfig, d),
+      );
+      newFailedDocs.push(siteIndexingConfig);
+      globalContext.update("failedDocs", newFailedDocs);
+    };
+
     try {
       this.docsIndexingQueue.add(startUrl);
 
@@ -553,6 +563,7 @@ export default class DocsService {
 
         void this.ide.showToast("info", `Failed to index ${startUrl}`);
         this.docsIndexingQueue.delete(startUrl);
+        markFailedInGlobalContext();
         return;
       }
 
@@ -628,6 +639,7 @@ export default class DocsService {
         status: "failed",
         progress: 1,
       });
+      markFailedInGlobalContext();
     } finally {
       this.docsIndexingQueue.delete(startUrl);
     }

--- a/core/indexing/docs/DocsService.ts
+++ b/core/indexing/docs/DocsService.ts
@@ -210,11 +210,11 @@ export default class DocsService {
     if (isAborted) {
       return true;
     }
-    // Handle indexing disabled change mid-indexing
-    if (this.config.disableIndexing) {
-      this.abort(startUrl);
-      return true;
-    }
+    // // Handle indexing disabled change mid-indexing
+    // if (this.config.disableIndexing) {
+    //   this.abort(startUrl);
+    //   return true;
+    // }
     // Handle embeddings provider change mid-indexing
     if (this.config.embeddingsProvider.embeddingId !== startedWithEmbedder) {
       this.abort(startUrl);
@@ -276,9 +276,9 @@ export default class DocsService {
       const oldConfig = this.config;
       this.config = newConfig; // IMPORTANT - need to set up top, other methods below use this without passing it in
 
-      if (this.config.disableIndexing) {
-        return;
-      }
+      // if (this.config.disableIndexing) {
+      //   return;
+      // }
 
       // No point in indexing if no docs context provider
       const hasDocsContextProvider = this.hasDocsContextProvider();
@@ -367,10 +367,10 @@ export default class DocsService {
     siteIndexingConfig: SiteIndexingConfig,
     reIndex: boolean = false,
   ): Promise<void> {
-    if (this.config.disableIndexing) {
-      console.warn("Attempting to add/index docs when indexing is disabled");
-      return;
-    }
+    // if (this.config.disableIndexing) {
+    //   console.warn("Attempting to add/index docs when indexing is disabled");
+    //   return;
+    // }
     const { startUrl, useLocalCrawling, maxDepth } = siteIndexingConfig;
 
     const { isPreindexed, provider } =

--- a/core/util/GlobalContext.ts
+++ b/core/util/GlobalContext.ts
@@ -7,6 +7,7 @@ import {
 } from "../config/sharedConfig";
 
 import { getGlobalContextFilePath } from "./paths";
+import { SiteIndexingConfig } from "..";
 
 export type GlobalContextType = {
   indexingPaused: boolean;
@@ -27,6 +28,7 @@ export type GlobalContextType = {
   showConfigUpdateToast: boolean;
   isSupportedLanceDbCpuTarget: boolean;
   sharedConfig: SharedConfigSchema;
+  failedDocs: SiteIndexingConfig[];
 };
 
 /**

--- a/gui/src/components/indexing/DocsDetailsDialog.tsx
+++ b/gui/src/components/indexing/DocsDetailsDialog.tsx
@@ -127,25 +127,36 @@ function DocsDetailsDialog({ startUrl }: DocsDetailsDialogProps) {
                             </span>
                           </td>
                         </tr>
-                        <Tooltip
-                          id={urlToolTipId}
-                          place="top"
-                          className="max-w-full"
-                        >
-                          {chunk.filepath}
-                        </Tooltip>
-                        <Tooltip
-                          id={contentToolTipId}
-                          place="top"
-                          className="max-h-[300px] max-w-[170px] overflow-y-auto"
-                        >
-                          {chunk.content}
-                        </Tooltip>
                       </>
                     );
                   })}
                 </tbody>
               </table>
+              {/* Rending tooltips here because div can't be child of tbody apparently */}
+              {data.chunks.map((chunk, i) => {
+                const contentToolTipId = `docs-content-peek-${i}`;
+                const urlToolTipId = `docs-url-peek-${i}`;
+                return (
+                  <>
+                    <Tooltip
+                      key={urlToolTipId}
+                      id={urlToolTipId}
+                      place="top"
+                      className="max-w-full"
+                    >
+                      {chunk.filepath}
+                    </Tooltip>
+                    <Tooltip
+                      key={contentToolTipId}
+                      id={contentToolTipId}
+                      place="top"
+                      className="max-h-[300px] max-w-[170px] overflow-y-auto"
+                    >
+                      {chunk.content}
+                    </Tooltip>
+                  </>
+                );
+              })}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Description
If docs have failed with the same config before, do not automatically reattempt on config reload

Also removes `disableIndexing` from stopping docs indexing
and fixes a dom nesting validation error with Docs Details Dialog