### PR TITLE
Add IntelliJ inspection profiles and PHP configuration to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,9 @@ extensions/intellij/.idea/**
 **/.idea/workspace.xml
 **/.idea/usage.statistics.xml
 **/.idea/shelf/
+**/.idea/inspectionProfiles/Project_Default.xml
+**/.idea/php.xml
+
 
 extensions/intellij/bin
 extensions/.continue-debug/


### PR DESCRIPTION
## Description

When project are opened in both IntelliJ and VS Code, files under .idea are added by IntelliJ that is ignored if we work in IntellJ, but makes it hard to switch branches in VS Code.

I added the following files to gitignore:
```
**/.idea/inspectionProfiles/Project_Default.xml
**/.idea/php.xml
```
