### PR TITLE
Fix logic for setting IGNORE_SSH_TESTS

### DIFF
--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -460,7 +460,7 @@ jobs:
       - name: Run e2e tests
         run: |
           cd extensions/vscode
-          IGNORE_SSH_TESTS="${{ github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' }}" TEST_FILE="${{ matrix.test_file }}" npm run ${{ matrix.command }}
+          IGNORE_SSH_TESTS="${{ github.event.pull_request.head.repo.fork == true || github.actor == 'dependabot[bot]' }}" TEST_FILE="${{ matrix.test_file }}" npm run ${{ matrix.command }}
         env:
           DISPLAY: :99
 


### PR DESCRIPTION
The logic for checking for dependabot introduced in
    fda4cc8096 skip ssh on dependabot PRs
was somewhat confused; this was partially fixed in
    98739c63ec fix ignore api key tests

This makes the logic for `IGNORE_SSH_TESTS`  match that for `IGNORE_API_KEY_TESTS` and
be a proper logic opposite of:

```
if: ${{ github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' }} 
```