### PR TITLE
Only allow completions through continue for vllm for now

### DIFF
--- a/core/llm/llms/stubs/ContinueProxy.ts
+++ b/core/llm/llms/stubs/ContinueProxy.ts
@@ -85,6 +85,9 @@ class ContinueProxy extends OpenAI {
   }
 
   supportsCompletions(): boolean {
+    if (this.underlyingProviderName === "relace") {
+      return false;
+    }
     return true;
   }
 

--- a/core/llm/llms/stubs/ContinueProxy.ts
+++ b/core/llm/llms/stubs/ContinueProxy.ts
@@ -85,10 +85,13 @@ class ContinueProxy extends OpenAI {
   }
 
   supportsCompletions(): boolean {
-    if (this.underlyingProviderName === "relace") {
-      return false;
+    // This was a hotfix and contains duplicate logic from class-specific completion support methods
+    if (this.underlyingProviderName === "vllm") {
+      return true;
     }
-    return true;
+    // other providers that don't support completions include groq, mistral, nvidia, deepseek, etc.
+    // For now disabling all except vllm
+    return false;
   }
 
   supportsFim(): boolean {


### PR DESCRIPTION
Was causing errors with e.g. Anthropic models using apply
Followup to https://github.com/continuedev/continue/pull/5962, just makes it more targeted