### PR TITLE
default maxTokens setting for autocomplete

### DIFF
--- a/core/autocomplete/CompletionProvider.ts
+++ b/core/autocomplete/CompletionProvider.ts
@@ -175,11 +175,19 @@ export class CompletionProvider {
         this.ide.getWorkspaceDirs(),
       ]);
 
-      const { prompt, prefix, suffix, completionOptions } = renderPrompt({
+      const { prompt, prefix, suffix, completionOptions: _completionOptions } = renderPrompt({
         snippetPayload,
         workspaceDirs,
         helper,
       });
+
+      // Default maxTokens for autocomplete set in core/llm/llms/index.ts llmFromDescription()
+      const completionOptions = {
+        ..._completionOptions,
+        maxTokens: _completionOptions?.maxTokens ||
+          llm.completionOptions.autoCompleteMaxTokens ||
+          llm.completionOptions.maxTokens
+      };
 
       // Completion
       let completion: string | undefined = "";
@@ -220,11 +228,11 @@ export class CompletionProvider {
 
         const processedCompletion = helper.options.transform
           ? postprocessCompletion({
-              completion,
-              prefix: helper.prunedPrefix,
-              suffix: helper.prunedSuffix,
-              llm,
-            })
+            completion,
+            prefix: helper.prunedPrefix,
+            suffix: helper.prunedSuffix,
+            llm,
+          })
           : completion;
 
         completion = processedCompletion;

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -909,6 +909,7 @@ export interface BaseCompletionOptions {
   mirostat?: number;
   stop?: string[];
   maxTokens?: number;
+  autoCompleteMaxTokens?: number;
   numThreads?: number;
   useMmap?: boolean;
   keepAlive?: number;

--- a/core/llm/llms/index.ts
+++ b/core/llm/llms/index.ts
@@ -111,8 +111,7 @@ export async function llmFromDescription(
   ideSettings: IdeSettings,
   writeLog: (log: string) => Promise<void>,
   completionOptions?: BaseCompletionOptions,
-  systemMessage?: string,
-  isAutocomplete = false
+  systemMessage?: string
 ): Promise<BaseLLM | undefined> {
   const cls = LLMClasses.find((llm) => llm.providerName === desc.provider);
 

--- a/core/llm/llms/index.ts
+++ b/core/llm/llms/index.ts
@@ -19,7 +19,6 @@ import Cohere from "./Cohere";
 import DeepInfra from "./DeepInfra";
 import Deepseek from "./Deepseek";
 import Fireworks from "./Fireworks";
-import NCompass from "./NCompass";
 import Flowise from "./Flowise";
 import FreeTrial from "./FreeTrial";
 import FunctionNetwork from "./FunctionNetwork";
@@ -35,7 +34,9 @@ import Mistral from "./Mistral";
 import MockLLM from "./Mock";
 import Moonshot from "./Moonshot";
 import Msty from "./Msty";
+import NCompass from "./NCompass";
 import Nebius from "./Nebius";
+import Novita from "./Novita";
 import Nvidia from "./Nvidia";
 import Ollama from "./Ollama";
 import OpenAI from "./OpenAI";
@@ -49,7 +50,6 @@ import ContinueProxy from "./stubs/ContinueProxy";
 import TestLLM from "./Test";
 import TextGenWebUI from "./TextGenWebUI";
 import Together from "./Together";
-import Novita from "./Novita";
 import VertexAI from "./VertexAI";
 import Vllm from "./Vllm";
 import WatsonX from "./WatsonX";
@@ -112,6 +112,7 @@ export async function llmFromDescription(
   writeLog: (log: string) => Promise<void>,
   completionOptions?: BaseCompletionOptions,
   systemMessage?: string,
+  isAutocomplete = false
 ): Promise<BaseLLM | undefined> {
   const cls = LLMClasses.find((llm) => llm.providerName === desc.provider);
 
@@ -137,6 +138,11 @@ export async function llmFromDescription(
       maxTokens:
         finalCompletionOptions.maxTokens ??
         cls.defaultOptions?.completionOptions?.maxTokens,
+      autoCompleteMaxTokens:
+        finalCompletionOptions.autoCompleteMaxTokens ??
+        finalCompletionOptions.maxTokens ??
+        cls.defaultOptions?.completionOptions?.autoCompleteMaxTokens ??
+        256
     },
     systemMessage,
     writeLog,


### PR DESCRIPTION
## Description

Default maxTokens at 256 for autocomplete if there is no overriding user setting for the model. Added `autoCompleteMaxTokens`

Change from this comment:
https://github.com/continuedev/continue/issues/3994#issuecomment-2649166970

## Checklist

- [ ] The relevant docs, if any, have been updated or created - let's create a separate issue for this once the PR is approved and `autoCompleteMaxTokens` setting is kept in the completion options.
- [X] The relevant tests, if any, have been updated or created - no relevant tests as far as I know

## Testing instructions

I tested by directly putting a log message into the Ollama._streamFim() method.