### PR TITLE
fix: wait for permissions before initializing messenger

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessenger.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessenger.kt
@@ -83,9 +83,9 @@ class CoreMessenger(
     private fun setPermissions(destination: String) {
         val osName = System.getProperty("os.name").toLowerCase()
         if (osName.contains("mac") || osName.contains("darwin")) {
-            ProcessBuilder("xattr", "-dr", "com.apple.quarantine", destination).start()
+            ProcessBuilder("xattr", "-dr", "com.apple.quarantine", destination).start().waitFor()
             setFilePermissions(destination, "rwxr-xr-x")
-        } else if (osName.contains("nix") || osName.contains("nux") || osName.contains("mac")) {
+        } else if (osName.contains("nix") || osName.contains("nux")) {
             setFilePermissions(destination, "rwxr-xr-x")
         }
     }
@@ -146,9 +146,11 @@ class CoreMessenger(
                 e.printStackTrace()
             }
         } else {
-            // Set proper permissions
-            coroutineScope.launch(Dispatchers.IO) { setPermissions(continueCorePath) }
-
+            // Set proper permissions synchronously
+            runBlocking(Dispatchers.IO) {
+                setPermissions(continueCorePath)
+            }
+            
             // Start the subprocess
             val processBuilder =
                 ProcessBuilder(continueCorePath).directory(File(continueCorePath).parentFile)


### PR DESCRIPTION
## Description

fix: wait for permissions before initializing messenger

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed an issue where the messenger could start before file permissions were set, which could cause errors on some systems.

- **Bug Fixes**
  - Now waits for permissions to be set before initializing the messenger process.

<!-- End of auto-generated description by mrge. -->

