### PR TITLE
Fix 4947

### DIFF
--- a/core/llm/countTokens.ts
+++ b/core/llm/countTokens.ts
@@ -157,7 +157,7 @@ function countChatMessageTokens(
 ): number {
   // Doing simpler, safer version of what is here:
   // https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb
-  // every message follows <|im_start|>{role/name}\n{content}<|end|>\n
+  // every message follows  `{role/name}\n{content}<|end|>\n`
   const TOKENS_PER_MESSAGE: number = 4;
   return countTokens(chatMessage.content, modelName) + TOKENS_PER_MESSAGE;
 }
@@ -167,13 +167,27 @@ function pruneLinesFromTop(
   maxTokens: number,
   modelName: string,
 ): string {
-  let totalTokens = countTokens(prompt, modelName);
   const lines = prompt.split("\n");
-  while (totalTokens > maxTokens && lines.length > 0) {
-    totalTokens -= countTokens(lines.shift()!, modelName);
+  const lineTokens = lines.map((line) => countTokens(line, modelName));
+  let totalTokens = lineTokens.reduce((sum, tokens) => sum + tokens, 0);
+  let start = 0;
+  let currentLines = lines.length;
+
+  // Calculate initial token count including newlines
+  totalTokens += Math.max(0, currentLines - 1); // Add tokens for joining newlines
+
+  // Using indexes instead of array modifications.
+  // Remove lines from the top until the token count is within the limit.
+  while (totalTokens > maxTokens && start < currentLines) {
+    totalTokens -= lineTokens[start];
+    // Decrement token count for the removed line and its preceding/joining newline (if not the last line)
+    if (currentLines - start > 1) {
+      totalTokens--;
+    }
+    start++;
   }
 
-  return lines.join("\n");
+  return lines.slice(start).join("\n");
 }
 
 function pruneLinesFromBottom(
@@ -181,13 +195,26 @@ function pruneLinesFromBottom(
   maxTokens: number,
   modelName: string,
 ): string {
-  let totalTokens = countTokens(prompt, modelName);
   const lines = prompt.split("\n");
-  while (totalTokens > maxTokens && lines.length > 0) {
-    totalTokens -= countTokens(lines.pop()!, modelName);
+  const lineTokens = lines.map((line) => countTokens(line, modelName));
+  let totalTokens = lineTokens.reduce((sum, tokens) => sum + tokens, 0);
+  let end = lines.length;
+
+  // Calculate initial token count including newlines
+  totalTokens += Math.max(0, end - 1); // Add tokens for joining newlines
+
+  // Reverse traversal to avoid array modification
+  // Remove lines from the bottom until the token count is within the limit.
+  while (totalTokens > maxTokens && end > 0) {
+    end--;
+    totalTokens -= lineTokens[end];
+    // Decrement token count for the removed line and its following/joining newline (if not the first line)
+    if (end > 0) {
+      totalTokens--;
+    }
   }
 
-  return lines.join("\n");
+  return lines.slice(0, end).join("\n");
 }
 
 function pruneStringFromBottom(


### PR DESCRIPTION

## Description
Closes #4947 

This PR addresses issue #4947 by optimizing the performance of the `pruneLinesFromTop` and `pruneLinesFromBottom` functions in `core/llm/countTokens.ts`

### Problem

The previous implementations used `Array.prototype.shift()` and `Array.prototype.pop()` within a `while` loop to remove lines from the beginning or end of a prompt until it fit within the token limit. These array modification methods have a time complexity of O(n) because they require shifting subsequent elements. When dealing with very long prompts (e.g., thousands of lines), repeatedly calling `shift()` or `pop()` becomes computationally expensive, leading to significant performance degradation.

### Solution

The implemented solution refactors these functions to avoid costly array modifications within the loop:

1.  The prompt is split into lines.
2.  The token count for **each line** is calculated **once** upfront and stored in an array (`lineTokens`).
3.  The total initial token count is calculated by summing `lineTokens` and adding the count for necessary newline characters (`\n`).
4.  A `while` loop iterates as long as the `totalTokens` exceeds `maxTokens`.
5.  Inside the loop, instead of removing elements from the `lines` array, an index pointer (`start` or `end`) is adjusted.
6.  The pre-calculated token count for the line being (conceptually) removed, along with its corresponding newline token, is subtracted from `totalTokens`.
7.  After the loop, `Array.prototype.slice()` (an O(n) operation performed only **once**) is used with the final `start` or `end` index to extract the desired lines.
8.  The resulting lines are joined back into a string.

### Benefits

This approach drastically reduces the computational complexity, especially for large prompts, as the expensive O(n) operations (`shift`/`pop`) inside the loop are replaced by cheap O(1) index increments/decrements. The token calculation per line and the final `slice` operation are performed only once.


## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
