### PR TITLE
fix: :bug: Codebase indexing is not starting on load

### DIFF
--- a/core/core.ts
+++ b/core/core.ts
@@ -184,7 +184,7 @@ export class Core {
           return;
         }
 
-        await this.codeBaseIndexer.refreshCodebaseIndex(dirs);
+        void this.codeBaseIndexer.refreshCodebaseIndex(dirs);
       });
     });
 


### PR DESCRIPTION
## Description

Codebase indexing was not starting on load of the extension.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

Tested through visual inspection of loading the extension in the debugger and observing indexing now seems to start as expected.
