### PR TITLE
Mitigate registerCopyBufferSpy failures

### DIFF
--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -382,6 +382,7 @@ const getCommandsMap: (
       range,
     );
   }
+
   return {
     "continue.acceptDiff": async (newFileUri?: string, streamId?: string) =>
       processDiff(
@@ -950,7 +951,7 @@ const getCommandsMap: (
           if (core.configHandler.currentProfile?.profileDescription.id) {
             core.invoke("config/updateSelectedModel", {
               profileId:
-                core.configHandler.currentProfile?.profileDescription.id,
+              core.configHandler.currentProfile?.profileDescription.id,
               role: "autocomplete",
               title: selectedOption,
             });
@@ -1129,7 +1130,7 @@ export function registerAllCommands(
     //Non-critical error, it needs to be intercepted and not prevent the extension from starting
     console.log("Error registering CopyBufferService: ", e);
     Telemetry.capture(
-      "vscode_extension_activation_error",
+      "vscode_extension_copy_buffer_failure",
       {
         stack: extractMinimalStackTraceInfo(e.stack),
         message: e.message,
@@ -1137,13 +1138,5 @@ export function registerAllCommands(
       false,
       true,
     );
-    vscode.window.showWarningMessage(
-      "Failed to override 'editor.action.clipboardCopyAction'. Continue will not have access to the clipboard.",
-      "View Logs",
-    ).then((selection) => {
-      if (selection === "View Logs") {
-        vscode.commands.executeCommand("continue.viewLogs");
-      }
-    });
   }
 }


### PR DESCRIPTION
## Description

In some cases registerCopyBufferSpy fails to register due to 

>Error activating extension: Error: command 'editor.action.clipboardCopyAction' already exists"

<img width="455" alt="Screenshot 2025-04-07 at 09 49 50" src="https://github.com/user-attachments/assets/ad762bfd-d62b-4cba-ba61-3f55e365df61" />

And clicking on the "View Logs" button doesn't work because the catastrophique failure occurs before all commands are registered.

This apparently can happen if Continue is installed on both the host and a devcontainer, or when a Continue fork, such as Granite.Code, is used.

The hack used to hook into editor.action.clipboardCopyAction is pretty ugly, but an [alternative solution using the Paste API](https://github.com/continuedev/continue/commit/449d0b52532e1862d6b8b0eb281de80b535a3232 ) doesn't work as well as the existing solution: its support is limited to text documents. You can't intercept text copied from a webview, eg. the chat view, since it's not a TextDocument.

This PR sort of mitigates the failure:
- registerCopyBufferSpy call is moved after registering commands, so view logs still works
- registerCopyBufferSpy failure is caught and a specific message is displayed, hopefully downgrading the perceived severity of the problem. 
- the rest of the activation  can proceed after this specific failure.

However, I'm not completely happy with it as it would still show up 100% of the time, provided the conditions stay the same. So I'm inclined to add a "Don't show again" button. It could then store a flag in the global state (without an easy way to revert it), or in the user settings (but creating such setting feels wrong). We could also decide to always fail silently and only keep a trace in the logs. 

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots
<img width="456" alt="Screenshot 2025-04-09 at 15 29 51" src="https://github.com/user-attachments/assets/25145d27-4422-4f19-b444-b65277238be6" />

## Testing instructions

- Install [Granite.Code](https://marketplace.visualstudio.com/items?itemName=redhat.granitecode)
- Open Granite.Code's chat view
- Install Continue
- Restart  

cc @owtaylor @allanday
