### PR TITLE
Mode cycling focus fix

### DIFF
--- a/gui/src/components/ModeSelect/ModeSelect.tsx
+++ b/gui/src/components/ModeSelect/ModeSelect.tsx
@@ -34,7 +34,10 @@ export function ModeSelect() {
 
   const cycleMode = useCallback(() => {
     dispatch(setMode(mode === "chat" ? "agent" : "chat"));
-    mainEditor?.commands.focus();
+    // Only focus main editor if another one doesn't already have focus
+    if (!document.activeElement?.classList?.contains("ProseMirror")) {
+      mainEditor?.commands.focus();
+    }
   }, [mode, mainEditor]);
 
   const selectMode = useCallback(


### PR DESCRIPTION
Only focus main editor if another one doesn't already have focus
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where toggling modes would always focus the main editor, even if another editor was already focused.

- **Bug Fixes**
  - Now only focuses the main editor if no other editor has focus.

<!-- End of auto-generated description by cubic. -->

