### PR TITLE
add custom mcp timeout

### DIFF
--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -72,6 +72,7 @@ function convertYamlMcpToContinueMcp(
       args: server.args ?? [],
       env: server.env,
     },
+    timeout: server.timeout
   };
 }
 
@@ -444,6 +445,7 @@ async function configYamlToContinueConfig(options: {
         args: [],
         ...server,
       },
+      timeout: server.timeout
     })),
     false,
   );

--- a/core/context/mcp/MCPConnection.test.ts
+++ b/core/context/mcp/MCPConnection.test.ts
@@ -151,6 +151,21 @@ describe("MCPConnection", () => {
       expect(mockConnect).toHaveBeenCalled();
     });
 
+    it('should handle custom connection timeout', async () => {
+      const conn = new MCPConnection({ ...options, timeout: 11 });
+      const mockConnect = jest
+        .spyOn(Client.prototype, "connect")
+        .mockImplementation(
+          () => new Promise((resolve) => setTimeout(resolve, 10)),
+        );
+
+      const abortController = new AbortController();
+      await conn.connectClient(false, abortController.signal);
+
+      expect(conn.status).toBe("connected");
+      expect(mockConnect).toHaveBeenCalled();
+    });
+
     it("should handle connection timeout", async () => {
       const conn = new MCPConnection({ ...options, timeout: 1 });
       const mockConnect = jest

--- a/core/context/mcp/MCPConnection.ts
+++ b/core/context/mcp/MCPConnection.ts
@@ -14,7 +14,7 @@ import {
   MCPTool,
 } from "../..";
 
-export const DEFAULT_MCP_TIMEOUT = 20_000; // 10 seconds
+const DEFAULT_MCP_TIMEOUT = 20_000; // 20 seconds
 
 class MCPConnection {
   public client: Client;

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1211,6 +1211,7 @@ export interface ExperimentalModelRoles {
 export interface ExperimentalMCPOptions {
   transport: TransportOptions;
   faviconUrl?: string;
+  timeout?: number;
 }
 
 export type EditStatus =

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -380,6 +380,7 @@ prompts, context, and tool use. Continue supports any MCP server with the MCP co
 - `command` (**required**): The command used to start the server.
 - `args`: An optional array of arguments for the command.
 - `env`: An optional map of environment variables for the server process.
+- `timeout`: An optional connection timeout number to the server in milliseconds.
 
 **Example:**
 

--- a/packages/config-yaml/src/schemas/index.ts
+++ b/packages/config-yaml/src/schemas/index.ts
@@ -15,6 +15,7 @@ const mcpServerSchema = z.object({
   faviconUrl: z.string().optional(),
   args: z.array(z.string()).optional(),
   env: z.record(z.string()).optional(),
+  timeout: z.number().gt(0).optional()
 });
 
 export type MCPServer = z.infer<typeof mcpServerSchema>;


### PR DESCRIPTION
## Description

Adds an optional mcp connection timeout which can be specified in the config yaml.

closes https://github.com/continuedev/continue/issues/5325

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Testing instructions

- start an mcp server with a low timeout (or you can use[this mcp server](https://snippet.host/hvaaer))
- specify a timeout 2 seconds greater than the low timeout added above
- reload the mcp server on continue extension 
- see that the server waits until the specified timeout
