### PR TITLE
Add @codebase as experimental tool for agent mode

### DIFF
--- a/core/tools/builtIn.ts
+++ b/core/tools/builtIn.ts
@@ -13,6 +13,7 @@ export enum BuiltInToolNames {
   CreateRuleBlock = "builtin_create_rule_block",
   RequestRule = "builtin_request_rule",
   FetchUrlContent = "builtin_fetch_url_content",
+  CodebaseTool = "builtin_codebase",
 
   // excluded from allTools for now
   ViewRepoMap = "builtin_view_repo_map",

--- a/core/tools/callTool.ts
+++ b/core/tools/callTool.ts
@@ -3,6 +3,7 @@ import { MCPManagerSingleton } from "../context/mcp/MCPManagerSingleton";
 import { canParseUrl } from "../util/url";
 import { BuiltInToolNames } from "./builtIn";
 
+import { codebaseToolImpl } from "./implementations/codebaseTool";
 import { createNewFileImpl } from "./implementations/createNewFile";
 import { createRuleBlockImpl } from "./implementations/createRuleBlock";
 import { fetchUrlContentImpl } from "./implementations/fetchUrlContent";
@@ -164,6 +165,8 @@ async function callBuiltInTool(
       return await createRuleBlockImpl(args, extras);
     case BuiltInToolNames.RequestRule:
       return await requestRuleImpl(args, extras);
+    case BuiltInToolNames.CodebaseTool:
+      return await codebaseToolImpl(args, extras);
     default:
       throw new Error(`Tool "${functionName}" not found`);
   }

--- a/core/tools/definitions/codebaseTool.ts
+++ b/core/tools/definitions/codebaseTool.ts
@@ -1,0 +1,29 @@
+import { Tool } from "../..";
+import { BUILT_IN_GROUP_NAME, BuiltInToolNames } from "../builtIn";
+
+export const codebaseTool: Tool = {
+  type: "function",
+  displayTitle: "Codebase Search",
+  wouldLikeTo: "search the codebase for: {{{ query }}}",
+  isCurrently: "searching the codebase for: {{{ query }}}",
+  hasAlready: "searched the codebase for: {{{ query }}}",
+  readonly: true,
+  isInstant: false,
+  group: BUILT_IN_GROUP_NAME,
+  function: {
+    name: BuiltInToolNames.CodebaseTool,
+    description:
+      "Use this tool to semantically search through the codebase and retrieve relevant code snippets based on a natural language query. This helps find relevant code context for understanding or working with the codebase.",
+    parameters: {
+      type: "object",
+      required: ["query"],
+      properties: {
+        query: {
+          type: "string",
+          description:
+            "Natural language description of what you're looking for in the codebase (e.g., 'authentication logic', 'database connection setup', 'error handling')",
+        },
+      },
+    },
+  },
+};

--- a/core/tools/implementations/codebaseTool.ts
+++ b/core/tools/implementations/codebaseTool.ts
@@ -1,0 +1,61 @@
+import { ToolImpl } from ".";
+import { RangeInFile } from "../..";
+import { retrieveContextItemsFromEmbeddings } from "../../context/retrieval/retrieval";
+
+export const codebaseToolImpl: ToolImpl = async (args, extras) => {
+  if (!args.query || args.query.trim() === "") {
+    return [
+      {
+        name: "Error",
+        description: "Codebase search error",
+        content: "Query parameter is required and cannot be empty.",
+      },
+    ];
+  }
+
+  try {
+    const contextExtras = {
+      config: extras.config,
+      fullInput: args.query,
+      embeddingsProvider: extras.config.selectedModelByRole.embed,
+      reranker: extras.config.selectedModelByRole.rerank,
+      llm: extras.llm,
+      ide: extras.ide,
+      selectedCode: [] as RangeInFile[],
+      fetch: extras.fetch,
+    };
+
+    // Use the existing retrieval function to get context items
+    const results = await retrieveContextItemsFromEmbeddings(
+      contextExtras,
+      undefined,
+      undefined,
+    );
+
+    // If no results found, return helpful message
+    if (results.length === 0) {
+      return [
+        {
+          name: "No Results",
+          description: "Codebase search",
+          content: `No relevant code found for query: "${args.query}". This could mean:
+- The codebase hasn't been indexed yet
+- No code matches the search criteria
+- Embeddings provider is not configured
+
+Try re-indexing the codebase or using a more specific query.`,
+        },
+      ];
+    }
+
+    return results;
+  } catch (error) {
+    return [
+      {
+        name: "Error",
+        description: "Codebase search error",
+        content: `Failed to search codebase: ${error instanceof Error ? error.message : String(error)}`,
+      },
+    ];
+  }
+};

--- a/core/tools/index.ts
+++ b/core/tools/index.ts
@@ -1,4 +1,5 @@
 import { ConfigDependentToolParams, IDE, Tool } from "..";
+import { codebaseTool } from "./definitions/codebaseTool";
 import { createNewFileTool } from "./definitions/createNewFile";
 import { createRuleBlock } from "./definitions/createRuleBlock";
 import { editFileTool } from "./definitions/editFile";
@@ -37,7 +38,12 @@ export const getConfigDependentToolDefinitions = (
 ): Tool[] => [
   requestRuleTool(params),
   ...(params.enableExperimentalTools
-    ? [searchAndReplaceInFileTool, viewRepoMapTool, viewSubdirectoryTool]
+    ? [
+        searchAndReplaceInFileTool,
+        viewRepoMapTool,
+        viewSubdirectoryTool,
+        codebaseTool,
+      ]
     : [editFileTool]),
 ];
 


### PR DESCRIPTION
## Description

Add @codebase as experimental tool for agent mode

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots

![add @codebase to experimental tools](https://github.com/user-attachments/assets/11d7ac30-22b1-488e-973f-624e1d3401ab)

## Tests

Skipping tests for now as this is under experimental tools

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added @codebase as an experimental tool in agent mode, allowing semantic codebase search using natural language queries.

- **New Features**
  - Users can search the codebase for relevant code snippets by describing what they need.
  - Tool supports options for result count and re-ranking.

<!-- End of auto-generated description by cubic. -->

