### PR TITLE
Jacob/feature/dynamic switch autocomplete nextedit

### DIFF
--- a/core/nextEdit/diff/diff.ts
+++ b/core/nextEdit/diff/diff.ts
@@ -112,3 +112,76 @@ export function getRenderableDiffWithGutterAnnotations(
     },
   };
 }
+
+/**
+ * Check if the diff is indeed a FIM.
+ * @param oldEditRange Original string content.
+ * @param newEditRange New string content.
+ * @param cursorPosition The position of the cursor in the old string.
+ * @returns boolean indicating if the change is purely additive (FIM)
+ * @returns string of FIM text content.
+ */
+export function checkFim(
+  oldEditRange: string,
+  newEditRange: string,
+  cursorPosition: { line: number; character: number },
+): {
+  isFim: boolean;
+  fimText: string;
+} {
+  // Find the common prefix.
+  let prefixLength = 0;
+  while (
+    prefixLength < oldEditRange.length &&
+    prefixLength < newEditRange.length &&
+    oldEditRange[prefixLength] === newEditRange[prefixLength]
+  ) {
+    prefixLength++;
+  }
+
+  // Find the common suffix
+  let oldSuffixPos = oldEditRange.length - 1;
+  let newSuffixPos = newEditRange.length - 1;
+
+  while (
+    oldSuffixPos >= prefixLength &&
+    newSuffixPos >= prefixLength &&
+    oldEditRange[oldSuffixPos] === newEditRange[newSuffixPos]
+  ) {
+    oldSuffixPos--;
+    newSuffixPos--;
+  }
+
+  // The old text is purely preserved if:
+  // 1. The prefix ends before or at the cursor.
+  // 2. The suffix starts after or at the cursor.
+  // 3. There's no gap between prefix and suffix in the old text.
+
+  const suffixStartInOld = oldSuffixPos + 1;
+  const suffixStartInNew = newSuffixPos + 1;
+
+  // Convert cursor position to an offset in the string.
+  // For simplicity, we need to calculate the cursor's position in the string.
+  // This requires knowledge of line endings in the oldEditRange.
+  const lines = oldEditRange.substring(0, prefixLength).split("\n");
+  const cursorOffset =
+    lines.length > 1
+      ? lines.slice(0, -1).reduce((sum, line) => sum + line.length + 1, 0) +
+        cursorPosition.character
+      : cursorPosition.character;
+
+  // Check if the cursor is positioned between the prefix and suffix.
+  const cursorBetweenPrefixAndSuffix =
+    prefixLength <= cursorOffset && cursorOffset <= suffixStartInOld;
+
+  // Check if the old text is completely preserved (no deletion).
+  const noTextDeleted = suffixStartInOld - prefixLength <= 0;
+
+  // Extract the content between prefix and suffix in the new string.
+  const fimText = newEditRange.substring(prefixLength, suffixStartInNew);
+
+  return {
+    isFim: cursorBetweenPrefixAndSuffix && noTextDeleted,
+    fimText,
+  };
+}

--- a/extensions/vscode/src/activation/NextEditWindowManager.ts
+++ b/extensions/vscode/src/activation/NextEditWindowManager.ts
@@ -3,8 +3,8 @@ import { EXTENSION_NAME } from "core/control-plane/env";
 // @ts-ignore
 import * as vscode from "vscode";
 
+import { DiffLine } from "core";
 import { CodeRenderer } from "core/codeRenderer/CodeRenderer";
-import { myersDiff } from "core/diff/myers";
 import {
   NEXT_EDIT_EDITABLE_REGION_BOTTOM_MARGIN,
   NEXT_EDIT_EDITABLE_REGION_TOP_MARGIN,
@@ -225,7 +225,10 @@ export class NextEditWindowManager {
    */
   public async showNextEditWindow(
     editor: vscode.TextEditor,
+    currCursorPos: vscode.Position,
+    editableRegionStartLine: number,
     newEditRangeSlice: string,
+    diffLines: DiffLine[],
   ) {
     if (!newEditRangeSlice || !this.shouldRenderTip(editor.document.uri)) {
       return;
@@ -236,30 +239,6 @@ export class NextEditWindowManager {
 
     // Store the current tooltip text for accepting later.
     this.currentTooltipText = newEditRangeSlice;
-
-    // Get the contents of the old (current) editable region.
-    const currCursorPos = editor.selection.active;
-    const editableRegionStartLine = Math.max(
-      currCursorPos.line - NEXT_EDIT_EDITABLE_REGION_TOP_MARGIN,
-      0,
-    );
-    const editableRegionEndLine = Math.min(
-      currCursorPos.line + NEXT_EDIT_EDITABLE_REGION_BOTTOM_MARGIN,
-      editor.document.lineCount - 1,
-    );
-    const oldEditRangeSlice = editor.document
-      .getText()
-      .split("\n")
-      .slice(editableRegionStartLine, editableRegionEndLine + 1)
-      .join("\n");
-
-    // We don't need to show the next edit window under these conditions:
-    // - There are no predicted edits.
-    // - The predicted edits are identical to the previous version.
-    if (newEditRangeSlice === "" || oldEditRangeSlice === newEditRangeSlice)
-      return;
-
-    const diffLines = myersDiff(oldEditRangeSlice, newEditRangeSlice);
 
     // How far away is the current line from the start of the editable region?
     const lineOffsetAtCursorPos = currCursorPos.line - editableRegionStartLine;


### PR DESCRIPTION
## Description

Dynamically switch between rendering ghost text and svg decoration based on the model output.
If the model output is FIM, then we render a ghost text. Else, we render a SVG decoration.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Autocomplete now switches between showing ghost text or an SVG decoration based on the model output. If the output is a fill-in-the-middle (FIM) edit, ghost text is shown; otherwise, an SVG decoration appears.

- **New Features**
  - Added logic to detect FIM edits and render ghost text.
  - Non-FIM edits now show an SVG decoration instead.

<!-- End of auto-generated description by cubic. -->

