### PR TITLE
Do not break completion for unsupported FS providers

### DIFF
--- a/extensions/vscode/src/autocomplete/completionProvider.ts
+++ b/extensions/vscode/src/autocomplete/completionProvider.ts
@@ -11,6 +11,7 @@ import * as vscode from "vscode";
 
 import { handleLLMError } from "../util/errorHandling";
 import { showFreeTrialLoginMessage } from "../util/messages";
+import { VsCodeIde } from "../VsCodeIde";
 import { VsCodeWebviewProtocol } from "../webviewProtocol";
 
 import { getDefinitionsFromLsp } from "./lsp";
@@ -22,8 +23,6 @@ import {
   setupStatusBar,
   stopStatusBarLoading,
 } from "./statusBar";
-
-import type { IDE } from "core";
 
 interface VsCodeCompletionInput {
   document: vscode.TextDocument;
@@ -61,13 +60,15 @@ export class ContinueCompletionProvider
 
   private completionProvider: CompletionProvider;
   private recentlyVisitedRanges: RecentlyVisitedRangesService;
-  private recentlyEditedTracker = new RecentlyEditedTracker();
+  private recentlyEditedTracker: RecentlyEditedTracker;
 
   constructor(
     private readonly configHandler: ConfigHandler,
-    private readonly ide: IDE,
+    private readonly ide: VsCodeIde,
     private readonly webviewProtocol: VsCodeWebviewProtocol,
   ) {
+    this.recentlyEditedTracker = new RecentlyEditedTracker(ide.ideUtils);
+
     async function getAutocompleteModel() {
       const { config } = await configHandler.loadConfig();
       if (!config) {

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -570,13 +570,14 @@ const getCommandsMap: (
           for await (const fileUri of walkDirAsync(uri.toString(), ide, {
             source: "vscode continue.selectFilesAsContext command",
           })) {
-            addEntireFileToContext(
+            await addEntireFileToContext(
               vscode.Uri.parse(fileUri),
               sidebar.webviewProtocol,
+              ide.ideUtils
             );
           }
         } else {
-          addEntireFileToContext(uri, sidebar.webviewProtocol);
+          await addEntireFileToContext(uri, sidebar.webviewProtocol, ide.ideUtils);
         }
       }
     },

--- a/extensions/vscode/src/util/addCode.ts
+++ b/extensions/vscode/src/util/addCode.ts
@@ -1,6 +1,10 @@
-import { RangeInFileWithContents } from "core";
 import * as os from "node:os";
+
+import { RangeInFileWithContents } from "core";
 import * as vscode from "vscode";
+
+import { VsCodeIdeUtils } from "./ideUtils";
+
 import type { VsCodeWebviewProtocol } from "../webviewProtocol";
 
 export function getRangeInFileWithContents(
@@ -85,16 +89,18 @@ export async function addHighlightedCodeToContext(
 export async function addEntireFileToContext(
   uri: vscode.Uri,
   webviewProtocol: VsCodeWebviewProtocol | undefined,
+  ideUtils: VsCodeIdeUtils
 ) {
   // If a directory, add all files in the directory
-  const stat = await vscode.workspace.fs.stat(uri);
-  if (stat.type === vscode.FileType.Directory) {
-    const files = await vscode.workspace.fs.readDirectory(uri);
+  const stat = await ideUtils.stat(uri);
+  if (stat?.type === vscode.FileType.Directory) {
+    const files = (await ideUtils.readDirectory(uri))!;//files can't be null if we reached this point
     for (const [filename, type] of files) {
       if (type === vscode.FileType.File) {
         addEntireFileToContext(
           vscode.Uri.joinPath(uri, filename),
           webviewProtocol,
+          ideUtils
         );
       }
     }

--- a/extensions/vscode/src/util/ideUtils.ts
+++ b/extensions/vscode/src/util/ideUtils.ts
@@ -1,7 +1,9 @@
 import { EXTENSION_NAME } from "core/control-plane/env";
+import { findUriInDirs } from "core/util/uri";
 import _ from "lodash";
-import * as vscode from "vscode";
 import * as URI from "uri-js";
+import * as vscode from "vscode";
+
 import { threadStopped } from "../debug/debug";
 import { VsCodeExtension } from "../extension/VsCodeExtension";
 import { GitExtension, Repository } from "../otherExtensions/git";
@@ -14,11 +16,13 @@ import {
 
 import { getUniqueId, openEditorAndRevealRange } from "./vscode";
 
-import type { Range, RangeInFile, Thread } from "core";
-import { findUriInDirs } from "core/util/uri";
+import type { Range, Thread } from "core";
 
 const util = require("node:util");
 const asyncExec = util.promisify(require("node:child_process").exec);
+
+const NO_FS_PROVIDER_ERROR = "ENOPRO";
+const UNSUPPORTED_SCHEMES: Set<string> = new Set();
 
 export class VsCodeIdeUtils {
   visibleMessages: Set<string> = new Set();
@@ -99,10 +103,111 @@ export class VsCodeIdeUtils {
 
   async fileExists(uri: vscode.Uri): Promise<boolean> {
     try {
-      await vscode.workspace.fs.stat(uri);
-      return true;
+      return (await this.stat(uri)) !== null;
     } catch {
       return false;
+    }
+  }
+
+  /**
+   * Read the entire contents of a file from the given URI.
+   *
+   * @param uri - The URI of the file to read.
+   * @param ignoreMissingProviders - Optional flag to ignore missing file system providers for unsupported schemes.
+   *                                 Defaults to `true`.
+   * @returns A promise that resolves to the file content as a `Uint8Array`, or `null` if the scheme is unsupported
+   *          or the provider is missing and `ignoreMissingProviders` is `true`.
+   *          If `ignoreMissingProviders` is `false`, it will throw an error for unsupported schemes or missing providers.
+   * @throws Will rethrow any error that is not related to missing providers or unsupported schemes.
+   */
+  async readFile(
+    uri: vscode.Uri,
+    ignoreMissingProviders: boolean = true,
+  ): Promise<Uint8Array | null> {
+    return await this.fsOperation(
+      uri,
+      async (u) => {
+        return await vscode.workspace.fs.readFile(u);
+      },
+      ignoreMissingProviders,
+    );
+  }
+
+  /**
+   * Retrieve metadata about a file from the given URI.
+   *
+   * @param uri - The URI of the file or directory to retrieve metadata about.
+   * @param ignoreMissingProviders - Optional. If `true`, missing file system providers will be ignored. Defaults to `true`.
+   * @returns A promise that resolves to a `vscode.FileStat` object containing the file metadata,
+   *          or `null` if the scheme is unsupported or the provider is missing and `ignoreMissingProviders` is `true`.
+   */
+  async stat(
+    uri: vscode.Uri,
+    ignoreMissingProviders: boolean = true,
+  ): Promise<vscode.FileStat | null> {
+    return await this.fsOperation(
+      uri,
+      async (u) => {
+        return await vscode.workspace.fs.stat(uri);
+      },
+      ignoreMissingProviders,
+    );
+  }
+
+  /**
+   * Retrieve all entries of a directory from the given URI.
+   *
+   * @param uri - The URI of the directory to read.
+   * @param ignoreMissingProviders - Optional. If `true`, missing file system providers will be ignored. Defaults to `true`.
+   * @returns A promise that resolves to an array of tuples, where each tuple contains the name of a directory entry
+   *          and its type (`vscode.FileType`), or `null` if the scheme is unsupported or the provider is missing and `ignoreMissingProviders` is `true`.
+   */
+  async readDirectory(
+    uri: vscode.Uri,
+    ignoreMissingProviders: boolean = true,
+  ): Promise<[string, vscode.FileType][] | null> {
+    return await this.fsOperation(
+      uri,
+      async (u) => {
+        return await vscode.workspace.fs.readDirectory(uri);
+      },
+      ignoreMissingProviders,
+    );
+  }
+
+  /**
+   * Performs a file system operation on the given URI using the provided delegate function.
+   *
+   * @template T The type of the result returned by the delegate function.
+   * @param uri The URI on which the file system operation is to be performed.
+   * @param delegate A function that performs the desired operation on the given URI.
+   * @param ignoreMissingProviders Whether to ignore errors caused by missing file system providers. Defaults to `true`.
+   * @returns A promise that resolves to the result of the delegate function, or `null` if the operation is skipped due to unsupported schemes or missing providers.
+   * @throws Re-throws any error encountered during the operation, except for missing provider errors when `ignoreMissingProviders` is `true`.
+   */
+  private async fsOperation<T>(
+    uri: vscode.Uri,
+    delegate: (uri: vscode.Uri) => T,
+    ignoreMissingProviders: boolean = true,
+  ): Promise<T | null> {
+    const scheme = uri.scheme;
+    if (ignoreMissingProviders && UNSUPPORTED_SCHEMES.has(scheme)) {
+      return null;
+    }
+    try {
+      return await delegate(uri);
+    } catch (err: any) {
+      if (
+        ignoreMissingProviders &&
+        //see https://github.com/microsoft/vscode/blob/c9c54f9e775e5f57d97bef796797b5bc670c8150/src/vs/workbench/api/common/extHostFileSystemConsumer.ts#L230
+        (err.name === NO_FS_PROVIDER_ERROR ||
+          err.message?.includes(NO_FS_PROVIDER_ERROR))
+      ) {
+        UNSUPPORTED_SCHEMES.add(scheme);
+        console.log(`Ignoring missing provider error:`, err.message);
+        return null;
+      }
+      throw err;
     }
   }
 
@@ -185,9 +290,11 @@ export class VsCodeIdeUtils {
   }
 
   async readRangeInFile(uri: vscode.Uri, range: vscode.Range): Promise<string> {
-    const contents = new TextDecoder().decode(
-      await vscode.workspace.fs.readFile(uri),
-    );
+    const buffer = await this.readFile(uri);
+    if (buffer === null) {
+      return '';
+    }
+    const contents = new TextDecoder().decode(buffer);
     const lines = contents.split("\n");
     return `${lines
       .slice(range.start.line, range.end.line)


### PR DESCRIPTION
## Description

vscode-java uses a custom URI scheme, `jdt`, to represent binary class files. However it only provides a TextDocumentProvider so `jdt://` URIS can be opened as documents. Because vscode-java doesn't (yet) provide a FileSystem provider, vscode.workspace.fs.readFile calls throw an ugly exception:

> ENOPRO: No file system provider found for resource 'jdt://contents/java.base/java.lang/String.class?%3Ddemogorgon%2F%5C%2FUsers%5C%2Ffbricon%5C%2F.sdkman%5C%2Fcandidates%5C%2Fjava%5C%2F21.0.2-tem%5C%2Flib%5C%2Fjrt-fs.jar%60java.base%3D%2Fjavadoc_location%3D%2Fhttps%3A%5C%2F%5C%2Fdocs.oracle.com%5C%2Fen%5C%2Fjava%5C%2Fjavase%5C%2F21%5C%2Fdocs%5C%2Fapi%5C%2F%3D%2F%3D%2Fmaven.pomderived%3D%2Ftrue%3D%2F%3Cjava.lang%28String.class' 

Continue ends up handling these URIs most likely after performing some LSP calls that reach the Java language server.

The fix should be 2-fold:
- have vscode-java [provide a proper FileSystemProvider for the `jdt` scheme](https://github.com/redhat-developer/vscode-java/issues/4038), but that's gonna take some time (Hi @rgrunber)
- make Continue immune to such ENOPRO errors, which this PR tries to address.

Basically, the idea is to centralize all vscode.workspace.fs.readFile calls in one place, and intercept/ignore such ENOPRO errors, then ignore known problematic schemes in subsequent calls. 
~~Caveat: Similar calls to vscode.workspace.fs.stat and vscode.workspace.fs.readDirectory might be affected as well but I haven't seen it in the wild, so I didn't do anything there.~~ [done]

Fixes #4903, #3795, #5226

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Testing instructions

Open a Java project and try to complete in a java  file referencing external classes.
