### PR TITLE
Show warning message when last user input get pruned

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -321,7 +321,8 @@ export type ChatMessageRole =
   | "assistant"
   | "thinking"
   | "system"
-  | "tool";
+  | "tool"
+  | "warning";
 
 export type TextMessagePart = {
   type: "text";
@@ -385,12 +386,18 @@ export interface SystemChatMessage {
   content: string;
 }
 
+export interface WarningChatMessage {
+  role: "warning";
+  content: string;
+}
+
 export type ChatMessage =
   | UserChatMessage
   | AssistantChatMessage
   | ThinkingChatMessage
   | SystemChatMessage
-  | ToolResultChatMessage;
+  | ToolResultChatMessage
+  | WarningChatMessage;
 
 export interface ContextItemId {
   providerTitle: string;

--- a/core/llm/countTokens.ts
+++ b/core/llm/countTokens.ts
@@ -27,9 +27,9 @@ class LlamaEncoding implements Encoding {
 }
 
 class NonWorkerAsyncEncoder implements AsyncEncoder {
-  constructor(private readonly encoding: Encoding) { }
+  constructor(private readonly encoding: Encoding) {}
 
-  async close(): Promise<void> { }
+  async close(): Promise<void> {}
 
   async encode(text: string): Promise<number[]> {
     return this.encoding.encode(text);
@@ -243,12 +243,14 @@ function pruneChatHistory(
   chatHistory: ChatMessage[],
   contextLength: number,
   tokensForCompletion: number,
-): ChatMessage[] {
+): [ChatMessage[], boolean] {
   let totalTokens =
     tokensForCompletion +
     chatHistory.reduce((acc, message) => {
       return acc + countChatMessageTokens(modelName, message);
     }, 0);
+
+  let shouldWarn = false;
 
   // 0. Prune any messages that take up more than 1/3 of the context length
   const longestMessages = [...chatHistory];
@@ -275,6 +277,7 @@ function pruneChatHistory(
       content,
     );
     totalTokens -= delta;
+    shouldWarn = true;
   }
 
   // 1. Replace beyond last 5 messages with summary
@@ -327,9 +330,10 @@ function pruneChatHistory(
       tokensForCompletion,
     );
     totalTokens = contextLength;
+    shouldWarn = true;
   }
 
-  return chatHistory;
+  return [chatHistory, shouldWarn];
 }
 
 function messageIsEmpty(message: ChatMessage): boolean {
@@ -367,6 +371,7 @@ function chatMessageIsEmpty(message: ChatMessage): boolean {
         !message.toolCalls
       );
     case "thinking":
+    case "warning":
     case "tool":
       return false;
   }
@@ -381,11 +386,16 @@ function compileChatMessages(
   prompt: string | undefined = undefined,
   functions: any[] | undefined = undefined,
   systemMessage: string | undefined = undefined,
-): ChatMessage[] {
+): [ChatMessage[], boolean] {
   let msgsCopy = msgs
     ? msgs
-      .map((msg) => ({ ...msg }))
-      .filter((msg) => !chatMessageIsEmpty(msg) && msg.role !== "system")
+        .map((msg) => ({ ...msg }))
+        .filter(
+          (msg) =>
+            !chatMessageIsEmpty(msg) &&
+            msg.role !== "system" &&
+            msg.role !== "warning",
+        )
     : [];
 
   msgsCopy = addSpaceToAnyEmptyMessages(msgsCopy);
@@ -445,7 +455,7 @@ function compileChatMessages(
     }
   }
 
-  const history = pruneChatHistory(
+  const [history, shouldWarn] = pruneChatHistory(
     modelName,
     msgsCopy,
     contextLength,
@@ -459,7 +469,7 @@ function compileChatMessages(
 
   const flattenedHistory = flattenMessages(history);
 
-  return flattenedHistory;
+  return [flattenedHistory, shouldWarn];
 }
 
 export {
@@ -470,6 +480,5 @@ export {
   pruneLinesFromTop,
   pruneRawPromptFromTop,
   pruneStringFromBottom,
-  pruneStringFromTop
+  pruneStringFromTop,
 };
-

--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -195,11 +195,11 @@ export abstract class BaseLLM implements ILLM {
         options.completionOptions?.maxTokens ??
         (llmInfo?.maxCompletionTokens
           ? Math.min(
-            llmInfo.maxCompletionTokens,
-            // Even if the model has a large maxTokens, we don't want to use that every time,
-            // because it takes away from the context length
-            this.contextLength / 4,
-          )
+              llmInfo.maxCompletionTokens,
+              // Even if the model has a large maxTokens, we don't want to use that every time,
+              // because it takes away from the context length
+              this.contextLength / 4,
+            )
           : DEFAULT_MAX_TOKENS),
     };
     this.requestOptions = options.requestOptions;
@@ -766,7 +766,18 @@ export abstract class BaseLLM implements ILLM {
 
     completionOptions = this._modifyCompletionOptions(completionOptions);
 
-    const messages = this._compileChatMessages(completionOptions, _messages);
+    const [messages, shouldWarn] = this._compileChatMessages(
+      completionOptions,
+      _messages,
+    );
+
+    if (shouldWarn) {
+      yield {
+        role: "warning",
+        content:
+          "The context has reached its limit. This may lead to less accurate or incomplete answers.",
+      };
+    }
 
     const prompt = this.templateMessages
       ? this.templateMessages(messages)
@@ -840,7 +851,6 @@ export abstract class BaseLLM implements ILLM {
             signal,
             completionOptions,
           )) {
-
             if (chunk.role === "assistant") {
               completion += chunk.content;
               yield chunk;
@@ -948,7 +958,7 @@ export abstract class BaseLLM implements ILLM {
     );
   }
 
-  protected async * _streamComplete(
+  protected async *_streamComplete(
     prompt: string,
     signal: AbortSignal,
     options: CompletionOptions,
@@ -956,7 +966,7 @@ export abstract class BaseLLM implements ILLM {
     throw new Error("Not implemented");
   }
 
-  protected async * _streamChat(
+  protected async *_streamChat(
     messages: ChatMessage[],
     signal: AbortSignal,
     options: CompletionOptions,

--- a/core/llm/llms/Bedrock.ts
+++ b/core/llm/llms/Bedrock.ts
@@ -3,7 +3,7 @@ import {
   ContentBlock,
   ConverseStreamCommand,
   InvokeModelCommand,
-  Message
+  Message,
 } from "@aws-sdk/client-bedrock-runtime";
 import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
 
@@ -11,7 +11,7 @@ import {
   ChatMessage,
   Chunk,
   CompletionOptions,
-  LLMOptions
+  LLMOptions,
 } from "../../index.js";
 import { renderChatMessage } from "../../util/messageContent.js";
 import { BaseLLM } from "../index.js";
@@ -42,7 +42,11 @@ class Bedrock extends BaseLLM {
 
   private _currentToolResponse: Partial<ToolUseState> | null = null;
 
-  public requestOptions: { region?: string; credentials?: any; headers?: Record<string, string> };
+  public requestOptions: {
+    region?: string;
+    credentials?: any;
+    headers?: Record<string, string>;
+  };
 
   constructor(options: LLMOptions) {
     super(options);
@@ -108,7 +112,10 @@ class Bedrock extends BaseLLM {
       },
     );
 
-    const input = this._generateConverseInput(messages, { ...options, stream: true });
+    const input = this._generateConverseInput(messages, {
+      ...options,
+      stream: true,
+    });
     const command = new ConverseStreamCommand(input);
 
     let response;
@@ -126,49 +133,70 @@ class Bedrock extends BaseLLM {
 
     try {
       for await (const chunk of response.stream) {
-
         if (chunk.contentBlockDelta?.delta) {
-
-          const delta: any = chunk.contentBlockDelta.delta
+          const delta: any = chunk.contentBlockDelta.delta;
 
           // Handle text content
           if (chunk.contentBlockDelta.delta.text) {
-            yield { role: "assistant", content: chunk.contentBlockDelta.delta.text };
+            yield {
+              role: "assistant",
+              content: chunk.contentBlockDelta.delta.text,
+            };
             continue;
           }
 
           // Handle text content
           if ((chunk.contentBlockDelta.delta as any).reasoningContent?.text) {
-            yield { role: "thinking", content: (chunk.contentBlockDelta.delta as any).reasoningContent.text };
+            yield {
+              role: "thinking",
+              content: (chunk.contentBlockDelta.delta as any).reasoningContent
+                .text,
+            };
             continue;
           }
 
           // Handle signature for thinking
           if (delta.reasoningContent?.signature) {
-            yield { role: "thinking", content: "", signature: delta.reasoningContent.signature };
+            yield {
+              role: "thinking",
+              content: "",
+              signature: delta.reasoningContent.signature,
+            };
             continue;
           }
 
           // Handle redacted thinking
           if (delta.redactedReasoning?.data) {
-            yield { role: "thinking", content: "", redactedThinking: delta.redactedReasoning.data };
+            yield {
+              role: "thinking",
+              content: "",
+              redactedThinking: delta.redactedReasoning.data,
+            };
             continue;
           }
 
-          if (chunk.contentBlockDelta.delta.toolUse?.input && this._currentToolResponse) {
+          if (
+            chunk.contentBlockDelta.delta.toolUse?.input &&
+            this._currentToolResponse
+          ) {
             // Append the new input to the existing string
             if (this._currentToolResponse.input === undefined) {
               this._currentToolResponse.input = "";
             }
-            this._currentToolResponse.input += chunk.contentBlockDelta.delta.toolUse.input;
+            this._currentToolResponse.input +=
+              chunk.contentBlockDelta.delta.toolUse.input;
             continue;
           }
         }
 
         if (chunk.contentBlockStart?.start) {
-          const start: any = chunk.contentBlockStart.start
+          const start: any = chunk.contentBlockStart.start;
           if (start.redactedReasoning) {
-            yield { role: "thinking", content: "", redactedThinking: start.redactedReasoning.data };
+            yield {
+              role: "thinking",
+              content: "",
+              redactedThinking: start.redactedReasoning.data,
+            };
             continue;
           }
 
@@ -177,7 +205,7 @@ class Bedrock extends BaseLLM {
             this._currentToolResponse = {
               toolUseId: toolUse.toolUseId,
               name: toolUse.name,
-              input: ""
+              input: "",
             };
           }
           continue;
@@ -188,14 +216,16 @@ class Bedrock extends BaseLLM {
             yield {
               role: "assistant",
               content: "",
-              toolCalls: [{
-                id: this._currentToolResponse.toolUseId,
-                type: "function",
-                function: {
-                  name: this._currentToolResponse.name,
-                  arguments: this._currentToolResponse.input
-                }
-              }],
+              toolCalls: [
+                {
+                  id: this._currentToolResponse.toolUseId,
+                  type: "function",
+                  function: {
+                    name: this._currentToolResponse.name,
+                    arguments: this._currentToolResponse.input,
+                  },
+                },
+              ],
             };
             this._currentToolResponse = null;
           }
@@ -207,13 +237,16 @@ class Bedrock extends BaseLLM {
       if (error instanceof Error) {
         if ("code" in error) {
           // AWS SDK specific errors
-          throw new Error(`AWS Bedrock stream error (${(error as any).code}): ${error.message}`);
+          throw new Error(
+            `AWS Bedrock stream error (${(error as any).code}): ${error.message}`,
+          );
         }
         throw new Error(`Error processing Bedrock stream: ${error.message}`);
       }
-      throw new Error("Error processing Bedrock stream: Unknown error occurred");
+      throw new Error(
+        "Error processing Bedrock stream: Unknown error occurred",
+      );
     }
-
   }
 
   /**
@@ -228,22 +261,26 @@ class Bedrock extends BaseLLM {
   ): any {
     const convertedMessages = this._convertMessages(messages);
 
-    const supportsTools = PROVIDER_TOOL_SUPPORT.bedrock?.(options.model || "") ?? false;
+    const supportsTools =
+      PROVIDER_TOOL_SUPPORT.bedrock?.(options.model || "") ?? false;
     return {
       modelId: options.model,
       messages: convertedMessages,
       system: this.systemMessage ? [{ text: this.systemMessage }] : undefined,
-      toolConfig: supportsTools && options.tools ? {
-        tools: options.tools.map(tool => ({
-          toolSpec: {
-            name: tool.function.name,
-            description: tool.function.description,
-            inputSchema: {
-              json: tool.function.parameters
+      toolConfig:
+        supportsTools && options.tools
+          ? {
+              tools: options.tools.map((tool) => ({
+                toolSpec: {
+                  name: tool.function.name,
+                  description: tool.function.description,
+                  inputSchema: {
+                    json: tool.function.parameters,
+                  },
+                },
+              })),
             }
-          }
-        }))
-      } : undefined,
+          : undefined,
       inferenceConfig: {
         maxTokens: options.maxTokens,
         temperature: options.temperature,
@@ -261,17 +298,23 @@ class Bedrock extends BaseLLM {
           .slice(0, 4),
       },
       additionalModelRequestFields: {
-        "thinking": options.reasoning ? {
-          "type": "enabled",
-          "budget_tokens": options.reasoningBudgetTokens
-        } : undefined,
-      }
+        thinking: options.reasoning
+          ? {
+              type: "enabled",
+              budget_tokens: options.reasoningBudgetTokens,
+            }
+          : undefined,
+      },
     };
   }
 
   private _convertMessage(message: ChatMessage): Message | null {
     // Handle system messages explicitly
     if (message.role === "system") {
+      return null;
+    }
+
+    if (message.role === "warning") {
       return null;
     }
 
@@ -285,12 +328,12 @@ class Bedrock extends BaseLLM {
               toolUseId: message.toolCallId,
               content: [
                 {
-                  text: message.content || ""
-                }
-              ]
-            }
-          }
-        ]
+                  text: message.content || "",
+                },
+              ],
+            },
+          },
+        ],
       };
     }
 
@@ -303,8 +346,8 @@ class Bedrock extends BaseLLM {
             toolUseId: toolCall.id,
             name: toolCall.function?.name,
             input: JSON.parse(toolCall.function?.arguments || "{}"),
-          }
-        }))
+          },
+        })),
       };
     }
 
@@ -312,26 +355,27 @@ class Bedrock extends BaseLLM {
       if (message.redactedThinking) {
         const content: ContentBlock.ReasoningContentMember = {
           reasoningContent: {
-            redactedContent: new Uint8Array(Buffer.from(message.redactedThinking))
-          }
+            redactedContent: new Uint8Array(
+              Buffer.from(message.redactedThinking),
+            ),
+          },
         };
         return {
           role: "assistant",
-          content: [content]
+          content: [content],
         };
       } else {
         const content: ContentBlock.ReasoningContentMember = {
           reasoningContent: {
             reasoningText: {
               text: (message.content as string) || "",
-              signature: message.signature
-            }
-
-          }
+              signature: message.signature,
+            },
+          },
         };
         return {
           role: "assistant",
-          content: [content]
+          content: [content],
         };
       }
     }
@@ -340,7 +384,7 @@ class Bedrock extends BaseLLM {
     if (typeof message.content === "string") {
       return {
         role: message.role,
-        content: [{ text: message.content }]
+        content: [{ text: message.content }],
       };
     }
 
@@ -348,36 +392,37 @@ class Bedrock extends BaseLLM {
     if (Array.isArray(message.content)) {
       return {
         role: message.role,
-        content: message.content.map(part => {
-          if (part.type === "text") {
-            return { text: part.text };
-          }
-          if (part.type === "imageUrl" && part.imageUrl) {
-            try {
-              const [mimeType, base64Data] = part.imageUrl.url.split(",");
-              const format = mimeType.split("/")[1]?.split(";")[0] || "jpeg";
-              return {
-                image: {
-                  format,
-                  source: {
-                    bytes: Buffer.from(base64Data, "base64")
-                  }
-                }
-              };
-            } catch (error) {
-              console.warn(`Failed to process image: ${error}`);
-              return null;
+        content: message.content
+          .map((part) => {
+            if (part.type === "text") {
+              return { text: part.text };
             }
-          }
-          return null;
-        }).filter(Boolean)
+            if (part.type === "imageUrl" && part.imageUrl) {
+              try {
+                const [mimeType, base64Data] = part.imageUrl.url.split(",");
+                const format = mimeType.split("/")[1]?.split(";")[0] || "jpeg";
+                return {
+                  image: {
+                    format,
+                    source: {
+                      bytes: Buffer.from(base64Data, "base64"),
+                    },
+                  },
+                };
+              } catch (error) {
+                console.warn(`Failed to process image: ${error}`);
+                return null;
+              }
+            }
+            return null;
+          })
+          .filter(Boolean),
       } as Message;
     }
     return null;
   }
 
   private _convertMessages(messages: ChatMessage[]): any[] {
-
     const converted = messages
       .map((message) => {
         try {
@@ -389,7 +434,6 @@ class Bedrock extends BaseLLM {
       })
       .filter(Boolean);
     return converted;
-
   }
 
   private async _getCredentials() {
@@ -452,7 +496,6 @@ class Bedrock extends BaseLLM {
     const modelConfig = this._getModelConfig();
     return modelConfig.extractEmbeddings(responseBody);
   }
-
 
   private _getModelConfig() {
     const modelConfigs: { [key: string]: ModelConfig } = {
@@ -530,11 +573,15 @@ class Bedrock extends BaseLLM {
       if (error instanceof Error) {
         if ("code" in error) {
           // AWS SDK specific errors
-          throw new Error(`AWS Bedrock rerank error (${(error as any).code}): ${error.message}`);
+          throw new Error(
+            `AWS Bedrock rerank error (${(error as any).code}): ${error.message}`,
+          );
         }
         throw new Error(`Error in BedrockReranker.rerank: ${error.message}`);
       }
-      throw new Error("Error in BedrockReranker.rerank: Unknown error occurred");
+      throw new Error(
+        "Error in BedrockReranker.rerank: Unknown error occurred",
+      );
     }
   }
 }

--- a/core/llm/llms/Ollama.ts
+++ b/core/llm/llms/Ollama.ts
@@ -89,10 +89,10 @@ type OllamaBaseResponse = {
   model: string;
   created_at: string;
 } & (
-    | {
+  | {
       done: false;
     }
-    | {
+  | {
       done: true;
       done_reason: string;
       total_duration: number; // Time spent generating the response in nanoseconds
@@ -103,7 +103,7 @@ type OllamaBaseResponse = {
       eval_duration: number; // Time spent generating the response in nanoseconds
       context: number[]; // An encoding of the conversation used in this response; can be sent in the next request to keep conversational memory
     }
-  );
+);
 
 type OllamaErrorResponse = {
   error: string;
@@ -112,14 +112,14 @@ type OllamaErrorResponse = {
 type OllamaRawResponse =
   | OllamaErrorResponse
   | (OllamaBaseResponse & {
-    response: string; // the generated response
-  });
+      response: string; // the generated response
+    });
 
 type OllamaChatResponse =
   | OllamaErrorResponse
   | (OllamaBaseResponse & {
-    message: OllamaChatMessage;
-  });
+      message: OllamaChatMessage;
+    });
 
 interface OllamaTool {
   type: "function";
@@ -365,7 +365,7 @@ class Ollama extends BaseLLM implements ModelInstaller {
             if ("error" in j) {
               throw new Error(j.error);
             }
-            j.response ??= ''
+            j.response ??= "";
             yield j.response;
           } catch (e) {
             throw new Error(`Error parsing Ollama response: ${e} ${chunk}`);

--- a/core/util/messageContent.ts
+++ b/core/util/messageContent.ts
@@ -23,6 +23,7 @@ export function renderChatMessage(message: ChatMessage): string {
     case "assistant":
     case "thinking":
     case "system":
+    case "warning":
       return stripImages(message.content);
     case "tool":
       return message.content;
@@ -41,6 +42,7 @@ export function normalizeToMessageParts(message: ChatMessage): MessagePart[] {
     case "assistant":
     case "thinking":
     case "system":
+    case "warning":
       return Array.isArray(message.content)
         ? message.content
         : [{ type: "text", text: message.content }];

--- a/gui/src/pages/gui/Chat.tsx
+++ b/gui/src/pages/gui/Chat.tsx
@@ -135,6 +135,7 @@ export function Chat() {
   const hasDismissedExploreDialog = useAppSelector(
     (state) => state.ui.hasDismissedExploreDialog,
   );
+  const warningMessage = useAppSelector((state) => state.session.warning);
 
   useEffect(() => {
     // Cmd + Backspace to delete current step
@@ -389,6 +390,13 @@ export function Chat() {
             </ErrorBoundary>
           </div>
         ))}
+        {warningMessage.length > 0 && (
+          <div className="relative m-2 flex justify-center rounded-md border border-solid border-red-600 bg-transparent p-4">
+            <p className="thread-message text-red-500">
+              {`Warning: ${warningMessage}`}
+            </p>
+          </div>
+        )}
       </StepsDiv>
       <div className={"relative"}>
         {toolCallState?.status === "generated" && <ToolCallButtons />}

--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -54,6 +54,7 @@ type SessionState = {
     curIndex: number;
   };
   newestCodeblockForInput: Record<string, string>;
+  warning: string;
 };
 
 function isCodeToEditEqual(a: CodeToEdit, b: CodeToEdit) {
@@ -92,6 +93,7 @@ const initialState: SessionState = {
   },
   lastSessionId: undefined,
   newestCodeblockForInput: {},
+  warning: "",
 };
 
 export const sessionSlice = createSlice({
@@ -226,6 +228,7 @@ export const sessionSlice = createSlice({
     deleteMessage: (state, action: PayloadAction<number>) => {
       // Deletes the current assistant message and the previous user message
       state.history.splice(action.payload - 1, 2);
+      state.warning = "";
     },
     updateHistoryItemAtIndex: (
       state,
@@ -653,6 +656,9 @@ export const sessionSlice = createSlice({
     ) => {
       state.newestCodeblockForInput[payload.inputId] = payload.contextItemId;
     },
+    setWarning: (state, action: PayloadAction<string>) => {
+      state.warning = action.payload;
+    },
   },
   selectors: {
     selectIsGatheringContext: (state) => {
@@ -754,6 +760,7 @@ export const {
   deleteSessionMetadata,
   setNewestCodeblocksForInput,
   cycleMode,
+  setWarning,
 } = sessionSlice.actions;
 
 export const {

--- a/gui/src/redux/thunks/streamNormalInput.ts
+++ b/gui/src/redux/thunks/streamNormalInput.ts
@@ -9,6 +9,7 @@ import {
   addPromptCompletionPair,
   selectUseTools,
   setToolGenerated,
+  setWarning,
   streamUpdate,
 } from "../slices/sessionSlice";
 import { ThunkApiType } from "../store";
@@ -60,6 +61,7 @@ export const streamNormalInput = createAsyncThunk<
     );
 
     // Stream response
+    let warningMessage = "";
     let next = await gen.next();
     while (!next.done) {
       if (!getState().session.isStreaming) {
@@ -67,9 +69,21 @@ export const streamNormalInput = createAsyncThunk<
         break;
       }
 
-      dispatch(streamUpdate(next.value));
+      const filteredMessages: ChatMessage[] = [];
+
+      next.value.forEach((msg) => {
+        if (msg.role === "warning") {
+          warningMessage += msg.content;
+        } else {
+          filteredMessages.push(msg);
+        }
+      });
+
+      dispatch(streamUpdate(filteredMessages));
       next = await gen.next();
     }
+
+    dispatch(setWarning(warningMessage));
 
     // Attach prompt log
     if (next.done && next.value) {


### PR DESCRIPTION
## Description

If the user's last input is pruned due to context overflow, a warning message will be displayed in the chat section, alerting them that some details may have been lost. As a result, the response they receive might be incomplete or inaccurate due to the truncated input.
https://github.com/Granite-Code/granite-code/issues/22

## Screenshots

![show-warning-in-chat](https://github.com/user-attachments/assets/eb6e0a9d-5f89-45ae-9175-4fb8e459d2d2)


## Testing instructions

Set the model’s context length to a small value (e.g., 512) and continue asking questions until the limit is reached. Once exceeded, a warning message will appear at the bottom of the chat section, indicating that some input may have been truncated. Deleting previous messages will remove the warning.
