### PR TITLE
New rule to enfore that EditAggregator is a singleton

### DIFF
--- a/.continue/rules/edit-aggregator-singleton-rule.md
+++ b/.continue/rules/edit-aggregator-singleton-rule.md
@@ -1,0 +1,8 @@
+---
+patterns: ["EditAggregator", "processEdit"]
+glob: "**/*.tsx"
+name: "Enforce EditAggregator Singleton"
+description: "Ensure that EditAggregator is used as a singleton in the codebase."
+---
+
+When you encounter usage of EditAggregator, be sure that this is compatible with the singleton nature of the EditAggregator class. If you are creating a new instance of EditAggregator, you should instead use the existing singleton. Refer to the `aggregateEdits.ts` to examine how the singleton pattern is used. Do not create a new instance of EditAggregator.


### PR DESCRIPTION
## Description

Pattern rule to make sure EditAggegator is always used as a singleton class.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a new pattern rule to enforce that EditAggregator is always used as a singleton and not instantiated directly. This helps prevent bugs from multiple instances.

- **New Rule**
 - Scans for EditAggregator usage and warns if a new instance is created instead of using the singleton.

<!-- End of auto-generated description by cubic. -->

