### PR TITLE
Add support for isWorkspaceRemote message type in IntelliJ extension

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/MessageTypes.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/MessageTypes.kt
@@ -41,11 +41,12 @@ class MessageTypes {
             "getTerminalContents",
             "showToast",
             "openUrl",
-            
+            "isWorkspaceRemote",
+
             // These only come from the GUI for now but should be here to prevent confusion
             "toggleDevTools",
             "showTutorial",
-            
+
             // These are jetbrains only and only come from the GUI for now
             // But again including for consistency
             "copyText",

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
@@ -202,6 +202,11 @@ class IdeProtocolClient(
                         respond(contents)
                     }
 
+                    "isWorkspaceRemote" -> {
+                        val isRemote = ide.isWorkspaceRemote()
+                        respond(isRemote)
+                    }
+
                     "saveFile" -> {
                         val params = Gson().fromJson(
                             dataElement.toString(),
@@ -475,7 +480,7 @@ class IdeProtocolClient(
         val editor = EditorUtils.getEditor(project)
         val rif = editor?.getHighlightedRIF() ?: return
 
-       val serializedRif = com.github.continuedev.continueintellijextension.RangeInFileWithContents(
+        val serializedRif = com.github.continuedev.continueintellijextension.RangeInFileWithContents(
             filepath = rif.filepath,
             range = rif.range,
             contents = rif.contents


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for the isWorkspaceRemote message type in the IntelliJ extension, allowing clients to check if the workspace is remote. 

- **New Features**
  - Handled isWorkspaceRemote requests and returned the remote status from the IDE.

<!-- End of auto-generated description by cubic. -->

