### PR TITLE
feat: reintroduce lazy apply for full files

### DIFF
--- a/core/edit/lazy/applyCodeBlock.ts
+++ b/core/edit/lazy/applyCodeBlock.ts
@@ -2,7 +2,7 @@ import { DiffLine, ILLM } from "../..";
 import { generateLines } from "../../diff/util";
 import { supportedLanguages } from "../../util/treeSitter";
 import { getUriFileExtension } from "../../util/uri";
-
+import { deterministicApplyLazyEdit } from "./deterministic";
 import { streamLazyApply } from "./streamLazyApply";
 import { applyUnifiedDiff, isUnifiedDiffFormat } from "./unifiedDiffApply";
 
@@ -16,32 +16,40 @@ export async function applyCodeBlock(
   newFile: string,
   filename: string,
   llm: ILLM,
-): Promise<[boolean, AsyncGenerator<DiffLine>]> {
-  // This was buggy, removed for now, maybe forever
-  // if (canUseInstantApply(filename)) {
-  //   const diffLines = await deterministicApplyLazyEdit(
-  //     oldFile,
-  //     newFile,
-  //     filename,
-  //   );
+): Promise<{
+  isInstantApply: boolean;
+  diffLinesGenerator: AsyncGenerator<DiffLine>;
+}> {
+  if (canUseInstantApply(filename)) {
+    const diffLines = await deterministicApplyLazyEdit(
+      oldFile,
+      newFile,
+      filename,
+    );
 
-  //   // Fall back to LLM method if we couldn't apply deterministically
-  //   if (diffLines !== undefined) {
-  //     const diffGenerator = generateLines(diffLines!);
-  //     return [true, diffGenerator];
-  //   }
-  // }
+    if (diffLines !== undefined) {
+      return {
+        isInstantApply: true,
+        diffLinesGenerator: generateLines(diffLines!),
+      };
+    }
+  }
 
   // If the code block is a diff
   if (isUnifiedDiffFormat(newFile)) {
     try {
       const diffLines = applyUnifiedDiff(oldFile, newFile);
-      const diffGenerator = generateLines(diffLines!);
-      return [true, diffGenerator];
+      return {
+        isInstantApply: true,
+        diffLinesGenerator: generateLines(diffLines!),
+      };
     } catch (e) {
       console.error("Failed to apply unified diff", e);
     }
   }
 
-  return [false, streamLazyApply(oldFile, filename, newFile, llm)];
+  return {
+    isInstantApply: false,
+    diffLinesGenerator: streamLazyApply(oldFile, filename, newFile, llm),
+  };
 }

--- a/core/edit/lazy/applyCodeBlock.ts
+++ b/core/edit/lazy/applyCodeBlock.ts
@@ -3,9 +3,8 @@ import { generateLines } from "../../diff/util";
 import { supportedLanguages } from "../../util/treeSitter";
 import { getUriFileExtension } from "../../util/uri";
 
-import { deterministicApplyLazyEdit } from "./deterministic";
 import { streamLazyApply } from "./streamLazyApply";
