### PR TITLE
open config when clicking on editing the prompt

### DIFF
--- a/gui/src/components/mainInput/Lump/sections/PromptsSection.tsx
+++ b/gui/src/components/mainInput/Lump/sections/PromptsSection.tsx
@@ -4,6 +4,8 @@ import {
 } from "@heroicons/react/24/outline";
 import { BookmarkIcon as BookmarkSolid } from "@heroicons/react/24/solid";
 import { SlashCommandDescription } from "core";
+import { useContext } from "react";
+import { IdeMessengerContext } from "../../../../context/IdeMessenger";
 import { useBookmarkedSlashCommands } from "../../../../hooks/useBookmarkedSlashCommands";
 import { useAppSelector } from "../../../../redux/hooks";
 import { fontSize } from "../../../../util";
@@ -89,14 +91,16 @@ function PromptRow({
  */
 export function PromptsSection() {
   const { isCommandBookmarked, toggleBookmark } = useBookmarkedSlashCommands();
+  const ideMessenger = useContext(IdeMessengerContext);
 
   const slashCommands = useAppSelector(
     (state) => state.config.config.slashCommands ?? [],
   );
 
-  const handleEdit = (prompt: any) => {
-    // Handle edit action here
-    console.log("Editing prompt:", prompt);
+  const handleEdit = (_prompt: SlashCommandDescription) => {
+    ideMessenger.post("config/openProfile", {
+      profileId: undefined,
+    });
   };
 
   const sortedCommands = [...slashCommands].sort((a, b) => {


### PR DESCRIPTION
## Description

the edit button on the prompts section opens the config page (local or hub) like other sections

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

https://github.com/user-attachments/assets/747812d8-8f5c-466f-9cab-bc6a3d39e8c7

https://github.com/user-attachments/assets/04068f52-a4ff-4214-888c-76bf5565dfec



## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
