### PR TITLE
chatOptions.baseSystemMessage option in the json config to being able to override the default system prompt

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1304,6 +1304,9 @@ export interface JSONModelDescription {
   template?: TemplateType;
   completionOptions?: BaseCompletionOptions;
   systemMessage?: string;
+  chatOptions?: {
+    baseSystemMessage?: string;
+  },
   requestOptions?: RequestOptions;
   cacheBehavior?: CacheBehavior;
 

--- a/core/llm/llms/index.ts
+++ b/core/llm/llms/index.ts
@@ -137,8 +137,8 @@ export async function llmFromDescription(
 
   let baseChatSystemMessage: string | undefined = undefined;
   if (desc.systemMessage !== undefined) {
-    baseChatSystemMessage = DEFAULT_CHAT_SYSTEM_MESSAGE;
-    baseChatSystemMessage += "\n\n";
+    baseChatSystemMessage = typeof desc.chatOptions?.baseSystemMessage === "string" ? desc.chatOptions.baseSystemMessage : DEFAULT_CHAT_SYSTEM_MESSAGE;
+    baseChatSystemMessage += desc.chatOptions?.baseSystemMessage === "" ? "" : "\n\n";
     baseChatSystemMessage += await renderTemplatedString(
       desc.systemMessage,
       readFile,

--- a/docs/docs/json-reference.md
+++ b/docs/docs/json-reference.md
@@ -30,7 +30,9 @@ Each model has specific configuration options tailored to its provider and funct
 - `template`: Chat template to format messages. Auto-detected for most models but can be overridden. See intelliJ suggestions.
 - `promptTemplates`: A mapping of prompt template names (e.g., `edit`) to template strings. [Customization Guide](https://docs.continue.dev/model-setup/configuration#customizing-the-edit-prompt).
 - `completionOptions`: Model-specific completion options, same format as top-level [`completionOptions`](#completionoptions), which they override.
-- `systemMessage`: A system message that will precede responses from the LLM.
+- `systemMessage`: A system message that will precede responses from the LLM. Note: If you want to override the default system prompt instead of setting additional instructions, use the `chatOptions.baseSystemMessage` config option.
+- `chatOptions`: If the model includes role `chat`, these settings apply for Chat and Agent mode:
+  - `baseSystemMessage`: Can be used to override the default system prompt.
 - `requestOptions`: Model-specific HTTP request options, same format as top-level [`requestOptions`](#requestoptions), which they override.
 - `apiType`: Specifies the type of API (`openai` or `azure`).
 - `apiVersion`: Azure API version (e.g., `2023-07-01-preview`).

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -410,6 +410,20 @@
           "description": "A system message that will always be followed by the LLM",
           "type": "string"
         },
+        "chatOptions": {
+          "title": "Chat Options",
+          "description": "If the model includes role chat, these settings apply for Chat and Agent mode",
+          "type": "object",
+          "default": {},
+          "properties": {
+            "baseSystemMessage": {
+              "title": "Base System Message",
+              "description": "Can be used to override the default system prompt",
+              "default": "<important_rules>\nAlways include the language and file name in the info string when you write code blocks. \nIf you are editing \"src/main.py\" for example, your code block should start with '```python src/main.py'\nWhen addressing code modification requests, present a concise code snippet that\nemphasizes only the necessary changes and uses abbreviated placeholders for\nunmodified sections. For instance:\n```typescript /path/to/file\n// ... rest of code here ...\n{{ modified code here }}\n// ... rest of code here ...\n{{ another modification }}\n// ... rest of code here ...\n```\nSince users have access to their complete file, they prefer reading only the\nrelevant modifications. It's perfectly acceptable to omit unmodified portions\nat the beginning, middle, or end of files using these \"lazy\" comments. Only\nprovide the complete file when explicitly requested. Include a concise explanation\nof changes unless the user specifically asks for code only.\n</important_rules>",
+              "type": "string"
+            }
+          }
+        },
         "requestOptions": {
           "title": "Request Options",
           "description": "Options for the HTTP request to the LLM.",


### PR DESCRIPTION
## Description

Previously it was impossible to override the default system prompt. Yaml config now has chatOptions.baseSystemMessage that can do that, but not available from json config.

Now added chatOptions.baseSystemMessage config option in the json config similar to the yaml config to being able to override the system message.

## Checklist

- [X] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created

## Testing instructions

You should be able to override the default system prompt with any of the following model config:
```
    {
      "title": "Anthropic Claude 3.7 Sonnet",
      "model": "claude-3-7-sonnet-latest",
      "provider": "anthropic",
      "apiKey": "YOUR_API_KEY",
      "systemMessage": "Your own system message",
      "chatOptions": {
        "baseSystemMessage": ""
      },
```

```
    {
      "title": "Anthropic Claude 3.7 Sonnet",
      "model": "claude-3-7-sonnet-latest",
      "provider": "anthropic",
      "apiKey": "YOUR_API_KEY",
      "chatOptions": {
        "baseSystemMessage": "Your own system message"
      },
```

Just setting `systemMessage` only should keep the legacy behaviour: systemMessage is appended to the default prompt with two newlines.