### PR TITLE
fix: prevent lines removal on docstring insertion

### DIFF
--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -157,6 +157,8 @@ const getCommandsMap: (
       throw new Error("Config not loaded");
     }
 
+    console.log("debug1 onlyOneInsertion", onlyOneInsertion);
+
     const llm =
       config.selectedModelByRole.edit ?? config.selectedModelByRole.chat;
 
@@ -355,10 +357,10 @@ const getCommandsMap: (
     "continue.writeDocstringForCode": async () => {
       captureCommandTelemetry("writeDocstringForCode");
 
-      streamInlineEdit(
+      void streamInlineEdit(
         "docstring",
         "Write a docstring for this code. Do not change anything about the code itself.",
-        true,
+        false,
       );
     },
     "continue.fixCode": async () => {

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -157,8 +157,6 @@ const getCommandsMap: (
       throw new Error("Config not loaded");
     }
 
-    console.log("debug1 onlyOneInsertion", onlyOneInsertion);
-
     const llm =
       config.selectedModelByRole.edit ?? config.selectedModelByRole.chat;
 


### PR DESCRIPTION
## Description

When generating docstring using the Continue menu > "Write a docstring for this code", it used to delete all lines after the first. This PR fix this behaviour.

- inside "continue.writeDocstringForCode" vscode command, for `streamInlineEdit`'s onlyOneInsertion is now set to false

closes #4126 

resolves CON-2048

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]


https://github.com/user-attachments/assets/8c06ff02-1547-4297-91e4-01e0ed4216ec



https://github.com/user-attachments/assets/d1259c02-620e-4a5b-b456-b9dee37ae3c9



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

## Reproduction

This is flaky on the main branch - it works correctly on some code while not on other.
This code mostly gives removes the line after adding the lines so it can be used for testing.

```py
def get_pc_model_class(name):
    global REGISTERED_PC_DATASET_CLASSES
    assert name in REGISTERED_PC_DATASET_CLASSES, f"available class: {REGISTERED_PC_DATASET_CLASSES}"
    return REGISTERED_PC_DATASET_CLASSES[name]
```
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where inserting a docstring using the Continue menu would remove lines after the first, preserving the rest of the code.

<!-- End of auto-generated description by cubic. -->

