### PR TITLE
verbose logging option for our custom fetch

### DIFF
--- a/packages/fetch/package-lock.json
+++ b/packages/fetch/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@continuedev/fetch",
-  "version": "1.0.9",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@continuedev/fetch",
-      "version": "1.0.9",
+      "version": "1.0.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.5",

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@continuedev/fetch",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Description

Adds an option to output extremely verbose logs for any fetch that passes through the @ continuedev/fetch package. To help debug and reconstruct curl requests. This has no effect unless a very specific environment variable is set

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created