### PR TITLE
fix: pasting images

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor/utils/editorConfig.ts
+++ b/gui/src/components/mainInput/TipTapEditor/utils/editorConfig.ts
@@ -155,22 +155,24 @@ export function createEditorConfig(options: {
                     for (const item of items) {
                       const file = item.getAsFile();
                       file &&
-                        void modelSupportsImages(
+                        modelSupportsImages(
                           model.provider,
                           model.model,
                           model.title,
                           model.capabilities,
                         ) &&
-                        handleImageFile(ideMessenger, file).then((resp) => {
-                          if (!resp) return;
-                          const [img, dataUrl] = resp;
-                          const { schema } = view.state;
-                          const node = schema.nodes.image.create({
-                            src: dataUrl,
-                          });
-                          const tr = view.state.tr.insert(0, node);
-                          view.dispatch(tr);
-                        });
+                        void handleImageFile(ideMessenger, file).then(
+                          (resp) => {
+                            if (!resp) return;
+                            const [img, dataUrl] = resp;
+                            const { schema } = view.state;
+                            const node = schema.nodes.image.create({
+                              src: dataUrl,
+                            });
+                            const tr = view.state.tr.insert(0, node);
+                            view.dispatch(tr);
+                          },
+                        );
                     }
                   }
                 },


### PR DESCRIPTION
## Description

Resolves https://github.com/continuedev/continue/issues/6348
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where pasting images did not work in the main input editor. Images can now be pasted and are inserted correctly.

<!-- End of auto-generated description by cubic. -->

