### PR TITLE
fix(files-context)-refresh-on-new-file-and-save

### DIFF
--- a/core/core.ts
+++ b/core/core.ts
@@ -735,6 +735,7 @@ export class Core {
         tool,
         toolCallId: toolCall.id,
         onPartialOutput,
+        core: this, // Add a reference to the Core instance
       });
     });
 
@@ -1075,7 +1076,7 @@ export class Core {
     this.indexingCancellationController = undefined;
   }
 
-  private async refreshCodebaseIndexFiles(files: string[]) {
+  async refreshCodebaseIndexFiles(files: string[]) {
     // Can be cancelled by codebase index but not vice versa
     if (
       this.indexingCancellationController &&
@@ -1103,7 +1104,7 @@ export class Core {
     }
 
     this.messenger.send("refreshSubmenuItems", {
-      providers: "dependsOnIndexing",
+      providers: "all",
     });
     this.indexingCancellationController = undefined;
   }

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -6,6 +6,7 @@ import {
 import Parser from "web-tree-sitter";
 import { LLMConfigurationStatuses } from "./llm/constants";
 import { GetGhTokenArgs } from "./protocol/ide";
+import { Core } from "./core";
 
 declare global {
   interface Window {
@@ -972,6 +973,7 @@ export interface ToolExtras {
     toolCallId: string;
     contextItems: ContextItem[];
   }) => void;
+  core?: Core; // Reference to the Core instance
 }
 
 export interface Tool {

--- a/core/tools/implementations/createNewFile.ts
+++ b/core/tools/implementations/createNewFile.ts
@@ -17,6 +17,10 @@ export const createNewFileImpl: ToolImpl = async (args, extras) => {
     }
     await extras.ide.writeFile(resolvedFileUri, args.contents);
     await extras.ide.openFile(resolvedFileUri);
+    await extras.ide.saveFile(resolvedFileUri);
+    if (extras.core) {
+      await extras.core.refreshCodebaseIndexFiles([resolvedFileUri]);
+    }
     return [
       {
         name: getUriPathBasename(resolvedFileUri),


### PR DESCRIPTION
## Description

* Traced the refreshes happening when new files are created and saved in the vscode UI. Noted that based on the parameter being sent to refresh the context certain contexts were being ignored noting they needed to wait for indexing to occur, but indexing was already performed before the call so I believe this was in error.
* Updated the create file tool to also make a call into refreshing the indexes.

TODO (Recommend a separate PR):

* Could also solve for adding a file watcher to the workspace to detect changes that might be caused by the terminal tool, or made through running scripts and via that hook update the index, and the contexts.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Testing instructions

New File in VsCode
1. Create a new file in the VsCode UI, and save it.
2. Validate the file now shows up in the @files context.

In Agent Mode
1. Ask for a new file to be created.
2. Validate the file now shows up the @files context.


