### PR TITLE
prevent premature autocomplete on intellisense suggestion

### DIFF
--- a/extensions/vscode/src/autocomplete/completionProvider.ts
+++ b/extensions/vscode/src/autocomplete/completionProvider.ts
@@ -96,7 +96,6 @@ export class ContinueCompletionProvider
 
   _lastShownCompletion: AutocompleteOutcome | undefined;
 
-  _lastVsCodeCompletionInput: VsCodeCompletionInput | undefined;
 
   public async provideInlineCompletionItems(
     document: vscode.TextDocument,
@@ -121,11 +120,13 @@ export class ContinueCompletionProvider
       return null;
     }
 
-    // This code checks if there is a selected completion suggestion in the given context and ensures that it is valid.
+    const selectedCompletionInfo = context.selectedCompletionInfo;
+
+    // This code checks if there is a selected completion suggestion in the given context and ensures that it is valid
     // To improve the accuracy of suggestions it checks if the user has typed at least 4 characters
     // This helps refine and filter out irrelevant autocomplete options
-    if (context.selectedCompletionInfo) {
-      const { text, range } = context.selectedCompletionInfo;
+    if (selectedCompletionInfo) {
+      const { text, range } = selectedCompletionInfo;
       const typedText = document.getText(range);
 
       const typedLength = range.end.character - range.start.character;
@@ -139,16 +140,6 @@ export class ContinueCompletionProvider
       }
     }
     let injectDetails: string | undefined = undefined;
-
-    // The first time intellisense dropdown shows up, and the first choice is selected,
-    // we should not consider this. Only once user explicitly moves down the list
-    const newVsCodeInput = {
-      context,
-      document,
-      position,
-    };
-    const selectedCompletionInfo = context.selectedCompletionInfo;
-    this._lastVsCodeCompletionInput = newVsCodeInput;
 
     try {
       const abortController = new AbortController();

--- a/extensions/vscode/src/autocomplete/completionProvider.ts
+++ b/extensions/vscode/src/autocomplete/completionProvider.ts
@@ -121,17 +121,23 @@ export class ContinueCompletionProvider
       return null;
     }
 
-    // If the text at the range isn't a prefix of the intellisense text,
-    // no completion will be displayed, regardless of what we return
-    if (
-      context.selectedCompletionInfo &&
-      !context.selectedCompletionInfo.text.startsWith(
-        document.getText(context.selectedCompletionInfo.range),
-      )
-    ) {
-      return null;
-    }
+    // This code checks if there is a selected completion suggestion in the given context and ensures that it is valid.
+    // To improve the accuracy of suggestions it checks if the user has typed at least 4 characters
+    // This helps refine and filter out irrelevant autocomplete options
+    if (context.selectedCompletionInfo) {
+      const { text, range } = context.selectedCompletionInfo;
+      const typedText = document.getText(range);
 
+      const typedLength = range.end.character - range.start.character;
+
+      if (typedLength < 4) {
+        return null;
+      }
+
+      if (!text.startsWith(typedText)) {
+        return null;
+      }
+    }
     let injectDetails: string | undefined = undefined;
 
     // The first time intellisense dropdown shows up, and the first choice is selected,


### PR DESCRIPTION
## Description

When editing JS files, typing "window." triggers intellisense and automatically selects the first suggestion 
 ("window.AbortController"). The AI model would then use this default selection to insert a completion without user input.

This update ensures that AI completion only activates after the user has typed at least 4 characters beyond the default suggestion, preventing unwanted completions from appearing too soon.

## Screenshots
<img width="490" alt="Screenshot 2025-03-13 at 11 29 56 AM" src="https://github.com/user-attachments/assets/22dccbe5-d41f-44cc-ad91-4ce34afb4bd6" />

<img width="717" alt="Screenshot 2025-03-13 at 11 39 18 AM" src="https://github.com/user-attachments/assets/3af7e138-5b29-4368-b0f2-dbeafb1ca342" />

<img width="715" alt="Screenshot 2025-03-13 at 11 39 39 AM" src="https://github.com/user-attachments/assets/cc6dea7c-ce8d-44bf-a229-3cc79688ecb6" />

https://github.com/Granite-Code/granite-code/issues/12

