### PR TITLE
fix: prevent autoscrolling on new tool msgs

### DIFF
--- a/gui/src/pages/gui/Chat.tsx
+++ b/gui/src/pages/gui/Chat.tsx
@@ -134,6 +134,8 @@ export function Chat() {
     return isJetBrains();
   }, []);
 
+  useAutoScroll(stepsDivRef, history);
+
   useEffect(() => {
     // Cmd + Backspace to delete current step
     const listener = (e: any) => {
@@ -284,8 +286,6 @@ export function Chat() {
 
   const showScrollbar = showChatScrollbar ?? window.innerHeight > 5000;
 
-  useAutoScroll(stepsDivRef, history);
-
   return (
     <>
       {widget}
@@ -301,7 +301,7 @@ export function Chat() {
           <div
             key={item.message.id}
             style={{
-              minHeight: index === history.length - 1 ? "25vh" : 0,
+              minHeight: index === history.length - 1 ? "200px" : 0,
             }}
           >
             <ErrorBoundary

--- a/gui/src/pages/gui/useAutoScroll.ts
+++ b/gui/src/pages/gui/useAutoScroll.ts
@@ -1,27 +1,24 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ChatHistoryItemWithMessageId } from "../../redux/slices/sessionSlice";
+
+/**
+ * Only reset scroll state when a new user message is added to the chat.
+ * We don't want to auto-scroll on new tool response messages.
+ */
+function getNumUserMsgs(history: ChatHistoryItemWithMessageId[]) {
+  return history.filter((msg) => msg.message.role === "user").length;
+}
 
 export const useAutoScroll = (
   ref: React.RefObject<HTMLDivElement>,
   history: ChatHistoryItemWithMessageId[],
 ) => {
   const [userHasScrolled, setUserHasScrolled] = useState(false);
-  const [numUserMsgs, setNumUserMsgs] = useState(0);
+  const numUserMsgs = useMemo(() => getNumUserMsgs(history), [history.length]);
 
   useEffect(() => {
-    /**
-     * Only reset scroll state when a new user message is added to the chat.
-     * We don't want to auto-scroll on new tool response messages.
-     */
-    const newNumUserMsgs = history.filter(
-      (msg) => msg.message.role === "user",
-    ).length;
-
-    if (newNumUserMsgs > numUserMsgs) {
-      setUserHasScrolled(false);
-      setNumUserMsgs(newNumUserMsgs);
-    }
-  }, [history.length]);
+    setUserHasScrolled(false);
+  }, [numUserMsgs]);
 
   useEffect(() => {
     if (!ref.current || history.length === 0) return;

--- a/gui/src/pages/gui/useAutoScroll.ts
+++ b/gui/src/pages/gui/useAutoScroll.ts
@@ -1,15 +1,23 @@
 import { useEffect, useState } from "react";
+import { ChatHistoryItemWithMessageId } from "../../redux/slices/sessionSlice";
 
 export const useAutoScroll = (
   ref: React.RefObject<HTMLDivElement>,
-  history: unknown[],
+  history: ChatHistoryItemWithMessageId[],
 ) => {
   const [userHasScrolled, setUserHasScrolled] = useState(false);
+  const [numUserMsgs, setNumUserMsgs] = useState(0);
 
   useEffect(() => {
-    if (history.length) {
+    const newNumUserMsgs = history.filter(
+      (msg) => msg.message.role === "user",
+    ).length;
+
+    if (newNumUserMsgs > numUserMsgs) {
       setUserHasScrolled(false);
     }
+
+    setNumUserMsgs(newNumUserMsgs);
   }, [history.length]);
 
   useEffect(() => {

--- a/gui/src/pages/gui/useAutoScroll.ts
+++ b/gui/src/pages/gui/useAutoScroll.ts
@@ -9,15 +9,18 @@ export const useAutoScroll = (
   const [numUserMsgs, setNumUserMsgs] = useState(0);
 
   useEffect(() => {
+    /**
+     * Only reset scroll state when a new user message is added to the chat.
+     * We don't want to auto-scroll on new tool response messages.
+     */
     const newNumUserMsgs = history.filter(
       (msg) => msg.message.role === "user",
     ).length;
 
     if (newNumUserMsgs > numUserMsgs) {
       setUserHasScrolled(false);
+      setNumUserMsgs(newNumUserMsgs);
     }
-
-    setNumUserMsgs(newNumUserMsgs);
   }, [history.length]);
 
   useEffect(() => {

--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -31,7 +31,7 @@ import { findCurrentToolCall, findToolCall } from "../util";
 
 // We need this to handle reorderings (e.g. a mid-array deletion) of the messages array.
 // The proper fix is adding a UUID to all chat messages, but this is the temp workaround.
-type ChatHistoryItemWithMessageId = ChatHistoryItem & {
+export type ChatHistoryItemWithMessageId = ChatHistoryItem & {
   message: ChatMessage & { id: string };
 };
 


### PR DESCRIPTION
## Description

Closes CON-1920

Prevents chat panel from auto scrolling on new tool messages by only overwriting the user's manual scroll state when we receive new messages of role type "user". 

This solves a bug where a user would scroll up to read some content in Agent mode, and then a new tool response would stream in, which would render as a new message, and force scroll the user to the bottom of the chat.

## Testing
- Enter Agent mode
- Send a message that uses some tools, eg "explore the codebase file by file"
- Wait for a full page of messages to fill up
- Then as messages continue to stream in, scroll up
- Confirm that you aren't force scrolled to the bottom of the chat as new tool responses come in
