### PR TITLE
fix word break on error section

### DIFF
--- a/gui/src/components/mainInput/Lump/sections/errors/ErrorSection.tsx
+++ b/gui/src/components/mainInput/Lump/sections/errors/ErrorSection.tsx
@@ -28,7 +28,7 @@ export function ErrorSection() {
             ) : (
               <ExclamationTriangleIcon className="mr-2 mt-1 h-3.5 w-3.5" />
             )}
-            <p className="m-0 whitespace-pre-wrap text-xs">{error.message}</p>
+            <p className="m-0 whitespace-pre-wrap text-wrap" style={{wordBreak: 'break-word'}}>{error.message}</p>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Description

Added word break on the error section's message so that it does not overflow

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

**before**
<img width="657" alt="Screenshot 2025-05-04 at 2 50 55 PM" src="https://github.com/user-attachments/assets/e45d23cb-b190-427c-aa4c-bfc5f4d68ecc" />

**after**
<img width="528" alt="Screenshot 2025-05-04 at 2 50 20 PM" src="https://github.com/user-attachments/assets/8002a9f1-86c4-4319-a209-5872490fc5d7" />

## Testing instructions

1. open any local config
2. make any error like indentation or invalid key
3. when the error appears, click on learn more
4. see that the text overflows on the red area
