### PR TITLE
fix: pass `env` obj to openai-adapters

### DIFF
--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - pe/watsonx-fix
 
 jobs:
   install-root:

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -75,6 +75,33 @@ jobs:
           cd packages/config-yaml
           npm ci
 
+  install-openai-adapters:
+    needs: install-root
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-root-node-modules-${{ hashFiles('package-lock.json') }}
+
+      - uses: actions/cache@v4
+        id: openai-adapters-cache
+        with:
+          path: packages/openai-adapters/node_modules
+          key: ${{ runner.os }}-openai-adapters-node-modules-${{ hashFiles('packages/openai-adapters/package-lock.json') }}
+
+      - name: Install openai-adapters dependencies
+        if: steps.openai-adapters-cache.outputs.cache-hit != 'true'
+        run: |
+          cd packages/openai-adapters
+          npm ci
+
   config-yaml-checks:
     needs: install-config-yaml
     runs-on: ubuntu-latest
@@ -103,7 +130,6 @@ jobs:
           # Tests are currently failing, commenting out for now
           # npm test 
           npm run build
-
   install-core:
     needs: install-root
     runs-on: ubuntu-latest
@@ -133,7 +159,7 @@ jobs:
           npm ci
 
   core-checks:
-    needs: [install-core, install-config-yaml]
+    needs: [install-core, install-config-yaml, install-openai-adapters]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -160,11 +186,21 @@ jobs:
           path: packages/config-yaml/node_modules
           key: ${{ runner.os }}-config-yaml-node-modules-${{ hashFiles('packages/config-yaml/package-lock.json') }}
 
+      - uses: actions/cache@v4
+        id: openai-adapters-cache
+        with:
+          path: packages/openai-adapters/node_modules
+          key: ${{ runner.os }}-openai-adapters-node-modules-${{ hashFiles('packages/openai-adapters/package-lock.json') }}
+
       - name: Build config-yaml
         run: |
           cd packages/config-yaml
           npm run build
 
+      - name: Build openai-adapters
+        run: |
+          cd packages/openai-adapters
+          npm run build
       - name: Type check and lint
         run: |
           cd core
@@ -174,7 +210,8 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
   install-gui:
-    needs: [install-root, install-core, install-config-yaml]
+    needs:
+      [install-root, install-core, install-config-yaml, install-openai-adapters]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -205,9 +242,20 @@ jobs:
           path: packages/config-yaml/node_modules
           key: ${{ runner.os }}-config-yaml-node-modules-${{ hashFiles('packages/config-yaml/package-lock.json') }}
 
+      - uses: actions/cache@v4
+        id: openai-adapters-cache
+        with:
+          path: packages/openai-adapters/node_modules
+          key: ${{ runner.os }}-openai-adapters-node-modules-${{ hashFiles('packages/openai-adapters/package-lock.json') }}
+
       - name: Build config-yaml
         run: |
           cd packages/config-yaml
+          npm run build
+
+      - name: Build openai-adapters
+        run: |
+          cd packages/openai-adapters
           npm run build
 
       - name: Install gui dependencies
@@ -221,7 +269,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
@@ -260,7 +307,8 @@ jobs:
           npm run lint
 
   binary-checks:
-    needs: [install-root, install-core, install-config-yaml]
+    needs:
+      [install-root, install-core, install-config-yaml, install-openai-adapters]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -291,9 +339,20 @@ jobs:
           path: packages/config-yaml/node_modules
           key: ${{ runner.os }}-config-yaml-node-modules-${{ hashFiles('packages/config-yaml/package-lock.json') }}
 
+      - uses: actions/cache@v4
+        id: openai-adapters-cache
+        with:
+          path: packages/openai-adapters/node_modules
+          key: ${{ runner.os }}-openai-adapters-node-modules-${{ hashFiles('packages/openai-adapters/package-lock.json') }}
+
       - name: Build config-yaml
         run: |
           cd packages/config-yaml
