### PR TITLE
yaml contextlength fix

### DIFF
--- a/core/config/yaml/convertFromJson.ts
+++ b/core/config/yaml/convertFromJson.ts
@@ -2,6 +2,9 @@ import { AssistantUnrolled, ModelConfig } from "@continuedev/config-yaml";
 
 import { SerializedContinueConfig } from "../..";
 
+/*
+TODO this is not functional
+*/
 export function convertConfigJsonToConfigYaml(
   configJson: SerializedContinueConfig,
 ): AssistantUnrolled {

--- a/core/config/yaml/models.ts
+++ b/core/config/yaml/models.ts
@@ -39,7 +39,7 @@ async function modelConfigToBaseLLM(
 
   let options: LLMOptions = {
     ...rest,
-    // contextLength: model.defaultCompletionOptions?.contextLength ?? undefined,
+    contextLength: model.defaultCompletionOptions?.contextLength,
     completionOptions: {
       ...(model.defaultCompletionOptions ?? {}),
       model: model.model,


### PR DESCRIPTION
Account for context length being moved to defaultCompletionOptions
This was done by @Jazzcort in https://github.com/continuedev/continue/pull/4602 but reverted for some reason. Because of little comment etc. I just did the same thing and then updated commit author