### PR TITLE
fix: :bug: The edit rules button doesn't open the rule file

### DIFF
--- a/core/config/markdown/loadCodebaseRules.ts
+++ b/core/config/markdown/loadCodebaseRules.ts
@@ -33,7 +33,7 @@ export async function loadCodebaseRules(ide: IDE): Promise<{
         const content = await ide.readFile(filePath);
         const rule = markdownToRule(content, { uriType: "file", filePath });
 
-        rules.push({ ...rule, source: "rules-block" });
+        rules.push({ ...rule, source: "rules-block", ruleFile: filePath });
       } catch (e) {
         errors.push({
           fatal: false,

--- a/core/config/markdown/loadMarkdownRules.ts
+++ b/core/config/markdown/loadMarkdownRules.ts
@@ -33,7 +33,7 @@ export async function loadMarkdownRules(ide: IDE): Promise<{
           uriType: "file",
           filePath: file.path,
         });
-        rules.push({ ...rule, source: "rules-block" });
+        rules.push({ ...rule, source: "rules-block", ruleFile: file.path });
       } catch (e) {
         errors.push({
           fatal: false,


### PR DESCRIPTION
## Description

The edit rules button doesn't open the related rule file, it instead always opens the main config file.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

I've performed manual testing with various rules and the related rule file is now opened.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the edit rules button so it now opens the correct rule file instead of always opening the main config file.

<!-- End of auto-generated description by cubic. -->

