### PR TITLE
Match all context to rules

### DIFF
--- a/core/edit/streamDiffLines.ts
+++ b/core/edit/streamDiffLines.ts
@@ -122,6 +122,7 @@ export async function* streamDiffLines({
                 (msg) => msg.role === "user" || msg.role === "tool",
               ) as UserChatMessage | ToolResultChatMessage | undefined),
         baseSystemMessage: undefined,
+        contextItems: [],
       })
     : undefined;
 

--- a/core/llm/constructMessages.ts
+++ b/core/llm/constructMessages.ts
@@ -84,8 +84,8 @@ ${EDIT_MESSAGE}
 function getUserContextItems(
   userMsg: UserChatMessage | ToolResultChatMessage | undefined,
   history: ChatHistoryItem[],
-): ContextItemWithId[] | undefined {
-  if (!userMsg) return undefined;
+): ContextItemWithId[] {
+  if (!userMsg) return [];
 
   // Find the history item that contains the userMsg
   const historyItem = history.find((item) => {
@@ -100,7 +100,7 @@ function getUserContextItems(
     );
   });
 
-  return historyItem?.contextItems;
+  return historyItem?.contextItems || [];
 }
 
 export function constructMessages(

--- a/core/llm/rules/getSystemMessageWithRules.test.ts
+++ b/core/llm/rules/getSystemMessageWithRules.test.ts
@@ -25,6 +25,14 @@ describe("getSystemMessageWithRules", () => {
     source: "rules-block",
   };
 
+  // JavaScript rule
+  const jsRule: RuleWithSource = {
+    name: "JavaScript Rule",
+    rule: "Follow JavaScript best practices",
+    globs: "**/*.js",
+    source: "rules-block",
+  };
+
   it("should not include pattern-matched rules when no file paths are mentioned", () => {
     const result = getSystemMessageWithRules({
       baseSystemMessage,
@@ -197,5 +205,62 @@ describe("getSystemMessageWithRules", () => {
 
     // Should not match any file paths
     expect(result).toBe(baseSystemMessage);
+  });
+
+  // New test for code block with filename only (no language)
+  it("should handle code blocks with filename only (no language identifier)", () => {
+    const userMessage: UserChatMessage = {
+      role: "user",
+      content: "```test.js\nclass Calculator { /* code */ }\n```",
+    };
+
+    const result = getSystemMessageWithRules({
+      baseSystemMessage,
+      userMessage,
+      rules: [jsRule, tsRule, generalRule],
+    });
+
+    // Should include JS rule and general rule
+    const expected = `${baseSystemMessage}\n\n${jsRule.rule}\n\n${generalRule.rule}`;
+    expect(result).toBe(expected);
+  });
+
+  // New test for code blocks with line ranges
+  it("should handle code blocks with line ranges", () => {
+    const userMessage: UserChatMessage = {
+      role: "user",
+      content: "```js test.js (19-25)\ndivide(number) { /* code */ }\n```",
+    };
+
+    const result = getSystemMessageWithRules({
+      baseSystemMessage,
+      userMessage,
+      rules: [jsRule, tsRule, generalRule],
+    });
+
+    // Should include JS rule and general rule
+    const expected = `${baseSystemMessage}\n\n${jsRule.rule}\n\n${generalRule.rule}`;
+    expect(result).toBe(expected);
+  });
+
+  // New test for mixed code block formats
+  it("should handle mixed code block formats in the same message", () => {
+    const userMessage: UserChatMessage = {
+      role: "user",
+      content:
+        "```test.js\nclass Calculator { /* code */ }\n```\n" +
+        "```js utils.js (19-25)\ndivide(number) { /* code */ }\n```\n" +
+        "```ts config/settings.ts\nconst config = {};\n```",
+    };
+
+    const result = getSystemMessageWithRules({
+      baseSystemMessage,
+      userMessage,
+      rules: [jsRule, tsRule, generalRule],
+    });
+
+    // Should include JS rule, TS rule, and general rule
+    const expected = `${baseSystemMessage}\n\n${jsRule.rule}\n\n${tsRule.rule}\n\n${generalRule.rule}`;
+    expect(result).toBe(expected);
   });
 });

--- a/core/llm/rules/getSystemMessageWithRules.ts
+++ b/core/llm/rules/getSystemMessageWithRules.ts
@@ -30,11 +30,16 @@ const matchesGlobs = (
 
 /**
  * Filters rules that apply to the given message and/or context items
+ *
+ * @param userMessage - The user or tool message to check for file paths in code blocks
+ * @param rules - The list of rules to filter
+ * @param contextItems - Context items to check for file paths
+ * @returns List of applicable rules
  */
 export const getApplicableRules = (
   userMessage: UserChatMessage | ToolResultChatMessage | undefined,
   rules: RuleWithSource[],
-  contextItems?: ContextItemWithId[],
+  contextItems: ContextItemWithId[],
 ): RuleWithSource[] => {
   const filePathsFromMessage = userMessage
     ? extractPathsFromCodeBlocks(renderChatMessage(userMessage))
@@ -42,11 +47,8 @@ export const getApplicableRules = (
 
   // Extract file paths from context items
   const filePathsFromContextItems = contextItems
-    ? contextItems
-        .filter((item) => item.uri?.type === "file" && item.uri?.value)
-        .map((item) => item.uri!.value)
-    : [];
-
+    .filter((item) => item.uri?.type === "file" && item.uri?.value)
+    .map((item) => item.uri!.value);
   // Combine file paths from both sources
   const allFilePaths = [...filePathsFromMessage, ...filePathsFromContextItems];
 
@@ -62,6 +64,15 @@ export const getApplicableRules = (
   });
 };
 
+/**
+ * Creates a system message string with applicable rules appended
+ *
+ * @param baseSystemMessage - The base system message to start with
+ * @param userMessage - The user message to check for file paths
+ * @param rules - The list of rules to filter
+ * @param contextItems - Context items to check for file paths
+ * @returns System message with applicable rules appended
+ */
 export const getSystemMessageWithRules = ({
   baseSystemMessage,
   userMessage,
@@ -71,7 +82,7 @@ export const getSystemMessageWithRules = ({
   baseSystemMessage?: string;
   userMessage: UserChatMessage | ToolResultChatMessage | undefined;
   rules: RuleWithSource[];
-  contextItems?: ContextItemWithId[];
+  contextItems: ContextItemWithId[];
 }) => {
   const applicableRules = getApplicableRules(userMessage, rules, contextItems);
   let systemMessage = baseSystemMessage ?? "";

--- a/core/llm/utils/extractPathsFromCodeBlocks.test.ts
+++ b/core/llm/utils/extractPathsFromCodeBlocks.test.ts
@@ -1,0 +1,35 @@
+import { extractPathsFromCodeBlocks } from "./extractPathsFromCodeBlocks";
+
+describe("extractPathsFromCodeBlocks", () => {
+  it("should extract paths from code blocks with language and filepath", () => {
+    const content = "```typescript src/main.ts\nconst x = 1;\n```";
+    expect(extractPathsFromCodeBlocks(content)).toEqual(["src/main.ts"]);
+  });
+
+  it("should extract paths from code blocks with filepath only (no language)", () => {
+    const content = "```test.js\nclass Calculator { }\n```";
+    expect(extractPathsFromCodeBlocks(content)).toEqual(["test.js"]);
+  });
+
+  it("should extract paths from code blocks with line ranges", () => {
+    const content = "```js test.js (19-25)\nfunction test() {}\n```";
+    expect(extractPathsFromCodeBlocks(content)).toEqual(["test.js"]);
+  });
+
+  it("should handle multiple code blocks with different formats", () => {
+    const content = 
+      "```typescript src/main.ts\nconst x = 1;\n```\n" +
+      "```test.js\nclass Calculator { }\n```\n" +
+      "```js utils.js (19-25)\nfunction test() {}\n```";
+    const result = extractPathsFromCodeBlocks(content);
+    expect(result).toContain("src/main.ts");
+    expect(result).toContain("test.js");
+    expect(result).toContain("utils.js");
+    expect(result.length).toBe(3);
+  });
+
+  it("should not extract paths from code blocks without file paths", () => {
+    const content = "```typescript\nconst x = 1;\n```";
+    expect(extractPathsFromCodeBlocks(content)).toEqual([]);
+  });
+});

--- a/core/llm/utils/extractPathsFromCodeBlocks.ts
+++ b/core/llm/utils/extractPathsFromCodeBlocks.ts
@@ -2,21 +2,37 @@
  * Extracts file paths from markdown code blocks
  */
 export function extractPathsFromCodeBlocks(content: string): string[] {
-  // Match:
-  // 1. Starting ```
-  // 2. Optional language identifier
-  // 3. Required whitespace
-  // 4. File path (captured) that must contain a dot and extension
-  const codeBlockRegex = /```(?:[\w-+#]+)?\s+([^\s\n()]+\.[a-zA-Z0-9]+)/g;
-  const paths: string[] = [];
-  let match;
+  console.log("CONTENT", content);
 
-  while ((match = codeBlockRegex.exec(content)) !== null) {
-    const path = match[1];
-    if (path && !path.startsWith("```")) {
-      paths.push(path);
+  const paths: string[] = [];
+
+  // Match code block opening patterns:
+  // 1. ```language filepath
+  // 2. ```filepath
+  // 3. ```language filepath (range)
+
+  // First match all code block starts
+  const codeBlockStarts = content.match(/```[^\n]+/g) || [];
+
+  for (const blockStart of codeBlockStarts) {
+    // Try to extract a valid filename with extension
+    const filenameMatches = blockStart.match(/([^\s()```]+\.[a-zA-Z0-9]+)/);
+
+    if (filenameMatches && filenameMatches[1]) {
+      const filename = filenameMatches[1];
+
+      // Verify this is a legitimate filename (not part of something else)
+      if (
+        // Check if valid extension
+        /\.[a-zA-Z0-9]+$/.test(filename) &&
+        // Make sure it's not a URL
+        !filename.includes("://") &&
+        // Avoid duplicates
+        !paths.includes(filename)
+      ) {
+        paths.push(filename);
+      }
     }
   }
-
   return paths;
 }

--- a/gui/src/redux/thunks/streamResponse.ts
+++ b/gui/src/redux/thunks/streamResponse.ts
@@ -100,6 +100,7 @@ export const streamResponseThunk = createAsyncThunk<
             ? (userMsg as UserChatMessage | ToolResultChatMessage)
             : undefined,
           rules,
+          selectedContextItems,
         );
 
         // Store in history for UI display


### PR DESCRIPTION
## Description

Match all context to rules.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated rule matching so that rules now apply to all files referenced in both user messages and context items, not just files mentioned in code blocks.

- **Bug Fixes**
  - Rules are now correctly matched to files from context, fixing cases where some rules were missed.
  - Improved file path extraction from code blocks to handle more formats.

<!-- End of auto-generated description by cubic. -->

