### PR TITLE
add codestral template

### DIFF
--- a/core/llm/autodetect.ts
+++ b/core/llm/autodetect.ts
@@ -9,6 +9,7 @@ import {
   anthropicTemplateMessages,
   chatmlTemplateMessages,
   codeLlama70bTemplateMessages,
+  codestralTemplateMessages,
   deepseekTemplateMessages,
   gemmaTemplateMessage,
   graniteTemplateMessages,
@@ -295,6 +296,7 @@ function autodetectTemplateFunction(
       gemma: gemmaTemplateMessage,
       granite: graniteTemplateMessages,
       llama3: llama3TemplateMessages,
+      codestral: codestralTemplateMessages,
       none: null,
     };
 

--- a/core/llm/templates/chat.ts
+++ b/core/llm/templates/chat.ts
@@ -93,6 +93,15 @@ function llama2TemplateMessages(msgs: ChatMessage[]): string {
   return prompt;
 }
 
+// Llama2 template with added \n to prevent Codestral from continuing user message
+function codestralTemplateMessages(msgs: ChatMessage[]): string {
+    let template = llama2TemplateMessages(msgs);
+    if (template.length == 0) {
+        return template;
+    }
+    return template + "\n";
+}
+
 function anthropicTemplateMessages(messages: ChatMessage[]): string {
   const HUMAN_PROMPT = "\n\nHuman:";
   const AI_PROMPT = "\n\nAssistant:";
@@ -300,4 +309,5 @@ export {
   templateAlpacaMessages,
   xWinCoderTemplateMessages,
   zephyrTemplateMessages,
+  codestralTemplateMessages,
 };

--- a/packages/config-yaml/src/schemas/models.ts
+++ b/packages/config-yaml/src/schemas/models.ts
@@ -88,6 +88,7 @@ const templateSchema = z.enum([
   "gemma",
   "granite",
   "llama3",
+  "codestral",
 ]);
 
 /** Prompt templates use Handlebars syntax */


### PR DESCRIPTION
## Description

Add support for a 'codestral' chat template: a llama2 template with added `\n` at the end. Without the new line, Codestral sometimes ignores the [/INST] token and continues or repeats the user input.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
