### PR TITLE
Feature/jira context provider added max result attribute

### DIFF
--- a/core/context/providers/JiraIssuesContextProvider/JiraClient.ts
+++ b/core/context/providers/JiraIssuesContextProvider/JiraClient.ts
@@ -148,7 +148,7 @@ export class JiraClient {
           `/search?fields=summary&jql=${
             this.options.issueQuery ??
             "assignee = currentUser() AND resolution = Unresolved order by updated DESC"
-          }&maxResults=${this.options.maxResults}`,
+          }&maxResults=${this.options.maxResults ?? "50"}`,
       ),
       {
         method: "GET",

--- a/core/context/providers/JiraIssuesContextProvider/JiraClient.ts
+++ b/core/context/providers/JiraIssuesContextProvider/JiraClient.ts
@@ -9,6 +9,7 @@ interface JiraClientOptions {
   password: string;
   issueQuery?: string;
   apiVersion?: string;
+  maxResults?: string;
   requestOptions?: RequestOptions;
 }
 
@@ -73,6 +74,7 @@ export class JiraClient {
         "assignee = currentUser() AND resolution = Unresolved order by updated DESC",
       apiVersion: "3",
       requestOptions: {},
+      maxResults: "50",
       ...options,
     };
     this.baseUrl = `https://${this.options.domain}/rest/api/${this.options.apiVersion}`;
@@ -146,7 +148,7 @@ export class JiraClient {
           `/search?fields=summary&jql=${
             this.options.issueQuery ??
             "assignee = currentUser() AND resolution = Unresolved order by updated DESC"
-          }`,
+          }&maxResults=${this.options.maxResults}`,
       ),
       {
         method: "GET",

--- a/core/context/providers/JiraIssuesContextProvider/index.ts
+++ b/core/context/providers/JiraIssuesContextProvider/index.ts
@@ -25,6 +25,7 @@ class JiraIssuesContextProvider extends BaseContextProvider {
       issueQuery: this.options.issueQuery,
       apiVersion: this.options.apiVersion,
       requestOptions: this.options.requestOptions,
+      maxResults: this.options.maxResults
     });
   }
 
@@ -32,8 +33,6 @@ class JiraIssuesContextProvider extends BaseContextProvider {
     query: string,
     extras: ContextProviderExtras,
   ): Promise<ContextItem[]> {
-    const issueId = query;
-
     const api = this.getApi();
     const issue = await api.issue(query, extras.fetch);
 

--- a/docs/docs/customize/context-providers.mdx
+++ b/docs/docs/customize/context-providers.mdx
@@ -879,6 +879,11 @@ assignee = currentUser() AND resolution = Unresolved order by updated DESC
 
 You can override this query by setting the `issueQuery` parameter.
 
+#### Max results
+
+You can set the `maxResults` parameter to limit the number of results returned. The default is `50`.
+
+
 ### `@Discord`
 
 Reference the messages in a Discord channel.

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -2329,6 +2329,10 @@
                     "type": "string",
                     "description": "Customize the query used to find Jira issues"
                   },
+                  "maxResults": {
+                    "type": "string",
+                    "description": "The maximum number of issues that will be returned. Defaults to 50."
+                  },
                   "apiVersion": {
                     "type": "integer",
                     "markdownDescription": "This context provider supports both Jira API version 2 and 3. It will use version 3 by default since that's what the cloud version uses, but if you have the datacenter version of Jira, you'll need to set the API Version to 2 using the `apiVersion` property.",


### PR DESCRIPTION
## Description

For the lira context provider it was not possible to configure the maximum number of result items. No wit is possible to configure this number.

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing instructions

1. setup jira context provider
2. configure a query which response with more then 50 items
