### PR TITLE
Fix typo in 'searched the web for', in searchWeb.ts

### DIFF
--- a/core/tools/definitions/searchWeb.ts
+++ b/core/tools/definitions/searchWeb.ts
@@ -7,7 +7,7 @@ export const searchWebTool: Tool = {
   displayTitle: "Search Web",
   wouldLikeTo: 'search the web for "{{{ query }}}"',
   isCurrently: 'searching the web for "{{{ query }}}"',
-  hasAlready: 'searched the web fore "{{{ query }}}"',
+  hasAlready: 'searched the web for "{{{ query }}}"',
   readonly: true,
   group: BUILT_IN_GROUP_NAME,
   function: {


### PR DESCRIPTION
## Description

Replaced "searched the web fore" with "searched the web for" in searchWeb.ts

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

N/A

## Testing instructions

Test a model that performs a search query in the chat view. After the search, there shouldn't be a typo in the "searched the web for" comment. 
