### PR TITLE
Fixed unwantted selecting behavior for send-to-chat

### DIFF
--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -123,9 +123,20 @@ function getRangeInFileWithContents(
       return null;
     }
 
-    // adjust starting position to include indentation
-    const start = new vscode.Position(selection.start.line, 0);
-    const selectionRange = new vscode.Range(start, selection.end);
+    let selectionRange = new vscode.Range(selection.start, selection.end);
+    const document = editor.document;
+    // Select the context from the beginning of the selection start line to the selection start position
+    const beginningOfSelectionStartLine = selection.start.with(undefined, 0);
+    const textBeforeSelectionStart = document.getText(
+      new vscode.Range(beginningOfSelectionStartLine, selection.start),
+    );
+    // If there are only whitespace before the start of the selection, include the indentation
+    if (textBeforeSelectionStart.trim().length === 0) {
+      selectionRange = selectionRange.with({
+        start: beginningOfSelectionStartLine,
+      });
+    }
+
     const contents = editor.document.getText(selectionRange);
 
     return {


### PR DESCRIPTION
## Description

The original behavior selects the entire first line even though it's only partially selected in the editor. This fix is to get rid of the extra selection from the first line and only send the exact part that gets selected in the editor to the chat section. https://github.com/Granite-Code/granite-code/issues/43

## Testing instructions

Partially select the first line and then Cmd-L, check if code snippet appearing in the chat section display the exact part you select in the editor.
