### PR TITLE
feat: manual ripgrep downloads for JB

### DIFF
--- a/binary/package-lock.json
+++ b/binary/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@octokit/rest": "^20.0.2",
+        "adm-zip": "^0.5.16",
         "commander": "^12.0.0",
         "core": "file:../core",
         "follow-redirects": "^1.15.5",
@@ -18,6 +19,7 @@
         "node-fetch": "^3.3.2",
         "posthog-node": "^3.6.3",
         "system-ca": "^1.0.2",
+        "tar": "^7.4.3",
         "uuid": "^9.0.1",
         "vectordb": "^0.4.20",
         "win-ca": "^3.5.1"
@@ -49,7 +51,7 @@
         "@aws-sdk/credential-providers": "^3.778.0",
         "@continuedev/config-types": "^1.0.13",
         "@continuedev/config-yaml": "file:../packages/config-yaml",
-        "@continuedev/fetch": "^1.0.4",
+        "@continuedev/fetch": "^1.0.6",
         "@continuedev/llm-info": "^1.0.8",
         "@continuedev/openai-adapters": "^1.0.19",
         "@modelcontextprotocol/sdk": "^1.5.0",
@@ -1526,6 +1528,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -2432,6 +2446,15 @@
       "dev": true,
       "bin": {
         "ncc": "dist/ncc/cli.js"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/agent-base": {
@@ -5222,12 +5245,39 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.1.tgz",
-      "integrity": "sha512-UZ7eQ+h8ywIRAW1hIEl2AqdwzJucU/Kp59+8kkZeSvafXhZjul247BvIJjEVFVeON6d7lM46XX1HXCduKAS8VA==",
-      "dev": true,
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
+      "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -5340,6 +5390,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -6410,6 +6461,23 @@
         "node": ">=12.17"
       }
     },
+    "node_modules/tar": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
+      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.0.1",
+        "mkdirp": "^3.0.1",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
@@ -6451,6 +6519,24 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/tar/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/test-exclude": {

--- a/binary/package.json
+++ b/binary/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@octokit/rest": "^20.0.2",
+    "adm-zip": "^0.5.16",
     "commander": "^12.0.0",
     "core": "file:../core",
     "follow-redirects": "^1.15.5",
@@ -50,6 +51,7 @@
     "node-fetch": "^3.3.2",
     "posthog-node": "^3.6.3",
     "system-ca": "^1.0.2",
+    "tar": "^7.4.3",
     "uuid": "^9.0.1",
     "vectordb": "^0.4.20",
     "win-ca": "^3.5.1"

