### PR TITLE
fix: Use MCP server_name from JSON config as display name

### DIFF
--- a/packages/config-yaml/src/converter.ts
+++ b/packages/config-yaml/src/converter.ts
@@ -70,13 +70,13 @@ function convertCustomCommand(
 
 function convertMcp(mcp: any): NonNullable<ConfigYaml["mcpServers"]>[number] {
   const { transport } = mcp;
-  const { command, args, env } = transport;
+  const { command, args, env, server_name } = transport;
 
   return {
     command,
     args,
     env,
-    name: "MCP Server",
+    name: server_name || "MCP Server",
   };
 }
 


### PR DESCRIPTION
## Description

Closes #4840 

This PR fixes issue #4840 where MCP server names were being properly handled in YAML configuration files but not in JSON configuration files. The MCP initialization options contain `server_name` which should be used as a display name, but it was being ignored when loading from JSON configs.

## Changes
- Modified `convertMcp` function to extract `server_name` from the MCP transport configuration
- Fall back to "MCP Server" as default name only when `server_name` is not provided


## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
