### PR TITLE
switch to the free trial assistant once logged in for the first time

### DIFF
--- a/core/llm/utils/extractPathsFromCodeBlocks.ts
+++ b/core/llm/utils/extractPathsFromCodeBlocks.ts
@@ -2,8 +2,6 @@
  * Extracts file paths from markdown code blocks
  */
 export function extractPathsFromCodeBlocks(content: string): string[] {
-  console.log("CONTENT", content);
-
   const paths: string[] = [];
 
   // Match code block opening patterns:

--- a/gui/src/components/OnboardingCard/platform/tabs/main.tsx
+++ b/gui/src/components/OnboardingCard/platform/tabs/main.tsx
@@ -4,7 +4,8 @@ import { ButtonSubtext } from "../../..";
 import { useAuth } from "../../../../context/Auth";
 import { IdeMessengerContext } from "../../../../context/IdeMessenger";
 import { selectCurrentOrg } from "../../../../redux";
-import { useAppSelector } from "../../../../redux/hooks";
+import { useAppDispatch, useAppSelector } from "../../../../redux/hooks";
+import { selectFirstHubProfile } from "../../../../redux/thunks";
 import { hasPassedFTL } from "../../../../util/freeTrial";
 import ContinueLogo from "../../../gui/ContinueLogo";
 import { Button } from "../../../ui/Button";
@@ -20,12 +21,17 @@ export default function MainTab({
   const ideMessenger = useContext(IdeMessengerContext);
   const onboardingCard = useOnboardingCard();
   const auth = useAuth();
+  const dispatch = useAppDispatch();
   const currentOrg = useAppSelector(selectCurrentOrg);
 
   function onGetStarted() {
     void auth.login(true).then((success) => {
       if (success) {
         onboardingCard.close(isDialog);
+
+        // A new assistant is created when the account is created
+        // We want to switch to this immediately
+        void dispatch(selectFirstHubProfile());
       }
     });
   }

--- a/gui/src/redux/thunks/index.ts
+++ b/gui/src/redux/thunks/index.ts
@@ -4,6 +4,7 @@ export * from "./cancelStream";
 export * from "./edit";
 export * from "./gatherContext";
 export * from "./resetStateForNewMessage";
+export * from "./selectFirstHubProfile";
 export * from "./streamNormalInput";
 export * from "./streamResponse";
 export * from "./streamResponseAfterToolCall";

--- a/gui/src/redux/thunks/selectFirstHubProfile.ts
+++ b/gui/src/redux/thunks/selectFirstHubProfile.ts
@@ -1,0 +1,33 @@
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import { setSelectedProfile } from "../slices";
+import { ThunkApiType } from "../store";
+
+/**
+ * If there is a hub profile, select it.
+ * Used primarily after onboarding when a new profile is created and we
+ * want to switch to it immediately
+ */
+export const selectFirstHubProfile = createAsyncThunk<
+  void,
+  undefined,
+  ThunkApiType
+>("selectFirstHubProfile", async (messages, { dispatch, extra, getState }) => {
+  const state = getState();
+
+  const currentOrgProfiles = state.profiles.organizations.find(
+    (org) => org.id === (state.profiles.selectedOrganizationId ?? "personal"),
+  );
+
+  const firstHubProfile = currentOrgProfiles?.profiles.find(
+    (profile) => profile.profileType === "platform",
+  );
+
+  if (!firstHubProfile) {
+    return;
+  }
+
+  dispatch(setSelectedProfile(firstHubProfile.id));
+  extra.ideMessenger.post("didChangeSelectedProfile", {
+    id: firstHubProfile.id,
+  });
+});


### PR DESCRIPTION
## Description

Prior to this update, after logging in during onboarding, you would still be on the local profile, without any models

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created