### PR TITLE
fix: avoid parsing md rules as yaml

### DIFF
--- a/core/config/loadLocalAssistants.test.ts
+++ b/core/config/loadLocalAssistants.test.ts
@@ -1,0 +1,241 @@
+import { walkDirCache } from "../indexing/walkDir";
+import { testIde } from "../test/fixtures";
+import { addToTestDir, setUpTestDir, tearDownTestDir } from "../test/testDir";
+import {
+  getAllDotContinueDefinitionFiles,
+  LoadAssistantFilesOptions,
+} from "./loadLocalAssistants";
+describe("getAllDotContinueDefinitionFiles with fileExtType option", () => {
+  beforeEach(() => {
+    setUpTestDir();
+    walkDirCache.invalidate();
+
+    // Add test files to the test directory
+    addToTestDir([
+      ".continue/assistants/",
+      [".continue/assistants/assistant1.yaml", "yaml content 1"],
+      [".continue/assistants/assistant2.yml", "yaml content 2"],
+      [".continue/assistants/assistant3.md", "markdown content 1"],
+      [".continue/assistants/assistant4.txt", "txt content"],
+    ]);
+  });
+
+  afterEach(() => {
+    tearDownTestDir();
+    walkDirCache.invalidate();
+  });
+
+  it("should return only YAML files when fileExtType is 'yaml'", async () => {
+    const options: LoadAssistantFilesOptions = {
+      includeGlobal: false, // Only test workspace for simplicity
+      includeWorkspace: true,
+      fileExtType: "yaml",
+    };
+
+    const result = await getAllDotContinueDefinitionFiles(
+      testIde,
+      options,
+      "assistants",
+    );
+    expect(result).toHaveLength(2);
+    expect(result.map((f) => f.path.split("/").pop())).toEqual(
+      expect.arrayContaining(["assistant1.yaml", "assistant2.yml"]),
+    );
+    expect(result.map((f) => f.path.split("/").pop())).not.toContain(
+      "assistant3.md",
+    );
+  });
+
+  it("should return only Markdown files when fileExtType is 'markdown'", async () => {
+    const options: LoadAssistantFilesOptions = {
+      includeGlobal: false,
+      includeWorkspace: true,
+      fileExtType: "markdown",
+    };
+
+    const result = await getAllDotContinueDefinitionFiles(
+      testIde,
+      options,
+      "assistants",
+    );
+    expect(result).toHaveLength(1);
+    expect(result.map((f) => f.path.split("/").pop())).toEqual([
+      "assistant3.md",
+    ]);
+    expect(result.map((f) => f.path.split("/").pop())).not.toContain(
+      "assistant1.yaml",
+    );
+    expect(result.map((f) => f.path.split("/").pop())).not.toContain(
+      "assistant2.yml",
+    );
+  });
+
+  it("should return all supported files when fileExtType is not specified", async () => {
+    const options: LoadAssistantFilesOptions = {
+      includeGlobal: false,
+      includeWorkspace: true,
+      // fileExtType not specified
+    };
+
+    const result = await getAllDotContinueDefinitionFiles(
+      testIde,
+      options,
+      "assistants",
+    );
+    expect(result).toHaveLength(3);
+    expect(result.map((f) => f.path.split("/").pop())).toEqual(
+      expect.arrayContaining([
+        "assistant1.yaml",
+        "assistant2.yml",
+        "assistant3.md",
+      ]),
+    );
+    // Should not include .txt files
+    expect(result.map((f) => f.path.split("/").pop())).not.toContain(
+      "assistant4.txt",
+    );
+  });
+
+  it("should respect includeWorkspace option with fileExtType", async () => {
+    // Test with includeWorkspace: false
+    const workspaceOffOptions: LoadAssistantFilesOptions = {
+      includeGlobal: false,
+      includeWorkspace: false,
+      fileExtType: "yaml",
+    };
+
+    const noWorkspaceResult = await getAllDotContinueDefinitionFiles(
+      testIde,
+      workspaceOffOptions,
+      "assistants",
+    );
+    expect(noWorkspaceResult).toHaveLength(0);
+
+    // Test with includeWorkspace: true
+    const workspaceOnOptions: LoadAssistantFilesOptions = {
+      includeGlobal: false,
+      includeWorkspace: true,
+      fileExtType: "yaml",
+    };
+
+    const workspaceResult = await getAllDotContinueDefinitionFiles(
+      testIde,
+      workspaceOnOptions,
+      "assistants",
+    );
+    expect(workspaceResult).toHaveLength(2);
+    expect(workspaceResult.map((f) => f.path.split("/").pop())).toEqual(
+      expect.arrayContaining(["assistant1.yaml", "assistant2.yml"]),
+    );
+  });
+
+  it("should return empty array when no files match the specified extension type", async () => {
+    // Create a test directory with only non-matching files
+    tearDownTestDir();
+    walkDirCache.invalidate();
+    setUpTestDir();
+    addToTestDir([
+      ".continue/assistants/",
+      [".continue/assistants/nonmatch1.txt", "txt content"],
+      [".continue/assistants/nonmatch2.json", "json content"],
+    ]);
+
+    const options: LoadAssistantFilesOptions = {
+      includeGlobal: false,
+      includeWorkspace: true,
+
+      fileExtType: "yaml",
+    };
+
+    const result = await getAllDotContinueDefinitionFiles(
+      testIde,
+      options,
+      "assistants",
+    );
+    expect(result).toHaveLength(0);
+  });
+
+  it("should handle directories that don't exist", async () => {
+    // Create a clean test directory without the assistants folder
+    tearDownTestDir();
+    setUpTestDir();
+
+    const options: LoadAssistantFilesOptions = {
+      includeGlobal: false,
+      includeWorkspace: true,
+      fileExtType: "yaml",
+    };
+
+    const result = await getAllDotContinueDefinitionFiles(
+      testIde,
+      options,
+      "assistants",
+    );
+    expect(result).toHaveLength(0);
+  });
+
+  it("should return correct file content", async () => {
+    const options: LoadAssistantFilesOptions = {
+      includeGlobal: false,
+      includeWorkspace: true,
+      fileExtType: "yaml",
+    };
+
+    const result = await getAllDotContinueDefinitionFiles(
+      testIde,
+      options,
+      "assistants",
+    );
+    expect(result).toHaveLength(2);
+    const yamlFile = result.find((f) => f.path.includes("assistant1.yaml"));
+    expect(yamlFile?.content).toBe("yaml content 1");
+  });
+
+  it("should filter by file extension case sensitively", async () => {
+    // Add files with uppercase extensions
+    addToTestDir([
+      [".continue/assistants/assistant5.YAML", "uppercase yaml"],
+      [".continue/assistants/assistant6.YML", "uppercase yml"],
+      [".continue/assistants/assistant7.MD", "uppercase md"],
+    ]);
+
+    const yamlOptions: LoadAssistantFilesOptions = {
+      includeGlobal: false,
+      includeWorkspace: true,
+      fileExtType: "yaml",
+    };
+
+    const yamlResult = await getAllDotContinueDefinitionFiles(
+      testIde,
+      yamlOptions,
+      "assistants",
+    );
+    // Should only get lowercase extensions (current implementation)
+    expect(yamlResult).toHaveLength(2);
+    expect(yamlResult.map((f) => f.path.split("/").pop())).toEqual(
+      expect.arrayContaining(["assistant1.yaml", "assistant2.yml"]),
+    );
+    expect(yamlResult.map((f) => f.path.split("/").pop())).not.toContain(
+      "assistant5.YAML",
+    );
+
+    const markdownOptions: LoadAssistantFilesOptions = {
+      includeGlobal: false,
+      includeWorkspace: true,
+      fileExtType: "markdown",
+    };
+
+    const markdownResult = await getAllDotContinueDefinitionFiles(
+      testIde,
+      markdownOptions,
+      "assistants",
+    );
+    expect(markdownResult).toHaveLength(1);
+    expect(markdownResult.map((f) => f.path.split("/").pop())).toEqual([
+      "assistant3.md",
+    ]);
+    expect(markdownResult.map((f) => f.path.split("/").pop())).not.toContain(
+      "assistant7.MD",
+    );
+  });
+});

