### PR TITLE
watsonx - handle tool calling

### DIFF
--- a/core/llm/llms/WatsonX.ts
+++ b/core/llm/llms/WatsonX.ts
@@ -84,17 +84,20 @@ class WatsonX extends BaseLLM {
 
   protected _convertMessage(message: ChatMessage) {
     let message_ = message as any;
-    if (message_.role == "tool") {
+    if (message_.role === "tool") {
       message_.tool_call_id = (message as ToolResultChatMessage).toolCallId;
       delete message_.toolCallId;
-    } else if (message.role == "assistant" && !!message.toolCalls) {
+    } else if (message.role === "assistant" && !!message.toolCalls) {
       message_.tool_calls = message.toolCalls.map((t) => ({
         ...t,
         type: "function",
       }));
       delete message_.toolCalls;
       delete message_.content;
-    } else if (message_.role == "user" && typeof message_.content == "string") {
+    } else if (
+      message_.role === "user" &&
+      typeof message_.content === "string"
+    ) {
       message_.content = [{ type: "text", text: message_.content }];
     }
     return message_;
@@ -301,7 +304,7 @@ class WatsonX extends BaseLLM {
           if (!!toolName) {
             accumulatedToolCallingChunks = "";
 
-            if (value?.choices?.[0]?.finish_reason == "tool_calls") {
+            if (value?.choices?.[0]?.finish_reason === "tool_calls") {
               // If final assistant message has "tool_calls" as finish_reason
               let args: string | undefined;
               try {


### PR DESCRIPTION
## Description

Add tool calling support for watsonx. 
Handle both structured outputs and parsable streamed outputs.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added tool calling support to watsonx, allowing it to handle both structured and streamed tool call outputs.

- **New Features**
  - Parses and accumulates tool call data from assistant responses.
  - Supports tool calling for both structured and unstructured output formats.

<!-- End of auto-generated description by cubic. -->

