### PR TITLE
fix loading configs from project .continue folder in JetBrains IDEs on Windows (bug #5474)

### DIFF
--- a/packages/config-yaml/src/registryClient.test.ts
+++ b/packages/config-yaml/src/registryClient.test.ts
@@ -3,6 +3,7 @@ import * as http from "node:http";
 import { AddressInfo } from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
+import { pathToFileURL } from "url";
 import { PackageIdentifier } from "./interfaces/slugs.js";
 import { RegistryClient } from "./registryClient.js";
 
@@ -134,12 +135,18 @@ describe("RegistryClient", () => {
 
   describe("getContentFromFilePath", () => {
     let absoluteFilePath: string;
+    let fileUrl: string;
     let relativeFilePath: string;
 
     beforeEach(() => {
       // Create test files
       absoluteFilePath = path.join(tempDir, "absolute-path.yaml");
       fs.writeFileSync(absoluteFilePath, "absolute file content", "utf8");
+
+      const urlFilePath = path.join(tempDir, "file-url-path.yaml");
+      fs.writeFileSync(urlFilePath, "file:// file content", "utf8");
+      const url = pathToFileURL(urlFilePath);
+      fileUrl = url.toString();
 
       // Create a subdirectory and file in the temp directory
       const subDir = path.join(tempDir, "sub");
@@ -158,6 +165,14 @@ describe("RegistryClient", () => {
       const result = (client as any).getContentFromFilePath(absoluteFilePath);
 
       expect(result).toBe("absolute file content");
+    });
+
+    it("should read from local file url directly", () => {
+      const client = new RegistryClient();
+
+      const result = (client as any).getContentFromFilePath(fileUrl);
+
+      expect(result).toBe("file:// file content");
     });
 
     it("should use rootPath for relative paths when provided", () => {

--- a/packages/config-yaml/src/registryClient.ts
+++ b/packages/config-yaml/src/registryClient.ts
@@ -38,11 +38,9 @@ export class RegistryClient implements Registry {
 
   private getContentFromFilePath(filepath: string): string {
     if (filepath.startsWith("file://")) {
-      const pathWithoutProtocol = filepath.slice(7);
-
       // For Windows file:///C:/path/to/file, we need to handle it properly
       // On other systems, we might have file:///path/to/file
-      return fs.readFileSync(decodeURIComponent(pathWithoutProtocol), "utf8");
+      return fs.readFileSync(new URL(filepath), "utf8");
     } else if (path.isAbsolute(filepath)) {
       return fs.readFileSync(filepath, "utf8");
     } else if (this.rootPath) {


### PR DESCRIPTION
## Description

This pull reqest fixes bug in loading configs from project's `.continue` folder in JetBrains IDEs with messages in `core.log` `Failed to unroll block [object Object]: ENOENT: no such file or directory, open '/D:/Projects/test/.continue/models/new-model.yaml'` (bug #5474). Also it should fix other issues with access to local files by urls on Windows.

The problem arises from incorrect handling `file://` URLs in `RegistryClient.getContent` on Windows: function `getContentFromFilePath` simply removes `file://` prefix, while on Windows it is needed to remove third `/` as well. So for URL `file:///C:/path/to/file` it will try to read file `/C:/path/to/file` while right file path is `C:/path/to/file` (UNIX-syle slashes is acceptable for node.js).

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Testing instructions

#5474 is reproduced in any JetBrains IDE (I have tested in CLion and IntelliJ Community) on Windows: before this fix no yaml files worked from project's `.continue` folder.

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed loading configs from the .continue folder in JetBrains IDEs on Windows by correcting file:// URL handling.

- **Bug Fixes**
  - Fixed reading local config files with file:// URLs on Windows, resolving errors when opening YAML files in the .continue folder.

<!-- End of auto-generated description by mrge. -->

