### PR TITLE
feat: :technologist: github workflow to measure issue/PR stats

### DIFF
--- a/.github/workflows/metrics.yaml
+++ b/.github/workflows/metrics.yaml
@@ -1,0 +1,46 @@
+name: Monthly issue metrics
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs every Monday at 9:00 AM PST (17:00 UTC)
+    - cron: "0 17 * * 1"
+
+  push:
+    branches:
+      - nate/metrics-action
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: issue metrics
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Get dates for last month
+        shell: bash
+        run: |
+          # Calculate the first day of the previous month
+          first_day=$(date -d "last month" +%Y-%m-01)
+
+          # Calculate the last day of the previous month
+          last_day=$(date -d "$first_day +1 month -1 day" +%Y-%m-%d)
+
+          #Set an environment variable with the date range
+          echo "$first_day..$last_day"
+          echo "last_month=$first_day..$last_day" >> "$GITHUB_ENV"
+
+      - name: Run issue-metrics tool
+        uses: github/issue-metrics@v3
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SEARCH_QUERY: 'repo:continuedev/continue created:${{ env.last_month }} -reason:"not planned"'
+
+      - name: Upload metrics report as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: issue-metrics-report
+          path: ./issue_metrics.md


### PR DESCRIPTION
## Description

GH Workflow to output stats around issue / PR responsiveness

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created