### PR TITLE
feat: add `claude-opus-4` tool support for bedrock models

### DIFF
--- a/core/llm/toolSupport.ts
+++ b/core/llm/toolSupport.ts
@@ -88,15 +88,14 @@ export const PROVIDER_TOOL_SUPPORT: Record<string, (model: string) => boolean> =
       );
     },
     bedrock: (model) => {
-      // For Bedrock, only support Claude Sonnet models with versions 3.5/3-5 and 3.7/3-7
       if (
-        model.toLowerCase().includes("sonnet") &&
         [
-          "claude-3-5",
-          "claude-3.5",
-          "claude-3-7",
-          "claude-3.7",
+          "claude-3-5-sonnet",
+          "claude-3.5-sonnet",
+          "claude-3-7-sonnet",
+          "claude-3.7-sonnet",
           "claude-sonnet-4",
+          "claude-opus-4",
         ].some((part) => model.toLowerCase().includes(part))
       ) {
         return true;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for the claude-opus-4 model to Bedrock tool support checks.

<!-- End of auto-generated description by cubic. -->

