### PR TITLE
docs: specify the schema versions in dev data reference

### DIFF
--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -406,7 +406,7 @@ Destinations to which [development data](./customize/deep-dives/development-data
 - `destination` (**required**): The destination/endpoint that will receive the data. Can be:
   - an HTTP endpoint that will receive a POST request with a JSON blob
   - a file URL to a directory in which events will be dumpted to `.jsonl` files
-- `schema` (**required**): the schema version of the JSON blobs to be sent
+- `schema` (**required**): the schema version of the JSON blobs to be sent. Options include `0.1.0` and `0.2.0`
 - `events`: an array of event names to include. Defaults to all events if not specified.
 - `level`: a pre-defined filter for event fields. Options include `all` and `noCode`; the latter excludes data like file
   contents, prompts, and completions. Defaults to `all`


### PR DESCRIPTION
## Description

Got mistaken that schema version refers to a key value pair which will be received in dev data. Corrected it to specify the versions it supports.

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

![image](https://github.com/user-attachments/assets/91aaa428-1e75-4882-a5f2-a94d607b71f9)

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the dev data reference docs to list supported schema versions for the JSON blobs.

<!-- End of auto-generated description by cubic. -->

