### PR TITLE
Sort models alphabetically in Chat view

### DIFF
--- a/gui/src/components/modelSelection/ModelSelect.tsx
+++ b/gui/src/components/modelSelection/ModelSelect.tsx
@@ -131,8 +131,9 @@ function ModelSelect() {
 
   // Sort so that options without an API key are at the end
   useEffect(() => {
-    const enabledOptions = options.filter((option) => option.apiKey !== "");
-    const disabledOptions = options.filter((option) => option.apiKey === "");
+    const alphaSort = options.sort((a, b) => a.title.localeCompare(b.title));
+    const enabledOptions = alphaSort.filter((option) => option.apiKey !== "");
+    const disabledOptions = alphaSort.filter((option) => option.apiKey === "");
 
     const sorted = [...enabledOptions, ...disabledOptions];
 

--- a/gui/src/pages/config/ModelRoleSelector.tsx
+++ b/gui/src/pages/config/ModelRoleSelector.tsx
@@ -108,7 +108,7 @@ const ModelRoleSelector = ({
               style={{ borderRadius: defaultBorderRadius }}
               className="min-w-40"
             >
-              {models.map((option, idx) => {
+              {[...models].sort((a,b)=>a.title.localeCompare(b.title)).map((option, idx) => {
                 const showMissingApiKeyMsg =
                   option.configurationStatus ===
                   LLMConfigurationStatuses.MISSING_API_KEY;


### PR DESCRIPTION
## Description

I have a *ton of models installed on Ollama, and selecting one of them in the Chat view is a PITA, because they're not sorted alphabetically. This PR fixes that, while maintaining the existing sort where models without an API key are listed at the end.
Also applied to the Models section.

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

Before: &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; After:
<img width="195" alt="Screenshot 2025-04-10 at 10 19 08" src="https://github.com/user-attachments/assets/31eade7d-56e9-4e43-bafa-2c52798620d5" />&nbsp; &nbsp; &nbsp; <img width="193" alt="Screenshot 2025-04-10 at 10 29 41" src="https://github.com/user-attachments/assets/a1c583f7-248e-4f5d-aca7-5ef19e72c4de" />

In Models section:
<img width="564" alt="Screenshot 2025-04-10 at 10 53 54" src="https://github.com/user-attachments/assets/421e4dda-69c6-4e52-a96a-797b525aa34c" />


## Testing instructions

Just have several models to choose from, they should be listed alphabetically in the Chat view
