### PR TITLE
feat: add proxy support for ripgrep download

### DIFF
--- a/binary/package-lock.json
+++ b/binary/package-lock.json
@@ -20,6 +20,7 @@
         "posthog-node": "^3.6.3",
         "system-ca": "^1.0.2",
         "tar": "^7.4.3",
+        "undici": "^7.10.0",
         "uuid": "^9.0.1",
         "vectordb": "^0.4.20",
         "win-ca": "^3.5.1"
@@ -52,9 +53,9 @@
         "@aws-sdk/credential-providers": "^3.778.0",
         "@continuedev/config-types": "^1.0.13",
         "@continuedev/config-yaml": "file:../packages/config-yaml",
-        "@continuedev/fetch": "^1.0.10",
+        "@continuedev/fetch": "^1.0.13",
         "@continuedev/llm-info": "^1.0.8",
-        "@continuedev/openai-adapters": "^1.0.25",
+        "@continuedev/openai-adapters": "^1.0.32",
         "@modelcontextprotocol/sdk": "^1.12.0",
         "@mozilla/readability": "^0.5.0",
         "@octokit/rest": "^20.1.1",
@@ -105,6 +106,7 @@
         "sqlite3": "^5.1.7",
         "system-ca": "^1.0.3",
         "tar": "^7.4.3",
+        "tree-sitter-structured-text": "^0.0.1",
         "tree-sitter-wasms": "^0.1.11",
         "uuid": "^9.0.1",
         "vectordb": "^0.4.20",
@@ -143,8 +145,10 @@
         "myers-diff": "^2.1.0",
         "onnxruntime-common": "1.14.0",
         "onnxruntime-web": "1.14.0",
+        "tree-sitter-cli": "^0.22.5",
         "ts-jest": "^29.1.1",
-        "typescript": "^5.6.3"
+        "typescript": "^5.6.3",
+        "vitest": "^3.1.4"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -6771,6 +6775,15 @@
       "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmmirror.com/undici/-/undici-7.10.0.tgz",
+      "integrity": "sha512-u5otvFBOBZvmdjWLVW+5DAc9Nkq8f24g0O9oY7qw2JVIF1VocIFoyz9JFkuVOS2j41AufeO0xnlweJ2RLT8nGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/universal-user-agent": {

--- a/binary/package.json
+++ b/binary/package.json
@@ -53,6 +53,7 @@
     "posthog-node": "^3.6.3",
     "system-ca": "^1.0.2",
     "tar": "^7.4.3",
+    "undici": "^7.10.0",
     "uuid": "^9.0.1",
     "vectordb": "^0.4.20",
     "win-ca": "^3.5.1"

--- a/binary/utils/ripgrep.js
+++ b/binary/utils/ripgrep.js
@@ -4,7 +4,7 @@ const { rimrafSync } = require("rimraf");
 const tar = require("tar");
 const { RIPGREP_VERSION, TARGET_TO_RIPGREP_RELEASE } = require("./targets");
 const AdmZip = require("adm-zip");
-const { ProxyAgent } = require('undici');
+const { ProxyAgent } = require("undici");
 
 const RIPGREP_BASE_URL = `https://github.com/BurntSushi/ripgrep/releases/download/${RIPGREP_VERSION}`;
 

--- a/binary/utils/ripgrep.js
+++ b/binary/utils/ripgrep.js
@@ -4,6 +4,7 @@ const { rimrafSync } = require("rimraf");
 const tar = require("tar");
 const { RIPGREP_VERSION, TARGET_TO_RIPGREP_RELEASE } = require("./targets");
 const AdmZip = require("adm-zip");
+const { ProxyAgent } = require('undici');
 
 const RIPGREP_BASE_URL = `https://github.com/BurntSushi/ripgrep/releases/download/${RIPGREP_VERSION}`;
 
@@ -16,8 +17,13 @@ const RIPGREP_BASE_URL = `https://github.com/BurntSushi/ripgrep/releases/downloa
  */
 async function downloadFile(url, destPath) {
   // Use the built-in fetch API instead of node-fetch
+  // Use proxy if set in environment variables
+  const proxy = process.env.https_proxy || process.env.HTTPS_PROXY;
+  const agent = proxy ? new ProxyAgent(proxy) : undefined;
+
   const response = await fetch(url, {
     redirect: "follow", // Automatically follow redirects
+    dispatcher: agent,
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## Description

- Added support for using a proxy (https_proxy/HTTPS_PROXY) when downloading ripgrep.
- The download process will automatically use the proxy if one is configured, and will work as usual if no proxy is set.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots

N/A

## Tests

- Manually tested ripgrep download with and without a proxy environment. Both scenarios work as expected.