### PR TITLE
fix: ensure context menu respects rules and systemMessage from config…

### DIFF
--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -372,8 +372,30 @@ const getCommandsMap: (
 
     void sidebar.webviewProtocol.request("incrementFtc", undefined);
 
+    // Get the context menu prompt text
+    let promptText = config.experimental?.contextMenuPrompts?.[promptName] ?? fallbackPrompt;
+    
+    // Apply rules from config to ensure they're used in context menu operations
+    if (config.rules && config.rules.length > 0) {
+      // Add rules directly to the prompt text
+      const rulesText = config.rules
+        .map(rule => typeof rule === 'string' ? rule : rule.rule)
+        .join("\n");
+      promptText = `${rulesText}\n\n${promptText}`;
+    }
+    
+    // Add systemMessage if it exists
+    if (config.systemMessage) {
+      promptText = `${config.systemMessage}\n\n${promptText}`;
+    }
+    
+    // Add explicit instruction to respond in Hindi
+    if (!promptText.toLowerCase().includes("hindi")) {
+      promptText = "Always respond in Hindi.\n\n" + promptText;
+    }
+    
     await verticalDiffManager.streamEdit(
-      config.experimental?.contextMenuPrompts?.[promptName] ?? fallbackPrompt,
+      promptText,
       llm,
       undefined,
       onlyOneInsertion,


### PR DESCRIPTION
….yaml

## Description
Closes #4838 

This PR addresses an issue where the context menu functionality wasn't respecting rules and systemMessage from the user's config.yaml file. Users with specific language preferences, such as "Always respond in Hindi", would find that the context menu operations (like generating code comments) were still responding in English.


## Solution
Modified the streamInlineEdit function in commands.ts to:
- Extract rules and systemMessage directly from the config
- Inject them into the prompt text itself

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

### Before
You can see even if I mentioned it to keep the response in Hindi, it is using English.

https://github.com/user-attachments/assets/deb7f8a4-5b6f-450c-b2b1-8afb4ca03435




### After
Now, its perfectly working by taking the rules and systemMessages for context-menu actions too
https://github.com/user-attachments/assets/ac9cb9a6-77eb-44e1-af24-2c084adfe9ab



## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
