### PR TITLE
toolUsage devdata events

### DIFF
--- a/core/core.ts
+++ b/core/core.ts
@@ -809,7 +809,7 @@ export class Core {
       this.messenger.send("toolCallPartialOutput", params);
     };
 
-    return await callTool(tool, toolCall, {
+    const result = await callTool(tool, toolCall, {
       config,
       ide: this.ide,
       llm: config.selectedModelByRole.chat,
@@ -820,6 +820,14 @@ export class Core {
       onPartialOutput,
       codeBaseIndexer: this.codeBaseIndexer,
     });
+
+    this.messenger.send("toolCallCompleted", {
+      toolCallId: toolCall.id,
+      contextItems: result.contextItems,
+      succeeded: !result.errorMessage,
+    });
+
+    return result;
   }
 
   private async isItemTooBig(item: ContextItemWithId) {

--- a/core/protocol/webview.ts
+++ b/core/protocol/webview.ts
@@ -43,5 +43,9 @@ export type ToWebviewFromIdeOrCoreProtocol = {
   "jetbrains/setColors": [Record<string, string | null | undefined>, void];
   sessionUpdate: [{ sessionInfo: ControlPlaneSessionInfo | undefined }, void];
   toolCallPartialOutput: [{ toolCallId: string; contextItems: any[] }, void];
+  toolCallCompleted: [
+    { toolCallId: string; contextItems: any[]; succeeded: boolean },
+    void,
+  ];
   freeTrialExceeded: [undefined, void];
 };

--- a/gui/src/hooks/ParallelListeners.tsx
+++ b/gui/src/hooks/ParallelListeners.tsx
@@ -27,10 +27,13 @@ import { setTTSActive } from "../redux/slices/uiSlice";
 import { exitEdit } from "../redux/thunks/edit";
 import { streamResponseAfterToolCall } from "../redux/thunks/streamResponseAfterToolCall";
 
+import { safeParseToolCallArgs } from "core/tools/parseArgs";
+import { store } from "../redux/store";
 import { cancelStream } from "../redux/thunks/cancelStream";
 import { refreshSessionMetadata } from "../redux/thunks/session";
 import { streamResponseThunk } from "../redux/thunks/streamResponse";
 import { updateFileSymbolsFromHistory } from "../redux/thunks/updateFileSymbols";
+import { findToolCall } from "../redux/util";
 import {
   setDocumentStylesFromLocalStorage,
   setDocumentStylesFromTheme,
@@ -283,6 +286,32 @@ function ParallelListeners() {
       }
     },
     [currentToolCallApplyState, history],
+  );
+
+  useWebviewListener(
+    "toolCallCompleted",
+    async (data) => {
+      const state = store.getState();
+      const toolCallState = findToolCall(
+        state.session.history,
+        data.toolCallId,
+      );
+      if (toolCallState) {
+        ideMessenger.post("devdata/log", {
+          name: "toolUsage",
+          data: {
+            toolCallId: toolCallState.toolCallId,
+            functionName: toolCallState.toolCall.function.name,
+            functionArgs: toolCallState.toolCall.function.arguments,
+            toolCallArgs: safeParseToolCallArgs(toolCallState.toolCall),
+            parsedArgs: toolCallState.parsedArgs,
+            output: data.contextItems,
+            succeeded: data.succeeded,
+          },
+        });
+      }
+    },
+    [ideMessenger, store],
   );
 
   useEffect(() => {

--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -18,9 +18,7 @@ import {
   RuleWithSource,
   Session,
   SessionMetadata,
-  ToolCallState,
 } from "core";
-import { safeParseToolCallArgs } from "core/tools/parseArgs";
 import { NEW_SESSION_TITLE } from "core/util/constants";
 import { renderChatMessage } from "core/util/messageContent";
 import { findUriInDirs, getUriPathBasename } from "core/util/uri";
@@ -31,23 +29,6 @@ import { streamResponseThunk } from "../thunks/streamResponse";
 import { findCurrentToolCall, findToolCall } from "../util";
 
 const getIdeMessenger = () => (window as any).ideMessenger;
-
-const logToolUsage = (toolCallState: ToolCallState, success: boolean) => {
-  const ideMessenger = getIdeMessenger();
-  if (ideMessenger) {
-    ideMessenger.post("devdata/log", {
-      name: "toolUsage",
-      data: {
-        toolCallId: toolCallState.toolCallId,
-        functionName: toolCallState.toolCall.function.name,
-        functionArgs: toolCallState.toolCall.function.arguments,
-        parsedArgs: safeParseToolCallArgs(toolCallState.toolCall),
-        succeeded: success,
-        output: toolCallState.output || [],
-      },
-    });
-  }
-};
 
 // We need this to handle reorderings (e.g. a mid-array deletion) of the messages array.
 // The proper fix is adding a UUID to all chat messages, but this is the temp workaround.
@@ -580,7 +561,6 @@ export const sessionSlice = createSlice({
       );
       if (toolCallState) {
         toolCallState.status = "errored";
-        logToolUsage(toolCallState, false);
       }
     },
     acceptToolCall: (
@@ -595,7 +575,6 @@ export const sessionSlice = createSlice({
       );
       if (toolCallState) {
         toolCallState.status = "done";
-        logToolUsage(toolCallState, true);
       }
     },
     setToolCallCalling: (

--- a/packages/config-yaml/src/schemas/data/toolUsage/index.ts
+++ b/packages/config-yaml/src/schemas/data/toolUsage/index.ts
@@ -5,6 +5,7 @@ export const toolUsageEventAllSchema = baseDevDataAllSchema.extend({
   toolCallId: z.string(),
   functionName: z.string(),
   functionArgs: z.string(),
+  toolCallArgs: z.any(),
   parsedArgs: z.any(),
   succeeded: z.boolean(),
   output: z.array(z.any()).optional(),

--- a/packages/config-yaml/src/schemas/data/toolUsage/v0.2.0.ts
+++ b/packages/config-yaml/src/schemas/data/toolUsage/v0.2.0.ts
@@ -13,6 +13,7 @@ export const toolUsageEventSchema_0_2_0 = toolUsageEventAllSchema.pick({
   toolCallId: true,
   functionName: true,
   functionArgs: true,
+  toolCallArgs: true,
   parsedArgs: true,
   succeeded: true,
   output: true,


### PR DESCRIPTION
## Description

Added dev data for tool usage. This was previously introduced (incorrectly) in #6299 and reverted in #6314 .

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created