### PR TITLE
docs: clarify local .env secret pull process for local assistants

### DIFF
--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -85,6 +85,12 @@ Blocks:
 You can find many examples of each of these block types on
 the [Continue Explore Page](https://hub.continue.dev/explore/models)
 
+:::info
+Local blocks utilizing mustache notation for secrets (`${{ secrets.SECRET_NAME }}`) can read secret values:
+- globally, from a `.env` located in the global `.continue` folder (`~/.continue/.env`)
+- per-workspace, from a `.env` file located at the root of the current workspace.
+:::
+
 ### Inputs
 
 Blocks can be passed user inputs, including hub secrets and raw text values. To create a block that has an input, use
@@ -111,7 +117,7 @@ models:
       TEMP: 0.9
 ```
 
-Note that hub secrets can be passed as inputs, using the a similar mustache format: `secrets.SECRET_NAME`.
+Note that hub secrets can be passed as inputs, using a similar mustache format: `secrets.SECRET_NAME`.
 
 ### Overrides
 


### PR DESCRIPTION
## Description

After exploring a bit about local assistants and blocks for testing prior to uploading changes to the Hub, I found that the [config.yaml Reference](https://docs.continue.dev/reference) page could benefit from an extra quick note around the behavior of `.env` files on the client machine.

There are no code changes made to the project. The only change is a minor markdown change in the form of a footnote on the `Introduction->Local Blocks` portion of the documentation, clarifying that local configurations using mustached `secrets.` notation can read those values from:

- A global `.env` file located at the root of the global `.continue` folder (from the logic in [`findSecretInLocalEnvFile`](https://github.com/continuedev/continue/blob/8b418165d9d4b67ad14e619c6b8cf33a38efc6ae/core/config/yaml/LocalPlatformClient.ts#L41))
- A workspace `.env` file located at the root of the current workspace (from the logic in [`findSecretInWorkspaceEnvFiles`](https://github.com/continuedev/continue/blob/8b418165d9d4b67ad14e619c6b8cf33a38efc6ae/core/config/yaml/LocalPlatformClient.ts#L53))

I have confirmed that this information is accurate for `v1.1.34-vscode`, with these locations acting as valid secrets sources for block configurations located in both the global `.continue` folder and the workspace `.continue` folder.

This fix also includes a minor typo fix for a subsequent piece of documentation about secrets in the `Introduction->Inputs` section.

I understand that your team's monetization is more in the cloud and team sync features than full local support, so I tried to keep this functionality footnote as straightforward as possible without biasing against the Hub features, as well as keeping this strictly to the Reference page rather than the `Hub->Secrets` page.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created (none required

## Screenshots

The change can be seen at the bottom of the Local Blocks portion of the `config.yaml` reference page:

<img width="800" alt="image" src="https://github.com/user-attachments/assets/f59b93ed-9c56-4406-8dfd-15c2ed127520" />

## Testing instructions

This change can be viewed via the documentation site serve process from the contributor's guide

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Clarified in the documentation how local assistants pull secret values from `.env` files, and fixed a minor typo in the secrets section.

- **Docs Update**
  - Added a note explaining that secrets can be read from a global `.env` in `~/.continue` or a workspace `.env` file.
  - Fixed a typo in the inputs section about hub secrets.

<!-- End of auto-generated description by mrge. -->

