### PR TITLE
fix: number of completions to generate is not supported

### DIFF
--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -206,7 +206,6 @@ chat, editing, and summarizing.
   - `topP`: The cumulative probability for nucleus sampling.
   - `topK`: Maximum number of tokens considered at each step.
   - `stop`: An array of stop tokens that will terminate the completion.
-  - `n`: Number of completions to generate.
   - `reasoning`: Boolean to enable thinking/reasoning for Anthropic Claude 3.7+ models.
   - `reasoningBudgetTokens`: Budget tokens for thinking/reasoning in Anthropic Claude 3.7+ models.
 - `requestOptions`: HTTP request options specific to the model.


### PR DESCRIPTION
## Description

[[ What changed? Feel free to be brief. ]](fix: number of completions to generate is not supported)

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Removed the unsupported "number of completions to generate" option from the API reference documentation.

<!-- End of auto-generated description by mrge. -->

