### PR TITLE
proxy tool support

### DIFF
--- a/core/llm/toolSupport.ts
+++ b/core/llm/toolSupport.ts
@@ -3,9 +3,24 @@ export const PROVIDER_TOOL_SUPPORT: Record<
   (model: string) => boolean | undefined
 > = {
   "continue-proxy": (model) => {
-    return ["claude-3-5", "claude-3.5", "claude-3-7", "claude-3.7", "gpt-4", "o3", "gemini"].some((part) =>
-      model.toLowerCase().startsWith(part),
-    );
+    // see getContinueProxyModelName
+    const provider = model.split("/")[2];
+    const _model = model.split("/")[3];
+    if (provider && _model && provider !== "continue-proxy") {
+      const fn = PROVIDER_TOOL_SUPPORT[provider];
+      if (fn) {
+        return fn(_model);
+      }
+    }
+    return [
+      "claude-3-5",
+      "claude-3.5",
+      "claude-3-7",
+      "claude-3.7",
+      "gpt-4",
+      "o3",
+      "gemini",
+    ].some((part) => model.toLowerCase().startsWith(part));
   },
   anthropic: (model) => {
     if (


### PR DESCRIPTION
## Description
Update `continue-proxy` provider, which replaces e.g. anthropic and uses a model name of the format `ownerslug/packageslug/provider/model` to check tool support using the actual provider/model parsed from the proxy model name.