### PR TITLE
Fix: codeblocks hanging on one line for tool calls

### DIFF
--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/index.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/index.tsx
@@ -243,7 +243,7 @@ export function StepContainerPreToolbar({
       const plural = numLines === 1 ? "" : "s";
       if (isGeneratingCodeBlock) {
         return (
-          <span className="text-lightgray inline-flex w-min items-center gap-2">
+          <span className="text-lightgray inline-flex items-center gap-2 text-right">
             {!isExpanded ? `${numLines} line${plural}` : "Generating"}{" "}
             <div>
               <Spinner />
@@ -252,7 +252,7 @@ export function StepContainerPreToolbar({
         );
       } else {
         return (
-          <span className="text-lightgray inline-flex w-min items-center gap-2">
+          <span className="text-lightgray inline-flex items-center gap-2 text-right">
             {`${numLines} line${plural} pending`}
           </span>
         );

--- a/gui/src/pages/gui/ToolCallDiv/CreateFile.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/CreateFile.tsx
@@ -8,6 +8,10 @@ interface CreateFileToolCallProps {
 }
 
 export function CreateFile(props: CreateFileToolCallProps) {
+  if (!props.fileContents) {
+    return null;
+  }
+
   const src = `\`\`\`${getMarkdownLanguageTagForFile(props.relativeFilepath ?? "output.txt")} ${props.relativeFilepath}\n${props.fileContents ?? ""}\n\`\`\``;
 
   return props.relativeFilepath ? (

--- a/gui/src/pages/gui/ToolCallDiv/EditFile.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/EditFile.tsx
@@ -16,13 +16,12 @@ type EditToolCallProps = {
 };
 
 export function EditFile(props: EditToolCallProps) {
-  const src = `\`\`\`${getMarkdownLanguageTagForFile(props.relativeFilePath ?? "test.txt")} ${props.relativeFilePath}\n${props.changes ?? ""}\n\`\`\``;
-
   const dispatch = useAppDispatch();
-  const isStreaming = useAppSelector((state) => state.session.isStreaming);
+
   const applyState = useAppSelector((state) =>
     selectApplyStateByToolCallId(state, props.toolCallId),
   );
+
   useEffect(() => {
     if (!applyState) {
       dispatch(
@@ -35,9 +34,11 @@ export function EditFile(props: EditToolCallProps) {
     }
   }, [applyState, props.toolCallId]);
 
-  if (!props.relativeFilePath) {
+  if (!props.relativeFilePath || !props.changes) {
     return null;
   }
+
+  const src = `\`\`\`${getMarkdownLanguageTagForFile(props.relativeFilePath ?? "test.txt")} ${props.relativeFilePath}\n${props.changes}\n\`\`\``;
 
   return (
     <StyledMarkdownPreview


### PR DESCRIPTION
## Description
- Fixes codeblock generation status hanging on one line for create and edit tools
- Fixes ugly generation text in codeblock header - moves alignment right rather than `width: min-content`

This was only happening for Anthropic models because they stream the tool call name but then don't stream any args till the full arg is generated. See note in Anthropic's docs [here](https://docs.anthropic.com/en/api/messages-streaming#input-json-delta)
> Note: Our current models only support emitting one complete key and value property from input at a time. As such, when using tools, there may be delays between streaming events while the model is working. Once an input key and value are accumulated, we emit them as multiple content_block_delta events with chunked partial json so that the format can automatically support finer granularity in future models.

Some other provider notes to clarify why only happening on Anthropic
- OpenAI models are some of the only ones that properly support tool call arg streaming, was working with e.g. GPT-4o
- Ollama doesn't support streaming with tools at all
- Gemini similarly does the entire tool call in one block but doesn't stream the tool name prior to streaming args

## Testing
Use the edit tool with an openAI model, watch the lines stream in
Use the edit tool with an anthropic model, doesn't show preview until args are present

BEFORE
<img width="243" alt="image" src="https://github.com/user-attachments/assets/893d71b6-a2e2-4b17-bd67-28837d2df5f2" />

AFTER
<img width="258" alt="image" src="https://github.com/user-attachments/assets/affd8c2c-47b5-48a1-b7b6-5437b4414219" />

<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Fixed code blocks in tool call views so they no longer display as a single line and only show when file contents or changes are present.

- **Bug Fixes**
  - Updated code block toolbar styling for better layout.
  - Prevented markdown preview from rendering if file contents or changes are missing.

<!-- End of auto-generated description by mrge. -->

