### PR TITLE
Use shortcuts component to render keyboard shortcuts on KeyboardShortcuts.tsx

### DIFF
--- a/gui/src/pages/config/KeyboardShortcuts.tsx
+++ b/gui/src/pages/config/KeyboardShortcuts.tsx
@@ -17,10 +17,10 @@ function KeyboardShortcut(props: KeyboardShortcutProps) {
         padding: '8px 0'
       }}
     >
-      <div className="flex-grow overflow-hidden pr-4">
-        <span className="text-xs">{props.description}:</span>
+      <div className="flex-grow overflow-hidden pr-4 min-w-0">
+        <span className="text-xs block text-ellipsis overflow-hidden">{props.description}:</span>
       </div>
-      <div>
+      <div className="flex-shrink-0 whitespace-nowrap">
         <Shortcut>{props.shortcut}</Shortcut>
       </div>
     </div>

--- a/gui/src/pages/config/KeyboardShortcuts.tsx
+++ b/gui/src/pages/config/KeyboardShortcuts.tsx
@@ -11,14 +11,13 @@ interface KeyboardShortcutProps {
 function KeyboardShortcut(props: KeyboardShortcutProps) {
   return (
     <div
-      className="flex items-center"
+      className="sm:flex-row flex-col flex items-start sm:items-center py-2"
       style={{
         backgroundColor: props.isEven ? '#1e1e1e' : 'transparent',
-        padding: '8px 0'
       }}
     >
-      <div className="flex-grow overflow-hidden pr-4 min-w-0">
-        <span className="text-xs block text-ellipsis overflow-hidden">{props.description}:</span>
+      <div className="flex-grow pr-4 pb-1 sm:pb-0 w-full sm:w-auto">
+        <span className="text-xs block break-words">{props.description}:</span>
       </div>
       <div className="flex-shrink-0 whitespace-nowrap">
         <Shortcut>{props.shortcut}</Shortcut>

--- a/gui/src/pages/config/KeyboardShortcuts.tsx
+++ b/gui/src/pages/config/KeyboardShortcuts.tsx
@@ -1,192 +1,122 @@
 import { useMemo } from "react";
-import styled from "styled-components";
-import {
-  defaultBorderRadius,
-  lightGray,
-  vscForeground,
-} from "../../components";
-import { ToolTip } from "../../components/gui/Tooltip";
-import { getPlatform, isJetBrains } from "../../util";
-
-const StyledKeyDiv = styled.div`
-  border: 0.5px solid ${lightGray};
-  border-radius: ${defaultBorderRadius};
-  padding: 2px;
-  color: ${vscForeground};
-
-  width: 16px;
-  height: 16px;
-
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`;
-
-const keyToName: { [key: string]: string } = {
-  "⌘": "Cmd",
-  "⌃": "Ctrl",
-  "⇧": "Shift",
-  "⏎": "Enter",
-  "⌫": "Backspace",
-  "⌥": "Option",
-  "⎇": "Alt",
-};
-
-function KeyDiv({ text }: { text: string }) {
-  return (
-    <>
-      <StyledKeyDiv data-tooltip-id={`header_button_${text}`}>
-        {text}
-      </StyledKeyDiv>
-
-      <ToolTip id={`header_button_${text}`} place="bottom">
-        {keyToName[text]}
-      </ToolTip>
-    </>
-  );
-}
+import Shortcut from "../../components/gui/Shortcut";
+import { isJetBrains } from "../../util";
 
 interface KeyboardShortcutProps {
-  mac: string;
-  windows: string;
+  shortcut: string;
   description: string;
 }
 
 function KeyboardShortcut(props: KeyboardShortcutProps) {
-  const shortcut = getPlatform() === "mac" ? props.mac : props.windows;
   return (
     <div className="flex w-full flex-wrap items-center justify-between gap-x-4 gap-y-1">
       <span className="max-w-60 text-xs">{props.description}:</span>
       <div className="flex flex-1 flex-row items-center justify-end gap-1.5">
-        {shortcut.split(" ").map((key, i) => {
-          return <KeyDiv key={i} text={key}></KeyDiv>;
-        })}
+        <Shortcut>{props.shortcut}</Shortcut>
       </div>
     </div>
   );
 }
 
+// Shortcut strings will be rendered correctly based on the platform by the Shortcut component
 const vscodeShortcuts: KeyboardShortcutProps[] = [
   {
-    mac: "⌘ '",
-    windows: "⌃ '",
+    shortcut: "cmd '",
     description: "Toggle Selected Model",
   },
   {
-    mac: "⌘ I",
-    windows: "⌃ I",
+    shortcut: "cmd I",
     description: "Edit highlighted code",
   },
   {
-    mac: "⌘ L",
-    windows: "⌃ L",
+    shortcut: "cmd L",
     description:
       "New Chat / New Chat With Selected Code / Close Continue Sidebar If Chat Already In Focus",
   },
   {
-    mac: "⌘ ⌫",
-    windows: "⌃ ⌫",
+    shortcut: "cmd backspace",
     description: "Cancel response",
   },
   {
-    mac: "⌘ ⇧ I",
-    windows: "⌃ ⇧ I",
+    shortcut: "cmd shift I",
     description: "Toggle inline edit focus",
   },
   {
-    mac: "⌘ ⇧ L",
-    windows: "⌃ ⇧ L",
+    shortcut: "cmd shift L",
     description:
       "Focus Current Chat / Add Selected Code To Current Chat / Close Continue Sidebar If Chat Already In Focus",
   },
   {
-    mac: "⌘ ⇧ R",
-    windows: "⌃ ⇧ R",
+    shortcut: "cmd shift R",
     description: "Debug Terminal",
   },
   {
-    mac: "⌘ ⇧ ⌫",
-    windows: "⌃ ⇧ ⌫",
+    shortcut: "cmd shift backspace",
     description: "Reject Diff",
   },
   {
-    mac: "⌘ ⇧ ⏎",
-    windows: "⌃ ⇧ ⏎",
+    shortcut: "cmd shift enter",
     description: "Accept Diff",
   },
   {
-    mac: "⌥ ⌘ N",
-    windows: "Alt ⌃ N",
+    shortcut: "alt cmd N",
     description: "Reject Top Change in Diff",
   },
   {
-    mac: "⌥ ⌘ Y",
-    windows: "Alt ⌃ Y",
+    shortcut: "alt cmd Y",
     description: "Accept Top Change in Diff",
   },
   {
-    mac: "⌘ K ⌘ A",
-    windows: "⌃ K ⌃ A",
+    shortcut: "cmd K cmd A",
     description: "Toggle Autocomplete Enabled",
   },
   {
-    mac: "⌘ K ⌘ M",
-    windows: "⌃ K ⌃ M",
+    shortcut: "cmd K cmd M",
     description: "Toggle Full Screen",
   },
 ];
 
 const jetbrainsShortcuts: KeyboardShortcutProps[] = [
   {
-    mac: "⌘ '",
-    windows: "⌃ '",
+    shortcut: "cmd '",
     description: "Toggle Selected Model",
   },
   {
-    mac: "⌘ I",
-    windows: "⌃ I",
+    shortcut: "cmd I",
     description: "Edit highlighted code",
   },
   {
-    mac: "⌘ J",
-    windows: "⌃ J",
+    shortcut: "cmd J",
     description:
       "New Chat / New Chat With Selected Code / Close Continue Sidebar If Chat Already In Focus",
   },
   {
-    mac: "⌘ ⌫",
-    windows: "⌃ ⌫",
+    shortcut: "cmd backspace",
     description: "Cancel response",
   },
   {
-    mac: "⌘ ⇧ I",
-    windows: "⌃ ⇧ I",
+    shortcut: "cmd shift I",
     description: "Toggle inline edit focus",
   },
   {
-    mac: "⌘ ⇧ J",
-    windows: "⌃ ⇧ J",
+    shortcut: "cmd shift J",
     description:
       "Focus Current Chat / Add Selected Code To Current Chat / Close Continue Sidebar If Chat Already In Focus",
   },
   {
-    mac: "⌘ ⇧ ⌫",
-    windows: "⌃ ⇧ ⌫",
+    shortcut: "cmd shift backspace",
     description: "Reject Diff",
   },
   {
-    mac: "⌘ ⇧ ⏎",
-    windows: "⌃ ⇧ ⏎",
+    shortcut: "cmd shift enter",
     description: "Accept Diff",
   },
   {
-    mac: "⌥ ⇧ J",
-    windows: "Alt ⇧ J",
+    shortcut: "alt shift J",
     description: "Quick Input",
   },
   {
-    mac: "⌥ ⌘ J",
-    windows: "Alt ⌃ J",
+    shortcut: "alt cmd J",
     description: "Toggle Sidebar",
   },
 ];
@@ -204,8 +134,7 @@ function KeyboardShortcuts() {
           return (
             <KeyboardShortcut
               key={i}
-              mac={shortcut.mac}
-              windows={shortcut.windows}
+              shortcut={shortcut.shortcut}
               description={shortcut.description}
             />
           );
@@ -216,3 +145,4 @@ function KeyboardShortcuts() {
 }
 
 export default KeyboardShortcuts;
+

--- a/gui/src/pages/config/KeyboardShortcuts.tsx
+++ b/gui/src/pages/config/KeyboardShortcuts.tsx
@@ -5,11 +5,17 @@ import { isJetBrains } from "../../util";
 interface KeyboardShortcutProps {
   shortcut: string;
   description: string;
+  isEven: boolean;
 }
 
 function KeyboardShortcut(props: KeyboardShortcutProps) {
   return (
-    <div className="flex w-full flex-wrap items-center justify-between gap-x-4 gap-y-1">
+    <div
+      className="flex w-full flex-wrap items-center justify-between gap-x-4 gap-y-1 p-2"
+      style={{
+        backgroundColor: props.isEven ? '#1e1e1e' : 'transparent'
+      }}
+    >
       <span className="max-w-60 text-xs">{props.description}:</span>
       <div className="flex flex-1 flex-row items-center justify-end gap-1.5">
         <Shortcut>{props.shortcut}</Shortcut>
@@ -19,7 +25,7 @@ function KeyboardShortcut(props: KeyboardShortcutProps) {
 }
 
 // Shortcut strings will be rendered correctly based on the platform by the Shortcut component
-const vscodeShortcuts: KeyboardShortcutProps[] = [
+const vscodeShortcuts: Omit<KeyboardShortcutProps, 'isEven'>[] = [
   {
     shortcut: "cmd '",
     description: "Toggle Selected Model",
@@ -76,7 +82,7 @@ const vscodeShortcuts: KeyboardShortcutProps[] = [
   },
 ];
 
-const jetbrainsShortcuts: KeyboardShortcutProps[] = [
+const jetbrainsShortcuts: Omit<KeyboardShortcutProps, 'isEven'>[] = [
   {
     shortcut: "cmd '",
     description: "Toggle Selected Model",
@@ -129,13 +135,14 @@ function KeyboardShortcuts() {
   return (
     <div className="flex max-w-[400px] flex-col">
       <h3 className="mb-2 text-xl">Keyboard shortcuts</h3>
-      <div className="flex flex-col items-center justify-center gap-x-3 gap-y-3 p-1">
+      <div className="flex flex-col items-center justify-center gap-y-1 overflow-hidden rounded">
         {shortcuts.map((shortcut, i) => {
           return (
             <KeyboardShortcut
               key={i}
               shortcut={shortcut.shortcut}
               description={shortcut.description}
+              isEven={i % 2 === 0}
             />
           );
         })}

--- a/gui/src/pages/config/KeyboardShortcuts.tsx
+++ b/gui/src/pages/config/KeyboardShortcuts.tsx
@@ -11,13 +11,16 @@ interface KeyboardShortcutProps {
 function KeyboardShortcut(props: KeyboardShortcutProps) {
   return (
     <div
-      className="flex w-full flex-wrap items-center justify-between gap-x-4 gap-y-1 p-2"
+      className="flex items-center"
       style={{
-        backgroundColor: props.isEven ? '#1e1e1e' : 'transparent'
+        backgroundColor: props.isEven ? '#1e1e1e' : 'transparent',
+        padding: '8px 0'
       }}
     >
-      <span className="max-w-60 text-xs">{props.description}:</span>
-      <div className="flex flex-1 flex-row items-center justify-end gap-1.5">
+      <div className="flex-grow overflow-hidden pr-4">
+        <span className="text-xs">{props.description}:</span>
+      </div>
+      <div>
         <Shortcut>{props.shortcut}</Shortcut>
       </div>
     </div>
@@ -133,9 +136,9 @@ function KeyboardShortcuts() {
   }, []);
 
   return (
-    <div className="flex max-w-[400px] flex-col">
-      <h3 className="mb-2 text-xl">Keyboard shortcuts</h3>
-      <div className="flex flex-col items-center justify-center gap-y-1 overflow-hidden rounded">
+    <div className="p-5 h-full overflow-auto">
+      <h3 className="mb-5 text-xl">Keyboard shortcuts</h3>
+      <div>
         {shortcuts.map((shortcut, i) => {
           return (
             <KeyboardShortcut


### PR DESCRIPTION
## Description

Using fancy shortcuts for keyboard shortcuts.  Added some alternating rows and better handling when sidebar is small:

Original:
![image](https://github.com/user-attachments/assets/1ed5ff6e-cf7f-48a4-97bb-1750c13c428e)

Original cramped layout:
![image](https://github.com/user-attachments/assets/cb2c8c7c-038f-47d7-b5ac-0ed9f80100ba)

Improved version:
![image](https://github.com/user-attachments/assets/c7fd00c6-6682-44f4-8357-7ff998ca6cb8)

Improved cramping:
![image](https://github.com/user-attachments/assets/d00c66aa-bac3-46d2-b278-b9dca32a54ea)

## Testing instructions

- [x] Tested on Windows / VS Code
- [] Tested on Windows / Jetbrains
- [x] Test on Mac / VS Code
- [] Test on Mac / Jetbrains

VS Code: Open settings>Shortcuts.  Try setting sidebar to different widths.
Jetbrains: not sure