### PR TITLE
rejected edits trailing whitespaces 

### DIFF
--- a/core/diff/streamDiff.ts
+++ b/core/diff/streamDiff.ts
@@ -35,7 +35,6 @@ export async function* streamDiff(
 
     let type: DiffLineType;
 
-    let isLineRemoval = false;
     const isNewLine = matchIndex === -1;
 
     if (isNewLine) {
@@ -45,7 +44,6 @@ export async function* streamDiff(
       for (let i = 0; i < matchIndex; i++) {
         yield { type: "old", line: oldLinesCopy.shift()! };
       }
-
       type = isPerfectMatch ? "same" : "old";
     }
 
@@ -60,22 +58,13 @@ export async function* streamDiff(
 
       case "old":
         yield { type, line: oldLinesCopy.shift()! };
-
-        if (oldLinesCopy[0] !== newLine) {
-          yield { type: "new", line: newLine };
-        } else {
-          isLineRemoval = true;
-        }
-
+        yield { type: "new", line: newLine };
         break;
 
       default:
         console.error(`Error streaming diff, unrecognized diff type: ${type}`);
     }
-
-    if (!isLineRemoval) {
-      newLineResult = await newLines.next();
-    }
+    newLineResult = await newLines.next();
   }
 
   // Once at the edge, only one choice

--- a/core/diff/util.ts
+++ b/core/diff/util.ts
@@ -62,18 +62,23 @@ export function matchLine(
   const isEndBracket = END_BRACKETS.includes(newLine.trim());
 
   for (let i = 0; i < oldLines.length; i++) {
+    // trims trailing whitespaces from the lines before comparison
+    //this ensures trailing spaces don't affect matching.
+    const oldLineTrimmed = oldLines[i].trimEnd();
+    const newLineTrimmed = newLine.trimEnd();
+
     // Don't match end bracket lines if too far away
     if (i > 4 && isEndBracket) {
       return { matchIndex: -1, isPerfectMatch: false, newLine };
     }
 
-    if (linesMatchPerfectly(newLine, oldLines[i])) {
+    if (linesMatchPerfectly(newLineTrimmed, oldLineTrimmed)) {
       return { matchIndex: i, isPerfectMatch: true, newLine };
     }
-    if (linesMatch(newLine, oldLines[i], i)) {
+    if (linesMatch(newLineTrimmed, oldLineTrimmed, i)) {
       // This is a way to fix indentation, but only for sufficiently long lines to avoid matching whitespace or short lines
       if (
-        newLine.trimStart() === oldLines[i].trimStart() &&
+        newLineTrimmed.trimStart() === oldLineTrimmed.trimStart() &&
         (permissiveAboutIndentation || newLine.trim().length > 8)
       ) {
         return {

--- a/core/edit/streamDiffLines.ts
+++ b/core/edit/streamDiffLines.ts
@@ -78,9 +78,6 @@ export async function* streamDiffLines(
     oldLines = [];
   }
 
-  // Trim end of oldLines, otherwise we have trailing \r on every line for CRLF files
-  oldLines = oldLines.map((line) => line.trimEnd());
-
   const prompt =
     overridePrompt ??
     constructPrompt(prefix, highlighted, suffix, llm, input, language);


### PR DESCRIPTION
## Description

Earlier trailing whitespace was stripped in streamDiffLines.ts before generating diffs, causing mismatches when rejecting a diff in the editor.
This fix updates linesMatchPerfectly to compare lines using trimEnd(), ensuring that trailing whitespace differences do not interfere with accurate diff rejection.

## Screenshots

<img width="834" alt="Screenshot 2025-03-14 at 3 14 53 PM" src="https://github.com/user-attachments/assets/56de1af2-9bb4-447a-8605-ca1a51c1697e" />

<img width="888" alt="Screenshot 2025-03-14 at 3 14 28 PM" src="https://github.com/user-attachments/assets/7f0cfeac-61e6-4f59-9890-340a568cd388" />


https://github.com/Granite-Code/granite-code/issues/50