### PR TITLE
fix: :bug: Fix the generating animation

### DIFF
--- a/gui/src/components/index.ts
+++ b/gui/src/components/index.ts
@@ -1,7 +1,6 @@
 import styled from "styled-components";
 import { varWithFallback } from "../styles/theme";
 
-// DEPRECATED - avoid using these where possible, use tailwind classes instead
 export const defaultBorderRadius = "5px";
 export const lightGray = "#999998";
 export const greenButtonColor = "#189e72";
@@ -210,8 +209,11 @@ export const AnimatedEllipsis = styled.span`
   &::after {
     content: ".";
     animation: ellipsis 2.5s infinite;
+    animation-fill-mode: forwards;
+    animation-play-state: running;
+    will-change: content;
     display: inline-block;
-    width: 12px;
+    width: 16px;
     text-align: left;
   }
 
@@ -224,6 +226,9 @@ export const AnimatedEllipsis = styled.span`
     }
     66% {
       content: "...";
+    }
+    100% {
+      content: ".";
     }
   }
 `;


### PR DESCRIPTION
## Description

I'm attempting to fix the "Generating..." animation. After a period of time it seems to stop animating which might cause the end user to believe the chat window has become un-responsive. This was an AI suggested change.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

I've performed manual testing across a number of senarios including creating files, using tools, and applying edits. The animation seems to consistently restart and display after the change. Before the change I often observe the animation has stopped and it just displayes "Generating." (with a single dot).
