### PR TITLE
Allow articles without `h2` tags

### DIFF
--- a/core/indexing/docs/article.ts
+++ b/core/indexing/docs/article.ts
@@ -139,24 +139,35 @@ export async function htmlPageToArticleWithChunks(
       return undefined;
     }
 
+    const title = readability.title || subpath;
+
     const titles = Array.from(dom.window.document.querySelectorAll("h2"));
-    const article_components = titles.map((titleElement) => {
-      const title = titleElement.textContent || "";
-      let body = "";
-      let nextSibling = titleElement.nextElementSibling;
 
-      while (nextSibling && nextSibling.tagName !== "H2") {
-        body += nextSibling.textContent || "";
-        nextSibling = nextSibling.nextElementSibling;
-      }
+    const article_components =
+      titles.length > 0
+        ? titles.map((titleElement) => {
+            const title = titleElement.textContent || "";
+            let body = "";
+            let nextSibling = titleElement.nextElementSibling;
 
-      return { title, body };
-    });
+            while (nextSibling && nextSibling.tagName !== "H2") {
+              body += nextSibling.textContent || "";
+              nextSibling = nextSibling.nextElementSibling;
+            }
+
+            return { title, body };
+          })
+        : [
+            {
+              title: title,
+              body: readability.textContent,
+            },
+          ];
 
     const article = {
       url,
       subpath,
-      title: readability.title,
+      title: title,
       article_components,
     };
     return {


### PR DESCRIPTION
## Description

Inlcude an entire page if no `h2` tags are found to split by titles. 

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Testing instructions

Index e.g.  `https://api.qdrant.tech/api-reference`

Relevant [discord thread](https://discord.com/channels/1108621136150929458/1333897568928927774 )
