### PR TITLE
Improved text selection by allowing multiple edit ranges to be highlighted

### DIFF
--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -569,7 +569,7 @@ const getCommandsMap: (
       const range =
         args?.range ?? new vscode.Range(startFromCharZero, endAtCharLast);
 
-      editDecorationManager.setDecoration(editor, range);
+      editDecorationManager.addDecorations(editor, [range]);
 
       const rangeInFileWithContents = getRangeInFileWithContents(true, range);
 

--- a/extensions/vscode/src/quickEdit/EditDecorationManager.ts
+++ b/extensions/vscode/src/quickEdit/EditDecorationManager.ts
@@ -2,6 +2,7 @@ import vscode from "vscode";
 class EditDecorationManager {
   private _lastEditor: vscode.TextEditor | undefined;
   private decorationType: vscode.TextEditorDecorationType;
+  private activeRangesMap: Map<string, vscode.Range> = new Map(); // Store unique active ranges
 
   constructor(context: vscode.ExtensionContext) {
     this.decorationType = vscode.window.createTextEditorDecorationType({
@@ -23,18 +24,55 @@ class EditDecorationManager {
     );
   }
 
-  setDecoration(editor: vscode.TextEditor, range: vscode.Range) {
-    if (this._lastEditor) {
-      this._lastEditor.setDecorations(this.decorationType, []);
+  // Converts each range to a unique string for storing in the map
+  private rangeToString(range: vscode.Range): string {
+    return `(${range.start.line},${range.start.character})-(${range.end.line},${range.end.character})`;
+  }
+
+  // Checks if two ranges are adjacent or overlapping
+  private rangesCoincide(range1: vscode.Range, range2: vscode.Range): boolean {
+    return range1.start.isEqual(range2.start)
+    || range1.end.isEqual(range2.start)
+    || range2.end.isEqual(range1.start)
+    || !!range1.intersection(range2);
+  }
+
+  // Merges new range with existing ranges in the map
+  private mergeNewRange(newRange: vscode.Range): void {
+    let mergedRange = newRange;
+    const rangesToPrune: string[] = [];
+
+    for (const [key, existingRange] of this.activeRangesMap.entries()) {
+      if (!this.rangesCoincide(mergedRange, existingRange)) continue; 
+      mergedRange = mergedRange.union(existingRange);
+      rangesToPrune.push(key);
     }
-    editor.setDecorations(this.decorationType, [range]);
+
+    for (const key of rangesToPrune) this.activeRangesMap.delete(key);
+    this.activeRangesMap.set(this.rangeToString(mergedRange), mergedRange);
+  }
+
+  // Adds a new decoration to the editor and merges it with existing ranges
+  addDecorations(editor: vscode.TextEditor, ranges: vscode.Range[]): void {
+    if (this._lastEditor?.document !== editor.document) {
+      this.clear(); // Clear previous decorations if editor has changed
+    }
     this._lastEditor = editor;
+
+    for (const range of ranges) this.mergeNewRange(range);
+
+    const activeRanges = Array.from(this.activeRangesMap.values());
+    if (activeRanges.length === 0) return; // No ranges to highlight
+
+    // Update active ranges and apply decorations
+    editor.setDecorations(this.decorationType, activeRanges);
     this.updateInEditMode(true);
   }
 
   clear() {
     if (this._lastEditor) {
       this._lastEditor.setDecorations(this.decorationType, []);
+      this.activeRangesMap.clear();
       this._lastEditor = undefined;
       this.updateInEditMode(false);
     }


### PR DESCRIPTION
## Description

Text Selection: Decorate all active edit ranges

If a user selects multiple chunks of code with cmd-I, only the most recent chunk of code is decorated as a selection.

This commit addresses that problem by changing setDecorations to addDecorations, and carefully tracking which ranges are currently active in the EditDecorationManager. 

Additionally, overlapping or adjacent ranges are now merged seamlessly to prevent redundant highlights.

## Screenshots
<img width="1312" alt="Screenshot 2025-03-19 at 12 44 14 PM" src="https://github.com/user-attachments/assets/9cfd10a8-e68c-4d48-8702-29351a214f04" />

[Granite.Code Issue #49](https://github.com/Granite-Code/granite-code/issues/49)
@halfline
