### PR TITLE
feat(config-yaml): Add promptCaching to Default Completion Options and enable Bedrock Tools Caching

### DIFF
--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -852,7 +852,6 @@ declare global {
   export interface CacheBehavior {
     cacheSystemMessage?: boolean;
     cacheConversation?: boolean;
-    cacheToolsConfig?: boolean;
   }
   
   export interface ClientCertificateOptions {

--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -852,6 +852,7 @@ declare global {
   export interface CacheBehavior {
     cacheSystemMessage?: boolean;
     cacheConversation?: boolean;
+    cacheToolsConfig?: boolean;
   }
   
   export interface ClientCertificateOptions {

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -927,7 +927,6 @@ export interface RequestOptions {
 export interface CacheBehavior {
   cacheSystemMessage?: boolean;
   cacheConversation?: boolean;
-  cacheToolsConfig?: boolean;
 }
 
 export interface ClientCertificateOptions {
@@ -1024,6 +1023,7 @@ export interface BaseCompletionOptions {
   toolChoice?: ToolChoice;
   reasoning?: boolean;
   reasoningBudgetTokens?: number;
+  promptCaching?: boolean;
 }
 
 export interface ModelCapability {

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -927,6 +927,7 @@ export interface RequestOptions {
 export interface CacheBehavior {
   cacheSystemMessage?: boolean;
   cacheConversation?: boolean;
+  cacheToolsConfig?: boolean;
 }
 
 export interface ClientCertificateOptions {

--- a/core/llm/llms/Bedrock.ts
+++ b/core/llm/llms/Bedrock.ts
@@ -292,10 +292,10 @@ class Bedrock extends BaseLLM {
     const convertedMessages = this._convertMessages(messages);
 
     const shouldCacheSystemMessage =
-      !!systemMessage && this.cacheBehavior?.cacheSystemMessage;
+      !!systemMessage && this.cacheBehavior?.cacheSystemMessage || this.completionOptions.promptCaching;
     const enablePromptCaching =
-      shouldCacheSystemMessage || this.cacheBehavior?.cacheConversation;
-    const shouldCacheToolsConfig = this.cacheBehavior?.cacheToolsConfig;
+      shouldCacheSystemMessage || this.cacheBehavior?.cacheConversation || this.completionOptions.promptCaching;
+    const shouldCacheToolsConfig = this.completionOptions.promptCaching;
 
     // Add header for prompt caching
     if (enablePromptCaching) {

--- a/packages/config-yaml/src/schemas/models.ts
+++ b/packages/config-yaml/src/schemas/models.ts
@@ -49,6 +49,7 @@ export const completionOptionsSchema = z.object({
   n: z.number().optional(),
   reasoning: z.boolean().optional(),
   reasoningBudgetTokens: z.number().optional(),
+  promptCaching: z.boolean().optional(),
 });
 export type CompletionOptions = z.infer<typeof completionOptionsSchema>;
 


### PR DESCRIPTION
## Description

Provides inital configuration support for this new feature: https://github.com/continuedev/continue/issues/5340

Adding the ability to specify if the model / provider should enable caching for the tools Configuration. The changes to enable the use of this configuration in providers will be done via separate PRs. The documenation to use this feature will be updated on a per model / provider basis.

Enabling tools caching for AWS Bedrock Claude Models.

Note, I'm not planning to make significant updates to the JSON schema to support this feature.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Testing instructions

defaultCompletionOptions:
  promptCaching: true

Add this configuration to a model and validate through debugging that it's loaded and available to the model / provider in question downstream.
