### PR TITLE
edit prompt hint text ellipsized by default

### DIFF
--- a/gui/src/components/mainInput/ContinueInputBox.tsx
+++ b/gui/src/components/mainInput/ContinueInputBox.tsx
@@ -100,7 +100,7 @@ function ContinueInputBox(props: ContinueInputBoxProps) {
 
   const historyKey = props.isEditMode ? "edit" : "chat";
   const placeholder = props.isEditMode
-    ? "Describe how to modify the code - use '#' to add files"
+    ? "Describe changes, '#' to add files"
     : undefined;
 
   const toolbarOptions: ToolbarOptions = props.isEditMode


### PR DESCRIPTION
## Description
The edit prompt hint text was too long to fit into the default side bar width. This is shorter (35 characters compared to 55), and the format is consistent with the hint text.

## Screenshots
![406908195-b2336836-4bbf-40d3-a557-fb70bb3a0995](https://github.com/user-attachments/assets/5ab5ad81-92dd-47e7-8658-e215d98d8abb)
<img width="286" alt="Screenshot 2025-04-16 at 12 13 56 PM" src="https://github.com/user-attachments/assets/ec3c3144-0dbd-41b9-9ebd-e2628cbfa7a5" />

https://github.com/Granite-Code/granite-code/issues/29
