### PR TITLE
fix: :bug: Fix for the ellipsis animation part deux

### DIFF
--- a/gui/src/components/index.ts
+++ b/gui/src/components/index.ts
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled, { keyframes } from "styled-components";
 import { varWithFallback } from "../styles/theme";
 
 export const defaultBorderRadius = "5px";
@@ -197,30 +197,20 @@ export const CloseButton = styled.button`
   cursor: pointer;
 `;
 
+const ellipsisAnimation = keyframes`
+  0% { width: 0; }
+  33% { width: 0.33em; }
+  66% { width: 0.66em; }
+  100% { width: 1em; }
+`;
+
 export const AnimatedEllipsis = styled.span`
   &::after {
-    content: ".";
-    animation: ellipsis 2.5s infinite;
-    animation-fill-mode: forwards;
-    animation-play-state: running;
-    will-change: content;
+    content: "...";
     display: inline-block;
-    width: 16px;
-    text-align: left;
-  }
-
-  @keyframes ellipsis {
-    0% {
-      content: ".";
-    }
-    33% {
-      content: "..";
-    }
-    66% {
-      content: "...";
-    }
-    100% {
-      content: ".";
-    }
+    overflow: hidden;
+    vertical-align: bottom;
+    animation: ${ellipsisAnimation} 2s infinite;
+    width: 0;
   }
 `;


### PR DESCRIPTION
## Description

I fixed the animation for the ellipsis previously but it appears with a recent change it has broken again. This is a second fix to get it animating again.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

I've visually inspected the annimation is functioning as expected.
