### PR TITLE
ui feedback on assistant refresh

### DIFF
--- a/gui/src/components/modelSelection/platform/AssistantSelect.tsx
+++ b/gui/src/components/modelSelection/platform/AssistantSelect.tsx
@@ -7,7 +7,7 @@ import {
   ExclamationTriangleIcon,
   PlusIcon,
 } from "@heroicons/react/24/outline";
-import { useContext, useEffect, useMemo, useRef } from "react";
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { useAuth } from "../../../context/Auth";
 import { IdeMessengerContext } from "../../../context/IdeMessenger";
 import {
@@ -33,6 +33,7 @@ import {
 import { ProfileDescription } from "core/config/ConfigHandler";
 import { useNavigate } from "react-router-dom";
 import { vscCommandCenterInactiveBorder } from "../..";
+import { cn } from "../../../util/cn";
 import { ROUTES } from "../../../util/navigation";
 import { ToolTip } from "../../gui/Tooltip";
 import { useLump } from "../../mainInput/Lump/LumpContext";
@@ -165,6 +166,7 @@ export default function AssistantSelect() {
   const orgs = useAppSelector((store) => store.profiles.organizations);
   const ideMessenger = useContext(IdeMessengerContext);
   const { isToolbarExpanded } = useLump();
+  const [loading, setLoading] = useState(false)
 
   const { profiles, session, login } = useAuth();
   const navigate = useNavigate();
@@ -297,13 +299,15 @@ export default function AssistantSelect() {
               <span>Assistants</span>
               <div
                 className="flex cursor-pointer flex-row items-center gap-1 hover:brightness-125"
-                onClick={(e) => {
+                onClick={async (e) => {
                   e.stopPropagation();
-                  refreshProfiles();
+                  setLoading(true)
+                  await refreshProfiles()
+                  setLoading(false)
                   buttonRef.current?.click();
                 }}
               >
-                <ArrowPathIcon className="text-lightgray h-2.5 w-2.5" />
+                <ArrowPathIcon className={cn("text-lightgray h-2.5 w-2.5", loading && 'animate-spin')} />
               </div>
             </div>
 

--- a/gui/src/components/modelSelection/platform/AssistantSelect.tsx
+++ b/gui/src/components/modelSelection/platform/AssistantSelect.tsx
@@ -307,7 +307,7 @@ export default function AssistantSelect() {
                   buttonRef.current?.click();
                 }}
               >
-                <ArrowPathIcon className={cn("text-lightgray h-2.5 w-2.5", loading && 'animate-spin')} />
+                <ArrowPathIcon className={cn("text-lightgray h-2.5 w-2.5", loading && 'animate-spin-slow')} />
               </div>
             </div>
 

--- a/gui/src/context/Auth.tsx
+++ b/gui/src/context/Auth.tsx
@@ -28,7 +28,7 @@ interface AuthContextType {
   login: (useOnboarding: boolean) => Promise<boolean>;
   selectedProfile: ProfileDescription | null;
   profiles: ProfileDescription[] | null;
-  refreshProfiles: () => void;
+  refreshProfiles: () => Promise<void>;
   organizations: OrganizationDescription[];
 }
 


### PR DESCRIPTION
## Description

Added loading in reload icon present inside assistant selection menu. This adds a user UI feedback indicating that the config is being reloaded instead of waiting for "Config refreshed" message which appears after delay.

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots



https://github.com/user-attachments/assets/d24a81f7-fe0b-41ee-98f1-a95e55de6f45





https://github.com/user-attachments/assets/a7441652-5629-47e5-aa2d-a18054e23eca


## Testing instructions


1. go to the chat area
2. click on the assistant selection dropdown
3. click on the refresh icon to reload the configs/assistants
4. check the new loading indicator on the refresh icon