### PR TITLE
feat: Attach thread dumps to Sentry events + report caught exceptions

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
@@ -6,6 +6,7 @@ import com.github.continuedev.continueintellijextension.activities.showTutorial
 import com.github.continuedev.continueintellijextension.auth.ContinueAuthService
 import com.github.continuedev.continueintellijextension.editor.DiffStreamService
 import com.github.continuedev.continueintellijextension.editor.EditorUtils
+import com.github.continuedev.continueintellijextension.error.ContinueErrorService
 import com.github.continuedev.continueintellijextension.protocol.*
 import com.github.continuedev.continueintellijextension.services.*
 import com.github.continuedev.continueintellijextension.utils.*
@@ -463,8 +464,10 @@ class IdeProtocolClient(
                         println("Unknown message type: $messageType")
                     }
                 }
-            } catch (error: Exception) {
-                ide.showToast(ToastType.ERROR, " Error handling message of type $messageType: $error")
+            } catch (exception: Exception) {
+                val exceptionMessage = "Error handling message of type $messageType: $exception"
+                service<ContinueErrorService>().report(exception, exceptionMessage)
+                ide.showToast(ToastType.ERROR, exceptionMessage)
             }
         }
     }

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IntelliJIde.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IntelliJIde.kt
@@ -1,9 +1,9 @@
 package com.github.continuedev.continueintellijextension.`continue`
 
 import com.github.continuedev.continueintellijextension.*
-import com.github.continuedev.continueintellijextension.constants.getContinueGlobalPath
 import com.github.continuedev.continueintellijextension.constants.ContinueConstants
-import com.github.continuedev.continueintellijextension.`continue`.GitService
+import com.github.continuedev.continueintellijextension.constants.getContinueGlobalPath
+import com.github.continuedev.continueintellijextension.error.ContinueErrorService
 import com.github.continuedev.continueintellijextension.services.ContinueExtensionSettings
 import com.github.continuedev.continueintellijextension.services.ContinuePluginService
 import com.github.continuedev.continueintellijextension.utils.*
@@ -11,7 +11,6 @@ import com.intellij.codeInsight.daemon.impl.HighlightInfo
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.util.ExecUtil
 import com.intellij.ide.BrowserUtil
-import com.intellij.ide.plugins.PluginManager
 import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.notification.NotificationAction
@@ -38,9 +37,7 @@ import java.io.BufferedReader
 import java.io.File
 import java.io.FileInputStream
 import java.io.InputStreamReader
-import java.net.URI
 import java.nio.charset.Charset
-import java.nio.file.Paths
 
 class IntelliJIDE(
     private val project: Project,
@@ -344,11 +341,10 @@ class IntelliJIDE(
                 command.setWorkDirectory(project.basePath)
                 val results = ExecUtil.execAndGetOutput(command).stdout
                 return results.split("\n")
-            } catch (e: Exception) {
-                showToast(
-                    ToastType.ERROR, 
-                    "Error executing ripgrep: ${e.message}"
-                )
+            } catch (exception: Exception) {
+                val message = "Error executing ripgrep: ${exception.message}"
+                service<ContinueErrorService>().report(exception, message)
+                showToast(ToastType.ERROR, message)
                 return emptyList()
             }
         } else {
@@ -386,11 +382,10 @@ class IntelliJIDE(
     
                 command.setWorkDirectory(project.basePath)
                 return ExecUtil.execAndGetOutput(command).stdout
-            } catch (e: Exception) {
-                showToast(
-                    ToastType.ERROR, 
-                    "Error executing ripgrep: ${e.message}"
-                )
+            } catch (exception: Exception) {
+                val message = "Error executing ripgrep: ${exception.message}"
+                service<ContinueErrorService>().report(exception, message)
+                showToast(ToastType.ERROR, message)
                 return "Error: Unable to execute ripgrep command."
             }
         } else {

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/error/ContinueErrorService.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/error/ContinueErrorService.kt
@@ -1,0 +1,50 @@
+package com.github.continuedev.continueintellijextension.error
+
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.diagnostic.Attachment
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.extensions.PluginId
+import com.intellij.ui.jcef.JBCefApp
+import io.sentry.Hint
+import io.sentry.Sentry
+import io.sentry.SentryEvent
+import io.sentry.protocol.Message
+
+private typealias SentryAttachment = io.sentry.Attachment
+
+@Service
+class ContinueErrorService {
+    private val log = Logger.getInstance(ContinueErrorService::class.java)
+
+    init {
+        Sentry.init { config ->
+            config.dsn = SENTRY_DSN
+            config.isSendDefaultPii = false
+            config.setTag("ide_version", ApplicationInfo.getInstance().build.asString())
+            config.setTag("jcef_supported", JBCefApp.isSupported().toString())
+            config.setTag("plugin_version", PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))?.version)
+        }
+    }
+
+    fun report(
+        throwable: Throwable,
+        message: String? = null,
+        attachments: List<Attachment>? = null
+    ) {
+        val sentryEvent = SentryEvent()
+        sentryEvent.throwable = throwable
+        sentryEvent.message = Message().apply { this.message = message }
+        val hint = Hint.withAttachments(attachments?.map { SentryAttachment(it.bytes, it.path) })
+        Sentry.captureEvent(sentryEvent, hint)
+        log.warn("Problem sent to Sentry: $message", throwable)
+    }
+
+    private companion object {
+        private const val PLUGIN_ID = "com.github.continuedev.continueintellijextension"
+        private const val SENTRY_DSN =
+            "https://fe99934dcdc537d84209893a3f96a196@o4505462064283648.ingest.us.sentry.io/4508184596054016"
+    }
+
+}

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/error/ContinueErrorSubmitter.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/error/ContinueErrorSubmitter.kt
@@ -1,30 +1,15 @@
 package com.github.continuedev.continueintellijextension.error
 
 import com.intellij.diagnostic.IdeaReportingEvent
