### PR TITLE
chore: :bug: add keep-alive header for streaming to stop premature close

### DIFF
--- a/core/llm/llms/Anthropic.ts
+++ b/core/llm/llms/Anthropic.ts
@@ -191,6 +191,7 @@ class Anthropic extends BaseLLM {
       headers: {
         "Content-Type": "application/json",
         Accept: "application/json",
+        Connection: "keep-alive", // Keep the connection open for streaming
         "anthropic-version": "2023-06-01",
         "x-api-key": this.apiKey as string,
         ...(shouldCacheSystemMessage || this.cacheBehavior?.cacheConversation

--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -171,7 +171,7 @@ class OpenAI extends BaseLLM {
     return finalOptions;
   }
 
-  protected _getHeaders() {
+  protected _getHeaders(): Record<string, string> {
     return {
       "Content-Type": "application/json",
       Authorization: `Bearer ${this.apiKey}`,

--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -176,6 +176,7 @@ class OpenAI extends BaseLLM {
       "Content-Type": "application/json",
       Authorization: `Bearer ${this.apiKey}`,
       "api-key": this.apiKey ?? "", // For Azure
+      Connection: "keep-alive", // Keep the connection open for streaming
     };
   }
 


### PR DESCRIPTION
## Description

I'm not 100% certain that this solves the premature close error, but without an easy way to reproduce yet it seems like a worthwhile attempt.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Tests

I do not think that tests of 15+ second-long streams would be appropriate to run in CI
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added a keep-alive header to streaming requests to prevent connections from closing too early.

<!-- End of auto-generated description by mrge. -->

