### PR TITLE
feat: add support for Mistral models in Agent mode

### DIFF
--- a/core/llm/llm.test.ts
+++ b/core/llm/llm.test.ts
@@ -226,7 +226,11 @@ describe("LLM", () => {
       apiKey: process.env.MISTRAL_API_KEY,
       model: "codestral-latest",
     }),
-    { testFim: true, skip: false },
+    {
+      testFim: true,
+      skip: false,
+      testToolCall: true,
+    },
   );
   testLLM(
     new Azure({

--- a/core/llm/toolSupport.test.ts
+++ b/core/llm/toolSupport.test.ts
@@ -143,6 +143,36 @@ describe("PROVIDER_TOOL_SUPPORT", () => {
     });
   });
 
+  describe("mistral", () => {
+    const supportsFn = PROVIDER_TOOL_SUPPORT["mistral"];
+
+    it("should return true for supported models", () => {
+      expect(supportsFn("mistral-large-latest")).toBe(true);
+      expect(supportsFn("mistral-small-latest")).toBe(true);
+      expect(supportsFn("codestral-latest")).toBe(true);
+      expect(supportsFn("ministral-8b-latest")).toBe(true);
+      expect(supportsFn("ministral-3b-latest")).toBe(true);
+      expect(supportsFn("pixtral-12b-2409")).toBe(true);
+      expect(supportsFn("pixtral-large-latest")).toBe(true);
+      expect(supportsFn("open-mistral-nemo")).toBe(true);
+    });
+
+    it("should return false for other unsupported models", () => {
+      expect(supportsFn("mistral-saba-latest")).toBe(false);
+      expect(supportsFn("mistral-embed")).toBe(false);
+      expect(supportsFn("mistral-moderation-latest")).toBe(false);
+      expect(supportsFn("mistral-ocr-latest")).toBe(false);
+      expect(supportsFn("open-codestral-mamba")).toBe(false);
+    });
+
+    it("should handle case insensitivity", () => {
+      expect(supportsFn("MISTRAL-LARGE-LATEST")).toBe(true);
+      expect(supportsFn("CODESTRAL-LATEST")).toBe(true);
+      expect(supportsFn("MINISTRAL-8B-LATEST")).toBe(true);
+      expect(supportsFn("PIXTRAL-12B-2409")).toBe(true);
+    });
+  });
+
   describe("ollama", () => {
     const supportsFn = PROVIDER_TOOL_SUPPORT["ollama"];
 

--- a/core/llm/toolSupport.ts
+++ b/core/llm/toolSupport.ts
@@ -74,7 +74,8 @@ export const PROVIDER_TOOL_SUPPORT: Record<
   },
   mistral: (model) => {
     // https://docs.mistral.ai/capabilities/function_calling/
-    return [
+    return !model.toLowerCase().includes("mamba") &&
+    [
       "codestral",
       "mistral-large",
       "mistral-small",

--- a/core/llm/toolSupport.ts
+++ b/core/llm/toolSupport.ts
@@ -72,6 +72,17 @@ export const PROVIDER_TOOL_SUPPORT: Record<
       return true;
     }
   },
+  mistral: (model) => {
+    // https://docs.mistral.ai/capabilities/function_calling/
+    return [
+      "codestral",
+      "mistral-large",
+      "mistral-small",
+      "pixtral",
+      "ministral",
+      "mistral-nemo"
+    ].some((part) => model.toLowerCase().includes(part));
+  },
   // https://ollama.com/search?c=tools
   ollama: (model) => {
     let modelName = "";

--- a/docs/docs/agent/model-setup.mdx
+++ b/docs/docs/agent/model-setup.mdx
@@ -15,5 +15,6 @@ Currently the following providers are supported:
 - [Ollama](../customize/model-providers/top-level/ollama.mdx) - we recommend [Qwen 2.5 Coder 7b](https://hub.continue.dev/ollama/qwen2.5-coder-7b). Also see all Ollama models that support tools [here](https://ollama.com/search?c=tools).
 - [OpenAI](../customize/model-providers/top-level/openai.mdx) - we recommend [GPT-4o](https://hub.continue.dev/openai/gpt-4o)
 - [Gemini](../customize/model-providers/top-level/gemini.mdx) - we recommend [Gemini 2.0 Flash](https://hub.continue.dev/google/gemini-2.0-flash)
+- [Mistral](../customize/model-providers/top-level/mistral.mdx) - we recommend [Codestral](https://hub.continue.dev/mistral/codestral)
 
 The best chat models generally support tool usage. See [recommended chat models](../customize/model-roles/chat.mdx#recommended-chat-models) for more.


### PR DESCRIPTION
## Description

Added Mistral provider to `toolSupport.ts` so that agent mode is available for models that support function calling.
See supported models [here](https://docs.mistral.ai/capabilities/function_calling/).

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Testing instructions

Feel free to experiment with Mistral models in agent mode. I have not used agent mode with already supported providers so I could not compare the performance of Mistral models against them.
