### PR TITLE
fix: reverted the URL of llama.cpp back to 'completion'.

### DIFF
--- a/core/llm/llms/LlamaCpp.ts
+++ b/core/llm/llms/LlamaCpp.ts
@@ -35,7 +35,7 @@ class LlamaCpp extends BaseLLM {
       ...this.requestOptions?.headers,
     };
 
-    const resp = await this.fetch(new URL("completions", this.apiBase), {
+    const resp = await this.fetch(new URL("completion", this.apiBase), {
       method: "POST",
       headers,
       body: JSON.stringify({


### PR DESCRIPTION
## Description

Closes: #5530
Reverted the URL of llama.cpp back to 'completion' since it's not changed at all.

The latest documentation from llama.cpp:
https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md#post-completion-given-a-prompt-it-returns-the-predicted-completion

`/v1/completions` is for OAI-compatible clients only, but in LlamaCpp.ts there is no `/v1` presented, and I don't think it should.

## Tests

Local tests with the extension built.
