### PR TITLE
Fix: Use cheerio parser instead of JSDOM for docs

### DIFF
--- a/core/indexing/docs/article.ts
+++ b/core/indexing/docs/article.ts
@@ -1,5 +1,6 @@
 import { Readability } from "@mozilla/readability";
 import { JSDOM } from "jsdom";
+import * as cheerio from "cheerio";
 
 import { Chunk } from "../../";
 import { cleanFragment, cleanHeader, markdownChunker } from "../chunk/markdown";
@@ -141,18 +142,19 @@ export async function htmlPageToArticleWithChunks(
 
     const title = readability.title || subpath;
 
-    const titles = Array.from(dom.window.document.querySelectorAll("h2"));
-
+    const $ = cheerio.load(html);
+  
+    const titles = $('h2').toArray();
     const article_components =
       titles.length > 0
         ? titles.map((titleElement) => {
-            const title = titleElement.textContent || "";
+            const title = $(titleElement).text() || "";
             let body = "";
-            let nextSibling = titleElement.nextElementSibling;
+            let nextSibling = $(titleElement).next();
 
-            while (nextSibling && nextSibling.tagName !== "H2") {
-              body += nextSibling.textContent || "";
-              nextSibling = nextSibling.nextElementSibling;
+            while (nextSibling.length && nextSibling[0].tagName !== "h2") {
+              body += nextSibling.text() || "";
+              nextSibling = nextSibling.next();
             }
 
             return { title, body };


### PR DESCRIPTION
Replaces the JSDOM parser for HTML with the cheerio parser.

## Description

The JSDOM parser seems to be faulty in certain environments, causing it to omit major parts of the DOM from the parsed document. The cheerio parser does not have this problem, while offering the required functionality.

The original behavior of JSDOM has been tested on different machines, with varying results. On some machines it works flawlessly, on other machines major parts of the DOM are missing, for almost all HTML documents, making doc indexing unusable. No clear pattern (Node module versions, Node.js version, etc.) between the affected machines has been identified.
The fix using the cheerio parser has been tested on the same machines, working without issue on all of them.

## Checklist

- [X] The relevant docs, if any, have been updated or created (none relevant)
- [ ] The relevant tests, if any, have been updated or created (none relevant)

## Testing instructions

1. Run the extension in debug mode or build and install it from the .vsix file
2. Open the "Continue" blade from the Visual Studio Code sidebar
3. Switch to the "More" tab using the three dots in the top right corner
4. Add a documentation using the "Add" button next to the "@docs indexes" heading
5. Wait for indexing to finish and use the eye symbol next to the documentation index entry to view and validate that the documentation has been indexed correctly

<details>
<summary>Disclaimer</summary>
THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

</details>
