### PR TITLE
feat: :sparkles: Make the terminal command aware of its OS, platform and shell

### DIFF
--- a/core/tools/definitions/runTerminalCommand.ts
+++ b/core/tools/definitions/runTerminalCommand.ts
@@ -1,6 +1,27 @@
 import { Tool } from "../..";
 import { BUILT_IN_GROUP_NAME, BuiltInToolNames } from "../builtIn";
 
+import os from 'os';
+
+/**
+ * Get the preferred shell for the current platform
+ * @returns The preferred shell command or path
+ */
+export function getPreferredShell(): string {
+  const platform = os.platform();
+
+  if (platform === 'win32') {
+    return process.env.COMSPEC || 'cmd.exe';
+  } else if (platform === 'darwin') {
+    return process.env.SHELL || '/bin/zsh';
+  } else {
+    // Linux and other Unix-like systems
+    return process.env.SHELL || '/bin/bash';
+  }
+}
+
+export const PLATFORM_INFO = `Choose terminal commands and scripts optimized for ${os.platform} and ${os.arch} and shell ${getPreferredShell()}.`
+
 export const runTerminalCommandTool: Tool = {
   type: "function",
   displayTitle: "Run Terminal Command",
@@ -12,11 +33,12 @@ export const runTerminalCommandTool: Tool = {
   function: {
     name: BuiltInToolNames.RunTerminalCommand,
     description:
-      "Run a terminal command in the current directory.\
+      `Run a terminal command in the current directory.\
       The shell is not stateful and will not remember any previous commands.\
       When a command is run in the background ALWAYS suggest using shell commands to stop it; NEVER suggest using Ctrl+C.\
       When suggesting subsequent shell commands ALWAYS format them in shell command blocks.\
-      Do NOT perform actions requiring special/admin privileges.",
+      Do NOT perform actions requiring special/admin privileges.\
+      ${PLATFORM_INFO}`,
       parameters: {
         type: "object",
         required: ["command"],


### PR DESCRIPTION
## Description

* Made the terminal tool aware of its OS, Platform Arch and default Shell.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

Peformed manual testing on Windows 11, Linux in WSL and MacOS.
The shell is correctly reported and scripts that are created are optimized for the platform and shell.
It's assumed that the extension is installed on the extension host for the platform. For example on Windows 11, I tested using the extension installed in WSL as a remote extension with VSCode running on windows and the shell is reported as bash, running on Linux.
