### PR TITLE
style: set whitespace-nowrap on @mention dropdown items

### DIFF
--- a/gui/src/components/mainInput/AtMentionDropdown/index.tsx
+++ b/gui/src/components/mainInput/AtMentionDropdown/index.tsx
@@ -515,7 +515,7 @@ const AtMentionDropdown = forwardRef((props: AtMentionDropdownProps, ref) => {
                       ) : (
                         <DropdownIcon item={item} className="mr-2" />
                       )}
-                      <span title={item.id}>{item.title}</span>
+                      <span title={item.id} className="whitespace-nowrap">{item.title}</span>
                       {"  "}
                     </div>
                     <span
@@ -562,7 +562,7 @@ const AtMentionDropdown = forwardRef((props: AtMentionDropdownProps, ref) => {
               );
             })
           ) : (
-            <ItemDiv className="item">No results</ItemDiv>
+            <ItemDiv className="item whitespace-nowrap">No results</ItemDiv>
           )}
         </>
       )}


### PR DESCRIPTION
## Description
Applied the whitespace-nowrap utility class to dropdown items to prevent text from wrapping and ensure a consistent single-line layout.

## Checklist

- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

### before 
![image](https://github.com/user-attachments/assets/68f9d8c8-cac8-453c-be6b-d648c07a58b2)

### after
![image](https://github.com/user-attachments/assets/47148580-26ea-4553-a831-0e681def59c4)

## Testing instructions

unnecessary
