### PR TITLE
fix test dirs being created inside core folder

### DIFF
--- a/core/test/testDir.ts
+++ b/core/test/testDir.ts
@@ -43,7 +43,7 @@ export function addToTestDir(pathsOrUris: (string | [string, string])[]) {
     if (Array.isArray(p)) {
       fs.writeFileSync(filepath, p[1]);
     } else if (p.endsWith("/")) {
-      fs.mkdirSync(p, { recursive: true });
+      fs.mkdirSync(filepath, { recursive: true });
     } else {
       fs.writeFileSync(filepath, "");
     }


### PR DESCRIPTION
## Description

Some test directories were being created in the current directory (in our case the `core` folder) instead of the os tmp dir.

This was happening because [we were using the relative file path](https://github.com/continuedev/continue/blob/ec0180bf95bf6c127e78db5d8b02e3f57b7814a0/core/test/testDir.ts/#L46) (instead of the appended os tmp dir). This PR fixes it

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

**before**
<img width="394" alt="Screenshot 2025-05-09 at 5 18 40 PM" src="https://github.com/user-attachments/assets/7c79528f-129d-402a-8fec-19ba595153ae" />


## Testing instructions

- cd into the core folder
- run `npm run test -- walkDir`
- see that test folders like `xyz` are created
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed test directories being created in the core folder instead of the system temp directory.

<!-- End of auto-generated description by mrge. -->

