### PR TITLE
Streaming diff - error on max tokens reached (+recursive framework)

### DIFF
--- a/core/edit/recursiveStream.ts
+++ b/core/edit/recursiveStream.ts
@@ -1,0 +1,101 @@
+import { ChatMessage, ILLM, Prediction, PromptLog } from "..";
+import { DEFAULT_MAX_TOKENS } from "../llm/constants";
+import { countTokens } from "../llm/countTokens";
+import { renderChatMessage } from "../util/messageContent";
+
+const INFINITE_STREAM_SAFETY = 0.8;
+
+const DUD_PROMPT_LOG: PromptLog = {
+  modelTitle: "",
+  completionOptions: { model: "" },
+  prompt: "",
+  completion: "",
+};
+
+const RECURSIVE_PROMPT = `Continue EXACTLY where you left`;
+
+export async function* recursiveStream(
+  llm: ILLM,
+  prompt: ChatMessage[] | string,
+  prediction: Prediction | undefined,
+  currentBuffer = "",
+  isContinuation = false,
+): AsyncGenerator<string | ChatMessage> {
+  const maxTokens = llm.completionOptions?.maxTokens ?? DEFAULT_MAX_TOKENS;
+  const safeTokens = maxTokens * INFINITE_STREAM_SAFETY;
+  let totalTokens = 0;
+  let buffer = currentBuffer;
+  let whiteSpaceAtEndOfBuffer = buffer.match(/\s*$/)?.[0] ?? "";
+  let firstChunk = true;
+
+  if (typeof prompt === "string") {
+    const generator = llm.streamComplete(prompt, new AbortController().signal, {
+      raw: true,
+      prediction: undefined,
+      reasoning: false,
+    });
+
+    for await (const chunk of generator) {
+      firstChunk = false;
+
+      yield chunk;
+      buffer += chunk;
+      totalTokens += countTokens(chunk);
+
+      if (totalTokens >= safeTokens) {
+        const continuationPrompt = `${RECURSIVE_PROMPT}:\n\n${buffer}`;
+
+        await generator.return(DUD_PROMPT_LOG); // kill the previous generator
+
+        // TODO - Prediction capabilities lost because of partial input
+        yield* recursiveStream(
+          llm,
+          continuationPrompt,
+          undefined,
+          buffer,
+          true,
+        ); // Recursively stream the continuation
+
+        return;
+      }
+    }
+  } else {
+    const generator = llm.streamChat(prompt, new AbortController().signal, {
+      prediction,
+      reasoning: false,
+    });
+
+    for await (const chunk of generator) {
+      firstChunk = false;
+
+      yield chunk;
+      const rendered = renderChatMessage(chunk);
+      buffer += rendered;
+      totalTokens += countTokens(chunk.content);
+
+      if (totalTokens >= safeTokens) {
+        const continuationPrompt: ChatMessage[] = [
+          ...(isContinuation ? prompt.slice(0, -2) : prompt),
+          {
+            role: "assistant",
+            content: buffer,
+          },
+          {
+            role: "user",
+            content: RECURSIVE_PROMPT,
+          },
+        ];
+
+        await generator.return(DUD_PROMPT_LOG);
+        yield* recursiveStream(
+          llm,
+          continuationPrompt,
+          undefined,
+          buffer,
+          true,
+        );
+        return;
+      }
+    }
+  }
+}

--- a/core/edit/recursiveStream.ts
+++ b/core/edit/recursiveStream.ts
@@ -3,7 +3,7 @@ import { DEFAULT_MAX_TOKENS } from "../llm/constants";
 import { countTokens } from "../llm/countTokens";
 import { renderChatMessage } from "../util/messageContent";
 
