### PR TITLE
refresh-dependencies tasks

### DIFF
--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -4,23 +4,10 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "extensions/intellij/**"
-      - "extensions/vscode/**"
-      - "core/**"
-      - "gui/**"
-      - ".github/workflows/**"
-      - "docs/**"
 
   push:
     branches:
       - main
-    paths:
-      - "extensions/intellij/**"
-      - "extensions/vscode/**"
-      - "core/**"
-      - "gui/**"
-      - ".github/workflows/**"
 
 jobs:
   install-root:

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -186,6 +186,55 @@
       "command": "node",
       "args": ["${workspaceFolder}/scripts/uninstall.js"],
       "problemMatcher": []
+    },
+    {
+      "label": "refresh-dependencies:core",
+      "type": "shell",
+      "command": "npm",
+      "args": ["install"],
+      "problemMatcher": [],
+      "options": {
+        "cwd": "${workspaceFolder}/core"
+      },
+      "presentation": {
+        "close": true
+      }
+    },
+    {
+      "label": "refresh-dependencies:vscode",
+      "type": "shell",
+      "command": "npm",
+      "args": ["install"],
+      "problemMatcher": [],
+      "options": {
+        "cwd": "${workspaceFolder}/extensions/vscode"
+      },
+      "presentation": {
+        "close": true
+      }
+    },
+    {
+      "label": "refresh-dependencies:gui",
+      "type": "shell",
+      "command": "npm",
+      "args": ["install"],
+      "problemMatcher": [],
+      "options": {
+        "cwd": "${workspaceFolder}/gui"
+      },
+      "presentation": {
+        "close": true
+      }
+    },
+    {
+      "label": "refresh-dependencies:all",
+      "dependsOn": [
+        "refresh-dependencies:core",
+        "refresh-dependencies:gui",
+        "refresh-dependencies:vscode"
+      ],
+      "type": "shell",
+      "problemMatcher": []
     }
   ]
 }


### PR DESCRIPTION
New tasks to refresh npm dependencies:
- `refresh-dependencies:core`
- `refresh-dependencies:gui`
- `refresh-dependencies:vscode`

and `refresh-dependencies:all` to run all 3