### PR TITLE
fix: field name fix

### DIFF
--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -147,7 +147,7 @@ Parameters that control the behavior of text generation and completion settings.
 - `topP`: The cumulative probability for nucleus sampling. Lower values limit responses to tokens within the top probability mass.
 - `topK`: The maximum number of tokens considered at each step. Limits the generated text to tokens within this probability.
 - `presencePenalty`: Discourages the model from generating tokens that have already appeared in the output.
-- `frequencePenalty`: Penalizes tokens based on their frequency in the text, reducing repetition.
+- `frequencyPenalty`: Penalizes tokens based on their frequency in the text, reducing repetition.
 - `mirostat`: Enables Mirostat sampling, which controls the perplexity during text generation. Supported by Ollama, LM Studio, and llama.cpp providers (default: `0`, where `0` = disabled, `1` = Mirostat, and `2` = Mirostat 2.0).
 - `stop`: An array of stop tokens that, when encountered, will terminate the completion. Allows specifying multiple end conditions.
 - `maxTokens`: The maximum number of tokens to generate in a completion (default: `2048`).

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/reference.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/reference.md
@@ -149,7 +149,7 @@ Parameters that control the behavior of text generation and completion settings.
 - `topP`: The cumulative probability for nucleus sampling. Lower values limit responses to tokens within the top probability mass.
 - `topK`: The maximum number of tokens considered at each step. Limits the generated text to tokens within this probability.
 - `presencePenalty`: Discourages the model from generating tokens that have already appeared in the output.
-- `frequencePenalty`: Penalizes tokens based on their frequency in the text, reducing repetition.
+- `frequencyPenalty`: Penalizes tokens based on their frequency in the text, reducing repetition.
 - `mirostat`: Enables Mirostat sampling, which controls the perplexity during text generation. Supported by Ollama, LM Studio, and llama.cpp providers (default: `0`, where `0` = disabled, `1` = Mirostat, and `2` = Mirostat 2.0).
 - `stop`: An array of stop tokens that, when encountered, will terminate the completion. Allows specifying multiple end conditions.
 - `maxTokens`: The maximum number of tokens to generate in a completion (default: `2048`).

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -33,7 +33,7 @@
           "description": "The presence penalty Aof the completion.",
           "type": "number"
         },
-        "frequencePenalty": {
+        "frequencyPenalty": {
           "title": "Frequency Penalty",
           "description": "The frequency penalty of the completion.",
           "type": "number"


### PR DESCRIPTION
## Description

There's no such field `frequencePenalty`  in source codes.

So I correct it to `frequencyPenalty` in documents.

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

N/A

## Testing instructions

N/A
