### PR TITLE
Nate/hotfix-global-assistants

### DIFF
--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -279,10 +279,7 @@ export class ConfigHandler {
     if (options.includeWorkspace) {
       const assistantFiles = await getAllDotContinueYamlFiles(
         this.ide,
-        {
-          ...options,
-          includeGlobal: false, // Because the global comes from above
-        },
+        options,
         ASSISTANTS,
       );
       const profiles = assistantFiles.map((assistant) => {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "1.1.32",
+  "version": "1.1.33",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION
## Description

Removing an option that inadvertently caused ~/.continue/assistants to not be loaded

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created