### PR TITLE
Fix: Incorrect chat title generation

### DIFF
--- a/core/util/chatDescriber.ts
+++ b/core/util/chatDescriber.ts
@@ -30,19 +30,14 @@ export class ChatDescriber {
     completionOptions.maxTokens = ChatDescriber.maxTokens;
 
     // Prompt the user's current LLM for the title
-    const titleResponse = await model.chat(
-      [
-        {
-          role: "user",
-          content: ChatDescriber.prompt + message,
-        },
-      ],
+    const titleResponse = await model.complete(
+      ChatDescriber.prompt + message,
       new AbortController().signal,
       completionOptions,
     );
 
     // Set the title
-    return removeQuotesAndEscapes(titleResponse.content.toString());
+    return removeQuotesAndEscapes(titleResponse);
   }
 
   //   // TODO: Allow the user to manually set specific/tailored prompts to generate their titles


### PR DESCRIPTION
## Description
fixes: #4774 
The chat title was previously being generated as `[object Object][object Object]`. This issue has been fixed by ensuring the correct string representation is used for the title.

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots
As you can see in the attached screenshot, the chat title is now generated correctly.
![image](https://github.com/user-attachments/assets/ebcbe23e-9bd7-4c7a-95fb-a3bbb8736b85)

## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
