### PR TITLE
Changed Enter button icon and fixed sensitivity issues

### DIFF
--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -1,4 +1,4 @@
-import { AtSymbolIcon, PhotoIcon } from "@heroicons/react/24/outline";
+import { AtSymbolIcon, PaperAirplaneIcon, PhotoIcon } from "@heroicons/react/24/outline";
 import { InputModifiers } from "core";
 import { modelSupportsImages, modelSupportsTools } from "core/llm/autodetect";
 import { useRef } from "react";
@@ -50,7 +50,8 @@ const StyledDiv = styled.div<{ isHidden?: boolean }>`
 
 const EnterButton = styled.button<{ isPrimary?: boolean }>`
   all: unset;
-  padding: 2px 4px;
+  padding: 3px 4px;
+  padding-bottom: 0px;
   display: flex;
   align-items: center;
   background-color: ${(props) =>
@@ -83,6 +84,7 @@ interface InputToolbarProps {
   toolbarOptions?: ToolbarOptions;
   disabled?: boolean;
   isMainInput?: boolean;
+  hasText?: boolean;
 }
 
 function InputToolbar(props: InputToolbarProps) {
@@ -223,10 +225,18 @@ function InputToolbar(props: InputToolbarProps) {
             }}
             disabled={isEnterDisabled}
           >
-            <span className="hidden md:inline">
-              ⏎ {props.toolbarOptions?.enterText ?? "Enter"}
+            <span data-tooltip-id="submit-tooltip">
+              <PaperAirplaneIcon
+                className={`h-4 w-4 ${
+                  props.hasText
+                  ? "text-[var(--vscode-editorForeground)]"
+                  : "text-[var(--vscode-descriptionForeground)]"
+                } transition duration-150 ease-in-out`}
+              />
             </span>
-            <span className="md:hidden">⏎</span>
+            <ToolTip id="submit-tooltip" place="top-middle">
+              Send (Enter)
+            </ToolTip>
           </EnterButton>
         </div>
       </StyledDiv>

--- a/gui/src/components/mainInput/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor.tsx
@@ -551,6 +551,21 @@ function TipTapEditor(props: TipTapEditorProps) {
     editable: !isStreaming || props.isMainInput,
   });
 
+  const [hasText, setHasText] = useState(false);
+  useEffect(() => {
+    if (!editor) return;
+    // Check if the editor has text
+    const updateEditorHandler = () => {
+      const text = editor.getText().trim();
+      setHasText(text.length > 0);
+    };
+    editor.on("update", updateEditorHandler);
+    updateEditorHandler();
+    return () => {
+      editor.off("update", updateEditorHandler);
+    };
+  }, [editor]);
+
   const [shouldHideToolbar, setShouldHideToolbar] = useState(false);
   const debouncedShouldHideToolbar = debounce((value) => {
     setShouldHideToolbar(value);
@@ -1015,6 +1030,7 @@ function TipTapEditor(props: TipTapEditorProps) {
             });
           }}
           disabled={isStreaming}
+          hasText={hasText}
         />
       </div>
 


### PR DESCRIPTION
## Description

Chat view: Improve look and feel of the enter button

The chat view for continue currently consists of a Send(Enter) button that looks like an enter key icon (↵), which isn't ideal as many keyboards don't use that icon anymore.

Furthermore, there are some sensitivity issues:
 - the button is active sometimes when it shouldn't be (when there's no user input).
 - the styling of the button makes it appear insensitive sometimes, even when it's active.

This commit addresses these issues, by switching to a more modern airplane icon, using vscode theme colors for styling.
Marking the button insensitive when there's no user input.


## Screenshots
<img width="328" alt="Screenshot 2025-03-17 at 3 27 13 PM" src="https://github.com/user-attachments/assets/436c873a-9457-45a1-bfb8-c05fafbe2b46" />

<img width="325" alt="Screenshot 2025-03-17 at 3 26 35 PM" src="https://github.com/user-attachments/assets/b8a6aeed-4a51-4e59-afa1-37ecd44fe7a2" />


[Granite.Code Issue #32](https://github.com/Granite-Code/granite-code/issues/32)