### PR TITLE
Can't use more than one resource on a MCP server

### DIFF
--- a/core/context/mcp/index.ts
+++ b/core/context/mcp/index.ts
@@ -164,6 +164,7 @@ class MCPConnection {
       config.contextProviders.push(
         new MCPContextProvider({
           submenuItems,
+          mcpId,
         }),
       );
     }

--- a/core/context/providers/MCPContextProvider.ts
+++ b/core/context/providers/MCPContextProvider.ts
@@ -9,6 +9,7 @@ import {
 import { MCPManagerSingleton } from "../mcp";
 
 interface MCPContextProviderOptions {
+  mcpId: string;
   submenuItems: ContextSubmenuItem[];
 }
 
@@ -74,10 +75,10 @@ class MCPContextProvider extends BaseContextProvider {
     args: LoadSubmenuItemsArgs,
   ): Promise<ContextSubmenuItem[]> {
     return (this.options as MCPContextProviderOptions).submenuItems.map(
-      (item, index) => ({
+      (item) => ({
         ...item,
         id: JSON.stringify({
-          mcpId: String(index),
+          mcpId: (this.options as MCPContextProviderOptions).mcpId,
           uri: item.id,
         }),
       }),


### PR DESCRIPTION
## Description

MCP servers that define multiple resources are currently broken. 
Suppose you have one MCP server that defines three resources.
The first resource is accessed with from the MCP server with `mcpId` 0, which incidentally works. 
But the second resource is accessed from `mcpId` 1, which does not exist, and triggers the below error message:
<img width="473" alt="Screenshot 2025-02-15 at 5 51 32 PM" src="https://github.com/user-attachments/assets/1b7c9888-360d-4c59-b69a-f4bc1447797d" />
The third resource is accessed from `mcpId` 2, which also does not exist.

This PR fixes the bug by correctly associating each resources with the proper `mcpId` via a new property in `MCPContextProviderOptions`.

## Checklist

- [x] The relevant docs, if any, have been updated or created 
   - _This bug fix doesn't require any doc changes._ 
- [x] The relevant tests, if any, have been updated or created
   - _I don't see any test coverage on the changed files._ 

## Screenshots

## Testing instructions

Create a simple MCP server that defines two resources at `~/Desktop/test.js`

```js
import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";

const server = new McpServer({
  name: "test",
  version: "0.0.1",
});

server.resource("one", "test://one", () => ({
  contents: [
    {
      uri: "test://one",
      mimeType: "text/plain",
      text: "one",
    },
  ],
}));

server.resource("two", "test://two", () => ({
  contents: [
    {
      uri: "test://two",
      mimeType: "text/plain",
      text: "two",
    },
  ],
}));

const transport = new StdioServerTransport();
await server.connect(transport);
```

Add the MCP server to Continue's `config.json`

```json
{
    "experimental": {
      "modelContextProtocolServers": [{
        "transport": {
          "type": "stdio",
          "command": "node",
          "args": ["--experimental-vm-modules", "~/Desktop/test.js"]
        }
      }]
  },
}
```

Execute `Developer: Reload Window` from VSCode's command palette 

Type `@MCP` into Continue's chat sidebar, then select the `two` resource.

Currently, this results in the following error message
<img width="473" alt="Screenshot 2025-02-15 at 5 51 32 PM" src="https://github.com/user-attachments/assets/1b7c9888-360d-4c59-b69a-f4bc1447797d" />

After this commit, the context provider works without error.