### PR TITLE
Update CLA allowlist to include additional contributors

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -26,5 +26,6 @@ jobs:
           path-to-signatures: "signatures/version1/cla.json"
           path-to-document: "https://github.com/continuedev/continue/blob/main/docs/docs/CLA.md"
           branch: cla-signatures
-          allowlist: dependabot[bot]
+          # Bots and CLAs signed outside of GitHub
+          allowlist: dependabot[bot],fbricon,panyamkeerthana,Jazzcort,owtaylor,halfline
           signed-commit-message: "CLA signed in $pullRequestNo"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the CLA allowlist to include six additional contributors who have signed the CLA outside of GitHub.

<!-- End of auto-generated description by cubic. -->

