### PR TITLE
feat: add webview listener for index progress to load submenu items

### DIFF
--- a/gui/src/context/SubmenuContextProviders.tsx
+++ b/gui/src/context/SubmenuContextProviders.tsx
@@ -356,6 +356,16 @@ export const SubmenuContextProvidersProvider = ({
     [loadSubmenuItems],
   );
 
+  useWebviewListener(
+    "indexProgress",
+    async (data) => {
+      if (data.status === "done") {
+        loadSubmenuItems("dependsOnIndexing")
+      }
+    },
+    [loadSubmenuItems],
+  );
+
   // Reload all submenu items on the initial config load
   useEffect(() => {
     if (!submenuContextProviders.length) {


### PR DESCRIPTION
## Description

I could not reproduce the issue, but I Added a useWebviewListener for "indexProgress" events that triggers when the codebase indexing is complete `(status === "done")`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

fixes this https://github.com/continuedev/continue/issues/6017