### PR TITLE
Add JCEF out of process vm setting

### DIFF
--- a/extensions/intellij/.run/Run Extension.run.xml
+++ b/extensions/intellij/.run/Run Extension.run.xml
@@ -20,7 +20,7 @@
                     <option value="runIde"/>
                 </list>
             </option>
-            <option name="vmOptions"/>
+             <option name="vmOptions" value="-Dide.browser.jcef.out-of-process.enabled=false"/>
         </ExternalSystemSettings>
         <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
         <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>

--- a/extensions/intellij/.run/Run Qodana.run.xml
+++ b/extensions/intellij/.run/Run Qodana.run.xml
@@ -19,7 +19,7 @@
 <!--          <option value="runInspections" />-->
 <!--        </list>-->
 <!--      </option>-->
-<!--      <option name="vmOptions" />-->
+<!--       <option name="vmOptions" value="-Dide.browser.jcef.out-of-process.enabled=false"/>-->
 <!--    </ExternalSystemSettings>-->
 <!--    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>-->
 <!--    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>-->

--- a/extensions/intellij/.run/Run Test IDE.run.xml
+++ b/extensions/intellij/.run/Run Test IDE.run.xml
@@ -13,7 +13,7 @@
                     <option value="runIdeForUiTests"/>
                 </list>
             </option>
-            <option name="vmOptions"/>
+             <option name="vmOptions" value="-Dide.browser.jcef.out-of-process.enabled=false"/>
         </ExternalSystemSettings>
         <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
         <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>

--- a/extensions/intellij/.run/Run Tests.run.xml
+++ b/extensions/intellij/.run/Run Tests.run.xml
@@ -13,7 +13,7 @@
           <option value="test" />
         </list>
       </option>
-      <option name="vmOptions" />
+       <option name="vmOptions" value="-Dide.browser.jcef.out-of-process.enabled=false"/>
     </ExternalSystemSettings>
     <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
     <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>


### PR DESCRIPTION
Fixes https://github.com/continuedev/continue/issues/5698
Fix based on this thread https://youtrack.jetbrains.com/issue/IJPL-186252/JCEF.-NullPointerException-Cannot-read-field-objId-because-robj-is-null