### PR TITLE
Set telemetry to disabled by default

### DIFF
--- a/docs/docs/json-reference.md
+++ b/docs/docs/json-reference.md
@@ -374,7 +374,7 @@ Example:
 
 ### `allowAnonymousTelemetry`
 
-When `true`, anonymous usage data is collected using Posthog, to improve features. Default is `true`.
+When `true`, anonymous usage data is collected using Posthog, to improve features. Default is `false`.
 
 ### `userToken`
 

--- a/docs/docs/telemetry.md
+++ b/docs/docs/telemetry.md
@@ -24,7 +24,7 @@ The following usage information is collected and reported:
 - **System Information:** The name of your operating system (OS) and integrated development environment (IDE).
 - **Pageviews:** General pageview statistics.
 
-## How to Opt Out
+## How to Opt In
 
 You can enable anonymous telemetry by visiting the [User Settings Page](./customize/settings.md) and toggling "Allow Anonymous Telemetry" on.
 

--- a/docs/docs/telemetry.md
+++ b/docs/docs/telemetry.md
@@ -1,12 +1,12 @@
 ---
 title: Telemetry
 description: Learn how Continue collects anonymous usage information and how you can opt out.
-keywords: [telemetry, anonymous, usage info, opt out]
+keywords: [telemetry, anonymous, usage info, opt in]
 ---
 
 ## Overview
 
-The open-source Continue Extensions collect and report **anonymous** usage information to help us improve our product. This data enables us to understand user interactions and optimize the user experience effectively. You can opt out of telemetry collection at any time if you prefer not to share your usage information.
+Continue collects and reports **anonymous** usage information to help us improve our product. This data enables us to understand user interactions and optimize the user experience effectively. By default your usage information is not shared. Please consider opting in to improve our product and help the community.
 
 We utilize [Posthog](https://posthog.com/), an open-source platform for product analytics, to gather and store this data. For transparency, you can review the implementation code [here](https://github.com/continuedev/continue/blob/main/gui/src/hooks/CustomPostHogProvider.tsx) or read our [official privacy policy](https://continue.dev/privacy).
 
@@ -26,6 +26,6 @@ The following usage information is collected and reported:
 
 ## How to Opt Out
 
-You can disable anonymous telemetry by visiting the [User Settings Page](./customize/settings.md) and toggling "Allow Anonymous Telemetry" off.
+You can enable anonymous telemetry by visiting the [User Settings Page](./customize/settings.md) and toggling "Allow Anonymous Telemetry" on.
 
-Alternatively in VS Code, you can disable telemetry through your VS Code settings by unchecking the "Continue: Telemetry Enabled" box (this will override the Settings Page settings). VS Code settings can be accessed with `File` > `Preferences` > `Settings` (or use the keyboard shortcut <kbd>ctrl</kbd> + <kbd>,</kbd> on Windows/Linux or <kbd>cmd</kbd> + <kbd>,</kbd> on macOS).
+Alternatively in VS Code, you can enable telemetry through your VS Code settings by checking the "Continue: Telemetry Enabled" box (this will override the Settings Page settings). VS Code settings can be accessed with `File` > `Preferences` > `Settings` (or use the keyboard shortcut <kbd>ctrl</kbd> + <kbd>,</kbd> on Windows/Linux or <kbd>cmd</kbd> + <kbd>,</kbd> on macOS).

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -2606,7 +2606,7 @@
           "title": "Allow Anonymous Telemetry",
           "markdownDescription": "If this field is set to `true`, we will collect anonymous telemetry as described in the documentation page on telemetry. If set to `false`, we will not collect any data. Learn more in [the docs](https://docs.continue.dev/telemetry).",
           "x-intellij-html-description": "If this field is set to `true`, we will collect anonymous telemetry as described in the documentation page on telemetry. If set to `false`, we will not collect any data. Learn more in <a href='https://docs.continue.dev/telemetry'>the docs</a>.",
-          "default": true,
+          "default": false,
           "type": "boolean"
         },
         "models": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -88,7 +88,7 @@
       "properties": {
         "continue.telemetryEnabled": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "markdownDescription": "Continue collects anonymous usage data, cleaned of PII, to help us improve the product for our users. Read more  at [continue.dev › Telemetry](https://docs.continue.dev/telemetry)."
         },
         "continue.enableContinueForTeams": {


### PR DESCRIPTION
## Description

Disabling telemetry by default.  Why: Some users and corporations may not want to have an opt-out model but would rather have an opt-in to avoid accidentally sending potentially company sensitive data by accident upon install. Full disclosure I don't believe anything this plugin sends is sensitive but companies are very concerned about data egress. I personally think we should enable it for academic and personal usage but enterprise adoption - this may be frowned on or likely would be blocked anyway by firewalls.

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

![image](https://github.com/user-attachments/assets/c4179ec5-de3f-4cde-a127-325f83ec8116)

![image](https://github.com/user-attachments/assets/83af2b79-0b78-461b-aa52-870d022e6e95)

After install:
![image](https://github.com/user-attachments/assets/104a6e3e-4848-48a2-a72e-fd4e0dd70352)



## Testing instructions

I'll be honest and say I could not get this to build on my work network but I suspect it was a proxy thing and VS issue as even though I made what I believe are the correct modifications and pointed to my instance of VS 2022 it still failed on sqlite and I am not sure why.  I was able to pull the pipeline build at [https://github.com/continuedev/continue/actions/runs/13640223539/job/38128264263?pr=4452](https://github.com/continuedev/continue/actions/runs/13640223539/artifacts/2684470943). 

I believe to test this you basically follow the instructions on [contributing](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md).

1. Make sure you have the correct version of npm (v20.11.0)
2. Pull down my PR
3. Install all dependencies in VS Code
4. Build and Run Extension locally
5. Validate Telemetry is disabled by default (settings -> unchecked Telemetry Enabled)

Alternatively if you want to skip the build like I did locally:

1. Grab that binary at [https://github.com/continuedev/continue/actions/runs/13640223539/job/38128264263?pr=4452](https://github.com/continuedev/continue/actions/runs/13640223539/artifacts/2684470943).
2. Then Open VS Code and Install VSIX
3. Validate Telemetry is disabled by default (settings -> unchecked Telemetry Enabled)
