### PR TITLE
Docs + Login fixes

### DIFF
--- a/core/context/providers/DocsContextProvider.ts
+++ b/core/context/providers/DocsContextProvider.ts
@@ -23,7 +23,7 @@ class DocsContextProvider extends BaseContextProvider {
     // Todo: consider a different renderInline so that when multiple docs are referenced in one message,
     // Or the doc has an odd name unrelated to the content
     // The name of the doc itself doesn't skew the embedding results
-    // renderInlineAs: "<docs-context-provider>",
+    renderInlineAs: "",
   };
 
   constructor(options: any) {

--- a/gui/src/components/OnboardingCard/platform/tabs/main.tsx
+++ b/gui/src/components/OnboardingCard/platform/tabs/main.tsx
@@ -19,7 +19,7 @@ export default function MainTab({
   const auth = useAuth();
 
   function onGetStarted() {
-    auth.login(false).then((success) => {
+    auth.login(true).then((success) => {
       if (success) {
         onboardingCard.close(isDialog);
       }

--- a/gui/src/components/OnboardingCard/platform/tabs/main.tsx
+++ b/gui/src/components/OnboardingCard/platform/tabs/main.tsx
@@ -19,7 +19,7 @@ export default function MainTab({
   const auth = useAuth();
 
   function onGetStarted() {
-    auth.login(true).then((success) => {
+    auth.login(false).then((success) => {
       if (success) {
         onboardingCard.close(isDialog);
       }

--- a/gui/src/components/modelSelection/platform/AssistantSelectOptions.tsx
+++ b/gui/src/components/modelSelection/platform/AssistantSelectOptions.tsx
@@ -88,7 +88,7 @@ export function AssistantSelectOptions({
       <div className="mt-auto w-full">
         <OptionDiv
           key={"new-assistant"}
-          onClick={session ? onNewAssistant : () => login(true)}
+          onClick={session ? onNewAssistant : () => login(false)}
         >
           <div
             className="flex items-center py-0.5"

--- a/gui/src/pages/config/index.tsx
+++ b/gui/src/pages/config/index.tsx
@@ -273,7 +273,7 @@ function ConfigPage() {
                                     orgSlug: selectedOrganization?.slug,
                                   });
                                 } else {
-                                  login(true);
+                                  login(false);
                                 }
                               }}
                             >


### PR DESCRIPTION
## Description
- Render docs inline as "" - better retrieval quality experiment
- Don't use `useOnboarding` in extension `login` - unnecessary and causes bug where can't sign into extension if has completed onboarding.