### PR TITLE
feat: Provide workspace path to HttpContextProvider

### DIFF
--- a/core/context/providers/HttpContextProvider.ts
+++ b/core/context/providers/HttpContextProvider.ts
@@ -1,3 +1,4 @@
+import isLocalhost from "is-localhost-ip";
 import {
   ContextItem,
   ContextProviderDescription,
@@ -18,13 +19,8 @@ class HttpContextProvider extends BaseContextProvider {
   private async getWorkspacePath(ide: IDE, url: URL) {
     try {
       const currentFile = await ide.getCurrentFile();
-      const hostname = url.hostname.toLowerCase();
-      const isLocalServer= hostname === "localhost" ||
-             hostname === "127.0.0.1" ||
-             hostname.startsWith("192.168.") ||
-             hostname === "[::1]";
-
-      return isLocalServer ?
+      // `isLocalhost` actually also returns true for other local addresses, not just localhost
+      return await isLocalhost(url.hostname) ?
              (await ide.getWorkspaceDirs()).find(workspaceDirectory => {
                return currentFile?.path.startsWith(workspaceDirectory)
              }) : undefined

--- a/core/context/providers/HttpContextProvider.ts
+++ b/core/context/providers/HttpContextProvider.ts
@@ -2,6 +2,7 @@ import {
   ContextItem,
   ContextProviderDescription,
   ContextProviderExtras,
+  IDE,
 } from "../../index.js";
 import { BaseContextProvider } from "../index.js";
 
@@ -13,6 +14,24 @@ class HttpContextProvider extends BaseContextProvider {
     type: "normal",
     renderInlineAs: "",
   };
+
+  private async getWorkspacePath(ide: IDE, url: URL) {
+    try {
+      const currentFile = await ide.getCurrentFile();
+      const hostname = url.hostname.toLowerCase();
+      const isLocalServer= hostname === "localhost" ||
+             hostname === "127.0.0.1" ||
+             hostname.startsWith("192.168.") ||
+             hostname === "[::1]";
+
+      return isLocalServer ?
+             (await ide.getWorkspaceDirs()).find(workspaceDirectory => {
+               return currentFile?.path.startsWith(workspaceDirectory)
+             }) : undefined
+    } catch (e) {
+      return undefined;
+    }
+  }
 
   override get description(): ContextProviderDescription {
     return {
@@ -32,7 +51,8 @@ class HttpContextProvider extends BaseContextProvider {
     query: string,
     extras: ContextProviderExtras,
   ): Promise<ContextItem[]> {
-    const response = await extras.fetch(new URL(this.options.url), {
+    const parsedUrl = new URL(this.options.url)
+    const response = await extras.fetch(parsedUrl, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -42,6 +62,7 @@ class HttpContextProvider extends BaseContextProvider {
         query: query || "",
         fullInput: extras.fullInput,
         options: this.options.options,
+        workspacePath: await this.getWorkspacePath(extras.ide, parsedUrl),
       }),
     });
 

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -39,6 +39,7 @@
         "http-proxy-agent": "^7.0.1",
         "https-proxy-agent": "^7.0.3",
         "ignore": "^5.3.1",
+        "is-localhost-ip": "^2.0.0",
         "jinja-js": "0.1.8",
         "js-tiktoken": "^1.0.8",
         "jsdom": "^24.0.0",
@@ -9871,6 +9872,15 @@
       "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
       "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
       "optional": true
+    },
+    "node_modules/is-localhost-ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-localhost-ip/-/is-localhost-ip-2.0.0.tgz",
+      "integrity": "sha512-vlgs2cSgMOfnKU8c1ewgKPyum9rVrjjLLW2HBdL5i0iAJjOs8NY55ZBd/hqUTaYR0EO9CKZd3hVSC2HlIbygTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/is-map": {
       "version": "2.0.3",

--- a/core/package.json
+++ b/core/package.json
@@ -73,6 +73,7 @@
     "http-proxy-agent": "^7.0.1",
     "https-proxy-agent": "^7.0.3",
     "ignore": "^5.3.1",
+    "is-localhost-ip": "^2.0.0",
     "jinja-js": "0.1.8",
     "js-tiktoken": "^1.0.8",
     "jsdom": "^24.0.0",

--- a/docs/docs/customize/tutorials/build-your-own-context-provider.mdx
+++ b/docs/docs/customize/tutorials/build-your-own-context-provider.mdx
@@ -47,7 +47,17 @@ Continue can retrieve context from a custom HTTP server that you create and serv
 
 Then, create a server that responds to requests as are made from [HttpContextProvider.ts](https://github.com/continuedev/continue/blob/main/core/context/providers/HttpContextProvider.ts). See the `hello` endpoint in [context_provider_server.py](https://github.com/continuedev/continue/blob/main/core/context/providers/context_provider_server.py) for an example that uses FastAPI.
 
-The `"options"` property can be used to send additional parameters to your endpoint, which will be included in the request body.
+The `"options"` property can be used to send additional parameters to your endpoint. The full request body has the following shape:
+
+```typescript
+{
+  query: string;
+  fullInput: string;
+  options: Record<string, JsonValue>;
+
+  workspacePath?: string; // Only provided if the server is local.
+}
+```
 
 :::info
 The following methods for creating custom context providers are deprecated. We recommend using HTTP context providers, [MCP Servers](../context-providers.mdx#model-context-protocol), and [Prompts](../deep-dives/prompts.md) where possible.

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -132,6 +132,7 @@
         "http-proxy-agent": "^7.0.1",
         "https-proxy-agent": "^7.0.3",
         "ignore": "^5.3.1",
+        "is-localhost-ip": "^2.0.0",
         "jinja-js": "0.1.8",
         "js-tiktoken": "^1.0.8",
         "jsdom": "^24.0.0",

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -135,6 +135,7 @@
         "http-proxy-agent": "^7.0.1",
         "https-proxy-agent": "^7.0.3",
         "ignore": "^5.3.1",
+        "is-localhost-ip": "^2.0.0",
         "jinja-js": "0.1.8",
         "js-tiktoken": "^1.0.8",
         "jsdom": "^24.0.0",


### PR DESCRIPTION
## Description

While I appreciate that you generally want to discuss ideas beforehand, I figured that with things this simple, it's easier to just show the code.

I recently implemented my own indexing/search service and soon realized that unless the server knows which project is being worked on, it's not going to be usable. And so this would provide that information.

(I have restricted it to local servers because while I can't envision what an attacker might be able to do with workspace paths, I've seen it as generally frowned upon to publicly reveal information about local filesystems.
I would be fine with removing this restriction. Or to tweak things to e.g. provide only the "base name" of the workspace when the server isn't local - for possible other use cases where differentiating by project would still be beneficial.)

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Testing instructions

- Locally run a server of your choosing that can be used with this provider (maybe the [example](https://github.com/continuedev/continue/blob/main/core/context/providers/context_provider_server.py)?) and log the received request body.
- Whenever you use the context, you should see the workspace path getting sent - according to whatever workspace might currently be active.
