### PR TITLE
feat: more visible assistant refresh + submenus

### DIFF
--- a/binary/package-lock.json
+++ b/binary/package-lock.json
@@ -74,6 +74,7 @@
         "http-proxy-agent": "^7.0.1",
         "https-proxy-agent": "^7.0.3",
         "ignore": "^5.3.1",
+        "is-localhost-ip": "^2.0.0",
         "jinja-js": "0.1.8",
         "js-tiktoken": "^1.0.8",
         "jsdom": "^24.0.0",

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "1.1.28",
+  "version": "1.1.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "1.1.28",
+      "version": "1.1.29",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/fetch": "^1.0.3",

--- a/gui/src/components/mainInput/AtMentionDropdown/index.tsx
+++ b/gui/src/components/mainInput/AtMentionDropdown/index.tsx
@@ -4,8 +4,8 @@ import {
   ChatBubbleLeftIcon,
   PlusIcon,
 } from "@heroicons/react/24/outline";
-import { Editor } from "@tiptap/react";
-import { RangeInFile } from "core";
+import type { Editor } from "@tiptap/react";
+import type { RangeInFile } from "core";
 import {
   forwardRef,
   useContext,
@@ -32,7 +32,7 @@ import SafeImg from "../../SafeImg";
 import AddDocsDialog from "../../dialogs/AddDocsDialog";
 import HeaderButtonWithToolTip from "../../gui/HeaderButtonWithToolTip";
 import { NAMED_ICONS } from "../icons";
-import { ComboBoxItem, ComboBoxItemType } from "../types";
+import type { ComboBoxItem, ComboBoxItemType } from "../types";
 
 export function getIconFromDropdownItem(
   id: string | undefined,
@@ -509,7 +509,9 @@ const AtMentionDropdown = forwardRef((props: AtMentionDropdownProps, ref) => {
                       ) : (
                         <DropdownIcon item={item} className="mr-2" />
                       )}
-                      <span title={item.id} className="whitespace-nowrap">{item.title}</span>
+                      <span title={item.id} className="whitespace-nowrap">
+                        {item.title}
+                      </span>
                       {"  "}
                     </div>
                     <span
@@ -517,7 +519,12 @@ const AtMentionDropdown = forwardRef((props: AtMentionDropdownProps, ref) => {
                         color: lightGray,
                         float: "right",
                         textAlign: "right",
-                        opacity: isSelected ? 1 : 0,
+                        opacity:
+                          subMenuTitle || item.type !== "contextProvider"
+                            ? 1
+                            : isSelected
+                              ? 1
+                              : 0,
                         minWidth: "30px",
                       }}
                       className="ml-2 flex items-center overflow-hidden overflow-ellipsis whitespace-nowrap"

--- a/gui/src/components/modelSelection/platform/AssistantSelect.tsx
+++ b/gui/src/components/modelSelection/platform/AssistantSelect.tsx
@@ -30,7 +30,7 @@ import {
   Transition,
 } from "../../ui";
 
-import { ProfileDescription } from "core/config/ConfigHandler";
+import type { ProfileDescription } from "core/config/ConfigHandler";
 import { useNavigate } from "react-router-dom";
 import { vscCommandCenterInactiveBorder } from "../..";
 import { cn } from "../../../util/cn";
@@ -158,7 +158,7 @@ export default function AssistantSelect() {
   const orgs = useAppSelector((store) => store.profiles.organizations);
   const ideMessenger = useContext(IdeMessengerContext);
   const { isToolbarExpanded } = useLump();
-  const [loading, setLoading] = useState(false)
+  const [loading, setLoading] = useState(false);
 
   const { profiles, session, login } = useAuth();
   const navigate = useNavigate();
@@ -287,19 +287,24 @@ export default function AssistantSelect() {
 
         <Transition>
           <ListboxOptions className="pb-0">
-            <div className="flex justify-between gap-1.5 px-2.5 py-1">
+            <div className="flex gap-1.5 px-2.5 py-1">
               <span>Assistants</span>
               <div
                 className="flex cursor-pointer flex-row items-center gap-1 hover:brightness-125"
                 onClick={async (e) => {
                   e.stopPropagation();
-                  setLoading(true)
-                  await refreshProfiles()
-                  setLoading(false)
+                  setLoading(true);
+                  await refreshProfiles();
+                  setLoading(false);
                   buttonRef.current?.click();
                 }}
               >
-                <ArrowPathIcon className={cn("text-lightgray h-2.5 w-2.5", loading && 'animate-spin-slow')} />
+                <ArrowPathIcon
+                  className={cn(
+                    "text-lightgray h-2.5 w-2.5",
+                    loading && "animate-spin-slow",
+                  )}
+                />
               </div>
             </div>
 


### PR DESCRIPTION
## Description

This PR addresses a few points of feedback from a community member:
- It's not clear that you can refresh assistants without restarting the IDE
- Not being able to view descriptions on submenu items makes it difficult to know which option to select, particularly when providers like `@folder` have many of the same items

## Screenshots (new UI)

<img width="248" alt="image" src="https://github.com/user-attachments/assets/98d8156a-492f-48d9-b737-042b2b1c3338" />

<img width="331" alt="image" src="https://github.com/user-attachments/assets/2eeeb488-2dc0-44b4-9053-24e2d7201c6c" />

