### PR TITLE
Improve UI for tool calls that only have one context item

### DIFF
--- a/gui/src/components/mainInput/belowMainInput/ContextItemsPeek.tsx
+++ b/gui/src/components/mainInput/belowMainInput/ContextItemsPeek.tsx
@@ -4,7 +4,10 @@ import { ctxItemToRifWithContents } from "core/commands/util";
 import { getUriPathBasename } from "core/util/uri";
 import { ComponentType, useContext, useMemo } from "react";
 import { AnimatedEllipsis } from "../..";
-import { IdeMessengerContext } from "../../../context/IdeMessenger";
+import {
+  IdeMessengerContext,
+  IIdeMessenger,
+} from "../../../context/IdeMessenger";
 import { useAppSelector } from "../../../redux/hooks";
 import { selectIsGatheringContext } from "../../../redux/slices/sessionSlice";
 import FileIcon from "../../FileIcon";
@@ -24,32 +27,35 @@ interface ContextItemsPeekItemProps {
   contextItem: ContextItemWithId;
 }
 
+export function openContextItem(
+  contextItem: ContextItemWithId,
+  ideMessenger: IIdeMessenger,
+) {
+  const { uri, name, content } = contextItem;
+
+  if (uri && uri?.type === "file") {
+    const isRangeInFile = name.includes(" (") && name.endsWith(")");
+
+    if (isRangeInFile) {
+      const rif = ctxItemToRifWithContents(contextItem, true);
+      void ideMessenger.ide.showLines(
+        rif.filepath,
+        rif.range.start.line,
+        rif.range.end.line,
+      );
+    } else {
+      void ideMessenger.ide.openFile(uri.value);
+    }
+  } else {
+    void ideMessenger.ide.showVirtualFile(name, content);
+  }
+}
+
 export function ContextItemsPeekItem({
   contextItem,
 }: ContextItemsPeekItemProps) {
   const ideMessenger = useContext(IdeMessengerContext);
   const isUrl = contextItem.uri?.type === "url";
-
-  function openContextItem() {
-    const { uri, name, content } = contextItem;
-
-    if (uri && uri?.type === "file") {
-      const isRangeInFile = name.includes(" (") && name.endsWith(")");
-
-      if (isRangeInFile) {
-        const rif = ctxItemToRifWithContents(contextItem, true);
-        void ideMessenger.ide.showLines(
-          rif.filepath,
-          rif.range.start.line,
-          rif.range.end.line,
-        );
-      } else {
-        void ideMessenger.ide.openFile(uri.value);
-      }
-    } else {
-      void ideMessenger.ide.showVirtualFile(name, content);
-    }
-  }
 
   function getContextItemIcon() {
     const dimensions = "18px";
@@ -116,7 +122,7 @@ export function ContextItemsPeekItem({
 
   return (
     <div
-      onClick={openContextItem}
+      onClick={() => openContextItem(contextItem, ideMessenger)}
       className="group mr-2 flex cursor-pointer items-center overflow-hidden text-ellipsis whitespace-nowrap rounded px-1.5 py-1 text-xs hover:bg-white/10"
       data-testid="context-items-peek-item"
     >

--- a/gui/src/pages/gui/ToolCallDiv/SimpleToolCallUI.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/SimpleToolCallUI.tsx
@@ -1,7 +1,11 @@
 import { ChevronRightIcon } from "@heroicons/react/24/outline";
 import { ContextItemWithId, Tool, ToolCallState } from "core";
-import { ComponentType, useMemo, useState } from "react";
-import { ContextItemsPeekItem } from "../../../components/mainInput/belowMainInput/ContextItemsPeek";
+import { ComponentType, useContext, useMemo, useState } from "react";
+import {
+  ContextItemsPeekItem,
+  openContextItem,
+} from "../../../components/mainInput/belowMainInput/ContextItemsPeek";
+import { IdeMessengerContext } from "../../../context/IdeMessenger";
 import { ArgsItems, ArgsToggleIcon } from "./ToolCallArgs";
 import { ToolCallStatusMessage } from "./ToolCallStatusMessage";
 
@@ -18,66 +22,99 @@ export function SimpleToolCallUI({
   toolCallState,
   tool,
 }: SimpleToolCallUIProps) {
+  const ideMessenger = useContext(IdeMessengerContext);
+
   const ctxItems = useMemo(() => {
     return contextItems?.filter((ctxItem) => !ctxItem.hidden) ?? [];
   }, [contextItems]);
 
   const [open, setOpen] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
-
   const [showingArgs, setShowingArgs] = useState(false);
 
   const args: [string, any][] = useMemo(() => {
     return Object.entries(toolCallState.parsedArgs);
   }, [toolCallState.parsedArgs]);
 
+  const isToggleable = ctxItems.length > 1;
+  const isSingleItem = ctxItems.length === 1;
+  const shouldShowContent = isToggleable ? open : false;
+  const isClickable = isToggleable || isSingleItem;
+
+  function handleClick() {
+    if (isToggleable) {
+      setOpen((prev) => !prev);
+    } else if (isSingleItem) {
+      openContextItem(ctxItems[0], ideMessenger);
+    }
+  }
+
+  function renderIcon() {
+    if (!Icon && !isToggleable) {
+      return null;
+    }
+
+    if (isToggleable) {
+      const showChevron = isHovered || shouldShowContent;
+      return showChevron ? (
+        <ChevronRightIcon
+          className={`text-description h-4 w-4 transition-transform duration-200 ease-in-out ${
+            shouldShowContent ? "rotate-90" : "rotate-0"
+          }`}
+        />
+      ) : (
+        Icon && <Icon className="text-description h-4 w-4" />
+      );
+    }
+
+    return Icon ? <Icon className="text-description h-4 w-4" /> : null;
+  }
+
   return (
     <div className="flex flex-col pl-5 pr-2 pt-4">
       <div className="flex min-w-0 flex-row items-center justify-between gap-2">
         <div
-          className="text-description flex min-w-0 cursor-pointer flex-row items-center justify-between gap-1.5 text-xs transition-colors duration-200 ease-in-out hover:brightness-125"
-          onClick={() => setOpen((prev) => !prev)}
-          onMouseEnter={() => setIsHovered(true)}
-          onMouseLeave={() => setIsHovered(false)}
+          className={`text-description flex min-w-0 flex-row items-center justify-between gap-1.5 text-xs transition-colors duration-200 ease-in-out ${
+            isClickable ? "cursor-pointer hover:brightness-125" : ""
+          }`}
+          onClick={isClickable ? handleClick : undefined}
+          onMouseEnter={isToggleable ? () => setIsHovered(true) : undefined}
+          onMouseLeave={isToggleable ? () => setIsHovered(false) : undefined}
           data-testid="context-items-peek"
         >
           <div className="flex h-4 w-4 flex-shrink-0 flex-col items-center justify-center">
-            {Icon && !isHovered && !open ? (
-              <Icon className={`text-description h-4 w-4`} />
-            ) : (
-              <ChevronRightIcon
-                className={`text-description h-4 w-4 transition-transform duration-200 ease-in-out ${
-                  open ? "rotate-90" : "rotate-0"
-                }`}
-              />
-            )}
+            {renderIcon()}
           </div>
           <ToolCallStatusMessage tool={tool} toolCallState={toolCallState} />
         </div>
-        {args.length > 0 ? (
+        {args.length > 0 && (
           <ArgsToggleIcon
             isShowing={showingArgs}
             setIsShowing={setShowingArgs}
             toolCallId={toolCallState.toolCallId}
           />
-        ) : null}
-      </div>
-      <ArgsItems args={args} isShowing={showingArgs} />
-      <div
-        className={`mt-2 overflow-y-auto transition-all duration-300 ease-in-out ${
-          open ? "max-h-[50vh] opacity-100" : "max-h-0 opacity-0"
-        }`}
-      >
-        {ctxItems.length ? (
-          ctxItems.map((contextItem, idx) => (
-            <ContextItemsPeekItem key={idx} contextItem={contextItem} />
-          ))
-        ) : (
-          <div className="text-description pl-5 text-xs italic">
-            No tool call output
-          </div>
         )}
       </div>
+
+      <ArgsItems args={args} isShowing={showingArgs} />
+
+      {isToggleable && (
+        <div
+          className={`mt-2 overflow-y-auto transition-all duration-300 ease-in-out ${
+            shouldShowContent ? "max-h-[50vh] opacity-100" : "max-h-0 opacity-0"
+          }`}
+        >
+          {ctxItems.length > 0 ? (
+            ctxItems.map((contextItem, idx) => (
+              <ContextItemsPeekItem key={idx} contextItem={contextItem} />
+            ))
+          ) : (
+            <div className="text-description pl-5 text-xs italic">
+              No tool call output
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Description

For tool calls with a single context item, don't show the dropdown

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Tests

Just UI changed, I don't think tests are so helpful here
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the tool call UI to hide the dropdown when there is only one context item, making it clickable instead.

- **UI Improvements**
  - Shows a dropdown only when there are multiple context items.
  - Clicking a single context item now opens it directly.

<!-- End of auto-generated description by cubic. -->