-const INFINITE_STREAM_SAFETY = 0.8;
+const INFINITE_STREAM_SAFETY = 0.9;
 
 const DUD_PROMPT_LOG: PromptLog = {
   modelTitle: "",
@@ -25,8 +25,7 @@ export async function* recursiveStream(
   const safeTokens = maxTokens * INFINITE_STREAM_SAFETY;
   let totalTokens = 0;
   let buffer = currentBuffer;
-  let whiteSpaceAtEndOfBuffer = buffer.match(/\s*$/)?.[0] ?? "";
-  let firstChunk = true;
+  // let whiteSpaceAtEndOfBuffer = buffer.match(/\s*$/)?.[0] ?? ""; // attempts at fixing whitespace bug with recursive boundaries
 
   if (typeof prompt === "string") {
     const generator = llm.streamComplete(prompt, new AbortController().signal, {
@@ -36,27 +35,28 @@ export async function* recursiveStream(
     });
 
     for await (const chunk of generator) {
-      firstChunk = false;
-
       yield chunk;
       buffer += chunk;
       totalTokens += countTokens(chunk);
 
       if (totalTokens >= safeTokens) {
-        const continuationPrompt = `${RECURSIVE_PROMPT}:\n\n${buffer}`;
+        throw new Error(
+          "Token limit reached. File/range likely too large for this edit",
+        );
+        // const continuationPrompt = `${RECURSIVE_PROMPT}:\n\n${buffer}`;
 
-        await generator.return(DUD_PROMPT_LOG); // kill the previous generator
+        // await generator.return(DUD_PROMPT_LOG); // kill the previous generator
 
-        // TODO - Prediction capabilities lost because of partial input
-        yield* recursiveStream(
-          llm,
-          continuationPrompt,
-          undefined,
-          buffer,
-          true,
-        ); // Recursively stream the continuation
+        // // TODO - Prediction capabilities lost because of partial input
+        // yield* recursiveStream(
+        //   llm,
+        //   continuationPrompt,
+        //   undefined,
+        //   buffer,
+        //   true,
+        // ); // Recursively stream the continuation
 
-        return;
+        // return;
       }
     }
   } else {
@@ -66,35 +66,36 @@ export async function* recursiveStream(
     });
 
     for await (const chunk of generator) {
-      firstChunk = false;
-
       yield chunk;
       const rendered = renderChatMessage(chunk);
       buffer += rendered;
       totalTokens += countTokens(chunk.content);
 
       if (totalTokens >= safeTokens) {
-        const continuationPrompt: ChatMessage[] = [
-          ...(isContinuation ? prompt.slice(0, -2) : prompt),
-          {
-            role: "assistant",
-            content: buffer,
-          },
-          {
-            role: "user",
-            content: RECURSIVE_PROMPT,
-          },
-        ];
-
-        await generator.return(DUD_PROMPT_LOG);
-        yield* recursiveStream(
-          llm,
-          continuationPrompt,
-          undefined,
-          buffer,
-          true,
+        throw new Error(
+          "Token limit reached. File/range likely too large for this edit",
         );
-        return;
+        // const continuationPrompt: ChatMessage[] = [
+        //   ...(isContinuation ? prompt.slice(0, -2) : prompt),
+        //   {
+        //     role: "assistant",
+        //     content: buffer,
+        //   },
+        //   {
+        //     role: "user",
+        //     content: RECURSIVE_PROMPT,
+        //   },
+        // ];
+
+        // await generator.return(DUD_PROMPT_LOG);
+        // yield* recursiveStream(
+        //   llm,
+        //   continuationPrompt,
+        //   undefined,
+        //   buffer,
+        //   true,
+        // );
+        // return;
       }
     }
   }

--- a/core/edit/streamDiffLines.ts
+++ b/core/edit/streamDiffLines.ts
@@ -22,6 +22,7 @@ import { getSystemMessageWithRules } from "../llm/rules/getSystemMessageWithRule
 import { gptEditPrompt } from "../llm/templates/edit";
 import { findLast } from "../util/findLast";
 import { Telemetry } from "../util/posthog";
+import { recursiveStream } from "./recursiveStream";
 
 function constructPrompt(
   prefix: string,
@@ -156,17 +157,7 @@ export async function* streamDiffLines({
     content: highlighted,
   };
 
-  const completion =
-    typeof prompt === "string"
-      ? llm.streamComplete(prompt, new AbortController().signal, {
-          raw: true,
-          prediction,
-          reasoning: false,
-        })
-      : llm.streamChat(prompt, new AbortController().signal, {
-          prediction,
-          reasoning: false,
-        });
+  const completion = recursiveStream(llm, prompt, prediction);
 
   let lines = streamLines(completion);
 


### PR DESCRIPTION
## Description
Throw an error in edit/apply diff streaming when max token limit reached. Prevents truncation of files

I've placed this inside a recursive streaming function that would be great to implement soon but is commented out for now:

- Creates a recursive "Continue where you left off" generator that keeps track of tokens and recurses before hitting max tokens
* not infinite but makes the limiting factor the context length not the maxTokens, which is a 10x for many models
- with this implementation loses prediction abilities after first recursion
- in draft state because seems to be having whitespace issues that cause extra diff lines at recursion boundaries (see pictures with three recursions and a problematic diff at between the 2nd and 3rd group of ~400 tokens

<img width="941" alt="image" src="https://github.com/user-attachments/assets/7236373a-f58a-4fe4-a11c-4159dad4b7b0" />
