### PR TITLE
fix: add Delphi/Pascal syntax highlighting support

### DIFF
--- a/gui/src/components/StyledMarkdownPreview/rehypeHighlightPlugin.ts
+++ b/gui/src/components/StyledMarkdownPreview/rehypeHighlightPlugin.ts
@@ -1,6 +1,7 @@
 // Feel free to add more!
 // See gui/node_modules/highlight.js/lib/languages for the full available list
 import clojure from "highlight.js/lib/languages/clojure";
+import delphi from "highlight.js/lib/languages/delphi";
 import elixir from "highlight.js/lib/languages/elixir";
 import julia from "highlight.js/lib/languages/julia";
 import lisp from "highlight.js/lib/languages/lisp";
@@ -19,6 +20,7 @@ export function rehypeHighlightPlugin() {
       languages: {
         ...common,
         clojure,
+        delphi,
         elixir,
         julia,
         protobuf,


### PR DESCRIPTION
## Description

https://github.com/continuedev/continue/pull/4771 was supposed to fix Pascal highlighting support but it actually [removed Delphi support](https://github.com/continuedev/continue/pull/4771/commits/b55c7b308c3781925f5e55655ed6b26c657c9847) in the process. I'm just trying it again as I'm puzzled by the reason (delphi didn't exist according to tests).

Fixes #3586

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

<img width="293" alt="Screenshot 2025-05-19 at 09 53 15" src="https://github.com/user-attachments/assets/d86e0cd0-da31-4afe-9ef8-bd21b08c238d" />


## Tests

- ask a chat model to write a "hello world" program in Pascal.
- pascal snippet should be highlighted.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Restored Delphi/Pascal syntax highlighting support in the markdown preview so Pascal code snippets are highlighted correctly.

<!-- End of auto-generated description by cubic. -->

