### PR TITLE
fix: use last 2 parts of file uri for rule names

### DIFF
--- a/packages/config-yaml/src/markdown/markdownToRule.test.ts
+++ b/packages/config-yaml/src/markdown/markdownToRule.test.ts
@@ -1,5 +1,5 @@
 import { PackageIdentifier } from "../browser.js";
-import { markdownToRule } from "./markdownToRule.js";
+import { getRuleName, markdownToRule } from "./markdownToRule.js";
 
 describe("markdownToRule", () => {
   // Use a mock PackageIdentifier for testing
@@ -36,7 +36,7 @@ This is a test rule.`;
     const result = markdownToRule(content, mockId);
     expect(result.globs).toBe("**/test/**/*.kt");
     expect(result.rule).toBe("# Test Rule\n\nThis is a test rule.");
-    expect(result.name).toBe("/path/to/file"); // Should use packageIdentifierToDisplayName result
+    expect(result.name).toBe("to/file"); // Should use last two path segments
   });
 
   it("should handle missing frontmatter", () => {
@@ -47,7 +47,7 @@ This is a test rule without frontmatter.`;
     const result = markdownToRule(content, mockId);
     expect(result.globs).toBeUndefined();
     expect(result.rule).toBe(content);
-    expect(result.name).toBe("/path/to/file"); // Should use packageIdentifierToDisplayName result
+    expect(result.name).toBe("to/file"); // Should use last two path segments
   });
 
   it("should handle empty frontmatter", () => {
@@ -63,7 +63,7 @@ This is a test rule with empty frontmatter.`;
     expect(result.rule).toBe(
       "# Test Rule\n\nThis is a test rule with empty frontmatter.",
     );
-    expect(result.name).toBe("/path/to/file"); // Should use packageIdentifierToDisplayName result
+    expect(result.name).toBe("to/file"); // Should use last two path segments
   });
 
   it("should handle frontmatter with whitespace", () => {
@@ -78,7 +78,7 @@ This is a test rule.`;
     const result = markdownToRule(content, mockId);
     expect(result.globs).toBe("**/test/**/*.kt");
     expect(result.rule).toBe("# Test Rule\n\nThis is a test rule.");
-    expect(result.name).toBe("/path/to/file"); // Should use packageIdentifierToDisplayName result
+    expect(result.name).toBe("to/file"); // Should use last two path segments
   });
 
   it("should handle Windows line endings (CRLF)", () => {
@@ -95,7 +95,7 @@ This is a test rule.`;
     expect(result.globs).toBe("**/test/**/*.kt");
     // The result should be normalized to \n
     expect(result.rule).toBe("# Test Rule\n\nThis is a test rule.");
-    expect(result.name).toBe("/path/to/file"); // Should use packageIdentifierToDisplayName result
+    expect(result.name).toBe("to/file"); // Should use last two path segments
   });
 
   it("should handle malformed frontmatter", () => {
@@ -112,7 +112,7 @@ This is a test rule.`;
     const result = markdownToRule(content, mockId);
     expect(result.globs).toBeUndefined();
     expect(result.rule).toBe(content);
-    expect(result.name).toBe("/path/to/file"); // Should use packageIdentifierToDisplayName result
+    expect(result.name).toBe("to/file"); // Should use last two path segments
   });
 
   it("should use packageIdentifierToDisplayName if no heading or frontmatter name", () => {
@@ -125,7 +125,7 @@ globs: "**/test/**/*.kt"
 This is a test rule.`;
 
     const result = markdownToRule(content, mockId);
-    expect(result.name).toBe("/path/to/file"); // Should use packageIdentifierToDisplayName result
+    expect(result.name).toBe("to/file"); // Should use last two path segments
   });
 
   it("should use packageIdentifierToDisplayName if no heading or frontmatter name (no heading)", () => {
@@ -136,7 +136,7 @@ globs: "**/test/**/*.kt"
 This is a test rule without a heading.`;
 
     const result = markdownToRule(content, mockId);
-    expect(result.name).toBe("/path/to/file"); // Should use packageIdentifierToDisplayName result
+    expect(result.name).toBe("to/file"); // Should use last two path segments
   });
 
   it("should include description from frontmatter", () => {
@@ -169,5 +169,110 @@ This is a rule with alwaysApply explicitly set to false.`;
 
     const result = markdownToRule(content, mockId);
     expect(result.alwaysApply).toBe(false);
+  });
+});
+
+describe("getRuleName", () => {
+  it("should return frontmatter name when provided", () => {
+    const frontmatter = { name: "Custom Rule Name" };
+    const id: PackageIdentifier = {
+      uriType: "file",
+      filePath: "/path/to/my-rule.md",
+    };
+
+    const result = getRuleName(frontmatter, id);
+    expect(result).toBe("Custom Rule Name");
+  });
+
+  it("should return last two path segments for file identifier when no name", () => {
+    const frontmatter = {};
+    const id: PackageIdentifier = {
+      uriType: "file",
+      filePath: "/long/path/to/rules/my-rule.md",
+    };
+
+    const result = getRuleName(frontmatter, id);
+    expect(result).toBe("rules/my-rule.md");
+  });
+
+  it("should handle file paths with backslashes", () => {
+    const frontmatter = {};
+    const id: PackageIdentifier = {
+      uriType: "file",
+      filePath: "C:\\long\\path\\to\\rules\\my-rule.md",
+    };
+
+    const result = getRuleName(frontmatter, id);
+    expect(result).toBe("rules/my-rule.md");
+  });
+
+  it("should handle mixed forward and back slashes", () => {
+    const frontmatter = {};
+    const id: PackageIdentifier = {
+      uriType: "file",
+      filePath: "/path/to\\rules/my-rule.md",
+    };
+
+    const result = getRuleName(frontmatter, id);
+    expect(result).toBe("rules/my-rule.md");
+  });
+
+  it("should handle single segment path", () => {
+    const frontmatter = {};
+    const id: PackageIdentifier = {
+      uriType: "file",
+      filePath: "my-rule.md",
+    };
+
+    const result = getRuleName(frontmatter, id);
+    expect(result).toBe("my-rule.md");
+  });
+
+  it("should handle two segment path", () => {
+    const frontmatter = {};
+    const id: PackageIdentifier = {
+      uriType: "file",
+      filePath: "rules/my-rule.md",
+    };
+
+    const result = getRuleName(frontmatter, id);
+    expect(result).toBe("rules/my-rule.md");
+  });
+
+  it("should return display name for non-file identifiers", () => {
+    const frontmatter = {};
+    const id: PackageIdentifier = {
+      uriType: "slug",
+      fullSlug: {
+        ownerSlug: "test-owner",
+        packageSlug: "my-rule-package",
+        versionSlug: "v1.0.0",
+      },
+    };
+
+    const result = getRuleName(frontmatter, id);
+    expect(result).toBe("my-rule-package"); // packageIdentifierToDisplayName returns just the packageSlug
+  });
+
+  it("should prioritize frontmatter name over file path", () => {
+    const frontmatter = { name: "Override Name" };
+    const id: PackageIdentifier = {
+      uriType: "file",
+      filePath: "/very/long/path/to/rules/original-name.md",
+    };
+
+    const result = getRuleName(frontmatter, id);
+    expect(result).toBe("Override Name");
+  });
+
+  it("should handle empty string name in frontmatter by falling back to path", () => {
+    const frontmatter = { name: "" };
+    const id: PackageIdentifier = {
+      uriType: "file",
+      filePath: "/path/to/rules/my-rule.md",
+    };
+
+    const result = getRuleName(frontmatter, id);
+    expect(result).toBe("rules/my-rule.md"); // Empty string is falsy, so falls back to path logic
   });
 });

--- a/packages/config-yaml/src/markdown/markdownToRule.ts
+++ b/packages/config-yaml/src/markdown/markdownToRule.ts
@@ -46,6 +46,28 @@ export function parseMarkdownRule(content: string): {
   return { frontmatter: {}, markdown: normalizedContent };
 }
 
+export function getRuleName(
+  frontmatter: RuleFrontmatter,
+  id: PackageIdentifier,
+): string {
+  if (frontmatter.name) {
+    return frontmatter.name;
+  }
+
+  const displayName = packageIdentifierToDisplayName(id);
+
+  // If it's a file identifier, extract the last two parts of the file path
+  if (id.uriType === "file") {
+    // Handle both forward slashes and backslashes, get the last two segments
+    const segments = displayName.split(/[/\\]/);
+    const lastTwoParts = segments.slice(-2);
+    return lastTwoParts.join("/");
+  }
+
+  // Otherwise return the display name as-is (for slug identifiers)
+  return displayName;
+}
+
 export function markdownToRule(
   rule: string,
   id: PackageIdentifier,
@@ -53,7 +75,7 @@ export function markdownToRule(
   const { frontmatter, markdown } = parseMarkdownRule(rule);
 
   return {
-    name: frontmatter.name ?? packageIdentifierToDisplayName(id),
+    name: getRuleName(frontmatter, id),
     rule: markdown,
     globs: frontmatter.globs,
     description: frontmatter.description,


### PR DESCRIPTION
## Description

Current behavior is that the entire file URI is shown as rule name, which is more/less useless since we truncate the display, and the beginning of all file URIs for a workspace will always be the same.

This PR changes behavior to instead be the last 2 parts of the URI. I think ideally we'd somehow keep the full URI and let the callee decide how to render the name based on this, but for now this is 1% better.