### PR TITLE
docs: collapse customize page model provider items by default

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -68,7 +68,6 @@ const sidebars = {
     {
       type: "category",
       label: "Model providers",
-      collapsed: false,
       link: {
         slug: "/customize/model-providers",
         type: "generated-index",


### PR DESCRIPTION
## Description

I often go to the customize docs and need to understand how exactly a role works or deeper dive of a feature. The model providers being collapsed makes it hard to quickly navigate to these sections showing a long list and then find the particular item. If we can collapse it by default it would be great.

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots


https://github.com/user-attachments/assets/b4833a63-6395-4d4b-bf3e-6d50010d4ef9



## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
