### PR TITLE
Refresh items for new Context Provider titles + MCP Resource Improvements

### DIFF
--- a/core/config/profile/doLoadConfig.ts
+++ b/core/config/profile/doLoadConfig.ts
@@ -160,6 +160,7 @@ export default async function doLoadConfig(
         const serverContextProvider = new MCPContextProvider({
           submenuItems,
           mcpId: server.id,
+          serverName: server.name,
         });
         newConfig.contextProviders.push(serverContextProvider);
       }

--- a/core/context/providers/MCPContextProvider.ts
+++ b/core/context/providers/MCPContextProvider.ts
@@ -10,6 +10,7 @@ import { MCPManagerSingleton } from "../mcp";
 
 interface MCPContextProviderOptions {
   mcpId: string;
+  serverName: string;
   submenuItems: ContextSubmenuItem[];
 }
 
@@ -20,6 +21,14 @@ class MCPContextProvider extends BaseContextProvider {
     description: "Model Context Protocol",
     type: "submenu",
   };
+  override get description(): ContextProviderDescription {
+    return {
+      title: `${MCPContextProvider.description.title}-${this.options["mcpId"]}`,
+      displayTitle: this.options["displayTitle"] ?? "MCP",
+      description: "Model Context Protocol",
+      type: "submenu",
+    };
+  }
 
   static encodeMCPResourceId(mcpId: string, uri: string): string {
     return JSON.stringify({ mcpId, uri });

--- a/core/context/providers/MCPContextProvider.ts
+++ b/core/context/providers/MCPContextProvider.ts
@@ -24,7 +24,9 @@ class MCPContextProvider extends BaseContextProvider {
   override get description(): ContextProviderDescription {
     return {
       title: `${MCPContextProvider.description.title}-${this.options["mcpId"]}`,
-      displayTitle: this.options["displayTitle"] ?? "MCP",
+      displayTitle: this.options["serverName"]
+        ? `${this.options["serverName"]} resources`
+        : "MCP",
       description: "Model Context Protocol",
       type: "submenu",
     };

--- a/gui/src/context/SubmenuContextProviders.tsx
+++ b/gui/src/context/SubmenuContextProviders.tsx
@@ -50,6 +50,7 @@ export const SubmenuContextProvidersProvider = ({
 }) => {
   const ideMessenger = useContext(IdeMessengerContext);
   const submenuContextProviders = useAppSelector(selectSubmenuContextProviders);
+  const lastProviders = useRef(submenuContextProviders);
   const disableIndexing = useAppSelector(
     (store) => store.config.config.disableIndexing,
   );
@@ -356,15 +357,22 @@ export const SubmenuContextProvidersProvider = ({
   );
 
   // Reload all submenu items on the initial config load
-  // TODO - could refresh on any change
-  const initialLoad = useRef(false);
   useEffect(() => {
-    if (!submenuContextProviders.length || initialLoad.current) {
+    if (!submenuContextProviders.length) {
       return;
     }
-    void loadSubmenuItems("all");
-    initialLoad.current = true;
-  }, [loadSubmenuItems, submenuContextProviders, initialLoad]);
+    // Refresh submenu items when new titles detected
+    const newTitles = submenuContextProviders
+      .filter(
+        (provider) =>
+          !lastProviders.current.find((p) => p.title === provider.title),
+      )
+      .map((provider) => provider.title);
+    if (newTitles.length > 0) {
+      loadSubmenuItems(newTitles);
+    }
+    lastProviders.current = submenuContextProviders;
+  }, [loadSubmenuItems, submenuContextProviders]);
 
   return (
     <SubmenuContextProvidersContext.Provider


### PR DESCRIPTION
## Description
- Refresh submenu items when new provider title detected (replaces initial load concept as well)
- Fixes MCP resources not showing up as context submenu items
- More sensible MCP provider titles
