### PR TITLE
Feed edit tool output back to the model

### DIFF
--- a/core/llm/utils/extractPathsFromCodeBlocks.ts
+++ b/core/llm/utils/extractPathsFromCodeBlocks.ts
@@ -2,8 +2,6 @@
  * Extracts file paths from markdown code blocks
  */
 export function extractPathsFromCodeBlocks(content: string): string[] {
-  console.log("CONTENT", content);
-
   const paths: string[] = [];
 
   // Match code block opening patterns:


### PR DESCRIPTION
When edit tool is complete, read the new file contents and feed it back to the model. For now, just read the entire file. In the future, could send back diffs, ranges, etc but my hunch is that would confuse more than help the model.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
The edit tool now reads the updated file contents after an edit and sends them back to the model for further processing.

- **New Features**
  - Reads the entire edited file and returns its contents as context to the model.
  - Adds a helper to format and package the file output for the model.

<!-- End of auto-generated description by cubic. -->

