### PR TITLE
Fix: Codebase retrieval context item file links

### DIFF
--- a/core/context/retrieval/retrieval.ts
+++ b/core/context/retrieval/retrieval.ts
@@ -119,7 +119,7 @@ export async function retrieveContextItemsFromEmbeddings(
         }
 
         return {
-          name: `${baseName} (${r.startLine}-${r.endLine})`,
+          name: `${baseName} (${r.startLine + 1}-${r.endLine + 1})`,
           description: last2Parts,
           content: `\`\`\`${relativePathOrBasename}\n${r.content}\n\`\`\``,
           uri: {


### PR DESCRIPTION
## Description
Index was off by one in display and then would fail to open because resulted in negative line number on reconversion