### PR TITLE
fix(config-yaml): prompt caching and reasoning

### DIFF
--- a/packages/config-yaml/src/schemas/models.ts
+++ b/packages/config-yaml/src/schemas/models.ts
@@ -47,8 +47,16 @@ export const completionOptionsSchema = z.object({
   topK: z.number().optional(),
   stop: z.array(z.string()).optional(),
   n: z.number().optional(),
+  reasoning: z.boolean().optional(),
+  reasoningBudgetTokens: z.number().optional(),
 });
 export type CompletionOptions = z.infer<typeof completionOptionsSchema>;
+
+export const cacheBehaviorSchema = z.object({
+  cacheSystemMessage: z.boolean().optional(),
+  cacheConversation: z.boolean().optional(),
+})
+export type CacheBehavior = z.infer<typeof cacheBehaviorSchema>;
 
 export const embedOptionsSchema = z.object({
   maxChunkSize: z.number().optional(),
@@ -76,6 +84,7 @@ const baseModelFields = {
   roles: modelRolesSchema.array().optional(),
   capabilities: modelCapabilitySchema.array().optional(),
   defaultCompletionOptions: completionOptionsSchema.optional(),
+  cacheBehavior: cacheBehaviorSchema.optional(),
   requestOptions: requestOptionsSchema.optional(),
   embedOptions: embedOptionsSchema.optional(),
   chatOptions: chatOptionsSchema.optional(),


### PR DESCRIPTION
## Description

Could also resolve: https://github.com/continuedev/continue/issues/4918

* Enabled prompt caching and reasoning support again after the split out to use the config-yaml package to load the yaml configuration.

## Checklist

- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Testing instructions

Validated by enabling prompt caching and thinking with the AWS bedrock claude sonet 3.7 model. With this change I am now seeing prompt caching and thinking enabled.