### PR TITLE
Revert "Update default local models"

### DIFF
--- a/core/config/onboarding.ts
+++ b/core/config/onboarding.ts
@@ -4,8 +4,8 @@ export const TRIAL_FIM_MODEL = "codestral-latest";
 export const LOCAL_ONBOARDING_PROVIDER_TITLE = "Ollama";
 export const LOCAL_ONBOARDING_FIM_MODEL = "qwen2.5-coder:1.5b-base";
 export const LOCAL_ONBOARDING_FIM_TITLE = "Qwen2.5-Coder 1.5B";
-export const LOCAL_ONBOARDING_CHAT_MODEL = "qwen3:8b";
-export const LOCAL_ONBOARDING_CHAT_TITLE = "Qwen3-8B";
+export const LOCAL_ONBOARDING_CHAT_MODEL = "llama3.1:8b";
+export const LOCAL_ONBOARDING_CHAT_TITLE = "Llama 3.1 8B";
 export const LOCAL_ONBOARDING_EMBEDDINGS_MODEL = "nomic-embed-text:latest";
 export const LOCAL_ONBOARDING_EMBEDDINGS_TITLE = "Nomic Embed";
 


### PR DESCRIPTION
I tested Ollama 3.1 with tool use and Qwen 3 with tool use and Ollama 3.1 seems both faster and more stable when using tools. We should revert to Ollama 3.1.
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Reverted the default local chat model from Qwen3-8B back to Llama 3.1 8B for onboarding. This restores the previous model and title used in the onboarding config.

<!-- End of auto-generated description by mrge. -->

