### PR TITLE
Prevent going back to previous session when changing modes on a new initialized session

### DIFF
--- a/gui/src/components/modelSelection/ModeSelect.tsx
+++ b/gui/src/components/modelSelection/ModeSelect.tsx
@@ -43,7 +43,7 @@ function ModeSelect() {
   const mode = useAppSelector(selectCurrentMode);
   const selectedModel = useAppSelector(selectSelectedChatModel);
   const currentSession = useAppSelector((state) => state.session);
-  const [newChatSessionInitialized, setNewChatSessionInitialized] = useState(false);
+  const [newSessionInitialized, setNewSessionInitialized] = useState(false);
   const agentModeSupported = selectedModel && modelSupportsTools(selectedModel);
 
   const jetbrains = useMemo(() => {
@@ -87,12 +87,12 @@ function ModeSelect() {
   }, [dispatch, mode, jetbrains]);
 
   useWebviewListener("newSession", async () => {
-    setNewChatSessionInitialized(true);
+    setNewSessionInitialized(true);
   });
 
   useEffect(() => {
     if (currentSession.history.length > 0) {
-      setNewChatSessionInitialized(false);
+      setNewSessionInitialized(false);
     }
   }, [currentSession.history]);
 
@@ -104,8 +104,8 @@ function ModeSelect() {
           return;
         }
         dispatch(setMode(newMode));
-        if (newMode === "edit" || newChatSessionInitialized) {
-          // generate a new session for edit mode and if user opened a new chat explicitly
+        if (newMode === "edit" || newSessionInitialized) {
+          // generate a new session for edit mode and if user opened a new session explicitly
           await dispatch(
             saveCurrentSession({
               generateTitle: false,


### PR DESCRIPTION
## Description

This happens when we change the modes. Currently when we open a new session by clicking on the new session button, we go back to the previous session as we change mode from edit to chat/agent.

This should not happen because the user explicitly asked for a new chat session.

This PR fixes this by tracking when a new session was explicitly initialized then we do not go back to previous sessions on any mode change.

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots


https://github.com/user-attachments/assets/cb9f49a9-d6f8-46b6-ac8a-0012608e5a81


https://github.com/user-attachments/assets/f5e80ba4-fecd-476f-a1a7-771dd00006e1



## Testing instructions

1. Click on a new chat session plus button on the top right.
2. Change the mode to edit.
3. Now change the mode to chat or agent.
4. See that new session is preserved without going back to the previous session unexpectedly.
