### PR TITLE
Fix renderInlineAs

### DIFF
--- a/binary/package-lock.json
+++ b/binary/package-lock.json
@@ -48,7 +48,7 @@
         "@aws-sdk/client-sagemaker-runtime": "^3.621.0",
         "@aws-sdk/credential-providers": "^3.620.1",
         "@continuedev/config-types": "^1.0.13",
-        "@continuedev/config-yaml": "^1.0.50",
+        "@continuedev/config-yaml": "^1.0.52",
         "@continuedev/fetch": "^1.0.4",
         "@continuedev/llm-info": "^1.0.2",
         "@continuedev/openai-adapters": "^1.0.10",

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "1.1.0",
+      "version": "1.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/fetch": "^1.0.3",

--- a/gui/src/context/SubmenuContextProviders.tsx
+++ b/gui/src/context/SubmenuContextProviders.tsx
@@ -274,10 +274,12 @@ export const SubmenuContextProvidersProvider = ({
               }
               const submenuItems = result.content;
               const providerTitle = description.title;
+              const renderInlineAs = description.renderInlineAs;
 
               const itemsWithProvider = submenuItems.map((item) => ({
                 ...item,
                 providerTitle,
+                renderInlineAs
               }));
 
               const minisearch = new MiniSearch<ContextSubmenuItemWithProvider>(


### PR DESCRIPTION
## Description

Fixed `renderInlineAs` which was not working on the custom context providers or the HTTP context provider.

## Checklist

N/A

## Screenshots

N/A

## Testing instructions

In my case, since I use a custom context provider that makes an API call with the `fullInput` variable, I can see that before it would send the prompt with the context provider name despite me setting `renderInlineAs` to an empty string, and with the change, both my custom context provider and the HTTP context provider now send the value as configured, instead of the null value that was sent before.
