### PR TITLE
Handle empty string json args

### DIFF
--- a/core/tools/parseArgs.ts
+++ b/core/tools/parseArgs.ts
@@ -4,7 +4,7 @@ export function safeParseToolCallArgs(
   toolCall: ToolCallDelta,
 ): Record<string, any> {
   try {
-    return JSON.parse(toolCall.function?.arguments ?? "{}");
+    return JSON.parse(toolCall.function?.arguments?.trim() || "{}");
   } catch (e) {
     console.error(
       `Failed to parse tool call arguments:\nTool call: ${toolCall.function?.name + " " + toolCall.id}\nArgs:${toolCall.function?.arguments}\n`,

--- a/gui/src/components/console/ResultGroup.tsx
+++ b/gui/src/components/console/ResultGroup.tsx
@@ -10,7 +10,11 @@ const ResultGroup = memo(function ResultGroup({ group }: ResultGroupProps) {
   return (
     <>
       {group.map((result, i) => (
-        <Result key={i} result={result} prevResult={group[i - 1]}></Result>
+        <Result
+          key={`${result.timestamp}-${i}`}
+          result={result}
+          prevResult={group[i - 1]}
+        ></Result>
       ))}
     </>
   );

--- a/packages/openai-adapters/src/util/parseArgs.ts
+++ b/packages/openai-adapters/src/util/parseArgs.ts
@@ -3,7 +3,7 @@ export function safeParseArgs(
   errorId?: string,
 ): Record<string, any> {
   try {
-    return JSON.parse(args ?? "{}");
+    return JSON.parse(args?.trim() || "{}");
   } catch (e) {
     const identifier = errorId ? `Call: ${errorId}\nArgs:${args}\n` : "";
     console.error(


### PR DESCRIPTION
## Description
- handle empty args that have whitespace
- fix map key issue

These are both to just prevent error logging to the console, they don't change behavior