### PR TITLE
fix(docs): correct openai api key name

### DIFF
--- a/docs/docs/customize/model-providers/top-level/openai.mdx
+++ b/docs/docs/customize/model-providers/top-level/openai.mdx
@@ -21,7 +21,7 @@ We recommend configuring **GPT-4o** as your chat model.
     - name: GPT-4o
       provider: openai
       model: gpt-4o
-      apiKey: <YOUR_HUGGINGFACE_TEI_API_KEY>
+      apiKey: <YOUR_OPENAI_API_KEY>
   ```
   </TabItem>
   <TabItem value="json" label="JSON">
@@ -32,7 +32,7 @@ We recommend configuring **GPT-4o** as your chat model.
         "title": "GPT-4o",
         "provider": "openai", 
         "model": "gpt-4o",
-        "apiKey": "<YOUR_HUGGINGFACE_TEI_API_KEY>"
+        "apiKey": "<YOUR_OPENAI_API_KEY>"
       }
     ]
   }
@@ -57,7 +57,7 @@ We recommend configuring **text-embedding-3-large** as your embeddings model.
     - name: OpenAI Embeddings
       provider: openai
       model: text-embedding-3-large
-      apiKey: <YOUR_HUGGINGFACE_TEI_API_KEY>
+      apiKey: <YOUR_OPENAI_API_KEY>
       roles:
         - embed
   ```
@@ -68,7 +68,7 @@ We recommend configuring **text-embedding-3-large** as your embeddings model.
     "embeddingsProvider": {
       "provider": "openai",
       "model": "text-embedding-3-large", 
-      "apiKey": "<YOUR_HUGGINGFACE_TEI_API_KEY>"
+      "apiKey": "<YOUR_OPENAI_API_KEY>"
     }
   }
   ```


### PR DESCRIPTION
## Description

Earlier the openai api key name was called YOUR_HUGGINGFACE_TEI_API_KEY. Changed it to YOUR_OPENAI_KEY to avoid any confusions when reading docs.

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

NA

## Testing instructions

NA
