### PR TITLE
feat: :sparkles: Add support for Claude Sonnet 4

### DIFF
--- a/core/llm/llms/Bedrock.ts
+++ b/core/llm/llms/Bedrock.ts
@@ -306,7 +306,7 @@ class Bedrock extends BaseLLM {
     }
 
     const supportsTools =
-      PROVIDER_TOOL_SUPPORT.bedrock?.(options.model || "") ?? false;
+      (this.capabilities?.tools || PROVIDER_TOOL_SUPPORT.bedrock?.(options.model)) ?? false;
 
     let toolConfig = supportsTools && options.tools
     ? {

--- a/core/llm/toolSupport.ts
+++ b/core/llm/toolSupport.ts
@@ -17,6 +17,7 @@ export const PROVIDER_TOOL_SUPPORT: Record<
       "claude-3.5",
       "claude-3-7",
       "claude-3.7",
+      "claude-sonnet-4",
       "gpt-4",
       "o3",
       "gemini",
@@ -24,7 +25,7 @@ export const PROVIDER_TOOL_SUPPORT: Record<
   },
   anthropic: (model) => {
     if (
-      ["claude-3-5", "claude-3.5", "claude-3-7", "claude-3.7"].some((part) =>
+      ["claude-3-5", "claude-3.5", "claude-3-7", "claude-3.7","claude-sonnet-4"].some((part) =>
         model.toLowerCase().startsWith(part),
       )
     ) {
@@ -76,7 +77,7 @@ export const PROVIDER_TOOL_SUPPORT: Record<
     // For Bedrock, only support Claude Sonnet models with versions 3.5/3-5 and 3.7/3-7
     if (
       model.toLowerCase().includes("sonnet") &&
-      ["claude-3-5", "claude-3.5", "claude-3-7", "claude-3.7"].some((part) =>
+      ["claude-3-5", "claude-3.5", "claude-3-7", "claude-3.7","claude-sonnet-4"].some((part) =>
         model.toLowerCase().includes(part),
       )
     ) {


### PR DESCRIPTION
## Description

* Adding support for Claude Sonnet 4.
* Supporting Continue Proxy, Anthropic and Bedrock
* Updating Bedrock Provider so it can use Tools Use Override

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

Performed Manual testing of the Bedrock Provider.
Recommend testing Athropic and Continue Proxy

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for Claude Sonnet 4 across Continue Proxy, Anthropic, and Bedrock providers. Updated Bedrock to allow tool use override with this model.

<!-- End of auto-generated description by cubic. -->

