### PR TITLE
Nate/remove-log

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -50,6 +50,6 @@
   "conventionalCommits.showNewVersionNotes": false,
   "conventionalCommits.promptBody": false,
   "conventionalCommits.promptFooter": false,
-  "conventionalCommits.promptScopes": false,
-  "conventionalCommits.scopes": []
+  "conventionalCommits.promptScopes": true,
+  "conventionalCommits.scopes": ["reg"]
 }

--- a/core/util/logger.ts
+++ b/core/util/logger.ts
@@ -7,7 +7,9 @@ export const logger = winston.createLogger({
   format: winston.format.json(),
   transports: [
     // Write all logs with importance level of `info` or higher to `info.log`
-    new winston.transports.File({ filename: "e2e.log", level: "info" }),
+    ...(process.env.NODE_ENV === "test"
+      ? [new winston.transports.File({ filename: "e2e.log", level: "info" })]
+      : []),
     // Normal console.log behavior
     new winston.transports.Console(),
   ],


### PR DESCRIPTION
## Description

This appears to only have happened in certain linux distros, but was causing a log file to be created when Continue reached certain log lines

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created