### PR TITLE
Fix bug caused by empty config.json

### DIFF
--- a/core/config/migrateSharedConfig.ts
+++ b/core/config/migrateSharedConfig.ts
@@ -211,6 +211,6 @@ export function migrateJsonSharedConfig(filepath: string, ide: IDE): void {
       new GlobalContext().updateSharedConfig(shareConfigUpdates);
     }
   } catch (e) {
-    throw new Error(`Migration: Failed to parse config.json: ${e}`);
+    console.error(`Migration: Failed to parse config.json: ${e}`);
   }
 }

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "1.1.47",
+  "version": "1.1.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "1.1.47",
+      "version": "1.1.48",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",

--- a/extensions/vscode/src/stubs/WorkOsAuthProvider.ts
+++ b/extensions/vscode/src/stubs/WorkOsAuthProvider.ts
@@ -183,7 +183,6 @@ export class WorkOsAuthProvider implements AuthenticationProvider, Disposable {
 
   async refreshSessions() {
     try {
-      debugger;
       await this._refreshSessions();
     } catch (e) {
       console.error(`Error refreshing sessions: ${e}`);


### PR DESCRIPTION
## Description

Users who had an empty or invalid config.json were seeing an error loading the config because the migration was failing, but this isn't a critical error so it just needs to be logged instead of blocking all usage

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created