### PR TITLE
Handle empty query by sending "null" instead of empty string in MCP context provider

### DIFF
--- a/core/context/providers/MCPContextProvider.ts
+++ b/core/context/providers/MCPContextProvider.ts
@@ -56,7 +56,9 @@ class MCPContextProvider extends BaseContextProvider {
   private insertInputToUriTemplate(uri: string, query: string): string {
     const TEMPLATE_VAR = "query";
     if (uri.includes(`{${TEMPLATE_VAR}}`)) {
-      return uri.replace(`{${TEMPLATE_VAR}}`, encodeURIComponent(query));
+      // Sending an empty string will result in an error, so we instead send "null"
+      const queryOrNull = query.trim() === "" ? "null" : query;
+      return uri.replace(`{${TEMPLATE_VAR}}`, encodeURIComponent(queryOrNull));
     }
     return uri;
   }


### PR DESCRIPTION
Empty query was causing "resource not found" even though the user should be allowed to enter nothing in the input box. There was no way of handling the empty string with current MCP server frameworks