### PR TITLE
allow to upload same image more than once

### DIFF
--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -148,6 +148,9 @@ function InputToolbar(props: InputToolbarProps) {
                       for (const file of files) {
                         props.onImageFileSelected?.(file);
                       }
+                      if (fileInputRef.current) {
+                        fileInputRef.current.value = "";
+                      }
                     }}
                   />
                   <HoverItem className="">


### PR DESCRIPTION
## Description

Uploading the same image twice is allowed using drag and drop but non functional in click to upload.
This PR adds the ability to upload the same image file more than once using click to upload.

we need to clear the fileinput's current value before uploading the second image

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

https://github.com/user-attachments/assets/b8aaf33c-be20-495b-9346-c335cfd336da

https://github.com/user-attachments/assets/4abedcfc-f5f3-4d57-b5dc-52eca68453b5



## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
