### PR TITLE
 handle `data:[DONE]` without space properly

### DIFF
--- a/core/llm/stream.test.ts
+++ b/core/llm/stream.test.ts
@@ -1,0 +1,29 @@
+import { parseSseLine } from "./stream";
+
+// Jest unit tests
+describe('parseSseLine', () => {
+    it('should return done:true and data:undefined for line starting with "data:[DONE]"', () => {
+      const result = parseSseLine('data:[DONE]');
+      expect(result).toEqual({ done: true, data: undefined });
+    });
+
+    it('should return done:true and data:undefined for line starting with "data: [DONE]"', () => {
+      const result = parseSseLine('data: [DONE]');
+      expect(result).toEqual({ done: true, data: undefined });
+    });
+
+    it('should return done:false and parsed data for line starting with "data:"', () => {
+      const result = parseSseLine('data:Hello World');
+      expect(result).toEqual({ done: false, data: 'Hello World' });
+    });
+
+    it('should return done:true and data:undefined for line starting with ": ping"', () => {
+      const result = parseSseLine(': ping');
+      expect(result).toEqual({ done: true, data: undefined });
+    });
+
+    it('should return done:false and data:undefined for line not starting with specific prefixes', () => {
+      const result = parseSseLine('random line');
+      expect(result).toEqual({ done: false, data: undefined });
+    });
+  });

--- a/core/llm/stream.ts
+++ b/core/llm/stream.ts
@@ -58,7 +58,7 @@ function parseDataLine(line: string): any {
 }
 
 function parseSseLine(line: string): { done: boolean; data: any } {
-  if (line.startsWith("data: [DONE]")) {
+  if (line.startsWith("data:[DONE]") || line.startsWith("data: [DONE]")) {
     return { done: true, data: undefined };
   }
   if (line.startsWith("data:")) {

--- a/packages/fetch/src/stream.ts
+++ b/packages/fetch/src/stream.ts
@@ -58,7 +58,7 @@ function parseDataLine(line: string): any {
 }
 
 function parseSseLine(line: string): { done: boolean; data: any } {
-  if (line.startsWith("data: [DONE]")) {
+  if (line.startsWith("data:[DONE]") || line.startsWith("data: [DONE]")) {
     return { done: true, data: undefined };
   }
   if (line.startsWith("data:")) {


### PR DESCRIPTION
although https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#request-body says

>stream    boolean    Whether to stream back partial progress. If set, tokens will be sent as data-only server-sent events as they become available, with the stream terminated by a data: [DONE] message

but what I see is `data:[DONE]` (without space), e.g.

```
curl -q --location 'http://localhost:8080/openai/deployments/gpt-4o/chat/completions?api-version=2023-07-01-preview' \
--header 'Authorization: Bearer <token>' \
--header 'X-Forwarded-Client-Cert: secret' \
--header 'Content-Type: application/json' \
--data '{
    "stream": true,
    "messages": [
        {
            "role": "user",
            "content": "hello."
        }
    ]
}'
data:{"choices":[],"created":0,"id":"","model":"","object":"","prompt_filter_results":[{"prompt_index":0,"content_filter_results":{"hate":{"filtered":false,"severity":"safe"},"self_harm":{"filtered":false,"severity":"safe"},"sexual":{"filtered":false,"severity":"safe"},"violence":{"filtered":false,"severity":"safe"}}}]}

data:{"choices":[{"content_filter_results":{},"delta":{"refusal":null,"role":"assistant"},"finish_reason":null,"index":0}],"created":1746741184,"id":"chatcmpl-BV3SqfEtCuk3f8fW5x7azEkELkJZ0","model":"gpt-4o-2024-05-13","object":"chat.completion.chunk","system_fingerprint":"fp_ee1d74bde0"}
...
data:{"choices":[{"content_filter_results":{"hate":{"filtered":false,"severity":"safe"},"self_harm":{"filtered":false,"severity":"safe"},"sexual":{"filtered":false,"severity":"safe"},"violence":{"filtered":false,"severity":"safe"}},"delta":{"content":"?"},"finish_reason":null,"index":0}],"created":1746741184,"id":"chatcmpl-BV3SqfEtCuk3f8fW5x7azEkELkJZ0","model":"gpt-4o-2024-05-13","object":"chat.completion.chunk","system_fingerprint":"fp_ee1d74bde0"}

data:{"choices":[{"content_filter_results":{},"delta":{},"finish_reason":"stop","index":0}],"created":1746741184,"id":"chatcmpl-BV3SqfEtCuk3f8fW5x7azEkELkJZ0","model":"gpt-4o-2024-05-13","object":"chat.completion.chunk","system_fingerprint":"fp_ee1d74bde0"}

data:[DONE]
```

## Description

handle the last chunk of AzureOpenAI streaming chat completion response more robustly.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed parsing of server-sent events to handle both "data:[DONE]" (no space) and "data: [DONE]" (with space) as valid stream end markers.

<!-- End of auto-generated description by mrge. -->

