### PR TITLE
Walkdir caching first pass

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,8 +12,8 @@
       "cwd": "${workspaceFolder}/extensions/vscode",
       "args": [
         // Pass a directory to manually test in
-        "${workspaceFolder}/manual-testing-sandbox",
-        "${workspaceFolder}/manual-testing-sandbox/test.js",
+        "/Users/dallin/Documents/code/continuedev/continue-extras/react",
+        "/Users/dallin/Documents/code/continuedev/continue-extras/react/README.md",
         "--extensionDevelopmentPath=${workspaceFolder}/extensions/vscode"
       ],
       "pauseForSourceMap": false,

--- a/core/config/getSystemPromptDotFile.ts
+++ b/core/config/getSystemPromptDotFile.ts
@@ -41,7 +41,9 @@ export async function getAssistantFilesFromDir(
       return [];
     }
 
-    const uris = await walkDir(dir, ide);
+    const uris = await walkDir(dir, ide, {
+      source: "get dir assistant files",
+    });
     const assistantFilePaths = uris.filter(
       (p) => p.endsWith(".yaml") || p.endsWith(".yml"),
     );

--- a/core/context/providers/FileContextProvider.ts
+++ b/core/context/providers/FileContextProvider.ts
@@ -8,9 +8,9 @@ import {
 } from "../../";
 import { walkDirs } from "../../indexing/walkDir";
 import {
-  getUriPathBasename,
   getShortestUniqueRelativeUriPaths,
   getUriDescription,
+  getUriPathBasename,
 } from "../../util/uri";
 
 const MAX_SUBMENU_ITEMS = 10_000;
