### PR TITLE
http -> remote context provider and slash command

### DIFF
--- a/core/commands/slash/index.ts
+++ b/core/commands/slash/index.ts
@@ -10,7 +10,7 @@ export default [
   DraftIssueCommand,
   ShareSlashCommand,
   GenerateTerminalCommand,
-  HttpSlashCommand, // deprecated, use remote, left here for functionality
+  HttpSlashCommand, // deprecated, use remote, left here for legacy support
   RemoteServerSlashCommand,
   CommitMessageCommand,
   ReviewMessageCommand,

--- a/core/commands/slash/index.ts
+++ b/core/commands/slash/index.ts
@@ -1,8 +1,8 @@
 import GenerateTerminalCommand from "./cmd";
 import CommitMessageCommand from "./commit";
 import DraftIssueCommand from "./draftIssue";
-import HttpSlashCommand from "./http";
 import OnboardSlashCommand from "./onboard";
+import { RemoteServerSlashCommand, HttpSlashCommand } from "./remote";
 import ReviewMessageCommand from "./review";
 import ShareSlashCommand from "./share";
 
@@ -10,7 +10,8 @@ export default [
   DraftIssueCommand,
   ShareSlashCommand,
   GenerateTerminalCommand,
-  HttpSlashCommand,
+  HttpSlashCommand, // deprecated, use remote, left here for functionality
+  RemoteServerSlashCommand,
   CommitMessageCommand,
   ReviewMessageCommand,
   OnboardSlashCommand,

--- a/core/commands/slash/remote.ts
+++ b/core/commands/slash/remote.ts
@@ -2,8 +2,8 @@ import { SlashCommand } from "../../index.js";
 import { removeQuotesAndEscapes } from "../../util/index.js";
 import { streamResponse } from "../../llm/stream.js";
 
-const HttpSlashCommand: SlashCommand = {
-  name: "http",
+export const RemoteServerSlashCommand: SlashCommand = {
+  name: "remote",
   description: "Call an HTTP endpoint to serve response",
   run: async function* ({ ide, llm, input, params, fetch }) {
     const url = params?.url;
@@ -30,4 +30,7 @@ const HttpSlashCommand: SlashCommand = {
   },
 };
 
-export default HttpSlashCommand;
+export const HttpSlashCommand: SlashCommand = {
+  ...RemoteServerSlashCommand,
+  name: "http",
+};

--- a/core/config/util.ts
+++ b/core/config/util.ts
@@ -24,10 +24,12 @@ function stringify(obj: any, indentation?: number): string {
   );
 }
 
-export function addContextProvider(provider: ContextProviderWithParams, configHandler?: ConfigHandler) {
+export function addContextProvider(
+  provider: ContextProviderWithParams,
+  configHandler?: ConfigHandler,
+) {
   let isAdded = false;
   editConfigJson((config) => {
-
     if (!config.contextProviders) {
       config.contextProviders = [];
     }
@@ -136,7 +138,7 @@ export function isSupportedLanceDbCpuTarget(ide: IDE) {
   const platform = os.platform();
 
   // This check only applies to x64
-  //https://github.com/lancedb/lance/issues/2195#issuecomment-2057841311
+  // https://github.com/lancedb/lance/issues/2195#issuecomment-2057841311
   if (arch !== "x64") {
     globalContext.update("isSupportedLanceDbCpuTarget", true);
     return true;

--- a/core/context/providers/HttpContextProvider.ts
+++ b/core/context/providers/HttpContextProvider.ts
@@ -1,69 +1,15 @@
-import {
-  ContextItem,
-  ContextProviderDescription,
-  ContextProviderExtras,
-} from "../../index.js";
-import { BaseContextProvider } from "../index.js";
+import { ContextProviderDescription } from "../../index.js";
+import RemoteServerContextProvider from "./RemoteContextProvider.js";
 
-class HttpContextProvider extends BaseContextProvider {
+// Deprecated - move to Remote Context Provider
+class HttpContextProvider extends RemoteServerContextProvider {
   static description: ContextProviderDescription = {
     title: "http",
-    displayTitle: "HTTP",
+    displayTitle: "Remote Server",
     description: "Retrieve a context item from a custom server",
     type: "normal",
     renderInlineAs: "",
   };
-
-  override get description(): ContextProviderDescription {
-    return {
-      title: this.options.title || "http",
-      displayTitle: this.options.displayTitle || "HTTP",
-      description:
-        this.options.description ||
-        "Retrieve a context item from a custom server",
-      type: "normal",
-      renderInlineAs:
-        this.options.renderInlineAs ||
-        HttpContextProvider.description.renderInlineAs,
-    };
-  }
-
-  async getContextItems(
-    query: string,
-    extras: ContextProviderExtras,
-  ): Promise<ContextItem[]> {
-    const response = await extras.fetch(new URL(this.options.url), {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        query: query || "",
-        fullInput: extras.fullInput,
-        options: this.options.options,
-      }),
-    });
-
-    const json = await response.json();
-
-    try {
-      const createContextItem = (item: any) => ({
-        description: item.description ?? "HTTP Context Item",
-        content: item.content ?? "",
-        name: item.name ?? this.options.title ?? "HTTP",
-      });
-
-      return Array.isArray(json)
-        ? json.map(createContextItem)
-        : [createContextItem(json)];
-    } catch (e) {
-      console.warn(
-        `Failed to parse response from custom HTTP context provider.\nError:\n${e}\nResponse from server:\n`,
-        json,
-      );
-      return [];
-    }
-  }
 }
 
 export default HttpContextProvider;

--- a/core/context/providers/RemoteContextProvider.ts
+++ b/core/context/providers/RemoteContextProvider.ts
@@ -1,0 +1,73 @@
+import {
+  ContextItem,
+  ContextProviderDescription,
+  ContextProviderExtras,
+} from "../../index.js";
+import { BaseContextProvider } from "../index.js";
+
+// Formerly "http"
+class RemoteServerContextProvider extends BaseContextProvider {
+  static description: ContextProviderDescription = {
+    title: "remote",
+    displayTitle: "Remote Server",
+    description: "Retrieve a context item from a custom server",
+    type: "normal",
+    renderInlineAs: "",
+  };
+
+  override get description(): ContextProviderDescription {
+    return {
+      title: this.options.title || "remote",
+      displayTitle:
+        this.options.displayTitle ||
+        RemoteServerContextProvider.description.displayTitle,
+      description:
+        this.options.description ||
+        "Retrieve a context item from a custom server",
+      type: "normal",
+      renderInlineAs:
+        this.options.renderInlineAs ||
+        RemoteServerContextProvider.description.renderInlineAs,
+    };
+  }
+
+  async getContextItems(
+    query: string,
+    extras: ContextProviderExtras,
+  ): Promise<ContextItem[]> {
+    const response = await extras.fetch(new URL(this.options.url), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        query: query || "",
+        fullInput: extras.fullInput,
+        options: this.options.options,
+      }),
+    });
+
+    const json = await response.json();
+
+    try {
+      const createContextItem = (item: any) => ({
+        description:
+          item.description ?? `${this.options.displayTitle} context item`,
+        content: item.content ?? "",
+        name: item.name ?? this.options.title ?? "Remote",
+      });
+
+      return Array.isArray(json)
+        ? json.map(createContextItem)
+        : [createContextItem(json)];
+    } catch (e) {
+      console.warn(
+        `Failed to parse response from custom remote server context provider ${this.options.displayTitle}\nError:\n${e}\nResponse from server:\n`,
+        json,
+      );
+      return [];
+    }
+  }
+}
+
+export default RemoteServerContextProvider;

--- a/core/context/providers/context_provider_server.py
+++ b/core/context/providers/context_provider_server.py
@@ -1,5 +1,5 @@
 """
-This is an example of a server that can be used with the "http" context provider.
+This is an example of a server that can be used with the "remote" context provider.
 This can be useful if you want to write custom logic in another language, or on a server.
 """
 

--- a/core/context/providers/index.ts
+++ b/core/context/providers/index.ts
@@ -46,8 +46,8 @@ export const Providers: (typeof BaseContextProvider)[] = [
   TerminalContextProvider,
   DebugLocalsProvider,
   OpenFilesContextProvider,
-  HttpContextProvider, // Deprecated but left here for functionality
   RemoteServerContextProvider,
+  HttpContextProvider, // Deprecated but left here for legacy support
   SearchContextProvider,
   OSContextProvider,
   ProblemsContextProvider,

--- a/core/context/providers/index.ts
+++ b/core/context/providers/index.ts
@@ -24,6 +24,7 @@ import OpenFilesContextProvider from "./OpenFilesContextProvider";
 import OSContextProvider from "./OSContextProvider";
 import PostgresContextProvider from "./PostgresContextProvider";
 import ProblemsContextProvider from "./ProblemsContextProvider";
+import RemoteServerContextProvider from "./RemoteContextProvider";
 import RepoMapContextProvider from "./RepoMapContextProvider";
 import SearchContextProvider from "./SearchContextProvider";
 import TerminalContextProvider from "./TerminalContextProvider";
@@ -45,7 +46,8 @@ export const Providers: (typeof BaseContextProvider)[] = [
   TerminalContextProvider,
   DebugLocalsProvider,
   OpenFilesContextProvider,
-  HttpContextProvider,
+  HttpContextProvider, // Deprecated but left here for functionality
+  RemoteServerContextProvider,
   SearchContextProvider,
   OSContextProvider,
   ProblemsContextProvider,

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -43,13 +43,13 @@ export interface IndexingProgressUpdate {
   desc: string;
   shouldClearIndexes?: boolean;
   status:
-  | "loading"
-  | "indexing"
-  | "done"
-  | "failed"
-  | "paused"
-  | "disabled"
-  | "cancelled";
+    | "loading"
+    | "indexing"
+    | "done"
+    | "failed"
+    | "paused"
+    | "disabled"
+    | "cancelled";
   debugInfo?: string;
 }
 
@@ -667,10 +667,10 @@ export interface IDE {
   getCurrentFile(): Promise<
     | undefined
     | {
-      isUntitled: boolean;
-      path: string;
-      contents: string;
-    }
+        isUntitled: boolean;
+        path: string;
+        contents: string;
+      }
   >;
 
   getLastFileSaveTimestamp?(): number;
@@ -761,7 +761,7 @@ export type ContextProviderName =
   | "google"
   | "search"
   | "tree"
-  | "http"
+  | "remote"
   | "codebase"
   | "problems"
   | "folder"
@@ -853,11 +853,11 @@ export interface CustomCommand {
 export interface Prediction {
   type: "content";
   content:
-  | string
-  | {
-    type: "text";
-    text: string;
-  }[];
+    | string
+    | {
+        type: "text";
+        text: string;
+      }[];
 }
 
 export interface ToolExtras {
@@ -1186,9 +1186,9 @@ export interface Config {
   embeddingsProvider?: EmbeddingsProviderDescription | ILLM;
   /** The model that Continue will use for tab autocompletions. */
   tabAutocompleteModel?:
-  | CustomLLM
-  | ModelDescription
-  | (CustomLLM | ModelDescription)[];
+    | CustomLLM
+    | ModelDescription
+    | (CustomLLM | ModelDescription)[];
   /** Options for tab autocomplete */
   tabAutocompleteOptions?: Partial<TabAutocompleteOptions>;
   /** UI styles customization */
@@ -1279,9 +1279,9 @@ export type PackageDetailsSuccess = PackageDetails & {
 export type PackageDocsResult = {
   packageInfo: ParsedPackageInfo;
 } & (
-    | { error: string; details?: never }
-    | { details: PackageDetailsSuccess; error?: never }
-  );
+  | { error: string; details?: never }
+  | { details: PackageDetailsSuccess; error?: never }
+);
 
 export interface TerminalOptions {
   reuseTerminal?: boolean;

--- a/docs/docs/customize/context-providers.mdx
+++ b/docs/docs/customize/context-providers.mdx
@@ -931,7 +931,7 @@ The HttpContextProvider makes a POST request to the url passed in the configurat
   <TabItem value="yaml" label="YAML">
   ```yaml title="Package or config.yaml"
   context:
-    - provider: http
+    - provider: remote
       params:
         url: "https://api.example.com/v1/users"
   ```
@@ -941,7 +941,7 @@ The HttpContextProvider makes a POST request to the url passed in the configurat
   {
     "contextProviders": [
       {
-        "name": "http", 
+        "name": "remote", 
         "params": {
           "url": "https://api.example.com/v1/users"
         }

--- a/docs/docs/customize/slash-commands.mdx
+++ b/docs/docs/customize/slash-commands.mdx
@@ -67,7 +67,7 @@ Shows the LLM your current git diff and asks it to generate a commit message.
 }
 ```
 
-### `/http`
+### `/remote`
 
 Write a custom slash command at your own HTTP endpoint. Set 'url' in the params object for the endpoint you have setup. The endpoint should return a sequence of string updates, which will be streamed to the Continue sidebar. See our basic [FastAPI example](https://github.com/continuedev/continue/blob/74002369a5e435735b83278fb965e004ae38a97d/core/context/providers/context_provider_server.py#L34-L45) for reference.
 
@@ -75,7 +75,7 @@ Write a custom slash command at your own HTTP endpoint. Set 'url' in the params 
 {
   "slashCommands": [
     {
-      "name": "http",
+      "name": "remote",
       "description": "Does something custom",
       "params": { "url": "<my server endpoint>" }
     }

--- a/docs/docs/customize/tutorials/build-your-own-context-provider.md
+++ b/docs/docs/customize/tutorials/build-your-own-context-provider.md
@@ -186,15 +186,15 @@ Continue will use [esbuild](https://esbuild.github.io/) to bundle your `config.t
 
 ## Writing Context Providers in Other Languages
 
-If you'd like to write a context provider in a language other than TypeScript, you can use the "http" context provider to call a server that hosts your own code. Add the context provider to `config.json` like this:
+If you'd like to write a context provider in a language other than TypeScript, you can use the "remote" context provider to call a server that hosts your own code. Add the context provider to `config.json` like this:
 
 ```json title="config.json"
 {
-  "name": "http",
+  "name": "remote",
   "params": {
     "url": "https://myserver.com/context-provider",
-    "title": "http",
-    "description": "Custom HTTP Context Provider",
+    "title": "remote",
+    "description": "Custom Remote Server Context Provider",
     "displayTitle": "My Custom Context",
     "options": {}
   }

--- a/docs/docs/customize/tutorials/custom-code-rag.mdx
+++ b/docs/docs/customize/tutorials/custom-code-rag.mdx
@@ -90,11 +90,11 @@ In the beginning, you should probably run it by hand. Once you are confident tha
 
 In order for the Continue extension to access your custom RAG system, you'll need to set up a server. This server is responsible for recieving a query from the extension, querying the vector database, and returning the results in the format expected by Continue.
 
-Here is a reference implementation using FastAPI that is capable of handling requests from Continue's "http" context provider.
+Here is a reference implementation using FastAPI that is capable of handling requests from Continue's "remote" context provider.
 
 ```python
 """
-This is an example of a server that can be used with the "http" context provider.
+This is an example of a server that can be used with the "remote" context provider.
 """
 
 from fastapi import FastAPI
@@ -125,7 +125,7 @@ async def create_item(item: ContextProviderInput):
     return context_items
 ```
 
-After you've set up your server, you can configure Continue to use it by adding the "http" context provider to your `contextProviders` array in your configuration:
+After you've set up your server, you can configure Continue to use it by adding the "remote" context provider to your `contextProviders` array in your configuration:
 
 <Tabs groupId="config-example">
 <TabItem value="yaml" label="YAML">
@@ -135,7 +135,7 @@ After you've set up your server, you can configure Continue to use it by adding 
       params:
         url: https://myserver.com/retrieve
         name: http
-        description: Custom HTTP Context Provider
+        description: Custom Remote Server Context Provider
         displayTitle: My Custom Context
   ```
   </TabItem>
@@ -144,11 +144,11 @@ After you've set up your server, you can configure Continue to use it by adding 
   {
     "contextProviders": [
       {
-        "name": "http",
+        "name": "remote",
         "params": {
           "url": "https://myserver.com/retrieve",
-          "title": "http",
-          "description": "Custom HTTP Context Provider",
+          "title": "remote",
+          "description": "Custom Remote Server Context Provider",
           "displayTitle": "My Custom Context"
         }
       }

--- a/docs/docs/json-reference.md
+++ b/docs/docs/json-reference.md
@@ -258,7 +258,7 @@ Custom commands initiated by typing "/" in the sidebar. Commands include predefi
 
 **Properties:**
 
-- `name`: The command name. Options include "issue", "share", "cmd", "http", "commit", and "review".
+- `name`: The command name. Options include "issue", "share", "cmd", "remote", "commit", and "review".
 - `description`: Brief description of the command.
 - `step`: Used for built-in commands; set the name for pre-configured options.
 - `params`: Additional parameters to configure command behavior (command-specific - see code for command)

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -258,7 +258,7 @@ Custom commands initiated by typing "/" in the sidebar. Commands include predefi
 
 **Properties:**
 
-- `name`: The command name. Options include "issue", "share", "cmd", "http", "commit", and "review".
+- `name`: The command name. Options include "issue", "share", "cmd", "remote", "commit", and "review".
 - `description`: Brief description of the command.
 - `step`: (Deprecated) Used for built-in commands; set the name for pre-configured options.
 - `params`: Additional parameters to configure command behavior (command-specific - see code for command)

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/customize/context-providers.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/customize/context-providers.md
@@ -447,9 +447,9 @@ HttpContextProvider 创建一个 POST 请求到配置中的 url 。服务器必�
 {
   "contextProviders": [
     {
-      "name": "http",
+      "name": "remote",
       "params": {
-        "url": "https://api.example.com/v1/users",
+        "url": "https://api.example.com/v1/users"
       }
     }
   ]
@@ -457,6 +457,7 @@ HttpContextProvider 创建一个 POST 请求到配置中的 url 。服务器必�
 ```
 
 接收的 URL 应该接收下面的参数：
+
 ```json title="POST parameters"
 {
   query: string,
@@ -465,6 +466,7 @@ HttpContextProvider 创建一个 POST 请求到配置中的 url 。服务器必�
 ```
 
 响应 200 OK 应该是一个有以下结构的 JSON 对象：
+
 ```json title="Response"
 [
   {

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/customize/slash-commands.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/customize/slash-commands.md
@@ -98,7 +98,7 @@ Comment 工作就像 `/Edit` ，除了它将自动地给 LLM 注释代码的提�
 {
   "slashCommands": [
     {
-      "name": "http",
+      "name": "remote",
       "description": "Does something custom",
       "params": { "url": "<my server endpoint>" }
     }

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/customize/tutorials/build-your-own-context-provider.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/customize/tutorials/build-your-own-context-provider.md
@@ -172,21 +172,21 @@ Continue 将使用 [esbuild](https://esbuild.github.io/) 打包你的 `config.ts
 
 ## 使用其他语言编写上下文提供者
 
-如果你想要用除了 TypeScript 的其他语言编写上下文提供者，你可以使用 "http" 上下文提供者，来调用一个托管你自己代码的服务器。添加上下文提供者到 `config.json` ，像这样：
+如果你想要用除了 TypeScript 的其他语言编写上下文提供者，你可以使用 "remote" 上下文提供者，来调用一个托管你自己代码的服务器。添加上下文提供者到 `config.json` ，像这样：
 
 ```json title="config.json"
 {
-  "name": "http",
+  "name": "remote",
   "params": {
     "url": "https://myserver.com/context-provider",
-    "title": "http",
-    "description": "Custom HTTP Context Provider",
+    "title": "remote",
+    "description": "Custom Remote Server Context Provider",
     "displayTitle": "My Custom Context"
   }
 }
 ```
 
-<!-- Then, create a server that responds to requests as are made from [HttpContextProvider.ts](../../../core/context/providers/HttpContextProvider.ts). See the `hello` endpoint in [context_provider_server.py](../../../core/context/providers/context_provider_server.py) for an example that uses FastAPI. -->
+<!-- Then, create a server that responds to requests as are made from [RemoteServerContextProvider.ts](../../../core/context/providers/RemoteServerContextProvider.ts). See the `hello` endpoint in [context_provider_server.py](../../../core/context/providers/context_provider_server.py) for an example that uses FastAPI. -->
 
 ## VSCode 的扩展 API
 

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/customize/tutorials/custom-code-rag.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/customize/tutorials/custom-code-rag.md
@@ -86,11 +86,11 @@ print(actual.text)
 
 为了 Continue 扩展能够访问你的定制 RAG 系统，你需要设置服务器。这个服务器负责接收来自扩展的查询，查询向量数据库，返回 Continue 想要的格式的结果。
 
-这是一个使用 FastAPI 的参考实现，适用于处理来自 Continue 的 "http" 上下文提供者的请求。
+这是一个使用 FastAPI 的参考实现，适用于处理来自 Continue 的 "remote" 上下文提供者的请求。
 
 ```python
 """
-This is an example of a server that can be used with the "http" context provider.
+This is an example of a server that can be used with the "remote" context provider.
 """
 
 from fastapi import FastAPI
@@ -121,15 +121,15 @@ async def create_item(item: ContextProviderInput):
     return context_items
 ```
 
-在你设置服务器之后，你可以配置 Continue 使用它，通过添加 "http" 上下文提供者到你的 `config.json` 中的 `contextProviders` 列表：
+在你设置服务器之后，你可以配置 Continue 使用它，通过添加 "remote" 上下文提供者到你的 `config.json` 中的 `contextProviders` 列表：
 
 ```json title="config.json"
 {
-  "name": "http",
+  "name": "remote",
   "params": {
     "url": "https://myserver.com/retrieve",
-    "title": "http",
-    "description": "Custom HTTP Context Provider",
+    "title": "remote",
+    "description": "Custom Remote Context Provider",
     "displayTitle": "My Custom Context"
   }
 }

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/reference.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/reference.md
@@ -264,7 +264,7 @@ Custom commands initiated by typing "/" in the sidebar. Commands include predefi
 
 **Properties:**
 
-- `name`: The command name. Options include "issue", "share", "cmd", "http", "commit", and "review".
+- `name`: The command name. Options include "issue", "share", "cmd", "remote", "commit", and "review".
 - `description`: Brief description of the command.
 - `step`: (Deprecated) Used for built-in commands; set the name for pre-configured options.
 - `params`: Additional parameters to configure command behavior (command-specific - see code for command)

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -1701,7 +1701,7 @@
                 "cmd",
                 "edit",
                 "comment",
-                "http",
+                "remote",
                 "commit",
                 "review"
               ],
@@ -1868,7 +1868,7 @@
                 "open",
                 "google",
                 "search",
-                "http",
+                "remote",
                 "codebase",
                 "problems",
                 "folder",
@@ -2341,7 +2341,7 @@
           "if": {
             "properties": {
               "name": {
-                "enum": ["http"]
+                "enum": ["remote"]
               }
             }
           },


### PR DESCRIPTION
## Description
- Change `http` context provider to `remote` (leave support for `http`)
- Change `/http` slash command to `/remote` (leave support for `/http`)
- Update docs