### PR TITLE
Update toolSupport.ts fixes for granite models from HF

### DIFF
--- a/core/llm/toolSupport.ts
+++ b/core/llm/toolSupport.ts
@@ -57,9 +57,18 @@ export const PROVIDER_TOOL_SUPPORT: Record<
   },
   // https://ollama.com/search?c=tools
   ollama: (model) => {
+    let modelName = "";
+    // Extract the model name after the last slash to support other registries
+    if(model.includes("/")) {
+      let parts = model.split('/');
+      modelName = parts[parts.length - 1];
+    } else {
+      modelName = model;
+    }
+    
     if (
       ["vision", "math", "guard", "mistrallite", "mistral-openorca"].some(
-        (part) => model.toLowerCase().includes(part),
+        (part) => modelName.toLowerCase().includes(part),
       )
     ) {
       return false;
@@ -79,10 +88,11 @@ export const PROVIDER_TOOL_SUPPORT: Record<
         "nemotron",
         "llama3-groq",
         "granite3",
+        "granite-3",
         "aya-expanse",
         "firefunction-v2",
         "mistral",
-      ].some((part) => model.toLowerCase().startsWith(part))
+      ].some((part) => modelName.toLowerCase().includes(part))
     ) {
       return true;
     }


### PR DESCRIPTION
3 Ollama logic changes.

## Description

- Added logic to pull off the model name from a model which includes an extended path like "hf.co/DevQuasar/ibm-granite.granite-3.2-8b-instruct-preview-GGUF:F16"
- added a "granite-3" check to support Hf format for the model name
- changed the string compare to look for the model names in the whole string
## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
