### PR TITLE
Ghost text for removed lines in apply

### DIFF
--- a/extensions/vscode/src/diff/vertical/decorations.ts
+++ b/extensions/vscode/src/diff/vertical/decorations.ts
@@ -1,14 +1,19 @@
 import * as vscode from "vscode";
 
-export const redDecorationType = vscode.window.createTextEditorDecorationType({
-  isWholeLine: true,
-  backgroundColor: { id: "diffEditor.removedLineBackground" },
-  color: "#808080",
-  outlineWidth: "1px",
-  outlineStyle: "solid",
-  outlineColor: { id: "diffEditor.removedTextBorder" },
-  rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
-});
+export const redDecorationType = (line: string) =>
+  vscode.window.createTextEditorDecorationType({
+    isWholeLine: true,
+    backgroundColor: { id: "diffEditor.removedLineBackground" },
+    // color: "#808080",
+    outlineWidth: "1px",
+    outlineStyle: "solid",
+    outlineColor: { id: "diffEditor.removedTextBorder" },
+    rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
+    after: {
+      contentText: line,
+      color: "#808080",
+    },
+  });
 
 export const greenDecorationType = vscode.window.createTextEditorDecorationType(
   {
@@ -34,6 +39,13 @@ export const belowIndexDecorationType =
     backgroundColor: "rgba(255, 255, 255, 0.1)",
     rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
   });
