### PR TITLE
fix: Eliminate Uncaught TypeError in dev tools

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinuePluginToolWindowFactory.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinuePluginToolWindowFactory.kt
@@ -11,7 +11,7 @@ import com.intellij.openapi.wm.ToolWindowFactory
 import com.intellij.ui.content.ContentFactory
 import javax.swing.*
 
-const val JS_QUERY_POOL_SIZE = "200"
+const val JS_QUERY_POOL_SIZE = 200
 
 class ContinuePluginToolWindowFactory : ToolWindowFactory, DumbAware {
   override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
@@ -42,11 +42,6 @@ class ContinuePluginToolWindowFactory : ToolWindowFactory, DumbAware {
 
   class ContinuePluginWindow(project: Project) {
     private val defaultGUIUrl = "http://continue/index.html"
-
-    init {
-      System.setProperty("ide.browser.jcef.jsQueryPoolSize", JS_QUERY_POOL_SIZE)
-      System.setProperty("ide.browser.jcef.contextMenu.devTools.enabled", "true")
-    }
 
     val browser: ContinueBrowser by lazy {
       val url = System.getenv("GUI_URL")?.toString() ?: defaultGUIUrl


### PR DESCRIPTION
## Description

Eliminate the `Uncaught TypeError: window.cefQuery_xxx is not a function` error that keeps appearing in the JS debug console.

## Screenshots

![err0315](https://github.com/user-attachments/assets/e23982b1-c275-453d-a5de-bb498198409f)

