### PR TITLE
feat: add a sessions loading indicator

### DIFF
--- a/gui/src/components/History/index.tsx
+++ b/gui/src/components/History/index.tsx
@@ -54,6 +54,9 @@ export function History() {
   const allSessionMetadata = useAppSelector(
     (state) => state.session.allSessionMetadata,
   );
+  const isSessionMetadataLoading = useAppSelector(
+    (state) => state.session.isSessionMetadataLoading,
+  );
 
   useEffect(() => {
     try {
@@ -107,7 +110,7 @@ export function History() {
 
             // actual update + refresh
             await ideMessenger.request("history/clear", undefined);
-            dispatch(refreshSessionMetadata({}));
+            void dispatch(refreshSessionMetadata({}));
 
             // start a new session
             dispatch(newSession());
@@ -148,8 +151,15 @@ export function History() {
       <div className="thin-scrollbar flex flex-1 flex-col overflow-y-auto pr-4">
         {filteredAndSortedSessions.length === 0 && (
           <div className="m-3 text-center">
-            No past sessions found. To start a new session, either click the "+"
-            button or use the keyboard shortcut: <Shortcut>meta L</Shortcut>
+            {isSessionMetadataLoading ? (
+              "Loading Sessions..."
+            ) : (
+              <>
+                No past sessions found. To start a new session, either click the
+                "+" button or use the keyboard shortcut:{" "}
+                <Shortcut>meta L</Shortcut>
+              </>
+            )}
           </div>
         )}
 

--- a/gui/src/hooks/ParallelListeners.tsx
+++ b/gui/src/hooks/ParallelListeners.tsx
@@ -22,6 +22,7 @@ import {
   addContextItemsAtIndex,
   selectCurrentToolCall,
   setHasReasoningEnabled,
+  setIsSessionMetadataLoading,
   updateApplyState,
 } from "../redux/slices/sessionSlice";
 import { setTTSActive } from "../redux/slices/uiSlice";
@@ -101,6 +102,7 @@ function ParallelListeners() {
 
   const initialLoadAuthAndConfig = useCallback(
     async (initial: boolean) => {
+      dispatch(setIsSessionMetadataLoading(true));
       dispatch(setConfigLoading(true));
       const result = await ideMessenger.request(
         "config/getSerializedProfileInfo",

--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -43,6 +43,7 @@ export type ChatHistoryItemWithMessageId = ChatHistoryItem & {
 
 type SessionState = {
   lastSessionId?: string;
+  isSessionMetadataLoading: boolean;
   allSessionMetadata: SessionMetadata[];
   history: ChatHistoryItemWithMessageId[];
   isStreaming: boolean;
@@ -62,6 +63,7 @@ type SessionState = {
 };
 
 const initialState: SessionState = {
+  isSessionMetadataLoading: false,
   allSessionMetadata: [],
   history: [],
   isStreaming: false,
@@ -423,6 +425,12 @@ export const sessionSlice = createSlice({
     updateSessionTitle: (state, { payload }: PayloadAction<string>) => {
       state.title = payload;
     },
+    setIsSessionMetadataLoading: (
+      state,
+      { payload }: PayloadAction<boolean>,
+    ) => {
+      state.isSessionMetadataLoading = payload;
+    },
     setAllSessionMetadata: (
       state,
       { payload }: PayloadAction<SessionMetadata[]>,
@@ -728,6 +736,7 @@ export const {
   setToolGenerated,
   updateToolCallOutput,
   setMode,
+  setIsSessionMetadataLoading,
   setAllSessionMetadata,
   addSessionMetadata,
   updateSessionMetadata,

--- a/gui/src/redux/thunks/session.ts
+++ b/gui/src/redux/thunks/session.ts
@@ -8,6 +8,7 @@ import {
   deleteSessionMetadata,
   newSession,
   setAllSessionMetadata,
+  setIsSessionMetadataLoading,
   updateSessionMetadata,
 } from "../slices/sessionSlice";
 import { ThunkApiType } from "../store";
@@ -43,6 +44,7 @@ export const refreshSessionMetadata = createAsyncThunk<
   if (result.status === "error") {
     throw new Error(result.error);
   }
+  dispatch(setIsSessionMetadataLoading(false));
   dispatch(setAllSessionMetadata(result.content));
   return result.content;
 });
@@ -63,7 +65,7 @@ export const deleteSession = createAsyncThunk<void, string, ThunkApiType>(
     if (result.status === "error") {
       throw new Error(result.error);
     }
-    dispatch(refreshSessionMetadata({}));
+    void dispatch(refreshSessionMetadata({}));
   },
 );
 


### PR DESCRIPTION
## Description

Show a loading indicator when sessions are loading. 

Previously, a "no sessions found" scenario happens when a user clicks the sessions button before the config and sessions loads (which can create a confusion like if all sessions were deleted, etc.)

- create a new `isSessionMetadataLoading` in session state
- set the loading as true when the config is first fetched and set it as false in `refreshSessionMetadata`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots



https://github.com/user-attachments/assets/7391e1e1-a8cd-40c3-9140-e1fd98eb4b96


https://github.com/user-attachments/assets/8c825472-7772-4fc1-8fb3-5e3bdc50ec74


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a loading indicator for sessions to prevent confusion when session data is still loading.

- **New Features**
  - Shows "Loading Sessions..." while session metadata is being fetched.
  - Tracks loading state with a new isSessionMetadataLoading flag.

<!-- End of auto-generated description by cubic. -->