+          npm run build
+
+      - name: Build openai-adapters
+        run: |
+          cd packages/openai-adapters
           npm run build
 
       - name: Install binary dependencies
@@ -308,7 +367,8 @@ jobs:
           npx tsc --noEmit
 
   install-vscode:
-    needs: [install-root, install-core, install-config-yaml]
+    needs:
+      [install-root, install-core, install-config-yaml, install-openai-adapters]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -402,7 +462,7 @@ jobs:
           npm run vitest
 
   core-tests:
-    needs: [install-core, install-config-yaml]
+    needs: [install-core, install-config-yaml, install-openai-adapters]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -422,9 +482,20 @@ jobs:
           path: packages/config-yaml/node_modules
           key: ${{ runner.os }}-config-yaml-node-modules-${{ hashFiles('packages/config-yaml/package-lock.json') }}
 
+      - uses: actions/cache@v4
+        id: openai-adapters-cache
+        with:
+          path: packages/openai-adapters/node_modules
+          key: ${{ runner.os }}-openai-adapters-node-modules-${{ hashFiles('packages/openai-adapters/package-lock.json') }}
+
       - name: Build config-yaml
         run: |
           cd packages/config-yaml
+          npm run build
+
+      - name: Build openai-adapters
+        run: |
+          cd packages/openai-adapters
           npm run build
 
       - name: Run core tests
@@ -476,7 +547,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache node modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: extensions/vscode/node_modules
           key: ${{ runner.os }}-vscode-node-modules-${{ hashFiles('extensions/vscode/package-lock.json') }}
@@ -515,7 +586,13 @@ jobs:
 
   vscode-package-extension:
     runs-on: ubuntu-latest
-    needs: [install-vscode, install-core, install-config-yaml]
+    needs:
+      [
+        install-vscode,
+        install-core,
+        install-config-yaml,
+        install-openai-adapters,
+      ]
     steps:
       - uses: actions/checkout@v4
 
@@ -541,9 +618,20 @@ jobs:
           path: packages/config-yaml/node_modules
           key: ${{ runner.os }}-config-yaml-node-modules-${{ hashFiles('packages/config-yaml/package-lock.json') }}
 
+      - uses: actions/cache@v4
+        id: openai-adapters-cache
+        with:
+          path: packages/openai-adapters/node_modules
+          key: ${{ runner.os }}-openai-adapters-node-modules-${{ hashFiles('packages/openai-adapters/package-lock.json') }}
+
       - name: Build config-yaml
         run: |
           cd packages/config-yaml
+          npm run build
+
+      - name: Build openai-adapters
+        run: |
+          cd packages/openai-adapters
           npm run build
 
       - name: Package extension
@@ -559,7 +647,13 @@ jobs:
 
   vscode-download-e2e-dependencies:
     runs-on: ubuntu-latest
-    needs: [install-vscode, install-core, install-config-yaml]
+    needs:
+      [
+        install-vscode,
+        install-core,
+        install-config-yaml,
+        install-openai-adapters,
+      ]
     steps:
       - uses: actions/checkout@v4
 
@@ -612,6 +706,7 @@ jobs:
         install-vscode,
         install-core,
         install-config-yaml,
+        install-openai-adapters,
       ]
     runs-on: ubuntu-latest
     # Tests requiring secrets need approval from maintainers
@@ -658,9 +753,20 @@ jobs:
           path: packages/config-yaml/node_modules
           key: ${{ runner.os }}-config-yaml-node-modules-${{ hashFiles('packages/config-yaml/package-lock.json') }}
 
+      - uses: actions/cache@v4
+        id: openai-adapters-cache
+        with:
+          path: packages/openai-adapters/node_modules
+          key: ${{ runner.os }}-openai-adapters-node-modules-${{ hashFiles('packages/openai-adapters/package-lock.json') }}
+
       - name: Build config-yaml
         run: |
           cd packages/config-yaml
