### PR TITLE
Fixing issue #4239 (FTS not working for multiple word query)

### DIFF
--- a/core/context/retrieval/pipelines/BaseRetrievalPipeline.ts
+++ b/core/context/retrieval/pipelines/BaseRetrievalPipeline.ts
@@ -68,7 +68,7 @@ export default class BaseRetrievalPipeline implements IRetrievalPipeline {
     const cleanedTokens = [...tokens].join(" ");
     const trigrams = nlp.string.ngram(cleanedTokens, 3);
 
-    return trigrams;
+    return trigrams.map(this.escapeFtsQueryString);
   }
 
   private escapeFtsQueryString(query: string): string {
@@ -84,9 +84,8 @@ export default class BaseRetrievalPipeline implements IRetrievalPipeline {
       return [];
     }
 
-    const tokensRaw = this.getCleanedTrigrams(args.query).join(" OR ");
-    const tokens = this.escapeFtsQueryString(tokensRaw);
-
+    const tokens = this.getCleanedTrigrams(args.query).join(" OR ");
+    
     return await this.ftsIndex.retrieve({
       n,
       text: tokens,


### PR DESCRIPTION
Fixing issue #4239 by escaping the trigrams instead of escaping the OR joined trigrams.

Currently OR joined trigrams are escaped, leading to OR getting treated literally and hence FTS is not matching any chunks.
