### PR TITLE
Fix: non-existent tool logic, better tool errors

### DIFF
--- a/core/tools/callTool.ts
+++ b/core/tools/callTool.ts
@@ -131,6 +131,37 @@ async function callToolFromUri(
   }
 }
 
+async function callBuiltInTool(
+  functionName: string,
+  args: any,
+  extras: ToolExtras,
+): Promise<ContextItem[]> {
+  switch (functionName) {
+    case BuiltInToolNames.ReadFile:
+      return await readFileImpl(args, extras);
+    case BuiltInToolNames.CreateNewFile:
+      return await createNewFileImpl(args, extras);
+    case BuiltInToolNames.GrepSearch:
+      return await grepSearchImpl(args, extras);
+    case BuiltInToolNames.FileGlobSearch:
+      return await fileGlobSearchImpl(args, extras);
+    case BuiltInToolNames.RunTerminalCommand:
+      return await runTerminalCommandImpl(args, extras);
+    case BuiltInToolNames.SearchWeb:
+      return await searchWebImpl(args, extras);
+    case BuiltInToolNames.ViewDiff:
+      return await viewDiffImpl(args, extras);
+    case BuiltInToolNames.LSTool:
+      return await lsToolImpl(args, extras);
+    case BuiltInToolNames.ReadCurrentlyOpenFile:
+      return await readCurrentlyOpenFileImpl(args, extras);
+    case BuiltInToolNames.CreateRuleBlock:
+      return await createRuleBlockImpl(args, extras);
+    default:
+      throw new Error(`Tool "${functionName}" not found`);
+  }
+}
+
 // Handles calls for core/non-client tools
 // Returns an error context item if the tool call fails
 // Note: Edit tool is handled on client
@@ -144,45 +175,9 @@ export async function callTool(
 }> {
   try {
     const args = JSON.parse(callArgs || "{}");
-    let contextItems: ContextItem[] = [];
-    if (tool.uri) {
-      contextItems = await callToolFromUri(tool.uri, args, extras);
-    } else {
-      switch (tool.function.name) {
-        case BuiltInToolNames.ReadFile:
-          contextItems = await readFileImpl(args, extras);
-          break;
-        case BuiltInToolNames.CreateNewFile:
-          contextItems = await createNewFileImpl(args, extras);
-          break;
-        case BuiltInToolNames.GrepSearch:
-          contextItems = await grepSearchImpl(args, extras);
-          break;
-        case BuiltInToolNames.FileGlobSearch:
-          contextItems = await fileGlobSearchImpl(args, extras);
-          break;
-        case BuiltInToolNames.RunTerminalCommand:
-          contextItems = await runTerminalCommandImpl(args, extras);
-          break;
-        case BuiltInToolNames.SearchWeb:
-          contextItems = await searchWebImpl(args, extras);
-          break;
-        case BuiltInToolNames.ViewDiff:
-          contextItems = await viewDiffImpl(args, extras);
-          break;
-        case BuiltInToolNames.LSTool:
-          contextItems = await lsToolImpl(args, extras);
-          break;
-        case BuiltInToolNames.ReadCurrentlyOpenFile:
-          contextItems = await readCurrentlyOpenFileImpl(args, extras);
-          break;
-        case BuiltInToolNames.CreateRuleBlock:
-          contextItems = await createRuleBlockImpl(args, extras);
-          break;
-        default:
-          throw new Error(`Tool "${tool.function.name}" not found`);
-      }
-    }
+    const contextItems = tool.uri
+      ? await callToolFromUri(tool.uri, args, extras)
+      : await callBuiltInTool(tool.function.name, args, extras);
     if (tool.faviconUrl) {
       contextItems.forEach((item) => {
         item.icon = tool.faviconUrl;

--- a/gui/src/components/modelSelection/ModeSelect.tsx
+++ b/gui/src/components/modelSelection/ModeSelect.tsx
@@ -173,17 +173,24 @@ function ModeSelect() {
             {mode === "chat" && <CheckIcon className="ml-auto h-3 w-3" />}
           </ListboxOption>
 
-          <ListboxOption value="agent" disabled={!agentModeSupported}>
+          <ListboxOption
+            value="agent"
+            disabled={!agentModeSupported}
+            className={"gap-1"}
+          >
             <div className="flex flex-row items-center gap-1.5">
               <SparklesIcon className="h-3 w-3" />
               <span className="">Agent</span>
             </div>
-            {mode === "agent" && <CheckIcon className="ml-auto h-3 w-3" />}
-            {!agentModeSupported && <span> (Not supported)</span>}
+            {agentModeSupported ? (
+              mode === "agent" && <CheckIcon className="ml-auto h-3 w-3" />
+            ) : (
+              <span>(Not supported)</span>
+            )}
           </ListboxOption>
 
           <div className="text-lightgray px-2 py-1">
-            {metaKeyLabel}. for next mode
+            {`${metaKeyLabel} . for next mode`}
           </div>
         </ListboxOptions>
       </div>


### PR DESCRIPTION

- Fixes tool call logic to prevent calling a nonexistent tool
- Provides more verbose errors to the model for MCP tool errors
- Fixes spacing issues for Agent `(Not supported)` note and `cmd .` mode toggle shortcut text
![image](https://github.com/user-attachments/assets/4b461ae4-d856-4a26-bd67-7f7eab9fbfba)
