### PR TITLE
Fix infinite config-reload loop caused by MCPConnection accidental mutation

### DIFF
--- a/core/context/mcp/MCPConnection.ts
+++ b/core/context/mcp/MCPConnection.ts
@@ -55,7 +55,9 @@ class MCPConnection {
   private constructTransport(options: MCPOptions): Transport {
     switch (options.transport.type) {
       case "stdio":
-        const env: Record<string, string> = options.transport.env || {};
+        const env: Record<string, string> = options.transport.env
+          ? { ...options.transport.env }
+          : {};
         if (process.env.PATH !== undefined) {
           env.PATH = process.env.PATH;
         }


### PR DESCRIPTION
## Description

The code that added the PATH to the stdio transport environment was mutating the original options.transport.env object, which can lead to an infinite loop of reloading the continue config since MCPMananagerSingletone.setConnections() compares the old and new options and forces a refresh if any existing server changed transport options. This triggers a config reload because in core.ts we have:

```
  MCPManagerSingleton.getInstance().onConnectionsRefreshed = async () => {
     await this.configHandler.reloadConfig();
  };
```

Which thens calls setConnections() and so forth...

## Testing instructions

In config.yaml, have a `command:` mcpServer with a non-empty environment , e.g.;

```
mcpServers:
  - name: GitHub
    command: npx
    args:
      - "-y"
      - "@modelcontextprotocol/server-github"
    env:
      GITHUB_PERSONAL_ACCESS_TOKEN:  [...]
```

then the config will infinitely reload triggering much cpu use and slowness, though the extension otherwise "works".

This occurs with git HEAD and the 1.1.31 pre-release, but not with 1.0.7, so something changed recently to complete the infinite loop, though the bug is older.