### PR TITLE
Default Agent Mode

### DIFF
--- a/gui/src/pages/gui/Chat.test.tsx
+++ b/gui/src/pages/gui/Chat.test.tsx
@@ -11,7 +11,7 @@ describe("Chat page test", () => {
 
   it("should be able to toggle modes", async () => {
     await renderWithProviders(<Chat />);
-    expect(screen.getByText("Chat")).toBeInTheDocument();
+    expect(screen.getByText("Agent")).toBeInTheDocument();
 
     // Simulate cmd+. keyboard shortcut to toggle modes
     act(() => {
@@ -24,7 +24,7 @@ describe("Chat page test", () => {
     });
 
     // Check that it switched to Agent mode
-    expect(await screen.findByText("Agent")).toBeInTheDocument();
+    expect(await screen.findByText("Chat")).toBeInTheDocument();
 
     act(() => {
       document.dispatchEvent(

--- a/gui/src/pages/gui/Chat.test.tsx
+++ b/gui/src/pages/gui/Chat.test.tsx
@@ -23,8 +23,8 @@ describe("Chat page test", () => {
       );
     });
 
-    // Check that it switched to Agent mode
-    expect(await screen.findByText("Chat")).toBeInTheDocument();
+    // Check that it switched to Edit mode
+    expect(await screen.findByText("Edit")).toBeInTheDocument();
 
     act(() => {
       document.dispatchEvent(
@@ -35,8 +35,8 @@ describe("Chat page test", () => {
       );
     });
 
-    // Check that it switched to Edit mode
-    expect(await screen.findByText("Edit")).toBeInTheDocument();
+    // Check that it switched to Chat mode
+    expect(await screen.findByText("Chat")).toBeInTheDocument();
   });
 
   it.skip("should send a message and receive a response", async () => {

--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -61,7 +61,7 @@ const initialState: SessionState = {
   id: uuidv4(),
   streamAborter: new AbortController(),
   symbols: {},
-  mode: "chat",
+  mode: "agent",
   codeBlockApplyStates: {
     states: [],
     curIndex: 0,


### PR DESCRIPTION
## Description

Updating the default mode to agent mode from chat.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots

N/A

## Tests

Updated the test that checks toggling modes using the keyboard short of CMD + . to expect Agent mode at the start of the test and the new stages when the keyboard shortcut is used.

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Changed the default mode from chat to agent mode and updated the related test to match the new default.

<!-- End of auto-generated description by mrge. -->

