### PR TITLE
feat: Openrouter reasoning support

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -361,6 +361,7 @@ export interface AssistantChatMessage {
   role: "assistant";
   content: MessageContent;
   toolCalls?: ToolCallDelta[];
+  reasoning?: string;
 }
 
 export interface SystemChatMessage {

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -445,6 +445,7 @@ interface Reasoning {
   text: string;
   startAt: number;
   endAt?: number;
+  inField: boolean; //< If true, then `reasoning` field used checked for text of reasoning, if false - <think> </think> tags in `content` used
 }
 
 export interface ChatHistoryItem {

--- a/core/llm/openaiTypeConverters.ts
+++ b/core/llm/openaiTypeConverters.ts
@@ -1,20 +1,17 @@
 import { FimCreateParamsStreaming } from "@continuedev/openai-adapters/dist/apis/base";
 import {
-  Chat,
   ChatCompletion,
   ChatCompletionAssistantMessageParam,
   ChatCompletionChunk,
   ChatCompletionCreateParams,
   ChatCompletionMessageParam,
-  ChatCompletionUserMessageParam,
-  CompletionCreateParams,
+  CompletionCreateParams
 } from "openai/resources/index";
 
 import {
   ChatMessage,
   CompletionOptions,
-  MessageContent,
-  TextMessagePart,
+  TextMessagePart
 } from "..";
 
 export function toChatMessage(
@@ -179,11 +176,19 @@ export function fromChatCompletionChunk(
   chunk: ChatCompletionChunk,
 ): ChatMessage | undefined {
   const delta = chunk.choices?.[0]?.delta;
+  const delta_any = delta as any;
 
   if (delta?.content) {
     return {
       role: "assistant",
       content: delta.content,
+      reasoning: delta_any.reasoning
+    };
+  } else if (delta_any?.reasoning) {
+    return {
+      role: "assistant",
+      content: "",
+      reasoning: delta_any.reasoning
     };
   } else if (delta?.tool_calls) {
     return {

--- a/core/util/messageContent.ts
+++ b/core/util/messageContent.ts
@@ -28,6 +28,14 @@ export function renderChatMessage(message: ChatMessage): string {
   }
 }
 
+export function renderReasoningMessage(message: ChatMessage): string | undefined {
+  if (message.role === "assistant" && message.reasoning) {
+    return stripImages(message.reasoning);
+  }
+
+  return undefined;
+}
+
 export function renderContextItems(contextItems: ContextItem[]): string {
   return contextItems.map((item) => item.content).join("\n\n");
 }

--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -364,10 +364,11 @@ export const sessionSlice = createSlice({
                   startAt: Date.now(),
                   active: true,
                   text: message.reasoning,
+                  inField: true,
                 };
               }
             } else if (message.role == "assistant") {
-              if (lastItem.reasoning?.active) {
+              if (lastItem.reasoning?.active && lastItem.reasoning?.inField) {
                 lastItem.reasoning.text += message.reasoning;
                 lastItem.reasoning.active = false;
                 lastItem.reasoning.endAt = Date.now();
@@ -382,6 +383,7 @@ export const sessionSlice = createSlice({
                   startAt: Date.now(),
                   active: true,
                   text: messageContent.replace("<think>", "").trim(),
+                  inField: false,
                 };
               } else if (
                 lastItem.reasoning?.active &&

--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -356,6 +356,24 @@ export const sessionSlice = createSlice({
             }
             state.history.push(historyItem);
           } else {
+            if (message.role == "assistant" && message.reasoning) {
+              if (lastItem.reasoning?.active) {
+                lastItem.reasoning.text += message.reasoning;
+              } else {
+                lastItem.reasoning = {
+                  startAt: Date.now(),
+                  active: true,
+                  text: message.reasoning,
+                };
+              }
+            } else if (message.role == "assistant") {
+              if (lastItem.reasoning?.active) {
+                lastItem.reasoning.text += message.reasoning;
+                lastItem.reasoning.active = false;
+                lastItem.reasoning.endAt = Date.now();
+              }
+            }
+
             // Add to the existing message
             if (message.content) {
               const messageContent = renderChatMessage(message);

--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -25,7 +25,7 @@ import { ProfileDescription } from "core/config/ConfigHandler";
 import { OrganizationDescription } from "core/config/ProfileLifecycleManager";
 import { NEW_SESSION_TITLE } from "core/util/constants";
 import { incrementalParseJson } from "core/util/incrementalParseJson";
-import { renderChatMessage } from "core/util/messageContent";
+import { renderChatMessage, renderReasoningMessage } from "core/util/messageContent";
 import { findUriInDirs, getUriPathBasename } from "core/util/uri";
 import { v4 as uuidv4 } from "uuid";
 import { RootState } from "../store";
@@ -356,20 +356,25 @@ export const sessionSlice = createSlice({
             }
             state.history.push(historyItem);
           } else {
+
             if (message.role == "assistant" && message.reasoning) {
+              const messageReasoning = renderReasoningMessage(message);
+
               if (lastItem.reasoning?.active) {
-                lastItem.reasoning.text += message.reasoning;
+                lastItem.reasoning.text += messageReasoning;
               } else {
                 lastItem.reasoning = {
                   startAt: Date.now(),
                   active: true,
-                  text: message.reasoning,
+                  text: messageReasoning ?? "",
                   inField: true,
                 };
               }
             } else if (message.role == "assistant") {
+              const messageReasoning = renderReasoningMessage(message);
+              
               if (lastItem.reasoning?.active && lastItem.reasoning?.inField) {
-                lastItem.reasoning.text += message.reasoning;
+                lastItem.reasoning.text += messageReasoning ?? "";
                 lastItem.reasoning.active = false;
                 lastItem.reasoning.endAt = Date.now();
               }


### PR DESCRIPTION
## Description

Added initial support of thinking retrieval from Openrouter.

Currently. It is required to set up `extraBodyProperties` and `provider` correctly:

Deepseek is working, but some models may not return reasoning even if they are thinking. Can be verified with curl.

```yaml
# Note: openai here, idk why, but with `openrouter` it will not work
  - provider: openai
    apiBase: https://openrouter.ai/api/v1
    apiKey: sk-*
    name: Openrouter Deepseek R1 FREE
    model: deepseek/deepseek-r1:free
    requestOptions:
      extraBodyProperties:
        stream: true
        include_reasoning: true
```

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

![изображение](https://github.com/user-attachments/assets/01e3d50c-4d08-4fbf-8e26-138ac16e98bf)
![изображение](https://github.com/user-attachments/assets/6e41ba4f-45da-4862-a041-c4c30fff9ea5)


## Testing instructions

1. set up config.yaml to use openrouter DeepSeek R1 model and add  `extraBodyProperties:` from __Description__ section.
2. Send chat request and ensure the `Thinking...` section appeared
3. It should be tested that Ollama Deepseek R1 still working.  
