### PR TITLE
Fix Chat mode cycling on VS Code

### DIFF
--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -642,8 +642,8 @@ export const sessionSlice = createSlice({
     },
     cycleMode: (state, action: PayloadAction<{ isJetBrains: boolean }>) => {
       const modes = action.payload.isJetBrains
-        ? ["chat", "edit", "agent"]
-        : ["chat", "agent"];
+        ? ["chat", "agent"]
+        : ["chat", "edit", "agent"];
       const currentIndex = modes.indexOf(state.mode);
       const nextIndex = (currentIndex + 1) % modes.length;
       state.mode = modes[nextIndex] as MessageModes;


### PR DESCRIPTION
## Description

The [commit](https://github.com/continuedev/continue/commit/dec06cbfe9f53da241cfa43db54b4a5d23ef2c04#diff-cafa67e3d2000288c38438034d7d5394de131d7d0c55488d37bb153a2fd21cf5R638) to disable cycling to edit mode on JB products used the wrong logic, thus preventing cycling to edit mode on VS Code. This PR simply inverts the check in `sessionSlice.reducers.cycleMode`.

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created


## Testing instructions

Press `Cmd+.` or `Ctrl+.` to switch to Edit mode in the Chat webview on VS Code.