### PR TITLE
fix: apply notch filename trunaction

### DIFF
--- a/gui/src/components/AcceptRejectDiffButtons.tsx
+++ b/gui/src/components/AcceptRejectDiffButtons.tsx
@@ -51,8 +51,7 @@ export default function AcceptRejectAllButtons({
       >
         <div className="flex flex-row items-center gap-1">
           <XMarkIcon className="text-error h-4 w-4" />
-          <span>Reject</span>
-          <span className="xs:inline-block hidden">All</span>
+          <span className="hidden sm:inline">Reject</span>
         </div>
       </button>
       <ToolTip id="reject-shortcut" />
@@ -66,8 +65,7 @@ export default function AcceptRejectAllButtons({
       >
         <div className="flex flex-row items-center gap-1">
           <CheckIcon className="text-success h-4 w-4" />
-          <span>Accept</span>
-          <span className="xs:inline-block hidden">All</span>
+          <span className="hidden sm:inline">Accept</span>
         </div>
       </button>
       <ToolTip id="accept-shortcut" />

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/ApplyActions.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/ApplyActions.tsx
@@ -31,7 +31,7 @@ export function ApplyActions(props: ApplyActionsProps) {
       );
     case "done":
       return (
-        <div className="flex select-none items-center rounded bg-zinc-700 px-1.5 sm:gap-1">
+        <div className="flex select-none items-center rounded bg-zinc-700 sm:gap-1 md:px-1.5">
           <span className="text-lightgray text-center text-xs max-md:hidden">
             {`${props.applyState?.numDiffs === 1 ? "1 diff" : `${props.applyState?.numDiffs} diffs`}`}
           </span>

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/ApplyActions.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/ApplyActions.tsx
@@ -32,7 +32,7 @@ export function ApplyActions(props: ApplyActionsProps) {
     case "done":
       return (
         <div className="flex select-none items-center rounded bg-zinc-700 px-1.5 sm:gap-1">
-          <span className="max-xs:hidden text-lightgray text-center text-xs">
+          <span className="text-lightgray text-center text-xs max-md:hidden">
             {`${props.applyState?.numDiffs === 1 ? "1 diff" : `${props.applyState?.numDiffs} diffs`}`}
           </span>
 
@@ -42,7 +42,7 @@ export function ApplyActions(props: ApplyActionsProps) {
               onClick={onClickReject}
               tooltipContent={`Reject all (${getMetaKeyLabel()}⇧⌫)`}
             >
-              <XMarkIcon className="h-3.5 w-3.5 text-red-600 hover:brightness-125" />
+              <XMarkIcon className="text-error h-3.5 w-3.5 hover:brightness-125" />
             </ToolbarButtonWithTooltip>
 
             <ToolbarButtonWithTooltip
@@ -50,7 +50,7 @@ export function ApplyActions(props: ApplyActionsProps) {
               onClick={props.onClickAccept}
               tooltipContent={`Accept all (${getMetaKeyLabel()}⇧⏎)`}
             >
-              <CheckIcon className="h-3.5 w-3.5 text-green-600 hover:brightness-125" />
+              <CheckIcon className="text-success h-3.5 w-3.5 hover:brightness-125" />
             </ToolbarButtonWithTooltip>
           </div>
         </div>

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/index.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/index.tsx
@@ -291,7 +291,7 @@ export function StepContainerPreToolbar({
   return (
     <TopDiv>
       <ToolbarDiv isExpanded={isExpanded} className="find-widget-skip gap-3">
-        <div className="flex max-w-72 flex-row items-center">
+        <div className="max-w-[50% flex flex-row items-center">
           <ChevronDownIcon
             onClick={() => setIsExpanded(!isExpanded)}
             className={`text-lightgray h-3.5 w-3.5 flex-shrink-0 cursor-pointer hover:brightness-125 ${

--- a/gui/src/components/mainInput/Lump/LumpToolbar/PendingApplyStatesToolbar.tsx
+++ b/gui/src/components/mainInput/Lump/LumpToolbar/PendingApplyStatesToolbar.tsx
@@ -28,9 +28,9 @@ export function PendingApplyStatesToolbar({
       {Object.entries(applyStatesByFilepath).map(([filepath, states]) => (
         <div key={filepath} className="flex justify-between gap-3">
           {filepath && (
-            <span className="bg-badge flex items-center gap-1 rounded px-0.5">
+            <span className="bg-badge flex min-w-0 max-w-[75%] items-center gap-1 truncate rounded pr-1 text-xs">
               <FileIcon filename={filepath} height="18px" width="18px" />
-              {getUriPathBasename(filepath)}
+              <span className="truncate">{getUriPathBasename(filepath)}</span>
             </span>
           )}
           <AcceptRejectDiffButtons


### PR DESCRIPTION
## Description
- Fixes overflow on apply notch by hiding the `Accept`/`Reject` text on xs screens
- Hides diff text on md screens and below for apply actions in toolbar

Closes CON-2134

## Screenshots
<img width="262" alt="Screenshot 2025-06-09 at 6 15 12 PM" src="https://github.com/user-attachments/assets/cee05e78-9992-49c9-854a-21e546d97bc2" />

<img width="329" alt="Screenshot 2025-06-09 at 6 22 03 PM" src="https://github.com/user-attachments/assets/5cab1438-5fa3-4fed-8913-0bf69f0dcd13" />

