### PR TITLE
Add icon to truncate history at last tool call

### DIFF
--- a/gui/src/components/mainInput/icons.ts
+++ b/gui/src/components/mainInput/icons.ts
@@ -18,6 +18,7 @@ import {
   PlusIcon,
   SparklesIcon,
   TrashIcon,
+  WrenchScrewdriverIcon,
 } from "@heroicons/react/24/outline";
 import { DiscordIcon } from "../svg/DiscordIcon";
 import { GithubIcon } from "../svg/GithubIcon";
@@ -55,4 +56,5 @@ export const NAMED_ICONS: { [key: string]: any } = {
   "gitlab-mr": GitlabIcon,
   http: GlobeAltIcon,
   trash: TrashIcon,
+  toolCall: WrenchScrewdriverIcon,
 };

--- a/gui/src/pages/gui/Chat.tsx
+++ b/gui/src/pages/gui/Chat.tsx
@@ -319,7 +319,7 @@ export function Chat() {
                     inputId={item.message.id}
                   />
                 </>
-              ) : item.message.role === "tool" ? null : item.message.role ===
+              ) : item.message.role === "tool" ? null : item.message.role === // /> //   toolCallId={item.message.toolCallId} //   contextItems={item.contextItems} // <ToolOutput
                   "assistant" &&
                 item.message.toolCalls &&
                 item.toolCallState ? (
@@ -330,7 +330,6 @@ export function Chat() {
                         key={i}
                         toolCallState={item.toolCallState!}
                         toolCall={toolCall}
-                        output={history[index + 1]?.contextItems}
                         historyIndex={index}
                       />
                     );

--- a/gui/src/pages/gui/ToolCallDiv/ToolCall.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/ToolCall.tsx
@@ -2,12 +2,14 @@ import { Tool, ToolCallState } from "core";
 import { useMemo, useState } from "react";
 import { ArgsItems, ArgsToggleIcon } from "./ToolCallArgs";
 import { ToolCallStatusMessage } from "./ToolCallStatusMessage";
+import { ToolTruncateHistoryIcon } from "./ToolTruncateHistoryIcon";
 
 interface ToolCallDisplayProps {
   children: React.ReactNode;
   icon: React.ReactNode;
   tool: Tool | undefined;
   toolCallState: ToolCallState;
+  historyIndex: number;
 }
 
 export function ToolCallDisplay({
@@ -15,6 +17,7 @@ export function ToolCallDisplay({
   toolCallState,
   children,
   icon,
+  historyIndex,
 }: ToolCallDisplayProps) {
   const [argsExpanded, setArgsExpanded] = useState(false);
 
@@ -39,13 +42,18 @@ export function ToolCallDisplay({
                 toolCallState={toolCallState}
               />
             </div>
-            {!!args.length ? (
-              <ArgsToggleIcon
-                isShowing={argsExpanded}
-                setIsShowing={setArgsExpanded}
-                toolCallId={toolCallState.toolCallId}
-              />
-            ) : null}
+            <div className="flex flex-row items-center gap-1.5">
+              {!!toolCallState.output && (
+                <ToolTruncateHistoryIcon historyIndex={historyIndex} />
+              )}
+              {!!args.length ? (
+                <ArgsToggleIcon
+                  isShowing={argsExpanded}
+                  setIsShowing={setArgsExpanded}
+                  toolCallId={toolCallState.toolCallId}
+                />
+              ) : null}
+            </div>
           </div>
           {argsExpanded && !!args.length && (
             <ArgsItems args={args} isShowing={argsExpanded} />

--- a/gui/src/pages/gui/ToolCallDiv/ToolTruncateHistoryIcon.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/ToolTruncateHistoryIcon.tsx
@@ -1,0 +1,40 @@
+import { BarsArrowUpIcon } from "@heroicons/react/24/outline";
+import { chatMessageIsEmpty } from "core/llm/messages";
+import { findLastIndex } from "core/util/findLast";
+import { useMemo } from "react";
+import { useMainEditor } from "../../../components/mainInput/TipTapEditor";
+import { ToolbarButtonWithTooltip } from "../../../components/StyledMarkdownPreview/StepContainerPreToolbar/ToolbarButtonWithTooltip";
+import { useAppDispatch, useAppSelector } from "../../../redux/hooks";
+import { truncateHistoryToMessage } from "../../../redux/slices/sessionSlice";
+
+export function ToolTruncateHistoryIcon({
+  historyIndex,
+}: {
+  historyIndex: number;
+}) {
+  const isStreaming = useAppSelector((state) => state.session.isStreaming);
+  const history = useAppSelector((state) => state.session.history);
+  const lastMessageIndex = useMemo(() => {
+    return findLastIndex(history, (item) => !chatMessageIsEmpty(item.message));
+  }, [history]);
+  const dispatch = useAppDispatch();
+  const { mainEditor } = useMainEditor();
+  if (isStreaming || historyIndex === lastMessageIndex) {
+    return null;
+  }
+  return (
+    <ToolbarButtonWithTooltip
+      tooltipContent="Truncate chat to this message"
+      onClick={() => {
+        dispatch(
+          truncateHistoryToMessage({
+            index: historyIndex,
+          }),
+        );
+        mainEditor?.commands.focus();
+      }}
+    >
+      <BarsArrowUpIcon className="h-2.5 w-2.5 flex-shrink-0" />
+    </ToolbarButtonWithTooltip>
+  );
+}

--- a/gui/src/pages/gui/ToolCallDiv/index.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/index.tsx
@@ -12,12 +12,7 @@ import {
   PencilIcon,
   XMarkIcon,
 } from "@heroicons/react/24/outline";
-import {
-  ContextItemWithId,
-  ToolCallDelta,
-  ToolCallState,
-  ToolStatus,
-} from "core";
+import { ToolCallDelta, ToolCallState, ToolStatus } from "core";
 import { BuiltInToolNames } from "core/tools/builtIn";
 import { ComponentType, useMemo } from "react";
 import { vscButtonBackground } from "../../../components";
@@ -30,7 +25,6 @@ import { ToolCallDisplay } from "./ToolCall";
 interface ToolCallDivProps {
   toolCall: ToolCallDelta;
   toolCallState: ToolCallState;
-  output?: ContextItemWithId[];
   historyIndex: number;
 }
 
@@ -86,7 +80,7 @@ export function ToolCallDiv(props: ToolCallDivProps) {
         icon={
           props.toolCallState.status === "generated" ? ArrowRightIcon : icon
         }
-        contextItems={props.output ?? []}
+        historyIndex={props.historyIndex}
       />
     );
   }
@@ -96,6 +90,7 @@ export function ToolCallDiv(props: ToolCallDivProps) {
       icon={getStatusIcon(props.toolCallState.status)}
       tool={tool}
       toolCallState={props.toolCallState}
+      historyIndex={props.historyIndex}
     >
       <FunctionSpecificToolCallDiv
         toolCall={props.toolCall}

--- a/gui/src/pages/gui/ToolCallDiv/toolCallStateToContextItem.ts
+++ b/gui/src/pages/gui/ToolCallDiv/toolCallStateToContextItem.ts
@@ -1,0 +1,27 @@
+import { ContextItem, ContextItemWithId, ToolCallState } from "core";
+
+export function toolCallStateToContextItems(
+  toolCallState: ToolCallState | undefined,
+): ContextItemWithId[] {
+  if (!toolCallState) {
+    return [];
+  }
+  return (
+    toolCallState.output?.map((ctxItem) =>
+      toolCallCtxItemToCtxItemWithId(ctxItem, toolCallState.toolCallId),
+    ) ?? []
+  );
+}
+
+export function toolCallCtxItemToCtxItemWithId(
+  ctxItem: ContextItem,
+  toolCallId: string,
+): ContextItemWithId {
+  return {
+    ...ctxItem,
+    id: {
+      providerTitle: "toolCall",
+      itemId: toolCallId,
+    },
+  };
+}

--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -203,6 +203,28 @@ export const sessionSlice = createSlice({
 
       state.isStreaming = true;
     },
+    truncateHistoryToMessage: (
+      state,
+      {
+        payload,
+      }: PayloadAction<{
+        index: number;
+      }>,
+    ) => {
+      const { index } = payload;
+
+      if (state.history.length && index < state.history.length) {
+        state.codeBlockApplyStates.curIndex = 0;
+        state.history = state.history.slice(0, index + 1).concat({
+          message: {
+            id: uuidv4(),
+            role: "assistant",
+            content: "", // IMPORTANT - this is subsequently updated by response streaming
+          },
+          contextItems: [],
+        });
+      }
+    },
     deleteMessage: (state, action: PayloadAction<number>) => {
       // Deletes the current assistant message and the previous user message
       state.history.splice(action.payload - 1, 2);
@@ -676,6 +698,7 @@ export const {
   addPromptCompletionPair,
   setActive,
   submitEditorAndInitAtIndex,
+  truncateHistoryToMessage,
   updateHistoryItemAtIndex,
   clearLastEmptyResponse,
   setMainEditorContentTrigger,


### PR DESCRIPTION
Builds on https://github.com/continuedev/continue/pull/6333 to add an icon for truncating chat history at a given message
