### PR TITLE
Fixed an issue where the Log data collection feature in IntelliJ would fail (#4340 #4475)

### DIFF
--- a/core/autocomplete/CompletionProvider.ts
+++ b/core/autocomplete/CompletionProvider.ts
@@ -262,7 +262,7 @@ export class CompletionProvider {
 
       // When using the JetBrains extension, Mark as displayed
       const ideType = (await this.ide.getIdeInfo()).ideType;
-      if (ideType === "jetbrains") {
+      if (ideType.toLowerCase() === "jetbrains") {
         this.markDisplayed(input.completionId, outcome);
       }
 

--- a/core/data/log.ts
+++ b/core/data/log.ts
@@ -46,8 +46,8 @@ export class DataLogger {
     if ("eventName" in zodSchema.shape) {
       newBody.eventName = eventName;
     }
-    if ("timestamp" in zodSchema.shape) {
-      newBody.timestamp = Date.now();
+    if (!newBody.timestamp && "timestamp" in zodSchema.shape) {
+      newBody.timestamp = new Date().toISOString();
     }
     if ("schema" in zodSchema.shape) {
       newBody.schema = schema;


### PR DESCRIPTION
Fixed an issue where the Log data collection feature in IntelliJ would fail.
Issue : #4340 #4475


## Description

1. Check "jetbranis" as the IDE identifier, but in reality "JETBRAINS" is transmitted, so correct this. (#4340)
2. Among the fields of the event, the type of timestamp is different between autocomplete and other events, so if they are processed in common, the zod parser fails to check the type. This has been fixed. (#4475)


## Checklist

- [ ] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created

## Screenshots


## Testing instructions

1. Add the following to config.json.
```
  "data": [
    {
      "schema": "0.2.0",
      "destination": "file://c:/tmp/continue_logs/"
    }
  ]
```
2. Enter a chat or activate the autocomplete function.
3. Check if the log files are created normally in the c:/tmp/continue_logs/ directory.
