### PR TITLE
feat/bedrock-prompt-caching

### DIFF
--- a/binary/package-lock.json
+++ b/binary/package-lock.json
@@ -44,9 +44,9 @@
       "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-bedrock-runtime": "^3.758.0",
-        "@aws-sdk/client-sagemaker-runtime": "^3.758.0",
-        "@aws-sdk/credential-providers": "^3.758.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.779.0",
+        "@aws-sdk/client-sagemaker-runtime": "^3.777.0",
+        "@aws-sdk/credential-providers": "^3.778.0",
         "@continuedev/config-types": "^1.0.13",
         "@continuedev/config-yaml": "^1.0.67",
         "@continuedev/fetch": "^1.0.4",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-bedrock-runtime": "^3.758.0",
-        "@aws-sdk/client-sagemaker-runtime": "^3.758.0",
-        "@aws-sdk/credential-providers": "^3.758.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.779.0",
+        "@aws-sdk/client-sagemaker-runtime": "^3.777.0",
+        "@aws-sdk/credential-providers": "^3.778.0",
         "@continuedev/config-types": "^1.0.13",
         "@continuedev/config-yaml": "^1.0.67",
         "@continuedev/fetch": "^1.0.4",
@@ -289,51 +289,51 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.758.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.758.0.tgz",
-      "integrity": "sha512-T7s+fULUxN3AcJP+lgoUKLawzVEtyCTi+5Ga+wrHnqEPwAsM/wg7VctsZfow1fCgARLT/lzmP2LTCi8ycRnQWg==",
+      "version": "3.779.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.779.0.tgz",
+      "integrity": "sha512-MyzZks8XxWwdsA4VlyPW4IekUjpgDI91VwMvEtOITHD8w+9nTGJtD32HcCKNQQCHWYfSoOj7yIoHRisVatR8yw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/credential-provider-node": "3.758.0",
-        "@aws-sdk/middleware-host-header": "3.734.0",
-        "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
-        "@aws-sdk/middleware-user-agent": "3.758.0",
-        "@aws-sdk/region-config-resolver": "3.734.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-endpoints": "3.743.0",
-        "@aws-sdk/util-user-agent-browser": "3.734.0",
-        "@aws-sdk/util-user-agent-node": "3.758.0",
-        "@smithy/config-resolver": "^4.0.1",
-        "@smithy/core": "^3.1.5",
-        "@smithy/eventstream-serde-browser": "^4.0.1",
-        "@smithy/eventstream-serde-config-resolver": "^4.0.1",
-        "@smithy/eventstream-serde-node": "^4.0.1",
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/hash-node": "^4.0.1",
-        "@smithy/invalid-dependency": "^4.0.1",
-        "@smithy/middleware-content-length": "^4.0.1",
-        "@smithy/middleware-endpoint": "^4.0.6",
-        "@smithy/middleware-retry": "^4.0.7",
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/middleware-stack": "^4.0.1",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/node-http-handler": "^4.0.3",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.6",
-        "@smithy/types": "^4.1.0",
-        "@smithy/url-parser": "^4.0.1",
+        "@aws-sdk/core": "3.775.0",
+        "@aws-sdk/credential-provider-node": "3.777.0",
+        "@aws-sdk/middleware-host-header": "3.775.0",
+        "@aws-sdk/middleware-logger": "3.775.0",
+        "@aws-sdk/middleware-recursion-detection": "3.775.0",
+        "@aws-sdk/middleware-user-agent": "3.775.0",
+        "@aws-sdk/region-config-resolver": "3.775.0",
+        "@aws-sdk/types": "3.775.0",
+        "@aws-sdk/util-endpoints": "3.775.0",
+        "@aws-sdk/util-user-agent-browser": "3.775.0",
+        "@aws-sdk/util-user-agent-node": "3.775.0",
+        "@smithy/config-resolver": "^4.1.0",
+        "@smithy/core": "^3.2.0",
+        "@smithy/eventstream-serde-browser": "^4.0.2",
+        "@smithy/eventstream-serde-config-resolver": "^4.1.0",
+        "@smithy/eventstream-serde-node": "^4.0.2",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/hash-node": "^4.0.2",
+        "@smithy/invalid-dependency": "^4.0.2",
+        "@smithy/middleware-content-length": "^4.0.2",
+        "@smithy/middleware-endpoint": "^4.1.0",
+        "@smithy/middleware-retry": "^4.1.0",
+        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/middleware-stack": "^4.0.2",
+        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/url-parser": "^4.0.2",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.7",
-        "@smithy/util-defaults-mode-node": "^4.0.7",
-        "@smithy/util-endpoints": "^3.0.1",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-retry": "^4.0.1",
-        "@smithy/util-stream": "^4.1.2",
+        "@smithy/util-defaults-mode-browser": "^4.0.8",
+        "@smithy/util-defaults-mode-node": "^4.0.8",
+        "@smithy/util-endpoints": "^3.0.2",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-retry": "^4.0.2",
+        "@smithy/util-stream": "^4.2.0",
         "@smithy/util-utf8": "^4.0.0",
         "@types/uuid": "^9.0.1",
         "tslib": "^2.6.2",
