### PR TITLE
edit mode code highlighting fixed to not override cursor selection

### DIFF
--- a/extensions/vscode/src/quickEdit/EditDecorationManager.ts
+++ b/extensions/vscode/src/quickEdit/EditDecorationManager.ts
@@ -6,7 +6,10 @@ class EditDecorationManager {
   constructor(context: vscode.ExtensionContext) {
     this.decorationType = vscode.window.createTextEditorDecorationType({
       backgroundColor: new vscode.ThemeColor(
-        "editor.inactiveSelectionBackground",
+        // "editor.selectionHighlightBackground" requires partial transparency.
+        // This ensures the highlight does not completely obscure the selection,
+        // making it useful for repurposing here.
+        "editor.selectionHighlightBackground",
       ),
       isWholeLine: true,
     });


### PR DESCRIPTION
## Description

When switching to the edit mode and we make a selection of code, it needs to appear above the highlighting not be obscured by it. In this fix, instead of using an opaque background colour for the highlighting decoration, we use a highlighting with opacity so that the selected code is visible below it


## Screenshots
<img width="462" alt="Screenshot 2025-03-05 at 3 46 25 PM" src="https://github.com/user-attachments/assets/44cb20ca-d2f5-4024-9a09-f823a18c4c82" />
<img width="776" alt="Screenshot 2025-03-05 at 3 31 22 PM" src="https://github.com/user-attachments/assets/475644ea-95d3-4877-959d-8b0a45555378" />

<img width="695" alt="Screenshot 2025-03-05 at 3 48 26 PM" src="https://github.com/user-attachments/assets/92202960-e675-4fa4-972c-33ecb0721f7d" />
<img width="530" alt="Screenshot 2025-03-05 at 3 50 01 PM" src="https://github.com/user-attachments/assets/2dc3f37f-0d7a-4e29-98fd-409df98f0ef2" />


Link: https://github.com/Granite-Code/granite-code/issues/47
