### PR TITLE
Nate/sse

### DIFF
--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -71,7 +71,7 @@ function convertYamlMcpToContinueMcp(
       command: server.command,
       args: server.args ?? [],
       env: server.env,
-    },
+    } as any, // TODO: Fix the mcpServers types in config-yaml (discriminated union)
     timeout: server.connectionTimeout,
   };
 }
@@ -458,7 +458,7 @@ async function configYamlToContinueConfig(options: {
       transport: {
         type: "stdio",
         args: [],
-        ...server,
+        ...(server as any), // TODO: fix the types on mcpServers in config-yaml
       },
       timeout: server.connectionTimeout,
     })),

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "1.1.38",
+  "version": "1.1.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "1.1.38",
+      "version": "1.1.39",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",

--- a/packages/config-yaml/src/schemas/index.ts
+++ b/packages/config-yaml/src/schemas/index.ts
@@ -9,9 +9,10 @@ export const contextSchema = z.object({
   params: z.any().optional(),
 });
 
+// TODO: This should be a discriminated union by type
 const mcpServerSchema = z.object({
   name: z.string(),
-  command: z.string(),
+  command: z.string().optional(),
   type: z.enum(["sse", "stdio"]).optional(),
   url: z.string().optional(),
   faviconUrl: z.string().optional(),

--- a/packages/config-yaml/src/schemas/index.ts
+++ b/packages/config-yaml/src/schemas/index.ts
@@ -12,10 +12,12 @@ export const contextSchema = z.object({
 const mcpServerSchema = z.object({
   name: z.string(),
   command: z.string(),
+  type: z.enum(["sse", "stdio"]).optional(),
+  url: z.string().optional(),
   faviconUrl: z.string().optional(),
   args: z.array(z.string()).optional(),
   env: z.record(z.string()).optional(),
-  connectionTimeout: z.number().gt(0).optional()
+  connectionTimeout: z.number().gt(0).optional(),
 });
 
 export type MCPServer = z.infer<typeof mcpServerSchema>;


### PR DESCRIPTION
## Description

This adds support for SSE MCP servers in Continue simply by making a type more lenient. There is a TODO on the type

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for SSE MCP servers in config files by making the MCP server type more flexible. This allows defining servers with a type and URL.

- **Config Updates**
  - MCP server schema now accepts optional type ("sse" or "stdio") and URL fields.

<!-- End of auto-generated description by cubic. -->

