### PR TITLE
Increase Jetbrains InlineEdit model titles timeout

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/InlineEditAction.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/InlineEditAction.kt
@@ -137,7 +137,10 @@ fun openInlineEdit(project: Project?, editor: Editor) {
         modelTitles.addAll(models.map { it["title"] as String })
     }
 
-    val maxWaitTime = 200
+    // This is a hacky way to not complicate getting model titles with coroutines
+    // 1500 feels like way upper limit of "would be weird if panel showed up after that long"
+    // And should always allow enough time to load config
+    val maxWaitTime = 1500
     val startTime = System.currentTimeMillis()
     while (modelTitles.isEmpty() && System.currentTimeMillis() - startTime < maxWaitTime) {
         Thread.sleep(20)


### PR DESCRIPTION
## Description
Often didn't load model titles in 200 ms, resulting in "null" in empty dropdown.
Increased to 1500