### PR TITLE
Create tool tweaks

### DIFF
--- a/core/tools/implementations/createNewFile.ts
+++ b/core/tools/implementations/createNewFile.ts
@@ -1,6 +1,7 @@
 import { inferResolvedUriFromRelativePath } from "../../util/ideUtils";
 
 import { ToolImpl } from ".";
+import { getCleanUriPath, getUriPathBasename } from "../../util/uri";
 
 export const createNewFileImpl: ToolImpl = async (args, extras) => {
   const resolvedFileUri = await inferResolvedUriFromRelativePath(
@@ -8,8 +9,26 @@ export const createNewFileImpl: ToolImpl = async (args, extras) => {
     extras.ide,
   );
   if (resolvedFileUri) {
+    const exists = await extras.ide.fileExists(resolvedFileUri);
+    if (exists) {
+      throw new Error(
+        `File ${args.filepath} already exists. Use the edit too to edit this file`,
+      );
+    }
     await extras.ide.writeFile(resolvedFileUri, args.contents);
     await extras.ide.openFile(resolvedFileUri);
+    return [
+      {
+        name: getUriPathBasename(resolvedFileUri),
+        description: getCleanUriPath(resolvedFileUri),
+        content: "File created successfuly",
+        uri: {
+          type: "file",
+          value: resolvedFileUri,
+        },
+      },
+    ];
+  } else {
+    throw new Error("Failed to resolve path");
   }
-  return [];
 };

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "1.1.18",
+      "version": "1.1.19",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/fetch": "^1.0.3",

--- a/gui/src/components/markdown/StepContainerPreToolbar/StepContainerPreToolbar.tsx
+++ b/gui/src/components/markdown/StepContainerPreToolbar/StepContainerPreToolbar.tsx
@@ -210,17 +210,16 @@ export default function StepContainerPreToolbar(
           {!isGeneratingCodeBlock && (
             <>
               <CopyButton text={props.codeBlockContent} />
-              {props.hideApply ||
-                (isTerminalCodeBlock(props.language, props.codeBlockContent) ? (
-                  <RunInTerminalButton command={props.codeBlockContent} />
-                ) : (
-                  <ApplyActions
-                    applyState={applyState}
-                    onClickApply={onClickApply}
-                    onClickAccept={onClickAcceptApply}
-                    onClickReject={onClickRejectApply}
-                  />
-                ))}
+              {isTerminalCodeBlock(props.language, props.codeBlockContent) ? (
+                <RunInTerminalButton command={props.codeBlockContent} />
+              ) : props.hideApply ? null : (
+                <ApplyActions
+                  applyState={applyState}
+                  onClickApply={onClickApply}
+                  onClickAccept={onClickAcceptApply}
+                  onClickReject={onClickRejectApply}
+                />
+              )}
             </>
           )}
         </div>

--- a/gui/src/components/markdown/StyledMarkdownPreview.tsx
+++ b/gui/src/components/markdown/StyledMarkdownPreview.tsx
@@ -130,6 +130,7 @@ interface StyledMarkdownPreviewProps {
   scrollLocked?: boolean;
   itemIndex?: number;
   useParentBackgroundColor?: boolean;
+  hideApply?: boolean;
 }
 
 const HLJS_LANGUAGE_CLASSNAME_PREFIX = "language-";
@@ -316,6 +317,7 @@ const StyledMarkdownPreview = memo(function StyledMarkdownPreview(
               relativeFilepath={relativeFilePath}
               isGeneratingCodeBlock={isGeneratingCodeBlock}
               range={range}
+              hideApply={props.hideApply}
             >
               <SyntaxHighlightedPre {...preProps} />
             </StepContainerPreToolbar>

--- a/gui/src/pages/gui/ToolCallDiv/CreateFile.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/CreateFile.tsx
@@ -7,9 +7,13 @@ interface CreateFileToolCallProps {
 }
 
 export function CreateFile(props: CreateFileToolCallProps) {
-  const src = `\`\`\`${getMarkdownLanguageTagForFile(props.relativeFilepath ?? "test.txt")} ${props.relativeFilepath}\n${props.fileContents ?? ""}\n\`\`\``;
+  const src = `\`\`\`${getMarkdownLanguageTagForFile(props.relativeFilepath ?? "output.txt")} ${props.relativeFilepath}\n${props.fileContents ?? ""}\n\`\`\``;
 
   return props.relativeFilepath ? (
-    <StyledMarkdownPreview isRenderingInStepContainer={true} source={src} />
+    <StyledMarkdownPreview
+      isRenderingInStepContainer={true}
+      source={src}
+      hideApply={true}
+    />
   ) : null;
 }


### PR DESCRIPTION
- error if attempting to create file that already exists. This is important because right now it overwrites in a way that is not undo-able, and this is bad regardless of if an edit tool is available
- hide apply button