### PR TITLE
Fix invalid mime type in Jetbrains IDE

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/factories/CustomhandlerFactory.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/factories/CustomhandlerFactory.kt
@@ -111,7 +111,10 @@ class OpenedConnection(private val connection: URLConnection?) :
     ) {
         try {
             if (connection != null) {
-                val url = connection.url.toString()
+                val fullUrl = connection.url.toString()
+                // Extract only the resource path after the JAR prefix to prevent incorrect mime type matching
+                // (e.g., if a user's home folder contains "js" in the path)
+                val url = fullUrl.substringAfterLast("jar!/", fullUrl)
                 when {
                     url.contains("css") -> cefResponse.mimeType = "text/css"
                     url.contains("js") -> cefResponse.mimeType = "text/javascript"


### PR DESCRIPTION
## Description

connection.url.toString() contains values like:

jar:file:/Users/some.username/Library/Application%20Support/JetBrains/IntelliJIdea2024.3/plugins/continue-intellij-extension/lib/instrumented-continue-intellij-extension-1.0.2.jar!/webview/index.html

if user has "js" in his home folder name (can happen for some surnames) then index.html will be treated as text/javascript and continue dev sidebar will output html source code instead of working app

this should fix https://github.com/continuedev/continue/issues/768

## Checklist

- [x]The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created
