### PR TITLE
fix: Fix the misleading naming of return value Config in function loa…

### DIFF
--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -457,14 +457,14 @@ export class ConfigHandler {
         configLoadInterrupted: true,
       };
     }
-    const config = await this.currentProfile.loadConfig(
+    const configResult = await this.currentProfile.loadConfig(
       this.additionalContextProviders,
     );
 
-    if (config.errors?.length) {
-      logger.warn("Errors loading config: ", config.errors);
+    if (configResult.errors?.length) {
+      logger.warn("Errors loading config: ", configResult.errors);
     }
-    return config;
+    return configResult;
   }
 
   async openConfigProfile(profileId?: string) {


### PR DESCRIPTION
Fix the misleading naming of return value Config in function loadConfig  within file ConfigHandle

## Description

Replace Config with ConfigResult


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Renamed the return value in loadConfig from Config to ConfigResult to better reflect its contents and avoid confusion.

<!-- End of auto-generated description by cubic. -->

