### PR TITLE
feat: Add shortcut to force autocomplete (VSCode)

### DIFF
--- a/binary/package-lock.json
+++ b/binary/package-lock.json
@@ -52,7 +52,7 @@
         "@aws-sdk/credential-providers": "^3.778.0",
         "@continuedev/config-types": "^1.0.13",
         "@continuedev/config-yaml": "file:../packages/config-yaml",
-        "@continuedev/fetch": "^1.0.10",
+        "@continuedev/fetch": "^1.0.13",
         "@continuedev/llm-info": "^1.0.8",
         "@continuedev/openai-adapters": "^1.0.25",
         "@modelcontextprotocol/sdk": "^1.12.0",
@@ -144,7 +144,8 @@
         "onnxruntime-common": "1.14.0",
         "onnxruntime-web": "1.14.0",
         "ts-jest": "^29.1.1",
-        "typescript": "^5.6.3"
+        "typescript": "^5.6.3",
+        "vitest": "^3.1.4"
       },
       "engines": {
         "node": ">=20.19.0"

--- a/core/autocomplete/CompletionProvider.ts
+++ b/core/autocomplete/CompletionProvider.ts
@@ -127,6 +127,7 @@ export class CompletionProvider {
   public async provideInlineCompletionItems(
     input: AutocompleteInput,
     token: AbortSignal | undefined,
+    force?: boolean,
   ): Promise<AutocompleteOutcome | undefined> {
     try {
       // Create abort signal if not given
@@ -146,8 +147,12 @@ export class CompletionProvider {
       const options = await this._getAutocompleteOptions(llm);
 
       // Debounce
-      if (await this.debouncer.delayAndShouldDebounce(options.debounceDelay)) {
-        return undefined;
+      if (!force) {
+        if (
+          await this.debouncer.delayAndShouldDebounce(options.debounceDelay)
+        ) {
+          return undefined;
+        }
       }
 
       if (llm.promptTemplates?.autocomplete) {

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -113,10 +113,10 @@
         "node": ">=20.19.0"
       }
     },
-    "../../../../dallin/documents/code/continuedev/continue/packages/config-yaml": {
+    "../../../dallin/documents/code/continuedev/continue/packages/config-yaml": {
       "extraneous": true
     },
-    "../../../../documents/code/continuedev/continue/packages/config-yaml": {
+    "../../../documents/code/continuedev/continue/packages/config-yaml": {
       "version": "1.0.78",
       "extraneous": true,
       "license": "Apache-2.0",

--- a/docs/docs/autocomplete/how-to-use-it.md
+++ b/docs/docs/autocomplete/how-to-use-it.md
@@ -23,3 +23,7 @@ Reject a full suggestion with <kbd>Esc</kbd>
 ### Partially accepting a suggestion
 
 For more granular control, use <kbd>cmd/ctrl</kbd> + <kbd>→</kbd> to accept parts of the suggestion word-by-word.
+
+### Forcing a suggestion
+
+If you want to trigger a suggestion immediately without waiting, or if you've dismissed a suggestion and want a new one, you can force it by using the keyboard shortcut **<kbd>cmd/ctrl</kbd> + <kbd>alt</kbd> + <kbd>space</kbd>**.

--- a/docs/docs/autocomplete/how-to-use-it.md
+++ b/docs/docs/autocomplete/how-to-use-it.md
@@ -24,6 +24,6 @@ Reject a full suggestion with <kbd>Esc</kbd>
 
 For more granular control, use <kbd>cmd/ctrl</kbd> + <kbd>→</kbd> to accept parts of the suggestion word-by-word.
 
-### Forcing a suggestion
+### Forcing a suggestion (VS Code)
 
 If you want to trigger a suggestion immediately without waiting, or if you've dismissed a suggestion and want a new one, you can force it by using the keyboard shortcut **<kbd>cmd/ctrl</kbd> + <kbd>alt</kbd> + <kbd>space</kbd>**.

--- a/extensions/vscode/e2e/actions/Autocomplete.actions.ts
+++ b/extensions/vscode/e2e/actions/Autocomplete.actions.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { TextEditor } from "vscode-extension-tester";
+import { TextEditor, VSBrowser, Workbench } from "vscode-extension-tester";
 
 import { DEFAULT_TIMEOUT } from "../constants";
 import { AutocompleteSelectors } from "../selectors/Autocomplete.selectors";
@@ -28,5 +28,18 @@ export class AutocompleteActions {
       AutocompleteSelectors.getGhostTextContent(driver),
     );
     expect(ghostText1).to.equal(messagePair1.llmResponse);
+  }
+
+    public static async forceCompletion(editor: TextEditor): Promise<string> {
+    await editor.setText("def main():\n    ");
+    await editor.moveCursor(2, 5);
+
+    await new Workbench().executeCommand("Continue: Force Autocomplete");
+
+    const ghostText = await TestUtils.waitForSuccess(() =>
+      AutocompleteSelectors.getGhostTextContent(VSBrowser.instance.driver)
+    );
+
+    return ghostText;
   }
 }

--- a/extensions/vscode/e2e/tests/Autocomplete.test.ts
+++ b/extensions/vscode/e2e/tests/Autocomplete.test.ts
@@ -1,3 +1,4 @@
+import { expect } from "chai";
 import { EditorView, TextEditor } from "vscode-extension-tester";
 
 import { AutocompleteActions } from "../actions/Autocomplete.actions";
@@ -22,5 +23,9 @@ describe("Autocomplete", () => {
 
   it("Should display completions", async () => {
     await AutocompleteActions.testCompletions(editor);
+  }).timeout(DEFAULT_TIMEOUT.XL);
+  it("Should force a completion using the command", async () => {
+    const ghostText = await AutocompleteActions.forceCompletion(editor);
+    expect(ghostText).to.not.be.empty;
   }).timeout(DEFAULT_TIMEOUT.XL);
 });

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "1.1.44",
+  "version": "1.1.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "1.1.44",
+      "version": "1.1.45",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -226,6 +226,11 @@
         "group": "Continue"
       },
       {
+        "command": "continue.forceAutocomplete",
+        "title": "Continue: Force Autocomplete",
+        "category": "Continue"
+      },
+      {
         "command": "continue.selectFilesAsContext",
         "category": "Continue",
         "title": "Select Files as Context",
@@ -410,6 +415,17 @@
         "mac": "cmd+k cmd+a",
         "key": "ctrl+k ctrl+a",
         "when": "!terminalFocus"
+      },
+      {
+        "command": "continue.forceAutocomplete",
+        "key": "ctrl+alt+space",
+        "when": "editorTextFocus && !editorHasSelection && !editorReadOnly && !inSnippetMode"
+      },
+      {
+        "command": "continue.forceAutocomplete",
+        "key": "cmd+alt+space",
+        "mac": "cmd+alt+space",
+        "when": "editorTextFocus && !editorHasSelection && !editorReadOnly && !inSnippetMode"
       },
       {
         "command": "continue.applyCodeFromChat",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -419,11 +419,6 @@
       {
         "command": "continue.forceAutocomplete",
         "key": "ctrl+alt+space",
-        "when": "editorTextFocus && !editorHasSelection && !editorReadOnly && !inSnippetMode"
-      },
-      {
-        "command": "continue.forceAutocomplete",
-        "key": "cmd+alt+space",
         "mac": "cmd+alt+space",
         "when": "editorTextFocus && !editorHasSelection && !editorReadOnly && !inSnippetMode"
       },

--- a/extensions/vscode/src/autocomplete/completionProvider.ts
+++ b/extensions/vscode/src/autocomplete/completionProvider.ts
@@ -189,6 +189,10 @@ export class ContinueCompletionProvider
       // Handle commit message input box
       let manuallyPassPrefix: string | undefined = undefined;
 
+      // handle manual autocompletion trigger
+      const wasManuallyTriggered =
+        context.triggerKind === vscode.InlineCompletionTriggerKind.Invoke;
+
       const input: AutocompleteInput = {
         pos,
         manuallyPassFileContents,
@@ -208,6 +212,7 @@ export class ContinueCompletionProvider
         await this.completionProvider.provideInlineCompletionItems(
           input,
           signal,
+          wasManuallyTriggered,
         );
 
       if (!outcome || !outcome.completion) {

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -624,9 +624,16 @@ const getCommandsMap: (
         }
       }
     },
-    "continue.forceAutocomplete": () => {
+    "continue.forceAutocomplete": async () => {
       captureCommandTelemetry("forceAutocomplete");
-      vscode.commands.executeCommand("editor.action.inlineSuggest.trigger");
+
+      // 1. Explicitly hide any existing suggestion. This clears VS Code's cache for the current position.
+      await vscode.commands.executeCommand("editor.action.inlineSuggest.hide");
+
+      // 2. Now trigger a new one. VS Code has no cached suggestion, so it's forced to call our provider.
+      await vscode.commands.executeCommand(
+        "editor.action.inlineSuggest.trigger",
+      );
     },
 
     "continue.openTabAutocompleteConfigMenu": async () => {

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -624,6 +624,11 @@ const getCommandsMap: (
         }
       }
     },
+    "continue.forceAutocomplete": () => {
+      captureCommandTelemetry("forceAutocomplete");
+      vscode.commands.executeCommand("editor.action.inlineSuggest.trigger");
+    },
+
     "continue.openTabAutocompleteConfigMenu": async () => {
       captureCommandTelemetry("openTabAutocompleteConfigMenu");
 

--- a/gui/src/pages/config/KeyboardShortcuts.tsx
+++ b/gui/src/pages/config/KeyboardShortcuts.tsx
@@ -76,6 +76,10 @@ const vscodeShortcuts: Omit<KeyboardShortcutProps, "isEven">[] = [
     description: "Toggle Autocomplete Enabled",
   },
   {
+    shortcut: "cmd alt space",
+    description: "Force an Autocomplete Trigger",
+  },
+  {
     shortcut: "cmd K cmd M",
     description: "Toggle Full Screen",
   },


### PR DESCRIPTION
## Description

This pull request introduces a new command and keyboard shortcut (`Cmd/Ctrl + Alt + Space`) for **VS Code** that allows users to manually force an autocomplete suggestion. This directly addresses the problem of wanting to trigger a suggestion without waiting for the debouncer or after dismissing a previous one.

The implementation works by:
1.  Adding a `force` parameter to the core `CompletionProvider` to bypass the debounce logic. This makes the core ready for other IDEs to implement this feature.
2.  Registering a new VS Code-specific command, `continue.forceAutocomplete`, that hides any existing suggestion and then triggers a new one.

This resolves issue #6008.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created



## Tests

- **Manual Testing:** The feature has been manually tested in VS Code. The shortcut successfully triggers an immediate suggestion, and it correctly forces a new generation even after a previous suggestion at the same position was rejected.
- **Automated Testing:** An End-to-End test has been added in `extensions/vscode/e2e/tests/Autocomplete.test.ts` (`Should force a completion using the command`). This test programmatically executes the `continue.forceAutocomplete` command and asserts that a suggestion appears.

**Note on Local E2E Tests:** I encountered significant environmental issues with the local E2E test runner on my WSL/Windows setup. The CI/CD pipeline should be able to run the tests in a clean, consistent environment, and I am happy to address any failures that appear in the CI run.