### PR TITLE
adding initial Continue Docs rule

### DIFF
--- a/.continue/rules/documentation-standards.md
+++ b/.continue/rules/documentation-standards.md
@@ -1,0 +1,16 @@
+---
+globs: docs/**/*.{md,mdx}
+description: Standards for writing and maintaining Continue Docs
+---
+
+# Continue Docs Standards
+
+- Follow Docusaurus documentation standards
+- Include YAML frontmatter with title, description, and keywords
+- Use consistent heading hierarchy starting with h2 (##)
+- Include relevant Admonition components for tips, warnings, and info
+- Use descriptive alt text for images
+- Include cross-references to related documentation
+- Reference other docs with relative paths
+- Keep paragraphs concise and scannable
+- Use code blocks with appropriate language tags


### PR DESCRIPTION
## Description

Added an initial rule for Continue Docs standards

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created