### PR TITLE
Feat: support maxStopWords model config option in yaml

### DIFF
--- a/core/config/util.ts
+++ b/core/config/util.ts
@@ -77,6 +77,7 @@ export function addModel(
         model: model.model,
         apiKey: model.apiKey,
         apiBase: model.apiBase,
+        maxStopWords: model.maxStopWords,
         defaultCompletionOptions: model.completionOptions,
       };
       if (model.systemMessage) {

--- a/core/control-plane/schema.ts
+++ b/core/control-plane/schema.ts
@@ -26,6 +26,7 @@ const modelDescriptionSchema = z.object({
   apiKey: z.string().optional(),
   apiBase: z.string().optional(),
   contextLength: z.number().optional(),
+  maxStopWords: z.number().optional(),
   template: z
     .enum([
       "llama2",

--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -188,6 +188,7 @@ chat, editing, and summarizing.
   not currently used.
 - `capabilities`: Array of strings denoting model capabilities, which will overwrite Continue's autodetection based on
   provider and model. Supported capabilities include `tool_use` and `image_input`.
+- `maxStopWords`: Maximum number of stop words allowed, to avoid API errors with extensive lists.
 - `promptTemplates`: Can be used to override the default prompt templates for different model roles. Valid values are
   `chat`, [`edit`](./customize/model-roles/edit.mdx#prompt-templating), [
   `apply`](./customize/model-roles/apply.mdx#prompt-templating) and [

--- a/packages/config-yaml/src/schemas/models.ts
+++ b/packages/config-yaml/src/schemas/models.ts
@@ -107,7 +107,7 @@ const templateSchema = z.enum([
 const promptTemplatesSchema = z.object({
   apply: z.string().optional(),
   chat: templateSchema.optional(),
-  edit: z.string().optional(),
+  edit: z.string().optional(), 
   autocomplete: z.string().optional(),
 });
 export type PromptTemplates = z.infer<typeof promptTemplatesSchema>;
@@ -117,6 +117,7 @@ const baseModelFields = {
   model: z.string(),
   apiKey: z.string().optional(),
   apiBase: z.string().optional(),
+  maxStopWords: z.number().optional(),
   roles: modelRolesSchema.array().optional(),
   capabilities: modelCapabilitySchema.array().optional(),
   defaultCompletionOptions: completionOptionsSchema.optional(),

--- a/packages/config-yaml/src/schemas/models.ts
+++ b/packages/config-yaml/src/schemas/models.ts
@@ -107,7 +107,7 @@ const templateSchema = z.enum([
 const promptTemplatesSchema = z.object({
   apply: z.string().optional(),
   chat: templateSchema.optional(),
-  edit: z.string().optional(), 
+  edit: z.string().optional(),
   autocomplete: z.string().optional(),
 });
 export type PromptTemplates = z.infer<typeof promptTemplatesSchema>;


### PR DESCRIPTION
## Description

I described the problem in this issue: https://github.com/continuedev/continue/issues/5663

Whats changed is that the `maxStopWords` config option that was present in the deprecated JSON but not in the YAML configuration is added to the YAML schema.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots

## Tests

I tested it using the vscode debug feature, with the config shown in the issue that initially led to the described error. After the changes, the `maxStopWords` config option is correctly working when using YAML config, leading to the same result as if the JSON version of the same config would be used.

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added support for the maxStopWords model config option in YAML, matching the previous JSON config behavior.

- **New Features**
  - You can now set maxStopWords in YAML model configs to control the maximum number of stop words.

<!-- End of auto-generated description by mrge. -->

