### PR TITLE
[Doc] context typo files replace with file

### DIFF
--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -227,7 +227,7 @@ More information about usage/params for each context provider can be found [here
 
 ```yaml title="config.yaml"
 context:
-  - provider: files
+  - provider: file
   - provider: code
   - provider: codebase
     params:


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

There is no context named `files`
https://docs.continue.dev/reference#context

This probably means that `file` is correct
https://docs.continue.dev/customize/context-providers#file

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

