### PR TITLE
fix: prevent focus out on mod backspace in chat area

### DIFF
--- a/gui/src/pages/gui/Chat.tsx
+++ b/gui/src/pages/gui/Chat.tsx
@@ -42,12 +42,12 @@ import {
   setDialogMessage,
   setShowDialog,
 } from "../../redux/slices/uiSlice";
-import { cancelStream } from "../../redux/thunks/cancelStream";
 import { streamEditThunk } from "../../redux/thunks/edit";
 import { loadLastSession } from "../../redux/thunks/session";
 import { streamResponseThunk } from "../../redux/thunks/streamResponse";
 import { isJetBrains, isMetaEquivalentKeyPressed } from "../../util";
 
+import { cancelStream } from "../../redux/thunks/cancelStream";
 import { getLocalStorage, setLocalStorage } from "../../util/localStorage";
 import { EmptyChatBody } from "./EmptyChatBody";
 import { ExploreDialogWatcher } from "./ExploreDialogWatcher";
@@ -125,14 +125,14 @@ export function Chat() {
 
   useEffect(() => {
     // Cmd + Backspace to delete current step
-    const listener = (e: any) => {
+    const listener = (e: KeyboardEvent) => {
       if (
         e.key === "Backspace" &&
         (jetbrains ? e.altKey : isMetaEquivalentKeyPressed(e)) &&
         !e.shiftKey
       ) {
-        dispatch(cancelStream());
-        ideMessenger.post("rejectDiff", {}); // just always cancel, if not in applying won't matter
+        void dispatch(cancelStream());
+        if (isInEdit) ideMessenger.post("rejectDiff", {});
       }
     };
     window.addEventListener("keydown", listener);
@@ -140,7 +140,7 @@ export function Chat() {
     return () => {
       window.removeEventListener("keydown", listener);
     };
-  }, [isStreaming, jetbrains]);
+  }, [isStreaming, jetbrains, isInEdit]);
 
   const { widget, highlights } = useFindWidget(
     stepsDivRef,

--- a/gui/src/util/index.ts
+++ b/gui/src/util/index.ts
@@ -1,12 +1,12 @@
 import { MessageModes, ModelDescription } from "core";
 import { ProfileDescription } from "core/config/ProfileLifecycleManager";
-import _ from "lodash";
-import { KeyboardEvent } from "react";
-import { getLocalStorage } from "./localStorage";
 import {
-  DEFAULT_CHAT_SYSTEM_MESSAGE,
   DEFAULT_AGENT_SYSTEM_MESSAGE,
+  DEFAULT_CHAT_SYSTEM_MESSAGE,
 } from "core/llm/constructMessages";
+import _ from "lodash";
+import { KeyboardEvent as ReactKeyboardEvent } from "react";
+import { getLocalStorage } from "./localStorage";
 
 export type Platform = "mac" | "linux" | "windows" | "unknown";
 
@@ -26,7 +26,7 @@ export function getPlatform(): Platform {
 export function isMetaEquivalentKeyPressed({
   metaKey,
   ctrlKey,
-}: KeyboardEvent): boolean {
+}: KeyboardEvent | ReactKeyboardEvent): boolean {
   const platform = getPlatform();
   switch (platform) {
     case "mac":


### PR DESCRIPTION
## Description

Earlier when doing cmd + backspace in the chat area, the editor would be automatically focused. This would let the user to focus back again on the chat area.
This PR adds the functionality to prevent this.

- only do "rejectDiff" is the session is in edit mode

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots



https://github.com/user-attachments/assets/9f5fb6ed-9f74-4125-bdcf-b62cfd0be35c

https://github.com/user-attachments/assets/191e458e-1fad-4105-84ac-98f974a50830




## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
