### PR TITLE
Remove llm/streamcomplete

### DIFF
--- a/core/core.ts
+++ b/core/core.ts
@@ -554,45 +554,6 @@ export class Core {
       llmStreamChat(this.configHandler, this.abortedMessageIds, msg),
     );
 
-    async function* llmStreamComplete(
-      configHandler: ConfigHandler,
-      abortedMessageIds: Set<string>,
-      msg: Message<ToCoreProtocol["llm/streamComplete"][0]>,
-    ): AsyncGenerator<string, PromptLog> {
-      const model = await configHandler.llmFromTitle(msg.data.title);
-      const gen = model.streamComplete(
-        msg.data.prompt,
-        new AbortController().signal,
-        msg.data.completionOptions,
-      );
-      let next = await gen.next();
-      while (!next.done) {
-        if (abortedMessageIds.has(msg.messageId)) {
-          abortedMessageIds.delete(msg.messageId);
-          next = await gen.return({
-            modelTitle: model.title ?? model.model,
-            completion: "",
-            prompt: "",
-            completionOptions: {
-              ...msg.data.completionOptions,
-              model: model.model,
-            },
-          });
-          break;
-        }
-        yield next.value;
-        next = await gen.next();
-      }
-      if (!next.done) {
-        throw new Error("This will never happen");
-      }
-      return next.value;
-    }
-
-    on("llm/streamComplete", (msg) =>
-      llmStreamComplete(this.configHandler, this.abortedMessageIds, msg),
-    );
-
     on("llm/complete", async (msg) => {
       const model = await this.configHandler.llmFromTitle(msg.data.title);
       const completion = await model.complete(

--- a/core/protocol/core.ts
+++ b/core/protocol/core.ts
@@ -124,14 +124,6 @@ export type ToCoreFromIdeOrWebviewProtocol = {
     string,
   ];
   "llm/listModels": [{ title: string }, string[] | undefined];
-  "llm/streamComplete": [
-    {
-      prompt: string;
-      completionOptions: LLMFullCompletionOptions;
-      title: string;
-    },
-    AsyncGenerator<string>,
-  ];
   "llm/streamChat": [
     {
       messages: ChatMessage[];

--- a/core/protocol/passThrough.ts
+++ b/core/protocol/passThrough.ts
@@ -38,7 +38,6 @@ export const WEBVIEW_TO_CORE_PASS_THROUGH: (keyof ToCoreFromWebviewProtocol)[] =
     "command/run",
     "tts/kill",
     "llm/complete",
-    "llm/streamComplete",
     "llm/streamChat",
     "llm/listModels",
     "streamDiffLines",

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/MessageTypes.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/MessageTypes.kt
@@ -106,7 +106,6 @@ class MessageTypes {
             "command/run",
             "tts/kill",
             "llm/complete",
-            "llm/streamComplete",
             "llm/streamChat",
             "llm/listModels",
             "streamDiffLines",


### PR DESCRIPTION
## Description
- Remove unused llm streamcomplete function/message
- This has been unused since `useLegacyCompletionsEndpoint` was introduced as far as I'm aware
