### PR TITLE
clear the edit mode add file input after adding file

### DIFF
--- a/gui/src/components/CodeToEditCard/AddFileCombobox.tsx
+++ b/gui/src/components/CodeToEditCard/AddFileCombobox.tsx
@@ -55,12 +55,14 @@ export default function AddFileCombobox({
           setSelectedFiles(files);
           void onSelect(files.map((file) => file.id));
           buttonRef.current?.click();
+          setQuery("");
         }}
       >
         {({ open }) => (
           <div className="relative">
             <ComboboxButton className="hidden" ref={buttonRef} />
             <ComboboxInput
+              value={query}
               ref={inputRef}
               onClick={() => {
                 if (!open) {


### PR DESCRIPTION
## Description

When adding a file by typing the file name in the add file input in edit mode, we would want to clear up the typed input.

We do that by resetting the query state after the file is added.

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots


https://github.com/user-attachments/assets/5a972ac6-6ef6-41a0-b37b-d6f461b82902


https://github.com/user-attachments/assets/aff26920-7865-4a13-9b9b-5afa6c35b25a



## Testing instructions

- go to edit mode
- add a file by typing the name in input box
- press enter
- see that the input name is still present
