### PR TITLE
Readded 'template' option on yaml autoComplete options

### DIFF
--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -421,6 +421,10 @@ async function configYamlToContinueConfig(options: {
     continueConfig.contextProviders.push(new DocsContextProvider({}));
   }
 
+  if (config.tabAutocompleteOptions) {
+    continueConfig.tabAutocompleteOptions = config.tabAutocompleteOptions;
+  }
+
   // Trigger MCP server refreshes (Config is reloaded again once connected!)
   const mcpManager = MCPManagerSingleton.getInstance();
   mcpManager.setConnections(

--- a/docs/docs/yaml-migration.md
+++ b/docs/docs/yaml-migration.md
@@ -343,9 +343,10 @@ The following top-level fields from `config.json` still work when using `config.
   - `debounceDelay`
   - `maxSuffixPercentage`
   - `prefixPercentage`
-  - `template`
   - `onlyMyCode`
 - `analytics`
+
+The `template` option under `tabAutocompleteOptions` is supported in YAML and can be used to specify a custom inline completion template.
 
 The following top-level fields from `config.json` have been deprecated. Most UI-related and user-specific options will move into a settings page in the UI
 

--- a/packages/config-yaml/src/schemas/index.ts
+++ b/packages/config-yaml/src/schemas/index.ts
@@ -210,6 +210,24 @@ const toolSchema = z.object({
 
 export const autoindentExtensionsSchema = z.array(z.string());
 
+export const tabAutocompleteOptionsSchema = z.object({
+  disable: z.boolean().optional(),
+  maxPromptTokens: z.number().optional(),
+  debounceDelay: z.number().optional(),
+  maxSuffixPercentage: z.number().optional(),
+  prefixPercentage: z.number().optional(),
+  transform: z.boolean().optional(),
+  template: z.string().optional(),
+  multilineCompletions: z.enum(["always", "never", "auto"]).optional(),
+  slidingWindowPrefixPercentage: z.number().optional(),
+  slidingWindowSize: z.number().optional(),
+  useCache: z.boolean().optional(),
+  onlyMyCode: z.boolean().optional(),
+  useRecentlyEdited: z.boolean().optional(),
+  disableInFiles: z.array(z.string()).optional(),
+  useImports: z.boolean().optional(),
+});
+
 export const configSchema = z.object({
   models: z.array(modelSchema).optional(),
   defaultModel: z.string().optional(),
@@ -220,6 +238,7 @@ export const configSchema = z.object({
   langMarkers: z.array(languageMarkerSchema).optional(),
   sidebar: sidebarSchema.optional(),
   tabAutocompleteModel: z.string().optional(),
+  tabAutocompleteOptions: tabAutocompleteOptionsSchema.optional(),
   rules: z.array(ruleObjectSchema).optional(),
   doneWithBannerForever: z.boolean().optional(),
   autoindentExtensions: autoindentExtensionsSchema.optional(),


### PR DESCRIPTION
## Description

Closes https://github.com/continuedev/continue/issues/6018

After the migration from old config.json to config.yaml, some features have been deprecated, including the possibility to use a template string for the inline autocompletion feature. This is needed for some self-hosted models such as Qwen Coder. Currently, there is no way to specify a template option in the tab auto-completion options, which limits functionality for these models.

This PR adds back the template option and documentation related to it.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

