### PR TITLE
Revert "Quick fix: removing functionally redundant items in dev data toolusage"

### DIFF
--- a/core/tools/callTool.ts
+++ b/core/tools/callTool.ts
@@ -179,7 +179,6 @@ function logToolUsage(
   contextItems: ContextItem[],
   success: boolean,
 ) {
-  console.log(toolCall.function.arguments);
   void DataLogger.getInstance().logDevData({
     name: "toolUsage",
     data: {
@@ -187,6 +186,7 @@ function logToolUsage(
       functionName: toolCall.function.name,
       functionArgs: toolCall.function.arguments,
       toolCallArgs: args,
+      parsedArgs: args,
       output: contextItems,
       succeeded: success,
     },

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -116,7 +116,7 @@
         "@continuedev/config-yaml": "file:../packages/config-yaml",
         "@continuedev/fetch": "^1.0.14",
         "@continuedev/llm-info": "^1.0.8",
-        "@continuedev/openai-adapters": "file:../packages/openai-adapters",
+        "@continuedev/openai-adapters": "1.0.42",
         "@modelcontextprotocol/sdk": "^1.12.0",
         "@mozilla/readability": "^0.5.0",
         "@octokit/rest": "^20.1.1",

--- a/gui/src/redux/util/index.ts
+++ b/gui/src/redux/util/index.ts
@@ -31,6 +31,7 @@ export function logToolUsage(
       functionName: toolCallState.toolCall?.function?.name,
       functionArgs: toolCallState.toolCall?.function?.arguments,
       toolCallArgs: safeParseToolCallArgs(toolCallState.toolCall),
+      parsedArgs: toolCallState.parsedArgs,
       output: finalOutput || toolCallState.output || [],
       succeeded: success,
     },

--- a/packages/config-yaml/src/schemas/data/toolUsage/index.ts
+++ b/packages/config-yaml/src/schemas/data/toolUsage/index.ts
@@ -6,6 +6,7 @@ export const toolUsageEventAllSchema = baseDevDataAllSchema.extend({
   functionName: z.string(),
   functionArgs: z.string(),
   toolCallArgs: z.any(),
+  parsedArgs: z.any(),
   succeeded: z.boolean(),
   output: z.array(z.any()).optional(),
 });

--- a/packages/config-yaml/src/schemas/data/toolUsage/v0.2.0.ts
+++ b/packages/config-yaml/src/schemas/data/toolUsage/v0.2.0.ts
@@ -14,6 +14,7 @@ export const toolUsageEventSchema_0_2_0 = toolUsageEventAllSchema.pick({
   functionName: true,
   functionArgs: true,
   toolCallArgs: true,
+  parsedArgs: true,
   succeeded: true,
   output: true,
 });
@@ -21,6 +22,6 @@ export const toolUsageEventSchema_0_2_0 = toolUsageEventAllSchema.pick({
 export const toolUsageEventSchema_0_2_0_noCode =
   toolUsageEventSchema_0_2_0.omit({
     functionArgs: true,
-    toolCallArgs: true,
+    parsedArgs: true,
     output: true,
   });


### PR DESCRIPTION
Reverts continuedev/continue#6392
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Restores the logging and schema fields for parsedArgs in tool usage dev data that were removed in a previous change.

- **Refactors**
  - Adds back parsedArgs to tool usage logging and related schemas.
  - Updates dependency for @continuedev/openai-adapters in the GUI.

<!-- End of auto-generated description by cubic. -->

