### PR TITLE
ignore running tests inside dist directory

### DIFF
--- a/packages/config-yaml/jest.config.mjs
+++ b/packages/config-yaml/jest.config.mjs
@@ -17,4 +17,5 @@ export default {
     __dirname: path.dirname(fileURLToPath(import.meta.url)),
     __filename: path.resolve(fileURLToPath(import.meta.url)),
   },
+  modulePathIgnorePatterns: ["<rootDir>/dist"],
 };


### PR DESCRIPTION
## Description

Many of the previous merges into main that touched `packages/config-yaml` failed to get released because our test suite was running tests inside `dist`. This PR safely removes them and maintains tests on `src`.

## Checklist

- [*] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [*] The relevant docs, if any, have been updated or created
- [*] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
