### PR TITLE
docs: specify that mcp can be used in agent mode only

### DIFF
--- a/docs/docs/customize/deep-dives/mcp.mdx
+++ b/docs/docs/customize/deep-dives/mcp.mdx
@@ -13,6 +13,10 @@ Currently custom tools can be configured using the [Model Context Protocol](http
 
 MCP Servers can be added to hub Assistants using `mcpServers` blocks. You can explore available MCP server blocks [here](https://hub.continue.dev/explore/mcp).
 
+:::info
+MCP can only used in the **agent** mode.
+:::
+
 To set up your own MCP server, read the [MCP quickstart](https://modelcontextprotocol.io/quickstart) and then [create an `mcpServers` block](https://hub.continue.dev/new?type=block&blockType=mcpServers) or add the following to your [config file](./configuration.md):
 
 <Tabs groupId="config-example">

--- a/docs/docs/customize/deep-dives/mcp.mdx
+++ b/docs/docs/customize/deep-dives/mcp.mdx
@@ -14,7 +14,7 @@ Currently custom tools can be configured using the [Model Context Protocol](http
 MCP Servers can be added to hub Assistants using `mcpServers` blocks. You can explore available MCP server blocks [here](https://hub.continue.dev/explore/mcp).
 
 :::info
-MCP can only used in the **agent** mode.
+MCP can only be used in the **agent** mode.
 :::
 
 To set up your own MCP server, read the [MCP quickstart](https://modelcontextprotocol.io/quickstart) and then [create an `mcpServers` block](https://hub.continue.dev/new?type=block&blockType=mcpServers) or add the following to your [config file](./configuration.md):


### PR DESCRIPTION
## Description

Explicitly specify that MCP can be used in agent mode only.

discussion: https://discord.com/channels/1108621136150929458/1376259774886445056/1376554550143619134

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

![image](https://github.com/user-attachments/assets/c79a888f-efde-4da5-b300-4d18488b674a)

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
