### PR TITLE
Fix tool call name merging

### DIFF
--- a/gui/src/util/toolCallState.test.ts
+++ b/gui/src/util/toolCallState.test.ts
@@ -57,6 +57,129 @@ describe("addToolCallDeltaToState", () => {
     expect(result.toolCall.function.name).toBe("searchFiles");
   });
 
+  it("should handle name streaming in full progressive chunks", () => {
+    // Test case where model streams the name progressively but includes full prefix each time
+    // e.g. "readFi" -> "readFil" -> "readFile"
+    const currentState: ToolCallState = {
+      status: "generating",
+      toolCall: {
+        id: "call123",
+        type: "function",
+        function: {
+          name: "readFi",
+          arguments: "{}",
+        },
+      },
+      toolCallId: "call123",
+      parsedArgs: {},
+    };
+
+    const delta: ToolCallDelta = {
+      function: {
+        name: "readFil",
+      },
+    };
+
+    const result = addToolCallDeltaToState(delta, currentState);
+    expect(result.toolCall.function.name).toBe("readFil");
+
+    // Continue the streaming
+    const nextDelta: ToolCallDelta = {
+      function: {
+        name: "readFile",
+      },
+    };
+
+    const finalResult = addToolCallDeltaToState(nextDelta, result);
+    expect(finalResult.toolCall.function.name).toBe("readFile");
+  });
+
+  it("should keep original name when receiving duplicate name chunks", () => {
+    // Test case where model streams the complete name multiple times
+    // e.g. "readFile" -> "readFile" -> "readFile"
+    const currentState: ToolCallState = {
+      status: "generating",
+      toolCall: {
+        id: "call123",
+        type: "function",
+        function: {
+          name: "readFile",
+          arguments: "{}",
+        },
+      },
+      toolCallId: "call123",
+      parsedArgs: {},
+    };
+
+    const delta: ToolCallDelta = {
+      function: {
+        name: "readFile",
+      },
+    };
+
+    const result = addToolCallDeltaToState(delta, currentState);
+    expect(result.toolCall.function.name).toBe("readFile");
+  });
+
+  it("should handle partial name streaming", () => {
+    // Test case where model streams the name in parts
+    // e.g. "read" -> "File"
+    const currentState: ToolCallState = {
+      status: "generating",
+      toolCall: {
+        id: "call123",
+        type: "function",
+        function: {
+          name: "read",
+          arguments: "{}",
+        },
+      },
+      toolCallId: "call123",
+      parsedArgs: {},
+    };
+
+    const delta: ToolCallDelta = {
+      function: {
+        name: "File",
+      },
+    };
+
+    const result = addToolCallDeltaToState(delta, currentState);
+    expect(result.toolCall.function.name).toBe("readFile");
+  });
+
+  it("should ignore new tool calls with different IDs", () => {
+    const currentState: ToolCallState = {
+      status: "generating",
+      toolCall: {
+        id: "call123",
+        type: "function",
+        function: {
+          name: "searchFiles",
+          arguments: '{"query":"test"}',
+        },
+      },
+      toolCallId: "call123",
+      parsedArgs: { query: "test" },
+    };
+
+    const delta: ToolCallDelta = {
+      id: "call456", // Different ID
+      type: "function",
+      function: {
+        name: "readFile",
+        arguments: '{"path":"file.txt"}',
+      },
+    };
+
+    const result = addToolCallDeltaToState(delta, currentState);
+
+    // Should keep the original state and ignore the new call
+    expect(result).toBe(currentState);
+    expect(result.toolCall.id).toBe("call123");
+    expect(result.toolCall.function.name).toBe("searchFiles");
+  });
+
   it("should merge function argument deltas correctly", () => {
     const currentState: ToolCallState = {
       status: "generating",


### PR DESCRIPTION
Fixes 2 bugs for tool call delta streaming
- Multiple tool calls overridden - this will make it simply ignore more than one
- some cases of name streaming caused super long names, introduced in https://github.com/continuedev/continue/pull/5849