### PR TITLE
Add alwaysApply property to rules for better control over rule applic…

### DIFF
--- a/core/config/markdown/parseMarkdownRule.test.ts
+++ b/core/config/markdown/parseMarkdownRule.test.ts
@@ -171,4 +171,22 @@ This is the content of the rule.`;
       "This is a rule description from frontmatter",
     );
   });
+
+  it("should include `alwaysApply` from frontmatter", () => {
+    const content = `---
+globs: "**/test/**/*.kt"
+name: Test Rule
+alwaysApply: false
+---
+
+# Test Rule
+
+This is a rule with alwaysApply explicitly set to false.`;
+
+    const result = convertMarkdownRuleToContinueRule(
+      "/path/to/rule.md",
+      content,
+    );
+    expect(result.alwaysApply).toBe(false);
+  });
 });

--- a/core/config/markdown/parseMarkdownRule.ts
+++ b/core/config/markdown/parseMarkdownRule.ts
@@ -2,11 +2,18 @@ import { basename } from "path";
 import * as YAML from "yaml";
 import { RuleWithSource } from "../..";
 
+export interface RuleFrontmatter {
+  globs?: RuleWithSource["globs"];
+  name?: RuleWithSource["name"];
+  description?: RuleWithSource["description"];
+  alwaysApply?: RuleWithSource["alwaysApply"];
+}
+
 /**
  * Parses markdown content with YAML frontmatter
  */
 export function parseMarkdownRule(content: string): {
-  frontmatter: Record<string, any>;
+  frontmatter: RuleFrontmatter;
   markdown: string;
 } {
   // Normalize line endings to \n

--- a/core/config/markdown/parseMarkdownRule.ts
+++ b/core/config/markdown/parseMarkdownRule.ts
@@ -63,6 +63,7 @@ export function convertMarkdownRuleToContinueRule(
     rule: markdown,
     globs: frontmatter.globs,
     description: frontmatter.description,
+    alwaysApply: frontmatter.alwaysApply,
     source: "rules-block",
     ruleFile: path,
   };

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1543,4 +1543,5 @@ export interface RuleWithSource {
   rule: string;
   description?: string;
   ruleFile?: string;
+  alwaysApply?: boolean;
 }

--- a/core/llm/rules/getSystemMessageWithRules.test.ts
+++ b/core/llm/rules/getSystemMessageWithRules.test.ts
@@ -1,5 +1,6 @@
+/* eslint-disable max-lines-per-function */
 import { ContextItemWithId, RuleWithSource, UserChatMessage } from "../..";
-import { getSystemMessageWithRules } from "./getSystemMessageWithRules";
+import { getSystemMessageWithRules, shouldApplyRule } from "./getSystemMessageWithRules";
 
 describe("getSystemMessageWithRules", () => {
   const baseSystemMessage = "Base system message";
@@ -401,5 +402,403 @@ describe("getSystemMessageWithRules", () => {
     // Should include JS, TS, Python rules and general rule
     const expected = `${baseSystemMessage}\n\n${jsRule.rule}\n\n${tsRule.rule}\n\n${pythonRule.rule}\n\n${generalRule.rule}`;
     expect(result).toBe(expected);
+  });
+
+  // Tests for alwaysApply property
+  describe("alwaysApply property", () => {
+    const alwaysApplyTrueRule: RuleWithSource = {
+      name: "Always Apply True Rule",
+      rule: "This rule should always be applied",
+      globs: "**/*.nonexistent",
+      alwaysApply: true,
+      source: "rules-block",
+    };
+
+    const alwaysApplyFalseRule: RuleWithSource = {
+      name: "Always Apply False Rule",
+      rule: "This rule should never be applied",
+      alwaysApply: false,
+      source: "rules-block",
+    };
+
+    const alwaysApplyFalseWithMatchingGlobs: RuleWithSource = {
+      name: "Always Apply False with Matching Globs",
+      rule: "This rule should never be applied even with matching globs",
+      globs: "**/*.ts?(x)",
+      alwaysApply: false,
+      source: "rules-block",
+    };
+
+    it("should always include rules with alwaysApply: true regardless of globs or file paths", () => {
+      const userMessage: UserChatMessage = {
+        role: "user",
+        content: "```js main.js\nconsole.log('hello');\n```",
+      };
+
+      const result = getSystemMessageWithRules({
+        baseSystemMessage,
+        userMessage,
+        rules: [alwaysApplyTrueRule, tsRule],
+        contextItems: emptyContextItems,
+      });
+
+      // Should include the alwaysApply:true rule even though globs don't match
+      const expected = `${baseSystemMessage}\n\n${alwaysApplyTrueRule.rule}`;
+      expect(result).toBe(expected);
+    });
+
+    it("should include rules with alwaysApply: false when globs match", () => {
+      const userMessage: UserChatMessage = {
+        role: "user",
+        content: "```tsx Component.tsx\nexport const Component = () => <div>Hello</div>;\n```",
+      };
+
+      const result = getSystemMessageWithRules({
+        baseSystemMessage,
+        userMessage,
+        rules: [alwaysApplyFalseWithMatchingGlobs, tsRule, generalRule],
+        contextItems: emptyContextItems,
+      });
+
+      // Should include alwaysApply:false rule because globs match
+      const expected = `${baseSystemMessage}\n\n${alwaysApplyFalseWithMatchingGlobs.rule}\n\n${tsRule.rule}\n\n${generalRule.rule}`;
+      expect(result).toBe(expected);
+    });
+
+    it("should include rules with alwaysApply: false when globs match", () => {
+      const userMessage: UserChatMessage = {
+        role: "user",
+        content:
+          "```ts Component.tsx\nexport const Component = () => <div>Hello</div>;\n```",
+      };
+
+      const result = getSystemMessageWithRules({
+        baseSystemMessage,
+        userMessage,
+        rules: [alwaysApplyFalseWithMatchingGlobs, tsRule, generalRule],
+        contextItems: emptyContextItems,
+      });
+
+      // Should include alwaysApply:false rule because globs match
+      const expected = `${baseSystemMessage}\n\n${alwaysApplyFalseWithMatchingGlobs.rule}\n\n${tsRule.rule}\n\n${generalRule.rule}`;
+      expect(result).toBe(expected);
+    });
+
+    it("should NOT include rules with alwaysApply: false when globs don't match", () => {
+      const userMessage: UserChatMessage = {
+        role: "user",
+        content: "```py script.py\nprint('hello')\n```",
+      };
+
+      const result = getSystemMessageWithRules({
+        baseSystemMessage,
+        userMessage,
+        rules: [alwaysApplyFalseWithMatchingGlobs, generalRule],
+        contextItems: emptyContextItems,
+      });
+
+      // Should only include general rule (alwaysApply:false rule doesn't match .py files)
+      const expected = `${baseSystemMessage}\n\n${generalRule.rule}`;
+      expect(result).toBe(expected);
+    });
+
+    it("should NOT include rules with alwaysApply: false when no globs are specified", () => {
+      const userMessage: UserChatMessage = {
+        role: "user",
+        content: "```js main.js\nconsole.log('hello');\n```",
+      };
+
+      const alwaysApplyFalseNoGlobs: RuleWithSource = {
+        name: "Always Apply False No Globs",
+        rule: "This rule has alwaysApply false and no globs",
+        alwaysApply: false,
+        source: "rules-block",
+      };
+
+      const result = getSystemMessageWithRules({
+        baseSystemMessage,
+        userMessage,
+        rules: [alwaysApplyFalseNoGlobs, jsRule, generalRule],
+        contextItems: emptyContextItems,
+      });
+
+      // Should NOT include alwaysApply:false rule when no globs specified
+      const expected = `${baseSystemMessage}\n\n${jsRule.rule}\n\n${generalRule.rule}`;
+      expect(result).toBe(expected);
+    });
+
+    it("should include rules with alwaysApply: true even when no files are present", () => {
+      const result = getSystemMessageWithRules({
+        baseSystemMessage,
+        userMessage: undefined,
+        rules: [alwaysApplyTrueRule, tsRule, pythonRule],
+        contextItems: emptyContextItems,
+      });
+
+      // Should only include the alwaysApply:true rule
+      const expected = `${baseSystemMessage}\n\n${alwaysApplyTrueRule.rule}`;
+      expect(result).toBe(expected);
+    });
+
+    it("should handle mixed alwaysApply values correctly", () => {
+      const userMessage: UserChatMessage = {
+        role: "user",
+        content:
+          "```ts Component.tsx\nexport const Component = () => <div>Hello</div>;\n```",
+      };
+
+      const result = getSystemMessageWithRules({
+        baseSystemMessage,
+        userMessage,
+        rules: [
+          alwaysApplyTrueRule,
+          alwaysApplyFalseRule,
+          alwaysApplyFalseWithMatchingGlobs,
+          tsRule,
+          generalRule,
+        ],
+        contextItems: emptyContextItems,
+      });
+
+      // Should include:
+      // - alwaysApplyTrueRule (always applies)
+      // - alwaysApplyFalseWithMatchingGlobs (has globs that match .tsx)
+      // - tsRule (globs match .tsx)
+      // - generalRule (no globs, so applies to all)
+      // Should NOT include:
+      // - alwaysApplyFalseRule (alwaysApply: false and no globs)
+      const expected = `${baseSystemMessage}\n\n${alwaysApplyTrueRule.rule}\n\n${alwaysApplyFalseWithMatchingGlobs.rule}\n\n${tsRule.rule}\n\n${generalRule.rule}`;
+      expect(result).toBe(expected);
+    });
+
+    it("should use glob matching when alwaysApply is false", () => {
+      // This tests that rules with alwaysApply: false follow glob matching
+      const ruleWithAlwaysApplyFalse: RuleWithSource = {
+        name: "Rule With Always Apply False",
+        rule: "This rule follows glob matching behavior",
+        globs: "**/*.ts?(x)",
+        alwaysApply: false,
+        source: "rules-block",
+      };
+
+      const userMessage: UserChatMessage = {
+        role: "user",
+        content:
+          "```ts Component.tsx\nexport const Component = () => <div>Hello</div>;\n```",
+      };
+
+      const result = getSystemMessageWithRules({
+        baseSystemMessage,
+        userMessage,
+        rules: [ruleWithAlwaysApplyFalse],
+        contextItems: emptyContextItems,
+      });
+
+      // Should include the rule because it matches the file path
+      const expected = `${baseSystemMessage}\n\n${ruleWithAlwaysApplyFalse.rule}`;
+      expect(result).toBe(expected);
+    });
+
+    it("should include rules with globs when context file paths match (alwaysApply false)", () => {
+      const ruleWithGlobsOnly: RuleWithSource = {
+        name: "TypeScript Only Rule",
+        rule: "This rule should apply to TypeScript files only",
+        globs: "**/*.ts",
+        alwaysApply: false,
+        source: "rules-block",
+      };
+
+      const tsContextItem: ContextItemWithId = {
+        content: "TypeScript file content",
+        name: "utils.ts",
+        description: "A TypeScript utility file",
+        id: { providerTitle: "file", itemId: "src/utils.ts" },
+        uri: { type: "file", value: "src/utils.ts" },
+      };
+
+      const result = getSystemMessageWithRules({
+        baseSystemMessage,
+        userMessage: undefined, // No message, only context
+        rules: [ruleWithGlobsOnly, pythonRule], // Include a non-matching rule
+        contextItems: [tsContextItem],
+      });
+
+      // Should include the TypeScript rule but not the Python rule
+      const expected = `${baseSystemMessage}\n\n${ruleWithGlobsOnly.rule}`;
+      expect(result).toBe(expected);
+    });
+
+    it("should NOT include rules with globs when context file paths don't match (alwaysApply false)", () => {
+      const ruleWithGlobsOnly: RuleWithSource = {
+        name: "TypeScript Only Rule",
+        rule: "This rule should apply to TypeScript files only",
+        globs: "**/*.ts",
+        alwaysApply: false,
+        source: "rules-block",
+      };
+
+      const pyContextItem: ContextItemWithId = {
+        content: "Python file content",
+        name: "utils.py",
+        description: "A Python utility file",
+        id: { providerTitle: "file", itemId: "src/utils.py" },
+        uri: { type: "file", value: "src/utils.py" },
+      };
+
+      const result = getSystemMessageWithRules({
+        baseSystemMessage,
+        userMessage: undefined, // No message, only context
+        rules: [ruleWithGlobsOnly],
+        contextItems: [pyContextItem], // Python file doesn't match *.ts pattern
+      });
+
+      // Should NOT include the rule because context doesn't match the glob
+      expect(result).toBe(baseSystemMessage);
+    });
+  });
+});
+
+describe("shouldApplyRule", () => {
+  const ruleWithGlobs: RuleWithSource = {
+    name: "Rule with Globs",
+    rule: "Apply to TypeScript files",
+    globs: "**/*.ts?(x)",
+    alwaysApply: false,
+    source: "rules-block",
+  };
+
+  const ruleWithoutGlobs: RuleWithSource = {
+    name: "Rule without Globs",
+    rule: "Apply to all files",
+    alwaysApply: true,
+    source: "rules-block",
+  };
+
+  const ruleAlwaysApplyTrue: RuleWithSource = {
+    name: "Always Apply True",
+    rule: "Always apply this rule",
+    globs: "**/*.nonexistent",
+    alwaysApply: true,
+    source: "rules-block",
+  };
+
+  const ruleAlwaysApplyFalse: RuleWithSource = {
+    name: "Always Apply False",
+    rule: "Never apply this rule",
+    globs: "**/*.ts?(x)",
+    alwaysApply: false,
+    source: "rules-block",
+  };
+
+  const ruleAlwaysApplyFalseNoGlobs: RuleWithSource = {
+    name: "Always Apply False No Globs",
+    rule: "Never apply this rule",
+    alwaysApply: false,
+    source: "rules-block",
+  };
+
+  describe("alwaysApply behavior", () => {
+    it("should return true when alwaysApply is true, regardless of file paths", () => {
+      expect(shouldApplyRule(ruleAlwaysApplyTrue, [])).toBe(true);
+      expect(shouldApplyRule(ruleAlwaysApplyTrue, ["src/main.js"])).toBe(true);
+      expect(shouldApplyRule(ruleAlwaysApplyTrue, ["Component.tsx"])).toBe(true);
+    });
+
+    it("should use glob matching when alwaysApply is false", () => {
+      // Should apply when globs match
+      expect(shouldApplyRule(ruleAlwaysApplyFalse, ["src/main.ts"])).toBe(true);
+      expect(shouldApplyRule(ruleAlwaysApplyFalse, ["Component.tsx"])).toBe(true);
+      
+      // Should not apply when globs don't match
+      expect(shouldApplyRule(ruleAlwaysApplyFalse, ["script.py"])).toBe(false);
+      expect(shouldApplyRule(ruleAlwaysApplyFalse, [])).toBe(false);
+    });
+
+    it("should return false when alwaysApply is false and no globs specified", () => {
+      expect(shouldApplyRule(ruleAlwaysApplyFalseNoGlobs, [])).toBe(false);
+      expect(shouldApplyRule(ruleAlwaysApplyFalseNoGlobs, ["any-file.js"])).toBe(false);
+    });
+  });
+
+  describe("default behavior (alwaysApply undefined)", () => {
+    it("should return true for rules without globs regardless of file paths", () => {
+      expect(shouldApplyRule(ruleWithoutGlobs, [])).toBe(true);
+      expect(shouldApplyRule(ruleWithoutGlobs, ["src/main.js"])).toBe(true);
+      expect(shouldApplyRule(ruleWithoutGlobs, ["Component.tsx", "utils.py"])).toBe(true);
+    });
+
+    it("should return false for rules with globs when no file paths are provided", () => {
+      expect(shouldApplyRule(ruleWithGlobs, [])).toBe(false);
+    });
+
+    it("should return true for rules with globs when matching file paths are provided", () => {
+      expect(shouldApplyRule(ruleWithGlobs, ["Component.tsx"])).toBe(true);
+      expect(shouldApplyRule(ruleWithGlobs, ["src/main.ts"])).toBe(true);
+      expect(shouldApplyRule(ruleWithGlobs, ["utils.js", "Component.tsx"])).toBe(true);
+    });
+
+    it("should return false for rules with globs when no matching file paths are provided", () => {
+      expect(shouldApplyRule(ruleWithGlobs, ["utils.py"])).toBe(false);
+      expect(shouldApplyRule(ruleWithGlobs, ["main.js", "script.rb"])).toBe(false);
+    });
+  });
+
+  describe("glob pattern matching", () => {
+    const ruleWithArrayGlobs: RuleWithSource = {
+      name: "Rule with Array Globs",
+      rule: "Apply to specific patterns",
+      globs: ["src/**/*.ts", "tests/**/*.test.js"],
+      source: "rules-block",
+    };
+
+    const ruleWithSpecificPattern: RuleWithSource = {
+      name: "Rule with Specific Pattern",
+      rule: "Apply to Python files",
+      globs: "**/*.py",
+      source: "rules-block",
+    };
+
+    it("should handle array of glob patterns", () => {
+      expect(shouldApplyRule(ruleWithArrayGlobs, ["src/main.ts"])).toBe(true);
+      expect(shouldApplyRule(ruleWithArrayGlobs, ["tests/unit.test.js"])).toBe(true);
+      expect(shouldApplyRule(ruleWithArrayGlobs, ["config/settings.json"])).toBe(false);
+    });
+
+    it("should handle string glob patterns", () => {
+      expect(shouldApplyRule(ruleWithSpecificPattern, ["utils.py"])).toBe(true);
+      expect(shouldApplyRule(ruleWithSpecificPattern, ["src/models/user.py"])).toBe(true);
+      expect(shouldApplyRule(ruleWithSpecificPattern, ["utils.js"])).toBe(false);
+    });
+
+    it("should return true if any file path matches when multiple paths provided", () => {
+      expect(shouldApplyRule(ruleWithSpecificPattern, ["utils.js", "models.py", "config.json"])).toBe(true);
+      expect(shouldApplyRule(ruleWithGlobs, ["utils.py", "Component.tsx", "script.rb"])).toBe(true);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty globs array", () => {
+      const ruleWithEmptyGlobs: RuleWithSource = {
+        name: "Rule with Empty Globs",
+        rule: "Test rule",
+        globs: [],
+        source: "rules-block",
+      };
+      
+      // Empty array should be treated as "no globs" (truthy check fails)
+      expect(shouldApplyRule(ruleWithEmptyGlobs, ["any-file.js"])).toBe(false);
+    });
+
+    it("should handle undefined globs", () => {
+      const ruleUndefinedGlobs: RuleWithSource = {
+        name: "Rule with Undefined Globs",
+        rule: "Test rule",
+        globs: undefined,
+        source: "rules-block",
+      };
+      
+      expect(shouldApplyRule(ruleUndefinedGlobs, ["any-file.js"])).toBe(true);
+      expect(shouldApplyRule(ruleUndefinedGlobs, [])).toBe(true);
+    });
   });
 });

--- a/core/llm/rules/getSystemMessageWithRules.ts
+++ b/core/llm/rules/getSystemMessageWithRules.ts
@@ -29,6 +29,42 @@ const matchesGlobs = (
 };
 
 /**
+ * Determines if a rule should be applied based on its alwaysApply property and file path matching
+ *
+ * @param rule - The rule to check
+ * @param filePaths - Array of file paths to check against the rule's globs
+ * @returns true if the rule should be applied, false otherwise
+ */
+export const shouldApplyRule = (
+  rule: RuleWithSource,
+  filePaths: string[],
+): boolean => {
+  if (rule.alwaysApply) {
+    return true;
+  }
+
+  // If alwaysApply is explicitly false, only apply if there are globs AND they match
+  if (rule.alwaysApply === false) {
+    if (!rule.globs) {
+      return false; // No globs specified, don't apply
+    }
+    return filePaths.some((path) => matchesGlobs(path, rule.globs));
+  }
+
+  // If alwaysApply is undefined, default behavior:
+  // - No globs: always apply
+  // - Has globs: only apply if they match
+  if (rule.alwaysApply === undefined) {
+    if (!rule.globs) {
+      return true;
+    }
+    return filePaths.some((path) => matchesGlobs(path, rule.globs));
+  }
+
+  return false;
+};
+
+/**
  * Filters rules that apply to the given message and/or context items
  *
  * @param userMessage - The user or tool message to check for file paths in code blocks
@@ -52,16 +88,7 @@ export const getApplicableRules = (
   // Combine file paths from both sources
   const allFilePaths = [...filePathsFromMessage, ...filePathsFromContextItems];
 
-  return rules.filter((rule) => {
-    // A rule is active if it has no globs (applies to all files)
-    // or if at least one file path matches its globs
-    const hasNoGlobs = !rule.globs;
-    const matchesAnyFilePath = allFilePaths.some((path) =>
-      matchesGlobs(path, rule.globs),
-    );
-
-    return hasNoGlobs || matchesAnyFilePath;
-  });
+  return rules.filter((rule) => shouldApplyRule(rule, allFilePaths));
 };
 
 /**

--- a/core/llm/rules/getSystemMessageWithRules.ts
+++ b/core/llm/rules/getSystemMessageWithRules.ts
@@ -54,14 +54,11 @@ export const shouldApplyRule = (
   // If alwaysApply is undefined, default behavior:
   // - No globs: always apply
   // - Has globs: only apply if they match
-  if (rule.alwaysApply === undefined) {
-    if (!rule.globs) {
-      return true;
-    }
-    return filePaths.some((path) => matchesGlobs(path, rule.globs));
+  if (!rule.globs) {
+    return true;
   }
 
-  return false;
+  return filePaths.some((path) => matchesGlobs(path, rule.globs));
 };
 
 /**

--- a/core/tools/definitions/createRuleBlock.ts
+++ b/core/tools/definitions/createRuleBlock.ts
@@ -37,6 +37,11 @@ export const createRuleBlock: Tool = {
           description:
             "Optional file patterns to which this rule applies (e.g. ['**/*.{ts,tsx}'] or ['src/**/*.ts', 'tests/**/*.ts'])",
         },
+        alwaysApply: {
+          type: "boolean",
+          description:
+            "Whether this rule should always be applied regardless of file pattern matching",
+        },
       },
     },
   },

--- a/core/tools/definitions/createRuleBlock.ts
+++ b/core/tools/definitions/createRuleBlock.ts
@@ -16,7 +16,7 @@ export const createRuleBlock: Tool = {
       "Creates a persistent rule for all future conversations. For establishing code standards or preferences that should be applied consistently. To modify existing rules, use the edit tool instead.",
     parameters: {
       type: "object",
-      required: ["name", "rule"],
+      required: ["name", "rule", "alwaysApply", "description"],
       properties: {
         name: {
           type: "string",

--- a/core/tools/implementations/createRuleBlock.test.ts
+++ b/core/tools/implementations/createRuleBlock.test.ts
@@ -93,4 +93,22 @@ describe("createRuleBlockImpl", () => {
     expect(markdown).toContain("# Complete Rule");
     expect(markdown).toContain("Follow this standard");
   });
+
+  it("should create a rule with alwaysApply set to false", async () => {
+    const args = {
+      name: "Conditional Rule",
+      rule: "This rule should not always be applied",
+      alwaysApply: false,
+    };
+
+    await createRuleBlockImpl(args, mockExtras as any);
+
+    const fileContent = mockIde.writeFile.mock.calls[0][1];
+
+    const { frontmatter } = parseMarkdownRule(fileContent);
+
+    expect(frontmatter).toEqual({
+      alwaysApply: false,
+    });
+  });
 });

--- a/core/tools/implementations/createRuleBlock.ts
+++ b/core/tools/implementations/createRuleBlock.ts
@@ -1,12 +1,14 @@
 import * as YAML from "yaml";
 import { ToolImpl } from ".";
+import { RuleWithSource } from "../..";
 import { joinPathsToUri } from "../../util/uri";
 
-export interface CreateRuleBlockArgs {
+export interface CreateRuleBlockArgs
+  extends Pick<
+    RuleWithSource,
+    "rule" | "description" | "alwaysApply" | "globs"
+  > {
   name: string;
-  rule: string;
-  description: string;
-  globs?: string;
 }
 
 export const createRuleBlockImpl: ToolImpl = async (
@@ -21,15 +23,21 @@ export const createRuleBlockImpl: ToolImpl = async (
 
   const fileExtension = "md";
 
-  const frontmatter: Record<string, string> = {};
+  const frontmatter: Record<string, string | string[] | boolean> = {};
 
   if (args.globs) {
-    frontmatter.globs = args.globs.trim();
+    frontmatter.globs =
+      typeof args.globs === "string" ? args.globs.trim() : args.globs;
   }
 
   if (args.description) {
     frontmatter.description = args.description.trim();
   }
+
+  if (args.alwaysApply !== undefined) {
+    frontmatter.alwaysApply = args.alwaysApply;
+  }
+
   const frontmatterYaml = YAML.stringify(frontmatter).trim();
   let fileContent = `---
 ${frontmatterYaml}

