### PR TITLE
feat: `description` in markdown yaml

### DIFF
--- a/core/config/markdown/parseMarkdownRule.test.ts
+++ b/core/config/markdown/parseMarkdownRule.test.ts
@@ -151,4 +151,24 @@ This is a test rule without a heading.`;
     );
     expect(result.name).toBe("custom-rule");
   });
+
+  it("should include description from frontmatter", () => {
+    const content = `---
+globs: "**/test/**/*.kt"
+name: Test Rule
+description: This is a rule description from frontmatter
+---
+
+# Test Rule
+
+This is the content of the rule.`;
+
+    const result = convertMarkdownRuleToContinueRule(
+      "/path/to/rule.md",
+      content,
+    );
+    expect(result.description).toBe(
+      "This is a rule description from frontmatter",
+    );
+  });
 });

--- a/core/config/markdown/parseMarkdownRule.ts
+++ b/core/config/markdown/parseMarkdownRule.ts
@@ -59,9 +59,10 @@ export function convertMarkdownRuleToContinueRule(
   }
 
   return {
+    name,
     rule: markdown,
     globs: frontmatter.globs,
-    name,
+    description: frontmatter.description,
     source: "rules-block",
     ruleFile: path,
   };

--- a/core/tools/definitions/createRuleBlock.ts
+++ b/core/tools/definitions/createRuleBlock.ts
@@ -28,6 +28,10 @@ export const createRuleBlock: Tool = {
           description:
             "Clear, imperative instruction for future code generation (e.g. 'Use named exports', 'Add Python type hints'). Each rule should focus on one specific standard.",
         },
+        description: {
+          type: "string",
+          description: "Short description of the rule",
+        },
         globs: {
           type: "string",
           description:

--- a/core/tools/implementations/createRuleBlock.test.ts
+++ b/core/tools/implementations/createRuleBlock.test.ts
@@ -1,4 +1,4 @@
-import * as YAML from "yaml";
+import { parseMarkdownRule } from "../../config/markdown/parseMarkdownRule";
 import { createRuleBlockImpl } from "./createRuleBlock";
 
 // Mock the extras parameter with necessary functions
@@ -17,36 +17,6 @@ describe("createRuleBlockImpl", () => {
     jest.clearAllMocks();
   });
 
-  it("should create a basic rule with name and rule content", async () => {
-    const args = {
-      name: "Test Rule",
-      rule: "Always write tests",
-    };
-
-    const result = await createRuleBlockImpl(args, mockExtras as any);
-
-    // Verify that writeFile was called
-    expect(mockIde.writeFile).toHaveBeenCalled();
-
-    // Verify the file name
-    const fileUri = mockIde.writeFile.mock.calls[0][0];
-    expect(fileUri).toContain("test-rule.md");
-
-    // Get the content
-    const fileContent = mockIde.writeFile.mock.calls[0][1];
-
-    // Verify the content structure
-    expect(fileContent).toContain("---");
-    expect(fileContent).toContain("# Test Rule");
-    expect(fileContent).toContain("Always write tests");
-
-    // Should have empty frontmatter - it will be "{}" not "" due to how YAML.stringify works with empty objects
-    const parts = fileContent.split(/^---\s*$/m);
-    expect(parts.length).toBeGreaterThanOrEqual(3);
-    const frontmatterStr = parts[1].trim();
-    expect(frontmatterStr === "" || frontmatterStr === "{}").toBeTruthy();
-  });
-
   it("should create a rule with glob pattern", async () => {
     const args = {
       name: "TypeScript Rule",
@@ -56,22 +26,16 @@ describe("createRuleBlockImpl", () => {
 
     await createRuleBlockImpl(args, mockExtras as any);
 
-    // Get the content
     const fileContent = mockIde.writeFile.mock.calls[0][1];
 
-    // Parse the frontmatter
-    const parts = fileContent.split(/^---\s*$/m);
-    const frontmatterStr = parts[1].trim();
-    const frontmatter = YAML.parse(frontmatterStr);
+    const { frontmatter, markdown } = parseMarkdownRule(fileContent);
 
-    // Verify the frontmatter contains globs
     expect(frontmatter).toEqual({
       globs: "**/*.{ts,tsx}",
     });
 
-    // Verify the content has the rule
-    expect(fileContent).toContain("# TypeScript Rule");
-    expect(fileContent).toContain("Use interfaces for object shapes");
+    expect(markdown).toContain("# TypeScript Rule");
+    expect(markdown).toContain("Use interfaces for object shapes");
   });
 
   it("should create a filename based on sanitized rule name", async () => {
@@ -82,12 +46,11 @@ describe("createRuleBlockImpl", () => {
 
     await createRuleBlockImpl(args, mockExtras as any);
 
-    // Check that the filename is sanitized
     const fileUri = mockIde.writeFile.mock.calls[0][0];
     expect(fileUri).toContain("special-chracters-spaces.md");
   });
 
-  it("should include description in frontmatter and content", async () => {
+  it("should create a rule with description pattern", async () => {
     const args = {
       name: "Description Test",
       rule: "This is the rule content",
@@ -96,23 +59,16 @@ describe("createRuleBlockImpl", () => {
 
     await createRuleBlockImpl(args, mockExtras as any);
 
-    // Get the content
     const fileContent = mockIde.writeFile.mock.calls[0][1];
 
-    // Parse the frontmatter
-    const parts = fileContent.split(/^---\s*$/m);
-    const frontmatterStr = parts[1].trim();
-    const frontmatter = YAML.parse(frontmatterStr);
+    const { frontmatter, markdown } = parseMarkdownRule(fileContent);
 
-    // Verify the frontmatter contains description
     expect(frontmatter).toEqual({
       description: "This is a detailed explanation of the rule",
     });
 
-    // Verify the content structure includes description before rule
-    expect(fileContent).toContain("# Description Test");
-    expect(fileContent).toContain("This is a detailed explanation of the rule");
-    expect(fileContent).toContain("This is the rule content");
+    expect(markdown).toContain("# Description Test");
+    expect(markdown).toContain("This is the rule content");
   });
 
   it("should include both globs and description in frontmatter", async () => {
@@ -125,18 +81,16 @@ describe("createRuleBlockImpl", () => {
 
     await createRuleBlockImpl(args, mockExtras as any);
 
-    // Get the content
     const fileContent = mockIde.writeFile.mock.calls[0][1];
 
-    // Parse the frontmatter
-    const parts = fileContent.split(/^---\s*$/m);
-    const frontmatterStr = parts[1].trim();
-    const frontmatter = YAML.parse(frontmatterStr);
+    const { frontmatter, markdown } = parseMarkdownRule(fileContent);
 
-    // Verify the frontmatter contains both description and globs
     expect(frontmatter).toEqual({
       description: "This rule enforces our team standards",
       globs: "**/*.js",
     });
+
+    expect(markdown).toContain("# Complete Rule");
+    expect(markdown).toContain("Follow this standard");
   });
 });

--- a/core/tools/implementations/createRuleBlock.ts
+++ b/core/tools/implementations/createRuleBlock.ts
@@ -5,8 +5,8 @@ import { joinPathsToUri } from "../../util/uri";
 export interface CreateRuleBlockArgs {
   name: string;
   rule: string;
+  description: string;
   globs?: string;
-  description?: string;
 }
 
 export const createRuleBlockImpl: ToolImpl = async (

--- a/core/tools/implementations/createRuleBlock.ts
+++ b/core/tools/implementations/createRuleBlock.ts
@@ -1,4 +1,3 @@
-import { ConfigYaml } from "@continuedev/config-yaml";
 import * as YAML from "yaml";
 import { ToolImpl } from ".";
 import { joinPathsToUri } from "../../util/uri";
@@ -7,7 +6,7 @@ export interface CreateRuleBlockArgs {
   name: string;
   rule: string;
   globs?: string;
-  format?: "yaml" | "markdown"; // Add format option with yaml as default
+  description?: string;
 }
 
 export const createRuleBlockImpl: ToolImpl = async (
@@ -20,26 +19,19 @@ export const createRuleBlockImpl: ToolImpl = async (
     .replace(/[^a-z0-9\s-]/g, "")
     .replace(/\s+/g, "-");
 
-  // Default to YAML format
-  const format = args.format ?? "yaml";
-  const fileExtension = format === "markdown" ? "md" : "yaml";
+  const fileExtension = "md";
 
-  const ruleObject = {
-    name: args.name,
-    rule: args.rule,
-    ...(args.globs ? { globs: args.globs.trim() } : {}),
-  };
+  const frontmatter: Record<string, string> = {};
 
-  let fileContent: string;
+  if (args.globs) {
+    frontmatter.globs = args.globs.trim();
+  }
 
-  if (format === "markdown") {
-    // Generate markdown format with frontmatter
-    const frontmatter = {
-      ...(args.globs ? { globs: args.globs.trim() } : {}),
-    };
-
-    const frontmatterYaml = YAML.stringify(frontmatter).trim();
-    fileContent = `---
+  if (args.description) {
+    frontmatter.description = args.description.trim();
+  }
+  const frontmatterYaml = YAML.stringify(frontmatter).trim();
+  let fileContent = `---
 ${frontmatterYaml}
 ---
 
@@ -47,18 +39,6 @@ ${frontmatterYaml}
 
 ${args.rule}
 `;
