### PR TITLE
Jetbrains Colors Fixes

### DIFF
--- a/core/protocol/webview.ts
+++ b/core/protocol/webview.ts
@@ -40,4 +40,5 @@ export type ToWebviewFromIdeOrCoreProtocol = {
   signInToControlPlane: [undefined, void];
   openDialogMessage: ["account", void];
   "docs/suggestions": [PackageDocsResult[], void];
+  "jetbrains/setColors": [Record<string, string>, void];
 };

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/activities/ContinuePluginStartupActivity.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/activities/ContinuePluginStartupActivity.kt
@@ -193,7 +193,6 @@ class ContinuePluginStartupActivity : StartupActivity, DumbAware {
 
             // Listen for theme changes
             connection.subscribe(LafManagerListener.TOPIC, LafManagerListener {
-                // val isDarkTheme = UIManager.getLookAndFeel()?.name?.lowercase()?.contains("dark") ?: false
                 val colors = GetTheme().getTheme();
                 continuePluginService.sendToWebview(
                     "jetbrains/setColors",

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/GetTheme.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/GetTheme.kt
@@ -46,26 +46,22 @@ class GetTheme {
             val background = JBColor.background()
             val foreground = JBColor.foreground()
 
-            val buttonBackground = JBColor.namedColor("Button.background")
-            val buttonForeground = JBColor.namedColor("Button.foreground")
+            val buttonBackground = JBColor.namedColor("Button.background", Color(230, 230, 230))
+            val buttonForeground = JBColor.namedColor("Button.foreground", Color(0, 0, 0))
 
-            val badgeBackground =  JBColor.namedColor("Panel.background")
-            val badgeForeground =  JBColor.namedColor("Panel.foreground")
+            val badgeBackground = JBColor.namedColor("Badge.background", Color(150, 150, 150))
+            val badgeForeground = JBColor.namedColor("Badge.foreground", Color(0, 0, 0))
 
-            val inputBackground = JBColor.namedColor("TextField.background")
+            val inputBackground = JBColor.namedColor("TextField.background", Color(255, 255, 255))
 
             val border = JBColor.border()
-            val focusBorder = JBColor.namedColor("Focus.borderColor")
-
+            val focusBorder = JBColor.namedColor("Focus.borderColor", Color(100, 100, 255))
             val editorScheme = EditorColorsManager.getInstance().globalScheme
 
             val editorBackground = editorScheme.defaultBackground
             val editorForeground = editorScheme.defaultForeground
 
-             val actionHoverBackground = JBColor.namedColor("ActionButton.hoverBackground")
-            // val inputBorder = JBColor.namedColor("TextField.borderColor")
-            // val focus = JBColor.namedColor("focusColor")
-             val highlight = editorScheme.getColor(EditorColors.MODIFIED_TAB_ICON_COLOR) ?: editorForeground
+            val actionHoverBackground = JBColor.namedColor("ActionButton.hoverBackground", Color(220, 220, 220))
 
             val findMatchBackground = editorScheme.getAttributes(EditorColors.SEARCH_RESULT_ATTRIBUTES)?.backgroundColor ?: Color(255, 221, 0)
 
@@ -76,7 +72,7 @@ class GetTheme {
                 "--vscode-button-background" to toHex(buttonBackground),
                 "--vscode-button-foreground" to toHex(buttonForeground),
 
-                "--vscode-list-activeSelectionBackground" to toHex(actionHoverBackground),
+                "--vscode-list-activeSelectionBackground" to toHex(actionHoverBackground) + "50",
 
                 "--vscode-quickInputList-focusForeground" to toHex(foreground),
                 "--vscode-quickInput-background" to toHex(inputBackground),

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/GetTheme.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/GetTheme.kt
@@ -1,15 +1,12 @@
 package com.github.continuedev.continueintellijextension.`continue`
 
-import com.intellij.codeInsight.template.impl.TemplateColors
-import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
 import com.intellij.openapi.editor.colors.EditorColors
 import com.intellij.openapi.editor.colors.EditorColorsManager
-import com.intellij.openapi.editor.colors.EditorColorsScheme
-import com.intellij.openapi.editor.colors.TextAttributesKey
 import java.awt.Color
 import kotlin.math.max
 import kotlin.math.min
-
+import com.intellij.ui.JBColor
+import com.intellij.ui.ColorUtil
 
 class GetTheme {
     fun getSecondaryDark(): Color {
@@ -42,62 +39,64 @@ class GetTheme {
     }
 
     fun getTheme(): Map<String, String> {
+        fun toHex(color: Color): String {
+            return String.format("#%02x%02x%02x", color.red, color.green, color.blue)
+        }
         try {
-            val globalScheme = EditorColorsManager.getInstance().globalScheme
-            val defaultBackground = globalScheme.defaultBackground
-            val defaultForeground = globalScheme.defaultForeground
-            val highlight = globalScheme.getColor(EditorColors.MODIFIED_TAB_ICON_COLOR) ?: defaultForeground
-            val defaultBackgroundHex =
-                String.format("#%02x%02x%02x", defaultBackground.red, defaultBackground.green, defaultBackground.blue)
-            val defaultForegroundHex =
-                String.format("#%02x%02x%02x", defaultForeground.red, defaultForeground.green, defaultForeground.blue)
-            val highlightHex = String.format("#%02x%02x%02x", highlight.red, highlight.green, highlight.blue)
+            val background = JBColor.background()
+            val foreground = JBColor.foreground()
 
-            val grayscale =
-                (defaultBackground.red * 0.3 + defaultBackground.green * 0.59 + defaultBackground.blue * 0.11).toInt()
+            val buttonBackground = JBColor.namedColor("Button.background")
+            val buttonForeground = JBColor.namedColor("Button.foreground")
 
-            val adjustedRed: Int
-            val adjustedGreen: Int
-            val adjustedBlue: Int
+            val badgeBackground =  JBColor.namedColor("Panel.background")
+            val badgeForeground =  JBColor.namedColor("Panel.foreground")
 
-            val tint: Int = 20
-            if (grayscale > 128) { // if closer to white
-                adjustedRed = max(0, defaultBackground.red - tint)
-                adjustedGreen = max(0, defaultBackground.green - tint)
-                adjustedBlue = max(0, defaultBackground.blue - tint)
-            } else { // if closer to black
-                adjustedRed = min(255, defaultBackground.red + tint)
-                adjustedGreen = min(255, defaultBackground.green + tint)
-                adjustedBlue = min(255, defaultBackground.blue + tint)
-            }
+            val inputBackground = JBColor.namedColor("TextField.background")
 
-            val secondaryDarkHex = String.format("#%02x%02x%02x", adjustedRed, adjustedGreen, adjustedBlue)
+            val border = JBColor.border()
+            val focusBorder = JBColor.namedColor("Focus.borderColor")
 
-            return mapOf(
-                "--vscode-editor-foreground" to defaultForegroundHex,
-                "--vscode-editor-background" to defaultBackgroundHex,
+            val editorScheme = EditorColorsManager.getInstance().globalScheme
 
-                "--vscode-button-background" to defaultBackgroundHex,
-                "--vscode-button-foreground" to defaultForegroundHex,
+            val editorBackground = editorScheme.defaultBackground
+            val editorForeground = editorScheme.defaultForeground
 
-                "--vscode-list-activeSelectionBackground" to defaultBackgroundHex,
+             val actionHoverBackground = JBColor.namedColor("ActionButton.hoverBackground")
+            // val inputBorder = JBColor.namedColor("TextField.borderColor")
+            // val focus = JBColor.namedColor("focusColor")
+             val highlight = editorScheme.getColor(EditorColors.MODIFIED_TAB_ICON_COLOR) ?: editorForeground
 
-                "--vscode-quickInputList-focusForeground" to defaultForegroundHex,
-                "--vscode-quickInput-background" to secondaryDarkHex,
+            val findMatchBackground = editorScheme.getAttributes(EditorColors.SEARCH_RESULT_ATTRIBUTES)?.backgroundColor ?: Color(255, 221, 0)
 
-                "--vscode-badge-background" to highlightHex,
-                "--vscode-badge-foreground" to defaultForegroundHex,
+            val theme = mapOf(
+                "--vscode-editor-foreground" to toHex(editorForeground),
+                "--vscode-editor-background" to toHex(editorBackground),
 
-                "--vscode-input-background" to secondaryDarkHex,
-                "--vscode-input-border" to "#80808080",
-                "--vscode-sideBar-background" to defaultBackgroundHex,
-                "--vscode-sideBar-border" to "#80808080",
-                "--vscode-focusBorder" to highlightHex,
+                "--vscode-button-background" to toHex(buttonBackground),
+                "--vscode-button-foreground" to toHex(buttonForeground),
 
-                "--vscode-commandCenter-activeBorder" to highlightHex,
-                "--vscode-commandCenter-inactiveBorder" to "#80808080"
+                "--vscode-list-activeSelectionBackground" to toHex(actionHoverBackground),
+
+                "--vscode-quickInputList-focusForeground" to toHex(foreground),
+                "--vscode-quickInput-background" to toHex(inputBackground),
+
+                "--vscode-badge-background" to toHex(badgeBackground),
+                "--vscode-badge-foreground" to toHex(badgeForeground),
+
+                "--vscode-input-background" to toHex(inputBackground),
+                "--vscode-input-border" to toHex(border),
+                "--vscode-sideBar-background" to toHex(background),
+                "--vscode-sideBar-border" to toHex(border),
+                "--vscode-focusBorder" to toHex(focusBorder),
+
+                "--vscode-commandCenter-activeBorder" to toHex(focusBorder),
+                "--vscode-commandCenter-inactiveBorder" to toHex(border),
+
+                "--vscode-editor-findMatchHighlightBackground" to toHex(findMatchBackground) + "40"
             )
 
+            return theme
         } catch (error: Error) {
             return mapOf()
         }

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/GetTheme.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/GetTheme.kt
@@ -75,18 +75,25 @@ class GetTheme {
 
             return mapOf(
                 "--vscode-editor-foreground" to defaultForegroundHex,
-                "--vscode-sideBar-background" to defaultBackgroundHex,
-                "--vscode-input-background" to secondaryDarkHex,
                 "--vscode-editor-background" to defaultBackgroundHex,
+
                 "--vscode-button-background" to defaultBackgroundHex,
+                "--vscode-button-foreground" to defaultForegroundHex,
+
                 "--vscode-list-activeSelectionBackground" to defaultBackgroundHex,
-                "--vscode-focusBorder" to highlightHex,
+
                 "--vscode-quickInputList-focusForeground" to defaultForegroundHex,
                 "--vscode-quickInput-background" to secondaryDarkHex,
-                "--vscode-input-border" to "#80808080",
+
                 "--vscode-badge-background" to highlightHex,
                 "--vscode-badge-foreground" to defaultForegroundHex,
+
+                "--vscode-input-background" to secondaryDarkHex,
+                "--vscode-input-border" to "#80808080",
+                "--vscode-sideBar-background" to defaultBackgroundHex,
                 "--vscode-sideBar-border" to "#80808080",
+                "--vscode-focusBorder" to highlightHex,
+
                 "--vscode-commandCenter-activeBorder" to highlightHex,
                 "--vscode-commandCenter-inactiveBorder" to "#80808080"
             )

--- a/gui/src/components/CodeToEditCard/AddFileCombobox.tsx
+++ b/gui/src/components/CodeToEditCard/AddFileCombobox.tsx
@@ -84,7 +84,7 @@ export default function AddFileCombobox({
                     className={({ active }) =>
                       `relative flex w-full cursor-pointer px-2 py-1 text-left text-xs ${
                         active
-                          ? "bg-vsc-list-active-background text-vsc-list-active-foreground"
+                          ? "bg-list-active text-list-active-foreground"
                           : ""
                       }`
                     }
@@ -112,7 +112,7 @@ export default function AddFileCombobox({
                   </Combobox.Option>
                 ))
               ) : (
-                <div className="text-vsc-list-active-foreground0 px-2 py-1 text-xs">
+                <div className="text-list-active-foreground px-2 py-1 text-xs">
                   No results
                 </div>
               )}

--- a/gui/src/components/dialogs/AddDocsDialog.tsx
+++ b/gui/src/components/dialogs/AddDocsDialog.tsx
@@ -202,14 +202,14 @@ function AddDocsDialog() {
                     <div>
                       <PencilIcon
                         data-tooltip-id={id + "-edit"}
-                        className="lightgray h-3 w-3"
+                        className="text-lightgray h-3 w-3"
                       />
                       <ToolTip id={id + "-edit"} place="bottom">
                         This may not be a docs page
                       </ToolTip>
                     </div>
                   ) : (
-                    <PlusIcon className="text-foreground-muted h-3.5 w-3.5" />
+                    <PlusIcon className="text-lightgray h-3.5 w-3.5" />
                   )}
                 </div>
                 <div className="flex items-center gap-0.5">

--- a/gui/src/components/dialogs/AddDocsDialog.tsx
+++ b/gui/src/components/dialogs/AddDocsDialog.tsx
@@ -184,7 +184,7 @@ function AddDocsDialog() {
         {!!sortedDocsSuggestions.length && (
           <p className="m-0 mb-1 mt-4 p-0 font-semibold">Suggestions</p>
         )}
-        <div className="border-vsc-foreground-muted max-h-[145px] overflow-y-scroll rounded-sm py-1 pr-2">
+        <div className="border-lightgray max-h-[145px] overflow-y-scroll rounded-sm py-1 pr-2">
           {sortedDocsSuggestions.map((docsResult) => {
             const { error, details } = docsResult;
             const { language, name, version } = docsResult.packageInfo;
@@ -202,7 +202,7 @@ function AddDocsDialog() {
                     <div>
                       <PencilIcon
                         data-tooltip-id={id + "-edit"}
-                        className="vsc-foreground-muted h-3 w-3"
+                        className="lightgray h-3 w-3"
                       />
                       <ToolTip id={id + "-edit"} place="bottom">
                         This may not be a docs page
@@ -224,7 +224,7 @@ function AddDocsDialog() {
                 </div>
                 <div>
                   {error || !details?.docsLink ? (
-                    <span className="text-vsc-foreground-muted italic">
+                    <span className="text-lightgray italic">
                       No docs link found
                     </span>
                   ) : (
@@ -251,7 +251,7 @@ function AddDocsDialog() {
                 >
                   <InformationCircleIcon
                     data-tooltip-id={id + "-info"}
-                    className="text-vsc-foreground-muted h-3.5 w-3.5 select-none"
+                    className="text-lightgray h-3.5 w-3.5 select-none"
                   />
                   <ToolTip id={id + "-info"} place="bottom">
                     <p className="m-0 p-0">{`Version: ${version}`}</p>
@@ -271,7 +271,7 @@ function AddDocsDialog() {
                   <div>
                     <InformationCircleIcon
                       data-tooltip-id={"add-docs-form-title"}
-                      className="text-vsc-foreground-muted h-3.5 w-3.5 select-none"
+                      className="text-lightgray h-3.5 w-3.5 select-none"
                     />
                     <ToolTip id={"add-docs-form-title"} place="top">
                       The title that will be displayed to users in the `@docs`
@@ -297,7 +297,7 @@ function AddDocsDialog() {
                   <div>
                     <InformationCircleIcon
                       data-tooltip-id={"add-docs-form-url"}
-                      className="text-vsc-foreground-muted h-3.5 w-3.5 select-none"
+                      className="text-lightgray h-3.5 w-3.5 select-none"
                     />
                     <ToolTip id={"add-docs-form-url"} place="top">
                       The starting location to begin crawling the documentation

--- a/gui/src/components/find/FindWidget.tsx
+++ b/gui/src/components/find/FindWidget.tsx
@@ -43,7 +43,7 @@ const HighlightOverlay = (props: HighlightOverlayProps) => {
   const { isCurrent, top, left, width, height } = props;
   return (
     <div
-      className={isCurrent ? "bg-vsc-find-match-selected" : "bg-blue-200/30"} // bg-vsc-find-match can"t get to work
+      className={isCurrent ? "bg-find-match-selected" : "bg-blue-200/30"} // bg-vsc-find-match can"t get to work
       key={`highlight-${top}-${left}`}
       style={{
         position: "absolute",

--- a/gui/src/components/index.ts
+++ b/gui/src/components/index.ts
@@ -4,10 +4,6 @@ import { getFontSize, isJetBrains } from "../util";
 export const VSC_INPUT_BACKGROUND_VAR = "--vscode-input-background";
 export const VSC_BACKGROUND_VAR = "--vscode-sideBar-background";
 export const VSC_FOREGROUND_VAR = "--vscode-editor-foreground";
-export const VSC_FOREGROUND_MUTED_VAR = "--vscode-foreground-muted";
-export const VSC_DESCRIPTION_FOREGROUND = "--vscode-descriptionForeground";
-export const VSC_INPUT_PLACEHOLDER_FOREGROUND =
-  "--vscode-input-placeholderForeground";
 export const VSC_BUTTON_BACKGROUND_VAR = "--vscode-button-background";
 export const VSC_BUTTON_FOREGROUND_VAR = "--vscode-button-foreground";
 export const VSC_EDITOR_BACKGROUND_VAR = "--vscode-editor-background";
@@ -21,11 +17,6 @@ export const VSC_INPUT_BORDER_VAR = "--vscode-input-border";
 export const VSC_INPUT_BORDER_FOCUS_VAR = "--vscode-focusBorder";
 export const VSC_BADGE_BACKGROUND_VAR = "--vscode-badge-background";
 export const VSC_BADGE_FOREGROUND_VAR = "--vscode-badge-foreground";
-export const VSC_SIDEBAR_BORDER_VAR = "--vscode-sideBar-border";
-export const VSC_DIFF_REMOVED_LINE_BACKGROUND_VAR =
-  "--vscode-diffEditor-removedLineBackground";
-export const VSC_DIFF_INSERTED_LINE_BACKGROUND_VAR =
-  "--vscode-diffEditor-insertedLineBackground";
 export const VSC_COMMAND_CENTER_ACTIVE_BORDER_VAR =
   "--vscode-commandCenter-activeBorder";
 export const VSC_COMMAND_CENTER_INACTIVE_BORDER_VAR =
@@ -35,9 +26,6 @@ export const VSC_THEME_COLOR_VARS = [
   VSC_INPUT_BACKGROUND_VAR,
   VSC_BACKGROUND_VAR,
   VSC_FOREGROUND_VAR,
-  VSC_FOREGROUND_MUTED_VAR,
-  VSC_DESCRIPTION_FOREGROUND,
-  VSC_INPUT_PLACEHOLDER_FOREGROUND,
   VSC_BUTTON_BACKGROUND_VAR,
   VSC_BUTTON_FOREGROUND_VAR,
   VSC_EDITOR_BACKGROUND_VAR,
@@ -48,10 +36,7 @@ export const VSC_THEME_COLOR_VARS = [
   VSC_INPUT_BORDER_VAR,
   VSC_INPUT_BORDER_FOCUS_VAR,
   VSC_BADGE_BACKGROUND_VAR,
-  VSC_SIDEBAR_BORDER_VAR,
   VSC_BADGE_FOREGROUND_VAR,
-  VSC_DIFF_REMOVED_LINE_BACKGROUND_VAR,
-  VSC_DIFF_INSERTED_LINE_BACKGROUND_VAR,
   VSC_COMMAND_CENTER_ACTIVE_BORDER_VAR,
   VSC_COMMAND_CENTER_INACTIVE_BORDER_VAR,
 ];
@@ -77,8 +62,9 @@ export const vscCommandCenterActiveBorder = `var(${VSC_COMMAND_CENTER_ACTIVE_BOR
 export const vscCommandCenterInactiveBorder = `var(${VSC_COMMAND_CENTER_INACTIVE_BORDER_VAR}, #1bbe84)`;
 
 if (typeof document !== "undefined") {
+  const jetbrains = isJetBrains();
   for (const colorVar of VSC_THEME_COLOR_VARS) {
-    if (isJetBrains()) {
+    if (jetbrains) {
       const cached = localStorage.getItem(colorVar);
       if (cached) {
         document.body.style.setProperty(colorVar, cached);
@@ -161,13 +147,6 @@ export const Button = styled.button`
     filter: brightness(1.2);
   }
 `;
-
-type NumberInputProps = {
-  value: number;
-  onChange: (value: number) => void;
-  max?: number;
-  min?: number;
-};
 
 export const SecondaryButton = styled.button`
   padding: 6px 12px;

--- a/gui/src/components/index.ts
+++ b/gui/src/components/index.ts
@@ -9,18 +9,19 @@ export const VSC_BUTTON_FOREGROUND_VAR = "--vscode-button-foreground";
 export const VSC_EDITOR_BACKGROUND_VAR = "--vscode-editor-background";
 export const VSC_LIST_SELECTION_BACKGROUND_VAR =
   "--vscode-list-activeSelectionBackground";
-export const VSC_FOCUS_BORDER = "--vscode-focus-border";
+export const VSC_FOCUS_BORDER_VAR = "--vscode-focusBorder";
 export const VSC_LIST_ACTIVE_FOREGROUND_VAR =
   "--vscode-quickInputList-focusForeground";
 export const VSC_QUICK_INPUT_BACKGROUND_VAR = "--vscode-quickInput-background";
 export const VSC_INPUT_BORDER_VAR = "--vscode-input-border";
-export const VSC_INPUT_BORDER_FOCUS_VAR = "--vscode-focusBorder";
 export const VSC_BADGE_BACKGROUND_VAR = "--vscode-badge-background";
 export const VSC_BADGE_FOREGROUND_VAR = "--vscode-badge-foreground";
 export const VSC_COMMAND_CENTER_ACTIVE_BORDER_VAR =
   "--vscode-commandCenter-activeBorder";
 export const VSC_COMMAND_CENTER_INACTIVE_BORDER_VAR =
   "--vscode-commandCenter-inactiveBorder";
+export const VSC_FIND_MATCH_SELECTED_VAR =
+  "--vscode-editor-findMatchHighlightBackground";
 
 export const VSC_THEME_COLOR_VARS = [
   VSC_INPUT_BACKGROUND_VAR,
@@ -30,15 +31,15 @@ export const VSC_THEME_COLOR_VARS = [
   VSC_BUTTON_FOREGROUND_VAR,
   VSC_EDITOR_BACKGROUND_VAR,
   VSC_LIST_SELECTION_BACKGROUND_VAR,
-  VSC_FOCUS_BORDER,
+  VSC_FOCUS_BORDER_VAR,
   VSC_LIST_ACTIVE_FOREGROUND_VAR,
   VSC_QUICK_INPUT_BACKGROUND_VAR,
   VSC_INPUT_BORDER_VAR,
-  VSC_INPUT_BORDER_FOCUS_VAR,
   VSC_BADGE_BACKGROUND_VAR,
   VSC_BADGE_FOREGROUND_VAR,
   VSC_COMMAND_CENTER_ACTIVE_BORDER_VAR,
   VSC_COMMAND_CENTER_INACTIVE_BORDER_VAR,
+  VSC_FIND_MATCH_SELECTED_VAR,
 ];
 
 export const defaultBorderRadius = "5px";
@@ -53,33 +54,14 @@ export const vscButtonBackground = `var(${VSC_BUTTON_BACKGROUND_VAR}, #1bbe84)`;
 export const vscButtonForeground = `var(${VSC_BUTTON_FOREGROUND_VAR}, #ffffff)`;
 export const vscEditorBackground = `var(${VSC_EDITOR_BACKGROUND_VAR}, ${VSC_BACKGROUND_VAR}, rgb(30 30 30))`;
 export const vscListActiveBackground = `var(${VSC_LIST_SELECTION_BACKGROUND_VAR}, #1bbe84)`;
-export const vscFocusBorder = `var(${VSC_FOCUS_BORDER}, #1bbe84)`;
+export const vscFocusBorder = `var(${VSC_FOCUS_BORDER_VAR}, #1bbe84)`;
 export const vscListActiveForeground = `var(${VSC_LIST_ACTIVE_FOREGROUND_VAR}, ${VSC_FOREGROUND_VAR})`;
 export const vscInputBorder = `var(${VSC_INPUT_BORDER_VAR}, ${lightGray})`;
-export const vscInputBorderFocus = `var(${VSC_INPUT_BORDER_FOCUS_VAR}, ${lightGray})`;
+export const vscInputBorderFocus = `var(${VSC_FOCUS_BORDER_VAR}, ${lightGray})`;
 export const vscBadgeBackground = `var(${VSC_BADGE_BACKGROUND_VAR}, #1bbe84)`;
 export const vscCommandCenterActiveBorder = `var(${VSC_COMMAND_CENTER_ACTIVE_BORDER_VAR}, #1bbe84)`;
 export const vscCommandCenterInactiveBorder = `var(${VSC_COMMAND_CENTER_INACTIVE_BORDER_VAR}, #1bbe84)`;
-
-if (typeof document !== "undefined") {
-  const jetbrains = isJetBrains();
-  for (const colorVar of VSC_THEME_COLOR_VARS) {
-    if (jetbrains) {
-      const cached = localStorage.getItem(colorVar);
-      if (cached) {
-        document.body.style.setProperty(colorVar, cached);
-      }
-    }
-
-    // Remove alpha channel from colors
-    const value = getComputedStyle(document.documentElement).getPropertyValue(
-      colorVar,
-    );
-    if (colorVar.startsWith("#") && value.length > 7) {
-      document.body.style.setProperty(colorVar, value.slice(0, 7));
-    }
-  }
-}
+export const vscFindMatchSelected = `var(${VSC_FIND_MATCH_SELECTED_VAR}, rgba(255, 223, 0))`;
 
 export function parseHexColor(hexColor: string): {
   r: number;

--- a/gui/src/components/modelSelection/platform/AssistantSelect.tsx
+++ b/gui/src/components/modelSelection/platform/AssistantSelect.tsx
@@ -57,7 +57,7 @@ export default function AssistantSelect() {
         <Popover.Button
           data-testid="assistant-select-button"
           ref={buttonRef}
-          className="text-vsc-foreground-muted cursor-pointer border-none bg-transparent text-gray-500 hover:brightness-125"
+          className="text-lightgray cursor-pointer border-none bg-transparent text-gray-500 hover:brightness-125"
           style={{ fontSize: `${getFontSize() - 2}px` }}
         >
           <div className="flex max-w-[50vw] items-center gap-0.5">

--- a/gui/src/index.css
+++ b/gui/src/index.css
@@ -3,14 +3,7 @@
 @tailwind utilities;
 
 :root {
-  --secondary-dark: rgb(37, 37, 38);
-  --vsc-background: rgb(30, 30, 30);
-  --button-color: rgb(113, 28, 59);
-  --button-color-hover: rgba(113, 28, 59, 0.667);
-  --def-border-radius: 5px;
-  --vscode-editor-background: rgb(30, 30, 30);
-  --vscode-editor-foreground: rgb(197, 200, 198);
-  --vscode-textBlockQuote-background: rgba(255, 255, 255, 1);
+  --example-var: rgb(30, 30, 30);
 }
 
 html,

--- a/gui/src/pages/config/index.tsx
+++ b/gui/src/pages/config/index.tsx
@@ -348,7 +348,7 @@ function ConfigPage() {
                       </>
                     ) : (
                       <div>
-                        <CheckIcon className="text-vsc-foreground-muted h-4 w-4" />
+                        <CheckIcon className="text-lightgray h-4 w-4" />
                       </div>
                     )}
                   </div>
@@ -390,13 +390,13 @@ function ConfigPage() {
                       </>
                     ) : (
                       <div>
-                        <CheckIcon className="text-vsc-foreground-muted h-4 w-4" />
+                        <CheckIcon className="text-lightgray h-4 w-4" />
                       </div>
                     )}
                   </div>
                 </div>
               </div>
-              <span className="text-vsc-foreground-muted self-end text-xs">
+              <span className="text-lightgray self-end text-xs">
                 Comma-separated list of path matchers
               </span>
             </form>

--- a/gui/tailwind.config.cjs
+++ b/gui/tailwind.config.cjs
@@ -26,7 +26,6 @@ module.exports = {
       },
       colors: {
         lightgray: "#999998",
-        "vsc-background": "var(--vsc-background)", //  "rgb(var(--vsc-background) / <alpha-value>)",
         "vsc-input-background": "var(--vscode-input-background, rgb(45 45 45))",
         "vsc-background": "var(--vscode-sideBar-background, rgb(30 30 30))",
         "vsc-foreground": "var(--vscode-editor-foreground, #fff)",
@@ -34,8 +33,8 @@ module.exports = {
           "var(--vscode-editor-background, var(--vscode-sideBar-background, rgb(30 30 30)))",
         "vsc-input-border": "var(--vscode-input-border, #999998)",
 
-        // I've moved a few over to the non-vsc-specific approach
-        // TODO move the rest
+        // Starting to make things less vsc-specific
+        // TODO make it all non-IDE-specific naming
         "find-match-selected":
           "var(--vscode-editor-findMatchHighlightBackground, rgba(255, 223, 0))",
         "list-active": "var(--vscode-list-activeSelectionBackground, #1bbe84)",

--- a/gui/tailwind.config.cjs
+++ b/gui/tailwind.config.cjs
@@ -33,7 +33,6 @@ module.exports = {
         "vsc-editor-background":
           "var(--vscode-editor-background, var(--vscode-sideBar-background, rgb(30 30 30)))",
         "vsc-input-border": "var(--vscode-input-border, #999998)",
-        "vsc-foreground-muted": "var(--vscode-foreground-muted, #999)",
 
         // I've moved a few over to the non-vsc-specific approach
         // TODO move the rest

--- a/gui/tailwind.config.cjs
+++ b/gui/tailwind.config.cjs
@@ -26,36 +26,22 @@ module.exports = {
       },
       colors: {
         lightgray: "#999998",
-        "vsc-background": "rgb(var(--vsc-background) / <alpha-value>)",
-        "secondary-dark": "rgb(var(--secondary-dark) / <alpha-value>)",
+        "vsc-background": "var(--vsc-background)", //  "rgb(var(--vsc-background) / <alpha-value>)",
         "vsc-input-background": "var(--vscode-input-background, rgb(45 45 45))",
-        "vsc-quick-input-background":
-          "var(--vscode-quickInput-background, var(--vscode-input-background, rgb(45 45 45)))",
         "vsc-background": "var(--vscode-sideBar-background, rgb(30 30 30))",
         "vsc-foreground": "var(--vscode-editor-foreground, #fff)",
-        "vsc-button-background": "var(--vscode-button-background, #1bbe84)",
-        "vsc-button-foreground": "var(--vscode-button-foreground, #ffffff)",
         "vsc-editor-background":
           "var(--vscode-editor-background, var(--vscode-sideBar-background, rgb(30 30 30)))",
-        "vsc-list-active-background":
-          "var(--vscode-list-activeSelectionBackground, #1bbe84)",
-        "vsc-focus-border": "var(--vscode-focus-border, #1bbe84)",
-        "vsc-list-active-foreground":
-          "var(--vscode-quickInputList-focusForeground, var(--vscode-editor-foreground))",
         "vsc-input-border": "var(--vscode-input-border, #999998)",
-        "vsc-input-border-focus": "var(--vscode-focusBorder, #999998)",
-        "vsc-badge-background": "var(--vscode-badge-background, #1bbe84)",
-        "vsc-badge-foreground": "var(--vscode-badge-foreground, #fff)",
-        "vsc-sidebar-border": "var(--vscode-sideBar-border, transparent)",
-        "vsc-find-match":
-          "var(--vscode-editor-findMatchBackground, rgba(255, 255, 0, 0.6))",
-        "vsc-find-match-selected":
-          "var(--vscode-editor-findMatchHighlightBackground, rgba(255, 223, 0, 0.8))",
         "vsc-foreground-muted": "var(--vscode-foreground-muted, #999)",
-        "vsc-description-foreground":
-          "var(--vscode-descriptionForeground, #999)",
-        "vsc-input-placeholder-foreground":
-          "var(--vscode-input-placeholderForeground, #999)",
+
+        // I've moved a few over to the non-vsc-specific approach
+        // TODO move the rest
+        "find-match-selected":
+          "var(--vscode-editor-findMatchHighlightBackground, rgba(255, 223, 0))",
+        "list-active": "var(--vscode-list-activeSelectionBackground, #1bbe84)",
+        "list-active-foreground":
+          "var(--vscode-quickInputList-focusForeground, var(--vscode-editor-foreground))",
       },
     },
   },


### PR DESCRIPTION
## Description
- Jetbrains colors now update immediately when the user changes the theme
- Jetbrains color choices are better. Specific major improvements include:
  - uses corresponding UI colors, not just similar editor colors
  - now distinguishes between editor background and sidebar background, same as VS code, which looks super nice
  - other specific fixes include badge color, find match highlight color
- removed dud `vsc-foreground-muted` tailwind class, unused tailwind classes/vsc colors, and moved a couple less-used ones to non-vsc-specific tailwind names

Tested on built-in Intellij/Darcula + several variations of the most popular themes Material and One Dark