### PR TITLE
fix: docstring always delete exsits code

### DIFF
--- a/extensions/vscode/src/diff/vertical/manager.ts
+++ b/extensions/vscode/src/diff/vertical/manager.ts
@@ -350,6 +350,10 @@ export class VerticalDiffManager {
       await existingHandler.clear(false);
     }
 
+    if(onlyOneInsertion) {
+      endLine = startLine
+    }
+
     await new Promise((resolve) => {
       setTimeout(resolve, 150);
     });


### PR DESCRIPTION
## Description
Background: In VSCode, there is a function called "write a doc string" in the right-click menu, which passes a parameter "onlyOneInsertion" to streamEdit, which only allows receiving up to one line of duplicate content.
<img width="852" alt="image" src="https://github.com/user-attachments/assets/812d5997-27c8-4616-89b6-f7452f4dcf46" />


Problem: Except for the first line, all other content will be delete by function reapplyWithMyersDiff，cause by wrong range
<img width="699" alt="image" src="https://github.com/user-attachments/assets/0db2e3dc-6b61-4f52-b995-0f5f41cf5a78" />

fixed：
when params onlyOneInsertion is true，set endrange = startrange

[ What changed? Feel free to be brief. ]
I have read the CLA Document and I hereby sign the CLA

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
