### PR TITLE
fix: The wrong file is edited if the active file is different from the Edit file directive

### DIFF
--- a/extensions/vscode/src/diff/vertical/handler.ts
+++ b/extensions/vscode/src/diff/vertical/handler.ts
@@ -129,7 +129,7 @@ export class VerticalDiffHandler implements vscode.Disposable {
       this._diffLinesQueue.push(diffLine);
     }
 
-    if (this._queueLock || this.editor !== vscode.window.activeTextEditor) {
+    if (this._queueLock) {
       return;
     }
 
@@ -154,6 +154,9 @@ export class VerticalDiffHandler implements vscode.Disposable {
   }
 
   async run(diffLineGenerator: AsyncGenerator<DiffLine>) {
+    console.log(
+      `[Continue] VerticalDiffHandler (${this.fileUri}) run started. Active editor: ${vscode.window.activeTextEditor?.document.uri.toString()}`,
+    );
     let diffLines = [];
 
     try {
@@ -174,10 +177,7 @@ export class VerticalDiffHandler implements vscode.Disposable {
       await this.reapplyWithMyersDiff(diffLines);
 
       const range = new vscode.Range(this.startLine, 0, this.startLine, 0);
-      this.editor.revealRange(
-        range,
-        vscode.TextEditorRevealType.Default,
-      );
+      this.editor.revealRange(range, vscode.TextEditorRevealType.Default);
 
       this.options.onStatusUpdate(
         "done",
@@ -423,11 +423,13 @@ export class VerticalDiffHandler implements vscode.Disposable {
   private incrementCurrentLineIndex() {
     this.currentLineIndex++;
     this.updateIndexLineDecorations();
-    const range = new vscode.Range(this.currentLineIndex, 0, this.currentLineIndex, 0);
-    this.editor.revealRange(
-      range,
-      vscode.TextEditorRevealType.Default,
+    const range = new vscode.Range(
+      this.currentLineIndex,
+      0,
+      this.currentLineIndex,
+      0,
     );
+    this.editor.revealRange(range, vscode.TextEditorRevealType.Default);
   }
 
   private async insertTextAboveLine(index: number, text: string) {
@@ -526,6 +528,7 @@ export class VerticalDiffHandler implements vscode.Disposable {
   }
 
   private async _handleDiffLine(diffLine: DiffLine) {
+    // Original logic continues here
     switch (diffLine.type) {
       case "same":
         await this.insertDeletionBuffer();

--- a/extensions/vscode/src/extension/VsCodeMessenger.ts
+++ b/extensions/vscode/src/extension/VsCodeMessenger.ts
@@ -228,6 +228,7 @@ export class VsCodeMessenger {
           new vscode.Position(end.line, end.character),
         ),
         rulesToInclude: config.rules,
+        fileUriFromQuickPick: msg.data.range.filepath,
       });
 
       // Log dev data

--- a/extensions/vscode/src/quickEdit/QuickEditQuickPick.ts
+++ b/extensions/vscode/src/quickEdit/QuickEditQuickPick.ts
@@ -326,12 +326,52 @@ export class QuickEdit {
 
     void this.webviewProtocol.request("incrementFtc", undefined);
 
+    const editorUriString = this.editorWhenOpened?.document?.uri?.toString();
+    if (this.editorWhenOpened && editorUriString) {
+      console.log(`
+
+
+!!!!!!!!!!!!!!
+[CONTINUE DEBUG QEQP - PATH A]
+EDITOR IS DEFINED AND HAS URI: ${editorUriString}
+PASSING TO streamEdit
+!!!!!!!!!!!!!!
+
+
+`);
+    } else if (this.editorWhenOpened) {
+      console.log(`
+
+
+!!!!!!!!!!!!!!
+[CONTINUE DEBUG QEQP - PATH B]
+EDITOR IS DEFINED BUT URI IS NOT: ${editorUriString}
+PASSING POTENTIALLY UNDEFINED URI TO streamEdit
+!!!!!!!!!!!!!!
+
+
+`);
+    } else {
+      console.log(`
+
+
+!!!!!!!!!!!!!!
+[CONTINUE DEBUG QEQP - PATH C]
+EDITOR IS UNDEFINED
+PASSING UNDEFINED URI TO streamEdit
+!!!!!!!!!!!!!!
+
+
+`);
+    }
+
     await this.verticalDiffManager.streamEdit({
       input: prompt,
       llm: model,
       quickEdit: this.previousInput,
       range: this.range,
       rulesToInclude: rules,
+      fileUriFromQuickPick: editorUriString, // Pass the potentially undefined string
     });
   }
 

--- a/gui/src/components/Layout.tsx
+++ b/gui/src/components/Layout.tsx
@@ -49,6 +49,7 @@ const Layout = () => {
 
   const showDialog = useAppSelector((state) => state.ui.showDialog);
   const isInEdit = useAppSelector((store) => store.session.isInEdit);
+  const codeToEdit = useAppSelector((store) => store.editModeState.codeToEdit);
 
   useWebviewListener(
     "newSession",
@@ -147,11 +148,16 @@ const Layout = () => {
   useWebviewListener(
     "focusEdit",
     async () => {
+      if (isInEdit && codeToEdit && codeToEdit.length > 0) {
+        mainEditor?.commands.focus();
+        return;
+      }
+
       await ideMessenger.request("edit/addCurrentSelection", undefined);
       await dispatch(enterEdit({ editorContent: mainEditor?.getJSON() }));
       mainEditor?.commands.focus();
     },
-    [ideMessenger, mainEditor],
+    [ideMessenger, mainEditor, dispatch, isInEdit, codeToEdit],
   );
 
   useWebviewListener(

--- a/gui/src/components/mainInput/TipTapEditor/utils/editorConfig.ts
+++ b/gui/src/components/mainInput/TipTapEditor/utils/editorConfig.ts
@@ -360,6 +360,12 @@ export function createEditorConfig(options: {
         addRef.current(json);
       }
 
+      console.log(
+        "[Continue DEBUG editorConfig] About to call props.onEnter. isInEdit:",
+        isInEdit,
+        "codeToEdit:",
+        codeToEdit,
+      );
       props.onEnter(json, modifiers, editor);
     },
     [props.onEnter, editor, props.isMainInput, codeToEdit, isInEdit],


### PR DESCRIPTION
Closes #5768 

## Description

### Problem:

Previously, if a user initiated an inline edit (e.g., via Cmd+I or by clicking a CodeLens) in a file (file A), then switched to a different active file (file B) before submitting the edit prompt in the Continue GUI, the resulting edit would incorrectly be applied to file B instead of the intended file A.

### Root Cause Analysis:
The core issue was that the mechanism for determining the target file for an edit was relying on the currently active text editor at the moment the edit was processed, rather than the file context established when the edit was initiated. Several factors contributed:
- GUI Message Handling: When an edit was submitted from the Continue GUI panel, the message handler in the VS Code extension (VsCodeMessenger.ts) was not consistently using the filepath associated with the original code selection. It would default to the active editor if this context wasn't properly passed.
- streamEdit Logic: The VerticalDiffManager.streamEdit method, responsible for applying the edit, had several areas that needed refinement to robustly use a provided file URI and to correctly generate and apply the diffs.
- Diff Generation: The function to generate diffs from the LLM output was not correctly invoked.

### Solution & Key Changes:
This PR implements a series of changes to ensure edits are reliably applied to the correct target file:
- Preserving Original File Context via GUI: The VsCodeMessenger.ts (edit/sendPrompt handler) was updated to correctly extract the filepath from the incoming message (which is set by the GUI based on the context when the edit was started) and pass this as fileUriFromQuickPick to VerticalDiffManager.streamEdit.
- Robust Editor and File URI Resolution in VerticalDiffManager.streamEdit: The streamEdit method in extensions/vscode/src/diff/vertical/manager.ts now prioritizes fileUriFromQuickPick.
If fileUriFromQuickPick is provided, it attempts to find a TextEditor instance for this URI. It first checks vscode.window.visibleTextEditors. If not found, it then attempts to open/reveal the document using vscode.window.showTextDocument(document, { preserveFocus: true }) to obtain an editor instance. The preserveFocus: true option is used to minimize disruption to the user's current focus, though VS Code's behavior can still sometimes bring the target editor to the foreground.
- Correct Diff Generation: streamEdit now correctly uses the streamDiffLines function from core/edit/streamDiffLines.ts to generate the AsyncGenerator<DiffLine> required by the VerticalDiffHandler. This involves passing the necessary context (prefix, highlighted code, suffix, LLM, input prompt, etc.).
For cases where newCode is directly provided (bypassing the LLM), a simplified diff stream is generated.
- Refined VerticalDiffHandlerOptions: The handlerOptions object passed to createVerticalDiffHandler has been cleaned up. Properties not belonging to the VerticalDiffHandlerOptions interface (like llm, range, fileUri, quickEdit, newCode, rulesToInclude, onlyOneInsertion) were removed. These parameters are now handled at the streamEdit level or passed directly to streamDiffLines.
- Improved Error Handling and Logic in streamEdit: The call to handleLLMError was corrected to pass only the necessary arguments.
The logic for checking the result of the diff operation now correctly uses the local diffLines variable returned by handler.run().


## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

https://github.com/user-attachments/assets/e4a43aa5-41b7-4416-8a7b-8514b8f002ba



## Tests

The primary test case involved:
- Opening a.txt and b.txt.
- Initiating an inline edit in a.txt.
- Typing a prompt.
- Switching focus to b.txt.
- Submitting the edit from the Continue panel.
After these changes, the edit is now correctly applied to a.txt.
