### PR TITLE
chore: move file info outside of the code

### DIFF
--- a/gui/src/components/mainInput/resolveInput.ts
+++ b/gui/src/components/mainInput/resolveInput.ts
@@ -79,11 +79,12 @@ async function resolveEditorContent({
             const fileExtension = getUriFileExtension(rif.filepath);
             // let extName = relativeFilepath.split(".").slice(-1)[0];
             const text =
-              "\n\n" +
+              "\n" +
+              `code file info: ${contextItem.description}` +
+              "\n" +
               "```" +
               fileExtension +
               " " +
-              contextItem.description +
               "\n" +
               contextItem.content +
               "\n```";


### PR DESCRIPTION
## Description
I found that during the chat conversation, the file information of the selected code was put in the code block and sent to the model together, making the model mistakenly think that the selected code information was also belongs code. 
Therefore, the return value of the model will also contain the selection code information.
![image](https://github.com/user-attachments/assets/eb47beff-6210-4256-a353-abb1cb887295)

[ What changed? Feel free to be brief. ]
## Before

![image](https://github.com/user-attachments/assets/0ea665bd-0222-4894-bd01-a15038a9e9c5)

## After:
![image](https://github.com/user-attachments/assets/6a1c32ea-a544-4fdb-a41f-4986b59b4c5c)

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
