### PR TITLE
Fix install-all-dependencies script

### DIFF
--- a/scripts/install-dependencies.ps1
+++ b/scripts/install-dependencies.ps1
@@ -76,6 +76,12 @@ if (($null -eq $node)) {
 Write-Host "`nInstalling root-level dependencies..." -ForegroundColor White
 npm install
 
+Write-Host "`nBuilding openai-adapters..." -ForegroundColor White
+Push-Location packages/openai-adapters
+npm install
+npm run build
+Pop-Location
+
 Write-Host "`nBuilding config-yaml..." -ForegroundColor White
 Push-Location packages/config-yaml
 npm install

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -30,6 +30,12 @@ fi
 echo "Installing root-level dependencies..."
 npm install
 
+echo "Building openai-adapters..."
+pushd packages/openai-adapters
+npm install
+npm run build
+popd
+
 echo "Building config-yaml..."
 pushd packages/config-yaml
 npm install


### PR DESCRIPTION
## Description

Because the script was missing the step to build `openai-adapters`, the build would fail, leading to the inability to run tests or the local copy of the extension. This change includes that step so that contributors can successfully test locally.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots

N/A, dev-only change

## Tests

N/A, dev-only change

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a missing build step for openai-adapters in the install-all-dependencies scripts to fix local build and test failures.

<!-- End of auto-generated description by cubic. -->

