### PR TITLE
error message when mcp arg has unsubstituted variable

### DIFF
--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -248,7 +248,7 @@ async function configYamlToContinueConfig(options: {
     if(mcpArgVariables.length === 0) return; 
     localErrors.push({
       fatal: false,
-      message: `MCP server "${mcpServer.name}" has unsubstituted variables in args: ${mcpArgVariables.join(", ")}`,
+      message: `MCP server "${mcpServer.name}" has unsubstituted variables in args: ${mcpArgVariables.join(", ")}. Please refer https://docs.continue.dev/hub/secrets/secret-types for managing hub secrets.`,
     });
   })
 

--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -9,6 +9,7 @@ import {
   PackageIdentifier,
   RegistryClient,
   Rule,
+  TEMPLATE_VAR_REGEX,
   unrollAssistant,
   validateConfigYaml,
 } from "@continuedev/config-yaml";
@@ -40,7 +41,6 @@ import { GlobalContext } from "../../util/GlobalContext";
 import { modifyAnyConfigWithSharedConfig } from "../sharedConfig";
 
 import { getControlPlaneEnvSync } from "../../control-plane/env";
-import { getMCPArgsWithVariables } from "../../util";
 import { logger } from "../../util/logger";
 import { getCleanUriPath } from "../../util/uri";
 import { getAllDotContinueYamlFiles } from "../loadLocalAssistants";
@@ -244,7 +244,7 @@ async function configYamlToContinueConfig(options: {
   }));
 
   config.mcpServers?.forEach(mcpServer => {
-    const mcpArgVariables = getMCPArgsWithVariables(mcpServer.args ?? []);
+    const mcpArgVariables = mcpServer.args?.filter(arg=> TEMPLATE_VAR_REGEX.test(arg)) ?? []
     if(mcpArgVariables.length === 0) return; 
     localErrors.push({
       fatal: false,

--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -243,14 +243,19 @@ async function configYamlToContinueConfig(options: {
     faviconUrl: doc.faviconUrl,
   }));
 
-  config.mcpServers?.forEach(mcpServer => {
-    const mcpArgVariables = mcpServer.args?.filter(arg=> TEMPLATE_VAR_REGEX.test(arg)) ?? []
-    if(mcpArgVariables.length === 0) return; 
+  config.mcpServers?.forEach((mcpServer) => {
+    const mcpArgVariables =
+      mcpServer.args?.filter((arg) => TEMPLATE_VAR_REGEX.test(arg)) ?? [];
+
+    if (mcpArgVariables.length === 0) {
+      return;
+    }
+
     localErrors.push({
       fatal: false,
-      message: `MCP server "${mcpServer.name}" has unsubstituted variables in args: ${mcpArgVariables.join(", ")}. Please refer https://docs.continue.dev/hub/secrets/secret-types for managing hub secrets.`,
+      message: `MCP server "${mcpServer.name}" has unsubstituted variables in args: ${mcpArgVariables.join(", ")}. Please refer to https://docs.continue.dev/hub/secrets/secret-types for managing hub secrets.`,
     });
-  })
+  });
 
   continueConfig.experimental = {
     modelContextProtocolServers: config.mcpServers?.map(
@@ -456,7 +461,7 @@ async function configYamlToContinueConfig(options: {
         args: [],
         ...server,
       },
-      timeout: server.connectionTimeout
+      timeout: server.connectionTimeout,
     })),
     false,
   );

--- a/core/util/index.ts
+++ b/core/util/index.ts
@@ -211,8 +211,3 @@ export function splitCamelCaseAndNonAlphaNumeric(value: string) {
     .filter(t => t.length > 0)
     .map(t => t.toLowerCase());
 }
-
-export function getMCPArgsWithVariables(args: string[]) {
-  const isVariableRegex = /\$\{\{ (.*?) \}\}/;
-  return args.filter((arg) => isVariableRegex.test(arg));
-}

--- a/core/util/index.ts
+++ b/core/util/index.ts
@@ -211,3 +211,8 @@ export function splitCamelCaseAndNonAlphaNumeric(value: string) {
     .filter(t => t.length > 0)
     .map(t => t.toLowerCase());
 }
+
+export function getMCPArgsWithVariables(args: string[]) {
+  const isVariableRegex = /\$\{\{ (.*?) \}\}/;
+  return args.filter((arg) => isVariableRegex.test(arg));
+}


### PR DESCRIPTION
## Description

Not substituted variables inside MCP args should show an error telling that it is missing or unsubstituted. This error should be shown for both hub and local variables. This helps narrows down the reason for the MCP connection error.

Using [this regex](https://regex101.com/r/TnGajR/1) we can check if args has an unsubstituted variable and show up in the errors section.

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

**before**
<img width="396" alt="Screenshot 2025-05-09 at 7 05 59 PM" src="https://github.com/user-attachments/assets/bf36b83c-5b4d-47c9-ba65-d23c7f568b1c" />

**after**
<img width="406" alt="Screenshot 2025-05-09 at 7 07 41 PM" src="https://github.com/user-attachments/assets/d21a80a1-5e3d-4a1d-8b6d-55ea37be0a18" />

## Testing instructions

1. go to local config.yaml
2. add an mcp server block
<details>
<summary>
for example like this one
</summary>
```yaml
- name: Filesystem
    command: npx
    args:
      - "-y"
      - "@modelcontextprotocol/server-filesystem"
      - "${{ inputs.PATH }}"
```
</details>
3. see that the errors section in the continue editor area says that the mcp variable is unsubstituted

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added an error message when an MCP server argument contains an unsubstituted variable, making it easier to spot missing or incorrect variables.

- **Bug Fixes**
  - Detects unsubstituted variables in MCP args and shows a clear error in the editor.

<!-- End of auto-generated description by mrge. -->

