### PR TITLE
fix: mention nvm use instructions when installing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ This will start a local server and you can see the documentation rendered in you
 You should have Node.js version 20.11.0 (LTS) or higher installed. You can get it on [nodejs.org](https://nodejs.org/en/download) or, if you are using NVM (Node Version Manager), you can set the correct version of Node.js for this project by running the following command in the root of the project:
 
 ```bash
-nvm use
+nvm use 20.11.0
 ```
 
 #### Fork the Continue Repository

--- a/extensions/intellij/CONTRIBUTING.md
+++ b/extensions/intellij/CONTRIBUTING.md
@@ -55,7 +55,7 @@ notes below).
 This project requires Node.js version 20.11.0 (LTS) or higher. You have two options for installation:
 
 1. Download and install directly from [nodejs.org](https://nodejs.org/en/download).
-2. If you're using NVM (Node Version Manager), set the correct Node.js version for this project by running `nvm use` in
+2. If you're using NVM (Node Version Manager), set the correct Node.js version for this project by running `nvm use 20.11.0` in
    the project root.
 
 ### Install all dependencies

--- a/scripts/install-dependencies.ps1
+++ b/scripts/install-dependencies.ps1
@@ -36,7 +36,7 @@ if (Test-Path ".nvmrc") {
 
     if ($requiredVersion -ne $currentVersion) {
         Write-Host "`n⚠️  Warning: Your Node.js version ($currentNodeVersion) does not match the required version ($requiredNodeVersion)" -ForegroundColor Yellow
-        Write-Host "Please consider switching to the correct version using: nvm use" -ForegroundColor Yellow
+        Write-Host "Please consider switching to the correct version using: nvm use 20.11.0" -ForegroundColor Yellow
         
         # Check if running in interactive mode
         if ([Environment]::UserInteractive -and [Environment]::GetCommandLineArgs().Count -eq 0) {

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -16,7 +16,7 @@ if [ -f .nvmrc ]; then
 
     if [ "$required_version" != "$current_version" ]; then
         echo "⚠️  Warning: Your Node.js version ($current_node_version) does not match the required version ($required_node_version)"
-        echo "Please consider switching to the correct version using: nvm use"
+        echo "Please consider switching to the correct version using: nvm use 20.11.0"
         
         if [ -t 0 ]; then
             read -p "Press Enter to continue with installation anyway..."


### PR DESCRIPTION
## Description

`nvm use` was missing the nodejs version to be installed. This PR fixes it with by mentioning `nvm use 20.11.0` wherever it was missing.

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

NA

## Testing instructions

NA
