### PR TITLE
feat: show warning for unrecommended model selected in agent mode

### DIFF
--- a/core/config/load.ts
+++ b/core/config/load.ts
@@ -641,6 +641,7 @@ function llmToSerializedModelDescription(llm: ILLM): ModelDescription {
     roles: llm.roles,
     configurationStatus: llm.getConfigurationStatus(),
     apiKeyLocation: llm.apiKeyLocation,
+    recommendedFor: llm.recommendedFor,
   };
 }
 

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -3,6 +3,7 @@ import {
   ModelRole,
   PromptTemplates,
 } from "@continuedev/config-yaml";
+import { UseCase } from "@continuedev/llm-info/dist/types";
 import Parser from "web-tree-sitter";
 import { CodebaseIndexer } from "./indexing/CodebaseIndexer";
 import { LLMConfigurationStatuses } from "./llm/constants";
@@ -96,6 +97,7 @@ export interface ILLM
   get underlyingProviderName(): string;
 
   autocompleteOptions?: Partial<TabAutocompleteOptions>;
+  recommendedFor?: UseCase[];
 
   complete(
     prompt: string,
@@ -1064,6 +1066,7 @@ export interface ModelDescription {
   capabilities?: ModelCapability;
   roles?: ModelRole[];
   configurationStatus?: LLMConfigurationStatuses;
+  recommendedFor?: UseCase[];
 }
 
 export interface JSONEmbedOptions {

--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -34,6 +34,7 @@ import { isOllamaInstalled } from "../util/ollamaHelper.js";
 import { Telemetry } from "../util/posthog.js";
 import { withExponentialBackoff } from "../util/withExponentialBackoff.js";
 
+import { UseCase } from "@continuedev/llm-info/dist/types.js";
 import {
   autodetectPromptTemplates,
   autodetectTemplateFunction,
@@ -163,6 +164,7 @@ export abstract class BaseLLM implements ILLM {
   cacheBehavior?: CacheBehavior;
   capabilities?: ModelCapability;
   roles?: ModelRole[];
+  recommendedFor?: UseCase[];
 
   deployment?: string;
   apiVersion?: string;
@@ -263,6 +265,7 @@ export abstract class BaseLLM implements ILLM {
     this.accountId = options.accountId;
     this.capabilities = options.capabilities;
     this.roles = options.roles;
+    this.recommendedFor = llmInfo?.recommendedFor;
 
     this.deployment = options.deployment;
     this.apiVersion = options.apiVersion;

--- a/extensions/vscode/src/stubs/WorkOsAuthProvider.ts
+++ b/extensions/vscode/src/stubs/WorkOsAuthProvider.ts
@@ -183,7 +183,6 @@ export class WorkOsAuthProvider implements AuthenticationProvider, Disposable {
 
   async refreshSessions() {
     try {
-      debugger;
       await this._refreshSessions();
     } catch (e) {
       console.error(`Error refreshing sessions: ${e}`);

--- a/gui/src/components/mainInput/ContinueInputBox.tsx
+++ b/gui/src/components/mainInput/ContinueInputBox.tsx
@@ -5,11 +5,11 @@ import styled, { keyframes } from "styled-components";
 import { defaultBorderRadius, vscBackground } from "..";
 import { useAppSelector } from "../../redux/hooks";
 import { selectSlashCommandComboBoxInputs } from "../../redux/selectors";
-import { ContextItemsPeek } from "./belowMainInput/ContextItemsPeek";
-import { RulesPeek } from "./belowMainInput/RulesPeek";
 import { ToolbarOptions } from "./InputToolbar";
 import { Lump } from "./Lump";
 import { TipTapEditor } from "./TipTapEditor";
+import { ContextItemsPeek } from "./belowMainInput/ContextItemsPeek";
+import { RulesPeek } from "./belowMainInput/RulesPeek";
 
 interface ContinueInputBoxProps {
   isLastUserInput: boolean;

--- a/gui/src/pages/gui/Chat.test.tsx
+++ b/gui/src/pages/gui/Chat.test.tsx
@@ -111,7 +111,7 @@ describe("Chat page test", () => {
     });
   });
 
-  describe.only("unrecommended agent model warning", () => {
+  describe("unrecommended agent model warning", () => {
     it("should not show warning if there are no models", async () => {
       await renderWithProviders(<Chat />);
       expect(

--- a/gui/src/pages/gui/Chat.tsx
+++ b/gui/src/pages/gui/Chat.tsx
@@ -387,35 +387,39 @@ export function Chat() {
           }
           inputId={MAIN_EDITOR_INPUT_ID}
         />
-
-        {!isRecommendedForAgentMode && !acknowledgedUnrecommendedAgent && (
-          <div className="text-warning mx-2 mt-1 flex items-center justify-between border border-solid border-yellow-300 p-1">
-            <div className="flex flex-col gap-y-1">
-              <span>
-                "{config.selectedModelByRole.chat?.model}" is not recommended
-                for agent mode
-              </span>
-              <a
-                className="cursor-pointer"
+        {!!config.selectedModelByRole.chat &&
+          !isRecommendedForAgentMode &&
+          !acknowledgedUnrecommendedAgent && (
+            <div
+              className="text-warning mx-2 mt-1 flex items-center justify-between border border-solid border-yellow-300 p-1"
+              data-testid="unrecommended-agent-warning"
+            >
+              <div className="flex flex-col gap-y-1">
+                <span>
+                  "{config.selectedModelByRole.chat?.model}" is not recommended
+                  for agent mode
+                </span>
+                <a
+                  className="cursor-pointer"
+                  onClick={() => {
+                    ideMessenger.post(
+                      "openUrl",
+                      "https://docs.continue.dev/agent/model-setup",
+                    );
+                  }}
+                >
+                  Know More
+                </a>
+              </div>
+              <XMarkIcon
+                className="h-3 w-3 cursor-pointer"
                 onClick={() => {
-                  ideMessenger.post(
-                    "openUrl",
-                    "https://docs.continue.dev/agent/model-setup",
-                  );
+                  setAcknowledgedUnrecommendedAgent(true);
+                  setLocalStorage("acknowledgedUnrecommendedAgent", true);
                 }}
-              >
-                Know More
-              </a>
+              />
             </div>
-            <XMarkIcon
-              className="h-3 w-3 cursor-pointer"
-              onClick={() => {
-                setAcknowledgedUnrecommendedAgent(true);
-                setLocalStorage("acknowledgedUnrecommendedAgent", true);
-              }}
-            />
-          </div>
-        )}
+          )}
 
         <div
           style={{

--- a/gui/src/pages/gui/Chat.tsx
+++ b/gui/src/pages/gui/Chat.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowLeftIcon,
   ChatBubbleOvalLeftIcon,
+  XMarkIcon,
 } from "@heroicons/react/24/outline";
 import { Editor, JSONContent } from "@tiptap/react";
 import { InputModifiers } from "core";
@@ -91,6 +92,7 @@ function fallbackRender({ error, resetErrorBoundary }: any) {
 
 export function Chat() {
   const dispatch = useAppDispatch();
+  const config = useAppSelector((state) => state.config.config);
   const ideMessenger = useContext(IdeMessengerContext);
   const onboardingCard = useOnboardingCard();
   const showSessionTabs = useAppSelector(
@@ -112,6 +114,8 @@ export function Chat() {
   const toolCallState = useAppSelector(selectCurrentToolCall);
   const mode = useAppSelector((store) => store.session.mode);
   const isInEdit = useAppSelector((store) => store.session.isInEdit);
+  const [acknowledgedUnrecommendedAgent, setAcknowledgedUnrecommendedAgent] =
+    useState(getLocalStorage("acknowledgedUnrecommendedAgent"));
 
   const lastSessionId = useAppSelector((state) => state.session.lastSessionId);
   const hasDismissedExploreDialog = useAppSelector(
@@ -141,6 +145,9 @@ export function Chat() {
       window.removeEventListener("keydown", listener);
     };
   }, [isStreaming, jetbrains]);
+
+  const isRecommendedForAgentMode =
+    config.selectedModelByRole.chat?.recommendedFor?.includes("chat") ?? false;
 
   const { widget, highlights } = useFindWidget(
     stepsDivRef,
@@ -380,6 +387,35 @@ export function Chat() {
           }
           inputId={MAIN_EDITOR_INPUT_ID}
         />
+
+        {!isRecommendedForAgentMode && !acknowledgedUnrecommendedAgent && (
+          <div className="text-warning mx-2 mt-1 flex items-center justify-between border border-solid border-yellow-300 p-1">
+            <div className="flex flex-col gap-y-1">
+              <span>
+                "{config.selectedModelByRole.chat?.model}" is not recommended
+                for agent mode
+              </span>
+              <a
+                className="cursor-pointer"
+                onClick={() => {
+                  ideMessenger.post(
+                    "openUrl",
+                    "https://docs.continue.dev/agent/model-setup",
+                  );
+                }}
+              >
+                Know More
+              </a>
+            </div>
+            <XMarkIcon
+              className="h-3 w-3 cursor-pointer"
+              onClick={() => {
+                setAcknowledgedUnrecommendedAgent(true);
+                setLocalStorage("acknowledgedUnrecommendedAgent", true);
+              }}
+            />
+          </div>
+        )}
 
         <div
           style={{

--- a/gui/src/util/localStorage.ts
+++ b/gui/src/util/localStorage.ts
@@ -16,6 +16,7 @@ type LocalStorageTypes = {
   showTutorialCard: boolean;
   shownProfilesIntroduction: boolean;
   disableIndexing: boolean;
+  acknowledgedUnrecommendedAgent: boolean;
 };
 
 export enum LocalStorageKey {


### PR DESCRIPTION
## Description

Show a warning below the text box when an unrecommended model is selected for agent mode.

- Model being suitable for agent mode is decided using the [llm-info's `recommendedFor` field](https://github.com/continuedev/continue/blob/0239baa1ca350321ed45d946c22e9b2e4a8a94f7/packages/llm-info/src/providers/openai.ts/#L83)
- A "Know more" link to the issue points to https://docs.continue.dev/agent/model-setup
- Once the warning is dismissed, it is never shown again for any model

related to CON-2301

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

https://github.com/user-attachments/assets/3501a176-3128-4457-be00-275b3e28700b




## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
