### PR TITLE
Autocomplete: make Granite 3 detection broader

### DIFF
--- a/core/autocomplete/templating/AutocompleteTemplate.ts
+++ b/core/autocomplete/templating/AutocompleteTemplate.ts
@@ -399,7 +399,8 @@ export function getTemplateForModel(model: string): AutocompleteTemplate {
     lowerCaseModel.includes("gpt") ||
     lowerCaseModel.includes("davinci-002") ||
     lowerCaseModel.includes("claude") ||
-    lowerCaseModel.includes("granite3")
+    lowerCaseModel.includes("granite3") ||
+    lowerCaseModel.includes("granite-3")
   ) {
     return holeFillerTemplate;
   }


### PR DESCRIPTION
The Granite 3 models on Hugging Face use names like:

 https://huggingface.co/ibm-granite/granite-3.1-8b-instruct

Compared to:

 https://ollama.com/library/granite3.1-dense

Use the hole-filler template for names with or without the dash.

cc: @fbricon 