### PR TITLE
Fix 'undefined' this on `files/changed` listener

### DIFF
--- a/core/core.ts
+++ b/core/core.ts
@@ -509,9 +509,9 @@ export class Core {
       streamDiffLinesGenerator(this.configHandler, this.abortedMessageIds, msg),
     );
 
-    on("completeOnboarding", this.handleCompleteOnboarding);
+    on("completeOnboarding", this.handleCompleteOnboarding.bind(this));
 
-    on("addAutocompleteModel", this.handleAddAutocompleteModel);
+    on("addAutocompleteModel", this.handleAddAutocompleteModel.bind(this));
 
     on("stats/getTokensPerDay", async (msg) => {
       const rows = await DevDataSqliteDb.getTokensPerDay();
@@ -552,7 +552,7 @@ export class Core {
     });
 
     // File changes - TODO - remove remaining logic for these from IDEs where possible
-    on("files/changed", this.handleFilesChanged);
+    on("files/changed", this.handleFilesChanged.bind(this));
     const refreshIfNotIgnored = async (uris: string[]) => {
       const toRefresh: string[] = [];
       for (const uri of uris) {


### PR DESCRIPTION
## Description

When saving config.yaml (at least while running continue in debug mode), an error is logged:

> rejected promise not handled within 1 second: TypeError: Cannot read properties of undefined (reading 'configHandler')
extensionHostProcess.js:179
stack trace: TypeError: Cannot read properties of undefined (reading 'configHandler')
    at handleFilesChanged (/Users/fbricon/Dev/projects/continue/core/core.ts:777:16)
    at InProcessMessenger.invoke (/Users/fbricon/Dev/projects/continue/core/protocol/messenger/index.ts:88:12)
    at Core.invoke (/Users/fbricon/Dev/projects/continue/core/core.ts:117:27)
    at /Users/fbricon/Dev/projects/continue/extensions/vscode/src/extension/VsCodeExtension.ts:287:17
    at ...
    
When passing `this.handleFilesChanged` as "files/changed" callback, the `this` context is lost. The proposed fix is to explicitly bind such event handlers to the current instance of Core. I also preemptively modified a couple other bindings, to guard against similar issues 

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

N/A

## Testing instructions

Open config.yaml, rename a model title, save the file. There should not be any errors logged.
