### PR TITLE
feat: Add 'Improve Prompt' button to chat input

### DIFF
--- a/core/llm/utils/improvePrompt.ts
+++ b/core/llm/utils/improvePrompt.ts
@@ -1,0 +1,7 @@
+export const improvePrompt = (prompt: string): Promise<string> => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(`${prompt} (improved)`);
+    }, 500);
+  });
+};

--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -21,6 +21,7 @@ import ModelSelect from "../modelSelection/ModelSelect";
 import ModeSelect from "../modelSelection/ModeSelect";
 import { useFontSize } from "../ui/font";
 import { EnterButton } from "./InputToolbar/EnterButton";
+import { default as ImprovePromptButton } from "./InputToolbar/ImprovePromptButton";
 import HoverItem from "./InputToolbar/HoverItem";
 
 export interface ToolbarOptions {
@@ -36,6 +37,7 @@ interface InputToolbarProps {
   onAddContextItem?: () => void;
   onClick?: () => void;
   onImageFileSelected?: (file: File) => void;
+  onImprovePrompt?: () => void;
   hidden?: boolean;
   activeKey: string | null;
   toolbarOptions?: ToolbarOptions;
@@ -196,6 +198,10 @@ function InputToolbar(props: InputToolbarProps) {
                 <i>Esc</i> to exit
               </span>
             </HoverItem>
+          )}
+
+          {props.onImprovePrompt && (
+            <ImprovePromptButton onClick={props.onImprovePrompt} />
           )}
 
           <EnterButton

--- a/gui/src/components/mainInput/InputToolbar/ImprovePromptButton.tsx
+++ b/gui/src/components/mainInput/InputToolbar/ImprovePromptButton.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { ToolTip } from '../../gui/Tooltip'; // Adjusted path
+
+interface ImprovePromptButtonProps {
+  onClick: () => void;
+}
+
+const ImprovePromptButton: React.FC<ImprovePromptButtonProps> = ({ onClick }) => {
+  const tooltipId = "improve-prompt-tooltip";
+  return (
+    <>
+      <button
+        onClick={onClick}
+        className="text-gray-400 hover:underline px-1 focus:outline-none"
+        data-tooltip-id={tooltipId}
+      >
+        Improve
+      </button>
+      <ToolTip id={tooltipId} place="top">
+        Improve Prompt
+      </ToolTip>
+    </>
+  );
+};
+
+export default ImprovePromptButton;

--- a/gui/src/components/mainInput/TipTapEditor/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor/TipTapEditor.tsx
@@ -1,7 +1,7 @@
 import { Editor, EditorContent, JSONContent } from "@tiptap/react";
 import { ContextProviderDescription, InputModifiers } from "core";
 import { modelSupportsImages } from "core/llm/autodetect";
-import { improvePrompt } from "../../../../core/llm/utils/improvePrompt";
+import { improvePrompt } from "core/llm/utils/improvePrompt";
 import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { IdeMessengerContext } from "../../../context/IdeMessenger";
 import useIsOSREnabled from "../../../hooks/useIsOSREnabled";


### PR DESCRIPTION
This commit introduces a new button to the chat input toolbar that allows you to improve your typed prompt using an AI service.

Key changes include:

- Added an `improvePrompt` placeholder function in `core/llm/utils/improvePrompt.ts` to simulate AI interaction.
- Created a new `ImprovePromptButton` React component in `gui/src/components/mainInput/InputToolbar/`.
- Integrated the `ImprovePromptButton` into the existing `InputToolbar.tsx` component.
- Modified `TipTapEditor.tsx` to handle the button's click event, call the `improvePrompt` service, and update the editor content with the improved prompt.
- Styled the new button to be visually consistent with other toolbar elements and added a tooltip.

## Description

[ What changed? Feel free to be brief. ]

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added an "Improve Prompt" button to the chat input toolbar that rewrites your typed prompt for better clarity.

- **New Features**
  - New button in the input toolbar to improve prompts.
  - Updates the editor with the improved prompt when clicked.

<!-- End of auto-generated description by cubic. -->

