### PR TITLE
chore: :rotating_light: fix lint errors in gui and introduce gui lint in CI

### DIFF
--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -235,10 +235,11 @@ jobs:
           cd packages/config-yaml
           npm run build
 
-      - name: Type check
+      - name: Type check and lint
         run: |
           cd gui
           npx tsc --noEmit
+          npm run lint
 
   binary-checks:
     needs: [install-root, install-core, install-config-yaml]

--- a/gui/.eslintrc.json
+++ b/gui/.eslintrc.json
@@ -3,7 +3,7 @@
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint", "eslint-plugin-react"],
   "parserOptions": {
-    "project": "gui/tsconfig.json"
+    "project": ["tsconfig.json", "tsconfig.node.json"]
   },
   "extends": [
     // "eslint:recommended",

--- a/gui/package.json
+++ b/gui/package.json
@@ -12,7 +12,8 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "lint": "eslint --ext ts"
   },
   "dependencies": {
     "@continuedev/config-yaml": "file:../packages/config-yaml",


### PR DESCRIPTION
## Description

Introduced `npm run lint` in `gui` in CI and fixed the few errors that previously existed from incorrect configuration

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Tests

Running `npm run lint` acts as a test—if it fails, so will CI.

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added linting to the gui package in CI and fixed existing lint errors.

- **Dependencies**
  - Added a lint script to gui/package.json.
  - Updated ESLint config to support multiple tsconfig files.

<!-- End of auto-generated description by mrge. -->

