### PR TITLE
fix: use `cmd` for windows MCP connections

### DIFF
--- a/core/context/mcp/MCPConnection.test.ts
+++ b/core/context/mcp/MCPConnection.test.ts
@@ -64,10 +64,10 @@ describe("MCPConnection", () => {
           url: "http://test.com/events",
           requestOptions: {
             headers: {
-              "Authorization": "Bearer token123",
-              "X-Custom-Header": "custom-value"
-            }
-          }
+              Authorization: "Bearer token123",
+              "X-Custom-Header": "custom-value",
+            },
+          },
         },
       };
 
@@ -172,7 +172,7 @@ describe("MCPConnection", () => {
       expect(mockConnect).toHaveBeenCalled();
     });
 
-    it('should handle custom connection timeout', async () => {
+    it("should handle custom connection timeout", async () => {
       const conn = new MCPConnection({ ...options, timeout: 11 });
       const mockConnect = jest
         .spyOn(Client.prototype, "connect")
@@ -199,7 +199,7 @@ describe("MCPConnection", () => {
       await conn.connectClient(false, abortController.signal);
 
       expect(conn.status).toBe("error");
-      expect(conn.errors[0]).toContain("Failed to connect to MCP server");
+      expect(conn.errors[0]).toContain("Failed to connect");
       expect(mockConnect).toHaveBeenCalled();
     });
 

--- a/core/context/mcp/MCPConnection.ts
+++ b/core/context/mcp/MCPConnection.ts
@@ -277,9 +277,9 @@ class MCPConnection {
             const msg = error.message.toLowerCase();
             if (msg.includes("spawn") && msg.includes("enoent")) {
               const command = msg.split(" ")[1];
-              errorMessage += `: command "${command}" not found. To use this MCP server, install the ${command} CLI.`;
+              errorMessage += `Error: command "${command}" not found. To use this MCP server, install the ${command} CLI.`;
             } else {
-              errorMessage += ": " + error.message;
+              errorMessage += "Error: " + error.message;
             }
           }
 

--- a/core/context/mcp/MCPConnection.ts
+++ b/core/context/mcp/MCPConnection.ts
@@ -17,7 +17,15 @@ import {
 const DEFAULT_MCP_TIMEOUT = 20_000; // 20 seconds
 
 // Commands that are batch scripts on Windows and need cmd.exe to execute
-const WINDOWS_BATCH_COMMANDS = ["npx", "uv", "uvx"];
+const WINDOWS_BATCH_COMMANDS = [
+  "npx",
+  "uv",
+  "uvx",
+  "pnpx",
+  "dlx",
+  "nx",
+  "bunx",
+];
 
 class MCPConnection {
   public client: Client;
@@ -272,7 +280,7 @@ class MCPConnection {
           ]);
         } catch (error) {
           // Otherwise it's a connection error
-          let errorMessage = `Failed to connect to MCP server "${this.options.name}"\n`;
+          let errorMessage = `Failed to connect to "${this.options.name}"\n`;
           if (error instanceof Error) {
             const msg = error.message.toLowerCase();
             if (msg.includes("spawn") && msg.includes("enoent")) {

--- a/core/context/mcp/MCPConnection.ts
+++ b/core/context/mcp/MCPConnection.ts
@@ -17,7 +17,7 @@ import {
 const DEFAULT_MCP_TIMEOUT = 20_000; // 20 seconds
 
 // Commands that are batch scripts on Windows and need cmd.exe to execute
-const WINDOWS_BATCH_COMMANDS = ["npx", "npm", "uv", "uvx"];
+const WINDOWS_BATCH_COMMANDS = ["npx", "uv", "uvx"];
 
 class MCPConnection {
   public client: Client;


### PR DESCRIPTION
## Description

Resolves https://github.com/continuedev/continue/issues/4913 https://github.com/continuedev/continue/issues/4874 https://github.com/continuedev/continue/issues/4791

When connecting to an MCP server via `StdioClientTransport` on Windows, we need to execute commands such as `npx` and `uvx` through the `cmd.exe` interpreter. 

## Testing instructions

- Use an MCP server on Windows and confirm you're able to connect, eg
```yaml
mcpServers:
  - uses: anthropic/memory-mcp
```
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed MCP server connections on Windows by running batch commands like `npx` and `uvx` through `cmd.exe` to ensure proper execution.

<!-- End of auto-generated description by mrge. -->

