### PR TITLE
remove unused vscode commands

### DIFF
--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -634,16 +634,6 @@ const getCommandsMap: (
       editDecorationManager.clear();
       void sidebar.webviewProtocol?.request("exitEditMode", undefined);
     },
-    // "continue.quickEdit": async (args: QuickEditShowParams) => {
-    //   let linesOfCode = undefined;
-    //   if (args.range) {
-    //     linesOfCode = args.range.end.line - args.range.start.line;
-    //   }
-    //   captureCommandTelemetry("quickEdit", {
-    //     linesOfCode,
-    //   });
-    //   quickEdit.show(args);
-    // },
     "continue.writeCommentsForCode": async () => {
       captureCommandTelemetry("writeCommentsForCode");
 
@@ -707,37 +697,6 @@ const getCommandsMap: (
 
       vscode.commands.executeCommand("continue.continueGUIView.focus");
       sidebar.webviewProtocol?.request("addModel", undefined);
-    },
-    "continue.sendMainUserInput": (text: string) => {
-      sidebar.webviewProtocol?.request("userInput", {
-        input: text,
-      });
-    },
-    "continue.selectRange": (startLine: number, endLine: number) => {
-      if (!vscode.window.activeTextEditor) {
-        return;
-      }
-      vscode.window.activeTextEditor.selection = new vscode.Selection(
-        startLine,
-        0,
-        endLine,
-        0,
-      );
-    },
-    "continue.foldAndUnfold": (
-      foldSelectionLines: number[],
-      unfoldSelectionLines: number[],
-    ) => {
-      vscode.commands.executeCommand("editor.unfold", {
-        selectionLines: unfoldSelectionLines,
-      });
-      vscode.commands.executeCommand("editor.fold", {
-        selectionLines: foldSelectionLines,
-      });
-    },
-    "continue.sendToTerminal": (text: string) => {
-      captureCommandTelemetry("sendToTerminal");
-      ide.runCommand(text);
     },
     "continue.newSession": () => {
       sidebar.webviewProtocol?.request("newSession", undefined);


### PR DESCRIPTION
Removed some unused commands

Should consider adding equivalents of these to jetbrains
- "continue.codebaseForceReIndex"
- "continue.rebuildCodebaseIndex"
- "continue.toggleTabAutocompleteEnabled"
- "continue.applyCodeFromChat"

Should consider refactoring these commands to not use the command pattern,
since they aren't contributed, require args, and/or are only used internally
- "continue.startLocalOllama"
- "continue.installModel"
- "continue.focusContinueSessionId"
- "continue.addModel"
- "continue.logAutocompleteOutcome"
- "continue.exitEditMode"
- "continue.giveAutocompleteFeedback"
- "continue.navigateTo"

Should audit quick fix/quick action and other old vs-code only commands
- "continue.customQuickActionSendToChat"
- "continue.defaultQuickAction"
- "continue.customQuickActionStreamInlineEdit"
- "continue.quickFix"
- "continue.openTabAutocompleteConfigMenu"
- "continue.debugTerminal"
- "continue.hideInlineTip"
- "continue.selectFilesAsContext"