### PR TITLE
refactor: wrap rules with application reasons in tuple structure

### DIFF
--- a/core/config/markdown/ruleCollocationApplication.vitest.ts
+++ b/core/config/markdown/ruleCollocationApplication.vitest.ts
@@ -161,19 +161,19 @@ describe("Rule Colocation Application", () => {
         rules,
         [componentTsxContextItem],
       );
-      expect(applicableRules.map((r) => r.name)).toContain("Root Rule");
+      expect(applicableRules.map((r) => r.rule.name)).toContain("Root Rule");
 
       // Test with redux file
       applicableRules = getApplicableRules(userMessageWithReduxFile, rules, [
         reduxContextItem,
       ]);
-      expect(applicableRules.map((r) => r.name)).toContain("Root Rule");
+      expect(applicableRules.map((r) => r.rule.name)).toContain("Root Rule");
 
       // Test with root-level file
       applicableRules = getApplicableRules(userMessageWithRootFile, rules, [
         rootContextItem,
       ]);
-      expect(applicableRules.map((r) => r.name)).toContain("Root Rule");
+      expect(applicableRules.map((r) => r.rule.name)).toContain("Root Rule");
     });
   });
 
@@ -194,7 +194,7 @@ describe("Rule Colocation Application", () => {
         [impliedComponentRule],
         [componentTsxContextItem],
       );
-      expect(applicableRules.map((r) => r.name)).toContain(
+      expect(applicableRules.map((r) => r.rule.name)).toContain(
         "Implied Components Rule",
       );
 
@@ -207,7 +207,7 @@ describe("Rule Colocation Application", () => {
       );
 
       // THIS WILL FAIL - Current implementation doesn't restrict by directory
-      expect(applicableRules.map((r) => r.name)).not.toContain(
+      expect(applicableRules.map((r) => r.rule.name)).not.toContain(
         "Implied Components Rule",
       );
 
@@ -220,7 +220,7 @@ describe("Rule Colocation Application", () => {
       );
 
       // THIS WILL FAIL - Current implementation doesn't restrict by directory
-      expect(applicableRules.map((r) => r.name)).not.toContain(
+      expect(applicableRules.map((r) => r.rule.name)).not.toContain(
         "Implied Components Rule",
       );
     });
@@ -243,7 +243,7 @@ describe("Rule Colocation Application", () => {
         [typescriptComponentRule],
         [componentTsxContextItem],
       );
-      expect(applicableRules.map((r) => r.name)).toContain(
+      expect(applicableRules.map((r) => r.rule.name)).toContain(
         "TypeScript Component Rule",
       );
 
@@ -254,7 +254,7 @@ describe("Rule Colocation Application", () => {
         [typescriptComponentRule],
         [componentJsxContextItem],
       );
-      expect(applicableRules.map((r) => r.name)).not.toContain(
+      expect(applicableRules.map((r) => r.rule.name)).not.toContain(
         "TypeScript Component Rule",
       );
 
@@ -267,7 +267,7 @@ describe("Rule Colocation Application", () => {
       );
 
       // THIS WILL FAIL - Current impl only checks file extension, not directory
-      expect(applicableRules.map((r) => r.name)).not.toContain(
+      expect(applicableRules.map((r) => r.rule.name)).not.toContain(
         "TypeScript Component Rule",
       );
     });
@@ -290,7 +290,7 @@ describe("Rule Colocation Application", () => {
         [apiUtilsRule],
         [apiUtilContextItem],
       );
-      expect(applicableRules.map((r) => r.name)).toContain("API Utils Rule");
+      expect(applicableRules.map((r) => r.rule.name)).toContain("API Utils Rule");
 
       // Test with TS file in general utils directory - should NOT apply
       // This test will fail because current implementation doesn't consider directory boundaries
@@ -301,7 +301,7 @@ describe("Rule Colocation Application", () => {
       );
 
       // THIS WILL FAIL - Current impl only checks file extension, not directory
-      expect(applicableRules.map((r) => r.name)).not.toContain(
+      expect(applicableRules.map((r) => r.rule.name)).not.toContain(
         "API Utils Rule",
       );
     });
@@ -364,10 +364,10 @@ describe("Rule Colocation Application", () => {
 
       // These assertions will fail with current implementation
       // but represent the desired behavior
-      expect(applicableModelsRules.map((r) => r.name)).toContain(
+      expect(applicableModelsRules.map((r) => r.rule.name)).toContain(
         "Inferred Rule for src/models",
       );
-      expect(applicableModelsRules.map((r) => r.name)).not.toContain(
+      expect(applicableModelsRules.map((r) => r.rule.name)).not.toContain(
         "Inferred Rule for src/services",
       );
 
@@ -380,10 +380,10 @@ describe("Rule Colocation Application", () => {
 
       // These assertions will fail with current implementation
       // but represent the desired behavior
-      expect(applicableServicesRules.map((r) => r.name)).not.toContain(
+      expect(applicableServicesRules.map((r) => r.rule.name)).not.toContain(
         "Inferred Rule for src/models",
       );
-      expect(applicableServicesRules.map((r) => r.name)).toContain(
+      expect(applicableServicesRules.map((r) => r.rule.name)).toContain(
         "Inferred Rule for src/services",
       );
     });

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -461,7 +461,7 @@ export interface ChatHistoryItem {
   toolCallState?: ToolCallState;
   isGatheringContext?: boolean;
   reasoning?: Reasoning;
-  appliedRules?: RuleWithSource[];
+  appliedRules?: RuleWithApplicationReason[];
 }
 
 export interface LLMFullCompletionOptions extends BaseCompletionOptions {
@@ -1623,6 +1623,19 @@ export interface RuleWithSource {
   description?: string;
   ruleFile?: string;
   alwaysApply?: boolean;
+}
+
+export type RuleApplicationReason =
+  | "alwaysApply"
+  | "implicitGlobal"
+  | "globMatch"
+  | "regexMatch"
+  | "globAndRegexMatch"
+  | "directoryMatch";
+
+export interface RuleWithApplicationReason {
+  rule: RuleWithSource;
+  reason: RuleApplicationReason;
 }
 export interface CompleteOnboardingPayload {
   mode: OnboardingModes;

--- a/core/llm/constructMessages.ts
+++ b/core/llm/constructMessages.ts
@@ -2,6 +2,7 @@ import {
   ChatHistoryItem,
   ChatMessage,
   ContextItemWithId,
+  RuleWithApplicationReason,
   RuleWithSource,
   TextMessagePart,
   ToolResultChatMessage,
@@ -111,7 +112,7 @@ export function constructMessages(
   messageMode: string,
   history: ChatHistoryItem[],
   baseChatOrAgentSystemMessage: string | undefined,
-  rules: RuleWithSource[],
+  rulesWithReasons: RuleWithApplicationReason[],
   rulePolicies?: RulePolicies,
 ): ChatMessage[] {
   const filteredHistory = history.filter(
@@ -166,7 +167,7 @@ export function constructMessages(
   );
   const systemMessage = getSystemMessageWithRules({
     baseSystemMessage: baseChatOrAgentSystemMessage,
-    rules,
+    rules: rulesWithReasons.map(r => r.rule),
     userMessage: lastUserMsg,
     contextItems: lastUserContextItems,
     rulePolicies,

--- a/core/llm/rules/alwaysApply.vitest.ts
+++ b/core/llm/rules/alwaysApply.vitest.ts
@@ -112,7 +112,7 @@ describe("alwaysApply Behavior", () => {
     );
     expect(applicableRules).toHaveLength(1);
     expect(applicableRules[0].name).toBe("Conditional Rule");
-    expect(applicableRules.map((r) => r.name)).not.toContain(
+    expect(applicableRules.map((r) => r.rule.name)).not.toContain(
       "Never Apply Rule",
     );
 
@@ -153,7 +153,7 @@ describe("alwaysApply Behavior", () => {
     );
     expect(applicableRules).toHaveLength(1);
     expect(applicableRules[0].name).toBe("Default No Globs Rule");
-    expect(applicableRules.map((r) => r.name)).not.toContain(
+    expect(applicableRules.map((r) => r.rule.name)).not.toContain(
       "Default With Globs Rule",
     );
 
@@ -164,10 +164,10 @@ describe("alwaysApply Behavior", () => {
       [matchingFileContext],
     );
     expect(applicableRules).toHaveLength(2);
-    expect(applicableRules.map((r) => r.name)).toContain(
+    expect(applicableRules.map((r) => r.rule.name)).toContain(
       "Default No Globs Rule",
     );
-    expect(applicableRules.map((r) => r.name)).toContain(
+    expect(applicableRules.map((r) => r.rule.name)).toContain(
       "Default With Globs Rule",
     );
 
@@ -179,7 +179,7 @@ describe("alwaysApply Behavior", () => {
     );
     expect(applicableRules).toHaveLength(1);
     expect(applicableRules[0].name).toBe("Default No Globs Rule");
-    expect(applicableRules.map((r) => r.name)).not.toContain(
+    expect(applicableRules.map((r) => r.rule.name)).not.toContain(
       "Default With Globs Rule",
     );
   });

--- a/core/llm/rules/alwaysApplyRules.vitest.ts
+++ b/core/llm/rules/alwaysApplyRules.vitest.ts
@@ -42,10 +42,11 @@ describe("Rule application with alwaysApply", () => {
 
     // The always apply rule should be included regardless of context
     expect(applicableRules).toHaveLength(1);
-    expect(applicableRules.map((r) => r.name)).toContain("Always Apply Rule");
-    expect(applicableRules.map((r) => r.name)).not.toContain(
+    expect(applicableRules.map((r) => r.rule.name)).toContain("Always Apply Rule");
+    expect(applicableRules.map((r) => r.rule.name)).not.toContain(
       "Nested Directory Rule",
     );
+    expect(applicableRules.find(r => r.rule.name === "Always Apply Rule")?.reason).toBe("alwaysApply");
   });
 
   it("should apply nested directory rules to files in that directory", () => {
@@ -67,8 +68,8 @@ describe("Rule application with alwaysApply", () => {
 
     // Both rules should apply
     expect(applicableRules).toHaveLength(2);
-    expect(applicableRules.map((r) => r.name)).toContain("Always Apply Rule");
-    expect(applicableRules.map((r) => r.name)).toContain(
+    expect(applicableRules.map((r) => r.rule.name)).toContain("Always Apply Rule");
+    expect(applicableRules.map((r) => r.rule.name)).toContain(
       "Nested Directory Rule",
     );
   });
@@ -92,10 +93,11 @@ describe("Rule application with alwaysApply", () => {
 
     // Only the always apply rule should be included
     expect(applicableRules).toHaveLength(1);
-    expect(applicableRules.map((r) => r.name)).toContain("Always Apply Rule");
-    expect(applicableRules.map((r) => r.name)).not.toContain(
+    expect(applicableRules.map((r) => r.rule.name)).toContain("Always Apply Rule");
+    expect(applicableRules.map((r) => r.rule.name)).not.toContain(
       "Nested Directory Rule",
     );
+    expect(applicableRules.find(r => r.rule.name === "Always Apply Rule")?.reason).toBe("alwaysApply");
   });
 
   it("should correctly apply rules when a file is mentioned in a message", () => {
@@ -115,8 +117,8 @@ describe("Rule application with alwaysApply", () => {
 
     // Both rules should apply
     expect(applicableRules).toHaveLength(2);
-    expect(applicableRules.map((r) => r.name)).toContain("Always Apply Rule");
-    expect(applicableRules.map((r) => r.name)).toContain(
+    expect(applicableRules.map((r) => r.rule.name)).toContain("Always Apply Rule");
+    expect(applicableRules.map((r) => r.rule.name)).toContain(
       "Nested Directory Rule",
     );
   });
@@ -125,7 +127,7 @@ describe("Rule application with alwaysApply", () => {
     // Test with no message or context
     let applicableRules = getApplicableRules(undefined, [alwaysApplyRule], []);
     expect(applicableRules).toHaveLength(1);
-    expect(applicableRules.map((r) => r.name)).toContain("Always Apply Rule");
+    expect(applicableRules.map((r) => r.rule.name)).toContain("Always Apply Rule");
 
     // Test with message but no file references and no context
     const simpleMessage: UserChatMessage = {
@@ -135,7 +137,7 @@ describe("Rule application with alwaysApply", () => {
 
     applicableRules = getApplicableRules(simpleMessage, [alwaysApplyRule], []);
     expect(applicableRules).toHaveLength(1);
-    expect(applicableRules.map((r) => r.name)).toContain("Always Apply Rule");
+    expect(applicableRules.map((r) => r.rule.name)).toContain("Always Apply Rule");
   });
 
   it("should respect 'off' rulePolicies over alwaysApply when there are no file paths", () => {
@@ -169,6 +171,6 @@ describe("Rule application with alwaysApply", () => {
     );
 
     expect(applicableRules).toHaveLength(0);
-    expect(applicableRules.map((r) => r.name)).not.toContain("Global Rule");
+    expect(applicableRules.map((r) => r.rule.name)).not.toContain("Global Rule");
   });
 });

--- a/core/llm/rules/getSystemMessageWithRules.vitest.ts
+++ b/core/llm/rules/getSystemMessageWithRules.vitest.ts
@@ -398,7 +398,8 @@ describe("Content pattern matching", () => {
     );
 
     expect(applicableRules).toHaveLength(1);
-    expect(applicableRules[0].name).toBe("Arrow Function Rule");
+    expect(applicableRules[0].rule.name).toBe("Arrow Function Rule");
+    expect(applicableRules[0].reason).toBe("regexMatch");
 
     // Message with code block that doesn't match the pattern
     const messageWithoutArrowFn: UserChatMessage = {

--- a/core/llm/rules/implicitGlobalRules.vitest.ts
+++ b/core/llm/rules/implicitGlobalRules.vitest.ts
@@ -46,13 +46,13 @@ describe("Implicit global rules application", () => {
 
     // Both global rules should be included regardless of context
     expect(applicableRules).toHaveLength(2);
-    expect(applicableRules.map((r) => r.name)).toContain(
+    expect(applicableRules.map((r) => r.rule.name)).toContain(
       "Implicit Global Rule",
     );
-    expect(applicableRules.map((r) => r.name)).toContain(
+    expect(applicableRules.map((r) => r.rule.name)).toContain(
       "Explicit Global Rule",
     );
-    expect(applicableRules.map((r) => r.name)).not.toContain(
+    expect(applicableRules.map((r) => r.rule.name)).not.toContain(
       "Nested Directory Rule",
     );
   });
@@ -96,13 +96,13 @@ describe("Implicit global rules application", () => {
 
     // Should include all rules
     expect(applicableRules).toHaveLength(3);
-    expect(applicableRules.map((r) => r.name)).toContain(
+    expect(applicableRules.map((r) => r.rule.name)).toContain(
       "Implicit Global Rule",
     );
-    expect(applicableRules.map((r) => r.name)).toContain(
+    expect(applicableRules.map((r) => r.rule.name)).toContain(
       "Explicit Global Rule",
     );
-    expect(applicableRules.map((r) => r.name)).toContain(
+    expect(applicableRules.map((r) => r.rule.name)).toContain(
       "Nested Directory Rule",
     );
   });

--- a/core/llm/rules/nestedDirectoryRules.vitest.ts
+++ b/core/llm/rules/nestedDirectoryRules.vitest.ts
@@ -47,8 +47,8 @@ describe("Nested directory rules application", () => {
 
     // Both rules should apply
     expect(applicableRules).toHaveLength(2);
-    expect(applicableRules.map((r) => r.name)).toContain("Global Rule");
-    expect(applicableRules.map((r) => r.name)).toContain("Nested Folder Rule");
+    expect(applicableRules.map((r) => r.rule.name)).toContain("Global Rule");
+    expect(applicableRules.map((r) => r.rule.name)).toContain("Nested Folder Rule");
   });
 
   it("should also work with file references in messages", () => {
@@ -68,8 +68,8 @@ describe("Nested directory rules application", () => {
 
     // Both rules should apply
     expect(applicableRules).toHaveLength(2);
-    expect(applicableRules.map((r) => r.name)).toContain("Global Rule");
-    expect(applicableRules.map((r) => r.name)).toContain("Nested Folder Rule");
+    expect(applicableRules.map((r) => r.rule.name)).toContain("Global Rule");
+    expect(applicableRules.map((r) => r.rule.name)).toContain("Nested Folder Rule");
   });
 
   it("should NOT apply nested directory rules to files outside that directory", () => {
@@ -90,8 +90,8 @@ describe("Nested directory rules application", () => {
     );
 
     // Only the global rule should be included
-    expect(applicableRules.map((r) => r.name)).toContain("Global Rule");
-    expect(applicableRules.map((r) => r.name)).not.toContain(
+    expect(applicableRules.map((r) => r.rule.name)).toContain("Global Rule");
+    expect(applicableRules.map((r) => r.rule.name)).not.toContain(
       "Nested Folder Rule",
     );
   });
@@ -148,8 +148,8 @@ describe("Nested directory rules application", () => {
       [srcPythonRule, utilsPythonRule],
       [srcPythonFileContext],
     );
-    expect(applicableRules.map((r) => r.name)).toContain("Src Python Rule");
-    expect(applicableRules.map((r) => r.name)).not.toContain(
+    expect(applicableRules.map((r) => r.rule.name)).toContain("Src Python Rule");
+    expect(applicableRules.map((r) => r.rule.name)).not.toContain(
       "Utils Python Rule",
     );
 
@@ -159,8 +159,8 @@ describe("Nested directory rules application", () => {
       [srcPythonRule, utilsPythonRule],
       [utilsPythonFileContext],
     );
-    expect(applicableRules.map((r) => r.name)).not.toContain("Src Python Rule");
-    expect(applicableRules.map((r) => r.name)).toContain("Utils Python Rule");
+    expect(applicableRules.map((r) => r.rule.name)).not.toContain("Src Python Rule");
+    expect(applicableRules.map((r) => r.rule.name)).toContain("Utils Python Rule");
 
     // Apply both rules to manual-testing-sandbox file - should not match either
     applicableRules = getApplicableRules(
@@ -168,8 +168,8 @@ describe("Nested directory rules application", () => {
       [srcPythonRule, utilsPythonRule],
       [manualTestingPythonFileContext],
     );
-    expect(applicableRules.map((r) => r.name)).not.toContain("Src Python Rule");
-    expect(applicableRules.map((r) => r.name)).not.toContain(
+    expect(applicableRules.map((r) => r.rule.name)).not.toContain("Src Python Rule");
+    expect(applicableRules.map((r) => r.rule.name)).not.toContain(
       "Utils Python Rule",
     );
   });

--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -15,6 +15,7 @@ import {
   FileSymbolMap,
   MessageModes,
   PromptLog,
+  RuleWithApplicationReason,
   RuleWithSource,
   Session,
   SessionMetadata,
@@ -255,7 +256,7 @@ export const sessionSlice = createSlice({
         payload,
       }: PayloadAction<{
         index: number;
-        appliedRules: RuleWithSource[];
+        appliedRules: RuleWithApplicationReason[];
       }>,
     ) => {
       if (state.history[payload.index]) {

--- a/gui/src/redux/thunks/streamResponse.ts
+++ b/gui/src/redux/thunks/streamResponse.ts
@@ -103,7 +103,7 @@ export const streamResponseThunk = createAsyncThunk<
 
         // Calculate applicable rules once
         // We need to check the message type to match what getApplicableRules expects
-        const applicableRules = getApplicableRules(
+        const applicableRulesWithReasons = getApplicableRules(
           userMsg.role === "user" || userMsg.role === "tool"
             ? (userMsg as UserChatMessage | ToolResultChatMessage)
             : undefined,
@@ -116,7 +116,7 @@ export const streamResponseThunk = createAsyncThunk<
         dispatch(
           setAppliedRulesAtIndex({
             index: inputIndex,
-            appliedRules: applicableRules,
+            appliedRules: applicableRulesWithReasons,
           }),
         );
 
@@ -130,7 +130,7 @@ export const streamResponseThunk = createAsyncThunk<
           messageMode,
           [...updatedHistory],
           baseChatOrAgentSystemMessage,
-          applicableRules,
+          applicableRulesWithReasons,
           rulePolicies,
         );
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Refactored rule application logic to wrap each applied rule with its application reason in a tuple structure, making rule usage and debugging clearer across the codebase.

- **Refactors**
  - Introduced `RuleWithApplicationReason` type to pair each rule with its reason for application.
  - Updated all rule application, storage, and test logic to use the new tuple structure.

<!-- End of auto-generated description by cubic. -->

