### PR TITLE
always show active file in input toolbar, not codebase

### DIFF
--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "1.1.39",
+  "version": "1.1.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "1.1.39",
+      "version": "1.1.40",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",
@@ -110,7 +110,7 @@
         "@continuedev/fetch": "^1.0.10",
         "@continuedev/llm-info": "^1.0.8",
         "@continuedev/openai-adapters": "^1.0.25",
-        "@modelcontextprotocol/sdk": "^1.5.0",
+        "@modelcontextprotocol/sdk": "^1.12.0",
         "@mozilla/readability": "^0.5.0",
         "@octokit/rest": "^20.1.1",
         "@typescript-eslint/eslint-plugin": "^7.8.0",

--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -11,11 +11,7 @@ import {
 } from "../../redux/selectors/selectCurrentToolCall";
 import { selectSelectedChatModel } from "../../redux/slices/configSlice";
 import { exitEdit } from "../../redux/thunks/edit";
-import {
-  getAltKeyLabel,
-  getMetaKeyLabel,
-  isMetaEquivalentKeyPressed,
-} from "../../util";
+import { getAltKeyLabel, isMetaEquivalentKeyPressed } from "../../util";
 import { ToolTip } from "../gui/Tooltip";
 import ModelSelect from "../modelSelection/ModelSelect";
 import { ModeSelect } from "../ModeSelect";
@@ -160,32 +156,28 @@ function InputToolbar(props: InputToolbarProps) {
             <div
               className={`${toolsSupported ? "md:flex" : "int:flex"} hover:underline" hidden transition-colors duration-200`}
             >
-              {props.activeKey === "Alt" ? (
-                <HoverItem className="underline">
-                  {`${getAltKeyLabel()}⏎
-                  ${useActiveFile ? "No active file" : "Active file"}`}
-                </HoverItem>
-              ) : (
-                <HoverItem
-                  className={props.activeKey === "Meta" ? "underline" : ""}
-                  onClick={(e) =>
-                    props.onEnter?.({
-                      useCodebase: true,
-                      noContext: !useActiveFile,
-                    })
-                  }
-                >
-                  <span data-tooltip-id="add-codebase-context-tooltip">
-                    {getMetaKeyLabel()}⏎ @codebase
-                  </span>
-                  <ToolTip id="add-codebase-context-tooltip" place="top-end">
-                    Send With Codebase as Context ({getMetaKeyLabel()}⏎)
-                  </ToolTip>
-                </HoverItem>
-              )}
+              <HoverItem
+                className={props.activeKey === "Alt" ? "underline" : ""}
+                onClick={(e) =>
+                  props.onEnter?.({
+                    useCodebase: false,
+                    noContext: !useActiveFile,
+                  })
+                }
+              >
+                <span data-tooltip-id="add-active-file-context-tooltip">
+                  {getAltKeyLabel()}⏎{" "}
+                  {useActiveFile ? "No active file" : "Active file"}
+                </span>
+                <ToolTip id="add-active-file-context-tooltip" place="top-end">
+                  {useActiveFile
+                    ? "Send Without Active File"
+                    : "Send With Active File"}{" "}
+                  ({getAltKeyLabel()}⏎)
+                </ToolTip>
+              </HoverItem>
             </div>
           )}
-
           {isInEdit && (
             <HoverItem
               className="hidden hover:underline sm:flex"


### PR DESCRIPTION
## Description

retrieval is just generally way less effective than agent mode grepping around the codebase and this button was encouraging overuse of the feature. active file is much more often useful and what users really need, so making that the default suggested shortcut

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Tests

I don't think it makes sense to test this