### PR TITLE
Autocomplete: don't look for imports outside workspace

### DIFF
--- a/core/autocomplete/context/ImportDefinitionsService.ts
+++ b/core/autocomplete/context/ImportDefinitionsService.ts
@@ -5,6 +5,7 @@ import {
   getParserForFile,
   getQueryForFile,
 } from "../../util/treeSitter";
+import { findUriInDirs } from "../../util/uri";
 
 interface FileInfo {
   imports: { [key: string]: RangeInFileWithContents[] };
@@ -44,7 +45,15 @@ export class ImportDefinitionsService {
 
     let fileContents: string | undefined = undefined;
     try {
-      fileContents = await this.ide.readFile(filepath);
+      const { foundInDir } = findUriInDirs(
+        filepath,
+        await this.ide.getWorkspaceDirs(),
+      );
+      if (!foundInDir) {
+        return null;
+      } else {
+        fileContents = await this.ide.readFile(filepath);
+      }
     } catch (err) {
       // File removed
       return null;


### PR DESCRIPTION
## Description
Import definition service goes outside workspace for e.g. Java