### PR TITLE
Fix selected profile not being persisted

### DIFF
--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -255,7 +255,7 @@ export class ConfigHandler {
     if (currentProfile) {
       this.globalContext.update("lastSelectedProfileForWorkspace", {
         ...selectedProfiles,
-        [profileKey]: selectedProfiles.id ?? null,
+        [profileKey]: currentProfile.profileDescription.id,
       });
     }
 


### PR DESCRIPTION
Was writing a nonexistent value to global context when rectifying profiles in org. Changed to the correct value
    
Before:
on load, switches to local
once profiles loaded from hub, switches to last selected org but loads fallback profile instead of selected profile

After:
on load, switches to local (this is a different issue that is less of a bug and more of a UI choice - could prevent any interaction till first org/profile loading from hub is complete)
once profiles, loaded from hub, switches to last selected org and profile correctly

<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed an issue where the selected profile was not saved correctly when switching organization profiles. Now the correct profile ID is stored in the global context.

<!-- End of auto-generated description by mrge. -->

