### PR TITLE
Enable Custom LLMs to use Tools

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -543,7 +543,7 @@ export interface CustomLLMWithOptionals {
     signal: AbortSignal,
     options: CompletionOptions,
     fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
-  ) => AsyncGenerator<string>;
+  ) => AsyncGenerator<ChatMessage | string>;
   listModels?: (
     fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
   ) => Promise<string[]>;


### PR DESCRIPTION
## Description

This PR enables Custom LLMs to yield `ChatMessage`'s as well as `string`s in customStreamChat. This enables customLLMs to use tools as well. The change is backwards compatible. 

## Checklist

- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

N/A

## Testing instructions

After launching the application in debug mode, you can edit your `config.ts` to the below to see both messages getting correctly yielded.

```
export function modifyConfig(config: Config): Config {
  config.models = [
    {
      options: {
        model: "Example Model",
        title: "Example Title",    // Required for ModelDescription
      },
      streamChat: async function* (
        messages: ChatMessage[],
        signal: AbortSignal,
        options: CompletionOptions,
        fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
      ): AsyncGenerator<ChatMessage | string> {
        yield "This is a string";
        yield {role: "assistant", content: "This is a ChatMessage"};
      }
    }
  ];

  return config;
}```
