### PR TITLE
chore: conditional tooltip on reasoning btn

### DIFF
--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -167,7 +167,9 @@ function InputToolbar(props: InputToolbarProps) {
                 />
 
                 <ToolTip id="model-reasoning-tooltip" place="top">
-                  Use Model Reasoning
+                  {hasReasoningEnabled
+                    ? "Disable model reasoning"
+                    : "Enable model reasoning"}
                 </ToolTip>
               </HoverItem>
             )}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the tooltip on the reasoning button to show "Enable model reasoning" or "Disable model reasoning" based on its current state.

<!-- End of auto-generated description by cubic. -->

