### PR TITLE
fix(diff-editor)-performance

### DIFF
--- a/extensions/vscode/src/diff/vertical/handler.ts
+++ b/extensions/vscode/src/diff/vertical/handler.ts
@@ -127,6 +127,11 @@ export class VerticalDiffHandler implements vscode.Disposable {
   private incrementCurrentLineIndex() {
     this.currentLineIndex++;
     this.updateIndexLineDecorations();
+    const range = new vscode.Range(this.currentLineIndex, 0, this.currentLineIndex, 0);
+    this.editor.revealRange(
+      range,
+      vscode.TextEditorRevealType.Default,
+    );
   }
 
   private async insertTextAboveLine(index: number, text: string) {
@@ -337,6 +342,12 @@ export class VerticalDiffHandler implements vscode.Disposable {
       await this.insertDeletionBuffer();
 
       await this.reapplyWithMyersDiff(diffLines);
+
+      const range = new vscode.Range(this.startLine, 0, this.startLine, 0);
+      this.editor.revealRange(
+        range,
+        vscode.TextEditorRevealType.Default,
+      );
 
       this.options.onStatusUpdate(
         "done",


### PR DESCRIPTION
## Description

When the diff editor was running in vscode it was frustrating that the progress would slowly start from the top of the file and make it's way to the bottom. Sometimes it felt like nothing was happening until the change cursor came into view.

I added code to change the focus in the editor depending on where the current edit is occuring. Interestingly this had the side effect of speeding the whole process up imensely for me. I'm curious if others see the same difference.

I also added code to push the viewport to the top of the file after all the edits are complete to give a visual indication that the process is done. Note, it might be better to focus the editor at the first diff but I didn't see an easy way to determine where that was without a more significant change.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Testing instructions

1. Ask for logging to be added to @test.js
2. Observe that after a bit of a wait the editing to the test.js file starts
3. Note that the current line displayed in the editor window follows the changes being made.
4. Observe the speed of applying those edits seems to be significantly improved. (side effect?)