-import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.ErrorReportSubmitter
 import com.intellij.openapi.diagnostic.IdeaLoggingEvent
 import com.intellij.openapi.diagnostic.SubmittedReportInfo
 import com.intellij.openapi.diagnostic.SubmittedReportInfo.SubmissionStatus
-import com.intellij.ui.jcef.JBCefApp
 import com.intellij.util.Consumer
-import io.sentry.Attachment
-import io.sentry.Hint
-import io.sentry.Sentry
-import io.sentry.SentryEvent
-import io.sentry.protocol.Message
 import java.awt.Component
 
 class ContinueErrorSubmitter : ErrorReportSubmitter() {
-
-    init {
-        Sentry.init { config ->
-            config.dsn = SENTRY_DSN
-            config.isSendDefaultPii = false
-            config.setTag("ide_version", ApplicationInfo.getInstance().build.asString())
-            config.setTag("jcef_supported", JBCefApp.isSupported().toString())
-        }
-    }
 
     override fun getReportActionText() =
         "Report to Continue"
@@ -38,27 +23,17 @@ class ContinueErrorSubmitter : ErrorReportSubmitter() {
         try {
             val event = events.filterIsInstance<IdeaReportingEvent>()
                 .firstOrNull() ?: return false
-            reportToSentry(event, additionalInfo)
+            service<ContinueErrorService>().report(
+                throwable = event.data.throwable,
+                message = additionalInfo ?: event.data.message,
+                attachments = event.data.allAttachments
+            )
         } catch (_: Exception) {
             consumer.consume(SubmittedReportInfo(SubmissionStatus.FAILED))
             return false
         }
         consumer.consume(SubmittedReportInfo(SubmissionStatus.NEW_ISSUE))
         return true
-    }
-
-    private fun reportToSentry(event: IdeaReportingEvent, additionalInfo: String?) {
-        val sentryEvent = SentryEvent()
-        sentryEvent.throwable = event.data.throwable
-        sentryEvent.message = Message().apply { message = additionalInfo ?: event.data.message }
-        val hint = Hint.withAttachments(event.data.allAttachments.map { Attachment(it.bytes, it.path) })
-        sentryEvent.setTag("plugin_version", event.plugin?.version)
-        Sentry.captureEvent(sentryEvent, hint)
-    }
-
-    private companion object {
-        private const val SENTRY_DSN =
-            "https://fe99934dcdc537d84209893a3f96a196@o4505462064283648.ingest.us.sentry.io/4508184596054016"
     }
 
 }


### PR DESCRIPTION
Also: add exception messages (like "Access is allowed from event dispatch thread only")
Also: merged branch with error reporter as a service to report caught exceptions (see usages)
Also: changed plugin version retrieval (more stable)

## Tests

The easiest way to test it is to comment out the try-catch in `IdeProtocolClient.handleMessage` (or re-throw exception), start the IDE, and call `getCurrentFile` using a question like "explain the current file". `getCurrentFile` currently violates the threading model, and in this case the submitter automatically attaches a thread dump.

## Screenshot

![image](https://github.com/user-attachments/assets/288167c8-d07f-49e9-a1c8-780a4b51beee)

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Thread dumps and exception messages are now attached to Sentry error reports for better debugging.

- **New Features**
  - Sends thread dumps and exception messages with Sentry events when errors occur.

<!-- End of auto-generated description by cubic. -->

