### PR TITLE
feat: add support for SSE MCP servers

### DIFF
--- a/core/config/workspace/workspaceBlocks.ts
+++ b/core/config/workspace/workspaceBlocks.ts
@@ -53,9 +53,15 @@ function getContentsForNewBlock(blockType: BlockType): ConfigYaml {
       configYaml.mcpServers = [
         {
           name: "New MCP server",
+          type: "stdio",
           command: "npx",
           args: ["-y", "<your-mcp-server>"],
           env: {},
+        },
+        {
+          name: "New MCP server",
+          type: "sse",
+          url: "https://example.org/sse"
         },
       ];
       break;

--- a/core/config/yaml/loadYaml.test.ts
+++ b/core/config/yaml/loadYaml.test.ts
@@ -1,0 +1,107 @@
+import { MCPServer } from "@continuedev/config-yaml";
+import { convertYamlMcpToContinueMcp } from "./loadYaml";
+
+describe("MCP Server Configuration Tests", () => {
+  test("should convert stdio MCP server correctly", () => {
+    const stdioServer: MCPServer = {
+      name: "Test Stdio Server",
+      type: "stdio",
+      command: "uvx",
+      args: ["mcp-server-sqlite", "--db-path", "/test.db"],
+      env: { TEST_ENV: "value" },
+      connectionTimeout: 5000
+    };
+
+    const result = convertYamlMcpToContinueMcp(stdioServer);
+    
+    expect(result).toEqual({
+      transport: {
+        type: "stdio",
+        command: "uvx",
+        args: ["mcp-server-sqlite", "--db-path", "/test.db"],
+        env: { TEST_ENV: "value" }
+      },
+      timeout: 5000
+    });
+  });
+
+  test("should convert SSE MCP server correctly", () => {
+    const sseServer: MCPServer = {
+      name: "Test SSE Server",
+      type: "sse",
+      url: "http://localhost:8150/cosmos/mcp/v1/sse",
+      connectionTimeout: 3000
+    };
+
+    const result = convertYamlMcpToContinueMcp(sseServer);
+    
+    expect(result).toEqual({
+      transport: {
+        type: "sse",
+        url: "http://localhost:8150/cosmos/mcp/v1/sse"
+      },
+      timeout: 3000
+    });
+  });
+
+  test("should convert WebSocket MCP server correctly", () => {
+    const wsServer: MCPServer = {
+      name: "Test WebSocket Server",
+      type: "websocket",
+      url: "ws://localhost:8150/cosmos/mcp/v1/ws",
+      connectionTimeout: 10000
+    };
+
+    const result = convertYamlMcpToContinueMcp(wsServer);
+    
+    expect(result).toEqual({
+      transport: {
+        type: "websocket",
+        url: "ws://localhost:8150/cosmos/mcp/v1/ws"
+      },
+      timeout: 10000
+    });
+  });
+
+  test("should handle legacy MCP server format for backward compatibility", () => {
+    // Test with old format that doesn't have a type field
+    const legacyServer = {
+      name: "Legacy Server",
+      command: "old-command",
+      args: ["--legacy"],
+      connectionTimeout: 2000
+    } as any;
+
+    const result = convertYamlMcpToContinueMcp(legacyServer);
+    
+    expect(result).toEqual({
+      transport: {
+        type: "stdio",
+        command: "old-command",
+        args: ["--legacy"],
+        env: undefined
+      },
+      timeout: 2000
+    });
+  });
+
+  test("should handle missing optional fields", () => {
+    const minimalServer: MCPServer = {
+      name: "Minimal Server",
+      type: "stdio",
+      command: "minimal"
+    };
+
+    const result = convertYamlMcpToContinueMcp(minimalServer);
+    
+    expect(result).toEqual({
+      transport: {
+        type: "stdio",
+        command: "minimal",
+        args: [],
+        env: undefined
+      },
+      timeout: undefined
+    });
+  });
+});

--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -270,7 +270,7 @@ async function configYamlToContinueConfig(options: {
 
   config.mcpServers?.forEach((mcpServer) => {
     const mcpArgVariables =
-      mcpServer.args?.filter((arg) => TEMPLATE_VAR_REGEX.test(arg)) ?? [];
+      (mcpServer.type === "stdio" ? mcpServer.args?.filter((arg) => TEMPLATE_VAR_REGEX.test(arg)) : []) ?? [];
 
     if (mcpArgVariables.length === 0) {
       return;

--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -63,17 +63,42 @@ function convertYamlRuleToContinueRule(rule: Rule): RuleWithSource {
   }
 }
 
-function convertYamlMcpToContinueMcp(
+export function convertYamlMcpToContinueMcp(
   server: MCPServer,
 ): ExperimentalMCPOptions {
+  const transportConfig = (() => {
+    switch (server.type) {
+      case "stdio":
+        return {
+          type: "stdio" as const,
+          command: server.command,
+          args: server.args ?? [],
+          env: server.env,
+        };
+      case "sse":
+        return {
+          type: "sse" as const,
+          url: server.url,
+        };
+      case "websocket":
+        return {
+          type: "websocket" as const,
+          url: server.url,
+        };
+      default:
+        // Default to stdio for backward compatibility
+        return {
+          type: "stdio" as const,
+          command: (server as any).command,
+          args: (server as any).args ?? [],
+          env: (server as any).env,
+        };
+    }
+  })();
+
   return {
-    transport: {
-      type: "stdio",
-      command: server.command,
-      args: server.args ?? [],
-      env: server.env,
-    },
-    timeout: server.connectionTimeout,
+    transport: transportConfig,
+    timeout: server.connectionTimeout
   };
 }
 
@@ -457,7 +482,6 @@ async function configYamlToContinueConfig(options: {
       id: server.name,
       name: server.name,
       transport: {
-        type: "stdio",
         args: [],
         ...server,
       },

--- a/docs/docs/customize/deep-dives/mcp.mdx
+++ b/docs/docs/customize/deep-dives/mcp.mdx
@@ -20,11 +20,15 @@ To set up your own MCP server, read the [MCP quickstart](https://modelcontextpro
   ```yaml title="config.yaml"
   mcpServers:
     - name: My MCP Server
+      type: stdio
       command: uvx
       args:
         - mcp-server-sqlite
         - --db-path
         - /Users/NAME/test.db
+    - name: My MCP Server with SSE
+      type: sse
+      url: "https://example.com/mcp-server/sse"
   ```
   </TabItem>
   <TabItem value="json" label="JSON">
@@ -37,6 +41,12 @@ To set up your own MCP server, read the [MCP quickstart](https://modelcontextpro
             "type": "stdio",
             "command": "uvx",
             "args": ["mcp-server-sqlite", "--db-path", "/Users/NAME/test.db"]
+          }  
+        },
+        {
+          "transport": {
+            "type": "sse",
+            "url": "https://example.com/mcp-server/sse"
           }  
         }
       ]

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -379,21 +379,33 @@ prompts, context, and tool use. Continue supports any MCP server with the MCP co
 **Properties:**
 
 - `name` (**required**): The name of the MCP server.
+- `type"` (**required**): The type of the MCP server. Can be "stdio", "sse", or "websocket.
+
+**Stdio type**
+
 - `command` (**required**): The command used to start the server.
 - `args`: An optional array of arguments for the command.
 - `env`: An optional map of environment variables for the server process.
 - `connectionTimeout`: An optional connection timeout number to the server in milliseconds.
 
+**SSE or Websocket type**
+
+- `url` (**required**): The URL of the MCP server.
+
 **Example:**
 
 ```yaml title="config.yaml"
 mcpServers:
-  - name: My MCP Server
+  - name: My MCP Server with stdio
+    type: stdio
     command: uvx
     args:
       - mcp-server-sqlite
       - --db-path
       - /Users/NAME/test.db
+  - name: My MCP Server with SSE
+    type: sse
+    url: "https://example.com/mcp-server/sse"
 ```
 
 ### `data`

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -379,7 +379,7 @@ prompts, context, and tool use. Continue supports any MCP server with the MCP co
 **Properties:**
 
 - `name` (**required**): The name of the MCP server.
-- `type"` (**required**): The type of the MCP server. Can be "stdio", "sse", or "websocket.
+- `type"` (**required**): The type of the MCP server. Can be "stdio", "sse", or "websocket".
 
 **Stdio type**
 


### PR DESCRIPTION
## Description

Add support for multiple MCP server types (stdio, sse, websocket) in the YAML configuration schema, ensuring backward compatibility with legacy configurations).

```
mcpServers:
   - name: Debug list
     type: stdio
     command: uv.exe
     args:
       - --directory
       - test-mcp-server
       - run
       - load-folders-mcp.py

   - name: Debug Local  MCP Python
     type: sse
     url: http://127.0.0.1:8000/sse
```

I just saw the #5511 I was working on this PR a few days ago, I leave here, but I don't know how to proceed

Closes #5359 

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
