### PR TITLE
Fix: improve command extraction in RunInTerminalButton (#5724)

### DIFF
--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/RunInTerminalButton.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/RunInTerminalButton.tsx
@@ -18,14 +18,38 @@ export function RunInTerminalButton({ command }: RunInTerminalButtonProps) {
 
   // Extract just the command line (the line after $ or the first line)
   function extractCommand(cmd: string): string {
-    // If the command contains a $ prompt, extract the line after it
+    // First handle the $ prompt case, extract the line after it
     if (cmd.includes("$")) {
       const match = cmd.match(/\$\s*([^\n]+)/);
-      return match ? match[1].trim() : "";
+      if (match) {
+        return match[1].trim();
+      }
     }
 
-    // Otherwise, just take the first line
-    return cmd.split("\n")[0].trim();
+    // Process all lines, filtering out comments and empty lines
+    const lines = cmd.split("\n")
+      .map(line => line.trim())
+      .filter(line => 
+        line && 
+        !line.startsWith("#") && 
+        !line.startsWith("//") && 
+        !line.startsWith("/*")
+      );
+
+    // Handle multi-line commands
+    let result = "";
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      result += line;
+      
+      // Add space for command continuation
+      if (line.endsWith("&&") || line.endsWith("|") || line.endsWith("\\")) {
+        result += " ";
+      } else if (i < lines.length - 1) {
+        result += " ";
+      }
+    }
+    return result.trim();
   }
 
   function runInTerminal() {

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/RunInTerminalButton.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/RunInTerminalButton.tsx
@@ -3,6 +3,7 @@ import { useContext } from "react";
 import { lightGray, vscForeground } from "../..";
 import { IdeMessengerContext } from "../../../context/IdeMessenger";
 import { isJetBrains } from "../../../util";
+import { extractCommand } from "../utils/commandExtractor";
 
 interface RunInTerminalButtonProps {
   command: string;
@@ -14,42 +15,6 @@ export function RunInTerminalButton({ command }: RunInTerminalButtonProps) {
   if (isJetBrains()) {
     // JetBrains plugin doesn't currently have a way to run the command in the terminal for the user
     return null;
-  }
-
-  // Extract just the command line (the line after $ or the first line)
-  function extractCommand(cmd: string): string {
-    // First handle the $ prompt case, extract the line after it
-    if (cmd.includes("$")) {
-      const match = cmd.match(/\$\s*([^\n]+)/);
-      if (match) {
-        return match[1].trim();
-      }
-    }
-
-    // Process all lines, filtering out comments and empty lines
-    const lines = cmd.split("\n")
-      .map(line => line.trim())
-      .filter(line => 
-        line && 
-        !line.startsWith("#") && 
-        !line.startsWith("//") && 
-        !line.startsWith("/*")
-      );
-
-    // Handle multi-line commands
-    let result = "";
-    for (let i = 0; i < lines.length; i++) {
-      const line = lines[i];
-      result += line;
-      
-      // Add space for command continuation
-      if (line.endsWith("&&") || line.endsWith("|") || line.endsWith("\\")) {
-        result += " ";
-      } else if (i < lines.length - 1) {
-        result += " ";
-      }
-    }
-    return result.trim();
   }
 
   function runInTerminal() {

--- a/gui/src/components/StyledMarkdownPreview/utils/commandExtractor.test.ts
+++ b/gui/src/components/StyledMarkdownPreview/utils/commandExtractor.test.ts
@@ -1,0 +1,80 @@
+import { extractCommand } from './commandExtractor';
+
+describe('extractCommand', () => {
+  // Test basic command extraction
+  it('should extract command from $ prompt', () => {
+    expect(extractCommand('$ echo hello')).toBe('echo hello');
+    expect(extractCommand('$  echo hello')).toBe('echo hello');
+    expect(extractCommand('$echo hello')).toBe('echo hello');
+  });
+
+  // Test comment removal
+  it('should remove comments at beginning of lines', () => {
+    expect(extractCommand('# shell comment\necho hello')).toBe('echo hello');
+    expect(extractCommand('// js comment\necho hello')).toBe('echo hello');
+    expect(extractCommand('/* multi-line\ncomment */\necho hello')).toBe('echo hello');
+  });
+
+  // Test multiline comment removal
+  it('should remove multiline comments anywhere in the text', () => {
+    expect(extractCommand('echo /* comment */ hello')).toBe('echo hello');
+    expect(extractCommand('echo hello /* comment */')).toBe('echo hello');
+    expect(extractCommand('echo /* multiple\nline\ncomment */ hello')).toBe('echo hello');
+  });
+
+  // Test line continuation handling
+  it('should handle line continuations correctly', () => {
+    expect(extractCommand('echo hello && \\\necho world')).toBe('echo hello && echo world');
+    expect(extractCommand('echo hello | \\\ngrep h')).toBe('echo hello | grep h');
+    expect(extractCommand('echo hello \\\nworld')).toBe('echo hello world');
+  });
+
+  // Test complex command combinations
+  it('should handle complex command combinations', () => {
+    expect(extractCommand(`
+      # shell comment
+      echo hello /* inline comment */ && \\
+      // js comment
+      echo world
+    `)).toBe('echo hello && echo world');
+  });
+
+  // Test empty and whitespace handling
+  it('should handle empty and whitespace inputs', () => {
+    expect(extractCommand('')).toBe('');
+    expect(extractCommand('   \n   \t   ')).toBe('');
+  });
+
+  // Test comment-only inputs
+  it('should handle comment-only inputs', () => {
+    expect(extractCommand('/* comment */')).toBe('');
+    expect(extractCommand('# comment')).toBe('');
+    expect(extractCommand('// comment')).toBe('');
+    expect(extractCommand('/* multi\nline\ncomment */')).toBe('');
+  });
+
+  // Test inline comments
+  it('should handle inline comments correctly according to implementation', () => {
+    // But removes multiline comments even when inline
+    expect(extractCommand('/* inline */ echo hello world')).toBe('echo hello world');
+  });
+
+  // Test multiple line continuations
+  it('should handle multiple line continuations', () => {
+    expect(extractCommand(`
+      echo hello && \\
+      echo world && \\
+      echo test
+    `)).toBe('echo hello && echo world && echo test');
+  });
+
+  // Test nested line continuations
+  it('should handle nested line continuations', () => {
+    expect(extractCommand(`
+      echo hello && \\
+      (echo nested && \\
+       echo more) && \\
+      echo final
+    `)).toBe('echo hello && (echo nested && echo more) && echo final');
+  });
+});

--- a/gui/src/components/StyledMarkdownPreview/utils/commandExtractor.ts
+++ b/gui/src/components/StyledMarkdownPreview/utils/commandExtractor.ts
@@ -1,0 +1,50 @@
+/**
+ * Extracts and processes command strings, handling comments and line continuations.
+ * @param cmd The command string to process
+ * @returns The processed command string
+ */
+export function extractCommand(cmd: string): string {
+  if (!cmd || cmd.trim() === '') {
+    return '';
+  }
+  
+  // Remove multi-line comments (/* ... */) and replace with a single space
+  cmd = cmd.replace(/\/\*[\s\S]*?\*\//g, " ");
+
+  // Handle the $ prompt case first
+  if (cmd.includes("$")) {
+    const match = cmd.match(/\$\s*([^\n]+)/);
+    if (match) {
+      // Return just the command after $ without further processing
+      return match[1].trim();
+    }
+  }
+
+  // Process lines - remove single-line comments only at beginning of lines
+  const lines = cmd.split('\n')
+    .map(line => line.replace(/^\s*#.*$/, '').replace(/^\s*\/\/.*$/, ''))
+    .map(line => line.trim())
+    .filter(line => line);
+
+  // Join lines with proper handling of continuations
+  let result = '';
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i];
+
+    // Remove trailing continuation characters and join with next line
+    while (
+      (line.endsWith('&&') || line.endsWith('|') || line.endsWith('\\')) &&
+      i < lines.length - 1
+    ) {
+      // Remove the continuation character(s) and any trailing spaces
+      line = line.replace(/(&&|\||\\)\s*$/, '').trim();
+      // Join with the next line
+      i++;
+      line += ' ' + lines[i];
+    }
+
+    result += line + ' ';
+  }
+
+  return result.trim().replace(/\s+/g, ' ');
+}


### PR DESCRIPTION
## Description

Enhanced the `extractCommand` function in RunInTerminalButton to handle command extraction more robustly:

1. Added support for multi-line command parsing by:
   - Splitting input on newlines
   - Filtering out comments (lines starting with #, //, /*)
   - Removing empty lines
   - Preserving command continuations (&&, |, \)

2. Improved command concatenation by:
   - Adding proper spacing between command parts
   - Maintaining command structure for piped commands
   - Preserving command operators

3. Maintained existing $ prompt handling while adding new functionality

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots

https://drive.google.com/file/d/1SBqtTkoslo4w7vVJ0DeCUPUCMc0HbJ0x/view?usp=sharing

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

The following test cases were verified:
1. Single-line commands with $ prompt
   ```bash
   $ echo "hello"
   ```

2. Multi-line commands
   ```bash
   echo "first line" && \
   echo "second line"
   ```

3. Commands with comments
   ```bash
   # This is a comment
   echo "actual command"
   ```

4. Commands with operators
   ```bash
   command1 && command2 | command3
   ```

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved the command extraction in RunInTerminalButton to better handle multi-line commands, comments, and command operators.

- **Bug Fixes**
  - Skips comment lines and empty lines.
  - Preserves command continuations and operators like &&, |, and \.
  - Keeps existing $ prompt handling.

<!-- End of auto-generated description by cubic. -->

