### PR TITLE
fix: removed files adding again in edit mode

### DIFF
--- a/gui/src/components/CodeToEditCard/AddFileCombobox.tsx
+++ b/gui/src/components/CodeToEditCard/AddFileCombobox.tsx
@@ -39,6 +39,17 @@ export default function AddFileCombobox({
     }
   }, []);
 
+  useEffect(() => {
+    // update selectedFiles showing only the files that are in codeToEdit
+    setSelectedFiles(
+      (prevSelectedFiles) =>
+        prevSelectedFiles.filter(
+          (file) =>
+            codeToEdit.findIndex((code) => code.filepath === file.id) !== -1,
+        ), 
+    );
+  }, [codeToEdit]);
+
   const filteredFiles =
     query === ""
       ? remainingFiles


### PR DESCRIPTION
## Description

When adding files in the edit mode's add file select box, we are adding the removed files as well.

We need to update the `codeToEdit` redux state (whenever it changes) with the Combobox's local `selectedFiles` state

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots


https://github.com/user-attachments/assets/d47a17b5-9d07-4160-a1ff-71f3e26b62be

https://github.com/user-attachments/assets/f2b9f62f-1c82-42f5-ad6f-1582b9e73bc9




## Testing instructions

- open the edit mode
- select 2-3 files  using the add file input and dropdown
- remove any of the selected files
- add another different file
- see that the removed file is added again even though a different file was added