### PR TITLE
fix(autocomplete): trim trailing <|file_separator|> for Gemini/Gemma

### DIFF
--- a/core/autocomplete/postprocessing/index.ts
+++ b/core/autocomplete/postprocessing/index.ts
@@ -132,6 +132,14 @@ export function postprocessCompletion({
     completion = "\n" + completion;
   }
 
+  if (
+    (llm.model.includes("gemini") || llm.model.includes("gemma")) &&
+    completion.endsWith("<|file_separator|>")
+  ) {
+    // "<|file_separator|>" is 18 characters long
+    completion = completion.slice(0, -18);
+  }
+
   // If prefix ends with space and so does completion, then remove the space from completion
 
   if (prefix.endsWith(" ") && completion.startsWith(" ")) {


### PR DESCRIPTION
## Description

See #6067. Change was made to remove the trailing 18 characters from the completion if the model is a Gemini or Gemma model, and the completion ends with <|file_separator|>. Attempting to do this within:
core/autocomplete/filtering/streamTransforms/lineStream.ts
Resulted in generations not showing. 

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots

N/A

## Tests

I don't believe any tests currently exist for the postprocessing code. 
