### PR TITLE
chore: ignore whitespaces in CLA check

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,9 +1,9 @@
 name: "CLA Assistant"
 on:
   issue_comment:
-    types: [created]
+    types: [ created ]
   pull_request_target:
-    types: [opened, closed, synchronize]
+    types: [ opened, closed, synchronize ]
 
 permissions:
   actions: write
@@ -18,7 +18,7 @@ jobs:
     if: github.repository == 'continuedev/continue'
     steps:
       - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        if: (contains(github.event.comment.body, 'recheck') || contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')) || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When you copy/paste the text for the CLA there are whitespaces by default, which causes the check to fail since it's currently an exact string match.    

<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Updated the CLA check workflow to ignore whitespace differences and use more flexible comment matching for rechecks.

<!-- End of auto-generated description by mrge. -->

