### PR TITLE
System_message_composition

### DIFF
--- a/core/config/load.ts
+++ b/core/config/load.ts
@@ -369,7 +369,7 @@ async function intermediateToFinalConfig(
               ideSettings,
               writeLog,
               config.completionOptions,
-              config.systemMessage,
+              config.systemMessage
             );
 
             if (llm?.providerName === "free-trial") {
@@ -397,8 +397,8 @@ async function intermediateToFinalConfig(
       (config.contextProviders || [])
         .filter(isContextProviderWithParams)
         .find((cp) => cp.name === "codebase") as
-        | ContextProviderWithParams
-        | undefined
+      | ContextProviderWithParams
+      | undefined
     )?.params || {};
 
   const DEFAULT_CONTEXT_PROVIDERS = [
@@ -991,5 +991,6 @@ export {
   finalToBrowserConfig,
   intermediateToFinalConfig,
   loadContinueConfigFromJson,
-  type BrowserSerializedContinueConfig,
+  type BrowserSerializedContinueConfig
 };
+

--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -1047,6 +1047,7 @@ declare global {
     useChromiumForDocsCrawling?: boolean;
     useTools?: boolean;
     modelContextProtocolServers?: MCPOptions[];
+    systemMessageComposition?: "legacy" | "append" | "prepend" | "placeholders";
   }
   
   interface AnalyticsConfig {

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -43,13 +43,13 @@ export interface IndexingProgressUpdate {
   desc: string;
   shouldClearIndexes?: boolean;
   status:
-    | "loading"
-    | "indexing"
-    | "done"
-    | "failed"
-    | "paused"
-    | "disabled"
-    | "cancelled";
+  | "loading"
+  | "indexing"
+  | "done"
+  | "failed"
+  | "paused"
+  | "disabled"
+  | "cancelled";
   debugInfo?: string;
 }
 
@@ -675,10 +675,10 @@ export interface IDE {
   getCurrentFile(): Promise<
     | undefined
     | {
-        isUntitled: boolean;
-        path: string;
-        contents: string;
-      }
+      isUntitled: boolean;
+      path: string;
+      contents: string;
+    }
   >;
 
   getLastFileSaveTimestamp?(): number;
@@ -862,11 +862,11 @@ export interface CustomCommand {
 export interface Prediction {
   type: "content";
   content:
-    | string
-    | {
-        type: "text";
-        text: string;
-      }[];
+  | string
+  | {
+    type: "text";
+    text: string;
+  }[];
 }
 
 export interface ToolExtras {
@@ -1134,6 +1134,7 @@ export interface ExperimentalConfig {
    */
   useChromiumForDocsCrawling?: boolean;
   modelContextProtocolServers?: MCPOptions[];
+  systemMessageComposition?: "legacy" | "append" | "prepend" | "placeholders";
 }
 
 export interface AnalyticsConfig {
@@ -1204,9 +1205,9 @@ export interface Config {
   embeddingsProvider?: EmbeddingsProviderDescription | ILLM;
   /** The model that Continue will use for tab autocompletions. */
   tabAutocompleteModel?:
-    | CustomLLM
-    | ModelDescription
-    | (CustomLLM | ModelDescription)[];
+  | CustomLLM
+  | ModelDescription
+  | (CustomLLM | ModelDescription)[];
   /** Options for tab autocomplete */
   tabAutocompleteOptions?: Partial<TabAutocompleteOptions>;
   /** UI styles customization */
@@ -1298,9 +1299,9 @@ export type PackageDetailsSuccess = PackageDetails & {
 export type PackageDocsResult = {
   packageInfo: ParsedPackageInfo;
 } & (
-  | { error: string; details?: never }
-  | { details: PackageDetailsSuccess; error?: never }
-);
+    | { error: string; details?: never }
+    | { details: PackageDetailsSuccess; error?: never }
+  );
 
 export interface TerminalOptions {
   reuseTerminal?: boolean;

--- a/core/llm/llms/index.ts
+++ b/core/llm/llms/index.ts
@@ -3,7 +3,7 @@ import {
   IdeSettings,
   ILLM,
   LLMOptions,
-  ModelDescription,
+  ModelDescription
 } from "../..";
 import { renderTemplatedString } from "../../promptFiles/v1/renderTemplatedString";
 import { BaseLLM } from "../index";
@@ -19,7 +19,6 @@ import Cohere from "./Cohere";
 import DeepInfra from "./DeepInfra";
 import Deepseek from "./Deepseek";
 import Fireworks from "./Fireworks";
-import NCompass from "./NCompass";
 import Flowise from "./Flowise";
 import FreeTrial from "./FreeTrial";
 import FunctionNetwork from "./FunctionNetwork";
@@ -35,7 +34,9 @@ import Mistral from "./Mistral";
 import MockLLM from "./Mock";
 import Moonshot from "./Moonshot";
 import Msty from "./Msty";
+import NCompass from "./NCompass";
 import Nebius from "./Nebius";
+import Novita from "./Novita";
 import Nvidia from "./Nvidia";
 import Ollama from "./Ollama";
 import OpenAI from "./OpenAI";
@@ -49,7 +50,6 @@ import ContinueProxy from "./stubs/ContinueProxy";
 import TestLLM from "./Test";
 import TextGenWebUI from "./TextGenWebUI";
 import Together from "./Together";
-import Novita from "./Novita";
 import VertexAI from "./VertexAI";
 import Vllm from "./Vllm";
 import WatsonX from "./WatsonX";

--- a/docs/docs/json-reference.md
+++ b/docs/docs/json-reference.md
@@ -405,6 +405,16 @@ Several experimental config parameters are available, as described below:
   - `fix`: Prompt for fixing code.
   - `optimize`: Prompt for optimizing code.
 - `modelContextProtocolServers`: See [Model Context Protocol](/customize/context-providers#model-context-protocol)
+- `systemMessageComposition`: Controls how the default system instructions and user-provided system message are combined:
+  - `legacy` or `append` (default): Default instructions are placed first, followed by user system message.
+  - `prepend`: User system message is placed first, followed by default instructions.
+  - `placeholders`: User system message can include special placeholders to control where default instructions appear:
+
+    - `{DEFAULT_INSTRUCTIONS}`: Includes both code block and tool use instructions.
+    - `{CODE_BLOCK_INSTRUCTIONS}`: Includes only the code block formatting instructions.
+    - `{TOOL_USE_RULES}`: Includes only the tool use rules (when applicable).
+
+    These placeholders correspond to templates that can be customized in a model's `promptTemplates` object using the keys `codeBlockInstructions` and `toolUseRules`.
 
 Example
 
@@ -432,7 +442,8 @@ Example
           "args": ["mcp-server-sqlite", "--db-path", "/Users/NAME/test.db"]
         }
       }
-    ]
+    ],
+    "systemMessageComposition": "placeholders"
   }
 }
 ```

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -371,6 +371,16 @@ Several experimental config parameters are available, as described below:
   - `fix`: Prompt for fixing code.
   - `optimize`: Prompt for optimizing code.
 - `modelContextProtocolServers`: See [Model Context Protocol](/customize/context-providers#model-context-protocol)
+- `systemMessageComposition`: Controls how the default system instructions and user-provided system message are combined:
+  - `legacy` or `append` (default): Default instructions are placed first, followed by user system message.
+  - `prepend`: User system message is placed first, followed by default instructions.
+  - `placeholders`: User system message can include special placeholders to control where default instructions appear:
+
+    - `{DEFAULT_INSTRUCTIONS}`: Includes both code block and tool use instructions.
+    - `{CODE_BLOCK_INSTRUCTIONS}`: Includes only the code block formatting instructions.
+    - `{TOOL_USE_RULES}`: Includes only the tool use rules (when applicable).
+
+    These placeholders correspond to templates that can be customized in a model's `promptTemplates` object using the keys `codeBlockInstructions` and `toolUseRules`.
 
 Example
 
@@ -398,7 +408,8 @@ Example
           "args": ["mcp-server-sqlite", "--db-path", "/Users/NAME/test.db"]
         }
       }
-    ]
+    ],
+    "systemMessageComposition": "placeholders"
   }
 }
 ```

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/reference.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/reference.md
@@ -402,8 +402,6 @@ Several experimental config parameters are available, as described below:
   - `inlineEdit`: Model title for inline edits.
   - `applyCodeBlock`: Model title for applying code blocks.
   - `repoMapFileSelection`: Model title for repo map selections.
-- `readResponseTTS`: If `true`, reads LLM responses aloud with TTS. Default is `true`.
-- `promptPath`: Change the path to custom prompt files from the default ".prompts"
 - `quickActions`: Array of custom quick actions
   - `title` (**required**): Display title for the quick action.
   - `prompt` (**required**): Prompt for quick action.
@@ -413,8 +411,17 @@ Several experimental config parameters are available, as described below:
   - `docstring`: Prompt for adding docstrings.
   - `fix`: Prompt for fixing code.
   - `optimize`: Prompt for optimizing code.
-  - `fixGrammar`: Prompt for fixing grammar or spelling.
-- `useChromiumForDocsCrawling`: Use Chromium to crawl docs locally. Useful if the default Cheerio crawler fails on sites that require JavaScript rendering. Downloads and installs Chromium to `~/.continue/.utils`..
+- `systemMessageComposition`: Controls how the default system instructions and user-provided system message are combined:
+
+  - `legacy` or `append` (default): Default instructions are placed first, followed by user system message.
+  - `prepend`: User system message is placed first, followed by default instructions.
+  - `placeholders`: User system message can include special placeholders to control where default instructions appear:
+
+    - `{DEFAULT_INSTRUCTIONS}`: Includes both code block and tool use instructions.
+    - `{CODE_BLOCK_INSTRUCTIONS}`: Includes only the code block formatting instructions.
+    - `{TOOL_USE_RULES}`: Includes only the tool use rules (when applicable).
+
+    These placeholders correspond to templates that can be customized in a model's `promptTemplates` object using the keys `codeBlockInstructions` and `toolUseRules`.
 
 Example
 
@@ -424,7 +431,6 @@ Example
     "modelRoles": {
       "inlineEdit": "Edit Model"
     },
-    "promptPath": "custom/.prompts",
     "quickActions": [
       {
         "title": "Tags",
@@ -435,8 +441,16 @@ Example
     "contextMenuPrompts": {
       "fixGrammar": "Fix grammar in the above but allow for typos."
     },
-    "readResponseTTS": false,
-    "useChromiumForDocsCrawling": true
+    "modelContextProtocolServers": [
+      {
+        "transport": {
+          "type": "stdio",
+          "command": "uvx",
+          "args": ["mcp-server-sqlite", "--db-path", "/Users/NAME/test.db"]
+        }
+      }
+    ],
+    "systemMessageComposition": "placeholders"
   }
 }
 ```

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -373,9 +373,23 @@
         },
         "promptTemplates": {
           "title": "Prompt Templates",
-          "markdownDescription": "A mapping of prompt template name ('edit' is currently the only one used in Continue) to a string giving the prompt template. See [here](https://docs.continue.dev/model-setup/configuration#customizing-the-edit-prompt) for an example.",
-          "x-intellij-html-description": "A mapping of prompt template name ('edit' is currently the only one used in Continue) to a string giving the prompt template. See <a href='https://docs.continue.dev/model-setup/configuration#customizing-the-edit-prompt'>here</a> for an example.",
+          "markdownDescription": "A mapping of prompt template names to strings giving the prompt templates. See [here](https://docs.continue.dev/model-setup/configuration#customizing-the-edit-prompt) for examples.",
+          "x-intellij-html-description": "A mapping of prompt template names to strings giving the prompt templates. See <a href='https://docs.continue.dev/model-setup/configuration#customizing-the-edit-prompt'>here</a> for examples.",
           "type": "object",
+          "properties": {
+            "edit": {
+              "type": "string",
+              "description": "Template used for edit operations in Continue"
+            },
+            "codeBlockInstructions": {
+              "type": "string",
+              "description": "Custom instructions for code block formatting (used with system message placeholders)"
+            },
+            "toolUseRules": {
+              "type": "string",
+              "description": "Custom instructions for tool usage (used with system message placeholders)"
+            }
+          },
           "additionalProperties": {
             "type": "string"
           }
@@ -3355,6 +3369,12 @@
                 },
                 "required": ["transport"]
               }
+            },
+            "systemMessageComposition": {
+              "type": "string",
+              "enum": ["legacy", "append", "prepend", "placeholders"],
+              "default": "legacy",
+              "description": "Controls how the default system instructions and user-provided system message are combined. 'legacy' or 'append': Default instructions first, then user message. 'prepend': User message first, then default instructions. 'placeholders': User message can include special placeholders {DEFAULT_INSTRUCTIONS}, {CODE_BLOCK_INSTRUCTIONS}, and {TOOL_USE_RULES}."
             }
           }
         }

--- a/gui/src/redux/thunks/streamResponse.ts
+++ b/gui/src/redux/thunks/streamResponse.ts
@@ -34,10 +34,10 @@ const getSlashCommandForInput = (
     typeof input === "string"
       ? input
       : (
-          input.filter((part) => part.type === "text").slice(-1)[0] as
-            | TextMessagePart
-            | undefined
-        )?.text || "";
+        input.filter((part) => part.type === "text").slice(-1)[0] as
+        | TextMessagePart
+        | undefined
+      )?.text || "";
 
   if (lastText.startsWith("/")) {
     slashCommandName = lastText.split(" ")[0].substring(1);
@@ -124,6 +124,7 @@ export const streamResponseThunk = createAsyncThunk<
           [...updatedHistory],
           defaultModel,
           useTools,
+          state.config.config
         );
 
         posthog.capture("step run", {

--- a/gui/src/redux/thunks/streamResponseAfterToolCall.ts
+++ b/gui/src/redux/thunks/streamResponseAfterToolCall.ts
@@ -64,6 +64,7 @@ export const streamResponseAfterToolCall = createAsyncThunk<
           [...updatedHistory],
           defaultModel,
           useTools,
+          state.config.config
         );
         const output = await dispatch(streamNormalInput(messages));
         unwrapResult(output);


### PR DESCRIPTION
## Description

Continuation of https://github.com/continuedev/continue/pull/4506

Replacement of https://github.com/continuedev/continue/pull/3787

On top of PR 4506 it adds experimental configuration systemMessageComposition. Changed documentation explains how it works.

Legacy logic remains working if user do not change the configuration.

## Checklist

- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing instructions

Experiment with config:
```
  "experimental": {
    "systemMessageComposition": "prepend"
  }
```

In the model description, you can also set:
```
     "promptTemplates": {
        "codeBlockInstructions": "My own instructions for code blocks",
        "toolUseRules": "My tool use rules"
      },
```