### PR TITLE
Persist edit mode state, disable tools in edit mode

### DIFF
--- a/gui/src/components/mainInput/ContinueInputBox.tsx
+++ b/gui/src/components/mainInput/ContinueInputBox.tsx
@@ -109,7 +109,6 @@ function ContinueInputBox(props: ContinueInputBoxProps) {
         hideImageUpload: false,
         hideUseCodebase: true,
         hideSelectModel: false,
-        hideTools: true,
         enterText: editModeState.editStatus === "accepting" ? "Retry" : "Edit",
       }
     : {};

--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -67,7 +67,6 @@ export interface ToolbarOptions {
   hideAddContext?: boolean;
   enterText?: string;
   hideSelectModel?: boolean;
-  hideTools?: boolean;
 }
 
 interface InputToolbarProps {
@@ -91,10 +90,7 @@ function InputToolbar(props: InputToolbarProps) {
   const hasCodeToEdit = useAppSelector(selectHasCodeToEdit);
   const isEditModeAndNoCodeToEdit = isInEditMode && !hasCodeToEdit;
   const isEnterDisabled = props.disabled || isEditModeAndNoCodeToEdit;
-  const toolsSupported =
-    defaultModel &&
-    modelSupportsTools(defaultModel) &&
-    !props.toolbarOptions?.hideTools;
+  const toolsSupported = defaultModel && modelSupportsTools(defaultModel);
 
   const supportsImages =
     defaultModel &&
@@ -158,7 +154,7 @@ function InputToolbar(props: InputToolbarProps) {
               </HoverItem>
             )}
 
-            <ToggleToolsButton disabled={!toolsSupported} />
+            {!isInEditMode && <ToggleToolsButton disabled={!toolsSupported} />}
           </div>
         </div>
 

--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -53,7 +53,6 @@ type SessionState = {
   streamAborter: AbortController;
   codeToEdit: CodeToEdit[];
   curCheckpointIndex: number;
-  currentMainEditorContent?: JSONContent;
   mainEditorContentTrigger?: JSONContent | undefined;
   symbols: FileSymbolMap;
   mode: MessageModes;

--- a/gui/src/redux/store.ts
+++ b/gui/src/redux/store.ts
@@ -38,14 +38,16 @@ const saveSubsetFilters = [
     "id",
     "lastSessionId",
     "title",
+
+    // Persist edit mode in case closes in middle
     "mode",
+    "codeToEdit",
 
     // TODO consider removing persisted profiles/orgs
     "availableProfiles",
     "organizations",
 
     // higher risk to persist
-    // codeToEdit
     // codeBlockApplyStates
     // symbols
     // curCheckpointIndex

--- a/gui/src/redux/store.ts
+++ b/gui/src/redux/store.ts
@@ -33,9 +33,22 @@ const rootReducer = combineReducers({
 const saveSubsetFilters = [
   createFilter("session", [
     "history",
-    "sessionId",
     "selectedOrganizationId",
     "selectedProfile",
+    "id",
+    "lastSessionId",
+    "title",
+    "mode",
+
+    // TODO consider removing persisted profiles/orgs
+    "availableProfiles",
+    "organizations",
+
+    // higher risk to persist
+    // codeToEdit
+    // codeBlockApplyStates
+    // symbols
+    // curCheckpointIndex
   ]),
   // Don't persist any of the edit state for now
   createFilter("editModeState", []),

--- a/gui/src/redux/thunks/streamNormalInput.ts
+++ b/gui/src/redux/thunks/streamNormalInput.ts
@@ -27,7 +27,10 @@ export const streamNormalInput = createAsyncThunk<
     throw new Error("Default model not defined");
   }
 
-  const includeTools = useTools && modelSupportsTools(defaultModel);
+  const includeTools =
+    useTools &&
+    modelSupportsTools(defaultModel) &&
+    state.session.mode === "chat";
 
   // Send request
   const gen = extra.ideMessenger.llmStreamChat(


### PR DESCRIPTION
## Description
- Persist edit mode state in case window is closed during edit.
- Fix logic to disable tools in edit mode (was showing disabled but still including tools in call)