### PR TITLE
feat: add llms.txt generation for docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -212,6 +212,15 @@ const config = {
       },
     ],
     [
+      "docusaurus-plugin-llms-txt",
+      {
+        // Optional configuration
+        outputPath: "static/llms.txt",
+        includePatterns: ["docs/**"],
+        excludePatterns: ["**/node_modules/**"],
+      },
+    ],
+    [
       "@docusaurus/plugin-client-redirects",
       {
         redirects: [

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -14,6 +14,7 @@
         "@docusaurus/preset-classic": "^3.7.0",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.1.0",
+        "docusaurus-plugin-llms-txt": "^0.1.3",
         "posthog-docusaurus": "^2.0.4",
         "prism-react-renderer": "^2.3.1",
         "react": "^18.2.0",
@@ -7602,6 +7603,23 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/docusaurus-plugin-llms-txt": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-llms-txt/-/docusaurus-plugin-llms-txt-0.1.3.tgz",
+      "integrity": "sha512-X/Dqf1/soHFjvELWXtfa9C023498HsWWwNPdVZEu0OoznI2Gzf+VCB/4obwpBSV9OeDeI8D94/dK/ETq534k9A==",
+      "license": "MIT",
+      "dependencies": {
+        "fs-extra": "^11.2.0",
+        "gray-matter": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": ">=2.0.0",
+        "react": ">=16.8.0"
       }
     },
     "node_modules/dom-converter": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -22,6 +22,7 @@
     "@docusaurus/preset-classic": "^3.7.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.1.0",
+    "docusaurus-plugin-llms-txt": "^0.1.3",
     "posthog-docusaurus": "^2.0.4",
     "prism-react-renderer": "^2.3.1",
     "react": "^18.2.0",


### PR DESCRIPTION
## Description

LLMs.txt files can provide AI systems with clean, structured, and authoritative information about our docs. This PR enabes it by adding the docusaurus plugin. 

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
