### PR TITLE
Fix a typo in the documentation

### DIFF
--- a/docs/docs/customize/model-roles/edit.mdx
+++ b/docs/docs/customize/model-roles/edit.mdx
@@ -45,4 +45,4 @@ In Continue, you can add `edit` to a model's roles to specify that it can be use
   </TabItem>
 </Tabs>
 
-Explore edit models in [the hub](https://hub.continue.dev/explore/models?roles=edit). Generally, we our recommendations for Edit overlap with recommendations for Chat.
+Explore edit models in [the hub](https://hub.continue.dev/explore/models?roles=edit). Generally, our recommendations for Edit overlap with recommendations for Chat.


### PR DESCRIPTION
## Description

Fixed a typo in the documentation

## Checklist

- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created