### PR TITLE
Long words in assistant chat responses now wrap properly

### DIFF
--- a/gui/src/components/StyledMarkdownPreview/index.tsx
+++ b/gui/src/components/StyledMarkdownPreview/index.tsx
@@ -67,7 +67,6 @@ const StyledMarkdown = styled.div<{
     max-width: calc(100vw - 24px);
     overflow-x: scroll;
     overflow-y: hidden;
-
     padding: 8px;
   }
 
@@ -115,6 +114,13 @@ const StyledMarkdown = styled.div<{
 
   > *:last-child {
     margin-bottom: 0;
+  }
+  * {
+    word-break: break-word;
+    overflow-wrap: break-word;
+  } 
+  p, span, div {
+    white-space: pre-wrap;
   }
 `;
 


### PR DESCRIPTION
## Description

Previously, very long unbroken words in assistant responses would overflow their container or get cut off, especially on smaller screens.
This was due to markdown-rendered content (via StyledMarkdown) not propagating word-break and overflow-wrap to deeply nested elements 

This change: 
Only added a global * { word-break: break-word; overflow-wrap: break-word; } rule inside StyledMarkdown
-> gui/src/components/StyledMarkdownPreview/index.tsx
An explicit white-space: pre-wrap rule for p, span, and div
These changes ensure all markdown-rendered assistant responses wrap gracefully, even with unusually long tokens.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots

<p align="center">
  <img src="https://github.com/user-attachments/assets/7159518a-6fe0-4ea9-b5d2-b3f54e2e63b1" height="300" />
  <img src="https://github.com/user-attachments/assets/1c39704d-2e0d-4ee9-a277-4003d59c6162" height="300" />
</p>
## Tests

None

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Long unbroken words in assistant chat responses now wrap correctly, preventing overflow and cut-off on all screen sizes.

- **Bug Fixes**
  - Added global word-break and overflow-wrap rules to StyledMarkdown.
  - Set white-space: pre-wrap for p, span, and div elements.

<!-- End of auto-generated description by mrge. -->

