### PR TITLE
change icon for grep search tool

### DIFF
--- a/gui/src/pages/gui/ToolCallDiv/index.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/index.tsx
@@ -2,7 +2,6 @@ import {
   ArrowRightIcon,
   CheckIcon,
   CodeBracketIcon,
-  CommandLineIcon,
   DocumentIcon,
   DocumentTextIcon,
   FolderIcon,
@@ -37,7 +36,7 @@ interface ToolCallDivProps {
 
 const toolCallIcons: Record<string, ComponentType> = {
   [BuiltInToolNames.FileGlobSearch]: MagnifyingGlassIcon,
-  [BuiltInToolNames.GrepSearch]: CommandLineIcon,
+  [BuiltInToolNames.GrepSearch]: MagnifyingGlassIcon,
   [BuiltInToolNames.LSTool]: FolderIcon,
   [BuiltInToolNames.ReadCurrentlyOpenFile]: DocumentTextIcon,
   [BuiltInToolNames.ReadFile]: DocumentIcon,


### PR DESCRIPTION
## Description

Minor change: changed icon for grep search tool because terminal icon was confusing

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created