### PR TITLE
Fix battery state not updating

### DIFF
--- a/extensions/vscode/src/util/battery.ts
+++ b/extensions/vscode/src/util/battery.ts
@@ -9,7 +9,6 @@ export class Battery implements Disposable {
   private readonly onChangeLevelEmitter = new EventEmitter<number>();
   private acConnected: boolean = true;
   private level = 100;
-  private readonly batteryStatsPromise = si.battery();
 
   constructor() {
     this.updateTimeout = setInterval(() => this.update(), UPDATE_INTERVAL_MS);
@@ -22,7 +21,7 @@ export class Battery implements Disposable {
   }
 
   private async update() {
-    const stats = await this.batteryStatsPromise;
+    const stats = await si.battery();
     const level = stats.hasBattery ? stats.percent : 100;
     const isACConnected =
       !stats.hasBattery || stats.acConnected || level == 100;


### PR DESCRIPTION
## Description
The method responsible for updating the battery state only gets the actual battery info on it's first call. All subsequent calls of the method use that initial battery info. Resulting in the battery state not changing.

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Testing instructions (needs a laptop)
- Enable pauseTabAutocompleteOnBattery in VSCode settings
- Plug and unplug the laptop to observe the auto-completion pausing and resuming (this doesn’t happen in the production version)
