### PR TITLE
Enable tools support for Cogito on Ollama

### DIFF
--- a/core/llm/toolSupport.ts
+++ b/core/llm/toolSupport.ts
@@ -82,7 +82,7 @@ export const PROVIDER_TOOL_SUPPORT: Record<
     } else {
       modelName = model;
     }
-    
+
     if (
       ["vision", "math", "guard", "mistrallite", "mistral-openorca"].some(
         (part) => modelName.toLowerCase().includes(part),
@@ -92,6 +92,7 @@ export const PROVIDER_TOOL_SUPPORT: Record<
     }
     if (
       [
+        "cogito",
         "llama3.3",
         "qwq",
         "llama3.2",


### PR DESCRIPTION
## Description

I managed to get the new [Cogito](https://ollama.com/library/cogito) model, running on Ollama, to call tools, by simply enabling it in core/llm/toolSupport.ts. It's one of the rare models that I managed to get tools working with on Ollama.

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

<img width="1057" alt="Screenshot 2025-04-09 at 14 44 32" src="https://github.com/user-attachments/assets/4ffd74cb-8c35-442b-b85b-571a9ea0dae4" />


## Testing instructions

- ollama pull cogito
- configure cogito for chat in Continue
- select cogito, in agent mode
- ask it to create a file
