### PR TITLE
feat: add tooltips to main input's lump toolbar

### DIFF
--- a/gui/src/components/mainInput/Lump/BlockSettingsTopToolbar.tsx
+++ b/gui/src/components/mainInput/Lump/BlockSettingsTopToolbar.tsx
@@ -12,6 +12,7 @@ import { vscBadgeBackground, vscBadgeForeground } from "../..";
 import { useAppDispatch, useAppSelector } from "../../../redux/hooks";
 import { toggleBlockSettingsToolbar } from "../../../redux/slices/uiSlice";
 import { fontSize } from "../../../util";
+import { ToolTip } from "../../gui/Tooltip";
 import AssistantSelect from "../../modelSelection/platform/AssistantSelect";
 import HoverItem from "../InputToolbar/HoverItem";
 
@@ -57,12 +58,16 @@ function BlockSettingsToolbarIcon(props: BlockSettingsToolbarIcon) {
         className={`relative flex select-none items-center rounded-full px-1 transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50 ${props.className || ""}`}
       >
         <props.icon
+          data-tooltip-id={`lump-settings-icon-${props.tooltip}`}
           className="h-[13px] w-[13px] flex-shrink-0 hover:brightness-125"
           style={{
             color: props.isSelected ? vscBadgeForeground : undefined,
           }}
           aria-hidden="true"
         />
+        <ToolTip id={`lump-settings-icon-${props.tooltip}`}>
+          {props.tooltip}
+        </ToolTip>
         <div
           style={{ fontSize: fontSize(-3) }}
           className={`overflow-hidden transition-all duration-200 ${


### PR DESCRIPTION
## Description

Adding tooltips to the lump toolbar's icons enhances user experience to understand what each icon does without selecting (and opening) them.

We usually hover icons to know what they indicate. The icons in turn show a tooltip indicating their function.

This PR adds this functionality to main input's lump toolbar.

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

![image](https://github.com/user-attachments/assets/a04d8598-c9a0-4de2-a7c5-e0d986aa86dd)

![image](https://github.com/user-attachments/assets/786f8ab9-b071-4d59-aeb7-3681f607349d)


## Testing instructions

- Checkout to the PR's branch
- Launch the extension on vscode and go to the continue extension tab
- Hover over chat input's tools
- See the new tooltips being added to continue's features
