### PR TITLE
remove auto-adding of the needs-triage tag

### DIFF
--- a/.github/workflows/auto-assign-issue.yaml
+++ b/.github/workflows/auto-assign-issue.yaml
@@ -16,9 +16,9 @@ jobs:
           repo-token: ${{ secrets.CI_GITHUB_TOKEN }}
           assignees: sestinj,Patrick-Erichsen,tomasz-stefaniak,RomneyDa
           numOfAssignee: 1
-      - name: "Add default labels"
-        uses: actions-ecosystem/action-add-labels@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: |
-            "needs-triage"
+      # - name: "Add default labels"
+      #   uses: actions-ecosystem/action-add-labels@v1
+      #   with:
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      #     labels: |
+      #       "needs-triage"


### PR DESCRIPTION
## Description

We are now using the Kanban board here: https://github.com/orgs/continuedev/projects/4/views/1?filterQuery=assignee:@me, so no longer need this tag

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created