### PR TITLE
Fix codebase indexer config logic

### DIFF
--- a/core/indexing/CodebaseIndexer.ts
+++ b/core/indexing/CodebaseIndexer.ts
@@ -249,7 +249,10 @@ export class CodebaseIndexer {
     }
 
     const { config } = await this.configHandler.loadConfig();
-    if (config?.disableIndexing) {
+    if (!config) {
+      return;
+    }
+    if (config.disableIndexing) {
       yield {
         progress,
         desc: "Indexing is disabled in config.json",


### PR DESCRIPTION
If config hasn't loaded, don't kickoff indexing
Might be a race condition somewhere that needs to be addressed since this might cause indexing to not be kicked off sometimes.
But at least it fixes a bug and respects the setting