### PR TITLE
feat: add Claude 3.7 support to toolSupport.ts

### DIFF
--- a/core/llm/toolSupport.ts
+++ b/core/llm/toolSupport.ts
@@ -3,13 +3,13 @@ export const PROVIDER_TOOL_SUPPORT: Record<
   (model: string) => boolean | undefined
 > = {
   "continue-proxy": (model) => {
-    return ["claude-3-5", "claude-3.5", "gpt-4", "o3", "gemini"].some((part) =>
+    return ["claude-3-5", "claude-3.5", "claude-3-7", "claude-3.7", "gpt-4", "o3", "gemini"].some((part) =>
       model.toLowerCase().startsWith(part),
     );
   },
   anthropic: (model) => {
     if (
-      ["claude-3-5", "claude-3.5"].some((part) =>
+      ["claude-3-5", "claude-3.5", "claude-3-7", "claude-3.7"].some((part) =>
         model.toLowerCase().startsWith(part),
       )
     ) {


### PR DESCRIPTION
## Description

Added support for the Claude 3.7 model in the PROVIDER_TOOL_SUPPORT function within toolSupport.ts. The checks for the continue-proxy and anthropic providers now include claude-3.7, ensuring proper recognition of this model.

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

