### PR TITLE
feat: add link to Hub on Help Center

### DIFF
--- a/gui/src/pages/config/HelpCenterSection.tsx
+++ b/gui/src/pages/config/HelpCenterSection.tsx
@@ -21,6 +21,15 @@ export function HelpCenterSection() {
       <h3 className="mb-4 mt-0 text-xl">Help center</h3>
       <div className="-mx-4 flex flex-col">
         <MoreHelpRow
+          title="Continue Hub"
+          description="Visit hub.continue.dev to explore custom assistants and blocks"
+          Icon={ArrowTopRightOnSquareIcon}
+          onClick={() =>
+            ideMessenger.post("openUrl", "https://hub.continue.dev/")
+          }
+        />
+
+        <MoreHelpRow
           title="Documentation"
           description="Learn how to configure and use Continue"
           Icon={ArrowTopRightOnSquareIcon}


### PR DESCRIPTION
<img width="423" alt="image" src="https://github.com/user-attachments/assets/24096ba8-d4ec-4f65-8059-80df632769ce" />

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added a new link in the Help Center to hub.continue.dev so users can explore custom assistants and blocks.

<!-- End of auto-generated description by mrge. -->

