### PR TITLE
mark all gpt- and o-series models as chat only (not /v1/completions)

### DIFF
--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -31,26 +31,10 @@ const NON_CHAT_MODELS = [
   "ada",
 ];
 
-const CHAT_ONLY_MODELS = [
-  "gpt-3.5-turbo",
-  "gpt-3.5-turbo-0613",
-  "gpt-3.5-turbo-16k",
-  "gpt-4",
-  "gpt-4-turbo",
-  "gpt-4o",
-  "gpt-35-turbo-16k",
-  "gpt-35-turbo-0613",
-  "gpt-35-turbo",
-  "gpt-4-32k",
-  "gpt-4-turbo-preview",
-  "gpt-4-vision",
-  "gpt-4-0125-preview",
-  "gpt-4-1106-preview",
-  "gpt-4o-mini",
-  "o1-preview",
-  "o1-mini",
-  "o3-mini",
-];
+function isChatOnlyModel(model: string): boolean {
+  // gpt and o-series models
+  return model.startsWith("gpt") || model.startsWith("o");
+}
 
 const formatMessageForO1 = (messages: ChatCompletionMessageParam[]) => {
   return messages?.map((message: any) => {
@@ -335,7 +319,7 @@ class OpenAI extends BaseLLM {
     options: CompletionOptions,
   ): AsyncGenerator<ChatMessage> {
     if (
-      !CHAT_ONLY_MODELS.includes(options.model) &&
+      !isChatOnlyModel(options.model) &&
       this.supportsCompletions() &&
       (NON_CHAT_MODELS.includes(options.model) ||
         this.useLegacyCompletionsEndpoint ||

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "1.1.31",
+  "version": "1.1.32",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION
## Description

We've been maintaining a list of exact model names that don't support /v1/completions and whenever a new one came out it was problematic. This more general function should solve that for many future models

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created