### PR TITLE
Update domain in docusaurus.config.js

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -19,7 +19,7 @@ const config = {
   favicon: "img/favicon.ico",
 
   // Set the production url of your site here
-  url: "https://continue.dev",
+  url: "https://docs.continue.dev",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: "/",


### PR DESCRIPTION
## Description

Change site url from `continue.dev` to `docs.continue.dev` so as to generate a correct sitemap.
related issue: https://github.com/continuedev/continue/issues/4245

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created

## Screenshots

N/A

## Testing instructions

N/A