+          npm run build
+
+      - name: Build openai-adapters
+        run: |
+          cd packages/openai-adapters
           npm run build
 
       - name: Fix VSCode binary permissions
@@ -726,7 +832,8 @@ jobs:
           path: extensions/vscode/e2e.log
 
   gui-tests:
-    needs: [install-gui, install-core, install-config-yaml]
+    needs:
+      [install-gui, install-core, install-config-yaml, install-openai-adapters]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -752,9 +859,20 @@ jobs:
           path: packages/config-yaml/node_modules
           key: ${{ runner.os }}-config-yaml-node-modules-${{ hashFiles('packages/config-yaml/package-lock.json') }}
 
+      - uses: actions/cache@v4
+        id: openai-adapters-cache
+        with:
+          path: packages/openai-adapters/node_modules
+          key: ${{ runner.os }}-openai-adapters-node-modules-${{ hashFiles('packages/openai-adapters/package-lock.json') }}
+
       - name: Build config-yaml
         run: |
           cd packages/config-yaml
+          npm run build
+
+      - name: Build openai-adapters
+        run: |
+          cd packages/openai-adapters
           npm run build
 
       - name: Install GUI dependencies
@@ -769,7 +887,8 @@ jobs:
           npm test
 
   jetbrains-tests:
-    needs: [install-root, core-checks, install-config-yaml]
+    needs:
+      [install-root, core-checks, install-config-yaml, install-openai-adapters]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -784,9 +903,20 @@ jobs:
           path: packages/config-yaml/node_modules
           key: ${{ runner.os }}-config-yaml-node-modules-${{ hashFiles('packages/config-yaml/package-lock.json') }}
 
+      - uses: actions/cache@v4
+        id: openai-adapters-cache
+        with:
+          path: packages/openai-adapters/node_modules
+          key: ${{ runner.os }}-openai-adapters-node-modules-${{ hashFiles('packages/openai-adapters/package-lock.json') }}
+
       - name: Build config-yaml
         run: |
           cd packages/config-yaml
+          npm run build
+
+      - name: Build openai-adapters
+        run: |
+          cd packages/openai-adapters
           npm run build
 
       - name: Setup Java
@@ -903,6 +1033,7 @@ jobs:
       - jetbrains-tests
       - config-yaml-checks
       - install-config-yaml
+      - install-openai-adapters
 
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -462,6 +462,28 @@ jobs:
           path: extensions/vscode/node_modules
           key: ${{ runner.os }}-vscode-node-modules-${{ hashFiles('extensions/vscode/package-lock.json') }}
 
+      - uses: actions/cache@v4
+        id: config-yaml-cache
+        with:
+          path: packages/config-yaml/node_modules
+          key: ${{ runner.os }}-config-yaml-node-modules-${{ hashFiles('packages/config-yaml/package-lock.json') }}
+
+      - uses: actions/cache@v4
+        id: openai-adapters-cache
+        with:
+          path: packages/openai-adapters/node_modules
+          key: ${{ runner.os }}-openai-adapters-node-modules-${{ hashFiles('packages/openai-adapters/package-lock.json') }}
+
+      - name: Build config-yaml
+        run: |
+          cd packages/config-yaml
+          npm run build
+
+      - name: Build openai-adapters
+        run: |
+          cd packages/openai-adapters
+          npm run build
+
       - name: Type check and lint
         run: |
           cd extensions/vscode

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -412,9 +412,20 @@ jobs:
           path: packages/config-yaml/node_modules
           key: ${{ runner.os }}-config-yaml-node-modules-${{ hashFiles('packages/config-yaml/package-lock.json') }}
 
+      - uses: actions/cache@v4
+        id: openai-adapters-cache
+        with:
+          path: packages/openai-adapters/node_modules
+          key: ${{ runner.os }}-openai-adapters-node-modules-${{ hashFiles('packages/openai-adapters/package-lock.json') }}
+
       - name: Build config-yaml
         run: |
           cd packages/config-yaml