-  } else {
-    // Generate YAML format
-    const ruleBlock: ConfigYaml = {
-      name: args.name,
-      version: "0.0.1",
-      schema: "v1",
-      rules: [ruleObject],
-    };
-
-    fileContent = YAML.stringify(ruleBlock);
-  }
-
   const [localContinueDir] = await extras.ide.getWorkspaceDirs();
   const rulesDirUri = joinPathsToUri(
     localContinueDir,
@@ -73,12 +53,12 @@ ${args.rule}
   return [
     {
       name: "New Rule Block",
-      description: "", // No description throws an error in the GUI
+      description: args.description || "",
       uri: {
         type: "file",
         value: rulesDirUri,
       },
-      content: `Rule created successfully in ${format} format`,
+      content: `Rule created successfully`,
     },
   ];
 };

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "1.1.36",
+  "version": "1.1.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "1.1.36",
+      "version": "1.1.38",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",

--- a/packages/config-yaml/src/schemas/index.ts
+++ b/packages/config-yaml/src/schemas/index.ts
@@ -15,7 +15,7 @@ const mcpServerSchema = z.object({
   faviconUrl: z.string().optional(),
   args: z.array(z.string()).optional(),
   env: z.record(z.string()).optional(),
-  connectionTimeout: z.number().gt(0).optional()
+  connectionTimeout: z.number().gt(0).optional(),
 });
 
 export type MCPServer = z.infer<typeof mcpServerSchema>;
@@ -39,6 +39,7 @@ export type DocsConfig = z.infer<typeof docSchema>;
 const ruleObjectSchema = z.object({
   name: z.string(),
   rule: z.string(),
+  description: z.string().optional(),
   globs: z.union([z.string(), z.array(z.string())]).optional(),
 });
 const ruleSchema = z.union([z.string(), ruleObjectSchema]);


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for a description field in markdown rule frontmatter, allowing rules to include a short description alongside name and globs.

- **New Features**
  - Rules can now have a description in the frontmatter and in the rule object.
  - Updated tests and schema to handle the new description field.

<!-- End of auto-generated description by cubic. -->

