### PR TITLE
fix(mode-switch)-tools-calls-broken

### DIFF
--- a/core/llm/constructMessages.ts
+++ b/core/llm/constructMessages.ts
@@ -8,14 +8,73 @@ import {
 } from "../";
 import { findLast } from "../util/findLast";
 import { normalizeToMessageParts } from "../util/messageContent";
-import { isUserOrToolMsg } from "./messages";
+import { isUserOrToolMsg, messageHasToolCallId } from "./messages";
 import { getSystemMessageWithRules } from "./rules/getSystemMessageWithRules";
+import { CHAT_UNSAFE_TOOLS } from "../tools/builtIn";
 
 export const DEFAULT_CHAT_SYSTEM_MESSAGE_URL =
   "https://github.com/continuedev/continue/blob/main/core/llm/constructMessages.ts";
 
+export const DEFAULT_AGENT_SYSTEM_MESSAGE_URL =
+  "https://github.com/continuedev/continue/blob/main/core/llm/constructMessages.ts";
+
 export const DEFAULT_CHAT_SYSTEM_MESSAGE = `\
 <important_rules>
+  You are in chat mode.
+  Only use functions that are explicitly listed in the toolsConfig provided to you. Ignore any previous tools that might have been used.
+  Before making any function call, verify that the function name exists in your current toolsConfig.
+  Never attempt to use functions you've observed in context if they aren't in your current toolsConfig.
+  Ignore any examples that use unavailable functions.
+  In chat mode, only suggest changes rather than attempting to make them directly. and can't actually edit or create files.
+  You can only suggest modifictions.
+  If the user asks to make changes offer that they can switch to Agent Mode to make the suggested updates automatically.
+  If needed consisely explain to the user they can switch to agent mode using the Mode Selector dropdown and provide no other details.
+
+  Always include the language and file name in the info string when you write code blocks.
+  If you are editing "src/main.py" for example, your code block should start with '\`\`\`python src/main.py'
+
+  When addressing code modification requests, present a concise code snippet that
+  emphasizes only the necessary changes and uses abbreviated placeholders for
+  unmodified sections. For example:
+
+  \`\`\`language /path/to/file
+  // ... existing code ...
+
+  {{ modified code here }}
+
+  // ... existing code ...
+
+  {{ another modification }}
+
+  // ... rest of code ...
+  \`\`\`
+
+  In existing files, you should always restate the function or class that the snippet belongs to:
+
+  \`\`\`language /path/to/file
+  // ... existing code ...
+  
+  function exampleFunction() {
+    // ... existing code ...
+    
+    {{ modified code here }}
+    
+    // ... rest of function ...
+  }
+  
+  // ... rest of code ...
+  \`\`\`
+
+  Since users have access to their complete file, they prefer reading only the
+  relevant modifications. It's perfectly acceptable to omit unmodified portions
+  at the beginning, middle, or end of files using these "lazy" comments. Only
+  provide the complete file when explicitly requested. Include a concise explanation
+  of changes unless the user specifically asks for code only.
+</important_rules>`;
+
+export const DEFAULT_AGENT_SYSTEM_MESSAGE = `\
+<important_rules>
+  You are in agent mode.
   Always include the language and file name in the info string when you write code blocks. 
   If you are editing "src/main.py" for example, your code block should start with '\`\`\`python src/main.py'
 
@@ -59,6 +118,7 @@ export const DEFAULT_CHAT_SYSTEM_MESSAGE = `\
 </important_rules>`;
 
 export function constructMessages(
+  messageMode: string,
   history: ChatHistoryItem[],
   baseChatOrAgentSystemMessage: string | undefined,
   rules: RuleWithSource[],
@@ -67,9 +127,25 @@ export function constructMessages(
     (item) => item.message.role !== "system",
   );
   const msgs: ChatMessage[] = [];
+  const toolCallIdsToRemove: string[] = [];
 
   for (let i = 0; i < filteredHistory.length; i++) {
     const historyItem = filteredHistory[i];
+
+    if (messageMode === "chat" && CHAT_UNSAFE_TOOLS.includes(historyItem.toolCallState?.toolCall.function.name || "")) {
+      // remove unsafe tools calls to avoid using them in chat mode.
+      // Some models ignore toolsConfig and instead use tools use in history.
+      if (historyItem.toolCallState?.toolCallId) {
+        toolCallIdsToRemove.push(historyItem.toolCallState.toolCall.id);
+      }
+      continue;
+    }
+
+    const toolMessage: ToolResultChatMessage = historyItem.message as ToolResultChatMessage;
+    if (messageMode === "chat" && toolCallIdsToRemove.includes(toolMessage.toolCallId || "")) {
+      // remove toolcall responses from the history for unsafe tools.
+      continue;
+    }
 
     if (historyItem.message.role === "user") {
       // Gather context items for user messages
@@ -100,8 +176,7 @@ export function constructMessages(
     | undefined;
 
   const systemMessage = getSystemMessageWithRules({
-    baseSystemMessage:
-      baseChatOrAgentSystemMessage ?? DEFAULT_CHAT_SYSTEM_MESSAGE,
+    baseSystemMessage: baseChatOrAgentSystemMessage,
     rules,
     userMessage: lastUserMsg,
   });

--- a/core/tools/builtIn.ts
+++ b/core/tools/builtIn.ts
@@ -16,6 +16,8 @@ export enum BuiltInToolNames {
   ViewSubdirectory = "builtin_view_subdirectory",
 }
 
+export const CHAT_UNSAFE_TOOLS: string[] = [ BuiltInToolNames.EditExistingFile, BuiltInToolNames.CreateNewFile, BuiltInToolNames.RunTerminalCommand ];
+
 export const BUILT_IN_GROUP_NAME = "Built-In";
 
 export const CLIENT_TOOLS = [BuiltInToolNames.EditExistingFile];

--- a/gui/src/redux/selectors/selectActiveTools.ts
+++ b/gui/src/redux/selectors/selectActiveTools.ts
@@ -1,6 +1,7 @@
 import { createSelector } from "@reduxjs/toolkit";
 import { Tool } from "core";
 import { RootState } from "../store";
+import { CHAT_UNSAFE_TOOLS } from "core/tools/builtIn";
 
 export const selectActiveTools = createSelector(
   [
@@ -10,13 +11,24 @@ export const selectActiveTools = createSelector(
     (store: RootState) => store.ui.toolGroupSettings,
   ],
   (mode, tools, policies, groupPolicies): Tool[] => {
-    if (mode !== "agent") {
+    if (mode === "chat") {
+      const chatSafeTools: Tool[] = tools.filter(
+        (tool) =>
+          !CHAT_UNSAFE_TOOLS.includes(tool.function.name) &&
+          policies[tool.function.name] !== "disabled" &&
+          groupPolicies[tool.group] !== "exclude",
+      );
+      return chatSafeTools;
+    }
+    else if (mode === "agent") {
+      return tools.filter(
+        (tool) =>
+          policies[tool.function.name] !== "disabled" &&
+          groupPolicies[tool.group] !== "exclude",
+      );
+    }
+    else {
       return [];
     }
-    return tools.filter(
-      (tool) =>
-        policies[tool.function.name] !== "disabled" &&
-        groupPolicies[tool.group] !== "exclude",
-    );
   },
 );

--- a/gui/src/redux/thunks/streamResponse.ts
+++ b/gui/src/redux/thunks/streamResponse.ts
@@ -89,8 +89,9 @@ export const streamResponseThunk = createAsyncThunk<
         const messageMode = getState().session.mode
 
         const baseChatOrAgentSystemMessage = getBaseSystemMessage(selectedChatModel, messageMode)
-        
+
         const messages = constructMessages(
+          messageMode,
           [...updatedHistory],
           baseChatOrAgentSystemMessage,
           state.config.config.rules,

--- a/gui/src/redux/thunks/streamResponseAfterToolCall.ts
+++ b/gui/src/redux/thunks/streamResponseAfterToolCall.ts
@@ -72,6 +72,7 @@ export const streamResponseAfterToolCall = createAsyncThunk<
         const baseChatOrAgentSystemMessage = getBaseSystemMessage(selectedChatModel, messageMode)
         
         const messages = constructMessages(
+          messageMode,
           [...updatedHistory],
           baseChatOrAgentSystemMessage,
           state.config.config.rules,

--- a/gui/src/util/index.ts
+++ b/gui/src/util/index.ts
@@ -3,6 +3,7 @@ import { ProfileDescription } from "core/config/ProfileLifecycleManager";
 import _ from "lodash";
 import { KeyboardEvent } from "react";
 import { getLocalStorage } from "./localStorage";
+import { DEFAULT_CHAT_SYSTEM_MESSAGE, DEFAULT_AGENT_SYSTEM_MESSAGE } from "core/llm/constructMessages";
 
 export type Platform = "mac" | "linux" | "windows" | "unknown";
 
@@ -122,9 +123,9 @@ export function isLocalProfile(profile: ProfileDescription): boolean {
 export function getBaseSystemMessage(modelDetails: ModelDescription | null, mode: MessageModes) {
   let baseChatOrAgentSystemMessage: string|undefined
   if(mode === 'agent') {
-    baseChatOrAgentSystemMessage = modelDetails?.baseAgentSystemMessage ?? modelDetails?.baseChatSystemMessage // fallback to chat system message if agent system message is unavailable
+    baseChatOrAgentSystemMessage = modelDetails?.baseAgentSystemMessage ?? DEFAULT_AGENT_SYSTEM_MESSAGE;
   } else {
-    baseChatOrAgentSystemMessage = modelDetails?.baseChatSystemMessage
+    baseChatOrAgentSystemMessage = modelDetails?.baseChatSystemMessage ?? DEFAULT_CHAT_SYSTEM_MESSAGE;
   }
   return baseChatOrAgentSystemMessage
 }


### PR DESCRIPTION
## Description

* Currently if the user is in agent mode and uses tools and swtiches back to chat mode a tools call error occurs.
* Further you can't currently use any tools in chat mode which isn't helpful if you want to lookup information on the web, call MCP tools, etc.
* Further in chat mode, it doesn't really make sense that you can use destructive tools such as edit or create file. You also want to block the use of the terminal tool creating new files etc. I've added a new list of unsafe tools for chat mode as as new const: CHAT_UNSAFE_TOOLS.
* I've added separate default system messages for Chat and Agent mode. I've made changes so that when you attempt to do unsafe operations in Chat mode, you are suggested to switch to Agent mode to continue.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Testing instructions

1. Start in Agent mode and add a power function to @test.js.
2. Note the change is done as expected.
3. Now ask to remove the function.
4. Note the change is done as expected.
5. Switch to chat mode.
6. Ask to add the power function to @test.js
7. Note that the edit isn't made, just a suggestion is presented.
8. Ask for the edit to be applied.
9. Note that switching to agent mode is suggested.
10. Switch back to agent mode.
11. Ask for the edit to be applied.
12. Note the edit is applied.