### PR TITLE
Update IdeProtocolClient.kt

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
@@ -46,6 +46,7 @@ class IdeProtocolClient(
      *
      * See this thread for details: https://github.com/continuedev/continue/issues/4098#issuecomment-2854865310
      */
+    @OptIn(ExperimentalCoroutinesApi::class)
     private val limitedDispatcher = Dispatchers.IO.limitedParallelism(4)
 
     init {
@@ -526,10 +527,16 @@ class IdeProtocolClient(
                                     null
                                 ) { response ->
                                     try {
-                                        val selectedModels = response.castNestedOrNull<Map<String, Any>>("content", "result", "config", "selectedModelByRole")
+                                        val selectedModels = response.castNestedOrNull<Map<String, Any>>(
+                                            "content",
+                                            "result",
+                                            "config",
+                                            "selectedModelByRole"
+                                        )
 
                                         // If "apply" role model is not found, try "chat" role
-                                        val applyCodeBlockModel = selectedModels?.get("apply") ?: selectedModels?.get("chat")
+                                        val applyCodeBlockModel =
+                                            selectedModels?.get("apply") ?: selectedModels?.get("chat")
 
                                         if (applyCodeBlockModel != null) {
                                             continuation.resume(applyCodeBlockModel)


### PR DESCRIPTION
Adding `@OptIn(ExperimentalCoroutinesApi::class)` was recommended by my intellisense in IntelliJ, this was missed in https://github.com/continuedev/continue/pull/5600
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added @OptIn(ExperimentalCoroutinesApi::class) to IdeProtocolClient.kt to fix a missing annotation for limitedParallelism usage. Also reformatted some code for better readability.

<!-- End of auto-generated description by mrge. -->

