### PR TITLE
style: update button styles and background color

### DIFF
--- a/gui/src/components/index.ts
+++ b/gui/src/components/index.ts
@@ -158,7 +158,7 @@ export const GhostButton = styled.button`
 
   border: none;
   color: ${vscForeground};
-  background-color: rgba(255, 255, 255, 0.08);
+  background-color: rgba(128, 128, 128, 0.4);
   &:disabled {
     color: gray;
     pointer-events: none;

--- a/gui/src/components/mainInput/Lump/sections/ExploreBlocksButton.tsx
+++ b/gui/src/components/mainInput/Lump/sections/ExploreBlocksButton.tsx
@@ -49,7 +49,7 @@ export function ExploreBlocksButton(props: { blockType: string }) {
 
   return (
     <GhostButton
-      className="w-full cursor-pointer rounded px-2 py-0.5 text-center text-gray-400 hover:text-gray-300"
+      className="w-full cursor-pointer rounded px-2 py-0.5 text-center"
       style={{
         fontSize: fontSize(-3),
       }}


### PR DESCRIPTION
## Description

Fixed button text not being clear on hover in the highlight theme

## Screenshots

![bug0517_1](https://github.com/user-attachments/assets/c60a6124-8b4c-48e8-9cd9-c59c5a67cf14)
![bug0517_2](https://github.com/user-attachments/assets/ec9ccad1-3a7d-4367-adf0-d9aa83cabbd0)


## Tests

![fix0517_1](https://github.com/user-attachments/assets/d98b2ba1-68db-4f1b-bf13-4ab7dcbe2a66)
![fix0517_2](https://github.com/user-attachments/assets/f7d3e36f-309d-4df5-811c-94c7755def1f)


    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Updated button background color and removed extra text color classes to improve button text visibility on hover in the highlight theme.

<!-- End of auto-generated description by mrge. -->

