### PR TITLE
fix: do not delete docs indexes on resync

### DIFF
--- a/core/indexing/docs/DocsService.ts
+++ b/core/indexing/docs/DocsService.ts
@@ -981,16 +981,10 @@ export default class DocsService {
       // Otherwise sync the index based on config changes
       const oldConfigDocs = oldConfig?.docs || [];
       const newConfigDocs = newConfig.docs || [];
-      const newConfigStartUrls = newConfigDocs.map((doc) => doc.startUrl);
 
       // NOTE since listMetadata filters by embeddings provider id embedding model changes are accounted for here
       const currentlyIndexedDocs = await this.listMetadata();
       const currentStartUrls = currentlyIndexedDocs.map((doc) => doc.startUrl);
-
-      // Anything found in sqlite but not in new config should be deleted
-      const deletedDocs = currentlyIndexedDocs.filter(
-        (doc) => !newConfigStartUrls.includes(doc.startUrl),
-      );
 
       // Anything found in old config, new config, AND sqlite that doesn't match should be reindexed
       // TODO if only favicon and title change, only update, don't embed
@@ -1038,10 +1032,6 @@ export default class DocsService {
         ...changedDocs.map((doc) => this.indexAndAdd(doc, true)),
         ...addedDocs.map((doc) => this.indexAndAdd(doc)),
       ]);
-
-      for (const doc of deletedDocs) {
-        await this.deleteIndexes(doc.startUrl);
-      }
     } catch (e) {
       console.error("Error syncing docs index on config update", e);
     } finally {


### PR DESCRIPTION
## Description

When Continue loads, it takes several seconds for it to fetch the remote assistant configs. Until then, it defaults back to the local assistant config. If the user has their docs set up in the remote assistant but not in the local assistant, then this code to delete all non-existent docs from the index will cause all doc indexes to be cleared out on every restart, which is the behavior I am seeing in #6139. This would also be an issue for users who have multiple assistants with different docs in each one.

Fixes #6139.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Tests

Manually verified that the fix works. There were no automated tests covering this functionality, and it is only deleting code.
