### PR TITLE
feat(JB): impl `showFile`

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -842,7 +842,7 @@ export interface SlashCommand {
   description: string;
   prompt?: string;
   params?: { [key: string]: any };
-  promptFile?: string
+  promptFile?: string;
   run: (sdk: ContinueSDK) => AsyncGenerator<string | undefined>;
 }
 
@@ -1251,6 +1251,10 @@ export interface HighlightedCodePayload {
 export interface AcceptOrRejectDiffPayload {
   filepath: string;
   streamId?: string;
+}
+
+export interface ShowFilePayload {
+  filepath: string;
 }
 
 export interface RangeInFileWithContents {

--- a/core/protocol/ideWebview.ts
+++ b/core/protocol/ideWebview.ts
@@ -8,6 +8,7 @@ import {
   MessageContent,
   RangeInFileWithContents,
   AcceptOrRejectDiffPayload,
+  ShowFilePayload,
 } from "../";
 
 export type ToIdeFromWebviewProtocol = ToIdeFromWebviewOrCoreProtocol & {
@@ -23,7 +24,7 @@ export type ToIdeFromWebviewProtocol = ToIdeFromWebviewOrCoreProtocol & {
   ];
   overwriteFile: [{ filepath: string; prevFileContent: string | null }, void];
   showTutorial: [undefined, void];
-  showFile: [{ filepath: string }, void];
+  showFile: [ShowFilePayload, void];
   toggleDevTools: [undefined, void];
   reloadWindow: [undefined, void];
   focusEditor: [undefined, void];

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
@@ -91,6 +91,15 @@ class IdeProtocolClient(
                         respond(jsonData)
                     }
 
+                    "showFile" -> {
+                        val params = Gson().fromJson(
+                            dataElement.toString(),
+                            ShowFilePayload::class.java
+                        )
+                        ide.openFile(params.filepath)
+                        respond(null)
+                    }
+
                     "getIdeSettings" -> {
                         val settings = ide.getIdeSettings()
                         respond(settings)
@@ -438,7 +447,7 @@ class IdeProtocolClient(
                     "acceptDiff" -> {
                         val params = Gson().fromJson(
                             dataElement.toString(),
-                            AcceptDiffParams::class.java
+                            AcceptOrRejectDiffPayload::class.java
                         )
                         val filepath = params.filepath;
 
@@ -454,7 +463,7 @@ class IdeProtocolClient(
                     "rejectDiff" -> {
                         val params = Gson().fromJson(
                             dataElement.toString(),
-                            RejectDiffParams::class.java
+                            AcceptOrRejectDiffPayload::class.java
                         )
                         val filepath = params.filepath;
 

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/protocol/ideWebview.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/protocol/ideWebview.kt
@@ -15,16 +15,6 @@ data class ApplyToFileParams(
     val toolCallId: String?
 )
 
-data class AcceptDiffParams(
-    val filepath: String,
-    val streamId: String
-)
-
-data class RejectDiffParams(
-    val filepath: String,
-    val streamId: String
-)
-
 data class InsertAtCursorParams(
     val text: String
 )

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/types.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/types.kt
@@ -251,3 +251,7 @@ data class AcceptOrRejectDiffPayload(
     val filepath: String,
     val streamId: String? = null
 )
+
+data class ShowFilePayload(
+    val filepath: String
+)


### PR DESCRIPTION
## Description

- Implements the missing `showFile` handler in JB
- Uses the correct `AcceptOrRejectDiffPayload` type for accept/reject diff (cleanup from old PR)

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added the missing showFile handler for JetBrains, allowing files to be opened from the UI. Also cleaned up diff handling by using the correct AcceptOrRejectDiffPayload type.

<!-- End of auto-generated description by cubic. -->

