### PR TITLE
feat(config-yaml): support configuring MCP server transport

### DIFF
--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -45,6 +45,7 @@ import { getCleanUriPath } from "../../util/uri";
 import { getAllDotContinueYamlFiles } from "../loadLocalAssistants";
 import { LocalPlatformClient } from "./LocalPlatformClient";
 import { llmsFromModelConfig } from "./models";
+import { TransportOptions } from "../..";
 
 function convertYamlRuleToContinueRule(rule: Rule): RuleWithSource {
   if (typeof rule === "string") {
@@ -67,7 +68,7 @@ function convertYamlMcpToContinueMcp(
 ): ExperimentalMCPOptions {
   return {
     transport: {
-      type: "stdio",
+      type: server.transport ?? "stdio" as TransportOptions["type"],
       command: server.command,
       args: server.args ?? [],
       env: server.env,

--- a/docs/docs/customize/deep-dives/mcp.mdx
+++ b/docs/docs/customize/deep-dives/mcp.mdx
@@ -37,7 +37,36 @@ To set up your own MCP server, read the [MCP quickstart](https://modelcontextpro
             "type": "stdio",
             "command": "uvx",
             "args": ["mcp-server-sqlite", "--db-path", "/Users/NAME/test.db"]
-          }  
+          }
+        }
+      ]
+    }
+  }
+  ```
+  </TabItem>
+</Tabs>
+
+Alternatively you can connect to a remote MCP server, for example using the `sse` transport:
+
+<Tabs groupId="config-remote-example">
+  <TabItem value="yaml" label="YAML">
+  ```yaml title="config.yaml"
+  mcpServers:
+    - name: Remote MCP Server
+      transport: sse
+      url: https://api.example.com/mcp/sse
+  ```
+  </TabItem>
+  <TabItem value="json" label="JSON">
+  ```json title="config.json"
+  {
+    "experimental": {
+      "modelContextProtocolServers": [
+        {
+          "transport": {
+            "type": "sse",
+            "url": "https://api.example.com/mcp/sse"
+          }
         }
       ]
     }

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -380,6 +380,8 @@ prompts, context, and tool use. Continue supports any MCP server with the MCP co
 - `name` (**required**): The name of the MCP server.
 - `command` (**required**): The command used to start the server.
 - `args`: An optional array of arguments for the command.
+- `transport`: An optional type of transport for remote servers, including `sse` and `websocket`.
+- `url`: An optional URL of the remote MCP server, if using remote transports.
 - `env`: An optional map of environment variables for the server process.
 - `connectionTimeout`: An optional connection timeout number to the server in milliseconds.
 

--- a/packages/config-yaml/src/schemas/index.ts
+++ b/packages/config-yaml/src/schemas/index.ts
@@ -12,6 +12,7 @@ export const contextSchema = z.object({
 const mcpServerSchema = z.object({
   name: z.string(),
   command: z.string(),
+  transport: z.string().optional(),
   faviconUrl: z.string().optional(),
   args: z.array(z.string()).optional(),
   env: z.record(z.string()).optional(),


### PR DESCRIPTION
## Description

Adds support for transport type (enabling SSE use via YAML).

Closes #5359 

⚒️ with ❤️ by [Siemens](https://opensource.siemens.com/)

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created