+
+function translateRange(range: vscode.Range, lineOffset: number): vscode.Range {
+  return new vscode.Range(
+    range.start.translate(lineOffset),
+    range.end.translate(lineOffset),
+  );
+}
 
 export class DecorationTypeRangeManager {
   constructor(
@@ -82,20 +94,10 @@ export class DecorationTypeRangeManager {
     return this.ranges;
   }
 
-  private translateRange(
-    range: vscode.Range,
-    lineOffset: number,
-  ): vscode.Range {
-    return new vscode.Range(
-      range.start.translate(lineOffset),
-      range.end.translate(lineOffset),
-    );
-  }
-
   shiftDownAfterLine(afterLine: number, offset: number) {
     for (let i = 0; i < this.ranges.length; i++) {
       if (this.ranges[i].start.line >= afterLine) {
-        this.ranges[i] = this.translateRange(this.ranges[i], offset);
+        this.ranges[i] = translateRange(this.ranges[i], offset);
       }
     }
     this.editor.setDecorations(this.decorationType, this.ranges);
@@ -104,6 +106,90 @@ export class DecorationTypeRangeManager {
   deleteRangeStartingAt(line: number) {
     for (let i = 0; i < this.ranges.length; i++) {
       if (this.ranges[i].start.line === line) {
+        return this.ranges.splice(i, 1)[0];
+      }
+    }
+  }
+}
+
+export class RedDecorationsManager {
+  constructor(private editor: vscode.TextEditor) {}
+
+  private ranges: {
+    range: vscode.Range;
+    decoration: vscode.TextEditorDecorationType;
+  }[] = [];
+
+  applyToNewEditor(newEditor: vscode.TextEditor) {
+    this.editor = newEditor;
+    this.applyDecorations();
+  }
+
+  addLines(startIndex: number, lines: string[]) {
+    let i = 0;
+    for (const line of lines) {
+      this.ranges.push({
+        range: new vscode.Range(
+          startIndex + i,
+          0,
+          startIndex + i,
+          Number.MAX_SAFE_INTEGER,
+        ),
+        decoration: redDecorationType(line),
+      });
+      i++;
+    }
+    this.applyDecorations();
+  }
+
+  addLine(index: number, line: string) {
+    this.addLines(index, [line]);
+  }
+
+  private getDecorationsMap() {
+    const decorationsMap = new Map<
+      vscode.TextEditorDecorationType,
+      vscode.Range[]
+    >();
+    for (const range of this.ranges) {
+      const ranges = decorationsMap.get(range.decoration) ?? [];
+      ranges.push(range.range);
+      decorationsMap.set(range.decoration, ranges);
+    }
+    return decorationsMap;
+  }
+
+  applyDecorations() {
+    const decorationsMap = this.getDecorationsMap();
+    for (const [decoration, ranges] of decorationsMap) {
+      this.editor.setDecorations(decoration, ranges);
+    }
+  }
+
+  clear() {
+    const decorationsMap = this.getDecorationsMap();
+    for (const [decoration, _] of decorationsMap) {
+      this.editor.setDecorations(decoration, []);
+    }
+    this.ranges = [];
+  }
+
+  getRanges() {
+    return this.ranges.map((r) => r.range);
+  }
+
+  shiftDownAfterLine(afterLine: number, offset: number) {
+    for (let i = 0; i < this.ranges.length; i++) {
+      if (this.ranges[i].range.start.line >= afterLine) {
+        this.ranges[i].range = translateRange(this.ranges[i].range, offset);
+      }
+    }
+    this.applyDecorations();
+  }
+
+  deleteRangeStartingAt(line: number) {
+    for (let i = 0; i < this.ranges.length; i++) {
+      if (this.ranges[i].range.start.line === line) {
         return this.ranges.splice(i, 1)[0];
       }
     }

--- a/extensions/vscode/src/diff/vertical/decorations.ts
+++ b/extensions/vscode/src/diff/vertical/decorations.ts
@@ -176,16 +176,15 @@ export class RemovedLineDecorationManager {
   deleteRangesStartingAt(line: number) {
     for (let i = 0; i < this.ranges.length; i++) {
       if (this.ranges[i].range.start.line === line) {
-        this.ranges[i].decoration.dispose();
-        let count = 1;
+        let sequential = 0;
         while (
-          i + count < this.ranges.length &&
-          this.ranges[i + count].range.start.line === line + count
+          i + sequential < this.ranges.length &&
+          this.ranges[i + sequential].range.start.line === line + sequential
         ) {
-          count++;
-          this.ranges[i + count].decoration.dispose();
+          this.ranges[i + sequential].decoration.dispose();
+          sequential++;
         }
-        return this.ranges.splice(i, count);
+        return this.ranges.splice(i, sequential);
       }
     }
   }

--- a/extensions/vscode/src/diff/vertical/handler.ts
+++ b/extensions/vscode/src/diff/vertical/handler.ts
@@ -228,8 +228,6 @@ export class VerticalDiffHandler implements vscode.Disposable {
       false,
     );
 
-    const redRanges = this.removedLineDecorations.getRanges();
-
     const deleteRangeLines = async (ranges: vscode.Range[]) => {
       await this.editor.edit(
         (editBuilder) => {
@@ -249,17 +247,17 @@ export class VerticalDiffHandler implements vscode.Disposable {
       );
     };
 
+    const removedRanges = this.removedLineDecorations.ranges;
     if (accept) {
       // Accept all: delete all the red ranges and clear green decorations
-      await deleteRangeLines(redRanges.map((r) => r.range));
+      await deleteRangeLines(removedRanges.map((r) => r.range));
     } else {
       // Reject all: Re-insert red lines, delete green ones
-      for (const r of redRanges) {
+      for (const r of removedRanges) {
         await deleteRangeLines([r.range]);
         await this.insertTextAboveLine(r.range.start.line, r.line);
       }
-      const greenRanges = this.addedLineDecorations.getRanges();
-      await deleteRangeLines(greenRanges);
+      await deleteRangeLines(this.addedLineDecorations.ranges);
     }
 
     this.clearDecorations();

--- a/extensions/vscode/src/diff/vertical/manager.ts
+++ b/extensions/vscode/src/diff/vertical/manager.ts
@@ -344,11 +344,11 @@ export class VerticalDiffManager {
       // startLine += effectiveLineDelta;
       // endLine += effectiveLineDelta;
 
-      existingHandler.clear(false);
+      await existingHandler.clear(false);
     }
 
     await new Promise((resolve) => {
-      setTimeout(resolve, 200);
+      setTimeout(resolve, 150);
     });
 
     // Create new handler with determined start/end


### PR DESCRIPTION
Updates apply behavior to fix linting errors caused by removed diff lines being "physically" present in the file
- Uses "ghost" text to show removed lines, overlayed using `after` styling. The underlying line is kept empty
- Because each red diff line has a unique decorator associated with it, the behavior is different enough that I created a second decoration manager with similar methods.

BEFORE
<img width="854" alt="image" src="https://github.com/user-attachments/assets/b0072261-ce2e-4b45-88b7-366910d1ac7d" />

AFTER
<img width="850" alt="image" src="https://github.com/user-attachments/assets/13a60627-3812-459c-87b6-e766b990c900" />

See comments below