### PR TITLE
fix code block preview needing to click twice to hide

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor/components/ExpandableToolbarPreview.tsx
+++ b/gui/src/components/mainInput/TipTapEditor/components/ExpandableToolbarPreview.tsx
@@ -118,6 +118,7 @@ export function ExpandableToolbarPreview(props: ExpandableToolbarPreviewProps) {
     props.itemId,
     props.initiallyHidden,
   ]);
+
   const [hidden, setHidden] = useState(calculatedInitiallyHidden);
   const [isExpanded, setIsExpanded] = useState(false);
 

--- a/gui/src/components/mainInput/TipTapEditor/components/ExpandableToolbarPreview.tsx
+++ b/gui/src/components/mainInput/TipTapEditor/components/ExpandableToolbarPreview.tsx
@@ -122,7 +122,6 @@ export function ExpandableToolbarPreview(props: ExpandableToolbarPreviewProps) {
   const [hidden, setHidden] = useState(calculatedInitiallyHidden);
   const [isExpanded, setIsExpanded] = useState(false);
 
-  // Track if user has manually toggled visibility
   const contentRef = useRef<HTMLDivElement>(null);
   const [contentDims, setContentDims] = useState({ width: 0, height: 0 });
 

--- a/gui/src/components/mainInput/TipTapEditor/components/ExpandableToolbarPreview.tsx
+++ b/gui/src/components/mainInput/TipTapEditor/components/ExpandableToolbarPreview.tsx
@@ -118,23 +118,20 @@ export function ExpandableToolbarPreview(props: ExpandableToolbarPreviewProps) {
     props.itemId,
     props.initiallyHidden,
   ]);
-
   const [hidden, setHidden] = useState(calculatedInitiallyHidden);
   const [isExpanded, setIsExpanded] = useState(false);
 
   // Track if user has manually toggled visibility
-  const [userToggled, setUserToggled] = useState(false);
-
   const contentRef = useRef<HTMLDivElement>(null);
   const [contentDims, setContentDims] = useState({ width: 0, height: 0 });
 
   useEffect(() => {
-    // Only update hidden state from props if user hasn't manually toggled
-    // or if initiallyHidden isn't explicitly set to false
-    if (!userToggled || props.initiallyHidden !== false) {
+    // Only update hidden state from props if initiallyHidden isn't explicitly set to false
+    if (props.initiallyHidden !== false) {
       setHidden(calculatedInitiallyHidden);
     }
-  }, [calculatedInitiallyHidden, userToggled, props.initiallyHidden]);
+  }, [calculatedInitiallyHidden, props.initiallyHidden]);
+
   useEffect(() => {
     const resizeObserver = new ResizeObserver(() => {
       setContentDims({
@@ -166,7 +163,6 @@ export function ExpandableToolbarPreview(props: ExpandableToolbarPreviewProps) {
           fontSize: getFontSize() - 3,
         }}
         onClick={() => {
-          setUserToggled(true);
           setHidden(!hidden);
         }}
       >


### PR DESCRIPTION
## Description

When selecting a code block and clicking on the hide icon, we see that code block re-renders and does not actually hide (attached video named _before_).

This is happening because we are resetting the `hidden` state again when the user toggles. We actually do not need the `userToggled` state because we only want to reset when our props change (which happens as soon as the `ExpandableToolbarPreview` component initially renders) and not when the user toggles.

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

### Before

https://github.com/user-attachments/assets/3e3a7865-ee27-45e8-92cb-af6baecbfded

### After

https://github.com/user-attachments/assets/e4d870e7-b775-4808-afb9-b46e9452b773



## Testing instructions

- Add any code to highlight in the chat section
- Click on the eye icon to hide the code
- See that code still stays shown
