### PR TITLE
fix: add checkmark icon to indicate selected model in dropdown

### DIFF
--- a/gui/src/components/modelSelection/ModelSelect.tsx
+++ b/gui/src/components/modelSelection/ModelSelect.tsx
@@ -5,6 +5,7 @@ import {
   CubeIcon,
   PlusIcon,
   TrashIcon,
+  CheckIcon,
 } from "@heroicons/react/24/outline";
 import { useContext, useEffect, useRef, useState } from "react";
 import { useDispatch } from "react-redux";
@@ -29,6 +30,7 @@ interface ModelOptionProps {
   idx: number;
   showMissingApiKeyMsg: boolean;
   showDelete?: boolean;
+  isSelected?: boolean;
 }
 
 interface Option {
@@ -132,6 +134,7 @@ function ModelOption({
   idx,
   showDelete,
   showMissingApiKeyMsg,
+  isSelected,
 }: ModelOptionProps) {
   const ideMessenger = useContext(IdeMessengerContext);
 
@@ -198,6 +201,9 @@ function ModelOption({
             <StyledCog6ToothIcon $hovered={hovered} onClick={onClickGear} />
             {showDelete && (
               <StyledTrashIcon $hovered={hovered} onClick={onClickDelete} />
+            )}
+            {isSelected && (
+              <CheckIcon className="ml-1 h-4 w-4" />
             )}
           </div>
         </div>
@@ -338,6 +344,7 @@ function ModelSelect() {
                 key={idx}
                 showDelete={options.length > 1}
                 showMissingApiKeyMsg={option.apiKey === ""}
+                isSelected={option.value === defaultModel?.title}
               />
             ))}
           </div>


### PR DESCRIPTION
## Description
Closes #4084 
This PR adds a visual indicator (checkmark icon) to show which model is currently selected in the model selection dropdown. The checkmark appears on the far right side of each model option box when that model is selected.

## Problem
Previously, there was no visual indication of which model was currently selected in the dropdown list, making it difficult for users to quickly identify their current selection. This change improves user experience by providing clear visual feedback.

Refer the before and after screenshots for clarity.

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

### Before
You can see, there's no visual representation in the dropdown of which model is currently being used.
![411854668-6632fd5e-cd26-421d-900c-e9a970d0370e](https://github.com/user-attachments/assets/0ede1727-cab8-4cbd-b5e2-5acbce7f75ef)


### After
Now you can see, there's a checkmark on the far right in the dropdown

https://github.com/user-attachments/assets/8890a4f8-e8e1-4163-9f36-bbc609245c72




## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
