### PR TITLE
Filter for files ending with .prompt in global Prompt Files

### DIFF
--- a/core/util/paths.ts
+++ b/core/util/paths.ts
@@ -368,7 +368,7 @@ export function readAllGlobalPromptFiles(
     if (stats.isDirectory()) {
       const nestedPromptFiles = readAllGlobalPromptFiles(filepath);
       promptFiles.push(...nestedPromptFiles);
-    } else {
+    } else if (file.endsWith(".prompt")) {
       const content = fs.readFileSync(filepath, "utf8");
       promptFiles.push({ path: filepath, content });
     }


### PR DESCRIPTION
## Description

added a check that files end with ".prompt" when searching for files in the global prompt directories. Before this change, all files are collected for `@Prompt Files`

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots

N/A

## Testing instructions

1. Add files ending with .prompt and .txt in ~/.continue/prompts
2. Write a new prompt using the `@Prompt Files` context.
3. Observe .txt file in the list before this change and only the .prompt file after this change.
