### PR TITLE
chore: :technologist: update the commit message for cla signing

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,9 +1,9 @@
 name: "CLA Assistant"
 on:
   issue_comment:
-    types: [ created ]
+    types: [created]
   pull_request_target:
-    types: [ opened, closed, synchronize ]
+    types: [opened, closed, synchronize]
 
 permissions:
   actions: write
@@ -27,3 +27,4 @@ jobs:
           path-to-document: "https://github.com/continuedev/continue/blob/main/docs/docs/CLA.md"
           branch: cla-signatures
           allowlist: dependabot[bot]
+          signed-commit-message: "CLA signed in $pullRequestNo"


### PR DESCRIPTION
## Description

If someone other than the signing user typed "recheck", it would cause the wrong user name to be referenced in the commit message...confusing. So removed that, and it's perfectly clear from the code changes who actually signed

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Tests

n/a
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Updated the commit message for CLA signing to always reference the pull request number, making it clear who signed. This removes confusion when someone else types "recheck".

<!-- End of auto-generated description by mrge. -->

