### PR TITLE
feat: reintroduce lazy apply for full files

### DIFF
--- a/.continue/rules/rules.yaml
+++ b/.continue/rules/rules.yaml
@@ -1,0 +1,6 @@
+name: Continue Repo rules
+version: 1.0.0
+schema: v1
+
+mcpServers:
+  - uses: continuedev/continue-repo-rules

--- a/.continue/rules/rules.yaml
+++ b/.continue/rules/rules.yaml
@@ -1,6 +1,0 @@
-name: Continue Repo rules
-version: 1.0.0
-schema: v1
-
-mcpServers:
-  - uses: continuedev/continue-repo-rules

--- a/core/edit/lazy/applyCodeBlock.ts
+++ b/core/edit/lazy/applyCodeBlock.ts
@@ -37,9 +37,9 @@ export async function applyCodeBlock(
   }
 
   // If the code block is a diff
-  if (isUnifiedDiffFormat(newFile)) {
+  if (isUnifiedDiffFormat(newLazyFile)) {
     try {
-      const diffLines = applyUnifiedDiff(oldFile, newFile);
+      const diffLines = applyUnifiedDiff(oldFile, newLazyFile);
       return {
         isInstantApply: true,
         diffLinesGenerator: generateLines(diffLines!),
@@ -51,6 +51,6 @@ export async function applyCodeBlock(
 
   return {
     isInstantApply: false,
-    diffLinesGenerator: streamLazyApply(oldFile, filename, newFile, llm),
+    diffLinesGenerator: streamLazyApply(oldFile, filename, newLazyFile, llm),
   };
 }

--- a/core/edit/lazy/applyCodeBlock.ts
+++ b/core/edit/lazy/applyCodeBlock.ts
@@ -2,7 +2,7 @@ import { DiffLine, ILLM } from "../..";
 import { generateLines } from "../../diff/util";
 import { supportedLanguages } from "../../util/treeSitter";
 import { getUriFileExtension } from "../../util/uri";
-
+import { deterministicApplyLazyEdit } from "./deterministic";
 import { streamLazyApply } from "./streamLazyApply";
 import { applyUnifiedDiff, isUnifiedDiffFormat } from "./unifiedDiffApply";
 
@@ -16,32 +16,40 @@ export async function applyCodeBlock(
   newFile: string,
   filename: string,
   llm: ILLM,
-): Promise<[boolean, AsyncGenerator<DiffLine>]> {
-  // This was buggy, removed for now, maybe forever
-  // if (canUseInstantApply(filename)) {
-  //   const diffLines = await deterministicApplyLazyEdit(
-  //     oldFile,
-  //     newFile,
-  //     filename,
-  //   );
+): Promise<{
+  isInstantApply: boolean;
+  diffLinesGenerator: AsyncGenerator<DiffLine>;
+}> {
+  if (canUseInstantApply(filename)) {
+    const diffLines = await deterministicApplyLazyEdit(
+      oldFile,
+      newFile,
+      filename,
+    );
 
-  //   // Fall back to LLM method if we couldn't apply deterministically
-  //   if (diffLines !== undefined) {
-  //     const diffGenerator = generateLines(diffLines!);
-  //     return [true, diffGenerator];
-  //   }
-  // }
+    if (diffLines !== undefined) {
+      return {
+        isInstantApply: true,
+        diffLinesGenerator: generateLines(diffLines!),
+      };
+    }
+  }
 
   // If the code block is a diff
   if (isUnifiedDiffFormat(newFile)) {
     try {
       const diffLines = applyUnifiedDiff(oldFile, newFile);
-      const diffGenerator = generateLines(diffLines!);
-      return [true, diffGenerator];
+      return {
+        isInstantApply: true,
+        diffLinesGenerator: generateLines(diffLines!),
+      };
     } catch (e) {
       console.error("Failed to apply unified diff", e);
     }
   }
 
-  return [false, streamLazyApply(oldFile, filename, newFile, llm)];
+  return {
+    isInstantApply: false,
+    diffLinesGenerator: streamLazyApply(oldFile, filename, newFile, llm),
+  };
 }

--- a/core/edit/lazy/applyCodeBlock.ts
+++ b/core/edit/lazy/applyCodeBlock.ts
@@ -13,7 +13,7 @@ function canUseInstantApply(filename: string) {
 
 export async function applyCodeBlock(
   oldFile: string,
-  newFile: string,
+  newLazyFile: string,
   filename: string,
   llm: ILLM,
 ): Promise<{
@@ -21,11 +21,12 @@ export async function applyCodeBlock(
   diffLinesGenerator: AsyncGenerator<DiffLine>;
 }> {
   if (canUseInstantApply(filename)) {
-    const diffLines = await deterministicApplyLazyEdit(
+    const diffLines = await deterministicApplyLazyEdit({
       oldFile,
-      newFile,
+      newLazyFile,
       filename,
-    );
+      onlyFullFileRewrite: true,
+    });
 
     if (diffLines !== undefined) {
       return {

--- a/core/edit/lazy/deterministic.test.ts
+++ b/core/edit/lazy/deterministic.test.ts
@@ -21,11 +21,11 @@ async function collectDiffs(
 ): Promise<{ ourDiffs: DiffLine[]; myersDiffs: any }> {
   const ourDiffs: DiffLine[] = [];
 
-  for (const diffLine of (await deterministicApplyLazyEdit(
+  for (const diffLine of (await deterministicApplyLazyEdit({
     oldFile,
-    newFile,
+    newLazyFile: newFile,
     filename,
-  )) ?? []) {
+  })) ?? []) {
     ourDiffs.push(diffLine);
   }
 
@@ -84,7 +84,7 @@ async function expectDiff(file: string) {
 }
 
 // Skipped while we have `ONLY_FULL_FILE_REWRITE` enabled
-describe.skip("deterministicApplyLazyEdit(", () => {
+describe("deterministicApplyLazyEdit(", () => {
   test("no changes", async () => {
     const file = dedent`
         function test() {

--- a/core/edit/lazy/deterministic.test.ts
+++ b/core/edit/lazy/deterministic.test.ts
@@ -83,7 +83,8 @@ async function expectDiff(file: string) {
   );
 }
 
-describe("deterministicApplyLazyEdit(", () => {
+// Skipped while we have `ONLY_FULL_FILE_REWRITE` enabled
+describe.skip("deterministicApplyLazyEdit(", () => {
   test("no changes", async () => {
     const file = dedent`
         function test() {

--- a/core/edit/lazy/deterministic.test.ts
+++ b/core/edit/lazy/deterministic.test.ts
@@ -83,7 +83,6 @@ async function expectDiff(file: string) {
   );
 }
 
-// Skipped while we have `ONLY_FULL_FILE_REWRITE` enabled
 describe("deterministicApplyLazyEdit(", () => {
   test("no changes", async () => {
     const file = dedent`

--- a/extensions/vscode/src/apply/ApplyManager.ts
+++ b/extensions/vscode/src/apply/ApplyManager.ts
@@ -116,17 +116,17 @@ export class ApplyManager {
       return;
     }
 
-    const [instant, diffLines] = await applyCodeBlock(
+    const { isInstantApply, diffLinesGenerator } = await applyCodeBlock(
       editor.document.getText(),
       text,
       getUriPathBasename(editor.document.uri.toString()),
       llm,
     );
 
-    if (instant) {
+    if (isInstantApply) {
       await this.verticalDiffManager.streamDiffLines(
-        diffLines,
-        instant,
+        diffLinesGenerator,
+        isInstantApply,
         streamId,
         toolCallId,
       );

--- a/gui/src/components/mainInput/Lump/BlockSettingsTopToolbar.tsx
+++ b/gui/src/components/mainInput/Lump/BlockSettingsTopToolbar.tsx
@@ -116,7 +116,7 @@ export function BlockSettingsTopToolbar() {
   );
 
   return (
-    <div className="flex w-full items-center justify-between">
+    <div className="flex w-full items-center justify-between gap-4">
       <div className="flex flex-row">
         <div className="xs:flex hidden items-center justify-center text-gray-400">
           <BlockSettingsToolbarIcon
@@ -150,7 +150,7 @@ export function BlockSettingsTopToolbar() {
           </div>
         </div>
       </div>
-      <div className="flex gap-0.5">
+      <div className="flex">
         <AssistantSelect />
       </div>
     </div>


### PR DESCRIPTION
## Description

Reintroduced lazy apply for a single use case, full file rewrites

## Testing instructions

- First, make sure you aren't using Relace (we don't show apply decorations for Relace which makes this hard to visually test)
- Prompt to add a method to one of the calculator classes. By default with our new system prompt, this should output lazy blocks. Click Apply and confirm that the diff is streamed
- Reprompt and specify "Rewrite the entire file". Confirm there are no lazy blocks. Click "Apply", confirm there is no apply decorations and the apply is instant.
