### PR TITLE
Add ApiKey to TEI embedding provider

### DIFF
--- a/core/llm/llms/HuggingFaceTEI.ts
+++ b/core/llm/llms/HuggingFaceTEI.ts
@@ -35,14 +35,20 @@ class HuggingFaceTEIEmbeddingsProvider extends BaseLLM {
   }
 
   async doEmbedRequest(batch: string[]): Promise<number[][]> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+  
+    if (this.apiKey) {
+      headers["Authorization"] = `Bearer ${this.apiKey}`;
+    }
+  
     const resp = await this.fetch(new URL("embed", this.apiBase), {
       method: "POST",
       body: JSON.stringify({
         inputs: batch,
       }),
-      headers: {
-        "Content-Type": "application/json",
-      },
+      headers,
     });
     if (!resp.ok) {
       const text = await resp.text();

--- a/docs/docs/customize/model-roles/embeddings.mdx
+++ b/docs/docs/customize/model-roles/embeddings.mdx
@@ -100,6 +100,7 @@ See [here](../model-providers/top-level/ollama.mdx#embeddings-model) for instruc
     - name: Huggingface TEI Embedder
       provider: huggingface-tei
       apiBase: http://localhost:8080
+      apiKey: <YOUR_TEI_API_KEY>
       roles: [embed]
   ```
   </TabItem>
@@ -108,7 +109,8 @@ See [here](../model-providers/top-level/ollama.mdx#embeddings-model) for instruc
   {
     "embeddingsProvider": {
       "provider": "huggingface-tei",
-      "apiBase": "http://localhost:8080"
+      "apiBase": "http://localhost:8080",
+      "apiKey": "<YOUR_TEI_API_KEY>"
     }
   }
   ```


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

Added the possibility to have an api-key in the tei embedding provider, following what was done for the rerank endpoint. 

## Checklist

- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
