### PR TITLE
Update bedrock.mdx mispelling for Poolside Point in Bedrock Customization Docs

### DIFF
--- a/docs/docs/customize/model-providers/top-level/bedrock.mdx
+++ b/docs/docs/customize/model-providers/top-level/bedrock.mdx
@@ -80,7 +80,7 @@ We recommend configuring **Claude 3.5 Sonnet** as your chat model.
 
 ## Autocomplete model
 
-Bedrock currently does not offer any autocomplete models. However, [Codestral from Mistral](https://mistral.ai/news/codestral-2501/) and [Point from Poolisde](https://aws.amazon.com/bedrock/poolside/) will be supported in the near future.
+Bedrock currently does not offer any autocomplete models. However, [Codestral from Mistral](https://mistral.ai/news/codestral-2501/) and [Point from Poolside](https://aws.amazon.com/bedrock/poolside/) will be supported in the near future.
 
 In the meantime, you can view a list of autocomplete model providers [here](../../model-roles/autocomplete.md).
 


### PR DESCRIPTION
Link in docs read "poolisde" instead of Poolside. Link is functional, just mispelled alias

## Description

Mispelling of the Poolside foundational model company.

## Checklist

- [] Fixed mispelling from "poolisde" to "poolside" in the AWS Bedrock Link
- [] The relevant tests, if any, have been updated or created

## Screenshots

n/a. Markdown preview was sufficient

## Testing instructions

Simple test typo fix. mdx preview validated.
