### PR TITLE
Non-native tools experiment

### DIFF
--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -1122,7 +1122,6 @@ declare global {
      * This is needed to crawl a large number of documentation sites that are dynamically rendered.
      */
     useChromiumForDocsCrawling?: boolean;
-    useTools?: boolean;
     modelContextProtocolServers?: MCPOptions[];
   }
   

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "1.1.36",
+  "version": "1.1.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "1.1.36",
+      "version": "1.1.38",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -63,7 +63,8 @@
         "tailwind-merge": "^3.0.2",
         "tippy.js": "^6.3.7",
         "unist-util-visit": "^5.0.0",
-        "uuid": "^9.0.1"
+        "uuid": "^9.0.1",
+        "xml2js": "^0.6.2"
       },
       "devDependencies": {
         "@swc/cli": "^0.3.14",
@@ -83,6 +84,7 @@
         "@types/react-syntax-highlighter": "^15.5.7",
         "@types/redux-logger": "^3.0.13",
         "@types/styled-components": "^5.1.26",
+        "@types/xml2js": "^0.4.14",
         "@vitejs/plugin-react-swc": "^3.9.0",
         "@vitest/coverage-v8": "^2.1.3",
         "@vitest/ui": "^2.1.3",
@@ -3331,6 +3333,16 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="
+    },
+    "node_modules/@types/xml2js": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
+      "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.16.0",
@@ -10983,6 +10995,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -13872,6 +13890,28 @@
       "dev": true,
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xmlchars": {

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -29,6 +29,7 @@
         "core": "file:../core",
         "dompurify": "^3.0.6",
         "downshift": "^7.6.0",
+        "fast-xml-parser": "^5.2.3",
         "lodash": "^4.17.21",
         "lowlight": "^3.3.0",
         "minisearch": "^7.0.2",
@@ -63,8 +64,7 @@
         "tailwind-merge": "^3.0.2",
         "tippy.js": "^6.3.7",
         "unist-util-visit": "^5.0.0",
-        "uuid": "^9.0.1",
-        "xml2js": "^0.6.2"
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@swc/cli": "^0.3.14",
@@ -84,7 +84,6 @@
         "@types/react-syntax-highlighter": "^15.5.7",
         "@types/redux-logger": "^3.0.13",
         "@types/styled-components": "^5.1.26",
-        "@types/xml2js": "^0.4.14",
         "@vitejs/plugin-react-swc": "^3.9.0",
         "@vitest/coverage-v8": "^2.1.3",
         "@vitest/ui": "^2.1.3",
@@ -3334,16 +3333,6 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="
     },
-    "node_modules/@types/xml2js": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
-      "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.16.0.tgz",
@@ -5786,6 +5775,24 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
       "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw=="
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.3.tgz",
+      "integrity": "sha512-OdCYfRqfpuLUFonTNjvd30rCBZUneHpSQkCqfaeWQ9qrKcl6XlWeDBNVwGb+INAIxRshuN2jF+BE0L6gbBO2mw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -10995,12 +11002,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
-    "node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-      "license": "ISC"
-    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -11523,6 +11524,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/strtok3": {
       "version": "7.1.1",
@@ -13890,28 +13903,6 @@
       "dev": true,
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/xml2js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
-      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
-      "license": "MIT",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/xmlchars": {

