### PR TITLE
isProperlyConfigured

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -162,6 +162,11 @@ export interface ILLM extends LLMOptions {
     otherData: Record<string, string>,
     canPutWordsInModelsMouth?: boolean,
   ): string | ChatMessage[];
+
+  /**
+   * This method should return false if the model is missing an API key or something else that would cause it to fail if called
+   */
+  isProperlyConfigured(): boolean;
 }
 
 export interface ModelInstaller {

--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -260,6 +260,12 @@ export abstract class BaseLLM implements ILLM {
       options.maxEmbeddingChunkSize ?? DEFAULT_MAX_CHUNK_SIZE;
     this.embeddingId = `${this.constructor.name}::${this.model}::${this.maxEmbeddingChunkSize}`;
   }
+  isProperlyConfigured(): boolean {
+    return true;
+  }
+  useLegacyCompletionsEndpoint?: boolean | undefined;
+  modelArn?: string | undefined;
+  env?: Record<string, string | number | boolean> | undefined;
 
   protected createOpenAiAdapter() {
     return constructLlmApi({

--- a/core/llm/llms/Relace.ts
+++ b/core/llm/llms/Relace.ts
@@ -9,4 +9,8 @@ export class Relace extends OpenAI {
     apiBase: "https://instantapply.endpoint.relace.run/v1/",
   };
   protected useOpenAIAdapterFor: (LlmApiRequestType | "*")[] = ["*"];
+
+  isProperlyConfigured(): boolean {
+    return !!this.apiKey;
+  }
 }

--- a/core/llm/llms/stubs/ContinueProxy.ts
+++ b/core/llm/llms/stubs/ContinueProxy.ts
@@ -1,4 +1,8 @@
-import { ContinueProperties } from "@continuedev/config-yaml";
+import {
+  ContinueProperties,
+  decodeSecretLocation,
+  SecretType,
+} from "@continuedev/config-yaml";
 
 import { ControlPlaneProxyInfo } from "../../../control-plane/analytics/IAnalyticsProvider.js";
 import { Telemetry } from "../../../util/posthog.js";
@@ -47,6 +51,18 @@ class ContinueProxy extends OpenAI {
     return {
       continueProperties,
     };
+  }
+
+  isProperlyConfigured(): boolean {
+    if (!this.apiKeyLocation) {
+      return true;
+    }
+    const secretLocation = decodeSecretLocation(this.apiKeyLocation);
+    if (secretLocation.secretType === SecretType.NotFound) {
+      return false;
+    }
+
+    return true;
   }
 
   protected _getHeaders() {


### PR DESCRIPTION
If a user has something like an apply model set up, but it is missing an API Key, or  it uses the continue-proxy with secret type not found, then we should be falling back to something that works. This is important if we want to make Relace a default model but not break the experience when users exist free trial and don't enter their own API key