### PR TITLE
LS Tool

### DIFF
--- a/core/context/providers/FolderContextProvider.ts
+++ b/core/context/providers/FolderContextProvider.ts
@@ -35,7 +35,7 @@ class FolderContextProvider extends BaseContextProvider {
     const folders = await walkDirs(
       args.ide,
       {
-        onlyDirs: true,
+        include: "dirs",
         source: "load submenu items - folder",
       },
       workspaceDirs,

--- a/core/context/providers/RepoMapContextProvider.ts
+++ b/core/context/providers/RepoMapContextProvider.ts
@@ -54,7 +54,7 @@ class RepoMapContextProvider extends BaseContextProvider {
     const folders = await walkDirs(
       args.ide,
       {
-        onlyDirs: true,
+        include: "dirs",
         source: "load submenu items - repo map",
       },
       workspaceDirs,

--- a/core/indexing/walkDir.test.ts
+++ b/core/indexing/walkDir.test.ts
@@ -97,7 +97,7 @@ describe("walkDir functions", () => {
       );
     });
 
-    it("should handle onlyDirs option", async () => {
+    it("should handle include option", async () => {
       addToTestDir([
         "src/",
         ["src/file1.ts", "content1"],
@@ -109,7 +109,7 @@ describe("walkDir functions", () => {
         (await testIde.getWorkspaceDirs())[0],
         testIde,
         {
-          onlyDirs: true,
+          include: "dirs",
         },
       );
 

--- a/core/tools/builtIn.ts
+++ b/core/tools/builtIn.ts
@@ -3,10 +3,14 @@ export enum BuiltInToolNames {
   ReadCurrentlyOpenFile = "builtin_read_currently_open_file",
   CreateNewFile = "builtin_create_new_file",
   RunTerminalCommand = "builtin_run_terminal_command",
-  ViewSubdirectory = "builtin_view_subdirectory",
-  ViewRepoMap = "builtin_view_repo_map",
   ExactSearch = "builtin_exact_search",
   SearchWeb = "builtin_search_web",
   ViewDiff = "builtin_view_diff",
+  LSTool = "builtin_ls",
+
+  // excluded from allTools for now
+  ViewRepoMap = "builtin_view_repo_map",
+  ViewSubdirectory = "builtin_view_subdirectory",
 }
+
 export const BUILT_IN_GROUP_NAME = "Built-In";

--- a/core/tools/callTool.ts
+++ b/core/tools/callTool.ts
@@ -5,13 +5,12 @@ import { BuiltInToolNames } from "./builtIn";
 
 import { createNewFileImpl } from "./implementations/createNewFile";
 import { exactSearchImpl } from "./implementations/exactSearch";
+import { lsToolImpl } from "./implementations/lsTool";
 import { readCurrentlyOpenFileImpl } from "./implementations/readCurrentlyOpenFile";
 import { readFileImpl } from "./implementations/readFile";
 import { runTerminalCommandImpl } from "./implementations/runTerminalCommand";
 import { searchWebImpl } from "./implementations/searchWeb";
 import { viewDiffImpl } from "./implementations/viewDiff";
-import { viewRepoMapImpl } from "./implementations/viewRepoMap";
-import { viewSubdirectoryImpl } from "./implementations/viewSubdirectory";
 
 async function callHttpTool(
   url: string,
@@ -149,12 +148,14 @@ export async function callTool(
       return await searchWebImpl(args, extras);
     case BuiltInToolNames.ViewDiff:
       return await viewDiffImpl(args, extras);
-    case BuiltInToolNames.ViewRepoMap:
-      return await viewRepoMapImpl(args, extras);
-    case BuiltInToolNames.ViewSubdirectory:
-      return await viewSubdirectoryImpl(args, extras);
+    case BuiltInToolNames.LSTool:
+      return await lsToolImpl(args, extras);
     case BuiltInToolNames.ReadCurrentlyOpenFile:
       return await readCurrentlyOpenFileImpl(args, extras);
+    // case BuiltInToolNames.ViewRepoMap:
+    //   return await viewRepoMapImpl(args, extras);
+    // case BuiltInToolNames.ViewSubdirectory:
+    //   return await viewSubdirectoryImpl(args, extras);
     default:
       return await callToolFromUri(uri, args, extras);
   }

--- a/core/tools/definitions/lsTool.ts
+++ b/core/tools/definitions/lsTool.ts
@@ -1,0 +1,33 @@
+import { Tool } from "../..";
+
+import { BUILT_IN_GROUP_NAME, BuiltInToolNames } from "../builtIn";
+
+export const lsTool: Tool = {
+  type: "function",
+  displayTitle: "LS Tool",
+  wouldLikeTo: "list files and folders in {{{ dirPath }}}",
+  isCurrently: "listing files and folders in {{{ dirPath }}}",
+  hasAlready: "listed files and folders in {{{ dirPath }}}",
+  readonly: true,
+  group: BUILT_IN_GROUP_NAME,
+  function: {
+    name: BuiltInToolNames.LSTool,
+    description: "List files and folders in a given directory",
+    parameters: {
+      type: "object",
+      required: ["dirPath", "recursive"],
+      properties: {
+        dirPath: {
+          type: "string",
+          description:
+            "The directory path relative to the root of the project. Always use forward slash paths like '/'. rather than e.g. '.'",
+        },
+        recursive: {
+          type: "boolean",
+          description:
+            "If true, lists files and folders recursively. To prevent unexpected large results, use this sparingly",
+        },
+      },
+    },
+  },
+};

--- a/core/tools/implementations/lsTool.ts
+++ b/core/tools/implementations/lsTool.ts
@@ -1,0 +1,31 @@
+import { ToolImpl } from ".";
+import { walkDir } from "../../indexing/walkDir";
+import { resolveRelativePathInDir } from "../../util/ideUtils";
+
+export const lsToolImpl: ToolImpl = async (args, extras) => {
+  const uri = await resolveRelativePathInDir(args.dirPath, extras.ide);
+  if (!uri) {
+    throw new Error(
+      `Directory ${args.dirPath} not found. Make sure to use forward-slash paths. Do not use e.g. "."`,
+    );
+  }
+
+  const entries = await walkDir(uri, extras.ide, {
+    returnRelativeUrisPaths: true,
+    include: "both",
+    recursive: args.recursive ?? false,
+  });
+
+  const content =
+    entries.length > 0
+      ? entries.join("\n")
+      : `No files/folders found in ${args.dirPath}`;
+
+  return [
+    {
+      name: "File/folder list",
+      description: `Files/folders in ${args.dirPath}`,
+      content,
+    },
+  ];
+};

--- a/core/tools/index.ts
+++ b/core/tools/index.ts
@@ -1,21 +1,24 @@
 import { createNewFileTool } from "./definitions/createNewFile";
 import { exactSearchTool } from "./definitions/exactSearch";
+import { lsTool } from "./definitions/lsTool";
 import { readCurrentlyOpenFileTool } from "./definitions/readCurrentlyOpenFile";
 import { readFileTool } from "./definitions/readFile";
 import { runTerminalCommandTool } from "./definitions/runTerminalCommand";
 import { searchWebTool } from "./definitions/searchWeb";
 import { viewDiffTool } from "./definitions/viewDiff";
-import { viewRepoMapTool } from "./definitions/viewRepoMap";
-import { viewSubdirectoryTool } from "./definitions/viewSubdirectory";
 
 export const allTools = [
   readFileTool,
   createNewFileTool,
   runTerminalCommandTool,
-  viewSubdirectoryTool,
-  viewRepoMapTool,
+
   exactSearchTool,
   searchWebTool,
   viewDiffTool,
   readCurrentlyOpenFileTool,
+
+  lsTool,
+  // replacing with ls tool for now
+  // viewSubdirectoryTool,
+  // viewRepoMapTool,
 ];

--- a/gui/src/components/mainInput/Lump/sections/SelectedSection.tsx
+++ b/gui/src/components/mainInput/Lump/sections/SelectedSection.tsx
@@ -4,7 +4,7 @@ import { MCPSection } from "./MCPSection";
 import { ModelsSection } from "./ModelsSection";
 import { PromptsSection } from "./PromptsSection";
 import { RulesSection } from "./RulesSection";
-import { ToolsSection } from "./ToolsSection";
+import { ToolPoliciesSection } from "./tool-policies/ToolPoliciesSection";
 
 interface SelectedSectionProps {
   selectedSection: string | null;
@@ -23,7 +23,7 @@ export function SelectedSection(props: SelectedSectionProps) {
     case "context":
       return <ContextSection />;
     case "tools":
-      return <ToolsSection />;
+      return <ToolPoliciesSection />;
     case "mcp":
       return <MCPSection />;
     default:

--- a/gui/src/components/mainInput/Lump/sections/ToolsSection.tsx
+++ b/gui/src/components/mainInput/Lump/sections/ToolsSection.tsx
@@ -1,7 +1,0 @@
-import { ToolPermissionsDialog } from "../../InputToolbar/ToolPermissionsDialog";
-
-interface ToolsSectionProps {}
-
-export function ToolsSection({}: ToolsSectionProps) {
-  return <ToolPermissionsDialog />;
-}

--- a/gui/src/components/mainInput/Lump/sections/tool-policies/ToolPoliciesSection.tsx
+++ b/gui/src/components/mainInput/Lump/sections/tool-policies/ToolPoliciesSection.tsx
@@ -1,12 +1,12 @@
 import { Tool } from "core";
 import { useMemo } from "react";
-import { useAppDispatch, useAppSelector } from "../../../redux/hooks";
-import { toggleToolGroupSetting } from "../../../redux/slices/uiSlice";
-import { fontSize } from "../../../util";
-import ToggleSwitch from "../../gui/Switch";
-import ToolDropdownItem from "./ToolDropdownItem";
+import { useAppDispatch, useAppSelector } from "../../../../../redux/hooks";
+import { toggleToolGroupSetting } from "../../../../../redux/slices/uiSlice";
+import { fontSize } from "../../../../../util";
+import ToggleSwitch from "../../../../gui/Switch";
+import ToolPolicyItem from "./ToolPolicyItem";
 
-export const ToolPermissionsDialog = () => {
+export const ToolPoliciesSection = () => {
   const availableTools = useAppSelector((state) => state.config.config.tools);
   const toolGroupSettings = useAppSelector(
     (store) => store.ui.toolGroupSettings,
@@ -61,7 +61,7 @@ export const ToolPermissionsDialog = () => {
           </div>
           <div className="relative flex flex-col p-1">
             {tools.map((tool) => (
-              <ToolDropdownItem
+              <ToolPolicyItem
                 key={tool.uri + tool.function.name}
                 tool={tool}
                 duplicatesDetected={duplicateDetection[tool.function.name]}

--- a/gui/src/components/mainInput/Lump/sections/tool-policies/ToolPolicyItem.tsx
+++ b/gui/src/components/mainInput/Lump/sections/tool-policies/ToolPolicyItem.tsx
@@ -2,10 +2,13 @@ import { InformationCircleIcon } from "@heroicons/react/24/outline";
 import { Tool } from "core";
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
-import { useAppSelector } from "../../../redux/hooks";
-import { addTool, toggleToolSetting } from "../../../redux/slices/uiSlice";
-import { fontSize } from "../../../util";
-import { ToolTip } from "../../gui/Tooltip";
+import { useAppSelector } from "../../../../../redux/hooks";
+import {
+  addTool,
+  toggleToolSetting,
+} from "../../../../../redux/slices/uiSlice";
+import { fontSize } from "../../../../../util";
+import { ToolTip } from "../../../../gui/Tooltip";
 
 interface ToolDropdownItemProps {
   tool: Tool;
@@ -13,19 +16,19 @@ interface ToolDropdownItemProps {
   excluded: boolean;
 }
 
-function ToolDropdownItem(props: ToolDropdownItemProps) {
+function ToolPolicyItem(props: ToolDropdownItemProps) {
   const dispatch = useDispatch();
-  const settings = useAppSelector(
+  const policy = useAppSelector(
     (state) => state.ui.toolSettings[props.tool.function.name],
   );
 
   useEffect(() => {
-    if (!settings) {
+    if (!policy) {
       dispatch(addTool(props.tool));
     }
-  }, [props.tool.function.name, settings]);
+  }, [props.tool.function.name, policy]);
 
-  if (!settings) {
+  if (!policy) {
     return null;
   }
 
@@ -81,13 +84,13 @@ function ToolDropdownItem(props: ToolDropdownItemProps) {
         <span className="text-lightgray">Excluded</span>
       ) : (
         <div className="flex cursor-pointer gap-2">
-          {(settings === "allowedWithPermission" || settings === undefined) && (
+          {(policy === "allowedWithPermission" || policy === undefined) && (
             <span className="text-yellow-500">Ask First</span>
           )}
-          {settings === "allowedWithoutPermission" && (
+          {policy === "allowedWithoutPermission" && (
             <span className="text-green-500">Automatic</span>
           )}
-          {settings === "disabled" && (
+          {policy === "disabled" && (
             <span className="text-lightgray">Excluded</span>
           )}
         </div>
@@ -96,4 +99,4 @@ function ToolDropdownItem(props: ToolDropdownItemProps) {
   );
 }
 
-export default ToolDropdownItem;
+export default ToolPolicyItem;

--- a/gui/src/pages/gui/ToolCallDiv/ToolCall.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/ToolCall.tsx
@@ -130,7 +130,7 @@ export function ToolCallDisplay(props: ToolCallDisplayProps) {
               {args.map(([key, value]) => (
                 <div key={key} className="flex gap-2 py-0.5">
                   <span className="text-lightgray">{key}:</span>
-                  <code className="line-clamp-1">{value}</code>
+                  <code className="line-clamp-1">{value.toString()}</code>
                 </div>
               ))}
             </div>

--- a/gui/src/redux/slices/uiSlice.ts
+++ b/gui/src/redux/slices/uiSlice.ts
@@ -52,6 +52,7 @@ export const uiSlice = createSlice({
       [BuiltInToolNames.ExactSearch]: "allowedWithoutPermission",
       [BuiltInToolNames.SearchWeb]: "allowedWithoutPermission",
       [BuiltInToolNames.ViewDiff]: "allowedWithoutPermission",
+      [BuiltInToolNames.LSTool]: "allowedWithoutPermission",
     },
     toolGroupSettings: {
       BUILT_IN_GROUP_NAME: "include",


### PR DESCRIPTION
## Description
- Adds LS tool which lists files/directories in a given relative directory, respecting continue ignore rules
- Removes repo map and viewSubdirectory tools for now
- adds `recursive` option to `walkDir` and changes `onlyDirs` to be able to output "both", "dirs", or "files"
- rearrange tool policies into notch toolbar folder
- Fix bug where boolean tool args were not displaying