### PR TITLE
Remove unused MCP connections on config reload

### DIFF
--- a/core/config/load.ts
+++ b/core/config/load.ts
@@ -28,6 +28,7 @@ import {
   IdeType,
   ILLM,
   LLMOptions,
+  MCPOptions,
   ModelDescription,
   RerankerDescription,
   SerializedContinueConfig,
@@ -542,40 +543,39 @@ async function intermediateToFinalConfig(
 
   // Apply MCP if specified
   const mcpManager = MCPManagerSingleton.getInstance();
+  function getMcpId(options: MCPOptions) {
+    return JSON.stringify(options);
+  }
+  if (config.experimental?.modelContextProtocolServers) {
+    await mcpManager.removeUnusedConnections(
+      config.experimental.modelContextProtocolServers.map(getMcpId),
+    );
+  }
+
   if (config.experimental?.modelContextProtocolServers) {
     const abortController = new AbortController();
     const mcpConnectionTimeout = setTimeout(
       () => abortController.abort(),
-      4000,
+      5000,
     );
 
     await Promise.allSettled(
       config.experimental.modelContextProtocolServers?.map(
         async (server, index) => {
           try {
-            const mcpId = index.toString();
+            const mcpId = getMcpId(server);
             const mcpConnection = mcpManager.createConnection(mcpId, server);
-            if (!mcpConnection) {
-              return;
-            }
-            const mcpError = await mcpConnection.modifyConfig(
+            await mcpConnection.modifyConfig(
               continueConfig,
               mcpId,
               abortController.signal,
               "MCP Server",
               server.faviconUrl,
             );
-            if (mcpError) {
-              errors.push(mcpError);
-            }
           } catch (e) {
             let errorMessage = "Failed to load MCP server";
             if (e instanceof Error) {
-              if (e.name === "AbortError") {
-                errorMessage += ": connection timed out";
-              } else {
-                errorMessage += ": " + e.message;
-              }
+              errorMessage += ": " + e.message;
             }
             errors.push({
               fatal: false,
@@ -998,6 +998,5 @@ export {
   finalToBrowserConfig,
   intermediateToFinalConfig,
   loadContinueConfigFromJson,
-  type BrowserSerializedContinueConfig
+  type BrowserSerializedContinueConfig,
 };
-

--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -369,6 +369,11 @@ async function configYamlToContinueConfig(
 
   // Apply MCP if specified
   const mcpManager = MCPManagerSingleton.getInstance();
+  if (config.mcpServers) {
+    await mcpManager.removeUnusedConnections(
+      config.mcpServers.map((s) => s.name),
+    );
+  }
   await Promise.allSettled(
     config.mcpServers?.map(async (server) => {
       const abortController = new AbortController();

--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -392,6 +392,7 @@ async function configYamlToContinueConfig(
             ...server,
           },
         });
+
         await mcpConnection.modifyConfig(
           continueConfig,
           mcpId,

--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -374,12 +374,13 @@ async function configYamlToContinueConfig(
       config.mcpServers.map((s) => s.name),
     );
   }
+
   await Promise.allSettled(
     config.mcpServers?.map(async (server) => {
       const abortController = new AbortController();
       const mcpConnectionTimeout = setTimeout(
         () => abortController.abort(),
-        4000,
+        5000,
       );
 
       try {
@@ -391,28 +392,17 @@ async function configYamlToContinueConfig(
             ...server,
           },
         });
-        if (!mcpConnection) {
-          return;
-        }
-
-        const mcpError = await mcpConnection.modifyConfig(
+        await mcpConnection.modifyConfig(
           continueConfig,
           mcpId,
           abortController.signal,
           server.name,
           server.faviconUrl,
         );
-        if (mcpError) {
-          localErrors.push(mcpError);
-        }
       } catch (e) {
         let errorMessage = `Failed to load MCP server ${server.name}`;
         if (e instanceof Error) {
-          if (e.name === "AbortError") {
-            errorMessage += ": connection timed out";
-          } else {
-            errorMessage += ": " + e.message;
-          }
+          errorMessage += ": " + e.message;
         }
         localErrors.push({
           fatal: false,

--- a/core/context/mcp/index.ts
+++ b/core/context/mcp/index.ts
@@ -47,10 +47,9 @@ export class MCPManagerSingleton {
   }
 
   async removeUnusedConnections(keepIds: string[]) {
-    const toRemove = this.connections
-      .keys()
-      .toArray()
-      .filter((k) => !keepIds.includes(k));
+    const toRemove = Array.from(this.connections.keys()).filter(
+      (k) => !keepIds.includes(k),
+    );
     await Promise.all(toRemove.map(this.removeConnection));
   }
 }

--- a/core/context/mcp/index.ts
+++ b/core/context/mcp/index.ts
@@ -46,6 +46,13 @@ export class MCPManagerSingleton {
 
     this.connections.delete(id);
   }
+
+  async removeUnusedConnections(keepIds: string[]) {
+    const toRemove = this.connections
+      .keys()
+      .filter((k) => !keepIds.includes(k));
+    await Promise.all(toRemove.map(this.removeConnection));
+  }
 }
 
 class MCPConnection {

--- a/core/context/mcp/index.ts
+++ b/core/context/mcp/index.ts
@@ -49,6 +49,7 @@ export class MCPManagerSingleton {
   async removeUnusedConnections(keepIds: string[]) {
     const toRemove = this.connections
       .keys()
+      .toArray()
       .filter((k) => !keepIds.includes(k));
     await Promise.all(toRemove.map(this.removeConnection));
   }

--- a/core/context/mcp/index.ts
+++ b/core/context/mcp/index.ts
@@ -140,13 +140,20 @@ class MCPConnection {
         }),
       ]);
     } catch (error) {
-      // don't throw error if it's just a "server already running" case
-      if (
-        !(
-          error instanceof Error &&
-          error.message.startsWith("StdioClientTransport already started")
-        )
-      ) {
+      if (error instanceof Error) {
+        const msg = error.message.toLowerCase();
+        if (msg.includes("spawn") && msg.includes("enoent")) {
+          const command = msg.split(" ")[1];
+          throw new Error(
+            `command "${command}" not found. To use this MCP server, install the ${command} CLI.`,
+          );
+        } else if (
+          !error.message.startsWith("StdioClientTransport already started")
+        ) {
+          // don't throw error if it's just a "server already running" case
+          throw error;
+        }
+      } else {
         throw error;
       }
     }


### PR DESCRIPTION
## Description
- remove unused MCP connections on config reload
- simplify/fix MCP error handling (especially in case of abort)
- use stringified config for mcp id in config json
- handle `spawn [command] ENOENT` errors - make them more readable