### PR TITLE
docs: adds missing key in yaml migration example

### DIFF
--- a/docs/docs/yaml-migration.md
+++ b/docs/docs/yaml-migration.md
@@ -114,6 +114,7 @@ models:
   - name: My Voyage Reranker
     provider: voyage
     apiKey: <YOUR_VOYAGE_KEY>
+    roles:
       - rerank
 
   - name: My Starcoder


### PR DESCRIPTION
Thanks for making continue. :muscle: 

This merge adds a missing key to the YAML migration example doc.

## Description

Added a missing key to the example reranker model config block in the YAML migration guide.

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created
