### PR TITLE
chore: add telemetry for context providers

### DIFF
--- a/core/context/providers/index.ts
+++ b/core/context/providers/index.ts
@@ -1,5 +1,6 @@
 import { BaseContextProvider } from "../";
 import { ContextProviderName } from "../../";
+import { Telemetry } from "../../util/posthog";
 
 import ClipboardContextProvider from "./ClipboardContextProvider";
 import CodebaseContextProvider from "./CodebaseContextProvider";
@@ -75,5 +76,12 @@ export const Providers: (typeof BaseContextProvider)[] = [
 export function contextProviderClassFromName(
   name: ContextProviderName,
 ): typeof BaseContextProvider | undefined {
-  return Providers.find((cls) => cls.description.title === name);
+  const provider = Providers.find((cls) => cls.description.title === name);
+
+  void Telemetry.capture("context_provider_load", {
+    providerName: name,
+    found: !!provider, // also capture those which user expected to be present
+  });
+
+  return provider;
 }

--- a/core/core.ts
+++ b/core/core.ts
@@ -1105,6 +1105,10 @@ export class Core {
         itemId: uuidv4(),
       };
 
+      void Telemetry.capture("context_provider_get_context_items", {
+        name: provider.description.title,
+      });
+
       const items = await provider.getContextItems(query, {
         config,
         llm,


### PR DESCRIPTION
## Description

Add telemetry data to track context provider usage. This is being done to replace context providers with their MCP tools. (for example, the [PostgresContextProvider](https://github.com/continuedev/continue/blob/79668ebb005cf52e88a2759a33b2248bb8d719ef/core/context/providers/PostgresContextProvider.ts) can be replaced with [PostgresMCP](https://github.com/crystaldba/postgres-mcp))

resolves CON-2596

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added telemetry to track when context providers are loaded and used. This helps monitor usage as context providers are replaced with MCP tools.

<!-- End of auto-generated description by cubic. -->

