### PR TITLE
:sparkles: add seed coder fim template

### DIFF
--- a/core/autocomplete/templating/AutocompleteTemplate.ts
+++ b/core/autocomplete/templating/AutocompleteTemplate.ts
@@ -71,6 +71,21 @@ const qwenCoderFimTemplate: AutocompleteTemplate = {
   },
 };
 
+const seedCoderFimTemplate: AutocompleteTemplate = {
+  template: "<[fim-prefix]>{{{prefix}}}<[fim-suffix]>{{{suffix}}}<[fim-middle]>",
+  completionOptions: {
+    stop: [
+      "<[end▁of▁sentence]>",
+      "<[fim-prefix]>",
+      "<[fim-middle]>",
+      "<[fim-suffix]>",
+      "<[PAD▁TOKEN]>",
+      "<[SEP▁TOKEN]>",
+      "<[begin▁of▁sentence]>",
+    ],
+  },
+};
+
 const codestralFimTemplate: AutocompleteTemplate = {
   template: "[SUFFIX]{{{suffix}}}[PREFIX]{{{prefix}}}",
   completionOptions: {
@@ -424,6 +439,10 @@ export function getTemplateForModel(model: string): AutocompleteTemplate {
 
   if (lowerCaseModel.includes("qwen") && lowerCaseModel.includes("coder")) {
     return qwenCoderFimTemplate;
+  }
+
+  if (lowerCaseModel.includes("seed") && lowerCaseModel.includes("coder")) {
+    return seedCoderFimTemplate;
   }
 
   if (


### PR DESCRIPTION
## Description

Add FIM template for [seed-coder](https://huggingface.co/ByteDance-Seed/Seed-Coder-8B-Base)

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)

## Testing instructions

1. compile the modified code and install it
2. run the [seed-coder-8b-base](https://huggingface.co/ByteDance-Seed/Seed-Coder-8B-Base)
3. in continue config.json, configure the model as *seed-coder*, or whatever name that includes both "seed" and "coder"
4. enable autocompletion, and enjoy the seed coder

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added a new FIM template for Seed Coder models to support autocompletion.

- **New Features**
  - Added template and stop tokens for models with "seed" and "coder" in the name.

<!-- End of auto-generated description by mrge. -->

