### PR TITLE
refactor: remove History component from GUI layout

### DIFF
--- a/gui/src/pages/gui/index.tsx
+++ b/gui/src/pages/gui/index.tsx
@@ -2,7 +2,7 @@ import { Chat } from "./Chat";
 
 export default function GUI() {
   return (
-    <div className="flex w-screen flex-row overflow-hidden"> 
+    <div className="flex w-screen flex-row overflow-hidden">
       <main className="no-scrollbar flex flex-1 flex-col overflow-y-auto">
         <Chat />
       </main>

--- a/gui/src/pages/gui/index.tsx
+++ b/gui/src/pages/gui/index.tsx
@@ -1,12 +1,8 @@
-import { History } from "../../components/History";
 import { Chat } from "./Chat";
 
 export default function GUI() {
   return (
-    <div className="flex w-screen flex-row overflow-hidden">
-      <aside className="4xl:flex border-vsc-input-border no-scrollbar hidden w-96 overflow-y-auto border-0 border-r border-solid">
-        <History />
-      </aside>
+    <div className="flex w-screen flex-row overflow-hidden"> 
       <main className="no-scrollbar flex flex-1 flex-col overflow-y-auto">
         <Chat />
       </main>


### PR DESCRIPTION
## Description
this PR removes the `<History />` component from the `Default route`, so there will be no history unexpectedly pop up, cause we already have `History` as a seperate tab.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

fixes this https://github.com/continuedev/continue/issues/6222