### PR TITLE
feat/bedrock-secure-prompt-caching

### DIFF
--- a/core/llm/llms/Bedrock.ts
+++ b/core/llm/llms/Bedrock.ts
@@ -14,6 +14,7 @@ import {
   CompletionOptions,
   LLMOptions,
 } from "../../index.js";
+import { getSecureID } from "../utils/getSecureID.js";
 import { renderChatMessage } from "../../util/messageContent.js";
 import { BaseLLM } from "../index.js";
 import { PROVIDER_TOOL_SUPPORT } from "../toolSupport.js";
@@ -427,6 +428,9 @@ class Bedrock extends BaseLLM {
 
     // Standard text message
     if (typeof message.content === "string") {
+      if (addCaching) {
+        message.content += getSecureID();
+      }
       const content: any[] = [{ text: message.content }];
       if (addCaching) {
         content.push({ cachePoint: { type: "default" } });
@@ -444,6 +448,9 @@ class Bedrock extends BaseLLM {
       // Process all parts first
       message.content.forEach((part) => {
         if (part.type === "text") {
+          if (addCaching) {
+            part.text += getSecureID();
+          }
           content.push({ text: part.text });
         } else if (part.type === "imageUrl" && part.imageUrl) {
           try {

--- a/core/llm/utils/__tests__/getSecureID.test.ts
+++ b/core/llm/utils/__tests__/getSecureID.test.ts
@@ -1,0 +1,49 @@
+import { getSecureID } from '../getSecureID';
+
+// Mock the crypto.randomUUID function
+const mockRandomUUID = jest.fn();
+global.crypto = {
+  ...global.crypto,
+  randomUUID: mockRandomUUID
+};
+
+describe('getSecureID', () => {
+  beforeEach(() => {
+    // Reset the static property before each test
+    (getSecureID as any).uuid = undefined;
+
+    // Reset the mock implementation
+    mockRandomUUID.mockReset();
+    // Setup a mock implementation that returns a fixed value for testing
+    mockRandomUUID.mockReturnValue('test-uuid-1234');
+  });
+
+  test('should generate a UUID on first call', () => {
+    const result = getSecureID();
+    expect(mockRandomUUID).toHaveBeenCalledTimes(1);
+    expect(result).toBe('<!-- SID: test-uuid-1234 -->');
+  });
+
+  test('should reuse the same UUID on subsequent calls', () => {
+    const firstResult = getSecureID();
+    const secondResult = getSecureID();
+
+    // The UUID generation should only happen once
+    expect(mockRandomUUID).toHaveBeenCalledTimes(1);
+
+    // Both results should be identical
+    expect(firstResult).toBe(secondResult);
+    expect(firstResult).toBe('<!-- SID: test-uuid-1234 -->');
+  });
+
+  test('should maintain the same UUID across different test cases if not reset', () => {
+    // Don't reset the UUID here to test persistence
+    (getSecureID as any).uuid = 'persistent-uuid';
+
+    const result = getSecureID();
+
+    // No new UUID should be generated
+    expect(mockRandomUUID).not.toHaveBeenCalled();
+    expect(result).toBe('<!-- SID: persistent-uuid -->');
+  });
+});

--- a/core/llm/utils/getSecureID.ts
+++ b/core/llm/utils/getSecureID.ts
@@ -1,0 +1,8 @@
+// Utility function to get or generate UUID for LLM prompts
+export function getSecureID(): string {
+  // Adding a type declaration for the static property
+  if (!(getSecureID as any).uuid) {
+    (getSecureID as any).uuid = crypto.randomUUID();
+  }
+  return `<!-- SID: ${(getSecureID as any).uuid} -->`;
+}


### PR DESCRIPTION
## Description

We have learned from our AWS account rep that prompt caching for AWS Bedrock is at the AWS account level. As such there is risk that similar prompts submitted by multiple users or system processes that may contain confidential information might result in leaked data between users. The best practice recommended is to add a unique value to user prompts to avoid prompt leakage between client sessions. This PR adds that feature.

## Checklist

- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Testing instructions

I've added unit tests and manually validated that the secure ID is added to the relevant prompts. I've noted that prompt caching is still functioning as expected.
