### PR TITLE
watsonx - add new line to prompt for Codestral

### DIFF
--- a/core/llm/llms/WatsonX.ts
+++ b/core/llm/llms/WatsonX.ts
@@ -224,10 +224,11 @@ class WatsonX extends BaseLLM {
     }
 
     let input = messages[messages.length - 1].content
-    // Prevent Codestral from continuing user input, regardless of chat template
+    // Add \n to prevent Codestral from continuing user input when using chat template
     if (
-        options.model?.toLowerCase()?.includes("codestral") ||
-        this.deploymentId?.toLowerCase()?.includes("codestral")
+        input.toString().endsWith("[/INST]") &&
+        (options.model?.toLowerCase()?.includes("codestral") ||
+        this.deploymentId?.toLowerCase()?.includes("codestral"))
     ) {
       input += "\n"
     }

--- a/core/llm/llms/WatsonX.ts
+++ b/core/llm/llms/WatsonX.ts
@@ -223,8 +223,16 @@ class WatsonX extends BaseLLM {
       parameters.top_k = options.topK || 100;
     }
 
+    let input = messages[messages.length - 1].content
+    // Prevent Codestral from continuing user input, regardless of chat template
+    if (
+        options.model?.toLowerCase()?.includes("codestral") ||
+        this.deploymentId?.toLowerCase()?.includes("codestral")
+    ) {
+      input += "\n"
+    }
     const payload: any = {
-      input: messages[messages.length - 1].content,
+      input: input,
       parameters: parameters,
     };
     if (!this.deploymentId) {


### PR DESCRIPTION
## Description

Add `\n` to end of prompt when using Codestral. Without the new line, Codestral sometimes ignores the `[/INST]` token and continues or repeats the user input.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created