--- a/core/tools/implementations/createRuleBlock.ts
+++ b/core/tools/implementations/createRuleBlock.ts
@@ -1,15 +1,14 @@
 import * as YAML from "yaml";
 import { ToolImpl } from ".";
 import { RuleWithSource } from "../..";
+import { RuleFrontmatter } from "../../config/markdown/parseMarkdownRule";
 import { joinPathsToUri } from "../../util/uri";
 
-export interface CreateRuleBlockArgs
-  extends Pick<
-    RuleWithSource,
-    "rule" | "description" | "alwaysApply" | "globs"
-  > {
-  name: string;
-}
+export type CreateRuleBlockArgs = Pick<
+  Required<RuleWithSource>,
+  "rule" | "description" | "alwaysApply" | "name"
+> &
+  Pick<RuleWithSource, "globs">;
 
 export const createRuleBlockImpl: ToolImpl = async (
   args: CreateRuleBlockArgs,
@@ -23,7 +22,7 @@ export const createRuleBlockImpl: ToolImpl = async (
 
   const fileExtension = "md";
 
-  const frontmatter: Record<string, string | string[] | boolean> = {};
+  const frontmatter: RuleFrontmatter = {};
 
   if (args.globs) {
     frontmatter.globs =

--- a/docs/docs/customize/deep-dives/rules.md
+++ b/docs/docs/customize/deep-dives/rules.md
@@ -27,7 +27,7 @@ For example, you can say "Create a rule for this", and a rule will be created fo
 
 ### Syntax
 
-Rules blocks can be simple text, or have the following properties:
+Rules blocks can be simple text, written in YAML configuration files, or as Markdown (`.md`) files. They can have the following properties:
 
 - `name` (**required**): A display name/title for the rule
 - `rule` (**required**): The text content of the rule

--- a/gui/src/components/mainInput/belowMainInput/RulesPeek.tsx
+++ b/gui/src/components/mainInput/belowMainInput/RulesPeek.tsx
@@ -35,7 +35,7 @@ const getSourceLabel = (source: RuleSource): string => {
 };
 
 export function RulesPeekItem({ rule }: RulesPeekItemProps) {
-  const isGlobal = !rule.globs;
+  const isGlobal = rule.alwaysApply ?? (!rule.globs);
   const [expanded, setExpanded] = useState(false);
 
   // Define maximum length for rule text display

--- a/packages/config-yaml/src/schemas/index.ts
+++ b/packages/config-yaml/src/schemas/index.ts
@@ -44,6 +44,7 @@ const ruleObjectSchema = z.object({
   rule: z.string(),
   description: z.string().optional(),
   globs: z.union([z.string(), z.array(z.string())]).optional(),
+  alwaysApply: z.boolean().optional(),
 });
 const ruleSchema = z.union([z.string(), ruleObjectSchema]);
 


### PR DESCRIPTION
This commit introduces an optional `alwaysApply` boolean property to rules that provides fine-grained control over when rules are included in system messages.

## Behavior

- `alwaysApply: true` - Always include the rule, regardless of file context
- `alwaysApply: false` - Only include if globs exist AND match file context
- `alwaysApply: undefined` - Default behavior: include if no globs OR globs match

## Changes

- Added `alwaysApply?: boolean` to `RuleWithSource` interface
- Updated `parseMarkdownRule` to handle frontmatter `alwaysApply` property
- Enhanced `shouldApplyRule` function with explicit logic for all three states
- Added `alwaysApply` to createRuleBlock tool definition and implementation
- Updated UI logic in RulesPeek component to match backend behavior
- Added comprehensive test coverage for all scenarios
- Updated documentation to mention Markdown file support for rules