### PR TITLE
fix: 🐛 Codebase Indexing still not work

### DIFF
--- a/core/indexing/CodebaseIndexer.ts
+++ b/core/indexing/CodebaseIndexer.ts
@@ -1,7 +1,6 @@
 import * as fs from "fs/promises";
 
 import { ConfigHandler } from "../config/ConfigHandler.js";
-import { IContinueServerClient } from "../continueServer/interface.js";
 import { IDE, IndexingProgressUpdate, IndexTag } from "../index.js";
 import type { FromCoreProtocol, ToCoreProtocol } from "../protocol";
 import type { IMessenger } from "../protocol/messenger";
@@ -549,10 +548,10 @@ export class CodebaseIndexer {
 
   // New methods using messenger directly
 
-  private async updateProgress(update: IndexingProgressUpdate) {
+  private updateProgress(update: IndexingProgressUpdate) {
     this.codebaseIndexingState = update;
     if (this.messenger) {
-      await this.messenger.request("indexProgress", update);
+      void this.messenger.request("indexProgress", update);
     }
   }
 
@@ -582,7 +581,7 @@ export class CodebaseIndexer {
         paths,
         this.indexingCancellationController.signal,
       )) {
-        await this.updateProgress(update);
+        this.updateProgress(update);
 
         if (update.status === "failed") {
           await this.sendIndexingErrorTelemetry(update);
@@ -613,7 +612,7 @@ export class CodebaseIndexer {
     this.indexingCancellationController = new AbortController();
     try {
       for await (const update of this.refreshFiles(files)) {
-        await this.updateProgress(update);
+        this.updateProgress(update);
 
         if (update.status === "failed") {
           await this.sendIndexingErrorTelemetry(update);
@@ -634,7 +633,7 @@ export class CodebaseIndexer {
   public async handleIndexingError(e: any) {
     if (e instanceof LLMError && this.messenger) {
       // Need to report this specific error to the IDE for special handling
-      await this.messenger.request("reportError", e);
+      void this.messenger.request("reportError", e);
     }
 
     // broadcast indexing error
@@ -644,7 +643,7 @@ export class CodebaseIndexer {
       desc: e.message,
     };
 
-    await this.updateProgress(updateToSend);
+    this.updateProgress(updateToSend);
     void this.sendIndexingErrorTelemetry(updateToSend);
   }
 


### PR DESCRIPTION
## Description

@chezsmithy @Patrick-Erichsen after refactoring in this PR #5894 and #5993 codebasing indexing still is not working properly. After starting extension, initialization message appears but process does not start. Problem is not with line:

`await this.codeBaseIndexer.refreshCodebaseIndex(dirs);`

which was replaced by the line below:

`void this.codeBaseIndexer.refreshCodebaseIndex(dirs);`

The problem is that during refactoring the lines with:

`void this.messenger.request...`

have been replaced by:

`await this.messenger.request...`

And we will never get response from messenger. The code works correctly before the refactor because it didn't wait for responses. In `useWebviewListener` we are unable to check whether the listener service has ended:

`window.addEventListener("message", listener);`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

Tested through visual inspection of loading the extension in the debugger and observing indexing now seems to start as expected.
