### PR TITLE
Resolve proxy error when adding Azure OpenAI model

### DIFF
--- a/packages/openai-adapters/src/apis/AzureOpenAI.ts
+++ b/packages/openai-adapters/src/apis/AzureOpenAI.ts
@@ -40,8 +40,10 @@ export class AzureOpenAIApi implements BaseLlmApi {
     if (PROXY) {
       const url = new URL(PROXY);
       proxyOptions = {
-        host: url.hostname,
-        port: Number(url.port),
+        host: (url.protocol ? url.protocol + "//" : "") + url.hostname,
+        port: Number(url.port || 80),
+        username: url.username,
+        password: url.password,
       };
     }
 


### PR DESCRIPTION
close #3993 #4202

## Description

This pull request corrects an error that occurs when adding an Azure OpenAI model while using a proxy.

The error stems from the fact that the Azure SDK's ProxySettings requires the proxy host to specify the schema (such as http://) as part of the hostname.

For reference, please see the relevant code snippet in the Azure SDK for JavaScript: 

https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/ts-http-runtime/src/policies/proxyPolicy.ts#L125-L132

Additionally, to verify this fix, I adjusted the dependency of core to use the local `@continuedev/openai-adapters` package.
This was done by modifying the core package's package.json to include the following dependency:
`"@continuedev/openai-adapters": "file:../packages/openai-adapters"`

### Error Logs

```
mainThreadExtensionService.ts:79 Error: Expecting a valid host string in proxy settings, but found "localhost".
    at getUrlFromProxySettings (c:\Users\aplulu\.vsc…tension.js:78239:11)
    at proxyPolicy (c:\Users\aplulu\.vsc…tension.js:78276:40)
    at createPipelineFromOptions (c:\Users\aplulu\.vsc…tension.js:78699:25)
    at createDefaultPipeline (c:\Users\aplulu\.vsc…tension.js:79525:21)
    at getClient (c:\Users\aplulu\.vsc…tension.js:79819:21)
    at createClient (c:\Users\aplulu\.vsc…tension.js:79940:18)
    at createOpenAI (c:\Users\aplulu\.vsc…tension.js:80071:25)
    at new OpenAIClient (c:\Users\aplulu\.vsc…tension.js:81125:24)
    at new AzureOpenAIApi (c:\Users\aplulu\.vsc…tension.js:81263:23)
    at constructLlmApi (c:\Users\aplulu\.vsc…tension.js:98300:14)
    at Azure2.createOpenAiAdapter (c:\Users\aplulu\.vsc…ension.js:109276:16)
    at new BaseLLM (c:\Users\aplulu\.vsc…ension.js:109270:35)
    at new OpenAI2 (c:\Users\aplulu\.vsc…tension.js:109997:9)
    at new Azure2 (c:\Users\aplulu\.vsc…tension.js:588808:9)
    at llmFromDescription (c:\Users\aplulu\.vsc…ension.js:600125:10)
    at intermediateToFinalConfig (c:\Users\aplulu\.vsc…ension.js:601050:19)
    at loadContinueConfigFromJson (c:\Users\aplulu\.vsc…ension.js:601527:56)
    at doLoadConfig (c:\Users\aplulu\.vsc…ension.js:602674:20)
    at _LocalProfileLoader.doLoadConfig (c:\Users\aplulu\.vsc…ension.js:602866:24)
    at c:\Users\aplulu\.vsc…ension.js:602991:26
```

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Testing instructions

To validate the fix for the proxy error when adding an Azure OpenAI model, please follow these steps:

1. Start a proxy server: You can use a tool like Squid to set up a local proxy server. For example, you can use the following command to start a Squid container:

```bash
docker run -d --name squid-container -e TZ=UTC -p 3128:3128 ubuntu/squid:5.2-22.04_beta
```

2. Configure VSCode to use the proxy: Create a command file (e.g., vscode-proxy.bat) with the following content, replacing the VSCode path if necessary:

```
@echo off

set "userVSCodePath=%LOCALAPPDATA%\Programs\Microsoft VS Code\bin\code.cmd"
set "systemVSCodePath=%ProgramFiles%\Microsoft VS Code\bin\code.cmd"

set "HTTP_PROXY=http://localhost:3128"
set "HTTPS_PROXY=http://localhost:3128"

if exist "%userVSCodePath%" (
    echo VSCode Path: %userVSCodePath%
    start "" "%userVSCodePath%"
) else if exist "%systemVSCodePath%" (
    echo VSCode Path: %systemVSCodePath%
    start "" "%systemVSCodePath%"
) else (
    echo VSCode not found
)
```

3. Launch VSCode using the command file: Double-click the vscode-proxy.bat file to launch VSCode with the proxy settings.

4. Add an Azure OpenAI model: In VSCode, attempt to add an Azure OpenAI model. With the fix, this should now be successful, and you should not encounter the proxy error.