--- a/gui/package.json
+++ b/gui/package.json
@@ -72,7 +72,8 @@
     "tailwind-merge": "^3.0.2",
     "tippy.js": "^6.3.7",
     "unist-util-visit": "^5.0.0",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "xml2js": "^0.6.2"
   },
   "devDependencies": {
     "@swc/cli": "^0.3.14",
@@ -92,6 +93,7 @@
     "@types/react-syntax-highlighter": "^15.5.7",
     "@types/redux-logger": "^3.0.13",
     "@types/styled-components": "^5.1.26",
+    "@types/xml2js": "^0.4.14",
     "@vitejs/plugin-react-swc": "^3.9.0",
     "@vitest/coverage-v8": "^2.1.3",
     "@vitest/ui": "^2.1.3",

--- a/gui/package.json
+++ b/gui/package.json
@@ -38,6 +38,7 @@
     "core": "file:../core",
     "dompurify": "^3.0.6",
     "downshift": "^7.6.0",
+    "fast-xml-parser": "^5.2.3",
     "lodash": "^4.17.21",
     "lowlight": "^3.3.0",
     "minisearch": "^7.0.2",
@@ -72,8 +73,7 @@
     "tailwind-merge": "^3.0.2",
     "tippy.js": "^6.3.7",
     "unist-util-visit": "^5.0.0",
-    "uuid": "^9.0.1",
-    "xml2js": "^0.6.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@swc/cli": "^0.3.14",
@@ -93,7 +93,6 @@
     "@types/react-syntax-highlighter": "^15.5.7",
     "@types/redux-logger": "^3.0.13",
     "@types/styled-components": "^5.1.26",
-    "@types/xml2js": "^0.4.14",
     "@vitejs/plugin-react-swc": "^3.9.0",
     "@vitest/coverage-v8": "^2.1.3",
     "@vitest/ui": "^2.1.3",

--- a/gui/src/redux/thunks/streamNormalInput.ts
+++ b/gui/src/redux/thunks/streamNormalInput.ts
@@ -1,8 +1,6 @@
 import { createAsyncThunk, unwrapResult } from "@reduxjs/toolkit";
 import { ChatMessage, LLMFullCompletionOptions } from "core";
-import { modelSupportsTools } from "core/llm/autodetect";
 import { ToCoreProtocol } from "core/protocol";
-import { selectActiveTools } from "../selectors/selectActiveTools";
 import { selectCurrentToolCall } from "../selectors/selectCurrentToolCall";
 import { selectSelectedChatModel } from "../slices/configSlice";
 import {
@@ -37,13 +35,13 @@ export const streamNormalInput = createAsyncThunk<
     }
 
     let completionOptions: LLMFullCompletionOptions = {};
-    const activeTools = selectActiveTools(state);
-    const toolsSupported = modelSupportsTools(selectedChatModel);
-    if (toolsSupported && activeTools.length > 0) {
-      completionOptions = {
-        tools: activeTools,
-      };
-    }
+    // const activeTools = selectActiveTools(state);
+    // const toolsSupported = modelSupportsTools(selectedChatModel);
+    // if (toolsSupported && activeTools.length > 0) {
+    //   completionOptions = {
+    //     tools: activeTools,
+    //   };
+    // }
 
     // Send request
     const gen = extra.ideMessenger.llmStreamChat(

--- a/gui/src/redux/thunks/streamResponse.ts
+++ b/gui/src/redux/thunks/streamResponse.ts
@@ -6,6 +6,7 @@ import { getApplicableRules } from "core/llm/rules/getSystemMessageWithRules";
 import posthog from "posthog-js";
 import { v4 as uuidv4 } from "uuid";
 import { getBaseSystemMessage } from "../../util";
+import { selectActiveTools } from "../selectors/selectActiveTools";
 import { selectSelectedChatModel } from "../slices/configSlice";
 import {
   setAppliedRulesAtIndex,
@@ -110,10 +111,13 @@ export const streamResponseThunk = createAsyncThunk<
           }),
         );
 
