### PR TITLE
Add tooltips for buttons in code display

### DIFF
--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/ApplyActions.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/ApplyActions.tsx
@@ -3,6 +3,8 @@ import { ApplyState } from "core";
 import { useEffect, useState } from "react";
 import { getMetaKeyLabel } from "../../../util";
 import Spinner from "../../gui/Spinner";
+import { ToolTip } from "../../gui/Tooltip";
+import HoverItem from "../../mainInput/InputToolbar/HoverItem";
 import { ToolbarButtonWithTooltip } from "./ToolbarButtonWithTooltip";
 
 interface ApplyActionsProps {
@@ -35,16 +37,24 @@ export function ApplyActions(props: ApplyActionsProps) {
   }
 
   const applyButton = (text: string) => (
-    <button
-      data-testid="codeblock-toolbar-apply"
-      className="text-lightgray text-[${vscForeground}] flex cursor-pointer items-center border-none bg-transparent pl-0 text-xs outline-none hover:brightness-125"
-      onClick={props.onClickApply}
+    <HoverItem
+      data-tooltip-id="codeblock-apply-code-button-tooltip"
+      className="!p-0"
     >
-      <div className="text-lightgray flex items-center gap-1">
-        <PlayIcon className="h-3.5 w-3.5" />
-        <span className="xs:inline hidden">{text}</span>
-      </div>
-    </button>
+      <button
+        data-testid="codeblock-toolbar-apply"
+        className="text-lightgray text-[${vscForeground}] flex cursor-pointer items-center border-none bg-transparent pl-0 text-xs outline-none hover:brightness-125"
+        onClick={props.onClickApply}
+      >
+        <div className="text-lightgray flex items-center gap-1">
+          <PlayIcon className="h-3.5 w-3.5" />
+          <span className="xs:inline hidden">{text}</span>
+        </div>
+      </button>
+      <ToolTip id="codeblock-apply-code-button-tooltip" place="top">
+        {text} Code
+      </ToolTip>
+    </HoverItem>
   );
 
   switch (props.applyState ? props.applyState.status : null) {

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/CopyButton.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/CopyButton.tsx
@@ -1,5 +1,7 @@
 import { CheckIcon, ClipboardIcon } from "@heroicons/react/24/outline";
 import useCopy from "../../../hooks/useCopy";
+import { ToolTip } from "../../gui/Tooltip";
+import HoverItem from "../../mainInput/InputToolbar/HoverItem";
 
 interface CopyButtonProps {
   text: string;
@@ -9,17 +11,22 @@ export function CopyButton({ text }: CopyButtonProps) {
   const { copyText, copied } = useCopy(text);
 
   return (
-    <div
-      className="text-lightgray flex cursor-pointer items-center border-none bg-transparent text-xs outline-none hover:brightness-125"
-      onClick={copyText}
-    >
-      <div className="flex items-center gap-1 transition-colors duration-200 hover:brightness-125">
-        {copied ? (
-          <CheckIcon className="h-3.5 w-3.5 text-green-500 hover:brightness-125" />
-        ) : (
-          <ClipboardIcon className="h-3.5 w-3.5 hover:brightness-125" />
-        )}
+    <HoverItem data-tooltip-id="codeblock-copy-button-tooltip" className="!p-0">
+      <div
+        className="text-lightgray flex cursor-pointer items-center border-none bg-transparent text-xs outline-none hover:brightness-125"
+        onClick={copyText}
+      >
+        <div className="flex items-center gap-1 transition-colors duration-200 hover:brightness-125">
+          {copied ? (
+            <CheckIcon className="h-3.5 w-3.5 text-green-500 hover:brightness-125" />
+          ) : (
+            <ClipboardIcon className="h-3.5 w-3.5 hover:brightness-125" />
+          )}
+        </div>
       </div>
-    </div>
+      <ToolTip id="codeblock-copy-button-tooltip" place="top">
+        Copy Code
+      </ToolTip>
+    </HoverItem>
   );
 }

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/CreateFileButton.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/CreateFileButton.tsx
@@ -1,5 +1,7 @@
 import { DocumentPlusIcon } from "@heroicons/react/24/outline";
 import { vscForeground } from "../..";
+import { ToolTip } from "../../gui/Tooltip";
+import HoverItem from "../../mainInput/InputToolbar/HoverItem";
 
 interface CreateFileButtonProps {
   onClick: () => void;
@@ -7,7 +9,10 @@ interface CreateFileButtonProps {
 
 export function CreateFileButton({ onClick }: CreateFileButtonProps) {
   return (
-    <>
+    <HoverItem
+      data-tooltip-id="codeblock-create-file-button-tooltip"
+      className="!p-0"
+    >
       <button
         data-testid="codeblock-toolbar-create"
         className={`text-lightgray flex items-center border-none bg-transparent pl-0 text-xs text-[${vscForeground}] cursor-pointer outline-none hover:brightness-125`}
@@ -20,6 +25,9 @@ export function CreateFileButton({ onClick }: CreateFileButtonProps) {
           </span>
         </div>
       </button>
-    </>
+      <ToolTip id="codeblock-create-file-button-tooltip" place="top">
+        Create File with Code
+      </ToolTip>
+    </HoverItem>
   );
 }

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/InsertButton.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/InsertButton.tsx
@@ -1,4 +1,6 @@
 import { ArrowLeftEndOnRectangleIcon } from "@heroicons/react/24/outline";
+import { ToolTip } from "../../gui/Tooltip";
+import HoverItem from "../../mainInput/InputToolbar/HoverItem";
 
 /**
  * Button that inserts code at the current cursor position
@@ -9,13 +11,21 @@ interface InsertButtonProps {
 
 export function InsertButton({ onInsert }: InsertButtonProps) {
   return (
-    <div
-      className="text-lightgray flex cursor-pointer items-center border-none bg-transparent text-xs outline-none hover:brightness-125"
-      onClick={onInsert}
+    <HoverItem
+      data-tooltip-id="codeblock-insert-button-tooltip"
+      className="!p-0"
     >
-      <div className="max-2xs:hidden flex items-center gap-1 transition-colors duration-200">
-        <ArrowLeftEndOnRectangleIcon className="h-3.5 w-3.5" />
+      <div
+        className="text-lightgray flex cursor-pointer items-center border-none bg-transparent text-xs outline-none hover:brightness-125"
+        onClick={onInsert}
+      >
+        <div className="max-2xs:hidden flex items-center gap-1 transition-colors duration-200">
+          <ArrowLeftEndOnRectangleIcon className="h-3.5 w-3.5" />
+        </div>
       </div>
-    </div>
+      <ToolTip id="codeblock-insert-button-tooltip" place="top">
+        Insert Code
+      </ToolTip>
+    </HoverItem>
   );
 }


### PR DESCRIPTION


## Description

Before this fix, the functionality of the Insert and Copy buttons was unclear, as their icons alone did not provide enough information. Users had to interact with the buttons to understand their purpose. By adding tooltips, users now receive immediate context about each button's functionality. This not only improves usability but also ensures a more consistent user experience, as most other UI components already include tooltips.

I also added tooltips to Create File and Apply buttons to maintain consistency across the UI.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots


https://github.com/user-attachments/assets/535b38d1-5673-4ec3-9dbb-92ee71be167f


## Testing instructions

Hover over these buttons and check if the tooltips appear properly.
