### PR TITLE
Fix config merging

### DIFF
--- a/core/config/load.ts
+++ b/core/config/load.ts
@@ -101,7 +101,14 @@ export function resolveSerializedConfig(
 
 const configMergeKeys = {
   models: (a: any, b: any) => a.title === b.title,
-  contextProviders: (a: any, b: any) => a.name === b.name,
+  contextProviders: (a: any, b: any) => {
+    // If not HTTP providers, use the name only
+    if (a.name !== "http" || b.name !== "http") {
+      return a.name === b.name;
+    }
+    // For HTTP providers, consider them different if they have different URLs
+    return a.name === b.name && a.params?.url === b.params?.url;
+  },
   slashCommands: (a: any, b: any) => a.name === b.name,
   customCommands: (a: any, b: any) => a.name === b.name,
 };
@@ -970,6 +977,5 @@ export {
   finalToBrowserConfig,
   intermediateToFinalConfig,
   loadContinueConfigFromJson,
-  type BrowserSerializedContinueConfig
+  type BrowserSerializedContinueConfig,
 };
-


### PR DESCRIPTION
## Description

if using remote config and local json config then without this fix only http providers from remote config are used due to the fact that providers have the same name "http".

Sample part of local config.json:

```
{ 
    "contextProviders": [
    {
      "name": "http",
      "params": {
        "url": "https://example.com/something1",
        "title": "Something1",
        "description": "Something1 desc",
        "displayTitle": "Something1"
    },
    {
      "name": "http",
      "params": {
        "url": "https://example.com/something2",
        "title": "Something2",
        "description": "Something2 desc",
        "displayTitle": "Something2"      
    }
    ]
}
```

Part of remote config:

```
{ 
    "contextProviders": [
    {
      "name": "http",
      "params": {
        "url": "https://example.com/something3",
        "title": "Something3",
        "description": "Something3 desc",
        "displayTitle": "Something3"
    }
    ]
}
```

With my fix Something1, Something2 and Something3 context providers will be available, without fix only Something3 can be used

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed config merging so that multiple HTTP context providers with different URLs from both local and remote configs are now included, instead of only one being used.

<!-- End of auto-generated description by cubic. -->

