### PR TITLE
fix: Update slash command filtering logic

### DIFF
--- a/gui/src/components/mainInput/tiptap/getSuggestion.ts
+++ b/gui/src/components/mainInput/tiptap/getSuggestion.ts
@@ -203,7 +203,7 @@ export function getSlashCommandDropdownOptions(
     const filteredCommands =
       query.length > 0
         ? options.filter((slashCommand) => {
-            const sc = slashCommand.title.substring(1).toLowerCase();
+            const sc = slashCommand.title.toLowerCase();
             const iv = query.toLowerCase();
             return sc.startsWith(iv);
           })


### PR DESCRIPTION
## Description

closes: #4896 
Updates the slash command filtering logic to match command titles without removing the first character.

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

before:
![image](https://github.com/user-attachments/assets/4563016f-d1a0-43be-ac09-0ed5591d75b1)

after:
![image](https://github.com/user-attachments/assets/6a4d8a8f-c0a0-4e10-8b96-48c4f2e17931)

## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
