### PR TITLE
feat: auto pre-release for VSC. +JB

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -34,7 +34,6 @@ jobs:
           gh release create "$NEW_VERSION" \
             --generate-notes \
             --title "$NEW_VERSION" \
-            --draft \
             --latest \
             --prerelease
 
@@ -65,6 +64,5 @@ jobs:
           gh release create "$NEW_VERSION" \
             --generate-notes \
             --title "$NEW_VERSION" \
-            --draft \
             --latest \
             --prerelease

--- a/extensions/intellij/build.gradle.kts
+++ b/extensions/intellij/build.gradle.kts
@@ -185,7 +185,7 @@ tasks {
         channels.set(listOf(environment("RELEASE_CHANNEL").getOrElse("eap")))
 
         // We always hide the stable releases until a few days of EAP have proven them stable
-        //        hidden = environment("RELEASE_CHANNEL").map { it == "stable" }.getOrElse(false)
+        hidden.set(environment("RELEASE_CHANNEL").map { it == "default" }.getOrElse(false))
     }
 
     runIde {


### PR DESCRIPTION
This PR removes the `--draft` flag from out automatic pre-release jobs, which will effectively push them to the actual pre-releases on the VSC/JB marketplaces.