### PR TITLE
fix(streamDiffLines)-disable-reasoning

### DIFF
--- a/core/edit/streamDiffLines.ts
+++ b/core/edit/streamDiffLines.ts
@@ -161,9 +161,11 @@ export async function* streamDiffLines({
       ? llm.streamComplete(prompt, new AbortController().signal, {
           raw: true,
           prediction,
+          reasoning: false,
         })
       : llm.streamChat(prompt, new AbortController().signal, {
           prediction,
+          reasoning: false,
         });
 
   let lines = streamLines(completion);


### PR DESCRIPTION
## Description

Resolves: https://github.com/continuedev/continue/issues/5434

When reasoning is enable, the model returns unexpected resoning lines which get injected into the edit. The easy fix here is to disable resoning just for the call to the LLM when appying the edits to the original file if it's enabled. 

In the longer term we might want to improve parsing to discard the reasoning response from the model and only include the relevant messages.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Testing instructions

On the main branch, enable resoning for a claude 3.7 model. Perform a simple edit and you will see extra lines included at the top of the file. This is the reasonging response.

Now using this branch perform the same edit, you will notice the extra lines are no longer present.
