### PR TITLE
Capture `result.content` while streaming from chat LLM

### DIFF
--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -821,6 +821,7 @@ export abstract class BaseLLM implements ILLM {
             for await (const chunk of stream) {
               const result = fromChatCompletionChunk(chunk);
               if (result) {
+                completion += result.content;
                 yield result;
               }
               if (!citations && (chunk as any).citations && Array.isArray((chunk as any).citations)) {


### PR DESCRIPTION
## Description

Fixes missing content mentioned in #4475 

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created