### PR TITLE
feat: Add configurable newline shortcuts with Ctrl+Enter as default

### DIFF
--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -1034,6 +1034,7 @@ declare global {
     displayRawMarkdown?: boolean;
     showChatScrollbar?: boolean;
     codeWrap?: boolean;
+    newlineShortcuts?: Array<"shift+enter" | "ctrl+enter" | "alt+enter">;
   }
   
   interface ContextMenuConfig {


### PR DESCRIPTION
## Description
Closes #4786 

As described in issue #4786 , users need a more flexible way to insert newlines in the editor, especially when sharing code or asking questions about manually written code.

## Solution

- Add UI configuration option to specify newline keyboard shortcuts
- Support ctrl+enter, and alt+enter for newline input

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

In the following screen recording I'm using cmd+enter in mac to get a newline in the editor
https://github.com/user-attachments/assets/d24895da-665d-4a5a-b410-b043370ec14b



## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
