### PR TITLE
feat(editor): implement up/down arrow key history navigation for edit…

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor.tsx
@@ -301,7 +301,9 @@ function TipTapEditor(props: TipTapEditorProps) {
     }
   }
 
-  const { prevRef, nextRef, addRef } = useInputHistory(props.historyKey);
+  // Ensure we're using the correct history key - chat for main input, edit for edit mode
+  const historyKey = props.historyKey === 'edit' ? 'edit' : 'chat';
+  const { prevRef, nextRef, addRef } = useInputHistory(historyKey);
 
   const editor: Editor | null = useEditor({
     extensions: [
@@ -659,9 +661,9 @@ function TipTapEditor(props: TipTapEditorProps) {
         return;
       }
 
-      if (props.isMainInput) {
-        addRef.current(json);
-      }
+      // Always add to input history regardless of input type
+      // This ensures that both chat and edit modes maintain their own history
+      addRef.current(json);
 
       props.onEnter(json, modifiers, editor);
     },

--- a/gui/src/hooks/useInputHistory.ts
+++ b/gui/src/hooks/useInputHistory.ts
@@ -1,5 +1,5 @@
 import { JSONContent } from "@tiptap/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { getLocalStorage, setLocalStorage } from "../util/localStorage";
 import useUpdatingRef from "./useUpdatingRef";
 
@@ -10,58 +10,112 @@ const emptyJsonContent = () => ({
 
 const MAX_HISTORY_LENGTH = 100;
 
+// Completely isolated memory stores for different history types
+// This ensures no crossover between edit and chat histories
+const CHAT_HISTORY_STORE: JSONContent[] = [];
+const EDIT_HISTORY_STORE: JSONContent[] = [];
+
+// Initialize the history stores from localStorage (only do this once)
+let storesInitialized = false;
+function initializeStores() {
+  
+  if (!storesInitialized) {
+    // Initialize chat history
+    const chatHistory = getLocalStorage('inputHistory_chat');
+    if (chatHistory) {
+      CHAT_HISTORY_STORE.push(...chatHistory.slice(-MAX_HISTORY_LENGTH));
+    }
+    
+    // Initialize edit history
+    const editHistory = getLocalStorage('inputHistory_edit');
+    if (editHistory) {
+      EDIT_HISTORY_STORE.push(...editHistory.slice(-MAX_HISTORY_LENGTH));
+    }
+    
+    storesInitialized = true;
+  }
+}
+
+
+// Initialize stores immediately
+initializeStores();
+
+/**
+ * Custom hook for managing input history with complete separation between history types
+ */
 export function useInputHistory(historyKey: string) {
-  const [inputHistory, setInputHistory] = useState<JSONContent[]>(
-    getLocalStorage(`inputHistory_${historyKey}`)?.slice(-MAX_HISTORY_LENGTH) ??
-      [],
-  );
-  const [pendingInput, setPendingInput] =
-    useState<JSONContent>(emptyJsonContent());
+  // Determine which history store to use
+  const historyStore = historyKey === 'edit' ? EDIT_HISTORY_STORE : CHAT_HISTORY_STORE;
+  const storageKey = historyKey === 'edit' ? 'inputHistory_edit' as const : 'inputHistory_chat' as const;
+  
+  // Use a reference to the appropriate history store
+  const [inputHistory, setInputHistory] = useState<JSONContent[]>(historyStore);
+  const [pendingInput, setPendingInput] = useState<JSONContent>(emptyJsonContent());
   const [currentIndex, setCurrentIndex] = useState(inputHistory.length);
+  
+  // Keep the view of history updated when the underlying store changes
+  useEffect(() => {
+    setInputHistory([...historyStore]);
+    setCurrentIndex(historyStore.length);
+  }, [historyStore.length]);
 
   function prev(currentInput: JSONContent) {
-    let index = currentIndex;
-
-    if (index === inputHistory.length) {
+    if (currentIndex === inputHistory.length) {
       setPendingInput(currentInput);
     }
 
-    if (index > 0 && index <= inputHistory.length) {
-      setCurrentIndex((prevState) => prevState - 1);
-      return inputHistory[index - 1];
+    if (currentIndex > 0) {
+      setCurrentIndex(currentIndex - 1);
+      return inputHistory[currentIndex - 1];
     }
+    
+    // Stay at the first history item if we're already there
+    if (currentIndex === 0 && inputHistory.length > 0) {
+      return inputHistory[0];
+    }
+    
+    return currentInput;
   }
 
   function next() {
-    let index = currentIndex;
-    if (index >= 0 && index < inputHistory.length) {
-      setCurrentIndex((prevState) => prevState + 1);
-      if (index === inputHistory.length - 1) {
+    if (currentIndex < inputHistory.length) {
+      setCurrentIndex(currentIndex + 1);
+      
+      if (currentIndex === inputHistory.length - 1) {
         return pendingInput;
       }
-      return inputHistory[index + 1];
+      
+      return inputHistory[currentIndex + 1];
     }
+    
+    // Stay at pending input if we're already at the end
+    return pendingInput;
   }
 
   function add(inputValue: JSONContent) {
     setPendingInput(emptyJsonContent());
 
+    // Don't add duplicates
     if (
-      JSON.stringify(inputHistory[inputHistory.length - 1]) ===
-      JSON.stringify(inputValue)
+      historyStore.length > 0 &&
+      JSON.stringify(historyStore[historyStore.length - 1]) === JSON.stringify(inputValue)
     ) {
-      setCurrentIndex(inputHistory.length);
+      setCurrentIndex(historyStore.length);
       return;
     }
 
-    setCurrentIndex(inputHistory.length + 1);
-    setInputHistory((prev) => {
-      return [...prev, inputValue].slice(-MAX_HISTORY_LENGTH);
-    });
-    setLocalStorage(
-      `inputHistory_${historyKey}`,
-      [...inputHistory, inputValue].slice(-MAX_HISTORY_LENGTH),
-    );
+    // Update the appropriate history store
+    while (historyStore.length >= MAX_HISTORY_LENGTH) {
+      historyStore.shift(); // Remove oldest items if we exceed the limit
+    }
+    historyStore.push(inputValue);
+    
+    // Update the view of history
+    setInputHistory([...historyStore]);
+    setCurrentIndex(historyStore.length);
+    
+    // Update localStorage
+    setLocalStorage(storageKey, [...historyStore]);
   }
 
   const prevRef = useUpdatingRef(prev, [inputHistory]);


### PR DESCRIPTION
## Description
Closes #3894 

- Create isolated memory stores for chat and edit history
- Enhance useInputHistory hook to use separate stores by key
- Update TipTapEditor to use correct history key
- Ensure consistent history navigation behavior across input modes
- Persist history correctly to localStorage

### Problem:
Currently, when users enter the edit mode by selecting text, the input box that appears doesn't maintain its own history. Unlike the chat input which allows navigating through previous inputs using up/down arrow keys, the edit mode input lacks this functionality. This creates an inconsistent user experience between the two input modes.

### Solution: 
This PR implements up/down arrow key history navigation for the edit mode, with completely isolated history storage from the chat mode. Now users can:

Use up/down arrow keys in edit mode to cycle through previously submitted edit inputs
Maintain separate history for chat mode and edit mode without any crossover
Experience consistent navigation behavior across both input modes
Technical Implementation
The implementation consists of several key components:

1. Isolated History Stores
Created completely separate memory stores for chat and edit histories:

```typescript
const CHAT_HISTORY_STORE: JSONContent[] = [];
const EDIT_HISTORY_STORE: JSONContent[] = [];
```

2. Enhanced useInputHistory Hook
Refactored the useInputHistory hook to:

- Use the appropriate history store based on the provided historyKey
- Maintain proper separation between different history types
- Handle edge cases during history navigation
- Correctly persist history to localStorage

3. TipTapEditor Component Updates
Modified the TipTapEditor component to:

- Consistently use the correct history key ('edit' or 'chat')
- Always save inputs to the appropriate history store
- Ensure proper navigation through history with up/down arrow keys


## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

### Before
You can see, in the video, when you are using up/down arrow, you are only getting the chat history inputs even though you are on the edit mode.
https://github.com/user-attachments/assets/8f91a69b-cc78-4939-9485-3e113073b88a


### After

You can see, in the video, we have separatation of chat and edit histories, hence you can go through all your edit and chat histories easily.

https://github.com/user-attachments/assets/49d3fb06-44f9-4969-8252-cbab47e1e684



## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
