### PR TITLE
Catch retreival rerank errors

### DIFF
--- a/core/context/providers/DocsContextProvider.ts
+++ b/core/context/providers/DocsContextProvider.ts
@@ -5,6 +5,7 @@ import {
   ContextProviderDescription,
   ContextProviderExtras,
   ContextSubmenuItem,
+  IDE,
   LoadSubmenuItemsArgs,
 } from "../..";
 import DocsService from "../../indexing/docs/DocsService";
@@ -36,6 +37,7 @@ class DocsContextProvider extends BaseContextProvider {
     chunks: Chunk[],
     reranker: NonNullable<ContextProviderExtras["reranker"]>,
     fullInput: ContextProviderExtras["fullInput"],
+    ide: IDE,
   ) {
     let chunksCopy = [...chunks];
 
@@ -51,7 +53,7 @@ class DocsContextProvider extends BaseContextProvider {
         this.options?.nFinal ?? DocsContextProvider.nFinal,
       );
     } catch (e) {
-      console.warn(`Failed to rerank docs results: ${e}`);
+      void ide.showToast("warning", `Failed to rerank retrieval results\n${e}`);
 
       chunksCopy = chunksCopy.splice(
         0,
@@ -116,6 +118,7 @@ class DocsContextProvider extends BaseContextProvider {
         chunks,
         extras.reranker,
         extras.fullInput,
+        extras.ide,
       );
     }
 

--- a/core/context/retrieval/pipelines/RerankerRetrievalPipeline.ts
+++ b/core/context/retrieval/pipelines/RerankerRetrievalPipeline.ts
@@ -82,29 +82,34 @@ export default class RerankerRetrievalPipeline extends BaseRetrievalPipeline {
     // remove empty chunks -- some APIs fail on that
     chunks = chunks.filter((chunk) => chunk.content);
 
-    let scores: number[] =
-      await this.options.config.selectedModelByRole.rerank.rerank(
-        input,
-        chunks,
+    try {
+      let scores: number[] =
+        await this.options.config.selectedModelByRole.rerank.rerank(
+          input,
+          chunks,
+        );
+
+      // Filter out low-scoring results
+      let results = chunks;
+      // let results = chunks.filter(
+      //   (_, i) => scores[i] >= RETRIEVAL_PARAMS.rerankThreshold,
+      // );
+      // scores = scores.filter(
+      //   (score) => score >= RETRIEVAL_PARAMS.rerankThreshold,
+      // );
+
+      const chunkIndexMap = new Map<Chunk, number>();
+      chunks.forEach((chunk, idx) => chunkIndexMap.set(chunk, idx));
+
+      results.sort(
+        (a, b) => scores[chunkIndexMap.get(a)!] - scores[chunkIndexMap.get(b)!],
       );
-
-    // Filter out low-scoring results
-    let results = chunks;
-    // let results = chunks.filter(
-    //   (_, i) => scores[i] >= RETRIEVAL_PARAMS.rerankThreshold,
-    // );
-    // scores = scores.filter(
-    //   (score) => score >= RETRIEVAL_PARAMS.rerankThreshold,
-    // );
-
-    const chunkIndexMap = new Map<Chunk, number>();
-    chunks.forEach((chunk, idx) => chunkIndexMap.set(chunk, idx));
-
-    results.sort(
-      (a, b) => scores[chunkIndexMap.get(a)!] - scores[chunkIndexMap.get(b)!],
-    );
-    results = results.slice(-this.options.nFinal);
-    return results;
+      results = results.slice(-this.options.nFinal);
+      return results;
+    } catch (e) {
+      console.warn(`Failed to rerank codebase retrieval results ${e}`);
+      return chunks;
+    }
   }
 
   private async _expandWithEmbeddings(chunks: Chunk[]): Promise<Chunk[]> {

--- a/core/context/retrieval/pipelines/RerankerRetrievalPipeline.ts
+++ b/core/context/retrieval/pipelines/RerankerRetrievalPipeline.ts
@@ -107,8 +107,11 @@ export default class RerankerRetrievalPipeline extends BaseRetrievalPipeline {
       results = results.slice(-this.options.nFinal);
       return results;
     } catch (e) {
-      console.warn(`Failed to rerank codebase retrieval results ${e}`);
-      return chunks;
+      void this.options.ide.showToast(
+        "warning",
+        `Failed to rerank retrieval results\n${e}`,
+      );
+      return chunks.slice(-this.options.nFinal);
     }
   }
 


### PR DESCRIPTION
## Description
Don't allow codebase reranking errors to interrupt @docs and @codebase requests
Surface as warning toasts

Fixes https://github.com/continuedev/continue/issues/4430 (on the extension side)