### PR TITLE
Update `AutocompleteLanguageInfo.ts` to include Lua and Luau

### DIFF
--- a/core/autocomplete/constants/AutocompleteLanguageInfo.ts
+++ b/core/autocomplete/constants/AutocompleteLanguageInfo.ts
@@ -240,6 +240,14 @@ export const Solidity = {
   endOfLine: [";"],
 };
 
+// Lua
+export const Lua = {
+  name: "Lua",
+  topLevelKeywords: ["function"],
+  singleLineComment: "--",
+  endOfLine: [],
+};
+
 // YAML
 export const YAML: AutocompleteLanguageInfo = {
   name: "YAML",
@@ -367,6 +375,8 @@ export const LANGUAGES: { [extension: string]: AutocompleteLanguageInfo } = {
   yaml: YAML,
   yml: YAML,
   md: Markdown,
+  lua: Lua,
+  luau: Lua,
 };
 
 export function languageForFilepath(fileUri: string): AutocompleteLanguageInfo {

--- a/core/util/treeSitter.ts
+++ b/core/util/treeSitter.ts
@@ -93,6 +93,7 @@ export const supportedLanguages: { [key: string]: LanguageName } = {
   htm: LanguageName.HTML,
   java: LanguageName.JAVA,
   lua: LanguageName.LUA,
+  luau: LanguageName.LUA,
   ocaml: LanguageName.OCAML,
   ml: LanguageName.OCAML,
   mli: LanguageName.OCAML,


### PR DESCRIPTION
## Description

Added language info for Lua.

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Testing instructions

None for now, as this is a minor fix.