@@ -344,47 +344,47 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.758.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.758.0.tgz",
-      "integrity": "sha512-8bOXVYtf/0OUN0jXTIHLv3V0TAS6kvvCRAy7nmiL/fDde0O+ChW1WZU7CVPAOtFEpFCdKskDcxFspM7m1k6qyg==",
+      "version": "3.777.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.777.0.tgz",
+      "integrity": "sha512-VGtFI3SH+jKfPln+9CM16F9zKieIqSxUSZNzQ6WZahPDVC79VmlG6QkXCqgm9Y4qZf4ebcdMhO23+FkR4s9vhA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/credential-provider-node": "3.758.0",
-        "@aws-sdk/middleware-host-header": "3.734.0",
-        "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
-        "@aws-sdk/middleware-user-agent": "3.758.0",
-        "@aws-sdk/region-config-resolver": "3.734.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-endpoints": "3.743.0",
-        "@aws-sdk/util-user-agent-browser": "3.734.0",
-        "@aws-sdk/util-user-agent-node": "3.758.0",
-        "@smithy/config-resolver": "^4.0.1",
-        "@smithy/core": "^3.1.5",
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/hash-node": "^4.0.1",
-        "@smithy/invalid-dependency": "^4.0.1",
-        "@smithy/middleware-content-length": "^4.0.1",
-        "@smithy/middleware-endpoint": "^4.0.6",
-        "@smithy/middleware-retry": "^4.0.7",
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/middleware-stack": "^4.0.1",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/node-http-handler": "^4.0.3",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.6",
-        "@smithy/types": "^4.1.0",
-        "@smithy/url-parser": "^4.0.1",
+        "@aws-sdk/core": "3.775.0",
+        "@aws-sdk/credential-provider-node": "3.777.0",
+        "@aws-sdk/middleware-host-header": "3.775.0",
+        "@aws-sdk/middleware-logger": "3.775.0",
+        "@aws-sdk/middleware-recursion-detection": "3.775.0",
+        "@aws-sdk/middleware-user-agent": "3.775.0",
+        "@aws-sdk/region-config-resolver": "3.775.0",
+        "@aws-sdk/types": "3.775.0",
+        "@aws-sdk/util-endpoints": "3.775.0",
+        "@aws-sdk/util-user-agent-browser": "3.775.0",
+        "@aws-sdk/util-user-agent-node": "3.775.0",
+        "@smithy/config-resolver": "^4.1.0",
+        "@smithy/core": "^3.2.0",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/hash-node": "^4.0.2",
+        "@smithy/invalid-dependency": "^4.0.2",
+        "@smithy/middleware-content-length": "^4.0.2",
+        "@smithy/middleware-endpoint": "^4.1.0",
+        "@smithy/middleware-retry": "^4.1.0",
+        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/middleware-stack": "^4.0.2",
+        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/url-parser": "^4.0.2",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.7",
-        "@smithy/util-defaults-mode-node": "^4.0.7",
-        "@smithy/util-endpoints": "^3.0.1",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-retry": "^4.0.1",
+        "@smithy/util-defaults-mode-browser": "^4.0.8",
+        "@smithy/util-defaults-mode-node": "^4.0.8",
+        "@smithy/util-endpoints": "^3.0.2",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-retry": "^4.0.2",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -393,51 +393,51 @@
       }
     },
     "node_modules/@aws-sdk/client-sagemaker-runtime": {
-      "version": "3.758.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sagemaker-runtime/-/client-sagemaker-runtime-3.758.0.tgz",
-      "integrity": "sha512-6pZdZT+Xol56UKcpUDzOlRwLgmVIgv4I2bvCsvq4YI0TnSNhO6/Ob2I8l0GzUTU2qoO2XBkrhO1t+zLuc681ig==",
+      "version": "3.777.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sagemaker-runtime/-/client-sagemaker-runtime-3.777.0.tgz",
+      "integrity": "sha512-b5IE89QOt7pvaImtDiOmUlKVGK7pcb3rW7nIKEqY65pJboIT/RNkehfA/XrlfgDjgGhVebojpUm/paqG+2xlDg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/credential-provider-node": "3.758.0",
-        "@aws-sdk/middleware-host-header": "3.734.0",
-        "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
-        "@aws-sdk/middleware-user-agent": "3.758.0",
-        "@aws-sdk/region-config-resolver": "3.734.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-endpoints": "3.743.0",
-        "@aws-sdk/util-user-agent-browser": "3.734.0",
-        "@aws-sdk/util-user-agent-node": "3.758.0",
-        "@smithy/config-resolver": "^4.0.1",
-        "@smithy/core": "^3.1.5",
-        "@smithy/eventstream-serde-browser": "^4.0.1",
-        "@smithy/eventstream-serde-config-resolver": "^4.0.1",
-        "@smithy/eventstream-serde-node": "^4.0.1",
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/hash-node": "^4.0.1",
-        "@smithy/invalid-dependency": "^4.0.1",
-        "@smithy/middleware-content-length": "^4.0.1",
-        "@smithy/middleware-endpoint": "^4.0.6",
-        "@smithy/middleware-retry": "^4.0.7",
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/middleware-stack": "^4.0.1",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/node-http-handler": "^4.0.3",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.6",
-        "@smithy/types": "^4.1.0",
-        "@smithy/url-parser": "^4.0.1",
+        "@aws-sdk/core": "3.775.0",
+        "@aws-sdk/credential-provider-node": "3.777.0",
+        "@aws-sdk/middleware-host-header": "3.775.0",
+        "@aws-sdk/middleware-logger": "3.775.0",
+        "@aws-sdk/middleware-recursion-detection": "3.775.0",
+        "@aws-sdk/middleware-user-agent": "3.775.0",
+        "@aws-sdk/region-config-resolver": "3.775.0",
+        "@aws-sdk/types": "3.775.0",
+        "@aws-sdk/util-endpoints": "3.775.0",
+        "@aws-sdk/util-user-agent-browser": "3.775.0",
+        "@aws-sdk/util-user-agent-node": "3.775.0",
+        "@smithy/config-resolver": "^4.1.0",
+        "@smithy/core": "^3.2.0",
+        "@smithy/eventstream-serde-browser": "^4.0.2",
+        "@smithy/eventstream-serde-config-resolver": "^4.1.0",
+        "@smithy/eventstream-serde-node": "^4.0.2",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/hash-node": "^4.0.2",
+        "@smithy/invalid-dependency": "^4.0.2",
+        "@smithy/middleware-content-length": "^4.0.2",
+        "@smithy/middleware-endpoint": "^4.1.0",
+        "@smithy/middleware-retry": "^4.1.0",
+        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/middleware-stack": "^4.0.2",
+        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/url-parser": "^4.0.2",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.7",
-        "@smithy/util-defaults-mode-node": "^4.0.7",
-        "@smithy/util-endpoints": "^3.0.1",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-retry": "^4.0.1",
-        "@smithy/util-stream": "^4.1.2",
+        "@smithy/util-defaults-mode-browser": "^4.0.8",
+        "@smithy/util-defaults-mode-node": "^4.0.8",
+        "@smithy/util-endpoints": "^3.0.2",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-retry": "^4.0.2",
+        "@smithy/util-stream": "^4.2.0",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -446,46 +446,46 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.758.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.758.0.tgz",
-      "integrity": "sha512-BoGO6IIWrLyLxQG6txJw6RT2urmbtlwfggapNCrNPyYjlXpzTSJhBYjndg7TpDATFd0SXL0zm8y/tXsUXNkdYQ==",
+      "version": "3.777.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.777.0.tgz",
+      "integrity": "sha512-0+z6CiAYIQa7s6FJ+dpBYPi9zr9yY5jBg/4/FGcwYbmqWPXwL9Thdtr0FearYRZgKl7bhL3m3dILCCfWqr3teQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/middleware-host-header": "3.734.0",
-        "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
-        "@aws-sdk/middleware-user-agent": "3.758.0",
-        "@aws-sdk/region-config-resolver": "3.734.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-endpoints": "3.743.0",
-        "@aws-sdk/util-user-agent-browser": "3.734.0",
-        "@aws-sdk/util-user-agent-node": "3.758.0",
-        "@smithy/config-resolver": "^4.0.1",
-        "@smithy/core": "^3.1.5",
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/hash-node": "^4.0.1",
-        "@smithy/invalid-dependency": "^4.0.1",
-        "@smithy/middleware-content-length": "^4.0.1",
-        "@smithy/middleware-endpoint": "^4.0.6",
-        "@smithy/middleware-retry": "^4.0.7",
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/middleware-stack": "^4.0.1",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/node-http-handler": "^4.0.3",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.6",
-        "@smithy/types": "^4.1.0",
-        "@smithy/url-parser": "^4.0.1",
+        "@aws-sdk/core": "3.775.0",
+        "@aws-sdk/middleware-host-header": "3.775.0",
+        "@aws-sdk/middleware-logger": "3.775.0",
+        "@aws-sdk/middleware-recursion-detection": "3.775.0",
+        "@aws-sdk/middleware-user-agent": "3.775.0",
+        "@aws-sdk/region-config-resolver": "3.775.0",
+        "@aws-sdk/types": "3.775.0",
+        "@aws-sdk/util-endpoints": "3.775.0",
+        "@aws-sdk/util-user-agent-browser": "3.775.0",
+        "@aws-sdk/util-user-agent-node": "3.775.0",
+        "@smithy/config-resolver": "^4.1.0",
+        "@smithy/core": "^3.2.0",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/hash-node": "^4.0.2",
+        "@smithy/invalid-dependency": "^4.0.2",
+        "@smithy/middleware-content-length": "^4.0.2",
+        "@smithy/middleware-endpoint": "^4.1.0",
+        "@smithy/middleware-retry": "^4.1.0",
+        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/middleware-stack": "^4.0.2",
+        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/url-parser": "^4.0.2",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.7",
-        "@smithy/util-defaults-mode-node": "^4.0.7",
-        "@smithy/util-endpoints": "^3.0.1",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-retry": "^4.0.1",
+        "@smithy/util-defaults-mode-browser": "^4.0.8",
+        "@smithy/util-defaults-mode-node": "^4.0.8",
+        "@smithy/util-endpoints": "^3.0.2",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-retry": "^4.0.2",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -494,19 +494,19 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.758.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.758.0.tgz",
-      "integrity": "sha512-0RswbdR9jt/XKemaLNuxi2gGr4xGlHyGxkTdhSQzCyUe9A9OPCoLl3rIESRguQEech+oJnbHk/wuiwHqTuP9sg==",
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.775.0.tgz",
+      "integrity": "sha512-8vpW4WihVfz0DX+7WnnLGm3GuQER++b0IwQG35JlQMlgqnc44M//KbJPsIHA0aJUJVwJAEShgfr5dUbY8WUzaA==",
       "dependencies": {
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/core": "^3.1.5",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/signature-v4": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.6",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-middleware": "^4.0.1",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/core": "^3.2.0",
+        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/signature-v4": "^5.0.2",
+        "@smithy/smithy-client": "^4.2.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-middleware": "^4.0.2",
         "fast-xml-parser": "4.4.1",
         "tslib": "^2.6.2"
       },
@@ -515,14 +515,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.758.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.758.0.tgz",
-      "integrity": "sha512-y/rHZqyChlEkNRr59gn4hv0gjhJwGmdCdW0JI1K9p3P9p7EurWGjr2M6+goTn3ilOlcAwrl5oFKR5jLt27TkOA==",
+      "version": "3.777.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.777.0.tgz",
+      "integrity": "sha512-lNvz3v94TvEcBvQqVUyg+c/aL3Max+8wUMXvehWoQPv9y9cJAHciZqvA/G+yFo/JB+1Y4IBpMu09W2lfpT6Euw==",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.758.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/client-cognito-identity": "3.777.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -530,14 +530,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.758.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.758.0.tgz",
-      "integrity": "sha512-N27eFoRrO6MeUNumtNHDW9WOiwfd59LPXPqDrIa3kWL/s+fOKFHb9xIcF++bAwtcZnAxKkgpDCUP+INNZskE+w==",
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.775.0.tgz",
+      "integrity": "sha512-6ESVxwCbGm7WZ17kY1fjmxQud43vzJFoLd4bmlR+idQSWdqlzGDYdcfzpjDKTcivdtNrVYmFvcH1JBUwCRAZhw==",
       "dependencies": {
-        "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/core": "3.775.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -545,19 +545,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.758.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.758.0.tgz",
-      "integrity": "sha512-Xt9/U8qUCiw1hihztWkNeIR+arg6P+yda10OuCHX6kFVx3auTlU7+hCqs3UxqniGU4dguHuftf3mRpi5/GJ33Q==",
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.775.0.tgz",
+      "integrity": "sha512-PjDQeDH/J1S0yWV32wCj2k5liRo0ssXMseCBEkCsD3SqsU8o5cU82b0hMX4sAib/RkglCSZqGO0xMiN0/7ndww==",
       "dependencies": {
-        "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/node-http-handler": "^4.0.3",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.6",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-stream": "^4.1.2",
+        "@aws-sdk/core": "3.775.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-stream": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -565,22 +565,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.758.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.758.0.tgz",
-      "integrity": "sha512-cymSKMcP5d+OsgetoIZ5QCe1wnp2Q/tq+uIxVdh9MbfdBBEnl9Ecq6dH6VlYS89sp4QKuxHxkWXVnbXU3Q19Aw==",
+      "version": "3.777.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.777.0.tgz",
+      "integrity": "sha512-1X9mCuM9JSQPmQ+D2TODt4THy6aJWCNiURkmKmTIPRdno7EIKgAqrr/LLN++K5mBf54DZVKpqcJutXU2jwo01A==",
       "dependencies": {
-        "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/credential-provider-env": "3.758.0",
-        "@aws-sdk/credential-provider-http": "3.758.0",
-        "@aws-sdk/credential-provider-process": "3.758.0",
-        "@aws-sdk/credential-provider-sso": "3.758.0",
-        "@aws-sdk/credential-provider-web-identity": "3.758.0",
-        "@aws-sdk/nested-clients": "3.758.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/credential-provider-imds": "^4.0.1",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/core": "3.775.0",
+        "@aws-sdk/credential-provider-env": "3.775.0",
+        "@aws-sdk/credential-provider-http": "3.775.0",
+        "@aws-sdk/credential-provider-process": "3.775.0",
+        "@aws-sdk/credential-provider-sso": "3.777.0",
+        "@aws-sdk/credential-provider-web-identity": "3.777.0",
+        "@aws-sdk/nested-clients": "3.777.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/credential-provider-imds": "^4.0.2",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/shared-ini-file-loader": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -588,21 +588,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.758.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.758.0.tgz",
-      "integrity": "sha512-+DaMv63wiq7pJrhIQzZYMn4hSarKiizDoJRvyR7WGhnn0oQ/getX9Z0VNCV3i7lIFoLNTb7WMmQ9k7+z/uD5EQ==",
+      "version": "3.777.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.777.0.tgz",
+      "integrity": "sha512-ZD66ywx1Q0KyUSuBXZIQzBe3Q7MzX8lNwsrCU43H3Fww+Y+HB3Ncws9grhSdNhKQNeGmZ+MgKybuZYaaeLwJEQ==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.758.0",
-        "@aws-sdk/credential-provider-http": "3.758.0",
-        "@aws-sdk/credential-provider-ini": "3.758.0",
-        "@aws-sdk/credential-provider-process": "3.758.0",
-        "@aws-sdk/credential-provider-sso": "3.758.0",
-        "@aws-sdk/credential-provider-web-identity": "3.758.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/credential-provider-imds": "^4.0.1",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/credential-provider-env": "3.775.0",
+        "@aws-sdk/credential-provider-http": "3.775.0",
+        "@aws-sdk/credential-provider-ini": "3.777.0",
+        "@aws-sdk/credential-provider-process": "3.775.0",
+        "@aws-sdk/credential-provider-sso": "3.777.0",
+        "@aws-sdk/credential-provider-web-identity": "3.777.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/credential-provider-imds": "^4.0.2",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/shared-ini-file-loader": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -610,15 +610,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.758.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.758.0.tgz",
-      "integrity": "sha512-AzcY74QTPqcbXWVgjpPZ3HOmxQZYPROIBz2YINF0OQk0MhezDWV/O7Xec+K1+MPGQO3qS6EDrUUlnPLjsqieHA==",
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.775.0.tgz",
+      "integrity": "sha512-A6k68H9rQp+2+7P7SGO90Csw6nrUEm0Qfjpn9Etc4EboZhhCLs9b66umUsTsSBHus4FDIe5JQxfCUyt1wgNogg==",
       "dependencies": {
-        "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/core": "3.775.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/shared-ini-file-loader": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -626,17 +626,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.758.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.758.0.tgz",
-      "integrity": "sha512-x0FYJqcOLUCv8GLLFDYMXRAQKGjoM+L0BG4BiHYZRDf24yQWFCAZsCQAYKo6XZYh2qznbsW6f//qpyJ5b0QVKQ==",
+      "version": "3.777.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.777.0.tgz",
+      "integrity": "sha512-9mPz7vk9uE4PBVprfINv4tlTkyq1OonNevx2DiXC1LY4mCUCNN3RdBwAY0BTLzj0uyc3k5KxFFNbn3/8ZDQP7w==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.758.0",
-        "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/token-providers": "3.758.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/client-sso": "3.777.0",
+        "@aws-sdk/core": "3.775.0",
+        "@aws-sdk/token-providers": "3.777.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/shared-ini-file-loader": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -644,15 +644,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.758.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.758.0.tgz",
-      "integrity": "sha512-XGguXhBqiCXMXRxcfCAVPlMbm3VyJTou79r/3mxWddHWF0XbhaQiBIbUz6vobVTD25YQRbWSmSch7VA8kI5Lrw==",
+      "version": "3.777.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.777.0.tgz",
+      "integrity": "sha512-uGCqr47fnthkqwq5luNl2dksgcpHHjSXz2jUra7TXtFOpqvnhOW8qXjoa1ivlkq8qhqlaZwCzPdbcN0lXpmLzQ==",
       "dependencies": {
-        "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/nested-clients": "3.758.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/core": "3.775.0",
+        "@aws-sdk/nested-clients": "3.777.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -660,26 +660,28 @@
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.758.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.758.0.tgz",
-      "integrity": "sha512-BaGVBdm9ynsErIc/mLuUwJ1OQcL/pkhCuAm24jpsif3evZ5wgyZnEAZB2yRin+mQnQaQT3L+KvTbdKGfjL8+fQ==",
+      "version": "3.778.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.778.0.tgz",
+      "integrity": "sha512-Yy1RSBvoDp/iqGDpmgy5/YnSP2ac9NxTv3wdAjKlqVVStlKWU9nG8MPHZRfy01oPNJ5YWZL9stxHjNKC9hg9eg==",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.758.0",
-        "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.758.0",
-        "@aws-sdk/credential-provider-env": "3.758.0",
-        "@aws-sdk/credential-provider-http": "3.758.0",
-        "@aws-sdk/credential-provider-ini": "3.758.0",
-        "@aws-sdk/credential-provider-node": "3.758.0",
-        "@aws-sdk/credential-provider-process": "3.758.0",
-        "@aws-sdk/credential-provider-sso": "3.758.0",
-        "@aws-sdk/credential-provider-web-identity": "3.758.0",
-        "@aws-sdk/nested-clients": "3.758.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/core": "^3.1.5",
-        "@smithy/credential-provider-imds": "^4.0.1",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/client-cognito-identity": "3.777.0",
+        "@aws-sdk/core": "3.775.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.777.0",
+        "@aws-sdk/credential-provider-env": "3.775.0",
+        "@aws-sdk/credential-provider-http": "3.775.0",
+        "@aws-sdk/credential-provider-ini": "3.777.0",
+        "@aws-sdk/credential-provider-node": "3.777.0",
+        "@aws-sdk/credential-provider-process": "3.775.0",
+        "@aws-sdk/credential-provider-sso": "3.777.0",
+        "@aws-sdk/credential-provider-web-identity": "3.777.0",
+        "@aws-sdk/nested-clients": "3.777.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/config-resolver": "^4.1.0",
+        "@smithy/core": "^3.2.0",
+        "@smithy/credential-provider-imds": "^4.0.2",
+        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -687,13 +689,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.734.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.734.0.tgz",
-      "integrity": "sha512-LW7RRgSOHHBzWZnigNsDIzu3AiwtjeI2X66v+Wn1P1u+eXssy1+up4ZY/h+t2sU4LU36UvEf+jrZti9c6vRnFw==",
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.775.0.tgz",
+      "integrity": "sha512-tkSegM0Z6WMXpLB8oPys/d+umYIocvO298mGvcMCncpRl77L9XkvSLJIFzaHes+o7djAgIduYw8wKIMStFss2w==",
       "dependencies": {
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -701,12 +703,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.734.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.734.0.tgz",
-      "integrity": "sha512-mUMFITpJUW3LcKvFok176eI5zXAUomVtahb9IQBwLzkqFYOrMJvWAvoV4yuxrJ8TlQBG8gyEnkb9SnhZvjg67w==",
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.775.0.tgz",
+      "integrity": "sha512-FaxO1xom4MAoUJsldmR92nT1G6uZxTdNYOFYtdHfd6N2wcNaTuxgjIvqzg5y7QIH9kn58XX/dzf1iTjgqUStZw==",
       "dependencies": {
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -714,13 +716,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.734.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.734.0.tgz",
-      "integrity": "sha512-CUat2d9ITsFc2XsmeiRQO96iWpxSKYFjxvj27Hc7vo87YUHRnfMfnc8jw1EpxEwMcvBD7LsRa6vDNky6AjcrFA==",
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.775.0.tgz",
+      "integrity": "sha512-GLCzC8D0A0YDG5u3F5U03Vb9j5tcOEFhr8oc6PDk0k0vm5VwtZOE6LvK7hcCSoAB4HXyOUM0sQuXrbaAh9OwXA==",
       "dependencies": {
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -728,16 +730,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.758.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.758.0.tgz",
-      "integrity": "sha512-iNyehQXtQlj69JCgfaOssgZD4HeYGOwxcaKeG6F+40cwBjTAi0+Ph1yfDwqk2qiBPIRWJ/9l2LodZbxiBqgrwg==",
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.775.0.tgz",
+      "integrity": "sha512-7Lffpr1ptOEDE1ZYH1T78pheEY1YmeXWBfFt/amZ6AGsKSLG+JPXvof3ltporTGR2bhH/eJPo7UHCglIuXfzYg==",
       "dependencies": {
-        "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-endpoints": "3.743.0",
-        "@smithy/core": "^3.1.5",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/core": "3.775.0",
+        "@aws-sdk/types": "3.775.0",
+        "@aws-sdk/util-endpoints": "3.775.0",
+        "@smithy/core": "^3.2.0",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -745,46 +747,46 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.758.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.758.0.tgz",
-      "integrity": "sha512-YZ5s7PSvyF3Mt2h1EQulCG93uybprNGbBkPmVuy/HMMfbFTt4iL3SbKjxqvOZelm86epFfj7pvK7FliI2WOEcg==",
+      "version": "3.777.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.777.0.tgz",
+      "integrity": "sha512-bmmVRsCjuYlStYPt06hr+f8iEyWg7+AklKCA8ZLDEJujXhXIowgUIqXmqpTkXwkVvDQ9tzU7hxaONjyaQCGybA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.758.0",
-        "@aws-sdk/middleware-host-header": "3.734.0",
-        "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
-        "@aws-sdk/middleware-user-agent": "3.758.0",
-        "@aws-sdk/region-config-resolver": "3.734.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-endpoints": "3.743.0",
-        "@aws-sdk/util-user-agent-browser": "3.734.0",
-        "@aws-sdk/util-user-agent-node": "3.758.0",
-        "@smithy/config-resolver": "^4.0.1",
-        "@smithy/core": "^3.1.5",
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/hash-node": "^4.0.1",
-        "@smithy/invalid-dependency": "^4.0.1",
-        "@smithy/middleware-content-length": "^4.0.1",
-        "@smithy/middleware-endpoint": "^4.0.6",
-        "@smithy/middleware-retry": "^4.0.7",
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/middleware-stack": "^4.0.1",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/node-http-handler": "^4.0.3",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.6",
-        "@smithy/types": "^4.1.0",
-        "@smithy/url-parser": "^4.0.1",
+        "@aws-sdk/core": "3.775.0",
+        "@aws-sdk/middleware-host-header": "3.775.0",
+        "@aws-sdk/middleware-logger": "3.775.0",
+        "@aws-sdk/middleware-recursion-detection": "3.775.0",
+        "@aws-sdk/middleware-user-agent": "3.775.0",
+        "@aws-sdk/region-config-resolver": "3.775.0",
+        "@aws-sdk/types": "3.775.0",
+        "@aws-sdk/util-endpoints": "3.775.0",
+        "@aws-sdk/util-user-agent-browser": "3.775.0",
+        "@aws-sdk/util-user-agent-node": "3.775.0",
+        "@smithy/config-resolver": "^4.1.0",
+        "@smithy/core": "^3.2.0",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/hash-node": "^4.0.2",
+        "@smithy/invalid-dependency": "^4.0.2",
+        "@smithy/middleware-content-length": "^4.0.2",
+        "@smithy/middleware-endpoint": "^4.1.0",
+        "@smithy/middleware-retry": "^4.1.0",
+        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/middleware-stack": "^4.0.2",
+        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/url-parser": "^4.0.2",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.7",
-        "@smithy/util-defaults-mode-node": "^4.0.7",
-        "@smithy/util-endpoints": "^3.0.1",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-retry": "^4.0.1",
+        "@smithy/util-defaults-mode-browser": "^4.0.8",
+        "@smithy/util-defaults-mode-node": "^4.0.8",
+        "@smithy/util-endpoints": "^3.0.2",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-retry": "^4.0.2",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -793,15 +795,15 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.734.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.734.0.tgz",
-      "integrity": "sha512-Lvj1kPRC5IuJBr9DyJ9T9/plkh+EfKLy+12s/mykOy1JaKHDpvj+XGy2YO6YgYVOb8JFtaqloid+5COtje4JTQ==",
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.775.0.tgz",
+      "integrity": "sha512-40iH3LJjrQS3LKUJAl7Wj0bln7RFPEvUYKFxtP8a+oKFDO0F65F52xZxIJbPn6sHkxWDAnZlGgdjZXM3p2g5wQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.1",
+        "@smithy/util-middleware": "^4.0.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -809,15 +811,15 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.758.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.758.0.tgz",
-      "integrity": "sha512-ckptN1tNrIfQUaGWm/ayW1ddG+imbKN7HHhjFdS4VfItsP0QQOB0+Ov+tpgb4MoNR4JaUghMIVStjIeHN2ks1w==",
+      "version": "3.777.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.777.0.tgz",
+      "integrity": "sha512-Yc2cDONsHOa4dTSGOev6Ng2QgTKQUEjaUnsyKd13pc/nLLz/WLqHiQ/o7PcnKERJxXGs1g1C6l3sNXiX+kbnFQ==",
       "dependencies": {
-        "@aws-sdk/nested-clients": "3.758.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/nested-clients": "3.777.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/shared-ini-file-loader": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -825,11 +827,11 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.734.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.734.0.tgz",
-      "integrity": "sha512-o11tSPTT70nAkGV1fN9wm/hAIiLPyWX6SuGf+9JyTp7S/rC2cFWhR26MvA69nplcjNaXVzB0f+QFrLXXjOqCrg==",
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.775.0.tgz",
+      "integrity": "sha512-ZoGKwa4C9fC9Av6bdfqcW6Ix5ot05F/S4VxWR2nHuMv7hzfmAjTOcUiWT7UR4hM/U0whf84VhDtXN/DWAk52KA==",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -837,13 +839,13 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.743.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.743.0.tgz",
-      "integrity": "sha512-sN1l559zrixeh5x+pttrnd0A3+r34r0tmPkJ/eaaMaAzXqsmKU/xYre9K3FNnsSS1J1k4PEfk/nHDTVUgFYjnw==",
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.775.0.tgz",
+      "integrity": "sha512-yjWmUgZC9tUxAo8Uaplqmq0eUh0zrbZJdwxGRKdYxfm4RG6fMw1tj52+KkatH7o+mNZvg1GDcVp/INktxonJLw==",
       "dependencies": {
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-endpoints": "^3.0.1",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-endpoints": "^3.0.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -862,25 +864,25 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.734.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.734.0.tgz",
-      "integrity": "sha512-xQTCus6Q9LwUuALW+S76OL0jcWtMOVu14q+GoLnWPUM7QeUw963oQcLhF7oq0CtaLLKyl4GOUfcwc773Zmwwng==",
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.775.0.tgz",
+      "integrity": "sha512-txw2wkiJmZKVdDbscK7VBK+u+TJnRtlUjRTLei+elZg2ADhpQxfVAQl436FUeIv6AhB/oRHW6/K/EAGXUSWi0A==",
       "dependencies": {
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/types": "^4.2.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.758.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.758.0.tgz",
-      "integrity": "sha512-A5EZw85V6WhoKMV2hbuFRvb9NPlxEErb4HPO6/SPXYY4QrjprIzScHxikqcWv1w4J3apB1wto9LPU3IMsYtfrw==",
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.775.0.tgz",
+      "integrity": "sha512-N9yhTevbizTOMo3drH7Eoy6OkJ3iVPxhV7dwb6CMAObbLneS36CSfA6xQXupmHWcRvZPTz8rd1JGG3HzFOau+g==",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.758.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/middleware-user-agent": "3.775.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4533,11 +4535,11 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.1.tgz",
-      "integrity": "sha512-fiUIYgIgRjMWznk6iLJz35K2YxSLHzLBA/RC6lBrKfQ8fHbPfvk7Pk9UvpKoHgJjI18MnbPuEju53zcVy6KF1g==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.2.tgz",
+      "integrity": "sha512-Sl/78VDtgqKxN2+1qduaVE140XF+Xg+TafkncspwM4jFP/LHr76ZHmIY/y3V1M0mMLNk+Je6IGbzxy23RSToMw==",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4545,14 +4547,14 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.0.1.tgz",
-      "integrity": "sha512-Igfg8lKu3dRVkTSEm98QpZUvKEOa71jDX4vKRcvJVyRc3UgN3j7vFMf0s7xLQhYmKa8kyJGQgUJDOV5V3neVlQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.0.tgz",
+      "integrity": "sha512-8smPlwhga22pwl23fM5ew4T9vfLUCeFXlcqNOCD5M5h8VmNPNUE9j6bQSuRXpDSV11L/E/SwEBQuW8hr6+nS1A==",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.1",
+        "@smithy/util-middleware": "^4.0.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4560,16 +4562,16 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.1.5.tgz",
-      "integrity": "sha512-HLclGWPkCsekQgsyzxLhCQLa8THWXtB5PxyYN+2O6nkyLt550KQKTlbV2D1/j5dNIQapAZM1+qFnpBFxZQkgCA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-k17bgQhVZ7YmUvA8at4af1TDpl0NDMBuBKJl8Yg0nrefwmValU+CnA5l/AriVdQNthU/33H3nK71HrLgqOPr1Q==",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
         "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-stream": "^4.1.2",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-stream": "^4.2.0",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -4578,14 +4580,14 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.1.tgz",
-      "integrity": "sha512-l/qdInaDq1Zpznpmev/+52QomsJNZ3JkTl5yrTl02V6NBgJOQ4LY0SFw/8zsMwj3tLe8vqiIuwF6nxaEwgf6mg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.2.tgz",
+      "integrity": "sha512-32lVig6jCaWBHnY+OEQ6e6Vnt5vDHaLiydGrwYMW9tPqO688hPGTYRamYJ1EptxEC2rAwJrHWmPoKRBl4iTa8w==",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "@smithy/url-parser": "^4.0.1",
+        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/types": "^4.2.0",
+        "@smithy/url-parser": "^4.0.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4593,12 +4595,12 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.1.tgz",
-      "integrity": "sha512-Q2bCAAR6zXNVtJgifsU16ZjKGqdw/DyecKNgIgi7dlqw04fqDu0mnq+JmGphqheypVc64CYq3azSuCpAdFk2+A==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.2.tgz",
+      "integrity": "sha512-p+f2kLSK7ZrXVfskU/f5dzksKTewZk8pJLPvER3aFHPt76C2MxD9vNatSfLzzQSQB4FNO96RK4PSXfhD1TTeMQ==",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.2.0",
         "@smithy/util-hex-encoding": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -4607,12 +4609,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.0.1.tgz",
-      "integrity": "sha512-HbIybmz5rhNg+zxKiyVAnvdM3vkzjE6ccrJ620iPL8IXcJEntd3hnBl+ktMwIy12Te/kyrSbUb8UCdnUT4QEdA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.0.2.tgz",
+      "integrity": "sha512-CepZCDs2xgVUtH7ZZ7oDdZFH8e6Y2zOv8iiX6RhndH69nlojCALSKK+OXwZUgOtUZEUaZ5e1hULVCHYbCn7pug==",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/eventstream-serde-universal": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4620,11 +4622,11 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.0.1.tgz",
-      "integrity": "sha512-lSipaiq3rmHguHa3QFF4YcCM3VJOrY9oq2sow3qlhFY+nBSTF/nrO82MUQRPrxHQXA58J5G1UnU2WuJfi465BA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.1.0.tgz",
+      "integrity": "sha512-1PI+WPZ5TWXrfj3CIoKyUycYynYJgZjuQo8U+sphneOtjsgrttYybdqESFReQrdWJ+LKt6NEdbYzmmfDBmjX2A==",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4632,12 +4634,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.0.1.tgz",
-      "integrity": "sha512-o4CoOI6oYGYJ4zXo34U8X9szDe3oGjmHgsMGiZM0j4vtNoT+h80TLnkUcrLZR3+E6HIxqW+G+9WHAVfl0GXK0Q==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.0.2.tgz",
+      "integrity": "sha512-C5bJ/C6x9ENPMx2cFOirspnF9ZsBVnBMtP6BdPl/qYSuUawdGQ34Lq0dMcf42QTjUZgWGbUIZnz6+zLxJlb9aw==",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/eventstream-serde-universal": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4645,12 +4647,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.0.1.tgz",
-      "integrity": "sha512-Z94uZp0tGJuxds3iEAZBqGU2QiaBHP4YytLUjwZWx+oUeohCsLyUm33yp4MMBmhkuPqSbQCXq5hDet6JGUgHWA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.0.2.tgz",
+      "integrity": "sha512-St8h9JqzvnbB52FtckiHPN4U/cnXcarMniXRXTKn0r4b4XesZOGiAyUdj1aXbqqn1icSqBlzzUsCl6nPB018ng==",
       "dependencies": {
-        "@smithy/eventstream-codec": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/eventstream-codec": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4658,13 +4660,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.1.tgz",
-      "integrity": "sha512-3aS+fP28urrMW2KTjb6z9iFow6jO8n3MFfineGbndvzGZit3taZhKWtTorf+Gp5RpFDDafeHlhfsGlDCXvUnJA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.2.tgz",
+      "integrity": "sha512-+9Dz8sakS9pe7f2cBocpJXdeVjMopUDLgZs1yWeu7h++WqSbjUYv/JAJwKwXw1HV6gq1jyWjxuyn24E2GhoEcQ==",
       "dependencies": {
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/querystring-builder": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/querystring-builder": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "@smithy/util-base64": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -4673,11 +4675,11 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.1.tgz",
-      "integrity": "sha512-TJ6oZS+3r2Xu4emVse1YPB3Dq3d8RkZDKcPr71Nj/lJsdAP1c7oFzYqEn1IBc915TsgLl2xIJNuxCz+gLbLE0w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.2.tgz",
+      "integrity": "sha512-VnTpYPnRUE7yVhWozFdlxcYknv9UN7CeOqSrMH+V877v4oqtVYuoqhIhtSjmGPvYrYnAkaM61sLMKHvxL138yg==",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.2.0",
         "@smithy/util-buffer-from": "^4.0.0",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
@@ -4687,11 +4689,11 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.1.tgz",
-      "integrity": "sha512-gdudFPf4QRQ5pzj7HEnu6FhKRi61BfH/Gk5Yf6O0KiSbr1LlVhgjThcvjdu658VE6Nve8vaIWB8/fodmS1rBPQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.2.tgz",
+      "integrity": "sha512-GatB4+2DTpgWPday+mnUkoumP54u/MDM/5u44KF9hIu8jF0uafZtQLcdfIKkIcUNuF/fBojpLEHZS/56JqPeXQ==",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4710,12 +4712,12 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.1.tgz",
-      "integrity": "sha512-OGXo7w5EkB5pPiac7KNzVtfCW2vKBTZNuCctn++TTSOMpe6RZO/n6WEC1AxJINn3+vWLKW49uad3lo/u0WJ9oQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.2.tgz",
+      "integrity": "sha512-hAfEXm1zU+ELvucxqQ7I8SszwQ4znWMbNv6PLMndN83JJN41EPuS93AIyh2N+gJ6x8QFhzSO6b7q2e6oClDI8A==",
       "dependencies": {
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4723,17 +4725,17 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.0.6.tgz",
-      "integrity": "sha512-ftpmkTHIFqgaFugcjzLZv3kzPEFsBFSnq1JsIkr2mwFzCraZVhQk2gqN51OOeRxqhbPTkRFj39Qd2V91E/mQxg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.0.tgz",
+      "integrity": "sha512-xhLimgNCbCzsUppRTGXWkZywksuTThxaIB0HwbpsVLY5sceac4e1TZ/WKYqufQLaUy+gUSJGNdwD2jo3cXL0iA==",
       "dependencies": {
-        "@smithy/core": "^3.1.5",
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "@smithy/url-parser": "^4.0.1",
-        "@smithy/util-middleware": "^4.0.1",
+        "@smithy/core": "^3.2.0",
+        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/shared-ini-file-loader": "^4.0.2",
+        "@smithy/types": "^4.2.0",
+        "@smithy/url-parser": "^4.0.2",
+        "@smithy/util-middleware": "^4.0.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4741,17 +4743,17 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.0.7.tgz",
-      "integrity": "sha512-58j9XbUPLkqAcV1kHzVX/kAR16GT+j7DUZJqwzsxh1jtz7G82caZiGyyFgUvogVfNTg3TeAOIJepGc8TXF4AVQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.0.tgz",
+      "integrity": "sha512-2zAagd1s6hAaI/ap6SXi5T3dDwBOczOMCSkkYzktqN1+tzbk1GAsHNAdo/1uzxz3Ky02jvZQwbi/vmDA6z4Oyg==",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/service-error-classification": "^4.0.1",
-        "@smithy/smithy-client": "^4.1.6",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-retry": "^4.0.1",
+        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/service-error-classification": "^4.0.2",
+        "@smithy/smithy-client": "^4.2.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-retry": "^4.0.2",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
@@ -4760,11 +4762,11 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.2.tgz",
-      "integrity": "sha512-Sdr5lOagCn5tt+zKsaW+U2/iwr6bI9p08wOkCp6/eL6iMbgdtc2R5Ety66rf87PeohR0ExI84Txz9GYv5ou3iQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.3.tgz",
+      "integrity": "sha512-rfgDVrgLEVMmMn0BI8O+8OVr6vXzjV7HZj57l0QxslhzbvVfikZbVfBVthjLHqib4BW44QhcIgJpvebHlRaC9A==",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4772,11 +4774,11 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.1.tgz",
-      "integrity": "sha512-dHwDmrtR/ln8UTHpaIavRSzeIk5+YZTBtLnKwDW3G2t6nAupCiQUvNzNoHBpik63fwUaJPtlnMzXbQrNFWssIA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.2.tgz",
+      "integrity": "sha512-eSPVcuJJGVYrFYu2hEq8g8WWdJav3sdrI4o2c6z/rjnYDd3xH9j9E7deZQCzFn4QvGPouLngH3dQ+QVTxv5bOQ==",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4784,13 +4786,13 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.1.tgz",
-      "integrity": "sha512-8mRTjvCtVET8+rxvmzRNRR0hH2JjV0DFOmwXPrISmTIJEfnCBugpYYGAsCj8t41qd+RB5gbheSQ/6aKZCQvFLQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.2.tgz",
+      "integrity": "sha512-WgCkILRZfJwJ4Da92a6t3ozN/zcvYyJGUTmfGbgS/FkCcoCjl7G4FJaCDN1ySdvLvemnQeo25FdkyMSTSwulsw==",
       "dependencies": {
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/shared-ini-file-loader": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4798,14 +4800,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.3.tgz",
-      "integrity": "sha512-dYCLeINNbYdvmMLtW0VdhW1biXt+PPCGazzT5ZjKw46mOtdgToQEwjqZSS9/EN8+tNs/RO0cEWG044+YZs97aA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.4.tgz",
+      "integrity": "sha512-/mdqabuAT3o/ihBGjL94PUbTSPSRJ0eeVTdgADzow0wRJ0rN4A27EOrtlK56MYiO1fDvlO3jVTCxQtQmK9dZ1g==",
       "dependencies": {
-        "@smithy/abort-controller": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/querystring-builder": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/abort-controller": "^4.0.2",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/querystring-builder": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4813,11 +4815,11 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.1.tgz",
-      "integrity": "sha512-o+VRiwC2cgmk/WFV0jaETGOtX16VNPp2bSQEzu0whbReqE1BMqsP2ami2Vi3cbGVdKu1kq9gQkDAGKbt0WOHAQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.2.tgz",
+      "integrity": "sha512-wNRoQC1uISOuNc2s4hkOYwYllmiyrvVXWMtq+TysNRVQaHm4yoafYQyjN/goYZS+QbYlPIbb/QRjaUZMuzwQ7A==",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4825,11 +4827,11 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.0.1.tgz",
-      "integrity": "sha512-TE4cpj49jJNB/oHyh/cRVEgNZaoPaxd4vteJNB0yGidOCVR0jCw/hjPVsT8Q8FRmj8Bd3bFZt8Dh7xGCT+xMBQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.0.tgz",
+      "integrity": "sha512-KxAOL1nUNw2JTYrtviRRjEnykIDhxc84qMBzxvu1MUfQfHTuBlCG7PA6EdVwqpJjH7glw7FqQoFxUJSyBQgu7g==",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4837,11 +4839,11 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.1.tgz",
-      "integrity": "sha512-wU87iWZoCbcqrwszsOewEIuq+SU2mSoBE2CcsLwE0I19m0B2gOJr1MVjxWcDQYOzHbR1xCk7AcOBbGFUYOKvdg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.2.tgz",
+      "integrity": "sha512-NTOs0FwHw1vimmQM4ebh+wFQvOwkEf/kQL6bSM1Lock+Bv4I89B3hGYoUEPkmvYPkDKyp5UdXJYu+PoTQ3T31Q==",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.2.0",
         "@smithy/util-uri-escape": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -4850,11 +4852,11 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.1.tgz",
-      "integrity": "sha512-Ma2XC7VS9aV77+clSFylVUnPZRindhB7BbmYiNOdr+CHt/kZNJoPP0cd3QxCnCFyPXC4eybmyE98phEHkqZ5Jw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.2.tgz",
+      "integrity": "sha512-v6w8wnmZcVXjfVLjxw8qF7OwESD9wnpjp0Dqry/Pod0/5vcEA3qxCr+BhbOHlxS8O+29eLpT3aagxXGwIoEk7Q==",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4862,22 +4864,22 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.1.tgz",
-      "integrity": "sha512-3JNjBfOWpj/mYfjXJHB4Txc/7E4LVq32bwzE7m28GN79+M1f76XHflUaSUkhOriprPDzev9cX/M+dEB80DNDKA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.2.tgz",
+      "integrity": "sha512-LA86xeFpTKn270Hbkixqs5n73S+LVM0/VZco8dqd+JT75Dyx3Lcw/MraL7ybjmz786+160K8rPOmhsq0SocoJQ==",
       "dependencies": {
-        "@smithy/types": "^4.1.0"
+        "@smithy/types": "^4.2.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.1.tgz",
-      "integrity": "sha512-hC8F6qTBbuHRI/uqDgqqi6J0R4GtEZcgrZPhFQnMhfJs3MnUTGSnR1NSJCJs5VWlMydu0kJz15M640fJlRsIOw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.2.tgz",
+      "integrity": "sha512-J9/gTWBGVuFZ01oVA6vdb4DAjf1XbDhK6sLsu3OS9qmLrS6KB5ygpeHiM3miIbj1qgSJ96GYszXFWv6ErJ8QEw==",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4885,15 +4887,15 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.1.tgz",
-      "integrity": "sha512-nCe6fQ+ppm1bQuw5iKoeJ0MJfz2os7Ic3GBjOkLOPtavbD1ONoyE3ygjBfz2ythFWm4YnRm6OxW+8p/m9uCoIA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.2.tgz",
+      "integrity": "sha512-Mz+mc7okA73Lyz8zQKJNyr7lIcHLiPYp0+oiqiMNc/t7/Kf2BENs5d63pEj7oPqdjaum6g0Fc8wC78dY1TgtXw==",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
         "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.1",
+        "@smithy/util-middleware": "^4.0.2",
         "@smithy/util-uri-escape": "^4.0.0",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
@@ -4903,16 +4905,16 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.1.6.tgz",
-      "integrity": "sha512-UYDolNg6h2O0L+cJjtgSyKKvEKCOa/8FHYJnBobyeoeWDmNpXjwOAtw16ezyeu1ETuuLEOZbrynK0ZY1Lx9Jbw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.2.0.tgz",
+      "integrity": "sha512-Qs65/w30pWV7LSFAez9DKy0Koaoh3iHhpcpCCJ4waj/iqwsuSzJna2+vYwq46yBaqO5ZbP9TjUsATUNxrKeBdw==",
       "dependencies": {
-        "@smithy/core": "^3.1.5",
-        "@smithy/middleware-endpoint": "^4.0.6",
-        "@smithy/middleware-stack": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-stream": "^4.1.2",
+        "@smithy/core": "^3.2.0",
+        "@smithy/middleware-endpoint": "^4.1.0",
+        "@smithy/middleware-stack": "^4.0.2",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-stream": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4920,9 +4922,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
-      "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.2.0.tgz",
+      "integrity": "sha512-7eMk09zQKCO+E/ivsjQv+fDlOupcFUCSC/L2YUPgwhvowVGWbPQHjEFcmjt7QQ4ra5lyowS92SV53Zc6XD4+fg==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -4931,12 +4933,12 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.1.tgz",
-      "integrity": "sha512-gPXcIEUtw7VlK8f/QcruNXm7q+T5hhvGu9tl63LsJPZ27exB6dtNwvh2HIi0v7JcXJ5emBxB+CJxwaLEdJfA+g==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.2.tgz",
+      "integrity": "sha512-Bm8n3j2ScqnT+kJaClSVCMeiSenK6jVAzZCNewsYWuZtnBehEz4r2qP0riZySZVfzB+03XZHJeqfmJDkeeSLiQ==",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/querystring-parser": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5002,13 +5004,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.7.tgz",
-      "integrity": "sha512-CZgDDrYHLv0RUElOsmZtAnp1pIjwDVCSuZWOPhIOBvG36RDfX1Q9+6lS61xBf+qqvHoqRjHxgINeQz47cYFC2Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.8.tgz",
+      "integrity": "sha512-ZTypzBra+lI/LfTYZeop9UjoJhhGRTg3pxrNpfSTQLd3AJ37r2z4AXTKpq1rFXiiUIJsYyFgNJdjWRGP/cbBaQ==",
       "dependencies": {
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/smithy-client": "^4.1.6",
-        "@smithy/types": "^4.1.0",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/smithy-client": "^4.2.0",
+        "@smithy/types": "^4.2.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -5017,16 +5019,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.7.tgz",
-      "integrity": "sha512-79fQW3hnfCdrfIi1soPbK3zmooRFnLpSx3Vxi6nUlqaaQeC5dm8plt4OTNDNqEEEDkvKghZSaoti684dQFVrGQ==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.8.tgz",
+      "integrity": "sha512-Rgk0Jc/UDfRTzVthye/k2dDsz5Xxs9LZaKCNPgJTRyoyBoeiNCnHsYGOyu1PKN+sDyPnJzMOz22JbwxzBp9NNA==",
       "dependencies": {
-        "@smithy/config-resolver": "^4.0.1",
-        "@smithy/credential-provider-imds": "^4.0.1",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/smithy-client": "^4.1.6",
-        "@smithy/types": "^4.1.0",
+        "@smithy/config-resolver": "^4.1.0",
+        "@smithy/credential-provider-imds": "^4.0.2",
+        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/smithy-client": "^4.2.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5034,12 +5036,12 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.1.tgz",
-      "integrity": "sha512-zVdUENQpdtn9jbpD9SCFK4+aSiavRb9BxEtw9ZGUR1TYo6bBHbIoi7VkrFQ0/RwZlzx0wRBaRmPclj8iAoJCLA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.2.tgz",
+      "integrity": "sha512-6QSutU5ZyrpNbnd51zRTL7goojlcnuOB55+F9VBD+j8JpRY50IGamsjlycrmpn8PQkmJucFW8A0LSfXj7jjtLQ==",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5058,11 +5060,11 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.1.tgz",
-      "integrity": "sha512-HiLAvlcqhbzhuiOa0Lyct5IIlyIz0PQO5dnMlmQ/ubYM46dPInB+3yQGkfxsk6Q24Y0n3/JmcA1v5iEhmOF5mA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.2.tgz",
+      "integrity": "sha512-6GDamTGLuBQVAEuQ4yDQ+ti/YINf/MEmIegrEeg7DdB/sld8BX1lqt9RRuIcABOhAGTA50bRbPzErez7SlDtDQ==",
       "dependencies": {
-        "@smithy/types": "^4.1.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5070,12 +5072,12 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.1.tgz",
-      "integrity": "sha512-WmRHqNVwn3kI3rKk1LsKcVgPBG6iLTBGC1iYOV3GQegwJ3E8yjzHytPt26VNzOWr1qu0xE03nK0Ug8S7T7oufw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.2.tgz",
+      "integrity": "sha512-Qryc+QG+7BCpvjloFLQrmlSd0RsVRHejRXd78jNO3+oREueCjwG1CCEH1vduw/ZkM1U9TztwIKVIi3+8MJScGg==",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@smithy/service-error-classification": "^4.0.2",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5083,13 +5085,13 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.1.2.tgz",
-      "integrity": "sha512-44PKEqQ303d3rlQuiDpcCcu//hV8sn+u2JBo84dWCE0rvgeiVl0IlLMagbU++o0jCWhYCsHaAt9wZuZqNe05Hw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.0.tgz",
+      "integrity": "sha512-Vj1TtwWnuWqdgQI6YTUF5hQ/0jmFiOYsc51CSMgj7QfyO+RF4EnT2HNjoviNlOOmgzgvf3f5yno+EiC4vrnaWQ==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/node-http-handler": "^4.0.3",
-        "@smithy/types": "^4.1.0",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/types": "^4.2.0",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-buffer-from": "^4.0.0",
         "@smithy/util-hex-encoding": "^4.0.0",

--- a/core/package.json
+++ b/core/package.json
@@ -43,9 +43,9 @@
     "typescript": "^5.6.3"
   },
   "dependencies": {
-    "@aws-sdk/client-bedrock-runtime": "^3.758.0",
-    "@aws-sdk/client-sagemaker-runtime": "^3.758.0",
-    "@aws-sdk/credential-providers": "^3.758.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.779.0",
+    "@aws-sdk/client-sagemaker-runtime": "^3.777.0",
+    "@aws-sdk/credential-providers": "^3.778.0",
     "@continuedev/config-types": "^1.0.13",
     "@continuedev/config-yaml": "^1.0.67",
     "@continuedev/fetch": "^1.0.4",

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -102,9 +102,9 @@
       "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-bedrock-runtime": "^3.758.0",
-        "@aws-sdk/client-sagemaker-runtime": "^3.758.0",
-        "@aws-sdk/credential-providers": "^3.758.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.779.0",
+        "@aws-sdk/client-sagemaker-runtime": "^3.777.0",
+        "@aws-sdk/credential-providers": "^3.778.0",
         "@continuedev/config-types": "^1.0.13",
         "@continuedev/config-yaml": "^1.0.67",
         "@continuedev/fetch": "^1.0.4",

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -107,9 +107,9 @@
       "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-bedrock-runtime": "^3.758.0",
-        "@aws-sdk/client-sagemaker-runtime": "^3.758.0",
-        "@aws-sdk/credential-providers": "^3.758.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.779.0",
+        "@aws-sdk/client-sagemaker-runtime": "^3.777.0",
+        "@aws-sdk/credential-providers": "^3.778.0",
         "@continuedev/config-types": "^1.0.13",
         "@continuedev/config-yaml": "^1.0.67",
         "@continuedev/fetch": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
         "@typescript-eslint/parser": "^7.8.0",
         "eslint-plugin-import": "^2.29.1",
         "prettier": "^3.3.3",
-        "prettier-plugin-tailwindcss": "^0.6.8"
+        "prettier-plugin-tailwindcss": "^0.6.8",
+        "typescript": "^5.6.3"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2976,7 +2977,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
## Description

Enable Prompt Caching for AWS Bedrock. It has gone GA for Claude 3.7 Sonet and Claude 3.5 Haiku.

https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html

To enable this feature:

```
{
      "title": "Bedrock: Claude 3.7 Sonnet V1 w/ Caching",
      "provider": "bedrock",
      "model": "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
      "region": "us-west-2",
      "cacheBehavior": {
          "cacheSystemMessage": true,
          "cacheConversation": true
      },
      "completionOptions": {
        "reasoning": true,
        "reasoningBudgetTokens": 2000
      }
}
```

## Checklist

- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. ]

## Testing instructions

I've enabled logging to the debug console so cached tokens can be monitored. Recommend removing or supressing this logging post review.

```{"cacheReadInputTokenCount":14062,"cacheReadInputTokens":14062,"cacheWriteInputTokenCount":0,"cacheWriteInputTokens":0,"inputTokens":1242,"outputTokens":47,"totalTokens":15351}```
