### PR TITLE
added tools support for fireworks.ai

### DIFF
--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -97,6 +97,10 @@ class OpenAI extends BaseLLM {
     return !!model && (model.startsWith("o1") || model.startsWith("o3"));
   }
 
+  private isFireworksAiModel(model?: string): boolean {
+    return !!model && model.startsWith("accounts/fireworks/models");
+  }
+
   protected supportsPrediction(model: string): boolean {
     const SUPPORTED_MODELS = ["gpt-4o-mini", "gpt-4o", "mistral-large"];
     return SUPPORTED_MODELS.some((m) => model.includes(m));
@@ -274,7 +278,13 @@ class OpenAI extends BaseLLM {
       body.max_completion_tokens = undefined;
     }
 
-    if (body.tools?.length && !body.model?.startsWith("o3")) {
+    if (body.tools?.length) {
+      if (this.isFireworksAiModel(body.model)) {
+        // fireworks.ai does not support parallel tool calls, but their api expects this to be true anyway otherwise they return an error.
+        // tooling works with them as a inference provider once this is set to true.
+        // https://docs.fireworks.ai/guides/function-calling#openai-compatibility
+        body.parallel_tool_calls = true;
+      }
       // To ensure schema adherence: https://platform.openai.com/docs/guides/function-calling#parallel-function-calling-and-structured-outputs
       // In practice, setting this to true and asking for multiple tool calls
       // leads to "arguments" being something like '{"file": "test.ts"}{"file": "test.js"}'

--- a/core/llm/toolSupport.ts
+++ b/core/llm/toolSupport.ts
@@ -39,6 +39,19 @@ export const PROVIDER_TOOL_SUPPORT: Record<
     ) {
       return true;
     }
+    // firworks-ai https://docs.fireworks.ai/guides/function-calling
+    if (model.startsWith("accounts/fireworks/models/")) {
+      switch (model.substring(26)) {
+        case "llama-v3p1-405b-instruct":
+        case "llama-v3p1-70b-instruct":
+        case "qwen2p5-72b-instruct":
+        case "firefunction-v1":
+        case "firefunction-v2":
+          return true;
+        default:
+          return false;
+      }
+    }
   },
   gemini: (model) => {
     // All gemini models support function calling


### PR DESCRIPTION
(as requested reopened from #4046)
## Description

Added support for tools for the models who support tooling running via fireworks.ai.
Its also using openai api with some quirks.
Left behind explanation in comment section.

https://docs.fireworks.ai/guides/function-calling

## Testing instructions

If one wanted to do so:
1. Check if tooling still works with other providers (I have no other providers available to me, but the changes are just a few lines and I don't think anything can go wrong here)
2. Use fireworks.ai as provider with and check if tooling works (it does for me now)

## Todo

Proper versioning, idk how you guys handle this nor if I should have done anything in that regard since its my first contribution. I could not find anything regarding that in the Contributing.md