-        const messageMode = getState().session.mode;
+        const newState = getState();
+        const messageMode = newState.session.mode;
+        const activeTools = selectActiveTools(newState);
         const baseChatOrAgentSystemMessage = getBaseSystemMessage(
           selectedChatModel,
           messageMode,
+          activeTools,
         );
 
         const messages = constructMessages(

--- a/gui/src/redux/thunks/streamResponseAfterToolCall.ts
+++ b/gui/src/redux/thunks/streamResponseAfterToolCall.ts
@@ -3,6 +3,7 @@ import { ChatMessage } from "core";
 import { constructMessages } from "core/llm/constructMessages";
 import { renderContextItems } from "core/util/messageContent";
 import { getBaseSystemMessage } from "../../util";
+import { selectActiveTools } from "../selectors/selectActiveTools";
 import { selectSelectedChatModel } from "../slices/configSlice";
 import {
   addContextItemsAtIndex,
@@ -65,12 +66,16 @@ export const streamResponseAfterToolCall = createAsyncThunk<
 
         dispatch(setActive());
 
-        
-        const updatedHistory = getState().session.history;
-        const messageMode = getState().session.mode
+        const newState = getState();
+        const updatedHistory = newState.session.history;
+        const messageMode = newState.session.mode;
+        const activeTools = selectActiveTools(newState);
+        const baseChatOrAgentSystemMessage = getBaseSystemMessage(
+          selectedChatModel,
+          messageMode,
+          activeTools,
+        );
 
-        const baseChatOrAgentSystemMessage = getBaseSystemMessage(selectedChatModel, messageMode)
-        
         const messages = constructMessages(
           messageMode,
           [...updatedHistory],

--- a/gui/src/util/index.ts
+++ b/gui/src/util/index.ts
@@ -1,9 +1,13 @@
-import { MessageModes, ModelDescription } from "core";
+import { MessageModes, ModelDescription, Tool } from "core";
 import { ProfileDescription } from "core/config/ProfileLifecycleManager";
+import {
+  DEFAULT_AGENT_SYSTEM_MESSAGE,
+  DEFAULT_CHAT_SYSTEM_MESSAGE,
+} from "core/llm/constructMessages";
 import _ from "lodash";
 import { KeyboardEvent } from "react";
 import { getLocalStorage } from "./localStorage";
-import { DEFAULT_CHAT_SYSTEM_MESSAGE, DEFAULT_AGENT_SYSTEM_MESSAGE } from "core/llm/constructMessages";
+import { generateNonNativeToolSystemMessage } from "./non-native-tools";
 
 export type Platform = "mac" | "linux" | "windows" | "unknown";
 
@@ -120,12 +124,23 @@ export function isLocalProfile(profile: ProfileDescription): boolean {
 /**
  * Get the base system message for the agent or chat mode from the model description.
  */
-export function getBaseSystemMessage(modelDetails: ModelDescription | null, mode: MessageModes) {
-  let baseChatOrAgentSystemMessage: string|undefined
-  if(mode === 'agent') {
-    baseChatOrAgentSystemMessage = modelDetails?.baseAgentSystemMessage ?? DEFAULT_AGENT_SYSTEM_MESSAGE;
+export function getBaseSystemMessage(
+  modelDetails: ModelDescription | null,
+  mode: MessageModes,
+  tools: Tool[],
+) {
+  let baseChatOrAgentSystemMessage: string | undefined;
+  if (mode === "agent") {
+    baseChatOrAgentSystemMessage =
+      modelDetails?.baseAgentSystemMessage ?? DEFAULT_AGENT_SYSTEM_MESSAGE;
+    if (tools.length > 0) {
+      const toolsSystemMessage = generateNonNativeToolSystemMessage(tools);
+      baseChatOrAgentSystemMessage += `\n\n${toolsSystemMessage}`;
+    }
   } else {
-    baseChatOrAgentSystemMessage = modelDetails?.baseChatSystemMessage ?? DEFAULT_CHAT_SYSTEM_MESSAGE;
+    baseChatOrAgentSystemMessage =
+      modelDetails?.baseChatSystemMessage ?? DEFAULT_CHAT_SYSTEM_MESSAGE;
   }
-  return baseChatOrAgentSystemMessage
+
+  return baseChatOrAgentSystemMessage;
 }

--- a/gui/src/util/non-native-tools.test.ts
+++ b/gui/src/util/non-native-tools.test.ts
@@ -1,0 +1,102 @@
+import { ToolCall } from "core";
+import { getXmlToolCallsFromContent } from "../../src/util/non-native-tools";
+
+test("getXmlToolCallsFromContent extracts single tool call correctly", () => {
+  const content = `
+    <tool_call>
+      <name>test_tool</name>
+      <args>
+        <param1>value1</param1>
+      </args>
+    </tool_call>
+  `;
+
+  const result = getXmlToolCallsFromContent(content);
+
+  expect(result).toHaveLength(1);
+  expect(result[0]).toEqual({
+    id: "tool-call-0",
+    type: "function",
+    function: {
+      name: "test_tool",
+      arguments: JSON.stringify({
+        param1: "value1",
+      }),
+    },
+  });
+});
+
+test("getXmlToolCallsFromContent extracts multiple tool calls correctly", () => {
+  const content = `
+    <tool_call>
+      <name>tool1</name>
+      <args>
+        <param1>value1</param1>
+      </args>
+    </tool_call>
+    <tool_call>
+      <name>tool2</name>
+      <args>
+        <param2>value2</param2>
+      </args>
+    </tool_call>
+  `;
+
+  const result = getXmlToolCallsFromContent(content);
+
+  expect(result).toHaveLength(2);
+  expect(result[0]).toEqual({
+    id: "tool-call-0",
+    type: "function",
+    function: {
+      name: "tool1",
+      arguments: JSON.stringify({
+        param1: "value1",
+      }),
+    },
+  });
+  expect(result[1]).toEqual({
+    id: "tool-call-1",
+    type: "function",
+    function: {
+      name: "tool2",
+      arguments: JSON.stringify({
+        param2: "value2",
+      }),
+    },
+  });
+});
+
+test("getXmlToolCallsFromContent preserves existing tool call IDs", () => {
+  const content = `
+    <tool_call>
+      <name>test_tool</name>
+      <args>
+        <param1>value1</param1>
+      </args>
+    </tool_call>
+  `;
+
+  const existingToolCalls: ToolCall[] = [
+    {
+      id: "existing-id",
+      type: "function",
+      function: {
+        name: "old_tool",
+        arguments: "{}",
+      },
+    },
+  ];
+
+  const result = getXmlToolCallsFromContent(content, existingToolCalls);
+
+  expect(result[0].id).toBe("existing-id");
+});
+
+test("getXmlToolCallsFromContent returns empty array for content without tool calls", () => {
+  const content = "Some content without tool calls";
+
+  const result = getXmlToolCallsFromContent(content);
+
+  expect(result).toEqual([]);
+});

--- a/gui/src/util/non-native-tools.ts
+++ b/gui/src/util/non-native-tools.ts
@@ -1,0 +1,70 @@
+import { Tool } from "core";
+import xml2js from "xml2js";
+
+export const TOOL_CALL_OPENING_TAG = "<tool-call>";
+export const TOOL_CALL_CLOSING_TAG = "</tool-call>";
+export const TOOL_CALL_NAME_OPENING_TAG = "<name>";
+export const TOOL_CALL_NAME_CLOSING_TAG = "</name>";
+export const TOOL_CALL_ARGS_OPENING_TAG = "<args>";
+export const TOOL_CALL_ARGS_CLOSING_TAG = "</args>";
+
+const EXAMPLE_TOOL = `<tool>
+    <name>example_tool</name>
+    <args>
+        <arg1>
+            <description>First argument</description>
+            <type>string</type>
+            <required>true</required>
+        </arg1>
+        <arg>
+            <description>Second argument</description>
+            <type>number</type>
+            <required>false</required>
+        </arg>
+    </args>
+    </tool>
+`;
+
+const EXAMPLE_TOOL_CALL = `<tool-call>
+    <name>example_tool</name>
+    <args>
+        <arg1>value1</arg1>
+    </args>
+</tool-call>
+`;
+
+function toolToXmlDefinition(tool: Tool): string {
+  const builder = new xml2js.Builder({
+    rootName: "tool",
+    headless: true,
+    renderOpts: { pretty: true, indent: "  ", newline: "\n" },
+  });
+  const xml = builder.buildObject({
+    name: tool.function.name,
+    args: tool.function.parameters,
+  });
+  return xml;
+}
+
+export const generateNonNativeToolSystemMessage = (tools: Tool[]) => {
+  if (tools.length === 0) {
+    return undefined;
+  }
+  let prompt = `The following tool definitions define tools that can be "called" to perform actions.
+    Decided whether to use them based on the user's request and the context. 
+    To use a tool, respond with a <tool-call> xml tag containing the tool name and args. For example, this tool:`;
+
+  prompt += EXAMPLE_TOOL;
+
+  prompt += "\n\nCan be called like this:\n";
+
+  prompt += EXAMPLE_TOOL_CALL;
+
+  prompt += "\n\nHere are the available tools:\n\n";
+
+  for (const tool of tools) {
+    prompt += toolToXmlDefinition(tool);
+    prompt += "\n";
+  }
+  return prompt;
+};


### PR DESCRIPTION
## Description
For visibility, a rough but working experiment for non-native tool calling

Improvements: catch tool_call tags as they come and convert partial xml to partial json to stream tool call delta rather than waiting till the end like this
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added experimental support for non-native tool calling by parsing XML tool_call tags in assistant messages and converting them to tool call objects in real time.

- **New Features**
  - Detects and streams tool calls from partial XML in assistant responses.
  - Converts tool call XML to JSON for tool execution.
  - Includes tests for XML tool call extraction.
  - Adds fast-xml-parser as a new dependency.

<!-- End of auto-generated description by cubic. -->

