### PR TITLE
Nate/watsonx-rules-support

### DIFF
--- a/core/llm/llms/stubs/ContinueProxy.ts
+++ b/core/llm/llms/stubs/ContinueProxy.ts
@@ -26,11 +26,13 @@ class ContinueProxy extends OpenAI {
   // but we need to keep track of the actual values that the proxy will use
   // to call whatever LLM API is chosen
   private actualApiBase?: string;
-  private env?: Record<string, any>;
+
+  // Contains extra properties that we pass along to the proxy. Originally from `env` property on LLMOptions
+  private configEnv?: Record<string, any>;
 
   constructor(options: LLMOptions) {
     super(options);
-    this.env = options.env;
+    this.configEnv = options.env;
     this.actualApiBase = options.apiBase;
     this.apiKeyLocation = options.apiKeyLocation;
     this.orgScopeId = options.orgScopeId;
@@ -50,7 +52,7 @@ class ContinueProxy extends OpenAI {
       apiKeyLocation: this.apiKeyLocation,
       apiBase: this.actualApiBase,
       orgScopeId: this.orgScopeId ?? null,
-      env: this.env,
+      env: this.configEnv,
     };
     return {
       continueProperties,

--- a/core/llm/llms/stubs/ContinueProxy.ts
+++ b/core/llm/llms/stubs/ContinueProxy.ts
@@ -26,9 +26,11 @@ class ContinueProxy extends OpenAI {
   // but we need to keep track of the actual values that the proxy will use
   // to call whatever LLM API is chosen
   private actualApiBase?: string;
+  private env?: Record<string, any>;
 
   constructor(options: LLMOptions) {
     super(options);
+    this.env = options.env;
     this.actualApiBase = options.apiBase;
     this.apiKeyLocation = options.apiKeyLocation;
     this.orgScopeId = options.orgScopeId;
@@ -48,6 +50,7 @@ class ContinueProxy extends OpenAI {
       apiKeyLocation: this.apiKeyLocation,
       apiBase: this.actualApiBase,
       orgScopeId: this.orgScopeId ?? null,
+      env: this.env,
     };
     return {
       continueProperties,

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -138,7 +138,7 @@
     },
     "../packages/config-yaml": {
       "name": "@continuedev/config-yaml",
-      "version": "1.0.87",
+      "version": "1.0.88",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "1.1.36",
+  "version": "1.1.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "1.1.36",
+      "version": "1.1.38",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "1.1.38",
+  "version": "1.1.39",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -211,7 +211,7 @@
     },
     "../packages/config-yaml": {
       "name": "@continuedev/config-yaml",
-      "version": "1.0.87",
+      "version": "1.0.88",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",

--- a/packages/config-yaml/package-lock.json
+++ b/packages/config-yaml/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@continuedev/config-yaml",
-  "version": "1.0.87",
+  "version": "1.0.88",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@continuedev/config-yaml",
-      "version": "1.0.87",
+      "version": "1.0.88",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",

--- a/packages/config-yaml/package.json
+++ b/packages/config-yaml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@continuedev/config-yaml",
-  "version": "1.0.87",
+  "version": "1.0.88",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/config-yaml/src/load/clientRender.ts
+++ b/packages/config-yaml/src/load/clientRender.ts
@@ -160,6 +160,7 @@ export const continuePropertiesSchema = z.object({
   apiKeyLocation: z.string().optional(),
   apiBase: z.string().optional(),
   orgScopeId: z.string().nullable(),
+  env: z.record(z.string(), z.any()).optional(),
 });
 
 export type ContinueProperties = z.infer<typeof continuePropertiesSchema>;

--- a/packages/openai-adapters/README.md
+++ b/packages/openai-adapters/README.md
@@ -64,7 +64,7 @@ They are concerned with:
 - [x] Vllm
 - [ ] Vertex AI
 - [x] Voyage AI
-- [ ] WatsonX
+- [x] WatsonX
 - [x] xAI
 - [x] Fireworks
 - [x] Moonshot

--- a/packages/openai-adapters/package.json
+++ b/packages/openai-adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@continuedev/openai-adapters",
-  "version": "1.0.21",
+  "version": "1.0.26",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/openai-adapters/src/apis/WatsonX.ts
+++ b/packages/openai-adapters/src/apis/WatsonX.ts
@@ -1,0 +1,228 @@
+import { streamSse } from "@continuedev/fetch";
+import { OpenAI } from "openai/index";
+import {
+  ChatCompletion,
+  ChatCompletionChunk,
+  ChatCompletionCreateParamsNonStreaming,
+  ChatCompletionCreateParamsStreaming,
+  Completion,
+  CompletionCreateParamsNonStreaming,
+  CompletionCreateParamsStreaming,
+} from "openai/resources/index";
+import { ChatCompletionCreateParams } from "openai/src/resources/index.js";
+import { WatsonXConfig } from "../types.js";
+import { customFetch } from "../util.js";
+import {
+  BaseLlmApi,
+  CreateRerankResponse,
+  FimCreateParamsStreaming,
+  RerankCreateParams,
+} from "./base.js";
+
+export class WatsonXApi implements BaseLlmApi {
+  apiBase: string;
+  apiVersion: string = "2023-05-29";
+  projectId?: string;
+  deploymentId?: string;
+
+  constructor(protected config: WatsonXConfig) {
+    this.apiBase = config.apiBase ?? "https://us-south.ml.cloud.ibm.com";
+    if (!this.apiBase.endsWith("/")) {
+      this.apiBase += "/";
+    }
+    this.apiVersion = config.apiVersion ?? this.apiVersion;
+    this.projectId = config.projectId;
+    this.deploymentId = config.deploymentId;
+  }
+
+  private getHeaders(): Record<string, string> {
+    return {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${this.config.apiKey}`,
+    };
+  }
+
+  private getEndpoint(endpoint: string): string {
+    return `${this.apiBase}ml/v1/${this.deploymentId ? `deployments/${this.deploymentId}/` : ""}text/${endpoint}_stream?version=${this.apiVersion}`;
+  }
+
+  private _convertBody(oaiBody: ChatCompletionCreateParams) {
+    const stopSequences = oaiBody.stop
+      ? Array.isArray(oaiBody.stop)
+        ? oaiBody.stop.filter((s) => s.trim() !== "")
+        : [oaiBody.stop]
+      : undefined;
+
+    const payload: any = {
+      messages: oaiBody.messages,
+      max_tokens: oaiBody.max_tokens ?? 1024,
+      stop: stopSequences,
+      frequency_penalty: oaiBody.frequency_penalty,
+      presence_penalty: oaiBody.presence_penalty,
+    };
+
+    if (!this.deploymentId) {
+      payload.model_id = oaiBody.model;
+      payload.project_id = this.projectId;
+    }
+
+    if (oaiBody.temperature !== undefined) {
+      payload.temperature = oaiBody.temperature;
+    }
+
+    if (oaiBody.top_p !== undefined) {
+      payload.top_p = oaiBody.top_p;
+    }
+
+    if (oaiBody.tools) {
+      payload.tools = oaiBody.tools;
+      if (oaiBody.tool_choice) {
+        payload.tool_choice = oaiBody.tool_choice;
+      } else {
+        payload.tool_choice_option = "auto";
+      }
+    }
+
+    return payload;
+  }
+
+  async chatCompletionNonStream(
+    body: ChatCompletionCreateParamsNonStreaming,
+    signal: AbortSignal,
+  ): Promise<ChatCompletion> {
+    throw new Error("Method not implemented.");
+  }
+
+  async *chatCompletionStream(
+    body: ChatCompletionCreateParamsStreaming,
+    signal: AbortSignal,
+  ): AsyncGenerator<ChatCompletionChunk, any, unknown> {
+    const url = this.getEndpoint("chat");
+    const response = await customFetch(this.config.requestOptions)(url, {
+      method: "POST",
+      headers: this.getHeaders(),
+      body: JSON.stringify(this._convertBody(body)),
+      signal,
+    });
+
+    if (!response.ok || !response.body) {
+      throw new Error(
+        `Failed to stream chat completion: ${await response.text()}`,
+      );
+    }
+
+    for await (const value of streamSse(response as any)) {
+      const chunk = value;
+      yield chunk;
+    }
+  }
+
+  async completionNonStream(
+    body: CompletionCreateParamsNonStreaming,
+    signal: AbortSignal,
+  ): Promise<Completion> {
+    throw new Error("Method not implemented.");
+  }
+
+  async *completionStream(
+    body: CompletionCreateParamsStreaming,
+    signal: AbortSignal,
+  ): AsyncGenerator<Completion, any, unknown> {
+    const params = {
+      decoding_method: body.temperature ? "sample" : "greedy",
+      max_new_tokens: body.max_tokens ?? 1024,
+      min_new_tokens: 1,
+      stop_sequences: body.stop
+        ? Array.isArray(body.stop)
+          ? body.stop
+          : [body.stop]
+        : [],
+      include_stop_sequence: false,
+      repetition_penalty: body.frequency_penalty || 1,
+      temperature: body.temperature,
+      top_p: body.top_p,
+      top_k: 100,
+    };
+
+    const payload: any = {
+      input: body.prompt,
+      parameters: params,
+    };
+
+    if (!this.deploymentId) {
+      payload.model_id = body.model;
+      payload.project_id = this.projectId;
+    }
+
+    const url = this.getEndpoint("generation");
+    const response = await customFetch(this.config.requestOptions)(url, {
+      method: "POST",
+      headers: this.getHeaders(),
+      body: JSON.stringify(payload),
+      signal,
+    });
+
+    if (!response.ok || !response.body) {
+      throw new Error(`Failed to stream completion: ${await response.text()}`);
+    }
+
+    let generatedText = "";
+    for await (const value of streamSse(response as any)) {
+      const lines = value.toString().split("\n");
+      let generatedChunk = "";
+
+      lines.forEach((line: string) => {
+        if (line.startsWith("data:")) {
+          const dataStr = line.replace(/^data:\s+/, "");
+          try {
+            const data = JSON.parse(dataStr);
+            data.results.forEach((result: any) => {
+              generatedChunk += result.generated_text || "";
+            });
+          } catch (e) {
+            // parsing error is expected with streaming response
+          }
+        }
+      });
+
+      if (generatedChunk) {
+        generatedText += generatedChunk;
+        yield {
+          id: `watsonx-${Date.now()}`,
+          object: "text_completion",
+          created: Date.now(),
+          model: body.model,
+          choices: [
+            {
+              text: generatedChunk,
+              index: 0,
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        };
+      }
+    }
+  }
+
+  async *fimStream(
+    body: FimCreateParamsStreaming,
+    signal: AbortSignal,
+  ): AsyncGenerator<ChatCompletionChunk, any, unknown> {
+    throw new Error("Method not implemented.");
+  }
+
+  async embed(
+    body: OpenAI.Embeddings.EmbeddingCreateParams,
+  ): Promise<OpenAI.Embeddings.CreateEmbeddingResponse> {
+    throw new Error("Method not implemented.");
+  }
+
+  async rerank(body: RerankCreateParams): Promise<CreateRerankResponse> {
+    throw new Error("Method not implemented.");
+  }
+
+  async list(): Promise<OpenAI.Models.Model[]> {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/packages/openai-adapters/src/apis/WatsonX.ts
+++ b/packages/openai-adapters/src/apis/WatsonX.ts
@@ -11,7 +11,7 @@ import {
 } from "openai/resources/index";
 import { ChatCompletionCreateParams } from "openai/src/resources/index.js";
 import { WatsonXConfig } from "../types.js";
-import { customFetch } from "../util.js";
+import { chatCompletion, customFetch } from "../util.js";
 import {
   BaseLlmApi,
   CreateRerankResponse,
@@ -157,7 +157,22 @@ export class WatsonXApi implements BaseLlmApi {
     body: ChatCompletionCreateParamsNonStreaming,
     signal: AbortSignal,
   ): Promise<ChatCompletion> {
-    throw new Error("Method not implemented.");
+    const generator = this.chatCompletionStream(
+      {
+        ...body,
+        stream: true,
+      },
+      signal,
+    );
+
+    let content = "";
+    for await (const chunk of generator) {
+      content += chunk.choices[0].delta.content ?? "";
+    }
+    return chatCompletion({
+      content,
+      model: body.model,
+    });
   }
 
   async *chatCompletionStream(

--- a/packages/openai-adapters/src/index.ts
+++ b/packages/openai-adapters/src/index.ts
@@ -11,6 +11,7 @@ import { MockApi } from "./apis/Mock.js";
 import { MoonshotApi } from "./apis/Moonshot.js";
 import { OpenAIApi } from "./apis/OpenAI.js";
 import { RelaceApi } from "./apis/Relace.js";
+import { WatsonXApi } from "./apis/WatsonX.js";
 import { BaseLlmApi } from "./apis/base.js";
 import { LLMConfig, OpenAIConfigSchema } from "./types.js";
 
@@ -48,6 +49,8 @@ export function constructLlmApi(config: LLMConfig): BaseLlmApi | undefined {
       return new RelaceApi(config);
     case "inception":
       return new InceptionApi(config);
+    case "watsonx":
+      return new WatsonXApi(config);
     case "x-ai":
       return openAICompatible("https://api.x.ai/v1/", config);
     case "voyage":
@@ -75,7 +78,10 @@ export function constructLlmApi(config: LLMConfig): BaseLlmApi | undefined {
     case "nvidia":
       return openAICompatible("https://integrate.api.nvidia.com/v1/", config);
     case "ovhcloud":
-      return openAICompatible("https://oai.endpoints.kepler.ai.cloud.ovh.net/v1/", config);
+      return openAICompatible(
+        "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1/",
+        config,
+      );
     case "scaleway":
       return openAICompatible("https://api.scaleway.ai/v1/", config);
     case "fireworks":
@@ -111,10 +117,9 @@ export {
   type Completion,
   type CompletionCreateParams,
   type CompletionCreateParamsNonStreaming,
-  type CompletionCreateParamsStreaming
+  type CompletionCreateParamsStreaming,
 } from "openai/resources/index";
 
 // export
 export type { BaseLlmApi } from "./apis/base.js";
 export type { LLMConfig } from "./types.js";
-

--- a/packages/openai-adapters/src/test/main.test.ts
+++ b/packages/openai-adapters/src/test/main.test.ts
@@ -10,6 +10,7 @@ function testConfig(config: ModelConfig) {
     provider: config.provider as any,
     apiKey: config.apiKey,
     apiBase: config.apiBase,
+    env: config.env,
   });
 
   if (false) {

--- a/packages/openai-adapters/src/types.ts
+++ b/packages/openai-adapters/src/types.ts
@@ -102,9 +102,11 @@ export type AnthropicConfig = z.infer<typeof AnthropicConfigSchema>;
 export const WatsonXConfigSchema = BasePlusConfig.extend({
   provider: z.literal("watsonx"),
   apiKey: z.string(),
-  apiVersion: z.string().optional(),
-  projectId: z.string().optional(),
-  deploymentId: z.string().optional(),
+  env: z.object({
+    apiVersion: z.string().optional(),
+    projectId: z.string().optional(),
+    deploymentId: z.string().optional(),
+  }),
 });
 export type WatsonXConfig = z.infer<typeof WatsonXConfigSchema>;
 

--- a/packages/openai-adapters/src/types.ts
+++ b/packages/openai-adapters/src/types.ts
@@ -99,6 +99,15 @@ export const AnthropicConfigSchema = OpenAIConfigSchema.extend({
 });
 export type AnthropicConfig = z.infer<typeof AnthropicConfigSchema>;
 
+export const WatsonXConfigSchema = BasePlusConfig.extend({
+  provider: z.literal("watsonx"),
+  apiKey: z.string(),
+  apiVersion: z.string().optional(),
+  projectId: z.string().optional(),
+  deploymentId: z.string().optional(),
+});
+export type WatsonXConfig = z.infer<typeof WatsonXConfigSchema>;
+
 export const JinaConfigSchema = OpenAIConfigSchema.extend({
   provider: z.literal("jina"),
 });
@@ -118,6 +127,7 @@ export const LLMConfigSchema = z.discriminatedUnion("provider", [
   AzureConfigSchema,
   GeminiConfigSchema,
   AnthropicConfigSchema,
+  WatsonXConfigSchema,
   JinaConfigSchema,
   MockConfigSchema,
   InceptionConfigSchema,


### PR DESCRIPTION
## Description

Add WatsonX to openai-adapters. This includes the change to pass "env" to "continueProperties", which is necessary for proxying providers that require extra info

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Tests

I tested the adapter a lot locally, but to avoid adding another flaky test to CI that depends on an LLM (which will cost a lot of money to keep deployed), I removed it
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added WatsonX support to openai-adapters, allowing it to act as a provider. Also updated code to pass the "env" field to continueProperties for providers that need extra configuration.

<!-- End of auto-generated description by cubic. -->

