### PR TITLE
Nate/resource-templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,7 @@ Icon?
 .continuerc.json
 .aider*
 
+*.notes.md
 notes.md
 
 manual-testing-sandbox/.idea/**

--- a/core/config/profile/doLoadConfig.ts
+++ b/core/config/profile/doLoadConfig.ts
@@ -176,12 +176,21 @@ export default async function doLoadConfig(options: {
       );
       newConfig.slashCommands.push(...serverSlashCommands);
 
-      const submenuItems = server.resources.map((resource) => ({
-        title: resource.name,
-        description: resource.description ?? resource.name,
-        id: resource.uri,
-        icon: server.faviconUrl,
-      }));
+      const submenuItems = server.resources
+        .map((resource) => ({
+          title: resource.name,
+          description: resource.description ?? resource.name,
+          id: resource.uri,
+          icon: server.faviconUrl,
+        }))
+        .concat(
+          server.resourceTemplates.map((template) => ({
+            title: template.name,
+            description: template.description ?? template.name,
+            id: template.uriTemplate,
+            icon: server.faviconUrl,
+          })),
+        );
       if (submenuItems.length > 0) {
         const serverContextProvider = new MCPContextProvider({
           submenuItems,

--- a/core/context/mcp/MCPConnection.ts
+++ b/core/context/mcp/MCPConnection.ts
@@ -3,14 +3,15 @@ import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { WebSocketClientTransport } from "@modelcontextprotocol/sdk/client/websocket.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { WebSocketClientTransport } from "@modelcontextprotocol/sdk/client/websocket.js";
 
 import {
   MCPConnectionStatus,
   MCPOptions,
   MCPPrompt,
   MCPResource,
+  MCPResourceTemplate,
   MCPServerStatus,
   MCPTool,
 } from "../..";
@@ -37,6 +38,7 @@ class MCPConnection {
   public prompts: MCPPrompt[] = [];
   public tools: MCPTool[] = [];
   public resources: MCPResource[] = [];
+  public resourceTemplates: MCPResourceTemplate[] = [];
   private transport: Transport;
   private connectionPromise: Promise<unknown> | null = null;
   private stdioOutput: { stdout: string; stderr: string } = {
@@ -72,6 +74,7 @@ class MCPConnection {
       errors: this.errors,
       prompts: this.prompts,
       resources: this.resources,
+      resourceTemplates: this.resourceTemplates,
       tools: this.tools,
       status: this.status,
     };
@@ -95,6 +98,7 @@ class MCPConnection {
     this.tools = [];
     this.prompts = [];
     this.resources = [];
+    this.resourceTemplates = [];
     this.errors = [];
     this.stdioOutput = { stdout: "", stderr: "" };
 
@@ -164,6 +168,23 @@ class MCPConnection {
                   this.resources = resources;
                 } catch (e) {
                   let errorMessage = `Error loading resources for MCP Server ${this.options.name}`;
+                  if (e instanceof Error) {
+                    errorMessage += `: ${e.message}`;
+                  }
+                  this.errors.push(errorMessage);
+                }
+
+                // Resource templates
+                try {
+                  const { resourceTemplates } =
+                    await this.client.listResourceTemplates(
+                      {},
+                      { signal: timeoutController.signal },
+                    );
+
+                  this.resourceTemplates = resourceTemplates;
+                } catch (e) {
+                  let errorMessage = `Error loading resource templates for MCP Server ${this.options.name}`;
                   if (e instanceof Error) {
                     errorMessage += `: ${e.message}`;
                   }
@@ -337,9 +358,12 @@ class MCPConnection {
           requestInit: { headers: options.transport.requestOptions?.headers },
         });
       case "streamable-http":
-        return new StreamableHTTPClientTransport(new URL(options.transport.url), {
-          requestInit: { headers: options.transport.requestOptions?.headers },
-        });
+        return new StreamableHTTPClientTransport(
+          new URL(options.transport.url),
+          {
+            requestInit: { headers: options.transport.requestOptions?.headers },
+          },
+        );
       default:
         throw new Error(
           `Unsupported transport type: ${(options.transport as any).type}`,

--- a/core/context/providers/MCPContextProvider.ts
+++ b/core/context/providers/MCPContextProvider.ts
@@ -20,6 +20,7 @@ class MCPContextProvider extends BaseContextProvider {
     displayTitle: "MCP",
     description: "Model Context Protocol",
     type: "submenu",
+    renderInlineAs: "",
   };
   override get description(): ContextProviderDescription {
     return {
@@ -27,6 +28,7 @@ class MCPContextProvider extends BaseContextProvider {
       displayTitle: this.options["serverName"]
         ? `${this.options["serverName"]} resources`
         : "MCP",
+      renderInlineAs: "",
       description: "Model Context Protocol",
       type: "submenu",
     };

--- a/core/context/providers/MCPContextProvider.ts
+++ b/core/context/providers/MCPContextProvider.ts
@@ -49,6 +49,18 @@ class MCPContextProvider extends BaseContextProvider {
     super(options);
   }
 
+  /**
+   * Continue experimentally supports resource templates (https://modelcontextprotocol.io/docs/concepts/resources#resource-templates)
+   * by allowing specifically just the "query" variable in the template, which we will update with the full input of the user in the input box
+   */
+  private insertInputToUriTemplate(uri: string, query: string): string {
+    const TEMPLATE_VAR = "query";
+    if (uri.includes(`{${TEMPLATE_VAR}}`)) {
+      return uri.replace(`{${TEMPLATE_VAR}}`, encodeURIComponent(query));
+    }
+    return uri;
+  }
+
   async getContextItems(
     query: string,
     extras: ContextProviderExtras,
@@ -60,7 +72,9 @@ class MCPContextProvider extends BaseContextProvider {
       throw new Error(`No MCP connection found for ${mcpId}`);
     }
 
-    const { contents } = await connection.client.readResource({ uri });
+    const { contents } = await connection.client.readResource({
+      uri: this.insertInputToUriTemplate(uri, extras.fullInput),
+    });
 
     return await Promise.all(
       contents.map(async (resource) => {

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1141,7 +1141,7 @@ export interface StreamableHTTPOptions {
   requestOptions?: RequestOptions;
 }
 
-export type TransportOptions = 
+export type TransportOptions =
   | StdioOptions
   | WebSocketOptions
   | SSEOptions
@@ -1174,9 +1174,18 @@ export interface MCPPrompt {
 // Leaving here to ideate on
 // export type ContinueConfigSource = "local-yaml" | "local-json" | "hub-assistant" | "hub"
 
+// https://modelcontextprotocol.io/docs/concepts/resources#direct-resources
 export interface MCPResource {
   name: string;
   uri: string;
+  description?: string;
+  mimeType?: string;
+}
+
+// https://modelcontextprotocol.io/docs/concepts/resources#resource-templates
+export interface MCPResourceTemplate {
+  uriTemplate: string;
+  name: string;
   description?: string;
   mimeType?: string;
 }
@@ -1197,6 +1206,7 @@ export interface MCPServerStatus extends MCPOptions {
   prompts: MCPPrompt[];
   tools: MCPTool[];
   resources: MCPResource[];
+  resourceTemplates: MCPResourceTemplate[];
 }
 
 export interface ContinueUIConfig {

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "1.1.39",
+  "version": "1.1.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "1.1.39",
+      "version": "1.1.40",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",
@@ -110,7 +110,7 @@
         "@continuedev/fetch": "^1.0.10",
         "@continuedev/llm-info": "^1.0.8",
         "@continuedev/openai-adapters": "^1.0.25",
-        "@modelcontextprotocol/sdk": "^1.5.0",
+        "@modelcontextprotocol/sdk": "^1.12.0",
         "@mozilla/readability": "^0.5.0",
         "@octokit/rest": "^20.1.1",
         "@typescript-eslint/eslint-plugin": "^7.8.0",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "1.1.40",
+  "version": "1.1.41",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"

--- a/gui/src/components/mainInput/Lump/sections/mcp/MCPSection.tsx
+++ b/gui/src/components/mainInput/Lump/sections/mcp/MCPSection.tsx
@@ -113,11 +113,15 @@ function MCPServerPreview({ server, serverFromYaml }: MCPServerStatusProps) {
             data-tooltip-id={resourcesTooltipId}
           >
             <CircleStackIcon className="h-3 w-3" />
-            <span className="text-xs">{server.resources.length}</span>
+            <span className="text-xs">
+              {server.resources.length + server.resourceTemplates.length}
+            </span>
             <ToolTip id={resourcesTooltipId} className="flex flex-col gap-0.5">
-              {server.resources.map((resource, idx) => (
-                <code key={idx}>{resource.name}</code>
-              ))}
+              {[...server.resources, ...server.resourceTemplates].map(
+                (resource, idx) => (
+                  <code key={idx}>{resource.name}</code>
+                ),
+              )}
               {server.resources.length === 0 && (
                 <span className="text-lightgray">No resources</span>
               )}


### PR DESCRIPTION
## Description

Add experimental support for MCP resource templates, currently only with access to the "query" template variable. This allows MCP servers to take the Continue user's input to do things like similarity search

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created