### PR TITLE
Support MCP Resource Templates / Dynamic Resources

### DIFF
--- a/core/context/providers/MCPTemplateContextProvider.ts
+++ b/core/context/providers/MCPTemplateContextProvider.ts
@@ -1,0 +1,74 @@
+import { ContextItem, ContextProviderExtras } from "../../index.js";
+import { BaseContextProvider } from "../index.js";
+import { MCPManagerSingleton } from "../mcp";
+
+interface MCPTemplateContextProviderOptions {
+  name: string;
+  description: string;
+}
+
+class MCPTemplateContextProvider extends BaseContextProvider {
+  private readonly _mcpId: string;
+  private readonly _parameter: string;
+  private readonly _uri: string;
+
+  constructor(options: { mcpId: string; parameter: string; uri: string }) {
+    super(options);
+    this._mcpId = options.mcpId;
+    this._parameter = options.parameter;
+    this._uri = options.uri;
+  }
+
+  async getContextItems(
+    query: string,
+    extras: ContextProviderExtras,
+  ): Promise<ContextItem[]> {
+    const connection = MCPManagerSingleton.getInstance().getConnection(
+      this._mcpId,
+    );
+    if (!connection) {
+      throw new Error(`No MCP connection found for ${this._mcpId}`);
+    }
+
+    const uri = this._uri.replace(`{${this._parameter}}`, query);
+
+    const { contents } = await connection.client.readResource({ uri });
+
+    return await Promise.all(
+      contents.map(async (resource) => {
+        const content = resource.text;
+        if (typeof content !== "string") {
+          throw new Error(
+            "Continue currently only supports text resources from MCP",
+          );
+        }
+
+        return {
+          name: resource.uri,
+          description: resource.uri,
+          content,
+          uri: {
+            type: "url",
+            value: resource.uri,
+          },
+        };
+      }),
+    );
+  }
+}
+
+// Factory to create subclasses with custom static descriptions
+export function createMCPTemplateContextProviderClass(
+  options: MCPTemplateContextProviderOptions,
+): typeof MCPTemplateContextProvider {
+  return class extends MCPTemplateContextProvider {
+    static description = {
+      title: options.name,
+      displayTitle: options.name,
+      description: options.description,
+      type: "query",
+    };
+  };
+}
+
+export default MCPTemplateContextProvider;


### PR DESCRIPTION
## Description

Enable support for dynamic MCP resources, such as `echo://{message}`.  

Ideally, this functionality should be expanded to accommodate resources with multiple inputs. However, this serves as an initial draft.

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots


https://github.com/user-attachments/assets/0bd7f615-692d-4b50-b5ca-b834300a6555



## Testing instructions

Create MCP test server, e.g.:
```python
from mcp.server.fastmcp import FastMCP

mcp = FastMCP("Echo")

@mcp.resource("echo://test", name="test")
def test_resource() -> str:
    """Echo a message as a resource"""
    return "Test"

@mcp.resource("echo://{message}", name="echo")
def echo_resource(message: str) -> str:
    """Echo a message as a resource"""
    return f"Resource echo: {message}"


@mcp.resource("echo://{input}", name="other_template_resource")
def echo_resource(input: str) -> str:
    """other template resource"""
    return f"Your input: {input}"


if __name__ == "__main__":
    print("Starting Echo Server ...")
    mcp.run()
```

Add to config e.g.: 
```
mcpServers:
  - name: MCPEcho
    command: uv
    args:
      - --directory=[PATH_TO_SERVER]
      - run
      - server.py
```