### PR TITLE
Binary Quick Build script

### DIFF
--- a/binary/package.json
+++ b/binary/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "test": "jest",
     "build": "node build.js",
+    "quick-build": "node build.js --target darwin-arm64",
     "build:darwin-x64": "node build.js --os darwin-x64"
   },
   "license": "Apache-2.0",

--- a/binary/package.json
+++ b/binary/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "test": "jest",
     "build": "node build.js",
-    "quick-build": "node build.js --target darwin-arm64",
+    "quick-build": "node quick-build.js --target darwin-arm64",
     "build:darwin-x64": "node build.js --os darwin-x64"
   },
   "license": "Apache-2.0",

--- a/binary/quick-build.js
+++ b/binary/quick-build.js
@@ -1,0 +1,86 @@
+const esbuild = require("esbuild");
+const fs = require("fs");
+const path = require("path");
+const {
+  execCmdSync,
+  validateFilesPresent,
+  autodetectPlatformAndArch,
+} = require("../scripts/util");
+
+// Paths
+const bin = path.join(__dirname, "bin");
+const esbuildOutputFile = "out/index.js";
+let targets = [
+  "darwin-x64",
+  "darwin-arm64",
+  "linux-x64",
+  "linux-arm64",
+  "win32-x64",
+];
+
+for (let i = 2; i < process.argv.length; i++) {
+  if (process.argv[i - 1] === "--target") {
+    targets = [process.argv[i]];
+  }
+}
+
+// Cleanup
+for (const target of targets) {
+  const exe = target.startsWith("win") ? ".exe" : "";
+  const targetDir = path.join(bin, target);
+  fs.rmSync(path.join(targetDir, `continue-binary${exe}`), { force: true });
+}
+
+// Validate files to ensure prerequisites are available
+const filesToValidate = [
+  "src/index.ts",
+  "../core/node_modules/jsdom/lib/jsdom/living/xhr/xhr-sync-worker.js",
+  "../core/llm/tiktokenWorkerPool.mjs",
+  "../core/llm/llamaTokenizerWorkerPool.mjs",
+];
+validateFilesPresent(filesToValidate);
+
+// Quick Build
+(async () => {
+  console.log("[info] Building with esbuild...");
+  await esbuild.build({
+    entryPoints: ["src/index.ts"],
+    bundle: true,
+    outfile: esbuildOutputFile,
+    external: [
+      "esbuild",
+      "./xhr-sync-worker.js",
+      "llamaTokenizerWorkerPool.mjs",
+      "tiktokenWorkerPool.mjs",
+      "vscode",
+      "./index.node",
+    ],
+    format: "cjs",
+    platform: "node",
+    sourcemap: true,
+    minify: true,
+    treeShaking: true,
+    loader: { ".node": "file" },
+    inject: ["./importMetaUrl.js"],
+    define: { "import.meta.url": "importMetaUrl" },
+  });
+
+  console.log("[info] Building binaries with pkg...");
+  for (const target of targets) {
+    const targetDir = path.join(bin, target);
+    fs.mkdirSync(targetDir, { recursive: true });
+    console.log(`[info] Building ${target}...`);
+    execCmdSync(
+      `npx pkg --no-bytecode --public-packages "*" --public pkgJson/${target} --out-path ${targetDir}`,
+    );
+  }
+
+  // Validate only continue-binary files
+  const pathsToVerify = targets.map((target) => {
+    const exe = target.startsWith("win") ? ".exe" : "";
+    return path.join(bin, target, `continue-binary${exe}`);
+  });
+  validateFilesPresent(pathsToVerify);
+
+  console.log("[info] Quick build completed!");
+})();


### PR DESCRIPTION
## Description
Additional binary script `quick-build` that 
- Skips the steps that download and copy non-esbuild/node binary files, including sqlite, lancedb, etc., and instead validates they are present up front
- only clears the target `continue-binary${exe}`s instead of all `build` `out` etc.
- just builds the binary and validates it is present at the end

To save time, have a binary script that doesn't need network requests