### PR TITLE
chore: terminate all tasks after debug

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,7 @@
       "pauseForSourceMap": false,
       "outFiles": ["${workspaceFolder}/extensions/vscode/out/extension.js"],
       "preLaunchTask": "vscode-extension:build",
+      "postDebugTask": "Terminate All Tasks",
       "env": {
         // "CONTROL_PLANE_ENV": "local",
         "CONTINUE_GLOBAL_DIR": "${workspaceFolder}/extensions/.continue-debug"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -223,6 +223,19 @@
       ],
       "type": "shell",
       "problemMatcher": []
+    },
+    {
+      "label": "Terminate All Tasks",
+      "command": "${input:terminate}",
+      "type": "shell"
+    }
+  ],
+  "inputs": [
+    {
+      "id": "terminate",
+      "type": "command",
+      "command": "workbench.action.tasks.terminate",
+      "args": "terminateAll"
     }
   ]
 }


### PR DESCRIPTION
## Description

In vscode, after when doing "Launch extension" and stopping it, we want to terminate all tasks. Previously this had to be done manually by terminating each of the tasks manually.

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

https://github.com/user-attachments/assets/dbea7032-0f4e-4eb8-bd9a-bd8141b7a9e0




## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
