### PR TITLE
prevent the expand icon from disappearing in prompt block

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor/components/ExpandableToolbarPreview.tsx
+++ b/gui/src/components/mainInput/TipTapEditor/components/ExpandableToolbarPreview.tsx
@@ -134,10 +134,10 @@ export function ExpandableToolbarPreview(props: ExpandableToolbarPreviewProps) {
 
   useEffect(() => {
     const resizeObserver = new ResizeObserver(() => {
-      setContentDims({
-        width: contentRef.current?.scrollWidth ?? 0,
-        height: contentRef.current?.scrollHeight ?? 0,
-      });
+      setContentDims(prevValue => ({
+        width: contentRef.current?.scrollWidth ?? prevValue.width,
+        height: contentRef.current?.scrollHeight ?? prevValue.height,
+      }));
     });
 
     if (contentRef.current) {


### PR DESCRIPTION
## Description

The expand/collapse icon disappears in the code context block in prompt blocks when unhiding the code block.
Fixed by resetting content dimensions to the previous height instead of 0.

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots


https://github.com/user-attachments/assets/83723947-f3ef-4853-b264-4d33e0c03e90


https://github.com/user-attachments/assets/8d255d8e-c472-4628-bfc4-175c45b7693d



## Testing instructions

- add a context to context and send to chat
- see the chevron button appears at the bottom of the code block and it is clickable
- click on the hide eye button and click on it again to show the code block
- see that the chevron disappears
