### PR TITLE
perf: Avoid storing services as a field in long-lived components

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/actions/ContinueActionPromote.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/actions/ContinueActionPromote.kt
@@ -5,7 +5,7 @@ import com.github.continuedev.continueintellijextension.services.ContinueExtensi
 import com.intellij.openapi.actionSystem.ActionPromoter
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.DataContext
-import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.components.service
 import org.jetbrains.annotations.NotNull
 
 class ContinueActionPromote : ActionPromoter {
@@ -13,7 +13,7 @@ class ContinueActionPromote : ActionPromoter {
     override fun promote(@NotNull actions: List<AnAction>, @NotNull context: DataContext): List<AnAction>? {
         // For autocomplete actions
         if (actions.any { it is AcceptAutocompleteAction }) {
-            val settings = ServiceManager.getService(ContinueExtensionSettings::class.java)
+            val settings = service<ContinueExtensionSettings>()
             if (settings.continueState.showIDECompletionSideBySide) {
                 return actions.filterIsInstance<AcceptAutocompleteAction>()
             }

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/actions/utils.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/actions/utils.kt
@@ -1,7 +1,7 @@
 package com.github.continuedev.continueintellijextension.actions
 
 import com.github.continuedev.continueintellijextension.services.ContinuePluginService
-import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindowManager
 
@@ -28,12 +28,5 @@ fun focusContinueInput(project: Project?) {
     continuePluginService.ideProtocolClient?.sendHighlightedCode()
 }
 
-fun getPluginService(project: Project?): ContinuePluginService? {
-    if (project == null) {
-        return null
-    }
-    return ServiceManager.getService(
-        project,
-        ContinuePluginService::class.java
-    )
-}
+fun getPluginService(project: Project?): ContinuePluginService? =
+    project?.service<ContinuePluginService>()

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/activities/ContinuePluginDisposable.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/activities/ContinuePluginDisposable.kt
@@ -1,9 +1,7 @@
 package com.github.continuedev.continueintellijextension.activities
 
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
-import com.intellij.openapi.project.Project
 
 /**
  * The service is a parent disposable that represents the entire plugin lifecycle
@@ -18,15 +16,4 @@ class ContinuePluginDisposable : Disposable {
     override fun dispose() {
     }
 
-    companion object {
-
-        fun getInstance(): ContinuePluginDisposable {
-            return ApplicationManager.getApplication().getService(ContinuePluginDisposable::class.java)
-        }
-
-        fun getInstance(project: Project): ContinuePluginDisposable {
-            return project.getService(ContinuePluginDisposable::class.java)
-        }
-
-    }
 }

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/activities/ContinuePluginStartupActivity.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/activities/ContinuePluginStartupActivity.kt
@@ -14,7 +14,6 @@ import com.github.continuedev.continueintellijextension.utils.toUriOrNull
 import com.intellij.openapi.actionSystem.KeyboardShortcut
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ApplicationNamesInfo
-import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.keymap.KeymapManager
@@ -122,14 +121,10 @@ class ContinuePluginStartupActivity : StartupActivity, DumbAware {
 
     private fun initializePlugin(project: Project) {
         val coroutineScope = CoroutineScope(Dispatchers.IO)
-        val continuePluginService = ServiceManager.getService(
-            project,
-            ContinuePluginService::class.java
-        )
+        val continuePluginService = project.service<ContinuePluginService>()
 
         coroutineScope.launch {
-            val settings =
-                ServiceManager.getService(ContinueExtensionSettings::class.java)
+            val settings = service<ContinueExtensionSettings>()
             if (!settings.continueState.shownWelcomeDialog) {
                 settings.continueState.shownWelcomeDialog = true
                 // Open tutorial file
@@ -270,7 +265,7 @@ class ContinuePluginStartupActivity : StartupActivity, DumbAware {
 
             EditorFactory.getInstance().eventMulticaster.addSelectionListener(
                 listener,
-                ContinuePluginDisposable.getInstance(project)
+                project.service<ContinuePluginDisposable>()
             )
 
             val coreMessengerManager = CoreMessengerManager(project, ideProtocolClient, coroutineScope)

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/AutocompleteService.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/AutocompleteService.kt
@@ -7,7 +7,6 @@ import com.github.continuedev.continueintellijextension.utils.uuid
 import com.intellij.injected.editor.VirtualFileWindow
 import com.intellij.openapi.application.*
 import com.intellij.openapi.components.Service
-import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.service
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.InlayProperties
@@ -64,8 +63,7 @@ class AutocompleteService(private val project: Project) {
     var lastChangeWasPartialAccept = false
 
     fun triggerCompletion(editor: Editor) {
-        val settings =
-            ServiceManager.getService(ContinueExtensionSettings::class.java)
+        val settings = service<ContinueExtensionSettings>()
         if (!settings.continueState.enableTabAutocomplete) {
             return
         }
@@ -183,7 +181,7 @@ class AutocompleteService(private val project: Project) {
         }
         if (isInjectedFile(editor)) return
         // Skip rendering completions if the code completion dropdown is already visible and the IDE completion side-by-side setting is disabled
-        if (shouldSkipRender(ServiceManager.getService(ContinueExtensionSettings::class.java))) {
+        if (shouldSkipRender()) {
             return
         }
 
@@ -230,9 +228,10 @@ class AutocompleteService(private val project: Project) {
         }
     }
 
-    private fun shouldSkipRender(settings: ContinueExtensionSettings) =
-        !settings.continueState.showIDECompletionSideBySide && !autocompleteLookupListener.isLookupEmpty()
-
+    private fun shouldSkipRender(): Boolean {
+        val settings = service<ContinueExtensionSettings>()
+        return !settings.continueState.showIDECompletionSideBySide && !autocompleteLookupListener.isLookupEmpty()
+    }
 
     private fun splitKeepingDelimiters(input: String, delimiterPattern: String = "\\s+"): List<String> {
         val initialSplit = input.split("(?<=$delimiterPattern)|(?=$delimiterPattern)".toRegex())

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/AutocompleteSpinnerWidgetFactory.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/AutocompleteSpinnerWidgetFactory.kt
@@ -26,7 +26,7 @@ class AutocompleteSpinnerWidget(project: Project) : EditorBasedWidget(project), 
     private val animatedIcon = AnimatedIcon.Default()
 
     init {
-        Disposer.register(ContinuePluginDisposable.getInstance(project), this)
+        Disposer.register(project.service<ContinuePluginDisposable>(), this)
         updateIcon()
     }
 

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/ApplyToFileHandler.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/ApplyToFileHandler.kt
@@ -10,6 +10,7 @@ import com.github.continuedev.continueintellijextension.editor.EditorUtils
 import com.github.continuedev.continueintellijextension.protocol.ApplyToFileParams
 import com.github.continuedev.continueintellijextension.services.ContinuePluginService
 import com.github.continuedev.continueintellijextension.utils.castNestedOrNull
+import com.intellij.openapi.components.service
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -174,7 +175,7 @@ class ApplyToFileHandler(
             else
                 EditorUtils.getEditorByCreateFile(project, params.filepath)
 
-            val diffStreamService = project.getService(DiffStreamService::class.java)
+            val diffStreamService = project.service<DiffStreamService>()
 
             val handler = ApplyToFileHandler(
                 project,

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/Diffs.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/Diffs.kt
@@ -9,7 +9,7 @@ import com.intellij.diff.contents.DiffContent
 import com.intellij.diff.requests.SimpleDiffRequest
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.WriteCommandAction
-import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.components.service
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
@@ -18,7 +18,6 @@ import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.LocalFileSystem
 import java.awt.Toolkit
 import java.io.File
-import java.net.URI
 import java.nio.file.Paths
 import javax.swing.Action
 import javax.swing.JComponent
@@ -89,11 +88,7 @@ class DiffManager(private val project: Project) : DumbAware {
         FileDocumentManager.getInstance().saveDocument(document)
 
         // Notify server of acceptance
-        val continuePluginService = ServiceManager.getService(
-            project,
-            ContinuePluginService::class.java
-        )
-        continuePluginService.ideProtocolClient?.sendAcceptRejectDiff(true, diffInfo.stepIndex)
+        project.service<ContinuePluginService>().ideProtocolClient?.sendAcceptRejectDiff(true, diffInfo.stepIndex)
 
         // Clean up state
         cleanUpFile(file)
@@ -102,10 +97,7 @@ class DiffManager(private val project: Project) : DumbAware {
     fun rejectDiff(file2: String?) {
         val file = (file2 ?: lastFile2) ?: return
         val diffInfo = diffInfoMap[file] ?: return
-        val continuePluginService = ServiceManager.getService(
-            project,
-            ContinuePluginService::class.java
-        )
+        val continuePluginService = project.service<ContinuePluginService>()
         continuePluginService.ideProtocolClient?.deleteAtIndex(diffInfo.stepIndex)
         continuePluginService.ideProtocolClient?.sendAcceptRejectDiff(false, diffInfo.stepIndex)
         continuePluginService.coreMessenger?.request("cancelApply", null, null) {}

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
@@ -46,7 +46,7 @@ class IdeProtocolClient(
     init {
         // Setup config.json / config.ts save listeners
         VirtualFileManager.getInstance().addAsyncFileListener(
-            AsyncFileSaveListener(continuePluginService), ContinuePluginDisposable.getInstance(project)
+            AsyncFileSaveListener(continuePluginService), project.service<ContinuePluginDisposable>()
         )
     }
 
@@ -67,8 +67,7 @@ class IdeProtocolClient(
                     }
 
                     "jetbrains/isOSREnabled" -> {
-                        val isOSREnabled =
-                            ServiceManager.getService(ContinueExtensionSettings::class.java).continueState.enableOSR
+                        val isOSREnabled = service<ContinueExtensionSettings>().continueState.enableOSR
                         respond(isOSREnabled)
                     }
 

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/DiffStreamHandler.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/DiffStreamHandler.kt
@@ -7,7 +7,7 @@ import com.github.continuedev.continueintellijextension.services.ContinuePluginS
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.command.undo.UndoManager
-import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.components.service
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.markup.HighlighterLayer
 import com.intellij.openapi.editor.markup.RangeHighlighter
@@ -42,7 +42,6 @@ class DiffStreamHandler(
     private var isRunning: Boolean = false
     private var hasAcceptedOrRejectedBlock: Boolean = false
     private val unfinishedHighlighters: MutableList<RangeHighlighter> = mutableListOf()
-    private val continuePluginService = ServiceManager.getService(project, ContinuePluginService::class.java)
     private val virtualFile = FileDocumentManager.getInstance().getFile(editor.document)
 
 
@@ -62,10 +61,10 @@ class DiffStreamHandler(
             numDiffs = diffBlocks.size,
             filepath = virtualFile?.url,
             fileContent = "not implemented",
-            toolCallId = toolCallId?.toString()
+            toolCallId = toolCallId
         )
 
-        continuePluginService.sendToWebview("updateApplyState", payload)
+        project.service<ContinuePluginService>().sendToWebview("updateApplyState", payload)
     }
 
     fun acceptAll() {
@@ -102,7 +101,7 @@ class DiffStreamHandler(
         isRunning = true
         sendUpdate(ApplyStateStatus.STREAMING)
 
-        continuePluginService.coreMessenger?.request(
+        project.service<ContinuePluginService>().coreMessenger?.request(
             "streamDiffLines",
             StreamDiffLinesPayload(
                 input = input,

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/services/ContinueExtensionSettingsService.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/services/ContinueExtensionSettingsService.kt
@@ -111,7 +111,7 @@ open class ContinueExtensionSettings : PersistentStateComponent<ContinueExtensio
 
     companion object {
         val instance: ContinueExtensionSettings
-            get() = ServiceManager.getService(ContinueExtensionSettings::class.java)
+            get() = service<ContinueExtensionSettings>()
     }
 
 

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinueBrowser.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinueBrowser.kt
@@ -9,30 +9,21 @@ import com.github.continuedev.continueintellijextension.utils.uuid
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
+import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.intellij.ui.jcef.*
 import com.intellij.ui.jcef.JBCefClient.Properties
-import com.intellij.util.application
 import org.cef.CefApp
 import org.cef.browser.CefBrowser
 import org.cef.handler.CefLoadHandlerAdapter
 
 class ContinueBrowser(val project: Project, url: String) {
-    private fun registerAppSchemeHandler() {
-        CefApp.getInstance().registerSchemeHandlerFactory(
-            "http",
-            "continue",
-            CustomSchemeHandlerFactory()
-        )
-    }
 
     val browser: JBCefBrowser
 
-    val continuePluginService: ContinuePluginService = project.getService(ContinuePluginService::class.java)
-
     init {
-        val isOSREnabled = application.getService(ContinueExtensionSettings::class.java).continueState.enableOSR
+        val isOSREnabled = service<ContinueExtensionSettings>().continueState.enableOSR
 
         this.browser = JBCefBrowser.createBuilder().setOffScreenRendering(isOSREnabled).build().apply {
             // To avoid using System.setProperty to affect other plugins,
@@ -43,7 +34,7 @@ class ContinueBrowser(val project: Project, url: String) {
         }
 
         registerAppSchemeHandler()
-        Disposer.register(ContinuePluginDisposable.getInstance(project), browser)
+        Disposer.register(project.service<ContinuePluginDisposable>(), browser)
 
         // Listen for events sent from browser
         val myJSQueryOpenInBrowser = JBCefJSQuery.create((browser as JBCefBrowserBase?)!!)
@@ -60,7 +51,7 @@ class ContinueBrowser(val project: Project, url: String) {
             }
 
             if (PASS_THROUGH_TO_CORE.contains(messageType)) {
-                continuePluginService.coreMessenger?.request(messageType, data, messageId, respond)
+                project.service<ContinuePluginService>().coreMessenger?.request(messageType, data, messageId, respond)
                 return@addHandler null
             }
 
@@ -75,7 +66,7 @@ class ContinueBrowser(val project: Project, url: String) {
             }
 
             if (msg != null) {
-                continuePluginService.ideProtocolClient?.handleMessage(msg, respondToWebview)
+                project.service<ContinuePluginService>().ideProtocolClient?.handleMessage(msg, respondToWebview)
             }
 
             null
@@ -99,7 +90,7 @@ class ContinueBrowser(val project: Project, url: String) {
         // Load the url only after the protocolClient is initialized,
         // otherwise some messages will be lost, which are some configurations when the page is loaded.
         // Moreover, we should add LoadHandler before loading the url.
-        continuePluginService.onProtocolClientInitialized {
+        project.service<ContinuePluginService>().onProtocolClientInitialized {
             browser.loadURL(url)
         }
 
@@ -136,6 +127,14 @@ class ContinueBrowser(val project: Project, url: String) {
         } catch (error: IllegalStateException) {
             println("Webview not initialized yet $error")
         }
+    }
+
+    private fun registerAppSchemeHandler() {
+        CefApp.getInstance().registerSchemeHandlerFactory(
+            "http",
+            "continue",
+            CustomSchemeHandlerFactory()
+        )
     }
 
     private fun buildJavaScript(jsonData: String): String {

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinuePluginToolWindowFactory.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinuePluginToolWindowFactory.kt
@@ -3,13 +3,13 @@ package com.github.continuedev.continueintellijextension.toolWindow
 import com.github.continuedev.continueintellijextension.services.ContinuePluginService
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.AnAction
-import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.components.service
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
 import com.intellij.ui.content.ContentFactory
-import javax.swing.*
+import javax.swing.JComponent
 
 const val JS_QUERY_POOL_SIZE = "200"
 
@@ -52,9 +52,7 @@ class ContinuePluginToolWindowFactory : ToolWindowFactory, DumbAware {
       val url = System.getenv("GUI_URL")?.toString() ?: defaultGUIUrl
 
       val browser = ContinueBrowser(project, url)
-      val continuePluginService =
-          ServiceManager.getService(project, ContinuePluginService::class.java)
-      continuePluginService.continuePluginWindow = this
+      project.service<ContinuePluginService>().continuePluginWindow = this
       browser
     }
 


### PR DESCRIPTION
## Description

Motivation: We should never acquire service instances prematurely or store them in fields for later use. This is considered as bad practice due to potential memory leaks. More details: https://plugins.jetbrains.com/docs/intellij/plugin-services.html#retrieving-a-service

FYI there's a nice extension method for retrieving services like `project.service<MyService>` or `service<MyService>` for application-level services (like Continue settings). I've applied this everywhere.

This fix is somewhat related to #5819