### PR TITLE
feat: :bricks: Enable terminals for additional vscode Remote Host Types

### DIFF
--- a/core/tools/implementations/runTerminalCommand.ts
+++ b/core/tools/implementations/runTerminalCommand.ts
@@ -7,13 +7,15 @@ import { isProcessBackgrounded, removeBackgroundedProcess } from "../../util/pro
 
 const asyncExec = util.promisify(childProcess.exec);
 
+const ENABLED_FOR_REMOTES = ["","local","wsl","dev-container","devcontainer","ssh-remote","attached-container","codespaces","tunnel"];
+
 export const runTerminalCommandImpl: ToolImpl = async (args, extras) => {
   // Default to waiting for completion if not specified
   const waitForCompletion = args.waitForCompletion !== false;
   const ideInfo = await extras.ide.getIdeInfo();
   const toolCallId = extras.toolCallId || "";
 
-  if (ideInfo.remoteName === "local" || ideInfo.remoteName === "") {
+  if (ENABLED_FOR_REMOTES.includes(ideInfo.remoteName)) {
     // For streaming output
     if (extras.onPartialOutput) {
       return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Description

Activate terminals for additional allowed VsCode Remote Host Types.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

I have tested these changes locally, and in a WSL environment on windows 11. Note you can force the extension host to run in WSL by updating the vscode settings for the extension and adding the following:

```
"remote.extensionKind": {
        "continue.continue": [
            "workspace"
        ]
    }
```


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enabled terminal commands on more VSCode remote host types, including WSL, SSH, Codespaces, and containers. This allows users to run terminal commands in a wider range of remote development environments.

<!-- End of auto-generated description by cubic. -->

