### PR TITLE
Only allow continue proxy completions for relace

### DIFF
--- a/core/llm/llms/stubs/ContinueProxy.ts
+++ b/core/llm/llms/stubs/ContinueProxy.ts
@@ -85,7 +85,10 @@ class ContinueProxy extends OpenAI {
   }
 
   supportsCompletions(): boolean {
-    return true;
+    if (this.underlyingProviderName === "relace") {
+      return true;
+    }
+    return false;
   }
 
   supportsFim(): boolean {


### PR DESCRIPTION
Was causing errors with e.g. Anthropic models trying to use completions because the prompt was a string