### PR TITLE
Fix apply cancellation and make slash commands cancelable

### DIFF
--- a/core/commands/index.ts
+++ b/core/commands/index.ts
@@ -25,6 +25,7 @@ export function slashFromCustomCommand(
       config,
       selectedCode,
       fetch,
+      abortController,
     }) {
       // Render prompt template
       let renderedPrompt: string;
@@ -63,7 +64,7 @@ export function slashFromCustomCommand(
 
       for await (const chunk of llm.streamChat(
         messages,
-        new AbortController().signal,
+        abortController.signal,
         completionOptions,
       )) {
         yield renderChatMessage(chunk);

--- a/core/commands/slash/commit.ts
+++ b/core/commands/slash/commit.ts
@@ -4,7 +4,7 @@ import { renderChatMessage } from "../../util/messageContent.js";
 const CommitMessageCommand: SlashCommand = {
   name: "commit",
   description: "Generate a commit message for current changes",
-  run: async function* ({ ide, llm, params }) {
+  run: async function* ({ ide, llm, params, abortController }) {
     const includeUnstaged = params?.includeUnstaged ?? false;
     const diff = await ide.getDiff(includeUnstaged);
 
@@ -16,7 +16,7 @@ const CommitMessageCommand: SlashCommand = {
     const prompt = `${diff.join("\n")}\n\nGenerate a commit message for the above set of changes. First, give a single sentence, no more than 80 characters. Then, after 2 line breaks, give a list of no more than 5 short bullet points, each no more than 40 characters. Output nothing except for the commit message, and don't surround it in quotes.`;
     for await (const chunk of llm.streamChat(
       [{ role: "user", content: prompt }],
-      new AbortController().signal,
+      abortController.signal,
     )) {
       yield renderChatMessage(chunk);
     }

--- a/core/commands/slash/draftIssue.ts
+++ b/core/commands/slash/draftIssue.ts
@@ -24,7 +24,7 @@ Body:\n\n`;
 const DraftIssueCommand: SlashCommand = {
   name: "issue",
   description: "Draft a GitHub issue",
-  run: async function* ({ input, llm, history, params }) {
+  run: async function* ({ input, llm, history, params, abortController }) {
     if (params?.repositoryUrl === undefined) {
       yield "This command requires a repository URL to be set in the config file.";
       return;
@@ -46,7 +46,7 @@ const DraftIssueCommand: SlashCommand = {
 
     for await (const chunk of llm.streamChat(
       messages,
-      new AbortController().signal,
+      abortController.signal,
     )) {
       body += chunk.content;
       yield renderChatMessage(chunk);

--- a/core/commands/slash/mcp.ts
+++ b/core/commands/slash/mcp.ts
@@ -60,7 +60,7 @@ export function constructMcpSlashCommand(
 
       for await (const chunk of context.llm.streamChat(
         messages,
-        new AbortController().signal,
+        context.abortController.signal,
         context.completionOptions,
       )) {
         yield renderChatMessage(chunk);

--- a/core/commands/slash/onboard.ts
+++ b/core/commands/slash/onboard.ts
@@ -41,7 +41,7 @@ const MAX_EXPLORE_DEPTH = 2;
 const OnboardSlashCommand: SlashCommand = {
   name: "onboard",
   description: "Familiarize yourself with the codebase",
-  run: async function* ({ llm, ide }) {
+  run: async function* ({ llm, ide, abortController }) {
     const [workspaceDir] = await ide.getWorkspaceDirs();
 
     const context = await gatherProjectContext(workspaceDir, ide);
@@ -49,7 +49,7 @@ const OnboardSlashCommand: SlashCommand = {
 
     for await (const chunk of llm.streamChat(
       [{ role: "user", content: prompt }],
-      new AbortController().signal,
+      abortController.signal,
     )) {
       yield renderChatMessage(chunk);
     }

--- a/core/commands/slash/review.ts
+++ b/core/commands/slash/review.ts
@@ -38,14 +38,14 @@ function getLastUserHistory(history: ChatMessage[]): string {
 const ReviewMessageCommand: SlashCommand = {
   name: "review",
   description: "Review code and give feedback",
-  run: async function* ({ llm, history }) {
+  run: async function* ({ llm, history, abortController }) {
     const reviewText = getLastUserHistory(history).replace("\\review", "");
 
     const content = `${prompt} \r\n ${reviewText}`;
 
     for await (const chunk of llm.streamChat(
       [{ role: "user", content: content }],
-      new AbortController().signal,
+      abortController.signal,
     )) {
       yield renderChatMessage(chunk);
     }

--- a/core/edit/lazy/applyCodeBlock.ts
+++ b/core/edit/lazy/applyCodeBlock.ts
@@ -16,6 +16,7 @@ export async function applyCodeBlock(
   newLazyFile: string,
   filename: string,
   llm: ILLM,
+  abortController: AbortController,
 ): Promise<{
   isInstantApply: boolean;
   diffLinesGenerator: AsyncGenerator<DiffLine>;
@@ -51,6 +52,12 @@ export async function applyCodeBlock(
 
   return {
     isInstantApply: false,
-    diffLinesGenerator: streamLazyApply(oldFile, filename, newLazyFile, llm),
+    diffLinesGenerator: streamLazyApply(
+      oldFile,
+      filename,
+      newLazyFile,
+      llm,
+      abortController,
+    ),
   };
 }

--- a/core/edit/lazy/replace.ts
+++ b/core/edit/lazy/replace.ts
@@ -59,6 +59,7 @@ export async function* getReplacementWithLlm(
   linesBefore: string[],
   linesAfter: string[],
   llm: ILLM,
+  abortController: AbortController,
 ): AsyncGenerator<string> {
   const userPrompt = dedent`
     ORIGINAL CODE:
@@ -83,10 +84,13 @@ export async function* getReplacementWithLlm(
     \`\`\`
   `;
 
-  const completion = await llm.streamChat([
-    { role: "user", content: userPrompt },
-    { role: "assistant", content: assistantPrompt },
-  ], new AbortController().signal);
+  const completion = await llm.streamChat(
+    [
+      { role: "user", content: userPrompt },
+      { role: "assistant", content: assistantPrompt },
+    ],
+    abortController.signal,
+  );
 
   let lines = streamLines(completion);
   lines = filterLeadingNewline(lines);

--- a/core/edit/lazy/streamLazyApply.ts
+++ b/core/edit/lazy/streamLazyApply.ts
@@ -16,6 +16,7 @@ export async function* streamLazyApply(
   filename: string,
   newCode: string,
   llm: ILLM,
+  abortController: AbortController,
 ): AsyncGenerator<DiffLine> {
   const promptFactory = lazyApplyPromptForModel(llm.model, llm.providerName);
   if (!promptFactory) {
@@ -23,10 +24,7 @@ export async function* streamLazyApply(
   }
 
   const promptMessages = promptFactory(oldCode, filename, newCode);
-  const lazyCompletion = llm.streamChat(
-    promptMessages,
-    new AbortController().signal,
-  );
+  const lazyCompletion = llm.streamChat(promptMessages, abortController.signal);
 
   // Do find and replace over the lazy edit response
   async function* replacementFunction(
@@ -39,6 +37,7 @@ export async function* streamLazyApply(
       linesBefore,
       linesAfter,
       llm,
+      abortController,
     )) {
       yield line;
     }

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -836,6 +836,7 @@ export interface ContinueSDK {
   config: ContinueConfig;
   fetch: FetchFunction;
   completionOptions?: LLMFullCompletionOptions;
+  abortController: AbortController;
 }
 
 export interface SlashCommand {
@@ -1141,7 +1142,7 @@ export interface StreamableHTTPOptions {
   requestOptions?: RequestOptions;
 }
 
-export type TransportOptions = 
+export type TransportOptions =
   | StdioOptions
   | WebSocketOptions
   | SSEOptions

--- a/core/llm/streamChat.ts
+++ b/core/llm/streamChat.ts
@@ -84,6 +84,7 @@ export async function* llmStreamChat(
           config.requestOptions,
         ),
       completionOptions,
+      abortController,
     });
     let next = await gen.next();
     while (!next.done) {

--- a/core/promptFiles/v1/slashCommandFromPromptFile.ts
+++ b/core/promptFiles/v1/slashCommandFromPromptFile.ts
@@ -98,7 +98,7 @@ export function slashCommandFromPromptFileV1(
 
       for await (const chunk of context.llm.streamChat(
         messages,
-        new AbortController().signal,
+        context.abortController.signal,
         context.completionOptions,
       )) {
         yield renderChatMessage(chunk);

--- a/extensions/vscode/src/apply/ApplyManager.ts
+++ b/extensions/vscode/src/apply/ApplyManager.ts
@@ -3,6 +3,7 @@ import { applyCodeBlock } from "core/edit/lazy/applyCodeBlock";
 import { getUriPathBasename } from "core/util/uri";
 import * as vscode from "vscode";
 
+import { StreamAbortManager } from "core/util/abortManager";
 import { VerticalDiffManager } from "../diff/vertical/manager";
 import { VsCodeIde } from "../VsCodeIde";
 import { VsCodeWebviewProtocol } from "../webviewProtocol";
@@ -116,11 +117,16 @@ export class ApplyManager {
       return;
     }
 
+    const fileUri = editor.document.uri.toString();
+    const abortManager = StreamAbortManager.getInstance();
+    const abortController = abortManager.get(fileUri);
+
     const { isInstantApply, diffLinesGenerator } = await applyCodeBlock(
       editor.document.getText(),
       text,
-      getUriPathBasename(editor.document.uri.toString()),
+      getUriPathBasename(fileUri),
       llm,
+      abortController,
     );
 
     if (isInstantApply) {


### PR DESCRIPTION
#5694 was intended to make apply cancelable but only worked for jetbrains because of how it was set up.
This PR fixes for VS Code
It also passes abort controllers to slash commands to make them cancelable as well.