### PR TITLE
Correct the "extensionkind" manifest entry

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -8,7 +8,6 @@
     "url": "https://github.com/continuedev/continue"
   },
   "extensionKind": [
-    "ui",
     "workspace"
   ],
   "bugs": {


### PR DESCRIPTION
For dev containers, continue vscode extension works best when loaded as "workspace" extension

## Description

For VS code dev containers, the continue dev extension is unable to index codebase when loaded as "ui" extension. Instead it should be loaded as "workspace" extension.

