### PR TITLE
open prompt file or slug on edit click

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -842,6 +842,7 @@ export interface SlashCommand {
   description: string;
   prompt?: string;
   params?: { [key: string]: any };
+  promptFile?: string
   run: (sdk: ContinueSDK) => AsyncGenerator<string | undefined>;
 }
 

--- a/core/promptFiles/v1/slashCommandFromPromptFile.ts
+++ b/core/promptFiles/v1/slashCommandFromPromptFile.ts
@@ -63,6 +63,7 @@ export function slashCommandFromPromptFileV1(
     name,
     description,
     prompt,
+    promptFile: path,
     run: async function* (context) {
       const userInput = extractUserInput(context.input, name);
       const [_, renderedPrompt] = await renderPromptFileV2(prompt, {

--- a/gui/src/components/mainInput/Lump/sections/PromptsSection.tsx
+++ b/gui/src/components/mainInput/Lump/sections/PromptsSection.tsx
@@ -1,10 +1,12 @@
+import { parseConfigYaml } from "@continuedev/config-yaml";
 import {
   BookmarkIcon as BookmarkOutline,
   PencilIcon,
 } from "@heroicons/react/24/outline";
 import { BookmarkIcon as BookmarkSolid } from "@heroicons/react/24/solid";
 import { SlashCommandDescription } from "core";
-import { useContext } from "react";
+import { useContext, useMemo } from "react";
+import { useAuth } from "../../../../context/Auth";
 import { IdeMessengerContext } from "../../../../context/IdeMessenger";
 import { useBookmarkedSlashCommands } from "../../../../hooks/useBookmarkedSlashCommands";
 import { useAppSelector } from "../../../../redux/hooks";
@@ -13,8 +15,10 @@ import { useMainEditor } from "../../TipTapEditor";
 import { useLump } from "../LumpContext";
 import { ExploreBlocksButton } from "./ExploreBlocksButton";
 
+type PromptWithSlug = SlashCommandDescription & { slug?: string };
+
 interface PromptRowProps {
-  prompt: SlashCommandDescription;
+  prompt: PromptWithSlug;
   isBookmarked: boolean;
   setIsBookmarked: (isBookmarked: boolean) => void;
   onEdit?: () => void;
@@ -90,6 +94,7 @@ function PromptRow({
  * Section that displays all available prompts with bookmarking functionality
  */
 export function PromptsSection() {
+  const { selectedProfile } = useAuth();
   const { isCommandBookmarked, toggleBookmark } = useBookmarkedSlashCommands();
   const ideMessenger = useContext(IdeMessengerContext);
 
@@ -97,19 +102,56 @@ export function PromptsSection() {
     (state) => state.config.config.slashCommands ?? [],
   );
 
-  const handleEdit = (_prompt: SlashCommandDescription) => {
-    ideMessenger.post("config/openProfile", {
-      profileId: undefined,
-    });
+  const handleEdit = (prompt: PromptWithSlug) => {
+    if (prompt.promptFile) {
+      ideMessenger.post("openFile", {
+        path: prompt.promptFile,
+      });
+    } else if (prompt.slug) {
+      void ideMessenger.request("controlPlane/openUrl", {
+        path: `${prompt.slug}/new-version`,
+        orgSlug: undefined,
+      });
+    } else {
+      ideMessenger.post("config/openProfile", {
+        profileId: undefined,
+      });
+    }
   };
 
-  const sortedCommands = [...slashCommands].sort((a, b) => {
-    const aBookmarked = isCommandBookmarked(a.name);
-    const bBookmarked = isCommandBookmarked(b.name);
-    if (aBookmarked && !bBookmarked) return -1;
-    if (!aBookmarked && bBookmarked) return 1;
-    return 0;
-  });
+  const sortedCommands = useMemo(() => {
+    const promptsWithSlug: PromptWithSlug[] = structuredClone(slashCommands);
+    // get the slugs from rawYaml
+    if (selectedProfile?.rawYaml) {
+      const parsed = parseConfigYaml(selectedProfile.rawYaml);
+      const parsedPrompts = parsed.prompts ?? [];
+
+      let index = 0;
+      for (const prompt of promptsWithSlug) {
+        // skip for local prompt files
+        if (prompt.promptFile) continue;
+
+        const yamlPrompt = parsedPrompts[index];
+        if (yamlPrompt) {
+          if ("uses" in yamlPrompt) {
+            prompt.slug = yamlPrompt.uses;
+          } else {
+            prompt.slug =
+              `${selectedProfile?.fullSlug.ownerSlug}/${selectedProfile?.fullSlug.packageSlug}`;
+          }
+        }
+        index = index + 1;
+      }
+    }
+
+    return promptsWithSlug.sort((a, b) => {
+      const aBookmarked = isCommandBookmarked(a.name);
+      const bBookmarked = isCommandBookmarked(b.name);
+      if (aBookmarked && !bBookmarked) return -1;
+      if (!aBookmarked && bBookmarked) return 1;
+      return 0;
+    });
+  }, [slashCommands, isCommandBookmarked, selectedProfile]);
 
   return (
     <div className="flex flex-col">


### PR DESCRIPTION
## Description

We had introduced [opening the config when clicking on prompt edit](https://github.com/continuedev/continue/pull/5503) a few weeks back. This PR implements [a suggestion made on that PR](https://github.com/continuedev/continue/pull/5503#pullrequestreview-2833878002) to open the exact prompt file or slug.

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
