### PR TITLE
chore: add props typing to Tooltip component

### DIFF
--- a/gui/src/components/gui/Tooltip.tsx
+++ b/gui/src/components/gui/Tooltip.tsx
@@ -1,9 +1,10 @@
+import { CSSProperties } from "react";
 import ReactDOM from "react-dom";
-import { Tooltip } from "react-tooltip";
+import { ITooltip, Tooltip } from "react-tooltip";
 import { vscBackground, vscForeground, vscInputBorder } from "..";
 import { fontSize } from "../../util";
 
-const TooltipStyles = {
+const TooltipStyles: CSSProperties = {
   fontSize: fontSize(-2),
   backgroundColor: vscBackground,
   outline: `0.5px solid ${vscInputBorder}`,
@@ -14,7 +15,7 @@ const TooltipStyles = {
   textAlign: "center",
 };
 
-export function ToolTip(props: any) {
+export function ToolTip(props: ITooltip) {
   const combinedStyles = {
     ...TooltipStyles,
     ...props.style,

--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -153,7 +153,7 @@ function InputToolbar(props: InputToolbarProps) {
                         fileInputRef.current?.click();
                       }}
                     />
-                    <ToolTip id="image-tooltip" place="top-middle">
+                    <ToolTip id="image-tooltip" place="top">
                       Attach an image
                     </ToolTip>
                   </HoverItem>
@@ -166,7 +166,7 @@ function InputToolbar(props: InputToolbarProps) {
                   className="h-3 w-3 hover:brightness-125"
                 />
 
-                <ToolTip id="add-context-item-tooltip" place="top-middle">
+                <ToolTip id="add-context-item-tooltip" place="top">
                   Add context (files, docs, urls, etc.)
                 </ToolTip>
               </HoverItem>


### PR DESCRIPTION
## Description

Added [react-tooltip's](https://react-tooltip.com) prop typing to the gui/Tooltip component.

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

NA

## Testing instructions

NA