--- a/binary/utils/ripgrep.js
+++ b/binary/utils/ripgrep.js
@@ -1,0 +1,122 @@
+const fs = require("fs");
+const path = require("path");
+const { rimrafSync } = require("rimraf");
+const tar = require("tar");
+const { RIPGREP_VERSION, TARGET_TO_RIPGREP_RELEASE } = require("./targets");
+const AdmZip = require("adm-zip");
+
+const RIPGREP_BASE_URL = `https://github.com/BurntSushi/ripgrep/releases/download/${RIPGREP_VERSION}`;
+
+// Mapping from our target triplets to ripgrep release file names is now imported from targets.js
+
+/**
+ * Downloads a file from a URL to a specified path
+ *
+ * @param {string} url - The URL to download from
+ * @param {string} destPath - The destination path for the downloaded file
+ * @returns {Promise<void>}
+ */
+async function downloadFile(url, destPath) {
+  // Use the built-in fetch API instead of node-fetch
+  const response = await fetch(url, {
+    redirect: "follow", // Automatically follow redirects
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to download file, status code: ${response.status}`);
+  }
+
+  // Get the response as an array buffer and write it to the file
+  const buffer = await response.arrayBuffer();
+  fs.writeFileSync(destPath, Buffer.from(buffer));
+}
+
+/**
+ * Extracts an archive to a specified directory
+ *
+ * @param {string} archivePath - Path to the archive file
+ * @param {string} targetDir - Directory to extract the archive to
+ * @param {string} platform - Platform identifier (e.g., 'darwin', 'linux', 'win32')
+ * @returns {Promise<void>}
+ */
+async function extractArchive(archivePath, targetDir, platform) {
+  if (platform === "win32" || archivePath.endsWith(".zip")) {
+    // Simple zip extraction for Windows - extract rg.exe
+    const zip = new AdmZip(archivePath);
+
+    const rgEntry = zip
+      .getEntries()
+      .find((entry) => entry.entryName.endsWith("rg.exe"));
+
+    if (!rgEntry) {
+      throw new Error("Could not find rg.exe in the downloaded archive");
+    }
+
+    // Extract the found rg.exe file to the target directory
+    const entryData = rgEntry.getData();
+    fs.writeFileSync(path.join(targetDir, "rg.exe"), entryData);
+  } else {
+    await tar.extract({
+      file: archivePath,
+      cwd: targetDir,
+      strip: 1, // Strip the top-level directory
+      filter: (path) => path.endsWith("/rg"),
+    });
+  }
+}
+/**
+ * Downloads and installs ripgrep for the specified target
+ *
+ * @param {string} target - Target platform-arch (e.g., 'darwin-x64')
+ * @param {string} targetDir - Directory to install ripgrep to
+ * @returns {Promise<string>} - Path to the installed ripgrep binary
+ */
+async function downloadRipgrep(target, targetDir) {
+  // Get the ripgrep release file name for the target
+  const releaseFile = TARGET_TO_RIPGREP_RELEASE[target];
+  if (!releaseFile) {
+    throw new Error(`Unsupported target: ${target}`);
+  }
+
+  const platform = target.split("-")[0];
+  const downloadUrl = `${RIPGREP_BASE_URL}/${releaseFile}`;
+  const tempDir = path.join(targetDir, "temp");
+
+  // Create temp directory
+  fs.mkdirSync(tempDir, { recursive: true });
+
+  const archivePath = path.join(tempDir, releaseFile);
+
+  try {
+    // Download the ripgrep release
+    console.log(`[info] Downloading ripgrep from ${downloadUrl}`);
+    await downloadFile(downloadUrl, archivePath);
+
+    // Extract the archive
+    console.log(`[info] Extracting ripgrep to ${targetDir}`);
+    await extractArchive(archivePath, targetDir, platform);
+
+    // Make the binary executable on Unix-like systems
+    if (platform !== "win32") {
+      const rgPath = path.join(targetDir, "rg");
+      fs.chmodSync(rgPath, 0o755);
+    }
+
+    // Clean up
+    rimrafSync(tempDir);
+
+    // Return the path to the ripgrep binary
+    const binName = platform === "win32" ? "rg.exe" : "rg";
+    return path.join(targetDir, binName);
+  } catch (error) {
+    console.error(`[error] Failed to download ripgrep for ${target}:`, error);
+    // Clean up temp directory on error
+    rimrafSync(tempDir);
+    throw error;
+  }
+}
+
+module.exports = {
+  downloadRipgrep,
+  RIPGREP_VERSION,
+};

--- a/binary/utils/ripgrep.js
+++ b/binary/utils/ripgrep.js
@@ -7,8 +7,6 @@ const AdmZip = require("adm-zip");
 
 const RIPGREP_BASE_URL = `https://github.com/BurntSushi/ripgrep/releases/download/${RIPGREP_VERSION}`;
 
-// Mapping from our target triplets to ripgrep release file names is now imported from targets.js
-
 /**
  * Downloads a file from a URL to a specified path
  *

--- a/binary/utils/targets.js
+++ b/binary/utils/targets.js
@@ -1,0 +1,42 @@
+const RIPGREP_VERSION = "14.1.1";
+
+/**
+ * All supported platform-architecture targets
+ */
+const ALL_TARGETS = [
+  "darwin-x64",
+  "darwin-arm64",
+  "linux-x64",
+  "linux-arm64",
+  "win32-x64",
+];
+
+/**
+ * Mapping from target triplets to ripgrep release file names
+ */
+const TARGET_TO_RIPGREP_RELEASE = {
+  "darwin-x64": `ripgrep-${RIPGREP_VERSION}-x86_64-apple-darwin.tar.gz`,
+  "darwin-arm64": `ripgrep-${RIPGREP_VERSION}-aarch64-apple-darwin.tar.gz`,
+  "linux-x64": `ripgrep-${RIPGREP_VERSION}-x86_64-unknown-linux-musl.tar.gz`,
+  "linux-arm64": `ripgrep-${RIPGREP_VERSION}-aarch64-unknown-linux-gnu.tar.gz`,
+  "win32-x64": `ripgrep-${RIPGREP_VERSION}-x86_64-pc-windows-msvc.zip`,
+};
+
+/**
+ * Mapping from target triplets to LanceDB package names
+ */
+const TARGET_TO_LANCEDB = {
+  "darwin-arm64": "@lancedb/vectordb-darwin-arm64",
+  "darwin-x64": "@lancedb/vectordb-darwin-x64",
+  "linux-arm64": "@lancedb/vectordb-linux-arm64-gnu",
+  "linux-x64": "@lancedb/vectordb-linux-x64-gnu",
+  "win32-x64": "@lancedb/vectordb-win32-x64-msvc",
+  "win32-arm64": "@lancedb/vectordb-win32-arm64-msvc",
+};
+
+module.exports = {
+  ALL_TARGETS,
+  TARGET_TO_RIPGREP_RELEASE,
+  TARGET_TO_LANCEDB,
+  RIPGREP_VERSION,
+};

--- a/extensions/intellij/build.gradle.kts
+++ b/extensions/intellij/build.gradle.kts
@@ -6,7 +6,6 @@ fun environment(key: String) = providers.environmentVariable(key)
 
 fun Sync.prepareSandbox() {
     from("../../binary/bin") { into("${intellij.pluginName.get()}/core/") }
-    from("../vscode/node_modules/@vscode/ripgrep") { into("${intellij.pluginName.get()}/ripgrep/") }
 }
 
 val remoteRobotVersion = "0.11.23"

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/PluginConstants.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/PluginConstants.kt
@@ -3,7 +3,7 @@ package com.github.continuedev.continueintellijextension.constants
 /**
  * Constants related to the Continue plugin.
  */
-object PluginConstants {
+object ContinueConstants {
     /**
      * The unique identifier for the Continue plugin.
      */

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/PluginConstants.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/PluginConstants.kt
@@ -1,0 +1,11 @@
+package com.github.continuedev.continueintellijextension.constants
+
+/**
+ * Constants related to the Continue plugin.
+ */
+object PluginConstants {
+    /**
+     * The unique identifier for the Continue plugin.
+     */
+    const val PLUGIN_ID = "com.github.continuedev.continueintellijextension"
+}

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessengerManager.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessengerManager.kt
@@ -2,12 +2,10 @@ package com.github.continuedev.continueintellijextension.`continue`
 
 import com.github.continuedev.continueintellijextension.services.TelemetryService
 import com.github.continuedev.continueintellijextension.utils.castNestedOrNull
+import com.github.continuedev.continueintellijextension.utils.getContinueBinaryPath
 import com.github.continuedev.continueintellijextension.utils.getMachineUniqueID
-import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.components.service
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
-import java.nio.file.Paths
 import kotlinx.coroutines.*
 
 class CoreMessengerManager(
@@ -21,38 +19,8 @@ class CoreMessengerManager(
 
     init {
         coroutineScope.launch {
-            val myPluginId = "com.github.continuedev.continueintellijextension"
-            val pluginDescriptor =
-                PluginManager.getPlugin(PluginId.getId(myPluginId)) ?: throw Exception("Plugin not found")
-
-            val pluginPath = pluginDescriptor.pluginPath
-            val osName = System.getProperty("os.name").toLowerCase()
-            val os =
-                when {
-                    osName.contains("mac") || osName.contains("darwin") -> "darwin"
-                    osName.contains("win") -> "win32"
-                    osName.contains("nix") || osName.contains("nux") || osName.contains("aix") -> "linux"
-                    else -> "linux"
-                }
-            val osArch = System.getProperty("os.arch").toLowerCase()
-            val arch =
-                when {
-                    osArch.contains("aarch64") || (osArch.contains("arm") && osArch.contains("64")) ->
-                        "arm64"
-
-                    osArch.contains("amd64") || osArch.contains("x86_64") -> "x64"
-                    else -> "x64"
-                }
-            val target = "$os-$arch"
-
-            println("Identified OS: $os, Arch: $arch")
-
-            val corePath = Paths.get(pluginPath.toString(), "core").toString()
-            val targetPath = Paths.get(corePath, target).toString()
-            val continueCorePath =
-                Paths.get(targetPath, "continue-binary" + (if (os == "win32") ".exe" else "")).toString()
-
-            setupCoreMessenger(continueCorePath)
+            val continueBinaryPath = getContinueBinaryPath()
+            setupCoreMessenger(continueBinaryPath)
         }
     }
 

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IntelliJIde.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IntelliJIde.kt
@@ -49,6 +49,21 @@ class IntelliJIDE(
 
     private val ripgrep: String = getRipgrepPath()
 
+    init {
+        try {
+            val os = getOS()
+            
+            if (os == OS.LINUX || os == OS.MAC) {
+                val file = File(ripgrep)
+                if (!file.canExecute()) {
+                    file.setExecutable(true)
+                }
+            }
+        } catch (e: Throwable) {
+            e.printStackTrace()
+        }
+    }
+
     /**
      * Updates the timestamp when a file is saved
      */

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IntelliJIde.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IntelliJIde.kt
@@ -1,5 +1,6 @@
 import com.github.continuedev.continueintellijextension.*
 import com.github.continuedev.continueintellijextension.constants.getContinueGlobalPath
+import com.github.continuedev.continueintellijextension.constants.PluginConstants
 import com.github.continuedev.continueintellijextension.`continue`.GitService
 import com.github.continuedev.continueintellijextension.services.ContinueExtensionSettings
 import com.github.continuedev.continueintellijextension.services.ContinuePluginService
@@ -46,31 +47,7 @@ class IntelliJIDE(
 
     private val gitService = GitService(project, continuePluginService)
 
-    private val ripgrep: String
-
-    init {
-        val myPluginId = "com.github.continuedev.continueintellijextension"
-        val pluginDescriptor =
-            PluginManager.getPlugin(PluginId.getId(myPluginId)) ?: throw Exception("Plugin not found")
-
-        val pluginPath = pluginDescriptor.pluginPath
-        val os = getOS()
-        ripgrep =
-            Paths.get(pluginPath.toString(), "ripgrep", "bin", "rg" + if (os == OS.WINDOWS) ".exe" else "").toString()
-
-        // Make ripgrep executable if on Unix-like systems
-        try {
-            if (os == OS.LINUX || os == OS.MAC) {
-                val file = File(ripgrep)
-                if (!file.canExecute()) {
-                    file.setExecutable(true)
-                }
-            }
-        } catch (e: Throwable) {
-            e.printStackTrace()
-        }
-
-    }
+    private val ripgrep: String = getRipgrepPath()
 
     /**
      * Updates the timestamp when a file is saved
@@ -91,7 +68,7 @@ class IntelliJIDE(
             remoteName = "ssh"
         }
 
-        val pluginId = "com.github.continuedev.continueintellijextension"
+        val pluginId = PluginConstants.PLUGIN_ID
         val plugin = PluginManagerCore.getPlugin(PluginId.getId(pluginId))
         val extensionVersion = plugin?.version ?: "Unknown"
 

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/utils/Paths.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/utils/Paths.kt
@@ -2,7 +2,7 @@ package com.github.continuedev.continueintellijextension.utils
 
 import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.extensions.PluginId
-import com.github.continuedev.continueintellijextension.constants.PluginConstants
+import com.github.continuedev.continueintellijextension.constants.ContinueConstants
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -14,7 +14,7 @@ import java.nio.file.Paths
  */
 fun getContinuePluginPath(): Path {
     val pluginDescriptor =
-        PluginManager.getPlugin(PluginId.getId(PluginConstants.PLUGIN_ID)) ?: throw Exception("Plugin not found")
+        PluginManager.getPlugin(PluginId.getId(ContinueConstants.PLUGIN_ID)) ?: throw Exception("Plugin not found")
     return pluginDescriptor.pluginPath
 }
 

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/utils/Paths.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/utils/Paths.kt
@@ -27,7 +27,7 @@ fun getContinuePluginPath(): Path {
 fun getContinueCorePath(): String {
     val pluginPath = getContinuePluginPath()
     val corePath = Paths.get(pluginPath.toString(), "core").toString()
-    val (_, _, target) = getOsAndArch()
+    val target = getOsAndArchTarget()
     return Paths.get(corePath, target).toString()
 }
 
@@ -39,8 +39,9 @@ fun getContinueCorePath(): String {
  */
 fun getContinueBinaryPath(): String {
     val targetPath = getContinueCorePath()
-    val (os, _, _) = getOsAndArch()
-    return Paths.get(targetPath, "continue-binary" + (if (os == "win32") ".exe" else "")).toString()
+    val os = getOS()
+    val exeSuffix = if (os == OS.WINDOWS) ".exe" else ""
+    return Paths.get(targetPath, "continue-binary$exeSuffix").toString()
 }
 
 /**
@@ -51,6 +52,7 @@ fun getContinueBinaryPath(): String {
  */
 fun getRipgrepPath(): String {
     val targetPath = getContinueCorePath()
-    val (os, _, _) = getOsAndArch()
-    return Paths.get(targetPath, "rg" + (if (os == "win32") ".exe" else "")).toString()
+    val os = getOS()
+    val exeSuffix = if (os == OS.WINDOWS) ".exe" else ""
+    return Paths.get(targetPath, "rg$exeSuffix").toString()
 }

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/utils/Paths.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/utils/Paths.kt
@@ -1,0 +1,56 @@
+package com.github.continuedev.continueintellijextension.utils
+
+import com.intellij.ide.plugins.PluginManager
+import com.intellij.openapi.extensions.PluginId
+import com.github.continuedev.continueintellijextension.constants.PluginConstants
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Gets the path to the Continue plugin directory
+ *
+ * @return Path to the plugin directory
+ * @throws Exception if the plugin is not found
+ */
+fun getContinuePluginPath(): Path {
+    val pluginDescriptor =
+        PluginManager.getPlugin(PluginId.getId(PluginConstants.PLUGIN_ID)) ?: throw Exception("Plugin not found")
+    return pluginDescriptor.pluginPath
+}
+
+/**
+ * Gets the path to the Continue core directory with target platform
+ *
+ * @return Path to the Continue core directory with target platform
+ * @throws Exception if the plugin is not found
+ */
+fun getContinueCorePath(): String {
+    val pluginPath = getContinuePluginPath()
+    val corePath = Paths.get(pluginPath.toString(), "core").toString()
+    val (_, _, target) = getOsAndArch()
+    return Paths.get(corePath, target).toString()
+}
+
+/**
+ * Gets the path to the Continue binary executable
+ *
+ * @return Path to the Continue binary executable
+ * @throws Exception if the plugin is not found
+ */
+fun getContinueBinaryPath(): String {
+    val targetPath = getContinueCorePath()
+    val (os, _, _) = getOsAndArch()
+    return Paths.get(targetPath, "continue-binary" + (if (os == "win32") ".exe" else "")).toString()
+}
+
+/**
+ * Gets the path to the Ripgrep executable
+ *
+ * @return Path to the Ripgrep executable
+ * @throws Exception if the plugin is not found
+ */
+fun getRipgrepPath(): String {
+    val targetPath = getContinueCorePath()
+    val (os, _, _) = getOsAndArch()
+    return Paths.get(targetPath, "rg" + (if (os == "win32") ".exe" else "")).toString()
+}

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/utils/Utils.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/utils/Utils.kt
@@ -94,20 +94,19 @@ fun Any?.getNestedOrNull(vararg keys: String): Any? {
 }
 
 /**
- * Get the OS and architecture as a string pair formatted for Continue binary.
+ * Get the target string for Continue binary.
  * The format is "$os-$arch" where:
  * - os is one of: darwin, win32, or linux
  * - arch is one of: arm64 or x64
  *
- * @return Triple of OS string, architecture string, and combined target string
+ * @return Target string in format "$os-$arch"
  */
-fun getOsAndArch(): Triple<String, String, String> {
-    val osName = System.getProperty("os.name").lowercase()
-    val os = when {
-        osName.contains("mac") || osName.contains("darwin") -> "darwin"
-        osName.contains("win") -> "win32"
-        osName.contains("nix") || osName.contains("nux") || osName.contains("aix") -> "linux"
-        else -> "linux"
+fun getOsAndArchTarget(): String {
+    val os = getOS()
+    val osStr = when (os) {
+        OS.MAC -> "darwin"
+        OS.WINDOWS -> "win32"
+        OS.LINUX -> "linux"
     }
 
     val osArch = System.getProperty("os.arch").lowercase()
@@ -117,7 +116,5 @@ fun getOsAndArch(): Triple<String, String, String> {
         else -> "x64"
     }
 
-    val target = "$os-$arch"
-
-    return Triple(os, arch, target)
+    return "$osStr-$arch"
 }

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/utils/Utils.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/utils/Utils.kt
@@ -4,7 +4,6 @@ import com.intellij.openapi.vfs.VirtualFile
 import java.net.NetworkInterface
 import java.util.*
 import java.awt.event.KeyEvent.*
-
 enum class OS {
     MAC, WINDOWS, LINUX
 }
@@ -92,4 +91,33 @@ fun Any?.getNestedOrNull(vararg keys: String): Any? {
         result = (result as? Map<*, *>)?.get(key) ?: return null
     }
     return result
+}
+
+/**
+ * Get the OS and architecture as a string pair formatted for Continue binary.
+ * The format is "$os-$arch" where:
+ * - os is one of: darwin, win32, or linux
+ * - arch is one of: arm64 or x64
+ *
+ * @return Triple of OS string, architecture string, and combined target string
+ */
+fun getOsAndArch(): Triple<String, String, String> {
+    val osName = System.getProperty("os.name").lowercase()
+    val os = when {
+        osName.contains("mac") || osName.contains("darwin") -> "darwin"
+        osName.contains("win") -> "win32"
+        osName.contains("nix") || osName.contains("nux") || osName.contains("aix") -> "linux"
+        else -> "linux"
+    }
+
+    val osArch = System.getProperty("os.arch").lowercase()
+    val arch = when {
+        osArch.contains("aarch64") || (osArch.contains("arm") && osArch.contains("64")) -> "arm64"
+        osArch.contains("amd64") || osArch.contains("x86_64") -> "x64"
+        else -> "x64"
+    }
+
+    val target = "$os-$arch"
+
+    return Triple(os, arch, target)
 }

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "1.1.31",
+  "version": "1.1.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "1.1.31",
+      "version": "1.1.32",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",

--- a/scripts/install-dependencies.ps1
+++ b/scripts/install-dependencies.ps1
@@ -76,6 +76,12 @@ if (($null -eq $node)) {
 Write-Host "`nInstalling root-level dependencies..." -ForegroundColor White
 npm install
 
+Write-Host "`nBuilding config-yaml..." -ForegroundColor White
+Push-Location packages/config-yaml
+npm install
+npm run build
+Pop-Location
+
 Write-Host "`nInstalling Core extension dependencies..." -ForegroundColor White
 Push-Location core
 npm install


### PR DESCRIPTION
## Description

Resolves https://github.com/continuedev/continue/issues/5542

This PR introduces a manual step in the build process for JetBrains to install `ripgrep` for the respective OS/arch.

In our VS Code build process, we don't need to do this because we run builds in CI on the appropriate runners for each OS/arch. But for JB, we need to upload a single zip that contains all the required deps for each OS/arch, so we only run on a single runner (`macOS-latest`), which then causes us to only install the ripgrep binary for that platform.
   
