### PR TITLE
fix(tools): Terminal command returns stdout but not stderr after error detected

### DIFF
--- a/core/tools/implementations/runTerminalCommand.ts
+++ b/core/tools/implementations/runTerminalCommand.ts
@@ -1,8 +1,8 @@
 import childProcess from "node:child_process";
 import util from "node:util";
 
-import { ToolImpl } from ".";
 import { fileURLToPath } from "node:url";
+import { ToolImpl } from ".";
 
 const asyncExec = util.promisify(childProcess.exec);
 
@@ -26,7 +26,7 @@ export const runTerminalCommandImpl: ToolImpl = async (args, extras) => {
         {
           name: "Terminal",
           description: "Terminal command output",
-          content: error.stderr ?? error.toString(),
+          content: error.stderr || error.stdout || error.toString(),
         },
       ];
     }


### PR DESCRIPTION
## Description

Fixes https://github.com/continuedev/continue/issues/4503

Some terminal commands like running cucumber tests seem to result in an error, but the results are returned to stdout vs stderr. This causes the terminal tool to not see the cucumber failures and is unable to fix the errors automatically.

## Checklist

- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing instructions

Run cucumber tests using javascript command npm run cucumber. The tests fail, and no results are observed in the tools terminal call. When setting a breakpoint stderr is empty but stdout is populated.

Curious if we should somehow concat the results so that the LLM can can see all the terminal content to process it to resolve issues.
