### PR TITLE
fix: use proper alternating colors in KeyboardShortcuts.tsx

### DIFF
--- a/gui/src/pages/config/KeyboardShortcuts.tsx
+++ b/gui/src/pages/config/KeyboardShortcuts.tsx
@@ -11,7 +11,7 @@ interface KeyboardShortcutProps {
 function KeyboardShortcut(props: KeyboardShortcutProps) {
   return (
     <div
-      className={`flex flex-col items-start p-2 py-2 sm:flex-row sm:items-center ${props.isEven ? "bg-list-active" : ""}`}
+      className={`flex flex-col items-start p-2 py-2 sm:flex-row sm:items-center ${props.isEven ? "" : "bg-table-odd-rows"}`}
     >
       <div className="w-full flex-grow pb-1 pr-4 sm:w-auto sm:pb-0">
         <span className="block break-words text-xs">{props.description}:</span>

--- a/gui/tailwind.config.cjs
+++ b/gui/tailwind.config.cjs
@@ -43,6 +43,7 @@ module.exports = {
         // TODO make it all non-IDE-specific naming
         "find-match-selected":
           "var(--vscode-editor-findMatchHighlightBackground, rgba(255, 223, 0))",
+        "table-odd-rows":"var(--vscode-tree-tableOddRowsBackground, #1bbe84)",
         "list-active": "var(--vscode-list-activeSelectionBackground, #1bbe84)",
         "list-active-foreground":
           "var(--vscode-quickInputList-focusForeground, var(--vscode-editor-foreground))",


### PR DESCRIPTION
## Description

KeyboardShortcuts.tsx use of color is ... not great, to put it mildly.

<img width="443" alt="Screenshot 2025-05-13 at 14 42 40" src="https://github.com/user-attachments/assets/983f0de0-dd87-4b15-b78f-5d14f93faff0" />

<img width="446" alt="Screenshot 2025-05-13 at 14 43 36" src="https://github.com/user-attachments/assets/0f211446-2b42-47e7-91d1-3802dd4edb59" />

Once my eyes stopped bleeding, I found a more soothing solution, by leveraging the `--vscode-tree-tableOddRowsBackground` variable (you can see it in action in VS Code's own shortcut page).

I created a new tailwind class, `table-odd-rows`, to avoid breaking `bg-list-active`, which is used in several other places. 

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots
This is the new look:

<img width="439" alt="Screenshot 2025-05-13 at 16 38 47" src="https://github.com/user-attachments/assets/b0e55148-d0ce-477f-b5b2-737a5602e4c1" />
<img width="438" alt="Screenshot 2025-05-13 at 16 40 41" src="https://github.com/user-attachments/assets/dfbf967c-5108-42b1-a42f-a319f479a1ea" />

## Tests
 - Open Continue's Shortcuts page

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Updated KeyboardShortcuts.tsx to use proper alternating row colors for better readability.

- **UI Improvements**
  - Added a new Tailwind class to apply the correct background color to odd rows, matching VS Code’s shortcut page.

<!-- End of auto-generated description by mrge. -->

