### PR TITLE
Refresh profiles button

### DIFF
--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -353,7 +353,11 @@ export class ConfigHandler {
       Promise.resolve(sessionInfo),
       this.ideSettingsPromise,
     );
-    await this.refreshProfiles();
+    this.fetchControlPlaneProfiles().catch(async (e) => {
+      console.error("Failed to fetch control plane profiles: ", e);
+      await this.updateAvailableProfiles([this.localProfileManager]);
+      await this.reloadConfig();
+    });
   }
 
   private profilesListeners: ((
@@ -432,11 +436,7 @@ export class ConfigHandler {
   }
 
   async refreshProfiles() {
-    this.fetchControlPlaneProfiles().catch(async (e) => {
-      console.error("Failed to fetch control plane profiles: ", e);
-      await this.updateAvailableProfiles([this.localProfileManager]);
-      await this.reloadConfig();
-    });
+    await this.loadAssistantsForSelectedOrg();
   }
 
   async loadConfig(): Promise<ConfigResult<ContinueConfig>> {

--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -353,11 +353,7 @@ export class ConfigHandler {
       Promise.resolve(sessionInfo),
       this.ideSettingsPromise,
     );
-    this.fetchControlPlaneProfiles().catch(async (e) => {
-      console.error("Failed to fetch control plane profiles: ", e);
-      await this.updateAvailableProfiles([this.localProfileManager]);
-      await this.reloadConfig();
-    });
+    await this.refreshProfiles();
   }
 
   private profilesListeners: ((
@@ -433,6 +429,14 @@ export class ConfigHandler {
 
   listProfiles(): ProfileDescription[] | null {
     return this.profiles?.map((p) => p.profileDescription) ?? null;
+  }
+
+  async refreshProfiles() {
+    this.fetchControlPlaneProfiles().catch(async (e) => {
+      console.error("Failed to fetch control plane profiles: ", e);
+      await this.updateAvailableProfiles([this.localProfileManager]);
+      await this.reloadConfig();
+    });
   }
 
   async loadConfig(): Promise<ConfigResult<ContinueConfig>> {

--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -435,10 +435,6 @@ export class ConfigHandler {
     return this.profiles?.map((p) => p.profileDescription) ?? null;
   }
 
-  async refreshProfiles() {
-    await this.loadAssistantsForSelectedOrg();
-  }
-
   async loadConfig(): Promise<ConfigResult<ContinueConfig>> {
     if (!this.currentProfile) {
       return {

--- a/core/core.ts
+++ b/core/core.ts
@@ -306,6 +306,10 @@ export class Core {
       return this.configHandler.listProfiles();
     });
 
+    on("config/refreshProfiles", async (msg) => {
+      await this.configHandler.refreshProfiles();
+    });
+
     on("config/addContextProvider", async (msg) => {
       addContextProvider(msg.data, this.configHandler);
     });

--- a/core/core.ts
+++ b/core/core.ts
@@ -307,7 +307,7 @@ export class Core {
     });
 
     on("config/refreshProfiles", async (msg) => {
-      await this.configHandler.refreshProfiles();
+      await this.configHandler.loadAssistantsForSelectedOrg();
     });
 
     on("config/addContextProvider", async (msg) => {

--- a/core/protocol/core.ts
+++ b/core/protocol/core.ts
@@ -69,6 +69,7 @@ export type ToCoreFromIdeOrWebviewProtocol = {
   "config/addContextProvider": [ContextProviderWithParams, void];
   "config/reload": [undefined, ConfigResult<BrowserSerializedContinueConfig>];
   "config/listProfiles": [undefined, ProfileDescription[] | null];
+  "config/refreshProfiles": [undefined, void];
   "config/openProfile": [{ profileId: string | undefined }, void];
   "config/updateSharedConfig": [SharedConfigSchema, SharedConfigSchema];
   "config/updateSelectedModel": [

--- a/core/protocol/passThrough.ts
+++ b/core/protocol/passThrough.ts
@@ -22,6 +22,7 @@ export const WEBVIEW_TO_CORE_PASS_THROUGH: (keyof ToCoreFromWebviewProtocol)[] =
     "config/getSerializedProfileInfo",
     "config/deleteModel",
     "config/listProfiles",
+    "config/refreshProfiles",
     "config/openProfile",
     "config/updateSharedConfig",
     "config/updateSelectedModel",

--- a/docs/docs/yaml-reference.md
+++ b/docs/docs/yaml-reference.md
@@ -69,7 +69,7 @@ Note that hub secrets can be passed as inputs, using the a similar mustache form
 
 ### Overrides
 
-Block properties can be also be directly overriden using `overrides`. For example:
+Block properties can be also be directly overriden using `override`. For example:
 
 ```yaml title="Assistant config.yaml"
 name: myprofile/custom-assistant
@@ -78,7 +78,7 @@ models:
     with:
       ANTHROPIC_API_KEY: ${{ secrets.MY_ANTHROPIC_API_KEY }}
       TEMP: 0.9
-    overrides:
+    override:
       roles:
         - chat
 ```
@@ -350,7 +350,7 @@ models:
   - uses: anthropic/claude-3.5-sonnet
     with:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-    overrides:
+    override:
       defaultCompletionOptions:
         temperature: 0.8
   - name: GPT-4

--- a/docs/docs/yaml-reference.md
+++ b/docs/docs/yaml-reference.md
@@ -435,26 +435,26 @@ model_defaults: &model_defaults
   apiBase: https://api.example.com/llm
 
 models:
-- name: mistral
-  <<: *model_defaults
-  model: mistral-7b-instruct
-  roles:
-    - chat
-    - edit
+  - name: mistral
+    <<: *model_defaults
+    model: mistral-7b-instruct
+    roles:
+      - chat
+      - edit
 
-- name: qwen2.5-coder-7b-instruct
-  <<: *model_defaults
-  model: qwen2.5-coder-7b-instruct
-  roles:
-    - chat
-    - edit
+  - name: qwen2.5-coder-7b-instruct
+    <<: *model_defaults
+    model: qwen2.5-coder-7b-instruct
+    roles:
+      - chat
+      - edit
 
-- name: qwen2.5-coder-7b
-  <<: *model_defaults
-  model: qwen2.5-coder-7b
-  useLegacyCompletionsEndpoint: false
-  roles:
-    - autocomplete
+  - name: qwen2.5-coder-7b
+    <<: *model_defaults
+    model: qwen2.5-coder-7b
+    useLegacyCompletionsEndpoint: false
+    roles:
+      - autocomplete
 ```
 
 ### Fully deprecated settings

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/MessageTypes.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/MessageTypes.kt
@@ -89,6 +89,7 @@ class MessageTypes {
             "config/getSerializedProfileInfo",
             "config/deleteModel",
             "config/listProfiles",
+            "config/refreshProfiles",
             "config/openProfile",
             "config/updateSharedConfig",
             "config/updateSelectedModel",

--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -126,7 +126,7 @@ function InputToolbar(props: InputToolbarProps) {
                       }
                     }}
                   />
-                  <HoverItem>
+                  <HoverItem className="">
                     <PhotoIcon
                       className="h-4 w-4 hover:brightness-125"
                       data-tooltip-id="image-tooltip"
@@ -160,7 +160,7 @@ function InputToolbar(props: InputToolbarProps) {
         <div className="flex items-center gap-2 whitespace-nowrap text-gray-400">
           {!props.toolbarOptions?.hideUseCodebase && !isInEditMode && (
             <div
-              className={`${toolsSupported ? "md:flex" : "sm:flex"} hover:underline" hidden transition-colors duration-200`}
+              className={`${toolsSupported ? "md:flex" : "int:flex"} hover:underline" hidden transition-colors duration-200`}
             >
               {props.activeKey === "Alt" ? (
                 <HoverItem className="underline">

--- a/gui/src/context/Auth.tsx
+++ b/gui/src/context/Auth.tsx
@@ -27,6 +27,7 @@ interface AuthContextType {
   login: (useOnboarding: boolean) => Promise<boolean>;
   selectedProfile: ProfileDescription | null;
   profiles: ProfileDescription[] | null;
+  refreshProfiles: () => void;
   controlServerBetaEnabled: boolean;
   organizations: OrganizationDescription[];
   selectedOrganization: OrganizationDescription | null;
@@ -175,6 +176,14 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     });
   }, []);
 
+  const refreshProfiles = () => {
+    try {
+      ideMessenger.post("config/refreshProfiles", undefined);
+    } catch (e) {
+      console.error("Failed to refresh profiles", e);
+    }
+  };
+
   useWebviewListener(
     "didChangeAvailableProfiles",
     async (data) => {
@@ -196,6 +205,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         login,
         selectedProfile,
         profiles,
+        refreshProfiles,
         selectedOrganization,
         organizations: orgs,
         controlServerBetaEnabled,

--- a/gui/src/context/Auth.tsx
+++ b/gui/src/context/Auth.tsx
@@ -176,11 +176,13 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     });
   }, []);
 
-  const refreshProfiles = () => {
+  const refreshProfiles = async () => {
     try {
-      ideMessenger.post("config/refreshProfiles", undefined);
+      await ideMessenger.request("config/refreshProfiles", undefined);
+      ideMessenger.post("showToast", ["info", "Config refreshed"]);
     } catch (e) {
       console.error("Failed to refresh profiles", e);
+      ideMessenger.post("showToast", ["error", "Failed to refresh config"]);
     }
   };
 

--- a/gui/src/pages/config/index.tsx
+++ b/gui/src/pages/config/index.tsx
@@ -42,6 +42,7 @@ function ConfigPage() {
     selectedProfile,
     controlServerBetaEnabled,
     selectedOrganization,
+    refreshProfiles,
   } = useAuth();
 
   const changeProfileId = (id: string) => {
@@ -296,6 +297,14 @@ function ConfigPage() {
                         ? "Open Assistant"
                         : "Open Workspace"}
                   </SecondaryButton>
+                )}
+                {hubEnabled && session && (
+                  <div className="flex flex-col gap-1">
+                    <span>{`If your hub secret values may have changed, refresh your assistants`}</span>
+                    <SecondaryButton onClick={refreshProfiles}>
+                      Refresh assistants
+                    </SecondaryButton>
+                  </div>
                 )}
               </>
             ) : (

--- a/gui/src/pages/config/index.tsx
+++ b/gui/src/pages/config/index.tsx
@@ -42,7 +42,6 @@ function ConfigPage() {
     selectedProfile,
     controlServerBetaEnabled,
     selectedOrganization,
-    refreshProfiles,
   } = useAuth();
 
   const changeProfileId = (id: string) => {
@@ -298,14 +297,14 @@ function ConfigPage() {
                         : "Open Workspace"}
                   </SecondaryButton>
                 )}
-                {hubEnabled && session && (
+                {/* {hubEnabled && session && (
                   <div className="flex flex-col gap-1">
                     <span>{`If your hub secret values may have changed, refresh your assistants`}</span>
                     <SecondaryButton onClick={refreshProfiles}>
                       Refresh assistants
                     </SecondaryButton>
                   </div>
-                )}
+                )} */}
               </>
             ) : (
               <div>Loading...</div>

--- a/gui/src/pages/config/index.tsx
+++ b/gui/src/pages/config/index.tsx
@@ -224,70 +224,76 @@ function ConfigPage() {
             <h2 className="mb-1 mt-0">Configuration</h2>
             {profiles ? (
               <>
-                <Listbox value={selectedProfile?.id} onChange={changeProfileId}>
-                  {({ open }) => (
-                    <div className="relative w-full">
-                      <Listbox.Button className="border-vsc-input-border bg-vsc-background hover:bg-vsc-input-background text-vsc-foreground relative m-0 flex w-full cursor-pointer items-center justify-between rounded-md border border-solid px-3 py-2 text-left">
-                        <span className="lines lines-1">
-                          {selectedProfile?.title ?? "No Assistant Selected"}
-                        </span>
-                        <div className="pointer-events-none flex items-center">
-                          <ChevronUpDownIcon
-                            className="h-5 w-5"
-                            aria-hidden="true"
-                          />
-                        </div>
-                      </Listbox.Button>
+                <div className="flex flex-col gap-1.5">
+                  <span className="text-lightgray">{`${hubEnabled ? "Assistant" : "Profile"}`}</span>
+                  <Listbox
+                    value={selectedProfile?.id}
+                    onChange={changeProfileId}
+                  >
+                    {({ open }) => (
+                      <div className="relative w-full">
+                        <Listbox.Button className="border-vsc-input-border bg-vsc-background hover:bg-vsc-input-background text-vsc-foreground relative m-0 flex w-full cursor-pointer items-center justify-between rounded-md border border-solid px-3 py-2 text-left">
+                          <span className="lines lines-1">
+                            {selectedProfile?.title ?? "No Assistant Selected"}
+                          </span>
+                          <div className="pointer-events-none flex items-center">
+                            <ChevronUpDownIcon
+                              className="h-5 w-5"
+                              aria-hidden="true"
+                            />
+                          </div>
+                        </Listbox.Button>
 
-                      <Transition
-                        as={Fragment}
-                        show={open}
-                        enter="transition ease-out duration-100"
-                        enterFrom="transform opacity-0 scale-95"
-                        enterTo="transform opacity-100 scale-100"
-                        leave="transition ease-in duration-75"
-                        leaveFrom="transform opacity-100 scale-100"
-                        leaveTo="transform opacity-0 scale-95"
-                      >
-                        <Listbox.Options className="bg-vsc-background max-h-80vh absolute z-50 mt-0.5 w-full overflow-y-scroll rounded-sm p-0">
-                          {profiles.map((option, idx) => (
-                            <Listbox.Option
-                              key={idx}
-                              value={option.id}
-                              className={`text-vsc-foreground hover:text-list-active-foreground flex cursor-pointer flex-row items-center gap-3 px-3 py-2 ${selectedProfile?.id === option.id ? "bg-list-active" : "bg-vsc-input-background"}`}
-                            >
-                              <span className="lines lines-1 relative flex h-5 items-center justify-between gap-3 pr-2 text-xs">
-                                {option.title}
-                              </span>
-                            </Listbox.Option>
-                          ))}
-                          {hubEnabled && (
-                            <Listbox.Option
-                              key={"no-profiles"}
-                              value={null}
-                              className={`text-vsc-foreground hover:bg-list-active bg-vsc-input-background flex cursor-pointer flex-row items-center gap-2 px-3 py-2`}
-                              onClick={() => {
-                                if (session) {
-                                  ideMessenger.post("controlPlane/openUrl", {
-                                    path: "new",
-                                    orgSlug: selectedOrganization?.slug,
-                                  });
-                                } else {
-                                  login(false);
-                                }
-                              }}
-                            >
-                              <PlusCircleIcon className="h-4 w-4" />
-                              <span className="lines lines-1 flex items-center justify-between text-xs">
-                                Create new Assistant
-                              </span>
-                            </Listbox.Option>
-                          )}
-                        </Listbox.Options>
-                      </Transition>
-                    </div>
-                  )}
-                </Listbox>
+                        <Transition
+                          as={Fragment}
+                          show={open}
+                          enter="transition ease-out duration-100"
+                          enterFrom="transform opacity-0 scale-95"
+                          enterTo="transform opacity-100 scale-100"
+                          leave="transition ease-in duration-75"
+                          leaveFrom="transform opacity-100 scale-100"
+                          leaveTo="transform opacity-0 scale-95"
+                        >
+                          <Listbox.Options className="bg-vsc-background max-h-80vh absolute z-50 mt-0.5 w-full overflow-y-scroll rounded-sm p-0">
+                            {profiles.map((option, idx) => (
+                              <Listbox.Option
+                                key={idx}
+                                value={option.id}
+                                className={`text-vsc-foreground hover:text-list-active-foreground flex cursor-pointer flex-row items-center gap-3 px-3 py-2 ${selectedProfile?.id === option.id ? "bg-list-active" : "bg-vsc-input-background"}`}
+                              >
+                                <span className="lines lines-1 relative flex h-5 items-center justify-between gap-3 pr-2 text-xs">
+                                  {option.title}
+                                </span>
+                              </Listbox.Option>
+                            ))}
+                            {hubEnabled && (
+                              <Listbox.Option
+                                key={"no-profiles"}
+                                value={null}
+                                className={`text-vsc-foreground hover:bg-list-active bg-vsc-input-background flex cursor-pointer flex-row items-center gap-2 px-3 py-2`}
+                                onClick={() => {
+                                  if (session) {
+                                    ideMessenger.post("controlPlane/openUrl", {
+                                      path: "new",
+                                      orgSlug: selectedOrganization?.slug,
+                                    });
+                                  } else {
+                                    login(false);
+                                  }
+                                }}
+                              >
+                                <PlusCircleIcon className="h-4 w-4" />
+                                <span className="lines lines-1 flex items-center justify-between text-xs">
+                                  Create new Assistant
+                                </span>
+                              </Listbox.Option>
+                            )}
+                          </Listbox.Options>
+                        </Transition>
+                      </div>
+                    )}
+                  </Listbox>
+                </div>
                 {selectedProfile && (
                   <SecondaryButton onClick={handleOpenConfig}>
                     {selectedProfile.id === "local"
@@ -310,9 +316,7 @@ function ConfigPage() {
               <div>Loading...</div>
             )}
             <div>
-              <h2 className="m-0 mb-3 p-0 text-center text-sm">
-                Active Models
-              </h2>
+              <h2 className="m-0 mb-3 p-0 text-center text-sm">Model Roles</h2>
               <div className="grid grid-cols-1 gap-x-3 gap-y-2 sm:grid-cols-[auto_1fr]">
                 <ModelRoleSelector
                   displayName="Chat"

--- a/gui/src/pages/gui/Chat.tsx
+++ b/gui/src/pages/gui/Chat.tsx
@@ -111,7 +111,7 @@ const StepsDiv = styled.div`
   }
 
   .thread-message {
-    margin: 0px 4px 0 4px;
+    margin: 0px 0px 0px 1px;
   }
 `;
 

--- a/gui/src/pages/gui/StreamError.tsx
+++ b/gui/src/pages/gui/StreamError.tsx
@@ -160,7 +160,7 @@ const StreamErrorDialog = ({ error }: StreamErrorProps) => {
             <div className="flex flex-col gap-1">
               <span>{`If your hub secret values may have changed, refresh your assistants`}</span>
               <SecondaryButton onClick={handleRefreshProfiles}>
-                Refresh profile secrets
+                Refresh assistant secrets
               </SecondaryButton>
             </div>
           )}

--- a/gui/src/pages/gui/StreamError.tsx
+++ b/gui/src/pages/gui/StreamError.tsx
@@ -1,14 +1,17 @@
-import { Cog8ToothIcon, ListBulletIcon } from "@heroicons/react/24/outline";
-import { useAppDispatch, useAppSelector } from "../../redux/hooks";
-import { useContext } from "react";
-import { GithubIcon } from "../../components/svg/GithubIcon";
-import { DiscordIcon } from "../../components/svg/DiscordIcon";
-import { IdeMessengerContext } from "../../context/IdeMessenger";
+import { Cog8ToothIcon } from "@heroicons/react/24/outline";
 import { DISCORD_LINK, GITHUB_LINK } from "core/util/constants";
-import { selectDefaultModel } from "../../redux/slices/configSlice";
-import { providers } from "../AddNewModel/configs/providers";
+import { useContext } from "react";
 import { Button, SecondaryButton } from "../../components";
+import { DiscordIcon } from "../../components/svg/DiscordIcon";
+import { GithubIcon } from "../../components/svg/GithubIcon";
+import { useAuth } from "../../context/Auth";
+import { IdeMessengerContext } from "../../context/IdeMessenger";
+import { useAppDispatch, useAppSelector } from "../../redux/hooks";
+import { selectUseHub } from "../../redux/selectors";
+import { selectDefaultModel } from "../../redux/slices/configSlice";
 import { setDialogMessage, setShowDialog } from "../../redux/slices/uiSlice";
+import { isLocalProfile } from "../../util";
+import { providers } from "../AddNewModel/configs/providers";
 
 interface StreamErrorProps {
   error: unknown;
@@ -17,6 +20,11 @@ const StreamErrorDialog = ({ error }: StreamErrorProps) => {
   const dispatch = useAppDispatch();
   const ideMessenger = useContext(IdeMessengerContext);
   const selectedModel = useAppSelector(selectDefaultModel);
+  const hubEnabled = useAppSelector(selectUseHub);
+  const selectedProfile = useAppSelector(
+    (store) => store.session.selectedProfile,
+  );
+  const { session, refreshProfiles } = useAuth();
 
   // Collect model information to display useful error info
   let modelTitle = "Chat model";
@@ -139,7 +147,18 @@ const StreamErrorDialog = ({ error }: StreamErrorProps) => {
   if (statusCode === 401) {
     errorContent = (
       <div className="flex flex-col gap-2">
-        <span>{`Likely cause: your API key is invalid.`}</span>
+        {hubEnabled &&
+          session &&
+          selectedProfile &&
+          !isLocalProfile(selectedProfile) && (
+            <div>
+              <span>{`If your hub secret values may have changed, refresh your profiles`}</span>
+              <SecondaryButton onClick={refreshProfiles}>
+                Refresh profile secrets
+              </SecondaryButton>
+            </div>
+          )}
+        <span>{`It's possible that your API key is invalid.`}</span>
         <div className="flex flex-row flex-wrap gap-2">
           {checkKeysButton}
           {configButton}

--- a/gui/src/pages/gui/StreamError.tsx
+++ b/gui/src/pages/gui/StreamError.tsx
@@ -26,6 +26,12 @@ const StreamErrorDialog = ({ error }: StreamErrorProps) => {
   );
   const { session, refreshProfiles } = useAuth();
 
+  const handleRefreshProfiles = () => {
+    refreshProfiles();
+    dispatch(setShowDialog(false));
+    dispatch(setDialogMessage(undefined));
+  };
+
   // Collect model information to display useful error info
   let modelTitle = "Chat model";
   let providerName = "the model provider";
@@ -151,9 +157,9 @@ const StreamErrorDialog = ({ error }: StreamErrorProps) => {
           session &&
           selectedProfile &&
           !isLocalProfile(selectedProfile) && (
-            <div>
-              <span>{`If your hub secret values may have changed, refresh your profiles`}</span>
-              <SecondaryButton onClick={refreshProfiles}>
+            <div className="flex flex-col gap-1">
+              <span>{`If your hub secret values may have changed, refresh your assistants`}</span>
+              <SecondaryButton onClick={handleRefreshProfiles}>
                 Refresh profile secrets
               </SecondaryButton>
             </div>

--- a/gui/tailwind.config.cjs
+++ b/gui/tailwind.config.cjs
@@ -13,6 +13,7 @@ module.exports = {
       "2xs": "170px", // Smallest width for Primary Sidebar in VS Code
       xs: "250px", // Avg default sidebar width in VS Code
       sm: "330px",
+      int: "380px",
       md: "460px",
       lg: "590px",
       xl: "720px",


### PR DESCRIPTION
## Description
Quick way to allow users to refresh their assistants in the case secret values change in the hub

401 stream error dialog:

<img width="302" alt="image" src="https://github.com/user-attachments/assets/ffa905f0-a536-4f93-a25b-dabe8f877aac" />

Other small fixes on this PR:
- thread message spacing: inputs had more x padding than responses in chat
- input enter pushed off screen
- assistant selector label
- overrides -> override in docs
