### PR TITLE
Add missing popd command at the end of install-dependencies.ps1

### DIFF
--- a/scripts/install-dependencies.ps1
+++ b/scripts/install-dependencies.ps1
@@ -114,3 +114,5 @@ Write-Output "`nInstalling docs dependencies..." -ForegroundColor White
 Push-Location docs
 
 npm install
+
+Pop-Location


### PR DESCRIPTION
## Description

Add missing popd command at the end of install-dependencies.ps1

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

## Testing instructions
