### PR TITLE
Fix count tokens bug

### DIFF
--- a/core/llm/countTokens.ts
+++ b/core/llm/countTokens.ts
@@ -280,7 +280,7 @@ function pruneChatHistory(
   // 1. Replace beyond last 5 messages with summary
   let i = 0;
   while (totalTokens > contextLength && i < chatHistory.length - 5) {
-    const message = chatHistory[0];
+    const message = chatHistory[i];
     totalTokens -= countTokens(message.content, modelName);
     totalTokens += countTokens(summarize(message), modelName);
     message.content = summarize(message);

--- a/core/llm/countTokens.ts
+++ b/core/llm/countTokens.ts
@@ -288,11 +288,7 @@ function pruneChatHistory(
   }
 
   // 2. Remove entire messages until the last 5
-  while (
-    chatHistory.length > 5 &&
-    totalTokens > contextLength &&
-    chatHistory.length > 0
-  ) {
+  while (chatHistory.length > 5 && totalTokens > contextLength) {
     const message = chatHistory.shift()!;
     totalTokens -= countTokens(message.content, modelName);
   }


### PR DESCRIPTION
## Description

The main fix improves the efficiency of preparing `longerThanOneThird` and `distanceFromThird` for pruning messages that exceed 1/3 of the context length. The key modifications are:

1. Optimized token counting – Each message is paired with its token count, ensuring `countTokens` is called only once per message. 
2. Refined sorting logic – The filtering step now occurs before sorting, so we only sort messages that exceed 1/3 of the context length instead of the entire message array.

Additionally, the update includes minor fixes such as typo corrections and the removal of an extra condition. For more details, refer to the commit messages.

## Testing instructions

1. Check `chatHistory` before and after the one-third-pruning, and see if the messages that exceed 1/3 the context length get pruned properly. 
4. Check if the messages that is beyond last 5 messages get correctly summarized when hitting the context length.
