### PR TITLE
explicitly specify that `uses` blocks are pulled from hub.continue.dev

### DIFF
--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -32,7 +32,7 @@ Assistants can either explicitly define blocks - see [Properties](#properties) b
 
 ### Using Blocks
 
-Hub blocks and assistants are identified with a slug in the format `owner-slug/block-or-assistant-slug`, where an owner can be a user or organization.
+Hub blocks and assistants are identified with a slug in the format `owner-slug/block-or-assistant-slug`, where an owner can be a user or organization (For example, if you want to use the [OpenAI 4o Model block](https://hub.continue.dev/openai/gpt-4o), your slug would be `openai/gpt-4o`). These blocks are pulled from https://hub.continue.dev.
 
 Blocks can be imported into an assistant by adding a `uses` clause under the block type. This can be alongside other `uses` clauses or explicit blocks of that type.
 


### PR DESCRIPTION
## Description

Local blocks references are creating some confusion with their usage. We need to explicitly specify that local block are pulled from hub.continue.dev and not referenced to some local config block

reference discussion: https://discord.com/channels/1108621136150929458/1347709899500425317

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
