### PR TITLE
fix: hardcode `fontSize` for tool call status msg

### DIFF
--- a/.idea/jsLinters/eslint.xml
+++ b/.idea/jsLinters/eslint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="EslintConfiguration">
+    <option name="fix-on-save" value="true" />
+  </component>
+</project>

--- a/.idea/prettier.xml
+++ b/.idea/prettier.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="PrettierConfiguration">
     <option name="myConfigurationMode" value="AUTOMATIC" />
+    <option name="myRunOnSave" value="true" />
   </component>
 </project>

--- a/gui/src/context/LocalStorage.tsx
+++ b/gui/src/context/LocalStorage.tsx
@@ -18,6 +18,7 @@ export const LocalStorageProvider: React.FC<{ children: React.ReactNode }> = ({
 }) => {
   const [values, setValues] = useState<LocalStorageType>(DEFAULT_LOCAL_STORAGE);
 
+  // TODO setvalue
   useEffect(() => {
     const isJetbrains = getLocalStorage("ide") === "jetbrains";
     let fontSize = getLocalStorage("fontSize") ?? (isJetbrains ? 15 : 14);

--- a/gui/src/context/LocalStorage.tsx
+++ b/gui/src/context/LocalStorage.tsx
@@ -18,8 +18,6 @@ export const LocalStorageProvider: React.FC<{ children: React.ReactNode }> = ({
 }) => {
   const [values, setValues] = useState<LocalStorageType>(DEFAULT_LOCAL_STORAGE);
 
-  // TODO setvalue
-
   useEffect(() => {
     const isJetbrains = getLocalStorage("ide") === "jetbrains";
     let fontSize = getLocalStorage("fontSize") ?? (isJetbrains ? 15 : 14);

--- a/gui/src/pages/gui/ToolCallDiv/ToolCallStatusMessage.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/ToolCallStatusMessage.tsx
@@ -2,6 +2,7 @@ import { Tool, ToolCallState } from "core";
 import Mustache from "mustache";
 import { ReactNode } from "react";
 import { getFontSize } from "../../../util";
+import { useFontSize } from "../../../components/ui/font";
 
 interface ToolCallStatusMessageProps {
   tool: Tool | undefined;
@@ -12,6 +13,7 @@ export function ToolCallStatusMessage({
   tool,
   toolCallState,
 }: ToolCallStatusMessageProps) {
+  const fontSize = useFontSize();
   if (!tool) return "Agent tool use";
 
   const defaultToolDescription = (
@@ -66,7 +68,7 @@ export function ToolCallStatusMessage({
     message = futureMessage;
   }
   return (
-    <div className="block" style={{ fontSize: getFontSize() }}>
+    <div className="block" style={{ fontSize }}>
       <span>Continue</span> {intro} {message}
     </div>
   );

--- a/gui/src/pages/gui/ToolCallDiv/ToolCallStatusMessage.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/ToolCallStatusMessage.tsx
@@ -1,6 +1,7 @@
 import { Tool, ToolCallState } from "core";
 import Mustache from "mustache";
 import { ReactNode } from "react";
+import { getFontSize } from "../../../util";
 
 interface ToolCallStatusMessageProps {
   tool: Tool | undefined;
@@ -65,7 +66,7 @@ export function ToolCallStatusMessage({
     message = futureMessage;
   }
   return (
-    <div className="block">
+    <div className="block" style={{ fontSize: getFontSize() }}>
       <span>Continue</span> {intro} {message}
     </div>
   );


### PR DESCRIPTION
## Description

Fixes a UI bug where the `fontSize` for `<ToolCallStatusMessage />` was larger than the default.

Also configured eslint + prettier to format on save.

## Screenshots

### Before
<img width="418" alt="image" src="https://github.com/user-attachments/assets/847f9446-f493-4279-a640-a81336a1baa8" />

### After
<img width="423" alt="image" src="https://github.com/user-attachments/assets/2aee7ff2-a31a-4d9d-ac7a-af119b9918b4" />


    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Set a fixed font size for the tool call status message to match the default UI text size.

- **Bug Fixes**
  - Tool call status message now uses the correct font size for consistency.

<!-- End of auto-generated description by mrge. -->

