### PR TITLE
fix: terminate thinking animation for reasoning model on request completion

### DIFF
--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -111,6 +111,12 @@ export const sessionSlice = createSlice({
       lastMessage.promptLogs = lastMessage.promptLogs
         ? lastMessage.promptLogs.concat(payload)
         : payload;
+
+      // Inactive thinking for reasoning models when '</think>' tag is not received on request completion
+      if (lastMessage.reasoning?.active) {
+        lastMessage.reasoning.active = false;
+        lastMessage.reasoning.endAt = Date.now();
+      }
     },
     setActive: (state) => {
       state.isStreaming = true;
@@ -432,13 +438,6 @@ export const sessionSlice = createSlice({
         }
       }
     },
-    streamComplete: (state) => {
-      const lastItem = state.history[state.history.length - 1];
-      if (lastItem.reasoning?.active) {
-        lastItem.reasoning.active = false;
-        lastItem.reasoning.endAt = Date.now();
-      }
-    },
     newSession: (state, { payload }: PayloadAction<Session | undefined>) => {
       state.lastSessionId = state.id;
 
@@ -730,7 +729,6 @@ export const {
   addContextItemsAtIndex,
   setInactive,
   streamUpdate,
-  streamComplete,
   newSession,
   updateSessionTitle,
   addHighlightedCode,

--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -432,6 +432,13 @@ export const sessionSlice = createSlice({
         }
       }
     },
+    streamComplete: (state) => {
+      const lastItem = state.history[state.history.length - 1];
+      if (lastItem.reasoning?.active) {
+        lastItem.reasoning.active = false;
+        lastItem.reasoning.endAt = Date.now();
+      }
+    },
     newSession: (state, { payload }: PayloadAction<Session | undefined>) => {
       state.lastSessionId = state.id;
 
@@ -723,6 +730,7 @@ export const {
   addContextItemsAtIndex,
   setInactive,
   streamUpdate,
+  streamComplete,
   newSession,
   updateSessionTitle,
   addHighlightedCode,

--- a/gui/src/redux/thunks/streamNormalInput.ts
+++ b/gui/src/redux/thunks/streamNormalInput.ts
@@ -9,7 +9,7 @@ import {
   addPromptCompletionPair,
   selectUseTools,
   setToolGenerated,
-  streamUpdate,
+  streamUpdate
 } from "../slices/sessionSlice";
 import { ThunkApiType } from "../store";
 import { callTool } from "./callTool";
@@ -71,7 +71,7 @@ export const streamNormalInput = createAsyncThunk<
       next = await gen.next();
     }
 
-    // Attach prompt log
+    // Attach prompt log and end thinking for reasoning models
     if (next.done && next.value) {
       dispatch(addPromptCompletionPair([next.value]));
 


### PR DESCRIPTION
## Description

Closes #4708 
This PR fixes "Thinking..." animation for reasoning models when "</think>" tag is not received before request completes.

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

### Before:

https://github.com/user-attachments/assets/303fc0e2-5ceb-4848-96ec-1ee095dc8efa


### After:

https://github.com/user-attachments/assets/6a01fcf6-b32a-4ea4-9dd6-5210abb0127f



## Testing instructions

1. Use chat.
2. Select a reasoning model such as Deepseek R1 32B for the chat request.
3. Set `models[number].completionOptions.maxTokens` to a value (i.e 50) where the model does not produce a "</think>" token. The "Thinking ..." progress indicator never shows that the request completed.
4. When the API request completes "Thinking ..." should terminate even if a </think> token has not been received.