### PR TITLE
fix: Prevent duplicate context provider addition

### DIFF
--- a/core/config/util.ts
+++ b/core/config/util.ts
@@ -12,6 +12,8 @@ import {
 import { GlobalContext } from "../util/GlobalContext";
 import { editConfigJson } from "../util/paths";
 
+import { ConfigHandler } from "./ConfigHandler";
+
 function stringify(obj: any, indentation?: number): string {
   return JSON.stringify(
     obj,
@@ -22,16 +24,24 @@ function stringify(obj: any, indentation?: number): string {
   );
 }
 
-export function addContextProvider(provider: ContextProviderWithParams) {
+export function addContextProvider(provider: ContextProviderWithParams, configHandler?: ConfigHandler) {
+  let isAdded = false;
   editConfigJson((config) => {
+
     if (!config.contextProviders) {
-      config.contextProviders = [provider];
-    } else {
+      config.contextProviders = [];
+    }
+    if (!config.contextProviders.some((p) => p.name === provider.name)) {
       config.contextProviders.push(provider);
+      isAdded = true;
     }
 
     return config;
   });
+
+  if (isAdded && configHandler) {
+    void configHandler.reloadConfig();
+  }
 }
 
 export function addModel(

--- a/core/core.ts
+++ b/core/core.ts
@@ -306,7 +306,7 @@ export class Core {
     });
 
     on("config/addContextProvider", async (msg) => {
-      addContextProvider(msg.data);
+      addContextProvider(msg.data, this.configHandler);
     });
 
     on("config/updateSharedConfig", async (msg) => {

--- a/core/indexing/docs/DocsService.ts
+++ b/core/indexing/docs/DocsService.ts
@@ -157,7 +157,8 @@ export default class DocsService {
 
       const currentStatus = this.statuses.get(doc.startUrl);
       if (currentStatus) {
-        return currentStatus;
+        this.handleStatusUpdate(currentStatus);
+        return;
       }
 
       const sharedStatus = {

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/MessageTypes.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/MessageTypes.kt
@@ -123,6 +123,7 @@ class MessageTypes {
             "indexing/setPaused",
             "docs/getSuggestedDocs",
             "docs/initStatuses",
+            "docs/getDetails",
             //
             "completeOnboarding",
             "addAutocompleteModel",


### PR DESCRIPTION
## Description

- Add check to avoid adding the same context provider multiple times and conditionally refresh configuration only after a new provider is added
- Add docs/getDetails endpoint in JetBrains to support viewing doc indexes
- Fixed the issue that the progress bar of indexed docs is not displayed after running continue