### PR TITLE
Add Llama 4 Scout Cerebras to definition schema

### DIFF
--- a/core/llm/llms/Cerebras.ts
+++ b/core/llm/llms/Cerebras.ts
@@ -12,6 +12,7 @@ class Cerebras extends OpenAI {
   private static modelConversion: { [key: string]: string } = {
     "llama3.1-8b": "llama3.1-8b",
     "llama3.1-70b": "llama3.1-70b",
+    "llama-4-scout-17b-16e-instruct": "llama-4-scout-17b-16e-instruct"
   };
   protected _convertModelName(model: string): string {
     return Cerebras.modelConversion[model] ?? model;

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -1454,7 +1454,7 @@
           "then": {
             "properties": {
               "model": {
-                "enum": ["llama3.1-8b", "llama3.1-70b"]
+                "enum": ["llama3.1-8b", "llama3.1-70b", "llama-4-scout-17b-16e-instruct"]
               }
             }
           }


### PR DESCRIPTION
Enterprise contract on Cerebras has access to Llama-4-Scout 
<img width="459" alt="image" src="https://github.com/user-attachments/assets/ca88e0aa-168f-4b87-9f00-97140aa720e1" />

Adding that to the config schema so that I can use it with Continue