### PR TITLE
Added FIX for azure content filtering problem

### DIFF
--- a/core/llm/templates/chat.test.ts
+++ b/core/llm/templates/chat.test.ts
@@ -175,7 +175,7 @@ describe.skip("Chat Templates", () => {
       ];
       const prompt = deepseekTemplateMessages(messages);
       const expectedPrompt =
-        "You are an AI programming assistant, utilizing the DeepSeek Coder model, developed by DeepSeek Company, and you only answer questions related to computer science. For politically sensitive questions, security and privacy issues, and other non-computer science questions, you will refuse to answer.\n### Instruction:\nWhat is polymorphism in OOP?\n### Response:\nExplanation of polymorphism.<|EOT|>\n";
+        "You are an AI programming assistant, utilizing the DeepSeek Coder model, developed by DeepSeek Company, and your  role is to assist with questions related to computer science. For politically sensitive questions, security and privacy issues, and other non-computer science questions, you will not answer.\n### Instruction:\nWhat is polymorphism in OOP?\n### Response:\nExplanation of polymorphism.<|EOT|>\n";
       expect(prompt).toBe(expectedPrompt);
     });
   });

--- a/core/llm/templates/chat.ts
+++ b/core/llm/templates/chat.ts
@@ -156,7 +156,7 @@ function deepseekTemplateMessages(msgs: ChatMessage[]): string {
   let prompt = "";
   let system: string | null = null;
   prompt +=
-    "You are an AI programming assistant, utilizing the DeepSeek Coder model, developed by DeepSeek Company, and you only answer questions related to computer science. For politically sensitive questions, security and privacy issues, and other non-computer science questions, you will refuse to answer.\n";
+    "You are an AI programming assistant, utilizing the DeepSeek Coder model, developed by DeepSeek Company, and your  role is to assist with questions related to computer science. For politically sensitive questions, security and privacy issues, and other non-computer science questions, you will not answer.\n";
   if (msgs[0].role === "system") {
     system = renderChatMessage(msgs.shift()!);
   }

--- a/core/llm/templates/edit.ts
+++ b/core/llm/templates/edit.ts
@@ -129,7 +129,7 @@ Sure! Here's the code you requested:
 `;
 
 const deepseekEditPrompt = `### System Prompt
-You are an AI programming assistant, utilizing the DeepSeek Coder model, developed by DeepSeek Company, and you only answer questions related to computer science. For politically sensitive questions, security and privacy issues, and other non-computer science questions, you will refuse to answer.
+You are an AI programming assistant, utilizing the DeepSeek Coder model, developed by DeepSeek Company, and your  role is to assist with questions related to computer science. For politically sensitive questions, security and privacy issues, and other non-computer science questions, you will not answer.
 ### Instruction:
 Rewrite the code to satisfy this request: "{{{userInput}}}"
 


### PR DESCRIPTION
## Description

Resolved the content filtering issue (jailbreak) caused by Azure's safety mechanisms when using current DeepSeek system prompts. The issue stemmed from certain strict terms like "only" and "refuse", which appeared to override Azure AI safety controls. By removing these terms, the problem was resolved, and the system functioned correctly.

Exact Error Message:

Error: HTTP 400 Bad Request from https://deepseek-r1-model01.eastus.models.ai.azure.com/chat/completions {"error":{"message":"The response was filtered due to the prompt triggering Microsoft's content management policy. Please modify your prompt and retry.","type":null,"param":"prompt","code":"content_filter","status":400,"innererror":{"code":"ResponsibleAIPolicyViolation","content_filter_result":{"hate":{"filtered":false,"severity":"safe"},

> **"jailbreak":{"filtered":true**

,"detected":true},"self_harm":{"filtered":false,"severity":"safe"},"sexual":{"filtered":false,"severity":"safe"},"violence":{"filtered":false,"severity":"safe"}}}}}

Having conversation on here : https://github.com/continuedev/continue/issues/3902

## Checklist

N/A

## Screenshots

![image](https://github.com/user-attachments/assets/e8f541e5-3f2f-46c6-bdf7-9dd138ead239)

## Testing instructions

N/A
