### PR TITLE
Jacob/feature/call alongside autocomplete

### DIFF
--- a/core/nextEdit/IgnoreNextEdit.ts
+++ b/core/nextEdit/IgnoreNextEdit.ts
@@ -1,0 +1,1 @@
+export const IGNORE_NEXT_EDIT = true;


### PR DESCRIPTION
## Description

Turn off next edit for other users until it is ready.

This only targets vscode -- we need another check for jetbrains. I don't see any message endpoints defined for next edit for the jetbrains extension, so we should be good for now.

## Checklist

- [*] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [*] The relevant docs, if any, have been updated or created
- [*] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
