### PR TITLE
remove generic esbuild binary from build

### DIFF
--- a/extensions/vscode/scripts/prepackage-cross-platform.js
+++ b/extensions/vscode/scripts/prepackage-cross-platform.js
@@ -209,10 +209,9 @@ async function package(target, os, arch, exe) {
         : `${target}${os === "linux" ? "-gnu" : ""}`
     }/index.node`,
     `out/node_modules/esbuild/lib/main.js`,
-    `out/node_modules/esbuild/bin/esbuild`,
   ]);
 }
 
-(async () => {
+void (async () => {
   await package(target, os, arch, exe);
 })();

--- a/extensions/vscode/scripts/prepackage.js
+++ b/extensions/vscode/scripts/prepackage.js
@@ -64,7 +64,7 @@ const isWinTarget = target?.startsWith("win");
 const isLinuxTarget = target?.startsWith("linux");
 const isMacTarget = target?.startsWith("darwin");
 
-(async () => {
+void (async () => {
   console.log("[info] Packaging extension for target ", target);
 
   // Generate and copy over config-yaml-schema.json
@@ -464,6 +464,9 @@ const isMacTarget = target?.startsWith("darwin");
     ),
   );
 
+  // delete esbuild/bin because platform-specific @esbuild is downloaded
+  fs.rmdirSync(`out/node_modules/esbuild/bin`, { recursive: true });
+
   console.log(`[info] Copied ${NODE_MODULES_TO_COPY.join(", ")}`);
 
   // Copy over any worker files
@@ -530,6 +533,5 @@ const isMacTarget = target?.startsWith("darwin");
     }`,
     `out/node_modules/@lancedb/vectordb-${target}${isWinTarget ? "-msvc" : ""}${isLinuxTarget ? "-gnu" : ""}/index.node`,
     `out/node_modules/esbuild/lib/main.js`,
-    `out/node_modules/esbuild/bin/esbuild`,
   ]);
 })();

--- a/extensions/vscode/scripts/utils.js
+++ b/extensions/vscode/scripts/utils.js
@@ -301,6 +301,9 @@ async function copyNodeModules() {
     ),
   );
 
+  // delete esbuild/bin because platform-specific @esbuild is downloaded
+  fs.rmdirSync(`out/node_modules/esbuild/bin`, {recursive: true});
+
   console.log(`[info] Copied ${NODE_MODULES_TO_COPY.join(", ")}`);
 }
 


### PR DESCRIPTION
## Description

We only need the `esbuild` (javascript wrapper) and `@esbuild` node_modules for our extension build. We are always download the platform specific esbuild binary which makes the `esbuild/bin/esbuild` binary redundant.

This reduces the extension size by 8.8MB

Closes #3999

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]

`cd extension/vscode && npm run package`

The extension works fine as before. I wanted to test it with `config.ts` as well but for some reason it is non-functional (even on main branch) on my machine.
