### PR TITLE
fix: skip ripgrep if workspace is remote

### DIFF
--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -39,7 +39,7 @@ import { GlobalContext } from "../../util/GlobalContext";
 import { modifyAnyConfigWithSharedConfig } from "../sharedConfig";
 
 import { getControlPlaneEnvSync } from "../../control-plane/env";
-import { baseToolDefinitions, remoteToolDefinitions } from "../../tools";
+import { getToolsForIde } from "../../tools";
 import { getCleanUriPath } from "../../util/uri";
 import { getAllDotContinueDefinitionFiles } from "../loadLocalAssistants";
 import { LocalPlatformClient } from "./LocalPlatformClient";
@@ -187,11 +187,7 @@ async function configYamlToContinueConfig(options: {
 
   const continueConfig: ContinueConfig = {
     slashCommands: [],
-    tools: [
-      ...((await ide.isWorkspaceRemote())
-        ? remoteToolDefinitions
-        : baseToolDefinitions),
-    ],
+    tools: await getToolsForIde(ide),
     mcpServerStatuses: [],
     contextProviders: [],
     modelsByRole: {

--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -188,7 +188,7 @@ async function configYamlToContinueConfig(options: {
   const continueConfig: ContinueConfig = {
     slashCommands: [],
     tools: [
-      ...(ide.isWorkspaceRemote()
+      ...((await ide.isWorkspaceRemote())
         ? remoteToolDefinitions
         : baseToolDefinitions),
     ],

--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -39,7 +39,7 @@ import { GlobalContext } from "../../util/GlobalContext";
 import { modifyAnyConfigWithSharedConfig } from "../sharedConfig";
 
 import { getControlPlaneEnvSync } from "../../control-plane/env";
-import { baseToolDefinitions } from "../../tools";
+import { baseToolDefinitions, remoteToolDefinitions } from "../../tools";
 import { getCleanUriPath } from "../../util/uri";
 import { getAllDotContinueDefinitionFiles } from "../loadLocalAssistants";
 import { LocalPlatformClient } from "./LocalPlatformClient";
@@ -187,7 +187,11 @@ async function configYamlToContinueConfig(options: {
 
   const continueConfig: ContinueConfig = {
     slashCommands: [],
-    tools: [...baseToolDefinitions],
+    tools: [
+      ...(ide.isWorkspaceRemote()
+        ? remoteToolDefinitions
+        : baseToolDefinitions),
+    ],
     mcpServerStatuses: [],
     contextProviders: [],
     modelsByRole: {

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -731,7 +731,7 @@ export interface IDE {
 
   isTelemetryEnabled(): Promise<boolean>;
 
-  isWorkspaceRemote(): boolean;
+  isWorkspaceRemote(): Promise<boolean>;
 
   getUniqueId(): Promise<string>;
 

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -731,6 +731,8 @@ export interface IDE {
 
   isTelemetryEnabled(): Promise<boolean>;
 
+  isWorkspaceRemote(): boolean;
+
   getUniqueId(): Promise<string>;
 
   getTerminalContents(): Promise<string>;

--- a/core/protocol/ide.ts
+++ b/core/protocol/ide.ts
@@ -70,6 +70,7 @@ export type ToIdeFromWebviewOrCoreProtocol = {
   ];
   getAvailableThreads: [undefined, Thread[]];
   isTelemetryEnabled: [undefined, boolean];
+  isWorkspaceRemote: [undefined, boolean];
   getUniqueId: [undefined, string];
   getTags: [string, IndexTag[]];
   readSecrets: [{ keys: string[] }, Record<string, string>];

--- a/core/protocol/messenger/messageIde.ts
+++ b/core/protocol/messenger/messageIde.ts
@@ -106,6 +106,10 @@ export class MessageIde implements IDE {
     return this.request("isTelemetryEnabled", undefined);
   }
 
+  isWorkspaceRemote(): Promise<boolean> {
+    return this.request("isWorkspaceRemote", undefined);
+  }
+
   getUniqueId(): Promise<string> {
     return this.request("getUniqueId", undefined);
   }

--- a/core/tools/index.ts
+++ b/core/tools/index.ts
@@ -13,6 +13,7 @@ import { runTerminalCommandTool } from "./definitions/runTerminalCommand";
 import { searchWebTool } from "./definitions/searchWeb";
 import { viewDiffTool } from "./definitions/viewDiff";
 
+// missing support for remote os calls: https://github.com/microsoft/vscode/issues/252269
 export const localOnlyToolDefinitions = [grepSearchTool];
 
 export const baseToolDefinitions = [

--- a/core/tools/index.ts
+++ b/core/tools/index.ts
@@ -13,12 +13,11 @@ import { runTerminalCommandTool } from "./definitions/runTerminalCommand";
 import { searchWebTool } from "./definitions/searchWeb";
 import { viewDiffTool } from "./definitions/viewDiff";
 
-export const baseToolDefinitions = [
+export const remoteToolDefinitions = [
   readFileTool,
   editFileTool,
   createNewFileTool,
   runTerminalCommandTool,
-  grepSearchTool,
   globSearchTool,
   searchWebTool,
   viewDiffTool,
@@ -30,6 +29,8 @@ export const baseToolDefinitions = [
   // viewSubdirectoryTool,
   // viewRepoMapTool,
 ];
+
+export const baseToolDefinitions = [...remoteToolDefinitions, grepSearchTool];
 
 export const getConfigDependentToolDefinitions = (
   params: ConfigDependentToolParams,

--- a/core/tools/index.ts
+++ b/core/tools/index.ts
@@ -1,4 +1,4 @@
-import { ConfigDependentToolParams, Tool } from "..";
+import { ConfigDependentToolParams, IDE, Tool } from "..";
 import { createNewFileTool } from "./definitions/createNewFile";
 import { createRuleBlock } from "./definitions/createRuleBlock";
 import { editFileTool } from "./definitions/editFile";
@@ -13,7 +13,9 @@ import { runTerminalCommandTool } from "./definitions/runTerminalCommand";
 import { searchWebTool } from "./definitions/searchWeb";
 import { viewDiffTool } from "./definitions/viewDiff";
 
-export const remoteToolDefinitions = [
+export const localOnlyToolDefinitions = [grepSearchTool];
+
+export const baseToolDefinitions = [
   readFileTool,
   editFileTool,
   createNewFileTool,
@@ -30,8 +32,11 @@ export const remoteToolDefinitions = [
   // viewRepoMapTool,
 ];
 
-export const baseToolDefinitions = [...remoteToolDefinitions, grepSearchTool];
-
 export const getConfigDependentToolDefinitions = (
   params: ConfigDependentToolParams,
 ): Tool[] => [requestRuleTool(params)];
+
+export const getToolsForIde = async (ide: IDE) =>
+  (await ide.isWorkspaceRemote())
+    ? baseToolDefinitions
+    : [...baseToolDefinitions, ...localOnlyToolDefinitions];

--- a/core/util/filesystem.ts
+++ b/core/util/filesystem.ts
@@ -48,8 +48,8 @@ class FileSystemIde implements IDE {
     return;
   }
 
-  isWorkspaceRemote(): boolean {
-    return false;
+  isWorkspaceRemote(): Promise<boolean> {
+    return Promise.resolve(false);
   }
 
   async getIdeSettings(): Promise<IdeSettings> {

--- a/core/util/filesystem.ts
+++ b/core/util/filesystem.ts
@@ -48,6 +48,10 @@ class FileSystemIde implements IDE {
     return;
   }
 
+  isWorkspaceRemote(): boolean {
+    return false;
+  }
+
   async getIdeSettings(): Promise<IdeSettings> {
     return {
       remoteConfigServerUrl: undefined,

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IntelliJIde.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IntelliJIde.kt
@@ -125,6 +125,10 @@ class IntelliJIDE(
         return true
     }
 
+    override suspend fun isWorkspaceRemote(): Boolean {
+        return this.getIdeInfo().remoteName != "local"
+    }
+
     override suspend fun getUniqueId(): String {
         return getMachineUniqueID()
     }

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/types.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/types.kt
@@ -102,6 +102,8 @@ interface IDE {
 
     suspend fun isTelemetryEnabled(): Boolean
 
+    suspend fun isWorkspaceRemote(): Boolean
+
     suspend fun getUniqueId(): String
 
     suspend fun getTerminalContents(): String

--- a/extensions/vscode/src/VsCodeIde.ts
+++ b/extensions/vscode/src/VsCodeIde.ts
@@ -200,8 +200,8 @@ class VsCodeIde implements IDE {
     return globalEnabled && continueEnabled;
   }
 
-  isWorkspaceRemote(): boolean {
-    return vscode.env.remoteName !== undefined;
+  isWorkspaceRemote(): Promise<boolean> {
+    return Promise.resolve(vscode.env.remoteName !== undefined);
   }
 
   getUniqueId(): Promise<string> {

--- a/extensions/vscode/src/VsCodeIde.ts
+++ b/extensions/vscode/src/VsCodeIde.ts
@@ -200,6 +200,10 @@ class VsCodeIde implements IDE {
     return globalEnabled && continueEnabled;
   }
 
+  isWorkspaceRemote(): boolean {
+    return vscode.env.remoteName !== undefined;
+  }
+
   getUniqueId(): Promise<string> {
     return Promise.resolve(vscode.env.machineId);
   }

--- a/scripts/create-docker-ssh-container.sh
+++ b/scripts/create-docker-ssh-container.sh
@@ -1,0 +1,35 @@
+# create the docker file
+
+cat > Dockerfile << 'EOF'
+FROM ubuntu:latest
+ENV DEBIAN_FRONTEND=noninteractive
+# Install SSH server
+RUN apt-get update && apt-get install -y openssh-server
+# Configure SSH
+RUN mkdir /var/run/sshd
+RUN echo 'root:my_password' | chpasswd
+# Allow root login
+RUN sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+# SSH login fix
+RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+EXPOSE 22
+CMD ["/usr/sbin/sshd", "-D"]
+EOF
+
+docker build -t continue-ubuntu-ssh . # build the image
+
+rm Dockerfile # remove the created Dockerfile
+
+container_name="continue-ssh-container"
+
+docker run -d -p 2222:22 --name $container_name continue-ubuntu-ssh # run the container
+
+echo "docker container ${container_name} running on port 2222"
+
+# add the instructions
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+echo "\n--------------------------------------"
+echo "now ssh into vscode (using remote explorer) with the following command: ${bold}ssh root@localhost -p 2222${normal}"
+echo "use the following password - \"${bold}my_password${normal}\""


### PR DESCRIPTION
## Description

When workspace is remote, we want to avoid running ripgrep. This is because ripgrep will run locally instead of running the workspace server.

- when workspace is remote, use `baseToolDefinitions` excluding `grepSearchTool`
- add a new type `IDE` interface `isWorkspaceRemote` to detect if workspace is remote in vscode and intellij

resolves CON-2298

If it is possible to run os remote call from remote installed extension, we should be able to implement grep search for remote ides. corresponding issue in vscode: https://github.com/microsoft/vscode/issues/252269


## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]


https://github.com/user-attachments/assets/f54872c8-78e1-4305-bd0a-ad8f411dd94b

https://github.com/user-attachments/assets/95eb01c5-4015-4129-bc52-0fa959dd5f69




## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


## Replication

You can run a docker container for ssh into a remote host.
You can this dockerfile: https://gist.github.com/uinstinct/314da2b450f5440069bbce5ab14043d2