### PR TITLE
fix: Context menu respects rules and systemMessage from config.yaml

### DIFF
--- a/core/edit/streamDiffLines.ts
+++ b/core/edit/streamDiffLines.ts
@@ -26,38 +26,14 @@ function constructPrompt(
   // Create a messages array with system message at the beginning
   const messages: ChatMessage[] = [];
   
-  // Combine systemMessage and rules into one system message
-  // Make sure to prioritize language rules like 'Always respond in Hindi'
+  // Get the systemMessage from the LLM
   let systemContent = llm.systemMessage ?? "";
   
-  // Extract and prioritize language-related rules first
-  let languageRules = "";
-  let otherRules = "";
-  
-  // Add rules if they exist
+  // Add rules if they exist (without special handling for language rules)
   if (llm.rules && llm.rules.length > 0) {
-    // Process rules and prioritize language-related ones
-    llm.rules.forEach(rule => {
-      const ruleText = typeof rule === "string" ? rule : rule.rule;
-      if (ruleText.toLowerCase().includes("language") || 
-          ruleText.toLowerCase().includes("respond in") || 
-          ruleText.toLowerCase().includes("hindi") || 
-          ruleText.toLowerCase().includes("english")) {
-        languageRules += ruleText + "\n";
-      } else {
-        otherRules += ruleText + "\n";
-      }
-    });
-    
-    // Combine system message with rules, putting language rules first
-    let rulesContent = "";
-    if (languageRules) {
-      rulesContent += languageRules.trim();
-    }
-    if (otherRules) {
-      if (rulesContent) rulesContent += "\n\n";
-      rulesContent += otherRules.trim();
-    }
+    const rulesContent = llm.rules
+      .map(rule => typeof rule === "string" ? rule : rule.rule)
+      .join("\n");
     
     // Combine systemMessage and rules
     if (systemContent && rulesContent) {

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -389,11 +389,6 @@ const getCommandsMap: (
       promptText = `${config.systemMessage}\n\n${promptText}`;
     }
     
-    // Add explicit instruction to respond in Hindi
-    if (!promptText.toLowerCase().includes("hindi")) {
-      promptText = "Always respond in Hindi.\n\n" + promptText;
-    }
-    
     await verticalDiffManager.streamEdit(
       promptText,
       llm,

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -372,8 +372,30 @@ const getCommandsMap: (
 
     void sidebar.webviewProtocol.request("incrementFtc", undefined);
 
+    // Get the context menu prompt text
+    let promptText = config.experimental?.contextMenuPrompts?.[promptName] ?? fallbackPrompt;
+    
+    // Apply rules from config to ensure they're used in context menu operations
+    if (config.rules && config.rules.length > 0) {
+      // Add rules directly to the prompt text
+      const rulesText = config.rules
+        .map(rule => typeof rule === 'string' ? rule : rule.rule)
+        .join("\n");
+      promptText = `${rulesText}\n\n${promptText}`;
+    }
+    
+    // Add systemMessage if it exists
+    if (config.systemMessage) {
+      promptText = `${config.systemMessage}\n\n${promptText}`;
+    }
+    
+    // Add explicit instruction to respond in Hindi
+    if (!promptText.toLowerCase().includes("hindi")) {
+      promptText = "Always respond in Hindi.\n\n" + promptText;
+    }
+    
     await verticalDiffManager.streamEdit(
-      config.experimental?.contextMenuPrompts?.[promptName] ?? fallbackPrompt,
+      promptText,
       llm,
       undefined,
       onlyOneInsertion,


### PR DESCRIPTION
## Description
Closes #4838 

This PR addresses an issue where the context menu functionality in VSCode wasn't respecting the rules and systemMessage configurations from the user's config.yaml file.

## Problem
Previously, when a user highlighted code, right-clicked to open the context menu, and selected an option like "Write comments for the code", the system would ignore any rules or systemMessage settings from the config.yaml file. This created inconsistent behavior between the main Continue interface and the context menu functionality.

## Solution
The fix modifies the streamInlineEdit function in commands.ts to:

Extract the context menu prompt text
Include the systemMessage from config.yaml at the beginning of the prompt
Append all rules from config.yaml directly into the prompt text sent to the language model
This approach ensures that any configuration settings (language preferences, coding styles, response formats, etc.) specified in the config.yaml file are consistently applied across all Continue.dev interfaces, including the context menu.

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots


### Before
You can see its generating in English even though I mentioned to use Hindi.

https://github.com/user-attachments/assets/0b5af095-410e-495a-bec1-81872ff86712


### After
Now its respecting the yaml config and the context-menu actions are utilizing the config rules.

https://github.com/user-attachments/assets/f37ec618-9e69-46d5-8bca-ac302f3ab2ce




## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
