### PR TITLE
Process thinking blocks for Anthropic with Bedrock provider

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -924,6 +924,8 @@ export interface BaseCompletionOptions {
   prediction?: Prediction;
   tools?: Tool[];
   toolChoice?: ToolChoice;
+  reasoning?: boolean;
+  reasoningBudgetTokens?: number;
 }
 
 export interface ModelCapability {

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -308,7 +308,7 @@ export interface CompletionOptions extends BaseCompletionOptions {
   model: string;
 }
 
-export type ChatMessageRole = "user" | "assistant" | "system" | "tool";
+export type ChatMessageRole = "user" | "assistant" | "thinking" | "system" | "tool";
 
 export type TextMessagePart = {
   type: "text";

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -43,13 +43,13 @@ export interface IndexingProgressUpdate {
   desc: string;
   shouldClearIndexes?: boolean;
   status:
-    | "loading"
-    | "indexing"
-    | "done"
-    | "failed"
-    | "paused"
-    | "disabled"
-    | "cancelled";
+  | "loading"
+  | "indexing"
+  | "done"
+  | "failed"
+  | "paused"
+  | "disabled"
+  | "cancelled";
   debugInfo?: string;
 }
 
@@ -353,6 +353,12 @@ export interface UserChatMessage {
   content: MessageContent;
 }
 
+export interface ThinkingChatMessage {
+  role: "thinking";
+  content: MessageContent;
+  toolCalls?: ToolCallDelta[];
+}
+
 export interface AssistantChatMessage {
   role: "assistant";
   content: MessageContent;
@@ -367,6 +373,7 @@ export interface SystemChatMessage {
 export type ChatMessage =
   | UserChatMessage
   | AssistantChatMessage
+  | ThinkingChatMessage
   | SystemChatMessage
   | ToolResultChatMessage;
 
@@ -675,10 +682,10 @@ export interface IDE {
   getCurrentFile(): Promise<
     | undefined
     | {
-        isUntitled: boolean;
-        path: string;
-        contents: string;
-      }
+      isUntitled: boolean;
+      path: string;
+      contents: string;
+    }
   >;
 
   getLastFileSaveTimestamp?(): number;
@@ -862,11 +869,11 @@ export interface CustomCommand {
 export interface Prediction {
   type: "content";
   content:
-    | string
-    | {
-        type: "text";
-        text: string;
-      }[];
+  | string
+  | {
+    type: "text";
+    text: string;
+  }[];
 }
 
 export interface ToolExtras {
@@ -1204,9 +1211,9 @@ export interface Config {
   embeddingsProvider?: EmbeddingsProviderDescription | ILLM;
   /** The model that Continue will use for tab autocompletions. */
   tabAutocompleteModel?:
-    | CustomLLM
-    | ModelDescription
-    | (CustomLLM | ModelDescription)[];
+  | CustomLLM
+  | ModelDescription
+  | (CustomLLM | ModelDescription)[];
   /** Options for tab autocomplete */
   tabAutocompleteOptions?: Partial<TabAutocompleteOptions>;
   /** UI styles customization */
@@ -1298,9 +1305,9 @@ export type PackageDetailsSuccess = PackageDetails & {
 export type PackageDocsResult = {
   packageInfo: ParsedPackageInfo;
 } & (
-  | { error: string; details?: never }
-  | { details: PackageDetailsSuccess; error?: never }
-);
+    | { error: string; details?: never }
+    | { details: PackageDetailsSuccess; error?: never }
+  );
 
 export interface TerminalOptions {
   reuseTerminal?: boolean;

--- a/core/llm/countTokens.ts
+++ b/core/llm/countTokens.ts
@@ -27,9 +27,9 @@ class LlamaEncoding implements Encoding {
 }
 
 class NonWorkerAsyncEncoder implements AsyncEncoder {
-  constructor(private readonly encoding: Encoding) {}
+  constructor(private readonly encoding: Encoding) { }
 
-  async close(): Promise<void> {}
+  async close(): Promise<void> { }
 
   async encode(text: string): Promise<number[]> {
     return this.encoding.encode(text);
@@ -366,6 +366,7 @@ function chatMessageIsEmpty(message: ChatMessage): boolean {
         message.content.trim() === "" &&
         !message.toolCalls
       );
+    case "thinking":
     case "tool":
       return false;
   }
@@ -383,8 +384,8 @@ function compileChatMessages(
 ): ChatMessage[] {
   let msgsCopy = msgs
     ? msgs
-        .map((msg) => ({ ...msg }))
-        .filter((msg) => !chatMessageIsEmpty(msg) && msg.role !== "system")
+      .map((msg) => ({ ...msg }))
+      .filter((msg) => !chatMessageIsEmpty(msg) && msg.role !== "system")
     : [];
 
   msgsCopy = addSpaceToAnyEmptyMessages(msgsCopy);
@@ -469,5 +470,6 @@ export {
   pruneLinesFromTop,
   pruneRawPromptFromTop,
   pruneStringFromBottom,
-  pruneStringFromTop,
+  pruneStringFromTop
 };
+

--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -181,11 +181,11 @@ export abstract class BaseLLM implements ILLM {
         options.completionOptions?.maxTokens ??
         (llmInfo?.maxCompletionTokens
           ? Math.min(
-              llmInfo.maxCompletionTokens,
-              // Even if the model has a large maxTokens, we don't want to use that every time,
-              // because it takes away from the context length
-              this.contextLength / 4,
-            )
+            llmInfo.maxCompletionTokens,
+            // Even if the model has a large maxTokens, we don't want to use that every time,
+            // because it takes away from the context length
+            this.contextLength / 4,
+          )
           : DEFAULT_MAX_TOKENS),
     };
     this.requestOptions = options.requestOptions;
@@ -811,8 +811,8 @@ export abstract class BaseLLM implements ILLM {
             signal,
             completionOptions,
           )) {
-            completion += chunk.content;
-            yield chunk;
+
+            if (chunk.role === "assistant") {
               completion += chunk.content;
               yield chunk;
             }
@@ -912,7 +912,7 @@ export abstract class BaseLLM implements ILLM {
     );
   }
 
-  protected async *_streamComplete(
+  protected async * _streamComplete(
     prompt: string,
     signal: AbortSignal,
     options: CompletionOptions,
@@ -920,7 +920,7 @@ export abstract class BaseLLM implements ILLM {
     throw new Error("Not implemented");
   }
 
-  protected async *_streamChat(
+  protected async * _streamChat(
     messages: ChatMessage[],
     signal: AbortSignal,
     options: CompletionOptions,

--- a/core/llm/llms/Anthropic.ts
+++ b/core/llm/llms/Anthropic.ts
@@ -32,9 +32,9 @@ class Anthropic extends BaseLLM {
       })),
       tool_choice: options.toolChoice
         ? {
-            type: "tool",
-            name: options.toolChoice.function.name,
-          }
+          type: "tool",
+          name: options.toolChoice.function.name,
+        }
         : undefined,
     };
 
@@ -174,12 +174,12 @@ class Anthropic extends BaseLLM {
         messages: msgs,
         system: shouldCacheSystemMessage
           ? [
-              {
-                type: "text",
-                text: this.systemMessage,
-                cache_control: { type: "ephemeral" },
-              },
-            ]
+            {
+              type: "text",
+              text: this.systemMessage,
+              cache_control: { type: "ephemeral" },
+            },
+          ]
           : systemMessage,
       }),
       signal,
@@ -222,6 +222,9 @@ class Anthropic extends BaseLLM {
           switch (value.delta.type) {
             case "text_delta":
               yield { role: "assistant", content: value.delta.text };
+              break;
+            case "thinking_delta":
+              yield { role: "thinking", content: value.delta.thinking };
               break;
             case "input_json_delta":
               if (!lastToolUseId || !lastToolUseName) {

--- a/core/llm/llms/Bedrock.ts
+++ b/core/llm/llms/Bedrock.ts
@@ -91,11 +91,15 @@ class Bedrock extends BaseLLM {
     );
 
     const input = this._generateConverseInput(messages, options);
+
+    console.log("input", input)
+
     const command = new ConverseStreamCommand(input);
     const response = await client.send(command, { abortSignal: signal });
 
     if (response.stream) {
       for await (const chunk of response.stream) {
+        console.log("chunk", chunk);
         if (chunk.contentBlockDelta?.delta?.text) {
           yield {
             role: "assistant",
@@ -112,7 +116,10 @@ class Bedrock extends BaseLLM {
   ): any {
     const convertedMessages = this._convertMessages(messages);
 
-    return {
+    return options.reasoning ?
+    
+    
+    : {
       modelId: options.model,
       messages: convertedMessages,
       system: this.systemMessage ? [{ text: this.systemMessage }] : undefined,
@@ -120,6 +127,10 @@ class Bedrock extends BaseLLM {
         maxTokens: options.maxTokens,
         temperature: options.temperature,
         topP: options.topP,
+        thinking: options.reasoning ? {
+          "type": "enabled",
+          "budget_tokens": options.reasoningBudgetTokens || 1024
+        } : undefined,
         // TODO: The current approach selects the first 4 items from the list to comply with Bedrock's requirement
         // of having at most 4 stop sequences, as per the AWS documentation:
         // https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_InferenceConfiguration.html

--- a/core/llm/llms/Ollama.ts
+++ b/core/llm/llms/Ollama.ts
@@ -1,12 +1,12 @@
 import { JSONSchema7, JSONSchema7Object } from "json-schema";
 
-import { ChatMessage, CompletionOptions, LLMOptions } from "../../index.js";
+import { ChatMessage, ChatMessageRole, CompletionOptions, LLMOptions } from "../../index.js";
 import { renderChatMessage } from "../../util/messageContent.js";
 import { BaseLLM } from "../index.js";
 import { streamResponse } from "../stream.js";
 
 type OllamaChatMessage = {
-  role: "tool" | "user" | "assistant" | "system";
+  role: ChatMessageRole;
   content: string;
   images?: string[] | null;
   tool_calls?: {
@@ -82,10 +82,10 @@ type OllamaBaseResponse = {
   model: string;
   created_at: string;
 } & (
-  | {
+    | {
       done: false;
     }
-  | {
+    | {
       done: true;
       done_reason: string;
       total_duration: number; // Time spent generating the response in nanoseconds
@@ -96,7 +96,7 @@ type OllamaBaseResponse = {
       eval_duration: number; // Time spent generating the response in nanoseconds
       context: number[]; // An encoding of the conversation used in this response; can be sent in the next request to keep conversational memory
     }
-);
+  );
 
 type OllamaErrorResponse = {
   error: string;
@@ -105,14 +105,14 @@ type OllamaErrorResponse = {
 type OllamaRawResponse =
   | OllamaErrorResponse
   | (OllamaBaseResponse & {
-      response: string; // the generated response
-    });
+    response: string; // the generated response
+  });
 
 type OllamaChatResponse =
   | OllamaErrorResponse
   | (OllamaBaseResponse & {
-      message: OllamaChatMessage;
-    });
+    message: OllamaChatMessage;
+  });
 
 interface OllamaTool {
   type: "function";
@@ -142,7 +142,7 @@ class Ollama extends BaseLLM {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
     };
-  
+
     if (this.apiKey) {
       headers.Authorization = `Bearer ${this.apiKey}`;
     }
@@ -331,7 +331,7 @@ class Ollama extends BaseLLM {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
     };
-  
+
     if (this.apiKey) {
       headers.Authorization = `Bearer ${this.apiKey}`;
     }
@@ -396,7 +396,7 @@ class Ollama extends BaseLLM {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
     };
-  
+
     if (this.apiKey) {
       headers.Authorization = `Bearer ${this.apiKey}`;
     }
@@ -482,7 +482,7 @@ class Ollama extends BaseLLM {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
     };
-  
+
     if (this.apiKey) {
       headers.Authorization = `Bearer ${this.apiKey}`;
     }
@@ -523,7 +523,7 @@ class Ollama extends BaseLLM {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
     };
-  
+
     if (this.apiKey) {
       headers.Authorization = `Bearer ${this.apiKey}`;
     }
@@ -549,7 +549,7 @@ class Ollama extends BaseLLM {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
     };
-  
+
     if (this.apiKey) {
       headers.Authorization = `Bearer ${this.apiKey}`;
     }

--- a/core/util/messageContent.ts
+++ b/core/util/messageContent.ts
@@ -21,6 +21,7 @@ export function renderChatMessage(message: ChatMessage): string {
   switch (message.role) {
     case "user":
     case "assistant":
+    case "thinking":
     case "system":
       return stripImages(message.content);
     case "tool":
@@ -36,6 +37,7 @@ export function normalizeToMessageParts(message: ChatMessage): MessagePart[] {
   switch (message.role) {
     case "user":
     case "assistant":
+    case "thinking":
     case "system":
       return Array.isArray(message.content)
         ? message.content


### PR DESCRIPTION
## Description

This is a continuation of PR https://github.com/continuedev/continue/pull/4426 with implementation for Bedrock.

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

(No docs have been updated because I believe more has to be done before this feature becomes public)

## Testing instructions

It can be tested the same way as the PR 4426 with the following config:
```
{
      "title": "AWS - Claude 3.7 Sonnet (reasoning)",
      "provider": "bedrock",
      "model": "arn:aws:bedrock:us-east-1:874087778966:inference-profile/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
      "region": "us-east-1",
      "profile": "default",
      "completionOptions": {
        "temperature": 1,
        "topP": 0.999,
        "maxTokens": 8192,
        "reasoning": true,
        "reasoningBudgetTokens": 1024,
      }
    }
```
