### PR TITLE
fix: undefined in title

### DIFF
--- a/core/config/util.ts
+++ b/core/config/util.ts
@@ -38,7 +38,7 @@ export function addModel(
         (prev, curr) => (curr.title.startsWith(model.title) ? prev + 1 : prev),
         0,
       );
-      if (numMatches !== 0) {
+      if (numMatches !== undefined && numMatches > 0) {
         model.title = `${model.title} (${numMatches})`;
       }
 
@@ -63,7 +63,7 @@ export function addModel(
           "name" in curr && curr.name.startsWith(model.title) ? prev + 1 : prev,
         0,
       );
-      if (numMatches !== 0) {
+      if (numMatches !== undefined && numMatches > 0) {
         model.title = `${model.title} (${numMatches})`;
       }
 


### PR DESCRIPTION
## Description

I added a model, undefined appears in the title.

<img width="390" alt="image" src="https://github.com/user-attachments/assets/d8f44d36-4473-4b9c-89a2-535f3cfb0a97" />

This is because models being undefined causes numMatches to be undefined.

https://github.com/continuedev/continue/blob/8665a083604f51244f60e0f9b5b11233e628f97e/core/config/util.ts#L61-L68

This PR fixes this.

## Checklist

- [v] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [v] The  docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

