### PR TITLE
feat: only autoscroll Continue console when focused on last element

### DIFF
--- a/gui/src/components/console/Details.tsx
+++ b/gui/src/components/console/Details.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { LLMInteraction } from "../../hooks/useLLMLog";
 import useLLMSummary from "../../hooks/useLLMSummary";
 import End from "./End";
@@ -50,6 +50,18 @@ export default function Details({ interaction }: DetailsProps) {
   const scrollTop = useRef<HTMLDivElement>(null);
   const lastResult = useRef<any>(null);
   const summary = useLLMSummary(interaction);
+  const [isAtBottom, setIsAtBottom] = useState(true);
+
+  // Handler to check if user is at the bottom
+  function handleScroll() {
+    const elt = scrollTop.current;
+    if (!elt) {
+      return;
+    }
+    // Allow a small threshold for floating point errors
+    const threshold = 5;
+    setIsAtBottom((elt.scrollHeight - elt.scrollTop - elt.clientHeight) < threshold);
+  }
 
   useEffect(() => {
     if (interaction.end) {
@@ -59,15 +71,17 @@ export default function Details({ interaction }: DetailsProps) {
     const last = interaction.results[interaction.results.length - 1];
     if (last != lastResult.current) {
       lastResult.current = last;
-      const lastChild = scrollTop.current?.lastChild;
-      if (lastChild) {
-        (lastChild as HTMLElement).scrollIntoView({
-          behavior: "auto",
-          block: "end",
-        });
+      if (isAtBottom) {
+        const lastChild = scrollTop.current?.lastChild;
+        if (lastChild) {
+          (lastChild as HTMLElement).scrollIntoView({
+            behavior: "auto",
+            block: "end",
+          });
+        }
       }
     }
-  });
+  }, [interaction, isAtBottom]);
 
   return (
     <div className="m-0 flex min-w-0 flex-1 shrink grow flex-col">
@@ -102,7 +116,11 @@ export default function Details({ interaction }: DetailsProps) {
           ></Cell>
         </div>
       </div>
-      <div ref={scrollTop} className="grow overflow-auto">
+      <div
+        ref={scrollTop}
+        className="grow overflow-auto"
+        onScroll={handleScroll}
+      >
         {interaction.start ? <Start item={interaction.start}></Start> : ""}
         <div className="whitespace-pre-wrap p-2">
           {interaction.results.map((group, i) => {


### PR DESCRIPTION
## Description

While the Continue console is adding content during an LLM response, it's impossible to scroll back up because scrolling is locked to the last item. This PR allows the user to scroll back up, which automatically suspends autoscroll. It resumes when scrolling back to the last item

cc @owtaylor 

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

https://github.com/user-attachments/assets/2a665bf0-2e1f-42c9-af1b-ec07eda65151


## Tests

Manual testing (see video)

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
The Continue console now only autoscrolls when you are focused on the last item, letting you scroll up and pause autoscroll during LLM responses.

- **New Features**
  - Autoscroll suspends when you scroll up and resumes when you return to the bottom.

<!-- End of auto-generated description by mrge. -->

