### PR TITLE
Set VSCODE_VERSION when running 'extest get-chromedriver'

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -594,7 +594,7 @@
     "e2e:compile": "tsc -p ./tsconfig.e2e.json",
     "e2e:build": "npm --prefix ../../gui run build && npm run package",
     "e2e:create-storage": "mkdir -p ./e2e/storage",
-    "e2e:get-chromedriver": "extest get-chromedriver --storage ./e2e/storage",
+    "e2e:get-chromedriver": "CODE_VERSION=\"1.95.0\" extest get-chromedriver --storage ./e2e/storage",
     "e2e:get-vscode": "CODE_VERSION=\"1.95.0\" extest get-vscode --storage ./e2e/storage",
     "e2e:sign-vscode": "codesign --entitlements entitlements.plist --deep --force -s - './e2e/storage/Visual Studio Code.app'",
     "e2e:copy-vsix": "chmod +x ./e2e/get-latest-vsix.sh && bash ./e2e/get-latest-vsix.sh",


### PR DESCRIPTION
If we only set the VSCODE_VERSION when running 'extest get-vscode', then we might get a version of chromedriver that is incompatible with the version of vscode we download.

This should fix e2e tests failing with errors like:
```
     SessionNotCreatedError: session not created: This version of ChromeDriver only supports Chrome version 132
Current browser version is 128.0.6613.186 with binary path /home/runner/work/continue/continue/extensions/vscode/e2e/storage/VSCode-linux-x64/code
```

e.g. in https://github.com/continuedev/continue/pull/4522 - I think the reason only *some* of the recent pull requests have these failures is caching of the downloads - in other cases we are getting versions downloaded extest was updated for newer vscode/chromedriver.

