### PR TITLE
add smooth scrolling to chat

### DIFF
--- a/extensions/vscode/e2e/tests/GUI.test.ts
+++ b/extensions/vscode/e2e/tests/GUI.test.ts
@@ -400,7 +400,7 @@ describe("GUI Test", () => {
         GUISelectors.getThreadMessageByText(view, llmResponse),
       );
 
-      await new Promise(resolve=>setTimeout(resolve, 200));
+      await new Promise(resolve=>setTimeout(resolve, 500));
 
       const viewportHeight = await driver.executeScript(
         "return window.innerHeight",

--- a/extensions/vscode/e2e/tests/GUI.test.ts
+++ b/extensions/vscode/e2e/tests/GUI.test.ts
@@ -400,6 +400,8 @@ describe("GUI Test", () => {
         GUISelectors.getThreadMessageByText(view, llmResponse),
       );
 
+      await new Promise(resolve=>setTimeout(resolve, 500));
+
       const viewportHeight = await driver.executeScript(
         "return window.innerHeight",
       );

--- a/extensions/vscode/e2e/tests/GUI.test.ts
+++ b/extensions/vscode/e2e/tests/GUI.test.ts
@@ -400,7 +400,7 @@ describe("GUI Test", () => {
         GUISelectors.getThreadMessageByText(view, llmResponse),
       );
 
-      await new Promise(resolve=>setTimeout(resolve, 500));
+      await new Promise(resolve=>setTimeout(resolve, 200));
 
       const viewportHeight = await driver.executeScript(
         "return window.innerHeight",

--- a/gui/src/pages/gui/useAutoScroll.ts
+++ b/gui/src/pages/gui/useAutoScroll.ts
@@ -9,6 +9,17 @@ export const useAutoScroll = (
   useEffect(() => {
     if (history.length) {
       setUserHasScrolled(false);
+      if (ref.current) {
+        // smooth scroll to the bottom of the chat
+        ref.current.style.scrollBehavior = "smooth";
+        ref.current.scrollTop = ref.current.scrollHeight;
+        
+        // use 100 ms delay to scroll to restore the scroll and wait for the chat to be scrolled
+        const timer = setTimeout(() => { 
+          ref.current!.style.scrollBehavior = "auto";
+          clearTimeout(timer);
+        }, 100); 
+      }
     }
   }, [history.length]);
 


### PR DESCRIPTION
## Description

Recently I was used Gemini Code Assist and the chat smooth scrolling (and last prompt's sticky behaviour) on a new prompt was something I liked. I wanted to add this to Continue as well.

Whenever a new prompt is given, the chat scrolls to the bottom in smoothly.

(I wanted to also add the sticky behaviour of the prompt. It would require changes to how we render the [history](https://github.com/continuedev/continue/blob/b8c92f26cad325ff79eca6b5d01fd4ac47b4a88f/gui/src/pages/gui/Chat.tsx/#L315) items such that all other items remain constant during generation)

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

https://github.com/user-attachments/assets/fcc98d54-b984-4a48-a9d5-074ca39f0800



https://github.com/user-attachments/assets/d332e400-bce5-4823-a56e-04ceb89bb2ba



## Testing instructions

1. open the chat messages area
2. add 2 or 3 prompts and long answers
3. see that when you prompt next, the last message is smoothly scrolled into view
