### PR TITLE
fix: :bug: Remove all history when a user request is cancelled

### DIFF
--- a/gui/src/components/mainInput/Lump/LumpToolbar.tsx
+++ b/gui/src/components/mainInput/Lump/LumpToolbar.tsx
@@ -96,6 +96,9 @@ export function LumpToolbar() {
         <StopButton
           className="text-gray-400"
           onClick={() => {
+            if (toolCallState?.status === "calling" || toolCallState?.status === "generating") {
+              dispatch(cancelCurrentToolCall);
+            }
             dispatch(cancelStream());
           }}
         >

--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -107,15 +107,21 @@ export const sessionSlice = createSlice({
       if (state.history.length < 2) {
         return;
       }
-      const lastMessage = state.history[state.history.length - 1];
 
-      // Only clear in the case of an empty message
-      if (!lastMessage.message.content.length) {
-        state.mainEditorContentTrigger =
-          state.history[state.history.length - 2].editorState;
-        state.history = state.history.slice(0, -2);
-        // TODO is this logic correct for tool use conversations?
-        // Maybe slice at last index of "user" role message?
+      // Find the index of the last user message
+      let lastUserIndex = -1;
+      for (let i = state.history.length - 1; i >= 0; i--) {
+        if (state.history[i].message.role === "user") {
+          lastUserIndex = i;
+          break;
+        }
+      }
+
+      // If we find a user message, set the editor state to the last user messsage
+      // and slice the history to remove it and all the messages after it
+      if (lastUserIndex >= 0) {
+        state.mainEditorContentTrigger = state.history[lastUserIndex].editorState;
+        state.history = state.history.slice(0, lastUserIndex);
       }
     },
     // Trigger value picked up by editor with isMainInput to set its content


### PR DESCRIPTION
## Description

Updated clearLastEmptyResponse to fully remove all history up until the last user message. This cleans up any dangling thinking, or tools use messages that may have been sent when the cancel button is used.

This should resolve any issues where dangling thinking or tools use messages are left behind when the cancel button is used breaking the ability to continue the session.

TODO: I discovered one edge case that I could use help fixing. When a file is edited there is a small window between when the edit is started and the editor displays the edits, Accept and Reject Buttons where the request can be cancelled. In this case the cancel button can leave things in an odd state with code still highlighted and the Accept / Reject buttons left behind. I wasn't sure how to check if we are in that state, and fully cancel the Edit Session. Effectively, I would like to perform he same operations as clicking the Reject Button. (Remove decorations, and cancel the edit session).

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Testing instructions

Enable Thinking
In Agent Mode:

1. Ask to update test.js and add a power function.
2. When thinking is displayed hit cancel.
3. Observe that thinking is removed, and you are retunred to the previous command.

In Agent Mode:

1. Ask to update test.js and add a power function.
2. Once thinking ends, and the LLM is starting to stream the next steps hit cancel.
3. Observe the edit step is stopped, and the thinking modes are cancelled.

Outcomes:
* All steps after the last user message should be removed from the UI and the messages should be removed from history. Tool calls in progress should be stopped.
