### PR TITLE
fix: support local slugs in document link provider

### DIFF
--- a/extensions/vscode/src/extension/ConfigYamlDocumentLinkProvider.ts
+++ b/extensions/vscode/src/extension/ConfigYamlDocumentLinkProvider.ts
@@ -1,3 +1,5 @@
+import * as path from "path";
+
 import * as vscode from "vscode";
 
 export class ConfigYamlDocumentLinkProvider
@@ -11,11 +13,35 @@ export class ConfigYamlDocumentLinkProvider
     const links: vscode.DocumentLink[] = [];
 
     for (let lineIndex = 0; lineIndex < document.lineCount; lineIndex++) {
+      if (token.isCancellationRequested) {
+        return [];
+      }
       const line = document.lineAt(lineIndex);
       const match = this.usesPattern.exec(line.text);
 
       if (match) {
-        const slug = match[1].trim();
+        let slug = match[1].trim();
+        // Remove any leading comment symbols (#)
+        slug = slug.replace(/^\s*(#\s*)+/, "");
+
+        // Check for surrounding quotes
+        const quoteMatch = slug.match(/^(['"])(.*)\1/);
+        if (quoteMatch) {
+          // If quoted, remove the quotes but keep everything inside (including #)
+          slug = quoteMatch[2].trim();
+        } else {
+          // If not quoted, remove any trailing comment
+          slug = slug.replace(/\s*#.*$/, "").trim();
+        }
+
+        if (slug === "") {
+          continue; // Skip empty slugs
+        }
+
+        if (/^(https?:\/\/|file:\/\/)/.test(slug)) {
+          // VS Code already handles external links, so skip them
+          continue;
+        }
         const startPos = line.text.indexOf(slug);
         const range = new vscode.Range(
           lineIndex,
@@ -24,10 +50,17 @@ export class ConfigYamlDocumentLinkProvider
           startPos + slug.length,
         );
 
-        const link = new vscode.DocumentLink(
-          range,
-          vscode.Uri.parse(`https://hub.continue.dev/${slug}`),
-        );
+        let linkUri: vscode.Uri;
+        if (slug.startsWith("./") || slug.startsWith("../")) {
+          const currentFilePath = document.uri.fsPath;
+          const parentPath = path.dirname(currentFilePath);
+          const resolvedPath = path.resolve(parentPath, slug);
+          linkUri = vscode.Uri.file(resolvedPath);
+        } else {
+          linkUri = vscode.Uri.parse(`https://hub.continue.dev/${slug}`);
+        }
+
+        const link = new vscode.DocumentLink(range, linkUri);
         links.push(link);
       }
     }


### PR DESCRIPTION
Document link navigation is currently broken if a config file "uses" a local slug, e.g. a "./", "file://" or "http://" url, the ConfigYamlDocumentLinkProvider always prefixes the path with https://hub.continue.dev/ and then opens an invalid url.

This PR fixes it.

https://github.com/user-attachments/assets/5581b88c-9b82-4e82-8504-f668675a3822

I'm hesitant to provide support for directory traversal (../..) it's often source of security issues, but I'm not even sure if continue supports it. You tell me.

The CLA has been sent to @sestinj.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed document link navigation for config files that use local slugs like "./" or "file://", so links now resolve correctly instead of always pointing to https://hub.continue.dev/.

<!-- End of auto-generated description by cubic. -->

