### PR TITLE
feat: add regex to allow for openai o-series models and rename method…

### DIFF
--- a/core/llm/llms/OpenAI.test.ts
+++ b/core/llm/llms/OpenAI.test.ts
@@ -1,0 +1,34 @@
+import OpenAI from "./OpenAI";
+
+describe("OpenAI", () => {
+  test("should identify correct o-series models", () => {
+    const openai = new OpenAI({
+      model: "o3-mini",
+    });
+    expect(openai.isOSeriesModel("o4-mini")).toBeTruthy();
+    expect(openai.isOSeriesModel("o3-mini")).toBeTruthy();
+    expect(openai.isOSeriesModel("o1-mini")).toBeTruthy();
+    expect(openai.isOSeriesModel("o1")).toBeTruthy();
+    expect(openai.isOSeriesModel("o3")).toBeTruthy();
+
+    // artificially correct samples for future models
+    expect(openai.isOSeriesModel("o5-mini")).toBeTruthy();
+    expect(openai.isOSeriesModel("o6")).toBeTruthy();
+    expect(openai.isOSeriesModel("o77")).toBeTruthy();
+    expect(openai.isOSeriesModel("o54-mini")).toBeTruthy();
+  });
+  test("should identify incorrect o-series models", () => {
+    const openai = new OpenAI({
+      model: "o3-mini",
+    });
+    expect(openai.isOSeriesModel("gpt-o4-mini")).toBeFalsy();
+    expect(openai.isOSeriesModel("gpt-4.5")).toBeFalsy();
+    expect(openai.isOSeriesModel("gpt-4.5")).toBeFalsy();
+
+    // artificially wrong samples
+    expect(openai.isOSeriesModel("os1")).toBeFalsy();
+    expect(openai.isOSeriesModel("so1")).toBeFalsy();
+    expect(openai.isOSeriesModel("o3s1")).toBeFalsy();
+    expect(openai.isOSeriesModel("os1")).toBeFalsy();
+  });
+});

--- a/core/llm/llms/OpenAI.test.ts
+++ b/core/llm/llms/OpenAI.test.ts
@@ -23,12 +23,12 @@ describe("OpenAI", () => {
     });
     expect(openai.isOSeriesModel("gpt-o4-mini")).toBeFalsy();
     expect(openai.isOSeriesModel("gpt-4.5")).toBeFalsy();
-    expect(openai.isOSeriesModel("gpt-4.5")).toBeFalsy();
+    expect(openai.isOSeriesModel("gpt-4.1")).toBeFalsy();
 
     // artificially wrong samples
     expect(openai.isOSeriesModel("os1")).toBeFalsy();
     expect(openai.isOSeriesModel("so1")).toBeFalsy();
-    expect(openai.isOSeriesModel("o3s1")).toBeFalsy();
-    expect(openai.isOSeriesModel("os1")).toBeFalsy();
+    expect(openai.isOSeriesModel("ao31")).toBeFalsy();
+    expect(openai.isOSeriesModel("1os")).toBeFalsy();
   });
 });

--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -77,8 +77,8 @@ class OpenAI extends BaseLLM {
     return model;
   }
 
-  private isO3orO1Model(model?: string): boolean {
-    return !!model && (model.startsWith("o1") || model.startsWith("o3"));
+  private isOSeriesModel(model?: string): boolean {
+    return !!model && model.match(/^o[0-9]+/);
   }
 
   private isFireworksAiModel(model?: string): boolean {
@@ -139,7 +139,7 @@ class OpenAI extends BaseLLM {
     finalOptions.stop = options.stop?.slice(0, this.getMaxStopWords());
 
     // OpenAI o1-preview and o1-mini or o3-mini:
-    if (this.isO3orO1Model(options.model)) {
+    if (this.isOSeriesModel(options.model)) {
       // a) use max_completion_tokens instead of max_tokens
       finalOptions.max_completion_tokens = options.maxTokens;
       finalOptions.max_tokens = undefined;
@@ -241,7 +241,7 @@ class OpenAI extends BaseLLM {
     body.stop = body.stop?.slice(0, this.getMaxStopWords());
 
     // OpenAI o1-preview and o1-mini or o3-mini:
-    if (this.isO3orO1Model(body.model)) {
+    if (this.isOSeriesModel(body.model)) {
       // a) use max_completion_tokens instead of max_tokens
       body.max_completion_tokens = body.max_tokens;
       body.max_tokens = undefined;

--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -77,7 +77,7 @@ class OpenAI extends BaseLLM {
     return model;
   }
 
-  private isOSeriesModel(model?: string): boolean {
+  public isOSeriesModel(model?: string): boolean {
     return !!model && !!model.match(/^o[0-9]+/);
   }
 

--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -78,7 +78,7 @@ class OpenAI extends BaseLLM {
   }
 
   private isOSeriesModel(model?: string): boolean {
-    return !!model && model.match(/^o[0-9]+/);
+    return !!model && !!model.match(/^o[0-9]+/);
   }
 
   private isFireworksAiModel(model?: string): boolean {


### PR DESCRIPTION
## Description
ref: #5728 
add regex /^o[0-9]+/ to allow for openai o-series models and rename method isO3orO1Model to isOSeriesModel

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots
no visual changes

## Tests
no tests to update