### PR TITLE
Remove unused onlyOneInsertion param

### DIFF
--- a/core/core.ts
+++ b/core/core.ts
@@ -558,7 +558,6 @@ export class Core {
           : undefined,
         input: data.input,
         language: data.language,
-        onlyOneInsertion: false,
         overridePrompt: undefined,
         abortController,
       });

--- a/core/edit/streamDiffLines.ts
+++ b/core/edit/streamDiffLines.ts
@@ -66,7 +66,6 @@ export async function* streamDiffLines({
   abortController,
   input,
   language,
-  onlyOneInsertion,
   overridePrompt,
   rulesToInclude,
 }: {
@@ -77,7 +76,6 @@ export async function* streamDiffLines({
   abortController: AbortController;
   input: string;
   language: string | undefined;
-  onlyOneInsertion: boolean;
   overridePrompt: ChatMessage[] | undefined;
   rulesToInclude: RuleWithSource[] | undefined;
 }): AsyncGenerator<DiffLine> {
@@ -182,13 +180,7 @@ export async function* streamDiffLines({
     diffLines = addIndentation(diffLines, indentation);
   }
 
-  let seenGreen = false;
   for await (const diffLine of diffLines) {
     yield diffLine;
-    if (diffLine.type === "new") {
-      seenGreen = true;
-    } else if (onlyOneInsertion && seenGreen && diffLine.type === "same") {
-      break;
-    }
   }
 }

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -142,14 +142,12 @@ const getCommandsMap: (
    *
    * @param  promptName - The key for the prompt in the context menu configuration.
    * @param  fallbackPrompt - The prompt to use if the configured prompt is not available.
-   * @param  [onlyOneInsertion] - Optional. If true, only one insertion will be made.
    * @param  [range] - Optional. The range to edit if provided.
    * @returns
    */
   async function streamInlineEdit(
     promptName: keyof ContextMenuConfig,
     fallbackPrompt: string,
-    onlyOneInsertion?: boolean,
     range?: vscode.Range,
   ) {
     const { config } = await configHandler.loadConfig();
@@ -170,7 +168,6 @@ const getCommandsMap: (
       input:
         config.experimental?.contextMenuPrompts?.[promptName] ?? fallbackPrompt,
       llm,
-      onlyOneInsertion,
       range,
       rulesToInclude: config.rules,
     });
@@ -243,7 +240,7 @@ const getCommandsMap: (
     ) => {
       captureCommandTelemetry("customQuickActionStreamInlineEdit");
 
-      streamInlineEdit("docstring", prompt, false, range);
+      streamInlineEdit("docstring", prompt, range);
     },
     "continue.codebaseForceReIndex": async () => {
       core.invoke("index/forceReIndex", undefined);
@@ -358,7 +355,6 @@ const getCommandsMap: (
       void streamInlineEdit(
         "docstring",
         "Write a docstring for this code. Do not change anything about the code itself.",
-        false,
       );
     },
     "continue.fixCode": async () => {

--- a/extensions/vscode/src/diff/vertical/manager.ts
+++ b/extensions/vscode/src/diff/vertical/manager.ts
@@ -287,7 +287,6 @@ export class VerticalDiffManager {
     input,
     llm,
     streamId,
-    onlyOneInsertion,
     quickEdit,
     range,
     newCode,
@@ -297,7 +296,6 @@ export class VerticalDiffManager {
     input: string;
     llm: ILLM;
     streamId?: string;
-    onlyOneInsertion?: boolean;
     quickEdit?: string;
     range?: vscode.Range;
     newCode?: string;
@@ -466,7 +464,6 @@ export class VerticalDiffManager {
           rulesToInclude,
           input,
           language: getMarkdownLanguageTagForFile(fileUri),
-          onlyOneInsertion: !!onlyOneInsertion,
           overridePrompt,
           abortController,
         });


### PR DESCRIPTION
## Description
Follow up to https://github.com/continuedev/continue/pull/6364
Removes unused `onlyOneInsertion` param
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the unused onlyOneInsertion parameter from core and VS Code extension code to simplify function signatures.

<!-- End of auto-generated description by cubic. -->

