### PR TITLE
ci: :green_heart: don't run cla assistant on fork repositories

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,9 +1,9 @@
 name: "CLA Assistant"
 on:
   issue_comment:
-    types: [ created ]
+    types: [created]
   pull_request_target:
-    types: [ opened,closed,synchronize ]
+    types: [opened, closed, synchronize]
 
 permissions:
   actions: write
@@ -14,6 +14,8 @@ permissions:
 jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
+    # Only run this workflow on the main repository (continuedev/continue)
+    if: github.repository == 'continuedev/continue'
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
@@ -21,7 +23,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://github.com/continuedev/continue/blob/main/docs/docs/CLA.md'
+          path-to-signatures: "signatures/version1/cla.json"
+          path-to-document: "https://github.com/continuedev/continue/blob/main/docs/docs/CLA.md"
           branch: cla-signatures
           allowlist: dependabot[bot]


### PR DESCRIPTION
## Description

Don't run the CLAAssitant workflow on forks of Continue, only the continuedev/continue repo

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Tests

N/A
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Stopped the CLA Assistant workflow from running on forked repositories. It now only runs on the main continuedev/continue repo.

<!-- End of auto-generated description by mrge. -->

