### PR TITLE
Removed alwaysApply from the required properties in createRuleBlock.ts

### DIFF
--- a/core/tools/definitions/createRuleBlock.ts
+++ b/core/tools/definitions/createRuleBlock.ts
@@ -16,7 +16,7 @@ export const createRuleBlock: Tool = {
       'Creates a "rule" that can be referenced in future conversations. This should be used whenever you want to establish code standards / preferences that should be applied consistently, or when you want to avoid making a mistake again. To modify existing rules, use the edit tool instead.',
     parameters: {
       type: "object",
-      required: ["name", "rule", "alwaysApply", "description"],
+      required: ["name", "rule", "description"],
       properties: {
         name: {
           type: "string",


### PR DESCRIPTION
## Description

Removed alwaysApply from the required properties in createRuleBlock.ts because there are no alwaysApply property in properties

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
