### PR TITLE
do not allow to edit code block preview

### DIFF
--- a/gui/src/components/markdown/StyledMarkdownPreview.tsx
+++ b/gui/src/components/markdown/StyledMarkdownPreview.tsx
@@ -381,6 +381,7 @@ const StyledMarkdownPreview = memo(function StyledMarkdownPreview(
   const codeWrapState = uiConfig?.codeWrap ? "pre-wrap" : "pre";
   return (
     <StyledMarkdown
+      contentEditable='false'
       fontSize={getFontSize()}
       whiteSpace={codeWrapState}
       bgColor={props.useParentBackgroundColor ? "" : vscBackground}


### PR DESCRIPTION
## Description

The code block preview is editable in the chat area. This creates confusion like editing the code block and when sent as prompt, edit disappears. Or when deleting the code block, user thinks the letter would be deleted instead the entire code block deletes.

fixed by adding contenteditable as false.

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots


https://github.com/user-attachments/assets/c2fa44c1-6533-4e7f-bbb8-50174ef5249c



https://github.com/user-attachments/assets/1f93dcc9-80e2-4194-9c60-f8a32cf38583



## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
