### PR TITLE
fix: dont toggle models when toggling assistants

### DIFF
--- a/gui/src/components/modelSelection/ModelSelect.tsx
+++ b/gui/src/components/modelSelection/ModelSelect.tsx
@@ -166,7 +166,11 @@ function ModelSelect() {
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "'" && isMetaEquivalentKeyPressed(event as any)) {
+      if (
+        event.key === "'" &&
+        isMetaEquivalentKeyPressed(event as any) &&
+        !event.shiftKey // To prevent collisions w/ assistant toggle logic
+      ) {
         if (!selectedProfile) {
           return;
         }
@@ -179,7 +183,7 @@ function ModelSelect() {
         if (nextIndex < 0) nextIndex = options.length - 1;
         const newModelTitle = options[nextIndex].value;
 
-        dispatch(
+        void dispatch(
           updateSelectedModelByRole({
             selectedProfile,
             role: "chat",
@@ -219,7 +223,7 @@ function ModelSelect() {
     <Listbox
       onChange={async (val: string) => {
         if (val === selectedModel?.title) return;
-        dispatch(
+        void dispatch(
           updateSelectedModelByRole({
             selectedProfile,
             role: mode === "edit" ? "edit" : "chat",


### PR DESCRIPTION
## Description

Resolves https://github.com/continuedev/continue/issues/5626
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed a bug where toggling assistants with the keyboard shortcut would also toggle models by mistake. Now, model selection only changes when the intended shortcut is used.

<!-- End of auto-generated description by mrge. -->

