### PR TITLE
add enable reasoning button

### DIFF
--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -1,4 +1,8 @@
-import { AtSymbolIcon, PhotoIcon } from "@heroicons/react/24/outline";
+import {
+  AtSymbolIcon,
+  LightBulbIcon,
+  PhotoIcon,
+} from "@heroicons/react/24/outline";
 import { InputModifiers } from "core";
 import { modelSupportsImages, modelSupportsTools } from "core/llm/autodetect";
 import { useContext, useRef } from "react";
@@ -10,8 +14,10 @@ import {
   selectCurrentToolCallApplyState,
 } from "../../redux/selectors/selectCurrentToolCall";
 import { selectSelectedChatModel } from "../../redux/slices/configSlice";
+import { setHasReasoningEnabled } from "../../redux/slices/sessionSlice";
 import { exitEdit } from "../../redux/thunks/edit";
 import { getAltKeyLabel, isMetaEquivalentKeyPressed } from "../../util";
+import { cn } from "../../util/cn";
 import { ToolTip } from "../gui/Tooltip";
 import ModelSelect from "../modelSelection/ModelSelect";
 import { ModeSelect } from "../ModeSelect";
@@ -50,6 +56,9 @@ function InputToolbar(props: InputToolbarProps) {
   const toolCallState = useAppSelector(selectCurrentToolCall);
   const currentToolCallApplyState = useAppSelector(
     selectCurrentToolCallApplyState,
+  );
+  const hasReasoningEnabled = useAppSelector(
+    (store) => store.session.hasReasoningEnabled,
   );
 
   const isEnterDisabled =
@@ -140,6 +149,25 @@ function InputToolbar(props: InputToolbarProps) {
 
                 <ToolTip id="add-context-item-tooltip" place="top">
                   Attach Context
+                </ToolTip>
+              </HoverItem>
+            )}
+            {defaultModel?.provider === "anthropic" && (
+              <HoverItem
+                onClick={() =>
+                  dispatch(setHasReasoningEnabled(!hasReasoningEnabled))
+                }
+              >
+                <LightBulbIcon
+                  data-tooltip-id="model-reasoning-tooltip"
+                  className={cn(
+                    "h-3 w-3 hover:brightness-150",
+                    hasReasoningEnabled && "brightness-200",
+                  )}
+                />
+
+                <ToolTip id="model-reasoning-tooltip" place="top">
+                  Use Model Reasoning
                 </ToolTip>
               </HoverItem>
             )}

--- a/gui/src/hooks/ParallelListeners.tsx
+++ b/gui/src/hooks/ParallelListeners.tsx
@@ -20,6 +20,7 @@ import {
 import {
   acceptToolCall,
   addContextItemsAtIndex,
+  setHasReasoningEnabled,
   updateApplyState,
 } from "../redux/slices/sessionSlice";
 import { setTTSActive } from "../redux/slices/uiSlice";
@@ -85,6 +86,13 @@ function ParallelListeners() {
       if (configResult.config?.ui?.fontSize) {
         setLocalStorage("fontSize", configResult.config.ui.fontSize);
         document.body.style.fontSize = `${configResult.config.ui.fontSize}px`;
+      }
+
+      if (
+        configResult.config?.selectedModelByRole.chat?.completionOptions
+          ?.reasoning
+      ) {
+        dispatch(setHasReasoningEnabled(true));
       }
     },
     [dispatch, hasDoneInitialConfigLoad],
@@ -241,7 +249,7 @@ function ParallelListeners() {
         dispatch(updateEditStateApplyState(state));
 
         if (state.status === "closed") {
-          dispatch(exitEdit({}));
+          void dispatch(exitEdit({}));
         }
       } else {
         // chat or agent

--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -51,6 +51,7 @@ type SessionState = {
     curIndex: number;
   };
   newestToolbarPreviewForInput: Record<string, string>;
+  hasReasoningEnabled?: boolean;
 };
 
 const initialState: SessionState = {
@@ -594,6 +595,9 @@ export const sessionSlice = createSlice({
     setIsInEdit: (state, action: PayloadAction<boolean>) => {
       state.isInEdit = action.payload;
     },
+    setHasReasoningEnabled: (state, action: PayloadAction<boolean>) => {
+      state.hasReasoningEnabled = action.payload;
+    },
     setNewestToolbarPreviewForInput: (
       state,
       {
@@ -691,6 +695,7 @@ export const {
   deleteSessionMetadata,
   setNewestToolbarPreviewForInput,
   setIsInEdit,
+  setHasReasoningEnabled,
 } = sessionSlice.actions;
 
 export const { selectIsGatheringContext } = sessionSlice.selectors;

--- a/gui/src/redux/thunks/streamNormalInput.ts
+++ b/gui/src/redux/thunks/streamNormalInput.ts
@@ -45,6 +45,14 @@ export const streamNormalInput = createAsyncThunk<
       };
     }
 
+    if (state.session.hasReasoningEnabled) {
+      completionOptions = {
+        ...completionOptions,
+        reasoning: true,
+        reasoningBudgetTokens: completionOptions.reasoningBudgetTokens ?? 2048,
+      };
+    }
+
     // Send request
     const gen = extra.ideMessenger.llmStreamChat(
       {


### PR DESCRIPTION
## Description

Show an enable reasoning button in the toolbar to force the model to use reasoning.
This is now only applicable for anthropic models.

- Adds a new state `hasReasoningEnabled` in config reducer
- Gets the initial state set on config refresh inside `ParallelListeners`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

https://github.com/user-attachments/assets/2c69d475-ab26-4fb6-b0e4-8ec1bde23159



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
