### PR TITLE
Refactor system message composition for better code proximity & allow user to enforce empty system message as required by Deepseek R1 series

### DIFF
--- a/core/config/load.ts
+++ b/core/config/load.ts
@@ -369,7 +369,7 @@ async function intermediateToFinalConfig(
               ideSettings,
               writeLog,
               config.completionOptions,
-              config.systemMessage,
+              config.systemMessage
             );
 
             if (llm?.providerName === "free-trial") {
@@ -397,8 +397,8 @@ async function intermediateToFinalConfig(
       (config.contextProviders || [])
         .filter(isContextProviderWithParams)
         .find((cp) => cp.name === "codebase") as
-        | ContextProviderWithParams
-        | undefined
+      | ContextProviderWithParams
+      | undefined
     )?.params || {};
 
   const DEFAULT_CONTEXT_PROVIDERS = [
@@ -991,5 +991,6 @@ export {
   finalToBrowserConfig,
   intermediateToFinalConfig,
   loadContinueConfigFromJson,
-  type BrowserSerializedContinueConfig,
+  type BrowserSerializedContinueConfig
 };
+

--- a/core/llm/llms/index.ts
+++ b/core/llm/llms/index.ts
@@ -3,7 +3,7 @@ import {
   IdeSettings,
   ILLM,
   LLMOptions,
-  ModelDescription,
+  ModelDescription
 } from "../..";
 import { renderTemplatedString } from "../../promptFiles/v1/renderTemplatedString";
 import { BaseLLM } from "../index";
@@ -19,7 +19,6 @@ import Cohere from "./Cohere";
 import DeepInfra from "./DeepInfra";
 import Deepseek from "./Deepseek";
 import Fireworks from "./Fireworks";
-import NCompass from "./NCompass";
 import Flowise from "./Flowise";
 import FreeTrial from "./FreeTrial";
 import FunctionNetwork from "./FunctionNetwork";
@@ -35,7 +34,9 @@ import Mistral from "./Mistral";
 import MockLLM from "./Mock";
 import Moonshot from "./Moonshot";
 import Msty from "./Msty";
+import NCompass from "./NCompass";
 import Nebius from "./Nebius";
+import Novita from "./Novita";
 import Nvidia from "./Nvidia";
 import Ollama from "./Ollama";
 import OpenAI from "./OpenAI";
@@ -49,7 +50,6 @@ import ContinueProxy from "./stubs/ContinueProxy";
 import TestLLM from "./Test";
 import TextGenWebUI from "./TextGenWebUI";
 import Together from "./Together";
-import Novita from "./Novita";
 import VertexAI from "./VertexAI";
 import Vllm from "./Vllm";
 import WatsonX from "./WatsonX";

--- a/gui/src/redux/thunks/streamResponse.ts
+++ b/gui/src/redux/thunks/streamResponse.ts
@@ -34,10 +34,10 @@ const getSlashCommandForInput = (
     typeof input === "string"
       ? input
       : (
-          input.filter((part) => part.type === "text").slice(-1)[0] as
-            | TextMessagePart
-            | undefined
-        )?.text || "";
+        input.filter((part) => part.type === "text").slice(-1)[0] as
+        | TextMessagePart
+        | undefined
+      )?.text || "";
 
   if (lastText.startsWith("/")) {
     slashCommandName = lastText.split(" ")[0].substring(1);
@@ -124,6 +124,7 @@ export const streamResponseThunk = createAsyncThunk<
           [...updatedHistory],
           defaultModel,
           useTools,
+          state.config.config
         );
 
         posthog.capture("step run", {

--- a/gui/src/redux/thunks/streamResponseAfterToolCall.ts
+++ b/gui/src/redux/thunks/streamResponseAfterToolCall.ts
@@ -64,6 +64,7 @@ export const streamResponseAfterToolCall = createAsyncThunk<
           [...updatedHistory],
           defaultModel,
           useTools,
+          state.config.config
         );
         const output = await dispatch(streamNormalInput(messages));
         unwrapResult(output);


### PR DESCRIPTION
## Description

1. Moved systemMessage composition to a single place - makes it easy to make changes discussed in issue https://github.com/continuedev/continue/issues/3786
2. When user defined systemMessage is an explicit empty string, no system message will be created - this resolves https://github.com/continuedev/continue/issues/3786#issuecomment-2701614971

Note: https://github.com/continuedev/continue/pull/4507 is built on top of this one, that contains a more complete, yet experimental solution for the issue https://github.com/continuedev/continue/issues/3786

## Checklist

- [ ] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Testing instructions

If you set empty systemMessage in the model config or in the top-level config, no systemMessage should be used (model config takes precedence even if it's an empty string)