-import { isUnifiedDiffFormat, applyUnifiedDiff } from "./unifiedDiffApply";
+import { applyUnifiedDiff, isUnifiedDiffFormat } from "./unifiedDiffApply";
 
 function canUseInstantApply(filename: string) {
   const fileExtension = getUriFileExtension(filename);
@@ -17,22 +16,21 @@ export async function applyCodeBlock(
   newFile: string,
   filename: string,
   llm: ILLM,
-  fastLlm: ILLM,
 ): Promise<[boolean, AsyncGenerator<DiffLine>]> {
   // This was buggy, removed for now, maybe forever
-  if (false && canUseInstantApply(filename)) {
-    const diffLines = await deterministicApplyLazyEdit(
-      oldFile,
-      newFile,
-      filename,
-    );
+  // if (canUseInstantApply(filename)) {
+  //   const diffLines = await deterministicApplyLazyEdit(
+  //     oldFile,
+  //     newFile,
+  //     filename,
+  //   );
 
-    // Fall back to LLM method if we couldn't apply deterministically
-    if (diffLines !== undefined) {
-      const diffGenerator = generateLines(diffLines!);
-      return [true, diffGenerator];
-    }
-  }
+  //   // Fall back to LLM method if we couldn't apply deterministically
+  //   if (diffLines !== undefined) {
+  //     const diffGenerator = generateLines(diffLines!);
+  //     return [true, diffGenerator];
+  //   }
+  // }
 
   // If the code block is a diff
   if (isUnifiedDiffFormat(newFile)) {
@@ -45,5 +43,5 @@ export async function applyCodeBlock(
     }
   }
 
-  return [false, streamLazyApply(oldFile, filename, newFile, llm, fastLlm)];
+  return [false, streamLazyApply(oldFile, filename, newFile, llm)];
 }

--- a/core/edit/lazy/streamLazyApply.ts
+++ b/core/edit/lazy/streamLazyApply.ts
@@ -16,7 +16,6 @@ export async function* streamLazyApply(
   filename: string,
   newCode: string,
   llm: ILLM,
-  fastLlm: ILLM,
 ): AsyncGenerator<DiffLine> {
   const promptFactory = lazyApplyPromptForModel(llm.model, llm.providerName);
   if (!promptFactory) {
@@ -39,7 +38,7 @@ export async function* streamLazyApply(
       oldCode,
       linesBefore,
       linesAfter,
-      fastLlm,
+      llm,
     )) {
       yield line;
     }

--- a/extensions/vscode/src/apply/ApplyManager.ts
+++ b/extensions/vscode/src/apply/ApplyManager.ts
@@ -116,17 +116,17 @@ export class ApplyManager {
       return;
     }
 
-    const [instant, diffLines] = await applyCodeBlock(
+    const { isInstantApply, diffLinesGenerator } = await applyCodeBlock(
       editor.document.getText(),
       text,
       getUriPathBasename(editor.document.uri.toString()),
       llm,
     );
 
-    if (instant) {
+    if (isInstantApply) {
       await this.verticalDiffManager.streamDiffLines(
-        diffLines,
-        instant,
+        diffLinesGenerator,
+        isInstantApply,
         streamId,
         toolCallId,
       );

--- a/extensions/vscode/src/apply/ApplyManager.ts
+++ b/extensions/vscode/src/apply/ApplyManager.ts
@@ -21,8 +21,8 @@ export class ApplyManager {
   constructor(
     private readonly ide: VsCodeIde,
     private readonly webviewProtocol: VsCodeWebviewProtocol,
-    private readonly verticalDiffManagerPromise: Promise<VerticalDiffManager>,
-    private readonly configHandlerPromise: Promise<ConfigHandler>,
+    private readonly verticalDiffManager: VerticalDiffManager,
+    private readonly configHandler: ConfigHandler,
   ) {}
 
   async applyToFile({
@@ -101,15 +101,11 @@ export class ApplyManager {
     streamId: string,
     toolCallId?: string,
   ) {
-    const configHandler = await this.configHandlerPromise;
-
-    const { config } = await configHandler.loadConfig();
+    const { config } = await this.configHandler.loadConfig();
     if (!config) {
       vscode.window.showErrorMessage("Config not loaded");
       return;
     }
-
-    const verticalDiffManager = await this.verticalDiffManagerPromise;
 
     const llm =
       config.selectedModelByRole.apply ?? config.selectedModelByRole.chat;
@@ -128,7 +124,7 @@ export class ApplyManager {
     );
 
     if (instant) {
-      await verticalDiffManager.streamDiffLines(
+      await this.verticalDiffManager.streamDiffLines(
         diffLines,
         instant,
         streamId,
@@ -140,7 +136,7 @@ export class ApplyManager {
         text,
         llm,
         streamId,
-        verticalDiffManager,
+        this.verticalDiffManager,
         toolCallId,
       );
     }

--- a/extensions/vscode/src/apply/ApplyManager.ts
+++ b/extensions/vscode/src/apply/ApplyManager.ts
@@ -1,5 +1,4 @@
 import { ConfigHandler } from "core/config/ConfigHandler";
-import { getModelByRole } from "core/config/util";
 import { applyCodeBlock } from "core/edit/lazy/applyCodeBlock";
 import { getUriPathBasename } from "core/util/uri";
 import * as vscode from "vscode";
@@ -16,7 +15,7 @@ export interface ApplyToFileOptions {
 }
 
 /**
- * Handles applying text/code to files in VS Code, including diff generation and streaming
+ * Handles applying text/code to files including diff generation and streaming
  */
 export class ApplyManager {
   constructor(
@@ -106,14 +105,11 @@ export class ApplyManager {
       return;
     }
 
-    const fastLlm = getModelByRole(config, "repoMapFileSelection") ?? llm;
-
     const [instant, diffLines] = await applyCodeBlock(
       editor.document.getText(),
       text,
       getUriPathBasename(editor.document.uri.toString()),
       llm,
-      fastLlm,
     );
 
     if (instant) {

--- a/extensions/vscode/src/apply/ApplyManager.ts
+++ b/extensions/vscode/src/apply/ApplyManager.ts
@@ -1,0 +1,162 @@
+import { ConfigHandler } from "core/config/ConfigHandler";
+import { getModelByRole } from "core/config/util";
+import { applyCodeBlock } from "core/edit/lazy/applyCodeBlock";
+import { getUriPathBasename } from "core/util/uri";
+import * as vscode from "vscode";
+
+import { VerticalDiffManager } from "../diff/vertical/manager";
+import { VsCodeIde } from "../VsCodeIde";
+import { VsCodeWebviewProtocol } from "../webviewProtocol";
+
+export interface ApplyToFileOptions {
+  streamId: string;
+  filepath?: string;
+  text: string;
+  toolCallId?: string;
+}
+
+/**
+ * Handles applying text/code to files in VS Code, including diff generation and streaming
+ */
+export class ApplyManager {
+  constructor(
+    private readonly ide: VsCodeIde,
+    private readonly webviewProtocol: VsCodeWebviewProtocol,
+    private readonly verticalDiffManagerPromise: Promise<VerticalDiffManager>,
+    private readonly configHandlerPromise: Promise<ConfigHandler>,
+  ) {}
+
+  async applyToFile({
+    streamId,
+    filepath,
+    text,
+    toolCallId,
+  }: ApplyToFileOptions) {
+    await this.webviewProtocol.request("updateApplyState", {
+      streamId,
+      status: "streaming",
+      fileContent: text,
+      toolCallId,
+    });
+
+    if (filepath) {
+      const fileExists = await this.ide.fileExists(filepath);
+      if (!fileExists) {
+        await this.ide.writeFile(filepath, "");
+        await this.ide.openFile(filepath);
+      }
+      await this.ide.openFile(filepath);
+    }
+
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      vscode.window.showErrorMessage("No active editor to apply edits to");
+      return;
+    }
+
+    // Handle empty document case
+    if (!editor.document.getText().trim()) {
+      await this.handleEmptyDocument(editor, text, streamId, toolCallId);
+      return;
+    }
+
+    await this.handleExistingDocument(editor, text, streamId, toolCallId);
+  }
+
+  private async handleEmptyDocument(
+    editor: vscode.TextEditor,
+    text: string,
+    streamId: string,
+    toolCallId?: string,
+  ) {
+    await editor.edit((builder) =>
+      builder.insert(new vscode.Position(0, 0), text),
+    );
+
+    await this.webviewProtocol.request("updateApplyState", {
+      streamId,
+      status: "closed",
+      numDiffs: 0,
+      fileContent: text,
+      toolCallId,
+    });
+  }
+
+  private async handleExistingDocument(
+    editor: vscode.TextEditor,
+    text: string,
+    streamId: string,
+    toolCallId?: string,
+  ) {
+    const configHandler = await this.configHandlerPromise;
+    const verticalDiffManager = await this.verticalDiffManagerPromise;
+
+    const { config } = await configHandler.loadConfig();
+    if (!config) {
+      vscode.window.showErrorMessage("Config not loaded");
+      return;
+    }
+
+    const llm =
+      config.selectedModelByRole.apply ?? config.selectedModelByRole.chat;
+    if (!llm) {
+      vscode.window.showErrorMessage(
+        `No model with roles "apply" or "chat" found in config.`,
+      );
+      return;
+    }
+
+    const fastLlm = getModelByRole(config, "repoMapFileSelection") ?? llm;
+
+    const [instant, diffLines] = await applyCodeBlock(
+      editor.document.getText(),
+      text,
+      getUriPathBasename(editor.document.uri.toString()),
+      llm,
+      fastLlm,
+    );
+
+    if (instant) {
+      await verticalDiffManager.streamDiffLines(
+        diffLines,
+        instant,
+        streamId,
+        toolCallId,
+      );
+    } else {
+      await this.handleNonInstantDiff(editor, text, llm, streamId, toolCallId);
+    }
+  }
+
+  private async handleNonInstantDiff(
+    editor: vscode.TextEditor,
+    text: string,
+    llm: any,
+    streamId: string,
+    toolCallId?: string,
+  ) {
+    const verticalDiffManager = await this.verticalDiffManagerPromise;
+
+    const prompt = `The following code was suggested as an edit:\n\`\`\`\n${text}\n\`\`\`\nPlease apply it to the previous code.`;
+    const fullEditorRange = new vscode.Range(
+      0,
+      0,
+      editor.document.lineCount - 1,
+      editor.document.lineAt(editor.document.lineCount - 1).text.length,
+    );
+    const rangeToApplyTo = editor.selection.isEmpty
+      ? fullEditorRange
+      : editor.selection;
+
+    await verticalDiffManager.streamEdit(
+      prompt,
+      llm,
+      streamId,
+      undefined,
+      undefined,
+      rangeToApplyTo,
+      text,
+      toolCallId,
+    );
+  }
+}

--- a/extensions/vscode/src/apply/index.ts
+++ b/extensions/vscode/src/apply/index.ts
@@ -1,0 +1,1 @@
+export * from "./ApplyManager";

--- a/extensions/vscode/src/apply/utils.ts
+++ b/extensions/vscode/src/apply/utils.ts
@@ -1,0 +1,23 @@
+import { ILLM } from "core";
+import { Relace } from "core/llm/llms/Relace";
+
+export const FAST_APPLY_MODELS: Record<
+  ILLM["providerName"],
+  Array<ILLM["model"]>
+> = {
+  [Relace.providerName]: ["Fast-Apply"],
+};
+
+/**
+ * Checks against model names, which can include proxy prefixes
+ * such as `continuedev/hub`
+ * @param llm
+ * @returns
+ */
+export function isFastApplyModel(llm: ILLM): boolean {
+  const fastModelsForProvider = FAST_APPLY_MODELS[llm.providerName];
+  return (
+    fastModelsForProvider?.some((fastModel) => llm.model.includes(fastModel)) ??
+    false
+  );
+}

--- a/extensions/vscode/src/apply/utils.ts
+++ b/extensions/vscode/src/apply/utils.ts
@@ -1,12 +1,6 @@
 import { ILLM } from "core";
-import { Relace } from "core/llm/llms/Relace";
 
-export const FAST_APPLY_MODELS: Record<
-  ILLM["providerName"],
-  Array<ILLM["model"]>
-> = {
-  [Relace.providerName]: ["Fast-Apply"],
-};
+export const FAST_APPLY_MODELS: Array<ILLM["model"]> = ["Fast-Apply"];
 
 /**
  * Checks against model names, which can include proxy prefixes
@@ -15,9 +9,7 @@ export const FAST_APPLY_MODELS: Record<
  * @returns
  */
 export function isFastApplyModel(llm: ILLM): boolean {
-  const fastModelsForProvider = FAST_APPLY_MODELS[llm.providerName];
-  return (
-    fastModelsForProvider?.some((fastModel) => llm.model.includes(fastModel)) ??
-    false
+  return FAST_APPLY_MODELS?.some((fastApplyModel) =>
+    llm.model.toLowerCase().includes(fastApplyModel.toLowerCase())
   );
 }

--- a/extensions/vscode/src/diff/vertical/manager.ts
+++ b/extensions/vscode/src/diff/vertical/manager.ts
@@ -6,6 +6,7 @@ import { getMarkdownLanguageTagForFile } from "core/util";
 import * as URI from "uri-js";
 import * as vscode from "vscode";
 
+import { isFastApplyModel } from "../../apply/utils";
 import EditDecorationManager from "../../quickEdit/EditDecorationManager";
 import { handleLLMError } from "../../util/errorHandling";
 import { VsCodeWebviewProtocol } from "../../webviewProtocol";
@@ -345,6 +346,7 @@ export class VerticalDiffManager {
       startLine,
       endLine,
       {
+        instant: isFastApplyModel(llm),
         input,
         onStatusUpdate: (status, numDiffs, fileContent) =>
           streamId &&

--- a/extensions/vscode/src/extension/VsCodeExtension.ts
+++ b/extensions/vscode/src/extension/VsCodeExtension.ts
@@ -14,6 +14,7 @@ import {
 import { v4 as uuidv4 } from "uuid";
 import * as vscode from "vscode";
 
+import { ApplyManager } from "../apply";
 import { ContinueCompletionProvider } from "../autocomplete/completionProvider";
 import {
   monitorBatteryChanges,
@@ -60,6 +61,7 @@ export class VsCodeExtension {
   private workOsAuthProvider: WorkOsAuthProvider;
   private fileSearch: FileSearch;
   private uriHandler = new UriEventHandler();
+  private applyManager: ApplyManager;
 
   constructor(context: vscode.ExtensionContext) {
     // Register auth provider
@@ -113,6 +115,13 @@ export class VsCodeExtension {
       FromCoreProtocol
     >();
 
+    this.applyManager = new ApplyManager(
+      this.ide,
+      this.sidebar.webviewProtocol,
+      verticalDiffManagerPromise,
+      configHandlerPromise,
+    );
+
     new VsCodeMessenger(
       inProcessMessenger,
       this.sidebar.webviewProtocol,
@@ -121,6 +130,7 @@ export class VsCodeExtension {
       configHandlerPromise,
       this.workOsAuthProvider,
       this.editDecorationManager,
+      this.applyManager,
     );
 
     this.core = new Core(inProcessMessenger, this.ide);

--- a/extensions/vscode/src/extension/VsCodeExtension.ts
+++ b/extensions/vscode/src/extension/VsCodeExtension.ts
@@ -14,7 +14,6 @@ import {
 import { v4 as uuidv4 } from "uuid";
 import * as vscode from "vscode";
 
-import { ApplyManager } from "../apply";
 import { ContinueCompletionProvider } from "../autocomplete/completionProvider";
 import {
   monitorBatteryChanges,
@@ -61,7 +60,6 @@ export class VsCodeExtension {
   private workOsAuthProvider: WorkOsAuthProvider;
   private fileSearch: FileSearch;
   private uriHandler = new UriEventHandler();
-  private applyManager: ApplyManager;
 
   constructor(context: vscode.ExtensionContext) {
     // Register auth provider
@@ -115,13 +113,6 @@ export class VsCodeExtension {
       FromCoreProtocol
     >();
 
-    this.applyManager = new ApplyManager(
-      this.ide,
-      this.sidebar.webviewProtocol,
-      verticalDiffManagerPromise,
-      configHandlerPromise,
-    );
-
     new VsCodeMessenger(
       inProcessMessenger,
       this.sidebar.webviewProtocol,
@@ -130,7 +121,6 @@ export class VsCodeExtension {
       configHandlerPromise,
       this.workOsAuthProvider,
       this.editDecorationManager,
-      this.applyManager,
     );
 
     this.core = new Core(inProcessMessenger, this.ide);

--- a/extensions/vscode/src/extension/VsCodeMessenger.ts
+++ b/extensions/vscode/src/extension/VsCodeMessenger.ts
@@ -78,7 +78,6 @@ export class VsCodeMessenger {
     private readonly configHandlerPromise: Promise<ConfigHandler>,
     private readonly workOsAuthProvider: WorkOsAuthProvider,
     private readonly editDecorationManager: EditDecorationManager,
-    private readonly applyManager: ApplyManager,
   ) {
     /** WEBVIEW ONLY LISTENERS **/
     this.onWebview("showFile", (msg) => {
@@ -126,7 +125,19 @@ export class VsCodeMessenger {
     });
 
     this.onWebview("applyToFile", async ({ data }) => {
-      await this.applyManager.applyToFile(data);
+      const [verticalDiffManager, configHandler] = await Promise.all([
+        verticalDiffManagerPromise,
+        configHandlerPromise,
+      ]);
+
+      const applyManager = new ApplyManager(
+        this.ide,
+        webviewProtocol,
+        verticalDiffManager,
+        configHandler,
+      );
+
+      await applyManager.applyToFile(data);
     });
 
     this.onWebview("showTutorial", async (msg) => {

--- a/extensions/vscode/src/extension/VsCodeMessenger.ts
+++ b/extensions/vscode/src/extension/VsCodeMessenger.ts
@@ -1,6 +1,4 @@
 import { ConfigHandler } from "core/config/ConfigHandler";
-import { getModelByRole } from "core/config/util";
-import { applyCodeBlock } from "core/edit/lazy/applyCodeBlock";
 import {
   FromCoreProtocol,
   FromWebviewProtocol,
@@ -15,9 +13,9 @@ import {
   WEBVIEW_TO_CORE_PASS_THROUGH,
 } from "core/protocol/passThrough";
 import { stripImages } from "core/util/messageContent";
-import { getUriPathBasename } from "core/util/uri";
 import * as vscode from "vscode";
 
+import { ApplyManager } from "../apply";
 import { VerticalDiffManager } from "../diff/vertical/manager";
 import EditDecorationManager from "../quickEdit/EditDecorationManager";
 import {
@@ -29,14 +27,13 @@ import { getExtensionUri } from "../util/vscode";
 import { VsCodeIde } from "../VsCodeIde";
 import { VsCodeWebviewProtocol } from "../webviewProtocol";
 
+type ToIdeOrWebviewFromCoreProtocol = ToIdeFromCoreProtocol &
+  ToWebviewFromCoreProtocol;
+
 /**
  * A shared messenger class between Core and Webview
  * so we don't have to rewrite some of the handlers
  */
-type TODO = any;
-type ToIdeOrWebviewFromCoreProtocol = ToIdeFromCoreProtocol &
-  ToWebviewFromCoreProtocol;
-
 export class VsCodeMessenger {
   onWebview<T extends keyof FromWebviewProtocol>(
     messageType: T,
@@ -81,6 +78,7 @@ export class VsCodeMessenger {
     private readonly configHandlerPromise: Promise<ConfigHandler>,
     private readonly workOsAuthProvider: WorkOsAuthProvider,
     private readonly editDecorationManager: EditDecorationManager,
+    private readonly applyManager: ApplyManager,
   ) {
     /** WEBVIEW ONLY LISTENERS **/
     this.onWebview("showFile", (msg) => {
@@ -128,110 +126,7 @@ export class VsCodeMessenger {
     });
 
     this.onWebview("applyToFile", async ({ data }) => {
-      webviewProtocol.request("updateApplyState", {
-        streamId: data.streamId,
-        status: "streaming",
-        fileContent: data.text,
-        toolCallId: data.toolCallId,
-      });
-
-      if (data.filepath) {
-        const fileExists = await this.ide.fileExists(data.filepath);
-        if (!fileExists) {
-          await this.ide.writeFile(data.filepath, "");
-          await this.ide.openFile(data.filepath);
-        }
-
-        await this.ide.openFile(data.filepath);
-      }
-
-      // Get active text editor
-      const editor = vscode.window.activeTextEditor;
-
-      if (!editor) {
-        vscode.window.showErrorMessage("No active editor to apply edits to");
-        return;
-      }
-
-      // If document is empty, insert at 0,0 and finish
-      if (!editor.document.getText().trim()) {
-        editor.edit((builder) =>
-          builder.insert(new vscode.Position(0, 0), data.text),
-        );
-
-        void webviewProtocol.request("updateApplyState", {
-          streamId: data.streamId,
-          status: "closed",
-          numDiffs: 0,
-          fileContent: data.text,
-          toolCallId: data.toolCallId,
-        });
-
-        return;
-      }
-
-      // Get LLM from config
-      const configHandler = await configHandlerPromise;
-      const { config } = await configHandler.loadConfig();
-
-      if (!config) {
-        vscode.window.showErrorMessage("Config not loaded");
-        return;
-      }
-
-      let llm =
-        config.selectedModelByRole.apply ?? config.selectedModelByRole.chat;
-
-      if (!llm) {
-        vscode.window.showErrorMessage(
-          `No model with roles "apply" or "chat" found in config.`,
-        );
-        return;
-      }
-
-      const fastLlm = getModelByRole(config, "repoMapFileSelection") ?? llm;
-
-      // Generate the diff and pass through diff manager
-      const [instant, diffLines] = await applyCodeBlock(
-        editor.document.getText(),
-        data.text,
-        getUriPathBasename(editor.document.uri.toString()),
-        llm,
-        fastLlm,
-      );
-
-      const verticalDiffManager = await this.verticalDiffManagerPromise;
-
-      if (instant) {
-        await verticalDiffManager.streamDiffLines(
-          diffLines,
-          instant,
-          data.streamId,
-          data.toolCallId,
-        );
-      } else {
-        const prompt = `The following code was suggested as an edit:\n\`\`\`\n${data.text}\n\`\`\`\nPlease apply it to the previous code.`;
-        const fullEditorRange = new vscode.Range(
-          0,
-          0,
-          editor.document.lineCount - 1,
-          editor.document.lineAt(editor.document.lineCount - 1).text.length,
-        );
-        const rangeToApplyTo = editor.selection.isEmpty
-          ? fullEditorRange
-          : editor.selection;
-
-        await verticalDiffManager.streamEdit(
-          prompt,
-          llm,
-          data.streamId,
-          undefined,
-          undefined,
-          rangeToApplyTo,
-          data.text,
-          data.toolCallId,
-        );
-      }
+      await this.applyManager.applyToFile(data);
     });
 
     this.onWebview("showTutorial", async (msg) => {

--- a/gui/src/components/mainInput/Lump/BlockSettingsTopToolbar.tsx
+++ b/gui/src/components/mainInput/Lump/BlockSettingsTopToolbar.tsx
@@ -116,7 +116,7 @@ export function BlockSettingsTopToolbar() {
   );
 
   return (
-    <div className="flex w-full items-center justify-between">
+    <div className="flex w-full items-center justify-between gap-4">
       <div className="flex flex-row">
         <div className="xs:flex hidden items-center justify-center text-gray-400">
           <BlockSettingsToolbarIcon
@@ -150,7 +150,7 @@ export function BlockSettingsTopToolbar() {
           </div>
         </div>
       </div>
-      <div className="flex gap-0.5">
+      <div className="flex">
         <AssistantSelect />
       </div>
     </div>

--- a/gui/src/components/mainInput/Lump/sections/ExploreBlocksButton.tsx
+++ b/gui/src/components/mainInput/Lump/sections/ExploreBlocksButton.tsx
@@ -60,7 +60,7 @@ export function ExploreBlocksButton(props: { blockType: string }) {
       }}
     >
       <div className="flex items-center justify-center gap-1">
-        <Icon className="h-2.5 w-2.5 pr-1" />
+        <Icon className="h-3 w-3 pr-1" />
         <span className="text-[11px]">{text}</span>
       </div>
     </GhostButton>

--- a/gui/src/components/markdown/StepContainerPreToolbar/ApplyActions.tsx
+++ b/gui/src/components/markdown/StepContainerPreToolbar/ApplyActions.tsx
@@ -25,7 +25,7 @@ export default function ApplyActions(props: ApplyActionsProps) {
       setShowApplied(true);
       const timer = setTimeout(() => {
         setShowApplied(false);
-      }, 5_000);
+      }, 3_000);
       return () => clearTimeout(timer);
     }
   }, [isClosed, isSuccessful]);


### PR DESCRIPTION
## Description

Reintroduced lazy apply for a single use case, full file rewrites

## Testing instructions

- First, make sure you aren't using Relace (we don't show apply decorations for Relace which makes this hard to visually test)
- Prompt to add a method to one of the calculator classes. By default with our new system prompt, this should output lazy blocks. Click Apply and confirm that the diff is streamed
- Reprompt and specify "Rewrite the entire file". Confirm there are no lazy blocks. Click "Apply", confirm there is no apply decorations and the apply is instant.
