### PR TITLE
fix function.arguments empty issue when use tools call with Qwen2.5 vllm

### DIFF
--- a/core/llm/openaiTypeConverters.ts
+++ b/core/llm/openaiTypeConverters.ts
@@ -51,7 +51,7 @@ export function toChatMessage(
         type: toolCall.type!,
         function: {
           name: toolCall.function?.name!,
-          arguments: toolCall.function?.arguments!,
+          arguments: toolCall.function?.arguments! || "{}",
         },
       }));
     }


### PR DESCRIPTION
## Description

This may useful for users using local opensource models run in vllm。vllm + Qwen2.5 supports tool call, but I get function.arguments empty Exception with vllm in Agent model. This PR works for me.

models:
  - name: Qwen2.5
    model: Qwen2.5-32B-Instruct
    apiBase: http://litellm.local/v1
    provider: openai
    api-key: fake-key
    capabilities:
      - tool_use 
    roles:
      - chat
      - edit
      - apply


## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
