### PR TITLE
Support completions with proxy

### DIFF
--- a/core/llm/llms/stubs/ContinueProxy.ts
+++ b/core/llm/llms/stubs/ContinueProxy.ts
@@ -85,7 +85,7 @@ class ContinueProxy extends OpenAI {
   }
 
   supportsCompletions(): boolean {
-    return false;
+    return true;
   }
 
   supportsFim(): boolean {

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -199,7 +199,8 @@
         "onnxruntime-common": "1.14.0",
         "onnxruntime-web": "1.14.0",
         "ts-jest": "^29.1.1",
-        "typescript": "^5.6.3"
+        "typescript": "^5.6.3",
+        "vitest": "^3.1.4"
       },
       "engines": {
         "node": ">=20.19.0"

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "1.1.41",
+  "version": "1.1.42",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -203,7 +203,8 @@
         "onnxruntime-common": "1.14.0",
         "onnxruntime-web": "1.14.0",
         "ts-jest": "^29.1.1",
-        "typescript": "^5.6.3"
+        "typescript": "^5.6.3",
+        "vitest": "^3.1.4"
       },
       "engines": {
         "node": ">=20.19.0"


### PR DESCRIPTION
## Description

Add support for completions with continue-proxy. It's already supported on server side, this just allows `useLegacyCompletionsEndpoint` to take effect, which is required by vLLM users who want autocomplete

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Test

Looking at all of the usages of supportsCompletions there don't seem to be super helpful tests to write, this is basically declarative