### PR TITLE
Reinstate VSCode copy buffer

### DIFF
--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -1056,7 +1056,7 @@ export function registerAllCommands(
   core: Core,
   editDecorationManager: EditDecorationManager,
 ) {
-  // registerCopyBufferSpy(context, core);
+  registerCopyBufferSpy(context, core);
 
   for (const [command, callback] of Object.entries(
     getCommandsMap(


### PR DESCRIPTION
## Description
Was removed on a hunch that it was causing extension hanging.
Appears to not have solved hanging issues, adding back in to return functionality to the clipboard context provider and autocomplete copy buffer access.