### PR TITLE
feat: support ollama streaming for tool calls

### DIFF
--- a/core/llm/llms/Ollama.ts
+++ b/core/llm/llms/Ollama.ts
@@ -405,7 +405,6 @@ class Ollama extends BaseLLM implements ModelInstaller {
           parameters: tool.function.parameters,
         },
       }));
-      chatOptions.stream = false; // Cannot set stream = true for tools calls
     }
     const headers: Record<string, string> = {
       "Content-Type": "application/json",


### PR DESCRIPTION
## Description

Since ollama now supports [streaming tool calls](https://ollama.com/blog/streaming-tool), that supported is now added to Continue as well.

closes  https://github.com/continuedev/continue/issues/6078

resolves CON-2300

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots



https://github.com/user-attachments/assets/b49ff19b-d006-4359-b6fa-385ec850a325


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
