### PR TITLE
fix @folder not limiting context items to selected folder in reranking pipeline

### DIFF
--- a/core/context/retrieval/pipelines/RerankerRetrievalPipeline.ts
+++ b/core/context/retrieval/pipelines/RerankerRetrievalPipeline.ts
@@ -41,7 +41,7 @@ export default class RerankerRetrievalPipeline extends BaseRetrievalPipeline {
     if (filterDirectory) {
       // Backup if the individual retrieval methods don't listen
       retrievalResults = retrievalResults.filter(
-        (chunk) => !!findUriInDirs(chunk.filepath, [filterDirectory]),
+        (chunk) => !!findUriInDirs(chunk.filepath, [filterDirectory]).foundInDir,
       );
     }
 


### PR DESCRIPTION
## Description

- Fix for the following issue: when using reranking, @folder is selecting context items from outside the selected folder due to bug in retrieval results filtering function in reranking pipeline

## Checklist

- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created
