### PR TITLE
docs: fix minor reference.md typo

### DIFF
--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -19,7 +19,7 @@ from [the Hub](https://hub.continue.dev/explore/assistants) or locally
   - in your workspace in a `/.continue/assistants` folder, with the same naming convention
 
 :::info
-Config YAML replaces [`config.json`](./json-reference.md), which is deprecated. View the \* \*[Migration Guide](./yaml-migration.md)\*\*.
+Config YAML replaces [`config.json`](./json-reference.md), which is deprecated. View the **[Migration Guide](./yaml-migration.md)**.
 :::
 
 An assistant is made up of:


### PR DESCRIPTION
## Description

Fix minor bold markdown formatting.

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Testing instructions

**before**

![image](https://github.com/user-attachments/assets/af4424ae-4aed-4b84-9499-063713446887)

**after**
![image](https://github.com/user-attachments/assets/394533e4-4f33-41e4-99cd-1f6969a812ff)

