### PR TITLE
fix: use bolt icon for shortcuts page

### DIFF
--- a/gui/src/pages/config/UserSettingsForm.tsx
+++ b/gui/src/pages/config/UserSettingsForm.tsx
@@ -77,10 +77,8 @@ export function UserSettingsForm() {
   // const codeBlockToolbarPosition = config.ui?.codeBlockToolbarPosition ?? "top";
   const useAutocompleteMultilineCompletions =
     config.tabAutocompleteOptions?.multilineCompletions ?? "auto";
-  const modelTimeout = 
-    config.tabAutocompleteOptions?.modelTimeout ?? 150;
-  const debounceDelay = 
-    config.tabAutocompleteOptions?.debounceDelay ?? 250;
+  const modelTimeout = config.tabAutocompleteOptions?.modelTimeout ?? 150;
+  const debounceDelay = config.tabAutocompleteOptions?.debounceDelay ?? 250;
   const fontSize = getFontSize();
 
   const cancelChangeDisableAutocomplete = () => {
@@ -103,7 +101,7 @@ export function UserSettingsForm() {
   }, [ideMessenger]);
 
   return (
-    <div className="flex flex-col pt-3">
+    <div className="flex flex-col">
       {/* {selectedProfile && isLocalProfile(selectedProfile) ? (
         <div className="flex items-center justify-center">
           <SecondaryButton
@@ -222,7 +220,7 @@ export function UserSettingsForm() {
                     }
                     text="Use Autocomplete Cache"
                   /> */}
-            
+
             <label className="flex items-center justify-between gap-3">
               <span className="text-left">Font Size</span>
               <NumberInput
@@ -236,52 +234,52 @@ export function UserSettingsForm() {
                 max={50}
               />
             </label>
-                <label className="flex items-center justify-between gap-3">
-                  <span className="lines lines-1 text-left">
-                    Multiline Autocompletions
-                  </span>
-                  <Select
-                    value={useAutocompleteMultilineCompletions}
-                    onChange={(e) =>
-                      handleUpdate({
-                        useAutocompleteMultilineCompletions: e.target.value as
-                          | "auto"
-                          | "always"
-                          | "never",
-                      })
-                    }
-                  >
-                    <option value="auto">Auto</option>
-                    <option value="always">Always</option>
-                    <option value="never">Never</option>
-                  </Select>
-                </label>
-                <label className="flex items-center justify-between gap-3">
-                    <span className="text-left">Model Timeout (ms)</span>
-                    <NumberInput
-                      value={modelTimeout}
-                      onChange={(val) =>
-                        handleUpdate({
-                          modelTimeout: val,
-                        })
-                      }
-                      min={100}
-                      max={5000}
-                    />
-                  </label>
-                  <label className="flex items-center justify-between gap-3">
-                    <span className="text-left">Model Debounce (ms)</span>
-                    <NumberInput
-                      value={debounceDelay}
-                      onChange={(val) =>
-                        handleUpdate({
-                          debounceDelay: val,
-                        })
-                      }
-                      min={0}
-                      max={2500}
-                    />
-                  </label>
+            <label className="flex items-center justify-between gap-3">
+              <span className="lines lines-1 text-left">
+                Multiline Autocompletions
+              </span>
+              <Select
+                value={useAutocompleteMultilineCompletions}
+                onChange={(e) =>
+                  handleUpdate({
+                    useAutocompleteMultilineCompletions: e.target.value as
+                      | "auto"
+                      | "always"
+                      | "never",
+                  })
+                }
+              >
+                <option value="auto">Auto</option>
+                <option value="always">Always</option>
+                <option value="never">Never</option>
+              </Select>
+            </label>
+            <label className="flex items-center justify-between gap-3">
+              <span className="text-left">Model Timeout (ms)</span>
+              <NumberInput
+                value={modelTimeout}
+                onChange={(val) =>
+                  handleUpdate({
+                    modelTimeout: val,
+                  })
+                }
+                min={100}
+                max={5000}
+              />
+            </label>
+            <label className="flex items-center justify-between gap-3">
+              <span className="text-left">Model Debounce (ms)</span>
+              <NumberInput
+                value={debounceDelay}
+                onChange={(val) =>
+                  handleUpdate({
+                    debounceDelay: val,
+                  })
+                }
+                min={0}
+                max={2500}
+              />
+            </label>
             <form
               className="flex flex-col gap-1"
               onSubmit={(e) => {

--- a/gui/src/pages/config/index.tsx
+++ b/gui/src/pages/config/index.tsx
@@ -1,5 +1,5 @@
 import {
-  AcademicCapIcon,
+  BoltIcon,
   CircleStackIcon,
   Cog6ToothIcon,
   QuestionMarkCircleIcon,
@@ -14,7 +14,6 @@ import { HelpCenterSection } from "./HelpCenterSection";
 import { IndexingSettingsSection } from "./IndexingSettingsSection";
 import KeyboardShortcuts from "./KeyboardShortcuts";
 import { UserSettingsForm } from "./UserSettingsForm";
-import { BoltIcon } from "@heroicons/react/16/solid";
 
 type TabOption = {
   id: string;
@@ -68,14 +67,14 @@ function ConfigPage() {
         />
 
         {/* Tab Headers */}
-        <div className="grid grid-cols-2 border-0 border-b-[1px] border-solid border-b-zinc-700 p-0.5 sm:flex sm:justify-center md:gap-x-2">
+        <div className="bg-vsc-input-background grid cursor-pointer grid-cols-2 border-0 border-b-[1px] border-solid border-b-zinc-700 p-0.5 sm:flex sm:justify-center md:gap-x-2">
           {tabs.map((tab) => (
             <div
               style={{
                 fontSize: fontSize(-2),
               }}
               key={tab.id}
-              className={`hover:bg-vsc-input-background flex cursor-pointer items-center justify-center gap-1.5 rounded-md px-2 py-2 ${
+              className={`flex cursor-pointer items-center justify-center gap-1.5 rounded-md px-2 py-2 hover:brightness-125 ${
                 activeTab === tab.id ? "" : "text-gray-400"
               }`}
               onClick={() => setActiveTab(tab.id)}

--- a/gui/src/pages/config/index.tsx
+++ b/gui/src/pages/config/index.tsx
@@ -14,6 +14,7 @@ import { HelpCenterSection } from "./HelpCenterSection";
 import { IndexingSettingsSection } from "./IndexingSettingsSection";
 import KeyboardShortcuts from "./KeyboardShortcuts";
 import { UserSettingsForm } from "./UserSettingsForm";
+import { BoltIcon } from "@heroicons/react/16/solid";
 
 type TabOption = {
   id: string;
@@ -52,7 +53,7 @@ function ConfigPage() {
       id: "shortcuts",
       label: "Shortcuts",
       component: <KeyboardShortcuts />,
-      icon: <AcademicCapIcon className="xs:h-4 xs:w-4 h-3 w-3 flex-shrink-0" />,
+      icon: <BoltIcon className="xs:h-4 xs:w-4 h-3 w-3 flex-shrink-0" />,
     },
   ];
 


### PR DESCRIPTION
## Description

- Replaces the academic cap icon with a bolt icon for Shortcuts page
- Gives the tab row a background color + `hover:brightness-125` for each tab
- Reduces excessive padding

## Screenshots

### Before
<img width="855" alt="image" src="https://github.com/user-attachments/assets/42b50fbf-6f84-46c2-b393-6fca92b3fceb" />


### After
<img width="857" alt="image" src="https://github.com/user-attachments/assets/3fe91298-00fe-4945-a9e9-73014ebb3e32" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
