### PR TITLE
fix: :bug: Add requestOptions to YAML config for mcp

### DIFF
--- a/packages/config-yaml/src/schemas/index.ts
+++ b/packages/config-yaml/src/schemas/index.ts
@@ -1,7 +1,11 @@
 import * as z from "zod";
 import { commonModelSlugs } from "./commonSlugs.js";
 import { dataSchema } from "./data/index.js";
-import { modelSchema, partialModelSchema } from "./models.js";
+import {
+  modelSchema,
+  partialModelSchema,
+  requestOptionsSchema,
+} from "./models.js";
 
 export const contextSchema = z.object({
   name: z.string().optional(),
@@ -19,6 +23,7 @@ const mcpServerSchema = z.object({
   args: z.array(z.string()).optional(),
   env: z.record(z.string()).optional(),
   connectionTimeout: z.number().gt(0).optional(),
+  requestOptions: requestOptionsSchema.optional(),
 });
 
 export type MCPServer = z.infer<typeof mcpServerSchema>;


### PR DESCRIPTION
## Description

Add request options to mcp server YAML config. Without this in place you can't pass headers for example.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

Confirmed the following configuration loads headers in:

https://github.com/chezsmithy/continue/blob/16ef20aeca9696f0b751e590671111eafc5fcda7/core/context/mcp/MCPConnection.ts#L352

```yaml
name: SSE Server
version: 0.0.1
schema: v1
mcpServers:
  - name: sse-server
    type: sse
    url: https://www.example.com
    requestOptions:
      headers: { Authorization: "Bearer ABC", JWT: XXASDASDSAS }
```