@@ -53,7 +53,13 @@ class FileContextProvider extends BaseContextProvider {
     args: LoadSubmenuItemsArgs,
   ): Promise<ContextSubmenuItem[]> {
     const workspaceDirs = await args.ide.getWorkspaceDirs();
-    const results = await walkDirs(args.ide, undefined, workspaceDirs);
+    const results = await walkDirs(
+      args.ide,
+      {
+        source: "load submenu items - file",
+      },
+      workspaceDirs,
+    );
     const files = results.flat().slice(-MAX_SUBMENU_ITEMS);
     const withUniquePaths = getShortestUniqueRelativeUriPaths(
       files,

--- a/core/context/providers/FileTreeContextProvider.ts
+++ b/core/context/providers/FileTreeContextProvider.ts
@@ -50,7 +50,9 @@ class FileTreeContextProvider extends BaseContextProvider {
         directories: [],
       };
 
-      const uris = await walkDir(workspaceDir, extras.ide);
+      const uris = await walkDir(workspaceDir, extras.ide, {
+        source: "get context items - file tree",
+      });
       const relativePaths = uris.map(
         (uri) => findUriInDirs(uri, [workspaceDir]).relativePathOrBasename,
       );

--- a/core/context/providers/FolderContextProvider.ts
+++ b/core/context/providers/FolderContextProvider.ts
@@ -36,6 +36,7 @@ class FolderContextProvider extends BaseContextProvider {
       args.ide,
       {
         onlyDirs: true,
+        source: "load submenu items - folder",
       },
       workspaceDirs,
     );

--- a/core/context/providers/RepoMapContextProvider.ts
+++ b/core/context/providers/RepoMapContextProvider.ts
@@ -55,6 +55,7 @@ class RepoMapContextProvider extends BaseContextProvider {
       args.ide,
       {
         onlyDirs: true,
+        source: "load submenu items - repo map",
       },
       workspaceDirs,
     );

--- a/core/core.ts
+++ b/core/core.ts
@@ -887,6 +887,7 @@ export class Core {
             uri.endsWith(".gitignore")
           ) {
             // Reindex the workspaces
+            // walkDirCache.invalidate();
             this.invoke("index/forceReIndex", {
               shouldClearIndexes: true,
             });

--- a/core/indexing/CodebaseIndexer.ts
+++ b/core/indexing/CodebaseIndexer.ts
@@ -282,7 +282,9 @@ export class CodebaseIndexer {
         status: "indexing",
       };
       const directoryFiles = [];
-      for await (const p of walkDirAsync(directory, this.ide)) {
+      for await (const p of walkDirAsync(directory, this.ide, {
+        source: "codebase indexing: refresh dirs",
+      })) {
         directoryFiles.push(p);
         if (abortSignal.aborted) {
           yield {

--- a/core/indexing/walkDir.ts
+++ b/core/indexing/walkDir.ts
@@ -157,6 +157,17 @@ const defaultOptions: WalkerOptions = {
   returnRelativeUrisPaths: false,
 };
 
+export async function* walkDirAsync(
+  path: string,
+  ide: IDE,
+  _optionOverrides?: WalkerOptions,
+): AsyncGenerator<string> {
+  const start = Date.now();
+  const options = { ...defaultOptions, ..._optionOverrides };
+  yield* new DFSWalker(path, ide, options).walk();
+  console.log(`walkDir took ${Date.now() - start}ms`);
+}
+
 export async function walkDir(
   uri: string,
   ide: IDE,
@@ -167,15 +178,6 @@ export async function walkDir(
     urisOrRelativePaths.push(p);
   }
   return urisOrRelativePaths;
-}
-
-export async function* walkDirAsync(
-  path: string,
-  ide: IDE,
-  _optionOverrides?: WalkerOptions,
-): AsyncGenerator<string> {
-  const options = { ...defaultOptions, ..._optionOverrides };
-  yield* new DFSWalker(path, ide, options).walk();
 }
 
 export async function walkDirs(

--- a/core/indexing/walkDir.ts
+++ b/core/indexing/walkDir.ts
@@ -55,6 +55,20 @@ class WalkDirCache {
       ignore: Promise<Ignore>;
     }
   > = new Map();
+  // The super safe approach for now
+  invalidate() {
+    this.dirListCache.clear();
+    this.dirIgnoreCache.clear();
+  }
+  // invalidateIgnore(uri: string) {
+  //   this.dirIgnoreCache.delete(uri);
+  // }
+  // invalidateParent(uri: string) {
+  //   const splitUri = fileUri.split("/");
+  //   splitUri.pop();
+  //   const parent = splitUri.join("/");
+  //   this.dirListCache.delete(uri);
+  // }
 }
 export const walkDirCache = new WalkDirCache(); // todo - singleton approach better?
 
@@ -102,6 +116,7 @@ class DFSWalker {
     const stack = [rootContext];
 
     for (let cur = stack.pop(); cur; cur = stack.pop()) {
+      // No caching approach:
       // const entries = await this.ide.listDir(cur.walkableEntry.uri);
       // const newIgnore = await getIgnoreContext(
       //   cur.walkableEntry.uri,

--- a/core/indexing/walkDir.ts
+++ b/core/indexing/walkDir.ts
@@ -70,15 +70,7 @@ class WalkDirCache {
   //   this.dirListCache.delete(uri);
   // }
 }
-export const walkDirCache = new WalkDirCache(); // todo - singleton approach better?
-
-// class ListDirCache {
-//   private cache: Map<string, >();
-//   getCacheKey(options: WalkerOptions) {
-//     return `${options.returnRelativeUrisPaths ? "relative" : "absolute"}-${options.onlyDirs ? "dirs" : "files"}`;
-//   }
-
-// }
+export const walkDirCache = new WalkDirCache(); // TODO - singleton approach better?
 
 class DFSWalker {
   constructor(
@@ -249,10 +241,9 @@ class DFSWalker {
         }
       }
     }
-    // console.log(walkDirCache.listDirCache.values().toArray().slice(0, 30));
-    console.log(
-      `Walk Dir Result:\nSource: ${this.options.source ?? "unknown"}\nDir: ${this.uri}\nDuration: ${Date.now() - start}ms:\n\tList dir: ${listDirTime}ms (${listDirCacheHits}/${dirs} cache hits)\n\tIgnore files: ${ignoreFileTime}ms (${ignoreCacheHits}/${dirs} cache hits)\n\tIgnoring: ${ignoreTime}ms`,
-    );
+    // console.log(
+    //   `Walk Dir Result:\nSource: ${this.options.source ?? "unknown"}\nDir: ${this.uri}\nDuration: ${Date.now() - start}ms:\n\tList dir: ${listDirTime}ms (${listDirCacheHits}/${dirs} cache hits)\n\tIgnore files: ${ignoreFileTime}ms (${ignoreCacheHits}/${dirs} cache hits)\n\tIgnoring: ${ignoreTime}ms`,
+    // );
   }
 
   private entryIsDirectory(entry: Entry) {

--- a/core/promptFiles/v2/getPromptFiles.ts
+++ b/core/promptFiles/v2/getPromptFiles.ts
@@ -16,7 +16,9 @@ export async function getPromptFilesFromDir(
       return [];
     }
 
-    const uris = await walkDir(dir, ide);
+    const uris = await walkDir(dir, ide, {
+      source: "get dir prompt files",
+    });
     const promptFilePaths = uris.filter((p) => p.endsWith(".prompt"));
     const results = promptFilePaths.map(async (uri) => {
       const content = await ide.readFile(uri); // make a try catch

--- a/core/util/generateRepoMap.ts
+++ b/core/util/generateRepoMap.ts
@@ -50,7 +50,13 @@ class RepoMapGenerator {
 
   async generate(): Promise<string> {
     this.dirs = this.options.dirUris ?? (await this.ide.getWorkspaceDirs());
-    this.allUris = await walkDirs(this.ide, undefined, this.dirs);
+    this.allUris = await walkDirs(
+      this.ide,
+      {
+        source: "generate repo map",
+      },
+      this.dirs,
+    );
 
     // Initialize
     await this.writeToStream(this.PREAMBLE);

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "1.1.5",
+  "version": "1.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "1.1.5",
+      "version": "1.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/fetch": "^1.0.3",

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -819,7 +819,9 @@ const getCommandsMap: (
           .stat(uri)
           ?.then((stat) => stat.type === vscode.FileType.Directory);
         if (isDirectory) {
-          for await (const fileUri of walkDirAsync(uri.toString(), ide)) {
+          for await (const fileUri of walkDirAsync(uri.toString(), ide, {
+            source: "vscode continue.selectFilesAsContext command",
+          })) {
             addEntireFileToContext(
               vscode.Uri.parse(fileUri),
               sidebar.webviewProtocol,
@@ -962,10 +964,7 @@ const getCommandsMap: (
           vscode.commands.executeCommand("continue.giveAutocompleteFeedback");
         } else if (selectedOption === "$(comment) Open chat") {
           vscode.commands.executeCommand("continue.focusContinueInput");
-        } else if (
-          selectedOption ===
-          "$(screen-full) Open full screen chat"
-        ) {
+        } else if (selectedOption === "$(screen-full) Open full screen chat") {
           vscode.commands.executeCommand("continue.toggleFullScreen");
         } else if (selectedOption === "$(question) Open help center") {
           focusGUI();

--- a/extensions/vscode/src/util/FileSearch.ts
+++ b/extensions/vscode/src/util/FileSearch.ts
@@ -24,7 +24,9 @@ export class FileSearch {
     },
   });
   private async initializeFileSearchState() {
-    const results = await walkDirs(this.ide);
+    const results = await walkDirs(this.ide, {
+      source: "file search initialization",
+    });
     this.miniSearch.addAll(
       results.flat().map((uri) => ({
         id: uri,


### PR DESCRIPTION
## Description
Cache listDir results and ignore file rectified ignores for directories
- for 30 seconds OR
- till invalidated
 
Any file changes, creations, deletions, or index requests will invalidate the cache, so the _only_ effect this has for now is that parallel walk dirs will be much more efficient. It will not speedup e.g. walkdir for a single instance of codebase reindexing.

Before:
![image](https://github.com/user-attachments/assets/735d64fb-5487-44e1-ae7b-714c7c86f369)

After:
![image](https://github.com/user-attachments/assets/7cadefe2-a459-4406-b704-a6c5723f6114)

Startup CPU load in `react` repo before/after:
![image](https://github.com/user-attachments/assets/51781189-a3fd-49d1-9081-aac2720f7211)
