### PR TITLE
Fetch no proxy logic updates

### DIFF
--- a/packages/fetch/src/fetch.ts
+++ b/packages/fetch/src/fetch.ts
@@ -98,9 +98,7 @@ export async function fetchwithRequestOptions(
   }
 
   // Check if should bypass proxy based on requestOptions or NO_PROXY env var
-  const shouldBypass =
-    requestOptions?.noProxy?.includes(url.hostname) ||
-    shouldBypassProxy(url.hostname);
+  const shouldBypass = shouldBypassProxy(url.hostname, requestOptions);
 
   // Create agent
   const protocol = url.protocol === "https:" ? https : http;

--- a/packages/fetch/src/util.test.ts
+++ b/packages/fetch/src/util.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, expect, test, vi } from "vitest";
-import { getProxyFromEnv, shouldBypassProxy } from "./util.js";
+import {
+  getProxyFromEnv,
+  patternMatchesHostname,
+  shouldBypassProxy,
+} from "./util.js";
 
 // Reset environment variables after each test
 afterEach(() => {
@@ -52,51 +56,159 @@ test("getProxyFromEnv prefers HTTPS_PROXY over other env vars for https protocol
   expect(getProxyFromEnv("https:")).toBe("https://preferred.example.com");
 });
 
+// Tests for patternMatchesHostname
+test("patternMatchesHostname with exact hostname match", () => {
+  expect(patternMatchesHostname("example.com", "example.com")).toBe(true);
+  expect(patternMatchesHostname("example.com", "different.com")).toBe(false);
+});
+
+test("patternMatchesHostname with wildcard domains", () => {
+  expect(patternMatchesHostname("sub.example.com", "*.example.com")).toBe(true);
+  expect(patternMatchesHostname("sub.sub.example.com", "*.example.com")).toBe(
+    true,
+  );
+  expect(patternMatchesHostname("example.com", "*.example.com")).toBe(false);
+  expect(patternMatchesHostname("sub.different.com", "*.example.com")).toBe(
+    false,
+  );
+});
+
+test("patternMatchesHostname with domain suffix", () => {
+  expect(patternMatchesHostname("sub.example.com", ".example.com")).toBe(true);
+  expect(patternMatchesHostname("example.com", ".example.com")).toBe(true);
+  expect(patternMatchesHostname("different.com", ".example.com")).toBe(false);
+});
+
+test("patternMatchesHostname with case insensitivity", () => {
+  expect(patternMatchesHostname("EXAMPLE.com", "example.COM")).toBe(true);
+  expect(patternMatchesHostname("sub.EXAMPLE.com", "*.example.COM")).toBe(true);
+});
+
+// Port handling tests
+test("patternMatchesHostname with exact port match", () => {
+  expect(patternMatchesHostname("example.com:8080", "example.com:8080")).toBe(
+    true,
+  );
+  expect(patternMatchesHostname("example.com:8080", "example.com:9090")).toBe(
+    false,
+  );
+});
+
+test("patternMatchesHostname with port in pattern but not in hostname", () => {
+  expect(patternMatchesHostname("example.com", "example.com:8080")).toBe(false);
+});
+
+test("patternMatchesHostname with port in hostname but not in pattern", () => {
+  expect(patternMatchesHostname("example.com:8080", "example.com")).toBe(true);
+});
+
+test("patternMatchesHostname with wildcard domains and ports", () => {
+  expect(
+    patternMatchesHostname("sub.example.com:8080", "*.example.com:8080"),
+  ).toBe(true);
+  expect(
+    patternMatchesHostname("sub.example.com:9090", "*.example.com:8080"),
+  ).toBe(false);
+  expect(patternMatchesHostname("sub.example.com", "*.example.com:8080")).toBe(
+    false,
+  );
+});
+
+test("patternMatchesHostname with domain suffix and ports", () => {
+  expect(
+    patternMatchesHostname("sub.example.com:8080", ".example.com:8080"),
+  ).toBe(true);
+  expect(patternMatchesHostname("example.com:8080", ".example.com:8080")).toBe(
+    true,
+  );
+  expect(
+    patternMatchesHostname("sub.example.com:9090", ".example.com:8080"),
+  ).toBe(false);
+});
+
 // Tests for shouldBypassProxy
 test("shouldBypassProxy returns false when NO_PROXY is not set", () => {
-  expect(shouldBypassProxy("example.com")).toBe(false);
+  expect(shouldBypassProxy("example.com", undefined)).toBe(false);
 });
 
 test("shouldBypassProxy returns true for exact hostname match", () => {
   process.env.NO_PROXY = "example.com,another.com";
-  expect(shouldBypassProxy("example.com")).toBe(true);
+  expect(shouldBypassProxy("example.com", undefined)).toBe(true);
 });
 
 test("shouldBypassProxy returns false when hostname doesn't match any NO_PROXY entry", () => {
   process.env.NO_PROXY = "example.com,another.com";
-  expect(shouldBypassProxy("different.com")).toBe(false);
+  expect(shouldBypassProxy("different.com", undefined)).toBe(false);
 });
 
 test("shouldBypassProxy handles lowercase no_proxy", () => {
   process.env.no_proxy = "example.com";
-  expect(shouldBypassProxy("example.com")).toBe(true);
+  expect(shouldBypassProxy("example.com", undefined)).toBe(true);
 });
 
 test("shouldBypassProxy works with wildcard domains", () => {
   process.env.NO_PROXY = "*.example.com";
-  expect(shouldBypassProxy("sub.example.com")).toBe(true);
-  expect(shouldBypassProxy("example.com")).toBe(false);
-  expect(shouldBypassProxy("different.com")).toBe(false);
+  expect(shouldBypassProxy("sub.example.com", undefined)).toBe(true);
+  expect(shouldBypassProxy("example.com", undefined)).toBe(false);
+  expect(shouldBypassProxy("different.com", undefined)).toBe(false);
 });
 
 test("shouldBypassProxy works with domain suffix", () => {
   process.env.NO_PROXY = ".example.com";
-  expect(shouldBypassProxy("sub.example.com")).toBe(true);
-  expect(shouldBypassProxy("example.com")).toBe(true);
-  expect(shouldBypassProxy("different.com")).toBe(false);
+  expect(shouldBypassProxy("sub.example.com", undefined)).toBe(true);
+  expect(shouldBypassProxy("example.com", undefined)).toBe(true);
+  expect(shouldBypassProxy("different.com", undefined)).toBe(false);
 });
 
 test("shouldBypassProxy handles multiple entries with different patterns", () => {
   process.env.NO_PROXY = "internal.local,*.example.com,.test.com";
-  expect(shouldBypassProxy("internal.local")).toBe(true);
-  expect(shouldBypassProxy("sub.example.com")).toBe(true);
-  expect(shouldBypassProxy("sub.test.com")).toBe(true);
-  expect(shouldBypassProxy("test.com")).toBe(true);
-  expect(shouldBypassProxy("example.org")).toBe(false);
+  expect(shouldBypassProxy("internal.local", undefined)).toBe(true);
+  expect(shouldBypassProxy("sub.example.com", undefined)).toBe(true);
+  expect(shouldBypassProxy("sub.test.com", undefined)).toBe(true);
+  expect(shouldBypassProxy("test.com", undefined)).toBe(true);
+  expect(shouldBypassProxy("example.org", undefined)).toBe(false);
 });
 
 test("shouldBypassProxy ignores whitespace in NO_PROXY", () => {
   process.env.NO_PROXY = " example.com , *.test.org ";
-  expect(shouldBypassProxy("example.com")).toBe(true);
-  expect(shouldBypassProxy("subdomain.test.org")).toBe(true);
+  expect(shouldBypassProxy("example.com", undefined)).toBe(true);
+  expect(shouldBypassProxy("subdomain.test.org", undefined)).toBe(true);
+});
+
+test("shouldBypassProxy with ports in NO_PROXY", () => {
+  process.env.NO_PROXY = "example.com:8080,*.test.org:443,.internal.net:8443";
+  expect(shouldBypassProxy("example.com:8080", undefined)).toBe(true);
+  expect(shouldBypassProxy("example.com:9090", undefined)).toBe(false);
+  expect(shouldBypassProxy("sub.test.org:443", undefined)).toBe(true);
+  expect(shouldBypassProxy("sub.internal.net:8443", undefined)).toBe(true);
+  expect(shouldBypassProxy("internal.net:8443", undefined)).toBe(true);
+});
+
+test("shouldBypassProxy accepts options with noProxy patterns", () => {
+  const options = { noProxy: ["example.com:8080", "*.internal.net"] };
+  expect(shouldBypassProxy("example.com:8080", options)).toBe(true);
+  expect(shouldBypassProxy("example.com", options)).toBe(false);
+  expect(shouldBypassProxy("server.internal.net", options)).toBe(true);
+});
+
+test("shouldBypassProxy combines environment and options noProxy patterns", () => {
+  process.env.NO_PROXY = "example.org,*.test.com";
+  const options = { noProxy: ["example.com:8080", "*.internal.net"] };
+  expect(shouldBypassProxy("example.org", options)).toBe(true);
+  expect(shouldBypassProxy("sub.test.com", options)).toBe(true);
+  expect(shouldBypassProxy("example.com:8080", options)).toBe(true);
+  expect(shouldBypassProxy("server.internal.net", options)).toBe(true);
+  expect(shouldBypassProxy("other.domain", options)).toBe(false);
+});
+
+test("shouldBypassProxy handles empty noProxy array in options", () => {
+  process.env.NO_PROXY = "example.org";
+  const options = { noProxy: [] };
+  expect(shouldBypassProxy("example.org", options)).toBe(true);
+  expect(shouldBypassProxy("different.com", options)).toBe(false);
+});
+
+test("shouldBypassProxy handles undefined options", () => {
+  process.env.NO_PROXY = "example.org";
+  expect(shouldBypassProxy("example.org", undefined)).toBe(true);
 });


### PR DESCRIPTION
## Description
Support for port patterns, case insensitivity, and ignoring empty patterns in NO_PROXY handling, and makes all the same logic apply to `requestOptions.noProxy` 