### PR TITLE
fix changing width when typing text

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor/TipTapEditor.css
+++ b/gui/src/components/mainInput/TipTapEditor/TipTapEditor.css
@@ -23,6 +23,7 @@
   height: 0;
   pointer-events: none;
   white-space: nowrap;
+  width: 1px;
 }
 
 .gap-cursor {


### PR DESCRIPTION
## Description

When the input box has the placeholder text and the placeholder text is not fully expanded, typing into the input shrinks the input box by a little amount.  

This can be noticed in the before video where the input box shrinks from the right side when something is typed.

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

https://github.com/user-attachments/assets/d3ff905c-d06c-467f-b2ac-6c7e30640bbe






https://github.com/user-attachments/assets/67cc8b8e-b5b8-4097-ad17-e42b4f3c967f



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