--- a/core/config/loadLocalAssistants.ts
+++ b/core/config/loadLocalAssistants.ts
@@ -1,4 +1,5 @@
 import ignore from "ignore";
+import * as URI from "uri-js";
 import { IDE } from "..";
 import {
   DEFAULT_IGNORE_DIRS,
@@ -12,18 +13,19 @@ import { joinPathsToUri } from "../util/uri";
 export const ASSISTANTS = "assistants";
 export const ASSISTANTS_FOLDER = `.continue/${ASSISTANTS}`;
 
-export function isLocalAssistantFile(uri: string): boolean {
+export function isLocalDefinitionFile(uri: string): boolean {
   if (!uri.endsWith(".yaml") && !uri.endsWith(".yml") && !uri.endsWith(".md")) {
     return false;
   }
 
-  const normalizedUri = uri.replace(/\\/g, "/");
+  const normalizedUri = URI.normalize(uri);
   return normalizedUri.includes(`/${ASSISTANTS_FOLDER}/`);
 }
 
 async function getDefinitionFilesInDir(
   ide: IDE,
   dir: string,
+  fileExtType?: "yaml" | "markdown",
 ): Promise<{ path: string; content: string }[]> {
   try {
     const exists = await ide.fileExists(dir);
@@ -40,9 +42,19 @@ async function getDefinitionFilesInDir(
       overrideDefaultIgnores,
       source: "get assistant files",
     });
-    const assistantFilePaths = uris.filter(
-      (p) => p.endsWith(".yaml") || p.endsWith(".yml") || p.endsWith(".md"),
-    );
+    let assistantFilePaths: string[];
+    if (fileExtType === "yaml") {
+      assistantFilePaths = uris.filter(
+        (p) => p.endsWith(".yaml") || p.endsWith(".yml"),
+      );
+    } else if (fileExtType === "markdown") {
+      assistantFilePaths = uris.filter((p) => p.endsWith(".md"));
+    } else {
+      assistantFilePaths = uris.filter(
+        (p) => p.endsWith(".yaml") || p.endsWith(".yml") || p.endsWith(".md"),
+      );
+    }
+
     const results = assistantFilePaths.map(async (uri) => {
       const content = await ide.readFile(uri); // make a try catch
       return { path: uri, content };
@@ -57,6 +69,7 @@ async function getDefinitionFilesInDir(
 export interface LoadAssistantFilesOptions {
   includeGlobal: boolean;
   includeWorkspace: boolean;
+  fileExtType?: "yaml" | "markdown";
 }
 
 export function getDotContinueSubDirs(
@@ -84,7 +97,7 @@ export function getDotContinueSubDirs(
 
 /**
  * This method searches in both ~/.continue and workspace .continue
- * for all YAML files in the specified subdirctory, for example .continue/assistants or .continue/prompts
+ * for all YAML/Markdown files in the specified subdirectory, for example .continue/assistants or .continue/prompts
  */
 export async function getAllDotContinueDefinitionFiles(
   ide: IDE,
@@ -101,15 +114,14 @@ export async function getAllDotContinueDefinitionFiles(
     subDirName,
   );
 
-  // Get all assistant files from the directories
-  const assistantFiles = (
-    await Promise.all(fullDirs.map((dir) => getDefinitionFilesInDir(ide, dir)))
+  // Get all definition files from the directories
+  const definitionFiles = (
+    await Promise.all(
+      fullDirs.map((dir) =>
+        getDefinitionFilesInDir(ide, dir, options.fileExtType),
+      ),
+    )
   ).flat();
 
-  return await Promise.all(
-    assistantFiles.map(async (file) => {
-      const content = await ide.readFile(file.path);
-      return { path: file.path, content };
-    }),
-  );
+  return definitionFiles;
 }

--- a/core/config/markdown/loadMarkdownRules.ts
+++ b/core/config/markdown/loadMarkdownRules.ts
@@ -17,7 +17,7 @@ export async function loadMarkdownRules(ide: IDE): Promise<{
     // Get all .md files from .continue/rules
     const markdownFiles = await getAllDotContinueDefinitionFiles(
       ide,
-      { includeGlobal: true, includeWorkspace: true },
+      { includeGlobal: true, includeWorkspace: true, fileExtType: "markdown" },
       "rules",
     );
 

--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -97,7 +97,7 @@ async function loadConfigYaml(options: {
   for (const blockType of BLOCK_TYPES) {
     const localBlocks = await getAllDotContinueDefinitionFiles(
       ide,
-      { includeGlobal: true, includeWorkspace: true },
+      { includeGlobal: true, includeWorkspace: true, fileExtType: "yaml" },
       blockType,
     );
     allLocalBlocks.push(

--- a/core/core.ts
+++ b/core/core.ts
@@ -49,7 +49,7 @@ import {
 
 import { ConfigYaml } from "@continuedev/config-yaml";
 import { getDiffFn, GitDiffCache } from "./autocomplete/snippets/gitDiffCache";
-import { isLocalAssistantFile } from "./config/loadLocalAssistants";
+import { isLocalDefinitionFile } from "./config/loadLocalAssistants";
 import {
   setupLocalConfig,
   setupProviderConfig,
@@ -600,7 +600,7 @@ export class Core {
         // If it's a local assistant being created, we want to reload all assistants so it shows up in the list
         let localAssistantCreated = false;
         for (const uri of data.uris) {
-          if (isLocalAssistantFile(uri)) {
+          if (isLocalDefinitionFile(uri)) {
             localAssistantCreated = true;
           }
         }

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "1.1.46",
+  "version": "1.1.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "1.1.46",
+      "version": "1.1.47",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",


### PR DESCRIPTION
Resolves https://github.com/continuedev/continue/issues/6095

## Add fileExtType option to LoadAssistantFilesOptions

Adds an optional `fileExtType` parameter to `LoadAssistantFilesOptions` to filter files by extension type.

### Changes
- Added `fileExtType?: "yaml" | "markdown"` to `LoadAssistantFilesOptions` interface
- Updated `getDefinitionFilesInDir()` to filter files based on extension type:
  - `"yaml"`: Returns only `.yaml` and `.yml` files
  - `"markdown"`: Returns only `.md` files  
  - `undefined`: Returns all supported files (default, backward compatible)
- Added comprehensive unit tests covering all filtering scenarios

### Usage
```typescript
// Get only YAML files
const yamlFiles = await getAllDotContinueYamlFiles(ide, {
  includeGlobal: true,
  includeWorkspace: true,
  fileExtType: "yaml"
}, "assistants");

// Get only Markdown files  
const mdFiles = await getAllDotContinueYamlFiles(ide, {
  includeGlobal: true,
  includeWorkspace: true,
  fileExtType: "markdown"
}, "rules");
```

Backward compatible - existing code continues to work unchanged.