### PR TITLE
add highlighted code to edit with range

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor/useMainEditorWebviewListeners.ts
+++ b/gui/src/components/mainInput/TipTapEditor/useMainEditorWebviewListeners.ts
@@ -3,7 +3,9 @@ import { InputModifiers } from "core";
 import { rifWithContentsToContextItem } from "core/commands/util";
 import { MutableRefObject } from "react";
 import { useWebviewListener } from "../../../hooks/useWebviewListener";
+import { useAppSelector } from "../../../redux/hooks";
 import {
+  addCodeToEdit,
   clearCodeToEdit,
   setNewestToolbarPreviewForInput,
 } from "../../../redux/slices/sessionSlice";
@@ -29,6 +31,8 @@ export function useMainEditorWebviewListeners({
   inputId: string;
   editorFocusedRef: MutableRefObject<boolean | undefined>;
 }) {
+  const messageMode = useAppSelector((state) => state.session.mode);
+
   useWebviewListener(
     "isContinueInputFocused",
     async () => {
@@ -123,6 +127,16 @@ export function useMainEditorWebviewListeners({
         }
       }
 
+      if (messageMode === "edit" && contextItem.uri?.value) {
+        dispatch(
+          addCodeToEdit({
+            filepath: data.rangeInFileWithContents.filepath,
+            contents: data.rangeInFileWithContents.contents,
+            range: data.rangeInFileWithContents.range,
+          }),
+        );
+      }
+
       editor
         .chain()
         .insertContentAt(index, {
@@ -155,7 +169,7 @@ export function useMainEditorWebviewListeners({
         editor.commands.focus("end");
       }, 20);
     },
-    [editor, inputId, onEnterRef.current],
+    [editor, inputId, onEnterRef.current, messageMode],
   );
 
   useWebviewListener(

--- a/gui/src/components/mainInput/TipTapEditor/useMainEditorWebviewListeners.ts
+++ b/gui/src/components/mainInput/TipTapEditor/useMainEditorWebviewListeners.ts
@@ -135,25 +135,26 @@ export function useMainEditorWebviewListeners({
             range: data.rangeInFileWithContents.range,
           }),
         );
+      } else {
+        editor
+          .chain()
+          .insertContentAt(index, {
+            type: CodeBlock.name,
+            attrs: {
+              item: contextItem,
+              inputId,
+            },
+          })
+          .run();
+  
+        dispatch(
+          setNewestToolbarPreviewForInput({
+            inputId,
+            contextItemId: contextItem.id.itemId,
+          }),
+        );
       }
 
-      editor
-        .chain()
-        .insertContentAt(index, {
-          type: CodeBlock.name,
-          attrs: {
-            item: contextItem,
-            inputId,
-          },
-        })
-        .run();
-
-      dispatch(
-        setNewestToolbarPreviewForInput({
-          inputId,
-          contextItemId: contextItem.id.itemId,
-        }),
-      );
 
       if (data.prompt) {
         editor.commands.focus("end");


### PR DESCRIPTION
## Description

When in edit mode, highlighted code add the only the selected range to edit. This prevents to edit the entire file.

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

https://github.com/user-attachments/assets/d8629e1a-f11d-42d1-a4e9-36a28f36ec0b




## Testing instructions

- open edit mode
- use cmd+l to select the highlighted code
- see that code is highlighted and added to chat as well
- only the selected/highlighted part is edited when prompted
