### PR TITLE
Protect use cases where systemMessage is missing

### DIFF
--- a/core/llm/llms/VertexAI.ts
+++ b/core/llm/llms/VertexAI.ts
@@ -94,9 +94,11 @@ class VertexAI extends BaseLLM {
   ): AsyncGenerator<ChatMessage> {
     const shouldCacheSystemMessage =
       !!this.systemMessage && this.cacheBehavior?.cacheSystemMessage;
-    const systemMessage: string = renderChatMessage(
-      messages.filter((m) => m.role === "system")[0],
-    );
+    const filteredSystemMessages : ChatMessage[] = messages.filter((m) => m.role === "system");
+    let systemMessage: string = "";
+    if(filteredSystemMessages.length > 0) {
+      systemMessage = renderChatMessage(filteredSystemMessages[0]);
+    }
     const apiURL = new URL(
       `publishers/anthropic/models/${options.model}:streamRawPredict`,
       this.apiBase,

--- a/core/util/messageContent.ts
+++ b/core/util/messageContent.ts
@@ -18,7 +18,7 @@ export function stripImages(messageContent: MessageContent): string {
 }
 
 export function renderChatMessage(message: ChatMessage): string {
-  switch (message.role) {
+  switch (message?.role) {
     case "user":
     case "assistant":
     case "thinking":
@@ -26,6 +26,8 @@ export function renderChatMessage(message: ChatMessage): string {
       return stripImages(message.content);
     case "tool":
       return message.content;
+    default:
+      return "";
   }
 }
 


### PR DESCRIPTION
## Description

Fixes issue #4723

1. `messageContent.ts#renderChatMessages` is protected from use cases where there is no systemMessage.
2. `VertexAI.ts` was updated to tolerate when none of the messages have a 'system' role.

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing instructions

See the reproduction instructions on #4723.