+          npm run build
+
+      - name: Build openai-adapters
+        run: |
+          cd packages/openai-adapters
           npm run build
 
       - name: Install vscode dependencies
@@ -450,22 +461,6 @@ jobs:
         with:
           path: extensions/vscode/node_modules
           key: ${{ runner.os }}-vscode-node-modules-${{ hashFiles('extensions/vscode/package-lock.json') }}
-
-      - uses: actions/cache@v4
-        id: config-yaml-cache
-        with:
-          path: packages/config-yaml/node_modules
-          key: ${{ runner.os }}-config-yaml-node-modules-${{ hashFiles('packages/config-yaml/package-lock.json') }}
-
-      - name: Build config-yaml
-        run: |
-          cd packages/config-yaml
-          npm run build
-
-      - name: Build openai-adapters
-        run: |
-          cd packages/openai-adapters
-          npm run build
 
       - name: Type check and lint
         run: |

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - pe/watsonx-fix
 
 jobs:
   install-root:
@@ -130,6 +131,7 @@ jobs:
           # Tests are currently failing, commenting out for now
           # npm test 
           npm run build
+
   install-core:
     needs: install-root
     runs-on: ubuntu-latest
@@ -290,6 +292,12 @@ jobs:
           key: ${{ runner.os }}-gui-node-modules-${{ hashFiles('gui/package-lock.json') }}
 
       - uses: actions/cache@v4
+        id: openai-adapters-cache
+        with:
+          path: packages/openai-adapters/node_modules
+          key: ${{ runner.os }}-openai-adapters-node-modules-${{ hashFiles('packages/openai-adapters/package-lock.json') }}
+
+      - uses: actions/cache@v4
         id: config-yaml-cache
         with:
           path: packages/config-yaml/node_modules
@@ -298,6 +306,11 @@ jobs:
       - name: Build config-yaml
         run: |
           cd packages/config-yaml
+          npm run build
+
+      - name: Build openai-adapters
+        run: |
+          cd packages/openai-adapters
           npm run build
 
       - name: Type check and lint
@@ -447,6 +460,11 @@ jobs:
       - name: Build config-yaml
         run: |
           cd packages/config-yaml
+          npm run build
+
+      - name: Build openai-adapters
+        run: |
+          cd packages/openai-adapters
           npm run build
 
       - name: Type check and lint

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - main
-      - pe/watsonx-fix
 
 jobs:
   install-root:

--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -292,6 +292,7 @@ export abstract class BaseLLM implements ILLM {
       apiKey: this.apiKey ?? "",
       apiBase: this.apiBase,
       requestOptions: this.requestOptions,
+      env: this._llmOptions.env,
     });
   }
 

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -16,7 +16,7 @@
         "@continuedev/config-yaml": "file:../packages/config-yaml",
         "@continuedev/fetch": "^1.0.13",
         "@continuedev/llm-info": "^1.0.8",
-        "@continuedev/openai-adapters": "^1.0.32",
+        "@continuedev/openai-adapters": "file:../packages/openai-adapters",
         "@modelcontextprotocol/sdk": "^1.12.0",
         "@mozilla/readability": "^0.5.0",
         "@octokit/rest": "^20.1.1",
