### PR TITLE
Add missing custom fetch use cases

### DIFF
--- a/core/llm/llms/Cohere.ts
+++ b/core/llm/llms/Cohere.ts
@@ -117,7 +117,7 @@ class Cohere extends BaseLLM {
   }
 
   async rerank(query: string, chunks: Chunk[]): Promise<number[]> {
-    const resp = await fetch(new URL("rerank", this.apiBase), {
+    const resp = await this.fetch(new URL("rerank", this.apiBase), {
       method: "POST",
       headers: {
         Authorization: `Bearer ${this.apiKey}`,

--- a/core/llm/llms/HuggingFaceTEI.ts
+++ b/core/llm/llms/HuggingFaceTEI.ts
@@ -1,5 +1,4 @@
 import { Chunk, LLMOptions } from "../../index.js";
-import { withExponentialBackoff } from "../../util/withExponentialBackoff.js";
 import { BaseLLM } from "../index.js";
 
 class HuggingFaceTEIEmbeddingsProvider extends BaseLLM {
@@ -36,17 +35,15 @@ class HuggingFaceTEIEmbeddingsProvider extends BaseLLM {
   }
 
   async doEmbedRequest(batch: string[]): Promise<number[][]> {
-    const resp = await withExponentialBackoff<Response>(() =>
-      this.fetch(new URL("embed", this.apiBase), {
-        method: "POST",
-        body: JSON.stringify({
-          inputs: batch,
-        }),
-        headers: {
-          "Content-Type": "application/json",
-        },
+    const resp = await this.fetch(new URL("embed", this.apiBase), {
+      method: "POST",
+      body: JSON.stringify({
+        inputs: batch,
       }),
-    );
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
     if (!resp.ok) {
       const text = await resp.text();
       const embedError = JSON.parse(text) as TEIEmbedErrorResponse;
@@ -59,11 +56,10 @@ class HuggingFaceTEIEmbeddingsProvider extends BaseLLM {
   }
 
   async doInfoRequest(): Promise<TEIInfoResponse> {
-    const resp = await withExponentialBackoff<Response>(() =>
-      this.fetch(new URL("info", this.apiBase), {
-        method: "GET",
-      }),
-    );
+    // TODO - need to use custom fetch for this request?
+    const resp = await this.fetch(new URL("info", this.apiBase), {
+      method: "GET",
+    });
     if (!resp.ok) {
       throw new Error(await resp.text());
     }
@@ -79,7 +75,7 @@ class HuggingFaceTEIEmbeddingsProvider extends BaseLLM {
       headers["Authorization"] = `Bearer ${this.apiKey}`;
     }
 
-    const resp = await fetch(new URL("rerank", this.apiBase), {
+    const resp = await this.fetch(new URL("rerank", this.apiBase), {
       method: "POST",
       headers,
       body: JSON.stringify({

--- a/core/llm/llms/Voyage.ts
+++ b/core/llm/llms/Voyage.ts
@@ -14,7 +14,7 @@ class Voyage extends OpenAI {
       return [];
     }
     const url = new URL("rerank", this.apiBase);
-    const resp = await fetch(url, {
+    const resp = await this.fetch(url, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/core/llm/llms/stubs/ContinueProxy.ts
+++ b/core/llm/llms/stubs/ContinueProxy.ts
@@ -65,7 +65,7 @@ class ContinueProxy extends OpenAI {
 
   async rerank(query: string, chunks: Chunk[]): Promise<number[]> {
     const url = new URL("rerank", this.apiBase);
-    const resp = await fetch(url, {
+    const resp = await this.fetch(url, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/packages/openai-adapters/src/apis/OpenAI.ts
+++ b/packages/openai-adapters/src/apis/OpenAI.ts
@@ -14,7 +14,7 @@ import {
 } from "openai/resources/index";
 import { z } from "zod";
 import { OpenAIConfigSchema } from "../types.js";
-import { maybeCustomFetch } from "../util.js";
+import { customFetch, maybeCustomFetch } from "../util.js";
 import {
   BaseLlmApi,
   CreateRerankResponse,
@@ -31,7 +31,7 @@ export class OpenAIApi implements BaseLlmApi {
     this.openai = new OpenAI({
       apiKey: config.apiKey,
       baseURL: this.apiBase,
-      fetch: maybeCustomFetch(config.requestOptions),
+      fetch: customFetch(config.requestOptions),
     });
   }
 
@@ -100,7 +100,7 @@ export class OpenAIApi implements BaseLlmApi {
     signal: AbortSignal,
   ): AsyncGenerator<ChatCompletionChunk, any, unknown> {
     const endpoint = new URL("fim/completions", this.apiBase);
-    const resp = await fetch(endpoint, {
+    const resp = await customFetch(this.config.requestOptions)(endpoint, {
       method: "POST",
       body: JSON.stringify({
         model: body.model,
@@ -139,7 +139,7 @@ export class OpenAIApi implements BaseLlmApi {
 
   async rerank(body: RerankCreateParams): Promise<CreateRerankResponse> {
     const endpoint = new URL("rerank", this.apiBase);
-    const response = await fetch(endpoint, {
+    const response = await customFetch(this.config.requestOptions)(endpoint, {
       method: "POST",
       body: JSON.stringify(body),
       headers: {


### PR DESCRIPTION
## Description
- Some uses of fetch were not using the custom fetch that accounts for request options, etc.
- HuggingFaceTEI had nested `withExponentialBackoff`

Effects
- All OpenAI and OpenAI-compatible `embed` and `autocomplete` calls that use the OpenAI adapter
- Continue Proxy rerank
- Voyage rerank
- HuggingFaceTEI rerank and embed