### PR TITLE
Use fetchwithRequestOptions for all calls in WatsonX.

### DIFF
--- a/core/llm/llms/WatsonX.ts
+++ b/core/llm/llms/WatsonX.ts
@@ -21,7 +21,7 @@ class WatsonX extends BaseLLM {
     if (this.apiBase?.includes("cloud.ibm.com")) {
       // watsonx SaaS
       const wxToken = await (
-        await fetch(
+        await this.fetch(
           `https://iam.cloud.ibm.com/identity/token?apikey=${this.apiKey}&grant_type=urn:ibm:params:oauth:grant-type:apikey`,
           {
             method: "POST",
@@ -48,7 +48,7 @@ class WatsonX extends BaseLLM {
         // Using username/password auth
         const userPass = this.apiKey?.split(":");
         const wxToken = await (
-          await fetch(`${this.apiBase}/icp4d-api/v1/authorize`, {
+          await this.fetch(`${this.apiBase}/icp4d-api/v1/authorize`, {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
@@ -61,7 +61,7 @@ class WatsonX extends BaseLLM {
           })
         ).json();
         const wxTokenExpiry = await (
-          await fetch(`${this.apiBase}/usermgmt/v1/user/tokenExpiry`, {
+          await this.fetch(`${this.apiBase}/usermgmt/v1/user/tokenExpiry`, {
             method: "GET",
             headers: {
               Accept: "application/json",


### PR DESCRIPTION
## Description

Small adjustment to rely on fetchWithRequestOptions rather than native node fetch call.
Not sure if it was left purposely, but it seems to be a miss from overall intention to rely on @continuedev/fetch package for all LLM calls.

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots

No UI changes

## Testing instructions

While this PR should not change the behavior of system, I am not quite sure how to test it as I have no access to WatsonX.
