### PR TITLE
fix: Move CoreMessenger write calls off AWT thread to prevent UI freeze

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessenger.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessenger.kt
@@ -43,7 +43,9 @@ class CoreMessenger(
         val message =
             gson.toJson(mapOf("messageId" to id, "messageType" to messageType, "data" to data))
         responseListeners[id] = onResponse
-        write(message)
+        coroutineScope.launch(Dispatchers.IO) {
+            write(message)
+        }
     }
 
     private fun handleMessage(json: String) {


### PR DESCRIPTION
Reproduced on Windows. Related to #5819

Motivation/Freeze analysis:

```
EDT is blocked on sun.nio.cs.StreamEncoder.write
Possibly locked by sun.nio.cs.StreamEncoder.writeBytes in Thread-22993
======= Stack Trace: ========= 
"AWT-EventQueue-0" #42 [7660] prio=6 os_prio=0 cpu=385656.25ms elapsed=2040.64s tid=0x000001d1a65dc8b0 nid=7660 waiting on condition  [0x000000a1779fd000]
   java.lang.Thread.State: WAITING (parking)
	at jdk.internal.misc.Unsafe.park(java.base@21.0.4/Native Method)
	- parking to wait for  <0x000000072f05d938> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)
	at java.util.concurrent.locks.LockSupport.park(java.base@21.0.4/LockSupport.java:221)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@21.0.4/AbstractQueuedSynchronizer.java:754)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@21.0.4/AbstractQueuedSynchronizer.java:990)
	at java.util.concurrent.locks.ReentrantLock$Sync.lock(java.base@21.0.4/ReentrantLock.java:153)
	at java.util.concurrent.locks.ReentrantLock.lock(java.base@21.0.4/ReentrantLock.java:322)
	at jdk.internal.misc.InternalLock.lock(java.base@21.0.4/InternalLock.java:74)
	at sun.nio.cs.StreamEncoder.write(java.base@21.0.4/StreamEncoder.java:137)
	at sun.nio.cs.StreamEncoder.write(java.base@21.0.4/StreamEncoder.java:167)
	at java.io.OutputStreamWriter.write(java.base@21.0.4/OutputStreamWriter.java:237)
	at java.io.Writer.write(java.base@21.0.4/Writer.java:278)
	at com.github.continuedev.continueintellijextension.continue.CoreMessenger.write(CoreMessenger.kt:34)
	at com.github.continuedev.continueintellijextension.continue.CoreMessenger.request(CoreMessenger.kt:46)
	at com.github.continuedev.continueintellijextension.autocomplete.AutocompleteService.cancelCompletion(AutocompleteService.kt:289)
	at com.github.continuedev.continueintellijextension.autocomplete.AutocompleteService.clearCompletions(AutocompleteService.kt:296)
	at com.github.continuedev.continueintellijextension.autocomplete.AutocompleteService.clearCompletions$default(AutocompleteService.kt:292)
	at com.github.continuedev.continueintellijextension.autocomplete.AutocompleteCaretListener.caretPositionChanged(AutocompleteEditorListener.kt:33)
	at java.lang.invoke.LambdaForm$DMH/0x000000080052c000.invokeInterface(java.base@21.0.4/LambdaForm$DMH)
	at java.lang.invoke.LambdaForm$MH/0x00000008025dc000.invoke(java.base@21.0.4/LambdaForm$MH)
	at java.lang.invoke.Invokers$Holder.invokeExact_MT(java.base@21.0.4/Invokers$Holder)
	at jdk.internal.reflect.DirectMethodHandleAccessor.invokeImpl(java.base@21.0.4/DirectMethodHandleAccessor.java:154)
	at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(java.base@21.0.4/DirectMethodHandleAccessor.java:103)
	at java.lang.reflect.Method.invoke(java.base@21.0.4/Method.java:580)
	at com.intellij.util.EventDispatcher.dispatchVoidMethod(EventDispatcher.java:119)
	at com.intellij.util.EventDispatcher.lambda$createMulticaster$1(EventDispatcher.java:84)
	at com.intellij.util.EventDispatcher$$Lambda/0x00000008005bc000.invoke(Unknown Source)
	at jdk.proxy2.$Proxy129.caretPositionChanged(jdk.proxy2/Unknown Source)
	at com.intellij.openapi.editor.impl.CaretModelImpl.fireCaretPositionChanged(CaretModelImpl.java:536)
	at com.intellij.openapi.editor.impl.CaretImpl.doMoveToVisualPosition(CaretImpl.java:593)
	at com.intellij.openapi.editor.impl.CaretImpl.lambda$moveToVisualPosition$4(CaretImpl.java:531)
	at com.intellij.openapi.editor.impl.CaretImpl$$Lambda/0x00000008021af998.run(Unknown Source)
	at com.intellij.openapi.editor.impl.CaretModelImpl.doWithCaretMerging(CaretModelImpl.java:412)
	at com.intellij.openapi.editor.impl.CaretImpl.moveToVisualPosition(CaretImpl.java:531)
	at com.intellij.openapi.editor.impl.CaretImpl.moveToVisualPosition(CaretImpl.java:527)
	at com.intellij.openapi.editor.CaretModel.moveToVisualPosition(CaretModel.java:68)
	at com.intellij.openapi.editor.impl.EditorImpl$MyMouseAdapter.processMousePressed(EditorImpl.java:4495)
	at com.intellij.openapi.editor.impl.EditorImpl$MyMouseAdapter.lambda$runMousePressedCommand$0(EditorImpl.java:4285)
	at com.intellij.openapi.editor.impl.EditorImpl$MyMouseAdapter$$Lambda/0x00000008021ac9e0.run(Unknown Source)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:226)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:178)
	at com.intellij.openapi.editor.impl.EditorImpl$MyMouseAdapter.runMousePressedCommand(EditorImpl.java:4290)
	at com.intellij.openapi.editor.impl.EditorImpl$MyMouseAdapter.mousePressed(EditorImpl.java:4204)
	at java.awt.Component.processMouseEvent(java.desktop/Component.java:6662)
	at javax.swing.JComponent.processMouseEvent(java.desktop/JComponent.java:3394)
	at java.awt.Component.processEvent(java.desktop/Component.java:6430)
	at java.awt.Container.processEvent(java.desktop/Container.java:2266)
	at java.awt.Component.dispatchEventImpl(java.desktop/Component.java:5035)
	at java.awt.Container.dispatchEventImpl(java.desktop/Container.java:2324)
	at java.awt.Component.dispatchEvent(java.desktop/Component.java:4860)
	at java.awt.LightweightDispatcher.retargetMouseEvent(java.desktop/Container.java:4963)
	at java.awt.LightweightDispatcher.processMouseEvent(java.desktop/Container.java:4574)
	at java.awt.LightweightDispatcher.dispatchEvent(java.desktop/Container.java:4518)
	at java.awt.Container.dispatchEventImpl(java.desktop/Container.java:2310)
	at java.awt.Window.dispatchEventImpl(java.desktop/Window.java:2810)
	at java.awt.Component.dispatchEvent(java.desktop/Component.java:4860)
	at java.awt.EventQueue.dispatchEventImpl(java.desktop/EventQueue.java:783)
	at java.awt.EventQueue$4.run(java.desktop/EventQueue.java:728)
	at java.awt.EventQueue$4.run(java.desktop/EventQueue.java:722)
	at java.security.AccessController.executePrivileged(java.base@21.0.4/AccessController.java:778)
	at java.security.AccessController.doPrivileged(java.base@21.0.4/AccessController.java:400)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(java.base@21.0.4/ProtectionDomain.java:87)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(java.base@21.0.4/ProtectionDomain.java:98)
	at java.awt.EventQueue$5.run(java.desktop/EventQueue.java:755)
	at java.awt.EventQueue$5.run(java.desktop/EventQueue.java:753)
	at java.security.AccessController.executePrivileged(java.base@21.0.4/AccessController.java:778)
	at java.security.AccessController.doPrivileged(java.base@21.0.4/AccessController.java:400)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(java.base@21.0.4/ProtectionDomain.java:87)
	at java.awt.EventQueue.dispatchEvent(java.desktop/EventQueue.java:752)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.kt:696)
	at com.intellij.ide.IdeEventQueue.dispatchMouseEvent(IdeEventQueue.kt:635)
	at com.intellij.ide.IdeEventQueue._dispatchEvent$lambda$14(IdeEventQueue.kt:581)
	at com.intellij.ide.IdeEventQueue$$Lambda/0x0000000800a93898.compute(Unknown Source)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:84)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.kt:581)
	at com.intellij.ide.IdeEventQueue.access$_dispatchEvent(IdeEventQueue.kt:73)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1$1.compute(IdeEventQueue.kt:357)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1$1.compute(IdeEventQueue.kt:356)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:843)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.invoke(IdeEventQueue.kt:356)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.invoke(IdeEventQueue.kt:351)
	at com.intellij.ide.IdeEventQueueKt$performActivity$runnableWithWIL$1.invoke$lambda$0(IdeEventQueue.kt:1035)
	at com.intellij.ide.IdeEventQueueKt$performActivity$runnableWithWIL$1$$Lambda/0x000000080079fc58.run(Unknown Source)
	at com.intellij.openapi.application.WriteIntentReadAction.lambda$run$0(WriteIntentReadAction.java:24)
	at com.intellij.openapi.application.WriteIntentReadAction$$Lambda/0x00000008007a0550.compute(Unknown Source)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:84)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteIntentReadAction(ApplicationImpl.java:910)
	at com.intellij.openapi.application.WriteIntentReadAction.compute(WriteIntentReadAction.java:55)
	at com.intellij.openapi.application.WriteIntentReadAction.run(WriteIntentReadAction.java:23)
	at com.intellij.ide.IdeEventQueueKt$performActivity$runnableWithWIL$1.invoke(IdeEventQueue.kt:1035)
	at com.intellij.ide.IdeEventQueueKt$performActivity$runnableWithWIL$1.invoke(IdeEventQueue.kt:1035)
	at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$1(IdeEventQueue.kt:1036)
	at com.intellij.ide.IdeEventQueueKt$$Lambda/0x000000080079f548.run(Unknown Source)
	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:114)
	at com.intellij.ide.IdeEventQueueKt.performActivity(IdeEventQueue.kt:1036)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$10(IdeEventQueue.kt:351)
	at com.intellij.ide.IdeEventQueue$$Lambda/0x0000000800795ed8.run(Unknown Source)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.kt:397)
	at java.awt.EventDispatchThread.pumpOneEventForFilters(java.desktop/EventDispatchThread.java:207)
	at java.awt.EventDispatchThread.pumpEventsForFilter(java.desktop/EventDispatchThread.java:128)
	at java.awt.EventDispatchThread.pumpEventsForHierarchy(java.desktop/EventDispatchThread.java:117)
	at java.awt.EventDispatchThread.pumpEvents(java.desktop/EventDispatchThread.java:113)
	at java.awt.EventDispatchThread.pumpEvents(java.desktop/EventDispatchThread.java:105)
	at java.awt.EventDispatchThread.run(java.desktop/EventDispatchThread.java:92)
   Locked ownable synchronizers:
	- None
, "Thread-22993" #23421 [4608] daemon prio=5 os_prio=0 cpu=7343.75ms elapsed=83.45s tid=0x000001d2a6ceae30 nid=4608 runnable  [0x000000a17e5fd000]
   java.lang.Thread.State: RUNNABLE
	at java.io.FileOutputStream.writeBytes(java.base@21.0.4/Native Method)
	at java.io.FileOutputStream.write(java.base@21.0.4/FileOutputStream.java:367)
	at java.io.BufferedOutputStream.implWrite(java.base@21.0.4/BufferedOutputStream.java:217)
	at java.io.BufferedOutputStream.write(java.base@21.0.4/BufferedOutputStream.java:200)
	at sun.nio.cs.StreamEncoder.writeBytes(java.base@21.0.4/StreamEncoder.java:309)
	at sun.nio.cs.StreamEncoder.implWrite(java.base@21.0.4/StreamEncoder.java:381)
	at sun.nio.cs.StreamEncoder.implWrite(java.base@21.0.4/StreamEncoder.java:357)
	at sun.nio.cs.StreamEncoder.lockedWrite(java.base@21.0.4/StreamEncoder.java:158)
	at sun.nio.cs.StreamEncoder.write(java.base@21.0.4/StreamEncoder.java:139)
	at sun.nio.cs.StreamEncoder.write(java.base@21.0.4/StreamEncoder.java:167)
	at java.io.OutputStreamWriter.write(java.base@21.0.4/OutputStreamWriter.java:237)
	at java.io.Writer.write(java.base@21.0.4/Writer.java:278)
	at com.github.continuedev.continueintellijextension.continue.CoreMessenger.write(CoreMessenger.kt:34)
	at com.github.continuedev.continueintellijextension.continue.CoreMessenger.request(CoreMessenger.kt:46)
	at com.github.continuedev.continueintellijextension.toolWindow.ContinueBrowser$2.invoke(ContinueBrowser.kt:63)
	at com.github.continuedev.continueintellijextension.toolWindow.ContinueBrowser$2.invoke(ContinueBrowser.kt:51)
	at com.github.continuedev.continueintellijextension.toolWindow.ContinueBrowser._init_$lambda$1(ContinueBrowser.kt:51)
	at com.github.continuedev.continueintellijextension.toolWindow.ContinueBrowser$$Lambda/0x0000000802fd8488.apply(Unknown Source)
	at com.intellij.ui.jcef.JBCefJSQuery$1.onQuery(JBCefJSQuery.java:123)
   Locked ownable synchronizers:
	- <0x000000072a2db3b0> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)
	- <0x000000072f05d938> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)
```