### PR TITLE
Feat{bedrock}: Enable Tools Support for Claude 3.7

### DIFF
--- a/core/llm/llms/Bedrock.ts
+++ b/core/llm/llms/Bedrock.ts
@@ -13,6 +13,7 @@ import {
 } from "../../index.js";
 import { renderChatMessage } from "../../util/messageContent.js";
 import { BaseLLM } from "../index.js";
+import { PROVIDER_TOOL_SUPPORT } from "../toolSupport.js";
 
 interface ModelConfig {
   formatPayload: (text: string) => any;
@@ -199,12 +200,12 @@ class Bedrock extends BaseLLM {
   ): any {
     const convertedMessages = this._convertMessages(messages);
 
-    const isClaudeModel = options.model?.toLowerCase().includes("claude");
+    const supportsTools = PROVIDER_TOOL_SUPPORT.bedrock?.(options.model || "") ?? false;
     return {
       modelId: options.model,
       messages: convertedMessages,
       system: this.systemMessage ? [{ text: this.systemMessage }] : undefined,
-      toolConfig: isClaudeModel && options.tools ? {
+      toolConfig: supportsTools && options.tools ? {
         tools: options.tools.map(tool => ({
           toolSpec: {
             name: tool.function.name,

--- a/core/llm/toolSupport.test.ts
+++ b/core/llm/toolSupport.test.ts
@@ -1,0 +1,195 @@
+// core/llm/toolSupport.test.ts
+import { PROVIDER_TOOL_SUPPORT } from "./toolSupport";
+
+describe("PROVIDER_TOOL_SUPPORT", () => {
+  describe("continue-proxy", () => {
+    const supportsFn = PROVIDER_TOOL_SUPPORT["continue-proxy"];
+
+    it("should return true for Claude 3.5 models", () => {
+      expect(supportsFn("claude-3-5-sonnet")).toBe(true);
+      expect(supportsFn("claude-3.5-sonnet")).toBe(true);
+    });
+
+    it("should return true for Claude 3.7 models", () => {
+      expect(supportsFn("claude-3-7-haiku")).toBe(true);
+      expect(supportsFn("claude-3.7-sonnet")).toBe(true);
+    });
+
+    it("should return true for GPT-4 models", () => {
+      expect(supportsFn("gpt-4-turbo")).toBe(true);
+      expect(supportsFn("gpt-4-1106-preview")).toBe(true);
+    });
+
+    it("should return true for O3 models", () => {
+      expect(supportsFn("o3-preview")).toBe(true);
+    });
+
+    it("should return true for Gemini models", () => {
+      expect(supportsFn("gemini-pro")).toBe(true);
+      expect(supportsFn("gemini-1.5-pro")).toBe(true);
+    });
+
+    it("should return false for unsupported models", () => {
+      expect(supportsFn("gpt-3.5-turbo")).toBe(false);
+      expect(supportsFn("claude-2")).toBe(false);
+      expect(supportsFn("llama-3")).toBe(false);
+    });
+
+    it("should handle case insensitivity", () => {
+      expect(supportsFn("CLAUDE-3-5-sonnet")).toBe(true);
+      expect(supportsFn("GPT-4-turbo")).toBe(true);
+      expect(supportsFn("GEMINI-pro")).toBe(true);
+    });
+  });
+
+  describe("anthropic", () => {
+    const supportsFn = PROVIDER_TOOL_SUPPORT["anthropic"];
+
+    it("should return true for Claude 3.5 models", () => {
+      expect(supportsFn("claude-3-5-sonnet")).toBe(true);
+      expect(supportsFn("claude-3.5-haiku")).toBe(true);
+    });
+
+    it("should return true for Claude 3.7 models", () => {
+      expect(supportsFn("claude-3-7-haiku")).toBe(true);
+      expect(supportsFn("claude-3.7-sonnet")).toBe(true);
+    });
+
+    it("should return undefined for unsupported models", () => {
+      expect(supportsFn("claude-2")).toBeUndefined();
+      expect(supportsFn("claude-instant")).toBeUndefined();
+    });
+
+    it("should handle case insensitivity", () => {
+      expect(supportsFn("CLAUDE-3-5-sonnet")).toBe(true);
+      expect(supportsFn("CLAUDE-3.7-haiku")).toBe(true);
+    });
+  });
+
+  describe("openai", () => {
+    const supportsFn = PROVIDER_TOOL_SUPPORT["openai"];
+
+    it("should return true for GPT-4 models", () => {
+      expect(supportsFn("gpt-4")).toBe(true);
+      expect(supportsFn("gpt-4-turbo")).toBe(true);
+      expect(supportsFn("gpt-4-1106-preview")).toBe(true);
+    });
+
+    it("should return true for O3 models", () => {
+      expect(supportsFn("o3")).toBe(true);
+      expect(supportsFn("o3-preview")).toBe(true);
+    });
+
+    it("should return undefined for unsupported models", () => {
+      expect(supportsFn("gpt-3.5-turbo")).toBeUndefined();
+      expect(supportsFn("davinci")).toBeUndefined();
+    });
+
+    it("should handle case insensitivity", () => {
+      expect(supportsFn("GPT-4-turbo")).toBe(true);
+      expect(supportsFn("O3-preview")).toBe(true);
+    });
+  });
+
+  describe("gemini", () => {
+    const supportsFn = PROVIDER_TOOL_SUPPORT["gemini"];
+
+    it("should return true for all Gemini models", () => {
+      expect(supportsFn("gemini-pro")).toBe(true);
+      expect(supportsFn("gemini-1.5-pro")).toBe(true);
+      expect(supportsFn("gemini-ultra")).toBe(true);
+    });
+
+    it("should return false for non-Gemini models", () => {
+      expect(supportsFn("gpt-4")).toBe(false);
+      expect(supportsFn("claude-3")).toBe(false);
+    });
+
+    it("should handle case insensitivity", () => {
+      expect(supportsFn("GEMINI-pro")).toBe(true);
+      expect(supportsFn("Gemini-1.5-Pro")).toBe(true);
+    });
+  });
+
+  describe("bedrock", () => {
+    const supportsFn = PROVIDER_TOOL_SUPPORT["bedrock"];
+
+    it("should return true for Claude 3.5 models", () => {
+      expect(supportsFn("anthropic.claude-3-5-sonnet-20240620-v1:0")).toBe(true);
+      expect(supportsFn("amazon.claude-3.5-sonnet-20240620-v1:0")).toBe(true);
+    });
+
+    it("should return true for Claude 3.7 models", () => {
+      expect(supportsFn("anthropic.claude-3-7-haiku-20240620-v1:0")).toBe(true);
+      expect(supportsFn("amazon.claude-3.7-sonnet-20240620-v1:0")).toBe(true);
+    });
+
+    it("should return undefined for unsupported models", () => {
+      expect(supportsFn("anthropic.claude-instant-v1")).toBeUndefined();
+      expect(supportsFn("amazon.titan-text-express-v1")).toBeUndefined();
+    });
+
+    it("should handle case insensitivity", () => {
+      expect(supportsFn("ANTHROPIC.CLAUDE-3-5-sonnet-20240620-v1:0")).toBe(true);
+      expect(supportsFn("AMAZON.CLAUDE-3.7-haiku-20240620-v1:0")).toBe(true);
+    });
+  });
+
+  describe("ollama", () => {
+    const supportsFn = PROVIDER_TOOL_SUPPORT["ollama"];
+
+    it("should return true for supported models", () => {
+      expect(supportsFn("llama3.1")).toBe(true);
+      expect(supportsFn("llama3.2-8b")).toBe(true);
+      expect(supportsFn("llama3.3-70b")).toBe(true);
+      expect(supportsFn("qwen2")).toBe(true);
+      expect(supportsFn("mixtral-8x7b")).toBe(true);
+      expect(supportsFn("command-r")).toBe(true);
+      expect(supportsFn("smollm2")).toBe(true);
+      expect(supportsFn("hermes3")).toBe(true);
+      expect(supportsFn("athene-v2")).toBe(true);
+      expect(supportsFn("nemotron-4-340b")).toBe(true);
+      expect(supportsFn("llama3-groq")).toBe(true);
+      expect(supportsFn("granite3")).toBe(true);
+      expect(supportsFn("aya-expanse")).toBe(true);
+      expect(supportsFn("firefunction-v2")).toBe(true);
+      expect(supportsFn("mistral-7b")).toBe(true);
+    });
+
+    it("should return false for explicitly unsupported models", () => {
+      expect(supportsFn("vision")).toBe(false);
+      expect(supportsFn("math")).toBe(false);
+      expect(supportsFn("guard")).toBe(false);
+      expect(supportsFn("mistrallite")).toBe(false);
+      expect(supportsFn("mistral-openorca")).toBe(false);
+    });
+
+    it("should return undefined for other models", () => {
+      expect(supportsFn("llama2")).toBeUndefined();
+      expect(supportsFn("phi-2")).toBeUndefined();
+      expect(supportsFn("falcon")).toBeUndefined();
+    });
+
+    it("should handle case insensitivity", () => {
+      expect(supportsFn("LLAMA3.1")).toBe(true);
+      expect(supportsFn("MIXTRAL-8x7b")).toBe(true);
+      expect(supportsFn("VISION")).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty model names", () => {
+      expect(PROVIDER_TOOL_SUPPORT["continue-proxy"]("")).toBe(false);
+      expect(PROVIDER_TOOL_SUPPORT["anthropic"]("")).toBeUndefined();
+      expect(PROVIDER_TOOL_SUPPORT["openai"]("")).toBeUndefined();
+      expect(PROVIDER_TOOL_SUPPORT["gemini"]("")).toBe(false);
+      expect(PROVIDER_TOOL_SUPPORT["bedrock"]("")).toBeUndefined();
+      expect(PROVIDER_TOOL_SUPPORT["ollama"]("")).toBeUndefined();
+    });
+
+    it("should handle non-existent provider", () => {
+      // @ts-ignore - Testing runtime behavior with invalid provider
+      expect(PROVIDER_TOOL_SUPPORT["non-existent"]).toBeUndefined();
+    });
+  });
+});

--- a/core/llm/toolSupport.test.ts
+++ b/core/llm/toolSupport.test.ts
@@ -114,24 +114,32 @@ describe("PROVIDER_TOOL_SUPPORT", () => {
   describe("bedrock", () => {
     const supportsFn = PROVIDER_TOOL_SUPPORT["bedrock"];
 
-    it("should return true for Claude 3.5 models", () => {
+    it("should return true for Claude 3.5 Sonnet models", () => {
       expect(supportsFn("anthropic.claude-3-5-sonnet-20240620-v1:0")).toBe(true);
-      expect(supportsFn("amazon.claude-3.5-sonnet-20240620-v1:0")).toBe(true);
+      expect(supportsFn("anthropic.claude-3.5-sonnet-20240620-v1:0")).toBe(true);
     });
 
-    it("should return true for Claude 3.7 models", () => {
-      expect(supportsFn("anthropic.claude-3-7-haiku-20240620-v1:0")).toBe(true);
-      expect(supportsFn("amazon.claude-3.7-sonnet-20240620-v1:0")).toBe(true);
+    it("should return true for Claude 3.7 Sonnet models", () => {
+      expect(supportsFn("anthropic.claude-3-7-sonnet-20240620-v1:0")).toBe(true);
+      expect(supportsFn("anthropic.claude-3.7-sonnet-20240620-v1:0")).toBe(true);
     });
 
-    it("should return undefined for unsupported models", () => {
+    it("should return undefined for Claude Haiku and Opus models", () => {
+      expect(supportsFn("anthropic.claude-3-5-haiku-20240307-v1:0")).toBeUndefined();
+      expect(supportsFn("anthropic.claude-3.5-haiku-20240620-v1:0")).toBeUndefined();
+      expect(supportsFn("anthropic.claude-3-7-haiku-20240620-v1:0")).toBeUndefined();
+      expect(supportsFn("anthropic.claude-3-5-opus-20240620-v1:0")).toBeUndefined();
+      expect(supportsFn("anthropic.claude-3.7-opus-20240620-v1:0")).toBeUndefined();
+    });
+
+    it("should return undefined for other unsupported models", () => {
       expect(supportsFn("anthropic.claude-instant-v1")).toBeUndefined();
-      expect(supportsFn("amazon.titan-text-express-v1")).toBeUndefined();
+      expect(supportsFn("anthropic.titan-text-express-v1")).toBeUndefined();
     });
 
     it("should handle case insensitivity", () => {
-      expect(supportsFn("ANTHROPIC.CLAUDE-3-5-sonnet-20240620-v1:0")).toBe(true);
-      expect(supportsFn("AMAZON.CLAUDE-3.7-haiku-20240620-v1:0")).toBe(true);
+      expect(supportsFn("ANTHROPIC.CLAUDE-3-5-SONNET-20240620-v1:0")).toBe(true);
+      expect(supportsFn("ANTHROPIC.CLAUDE-3.7-SONNET-20240620-v1:0")).toBe(true);
     });
   });
 

--- a/core/llm/toolSupport.ts
+++ b/core/llm/toolSupport.ts
@@ -30,9 +30,9 @@ export const PROVIDER_TOOL_SUPPORT: Record<
     return model.toLowerCase().includes("gemini");
   },
   bedrock: (model) => {
-    // Support only Claude 3.5 models on Bedrock, mirroring anthropic configuration
+    // Support Claude 3.5 and 3.7 models on Bedrock, mirroring anthropic configuration
     if (
-      ["claude-3-5", "claude-3.5"].some((part) =>
+      ["claude-3-5", "claude-3.5", "claude-3-7", "claude-3.7"].some((part) =>
         model.toLowerCase().includes(part),
       )
     ) {

--- a/core/llm/toolSupport.ts
+++ b/core/llm/toolSupport.ts
@@ -30,8 +30,9 @@ export const PROVIDER_TOOL_SUPPORT: Record<
     return model.toLowerCase().includes("gemini");
   },
   bedrock: (model) => {
-    // Support Claude 3.5 and 3.7 models on Bedrock, mirroring anthropic configuration
+    // For Bedrock, only support Claude Sonnet models with versions 3.5/3-5 and 3.7/3-7
     if (
+      model.toLowerCase().includes("sonnet") &&
       ["claude-3-5", "claude-3.5", "claude-3-7", "claude-3.7"].some((part) =>
         model.toLowerCase().includes(part),
       )


### PR DESCRIPTION
## Description

Enabling tools support for Claude 3.7 on aws bedrock.

## Checklist

- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing instructions

I've added new tests for toolSupport.ts

I've manually verified that tools support is enabled for claude sonnet 3.5 and claude sonnet 3.7 models, but not claude opus or haiku.
