### PR TITLE
Fixed multiline selection issue in edit mode

### DIFF
--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -534,9 +534,26 @@ const getCommandsMap: (
         return;
       }
 
+      const startFromCharZero = editor.selection.start.with(undefined, 0);
+      const document = editor.document;
+      let lastLine, lastChar;
+      // If the user selected onto a trailing line but didn't actually include any characters in it
+      // they don't want to include that line, so trim it off.
+      if (editor.selection.end.character === 0) {
+        // This is to prevent the rare case that the previous line gets selected when user
+        // is selecting nothing and the cursor is at the beginning of the line
+        if (editor.selection.end.line === editor.selection.start.line) {
+          lastLine = editor.selection.start.line;
+        } else {
+          lastLine = editor.selection.end.line - 1;
+        }
+      } else {
+        lastLine = editor.selection.end.line;
+      }
+      lastChar = document.lineAt(lastLine).range.end.character;
+      const endAtCharLast = new vscode.Position(lastLine, lastChar);
       const range =
-        args?.range ??
-        new vscode.Range(editor.selection.start, editor.selection.end);
+        args?.range ?? new vscode.Range(startFromCharZero, endAtCharLast);
 
       editDecorationManager.setDecoration(editor, range);
 


### PR DESCRIPTION
## Description

The original behavior was only selecting the highlighted part and if there is nothing selected in the trailing line it still got seleced to the edit mode. This fix is to expand the selection start to the very beginning of first line and the selection end to the very end of the last line. In addtion, prevent the trailing line getting selecting if there is nothing in it. 
https://github.com/Granite-Code/granite-code/issues/42

## Testing instructions

1. Partially select the first line and then Cmd-I, and check if the entire first line get selected in the editor and display correctly in the edit mode section.
2. Select empty trailing line and then Cmd-I, and check if the trailing line not get selected in the editor and not include in the display of the edit mode section.
