### PR TITLE
Implement #3244

### DIFF
--- a/core/autocomplete/prefiltering/index.ts
+++ b/core/autocomplete/prefiltering/index.ts
@@ -1,6 +1,7 @@
 import ignore from "ignore";
 
 import { IDE } from "../..";
+import { getGlobalContinueIgArray } from "../../indexing/ignore";
 import { getConfigJsonPath } from "../../util/paths";
 import { findUriInDirs } from "../../util/uri";
 import { HelperVars } from "../util/HelperVars";
@@ -50,7 +51,11 @@ export async function shouldPrefilter(
   }
 
   // Check whether autocomplete is disabled for this file
-  const disableInFiles = [...(helper.options.disableInFiles ?? []), "*.prompt"];
+  const disableInFiles = [
+    ...(helper.options.disableInFiles ?? []),
+    "*.prompt",
+    ...getGlobalContinueIgArray(),
+  ];
   if (await isDisabledForFile(helper.filepath, disableInFiles, ide)) {
     return true;
   }

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -199,7 +199,8 @@
         "onnxruntime-common": "1.14.0",
         "onnxruntime-web": "1.14.0",
         "ts-jest": "^29.1.1",
-        "typescript": "^5.6.3"
+        "typescript": "^5.6.3",
+        "vitest": "^3.1.4"
       },
       "engines": {
         "node": ">=20.19.0"

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -203,7 +203,8 @@
         "onnxruntime-common": "1.14.0",
         "onnxruntime-web": "1.14.0",
         "ts-jest": "^29.1.1",
-        "typescript": "^5.6.3"
+        "typescript": "^5.6.3",
+        "vitest": "^3.1.4"
       },
       "engines": {
         "node": ">=20.19.0"


### PR DESCRIPTION
## Description

`.continueignore` is respected for autocomplete.

Currently this only supports top-level `.continueignore` files inside your `.continue` directory. It also runs on every autocomplete request, but upon profiling, this takes a negligible ~2ms.

## Checklist

- [*] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [*] The relevant docs, if any, have been updated or created
- [*] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