@@ -139,7 +139,7 @@
     },
     "../packages/config-yaml": {
       "name": "@continuedev/config-yaml",
-      "version": "1.0.88",
+      "version": "1.0.94",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",
@@ -157,6 +157,30 @@
         "ts-jest": "^29.2.3",
         "ts-node": "^10.9.2",
         "zod-to-json-schema": "^3.24.5"
+      }
+    },
+    "../packages/openai-adapters": {
+      "name": "@continuedev/openai-adapters",
+      "version": "1.0.40",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@continuedev/config-types": "^1.0.5",
+        "@continuedev/config-yaml": "^1.0.51",
+        "@continuedev/fetch": "^1.0.11",
+        "dotenv": "^16.5.0",
+        "json-schema": "^0.4.0",
+        "node-fetch": "^3.3.2",
+        "openai": "^4.76.0",
+        "uuid": "^11.1.0",
+        "zod": "^3.24.2"
+      },
+      "devDependencies": {
+        "@types/follow-redirects": "^1.14.4",
+        "@types/jest": "^29.5.14",
+        "@types/json-schema": "^7.0.15",
+        "cross-env": "^7.0.3",
+        "ts-jest": "^29.2.3",
+        "ts-node": "^10.9.2"
       }
     },
     "node_modules/@75lb/deep-merge": {
@@ -2900,32 +2924,8 @@
       "integrity": "sha512-/htL7p4li3zQSwn9bXkI23WRpZNklWTPzRSSG3Fd5gvYW8cizjhlf7OzeDdKxBfi1S0lpqMm0VwHlx3KjMKLpw=="
     },
     "node_modules/@continuedev/openai-adapters": {
-      "version": "1.0.32",
-      "resolved": "https://registry.npmjs.org/@continuedev/openai-adapters/-/openai-adapters-1.0.32.tgz",
-      "integrity": "sha512-teNzbpcsa7Y0eBk+dxlLDo0m43sWI5txTYMIk6ezyS0cZAKFJODDB0Gkp3aEHXbD8mDE7H5dDSlM23ohKCirAA==",
-      "dependencies": {
-        "@continuedev/config-types": "^1.0.5",
-        "@continuedev/config-yaml": "^1.0.51",
-        "@continuedev/fetch": "^1.0.11",
-        "dotenv": "^16.5.0",
-        "json-schema": "^0.4.0",
-        "node-fetch": "^3.3.2",
-        "openai": "^4.76.0",
-        "uuid": "^11.1.0",
-        "zod": "^3.24.2"
-      }
-    },
-    "node_modules/@continuedev/openai-adapters/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
+      "resolved": "../packages/openai-adapters",
+      "link": true
     },
     "node_modules/@dabh/diagnostics": {
       "version": "2.0.3",

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     "@continuedev/config-yaml": "file:../packages/config-yaml",
     "@continuedev/fetch": "^1.0.13",
     "@continuedev/llm-info": "^1.0.8",
-    "@continuedev/openai-adapters": "^1.0.32",
+    "@continuedev/openai-adapters": "file:../packages/openai-adapters",
     "@modelcontextprotocol/sdk": "^1.12.0",
     "@mozilla/readability": "^0.5.0",
     "@octokit/rest": "^20.1.1",

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "1.1.49",
+  "version": "1.1.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "1.1.49",
+      "version": "1.1.50",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",
@@ -110,7 +110,7 @@
         "@continuedev/config-yaml": "file:../packages/config-yaml",
         "@continuedev/fetch": "^1.0.13",
         "@continuedev/llm-info": "^1.0.8",
-        "@continuedev/openai-adapters": "^1.0.32",
+        "@continuedev/openai-adapters": "file:../packages/openai-adapters",
         "@modelcontextprotocol/sdk": "^1.12.0",
         "@mozilla/readability": "^0.5.0",
         "@octokit/rest": "^20.1.1",

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -116,7 +116,7 @@
         "@continuedev/config-yaml": "file:../packages/config-yaml",
         "@continuedev/fetch": "^1.0.13",
         "@continuedev/llm-info": "^1.0.8",
-        "@continuedev/openai-adapters": "^1.0.32",
+        "@continuedev/openai-adapters": "file:../packages/openai-adapters",
         "@modelcontextprotocol/sdk": "^1.12.0",
         "@mozilla/readability": "^0.5.0",
         "@octokit/rest": "^20.1.1",


### PR DESCRIPTION
## Description

Handles a breaking change we made in `openai-adapters` that requires passing the proper `env` obj
