### PR TITLE
allow "unrolling" of markdown blocks

### DIFF
--- a/packages/config-yaml/package-lock.json
+++ b/packages/config-yaml/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@continuedev/config-yaml",
-  "version": "1.0.92",
+  "version": "1.0.93",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@continuedev/config-yaml",
-      "version": "1.0.92",
+      "version": "1.0.93",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",

--- a/packages/config-yaml/package.json
+++ b/packages/config-yaml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@continuedev/config-yaml",
-  "version": "1.0.92",
+  "version": "1.0.94",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/config-yaml/src/load/unroll.ts
+++ b/packages/config-yaml/src/load/unroll.ts
@@ -254,7 +254,7 @@ export async function unrollAssistantFromContent(
   options: UnrollAssistantOptions,
 ): Promise<ConfigResult<AssistantUnrolled>> {
   // Parse string to Zod-validated YAML
-  let parsedYaml = parseConfigYaml(rawYaml);
+  let parsedYaml = parseMarkdownRuleOrConfigYaml(rawYaml, id);
 
   // Unroll blocks and convert their secrets to FQSNs
   const {


### PR DESCRIPTION
## Description

This showed up (among potentially other places) when adding a markdown rule to an assistant in the hub. Makes sure to parse Markdown if YAML fails

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Tests

The method is already well tested