### PR TITLE
Update default local models

### DIFF
--- a/core/config/onboarding.ts
+++ b/core/config/onboarding.ts
@@ -5,7 +5,7 @@ export const LOCAL_ONBOARDING_PROVIDER_TITLE = "Ollama";
 export const LOCAL_ONBOARDING_FIM_MODEL = "qwen2.5-coder:1.5b-base";
 export const LOCAL_ONBOARDING_FIM_TITLE = "Qwen2.5-Coder 1.5B";
 export const LOCAL_ONBOARDING_CHAT_MODEL = "qwen3:8b";
-export const LOCAL_ONBOARDING_CHAT_TITLE = "Qwen3 8B";
+export const LOCAL_ONBOARDING_CHAT_TITLE = "Qwen3-8B";
 export const LOCAL_ONBOARDING_EMBEDDINGS_MODEL = "nomic-embed-text:latest";
 export const LOCAL_ONBOARDING_EMBEDDINGS_TITLE = "Nomic Embed";
 

--- a/core/config/onboarding.ts
+++ b/core/config/onboarding.ts
@@ -4,8 +4,8 @@ export const TRIAL_FIM_MODEL = "codestral-latest";
 export const LOCAL_ONBOARDING_PROVIDER_TITLE = "Ollama";
 export const LOCAL_ONBOARDING_FIM_MODEL = "qwen2.5-coder:1.5b-base";
 export const LOCAL_ONBOARDING_FIM_TITLE = "Qwen2.5-Coder 1.5B";
-export const LOCAL_ONBOARDING_CHAT_MODEL = "llama3.1:8b";
-export const LOCAL_ONBOARDING_CHAT_TITLE = "Llama 3.1 8B";
+export const LOCAL_ONBOARDING_CHAT_MODEL = "qwen3:8b";
+export const LOCAL_ONBOARDING_CHAT_TITLE = "Qwen3 8B";
 export const LOCAL_ONBOARDING_EMBEDDINGS_MODEL = "nomic-embed-text:latest";
 export const LOCAL_ONBOARDING_EMBEDDINGS_TITLE = "Nomic Embed";
 


### PR DESCRIPTION
## Description

Update default local models

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Updated the default local chat model and title in onboarding to use Qwen3 8B instead of Llama 3.1 8B.

<!-- End of auto-generated description by mrge. -->

