### PR TITLE
VSCoce API: update submenu items on config reload

### DIFF
--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -82,6 +82,17 @@ export class ConfigHandler {
     void this.init();
   }
 
+  /**
+   * Retrieves the titles of additional context providers that are of type "submenu".
+   *
+   * @returns {string[]} An array of titles of the additional context providers that have a description type of "submenu".
+   */
+  getAdditionalSubmenuContextProviders(): string[] {
+    return this.additionalContextProviders
+      .filter(provider => provider.description.type === "submenu")
+      .map(provider => provider.description.title);
+  }
+
   private async init() {
     const workspaceId = await this.getWorkspaceId();
     const lastSelectedOrgIds =

--- a/core/core.ts
+++ b/core/core.ts
@@ -140,9 +140,12 @@ export class Core {
       });
 
       // update additional submenu context providers registered via VSCode API
-      this.messenger.send("refreshSubmenuItems", {
-        providers: this.configHandler.getAdditionalSubmenuContextProviders()
-      });
+      const additionalProviders = this.configHandler.getAdditionalSubmenuContextProviders();
+      if (additionalProviders.length > 0) {
+        this.messenger.send("refreshSubmenuItems", {
+          providers: additionalProviders,
+        });
+      }
     });
 
     this.configHandler.onDidChangeAvailableProfiles((profiles) =>

--- a/core/core.ts
+++ b/core/core.ts
@@ -138,6 +138,11 @@ export class Core {
         result: serializedResult,
         profileId: this.configHandler.currentProfile.profileDescription.id,
       });
+
+      // update additional submenu context providers registered via VSCode API
+      this.messenger.send("refreshSubmenuItems", {
+        providers: this.configHandler.getAdditionalSubmenuContextProviders()
+      });
     });
 
     this.configHandler.onDidChangeAvailableProfiles((profiles) =>


### PR DESCRIPTION

This PR offers a fix for submenu items not showing up when registering via the VSCode API. 

possibly related TODO:
https://github.com/ajshedivy/continue/blob/e23a5db71403e65e37938147f688d03abe9b8712/gui/src/context/SubmenuContextProviders.tsx#L348

## Description

Main change:
- send `refreshSubmenuItems` on config reload

Enhancements to submenu context providers:

* [`core/config/ConfigHandler.ts`](diffhunk://#diff-dcb88fe77b65db9e319e7648f22f31c5a1ff12241ab25c6f97b1fbef96241e4fR85-R95): Added the `getAdditionalSubmenuContextProviders` method to retrieve titles of additional context providers that are of type "submenu".

Core functionality updates:

* [`core/core.ts`](diffhunk://#diff-a03dc9f249d34c9078573f4202b1511a2e8422eb89185404a267814c85e8e37bR141-R145): Updated the core class to send a "refreshSubmenuItems" message with the submenu context providers whenever a result is processed.

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
