### PR TITLE
feat: retrieve AWS credentials from Env and ECS/EC2 instance

### DIFF
--- a/core/llm/llms/Bedrock.test.ts
+++ b/core/llm/llms/Bedrock.test.ts
@@ -1,5 +1,5 @@
 import { BedrockRuntimeClient } from "@aws-sdk/client-bedrock-runtime";
-import { fromIni } from "@aws-sdk/credential-providers";
+import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
 import Bedrock from "./Bedrock.js";
 import { ChatMessage, Chunk, CompletionOptions, UserChatMessage } from "../../index.js";
 
@@ -15,7 +15,7 @@ jest.mock("@aws-sdk/client-bedrock-runtime", () => ({
 
 // Mock credential provider
 jest.mock("@aws-sdk/credential-providers", () => ({
-  fromIni: jest.fn().mockImplementation(() => async () => ({
+  fromNodeProviderChain: jest.fn().mockImplementation(() => async () => ({
     accessKeyId: "test-access-key",
     secretAccessKey: "test-secret-key",
     sessionToken: "test-session-token",

--- a/core/llm/llms/Bedrock.ts
+++ b/core/llm/llms/Bedrock.ts
@@ -3,7 +3,7 @@ import {
   ConverseStreamCommand,
   InvokeModelCommand,
 } from "@aws-sdk/client-bedrock-runtime";
-import { fromIni } from "@aws-sdk/credential-providers";
+import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
 
 import {
   ChatMessage,
@@ -328,7 +328,7 @@ class Bedrock extends BaseLLM {
 
   private async _getCredentials() {
     try {
-      return await fromIni({
+      return await fromNodeProviderChain({
         profile: this.profile,
         ignoreCache: true,
       })();
@@ -336,7 +336,7 @@ class Bedrock extends BaseLLM {
       console.warn(
         `AWS profile with name ${this.profile} not found in ~/.aws/credentials, using default profile`,
       );
-      return await fromIni()();
+      return await fromNodeProviderChain()();
     }
   }
 

--- a/core/llm/llms/BedrockImport.ts
+++ b/core/llm/llms/BedrockImport.ts
@@ -1,8 +1,8 @@
 import {
-  BedrockRuntimeClient,
-  InvokeModelWithResponseStreamCommand,
+    BedrockRuntimeClient,
+    InvokeModelWithResponseStreamCommand,
 } from "@aws-sdk/client-bedrock-runtime";
-import { fromIni } from "@aws-sdk/credential-providers";
+import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
 
 import { CompletionOptions, LLMOptions } from "../../index.js";
 import { BaseLLM } from "../index.js";
@@ -77,7 +77,7 @@ class BedrockImport extends BaseLLM {
 
   private async _getCredentials() {
     try {
-      return await fromIni({
+      return await fromNodeProviderChain({
         profile: this.profile,
         ignoreCache: true,
       })();
@@ -85,7 +85,7 @@ class BedrockImport extends BaseLLM {
       console.warn(
         `AWS profile with name ${this.profile} not found in ~/.aws/credentials, using default profile`,
       );
-      return await fromIni()();
+      return await fromNodeProviderChain()();
     }
   }
 }

--- a/core/llm/llms/SageMaker.ts
+++ b/core/llm/llms/SageMaker.ts
@@ -1,9 +1,9 @@
 import {
-  InvokeEndpointCommand,
-  InvokeEndpointWithResponseStreamCommand,
-  SageMakerRuntimeClient,
+    InvokeEndpointCommand,
+    InvokeEndpointWithResponseStreamCommand,
+    SageMakerRuntimeClient,
 } from "@aws-sdk/client-sagemaker-runtime";
-import { fromIni } from "@aws-sdk/credential-providers";
+import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
 
 // @ts-ignore
 import jinja from "jinja-js";
@@ -130,14 +130,14 @@ class SageMaker extends BaseLLM {
 
   private async _getCredentials() {
     try {
-      return await fromIni({
+      return await fromNodeProviderChain({
         profile: this.profile,
       })();
     } catch (e) {
       console.warn(
         `AWS profile with name ${this.profile} not found in ~/.aws/credentials, using default profile`,
       );
-      return await fromIni()();
+      return await fromNodeProviderChain()();
     }
   }
 


### PR DESCRIPTION
## Description

Use [`fromNodeProviderChain()`](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-credential-providers/#fromnodeproviderchain) instead of `fromInit()` to allow authenticating to AWS with env vars or with ECS/EC2/EKS instance credentials.

Here is my use case: I am using [code-server](https://github.com/coder/code-server) (a fork of VSCode by Coder designed to run in a browser) inside a pod in an AWS EKS cluster. AWS permissions are granted to this pod through a [Pod Identity Association](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html), which allows fine-grained permission control for pods.

In code-server, the installation of Continue works fine, but during authentication to AWS Bedrock, there is an issue because Continue cannot find the `~/.aws/credentials` file. This is expected—it does not exist. The Pod Identity controller only exposes an AWS token to the pod at the location `/var/run/secrets/pods.eks.amazonaws.com/serviceaccount/eks-pod-identity-token`. The `fromInit()` method used in Continue does not read this specific file.

That is why the AWS SDK documentation recommends using the `fromNodeProviderChain()` method, which sequentially searches for credentials across all possible locations, not just `~/.aws/credentials` and `/var/run/secrets/pods.eks.amazonaws.com/serviceaccount/eks-pod-identity-token`.

This credential provider method `fromNodeProviderChain()` will attempt to find credentials from the following sources (in order of precedence):
	•	Environment variables exposed via process.env
	•	SSO credentials from the token cache
	•	Web identity token credentials
	•	Shared credentials and config .ini files (including `~/.aws/credentials`)
	•	The EC2/ECS Instance Metadata Service (including EKS Pod Identity)

I tested my branch, and it connects to Bedrock without any issues!
It’s amazing to be able to use Claude 3.5 Sonnet in a fully browser-based VSCode without having to manually manage credentials.

I hope my contribution will help expand the possibilities of using Continue.

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created


## Testing instructions

- run [code-server](https://github.com/coder/code-server) in an EC2 instance with an IAM instance profile, an ECS container with a IAM role, or an EKS pod with a Pod Identity.
- install Continue (from the marketplace or from the .vsix package)
- use the config.json provided in the [Continue documentation for AWS Bedrock](https://docs.continue.dev/customize/model-providers/bedrock)
