### PR TITLE
Fix context item deduplication logic and add text truncation to context peek

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor/utils/resolveEditorContent.ts
+++ b/gui/src/components/mainInput/TipTapEditor/utils/resolveEditorContent.ts
@@ -201,12 +201,12 @@ async function gatherContextItems({
       if (
         !acc.some(
           (i) =>
-            (i.id.providerTitle === item.id.providerTitle &&
-              i.id.itemId === item.id.itemId) ||
-            (i.uri &&
-              item.uri &&
-              i.uri.type === item.uri.type &&
-              i.uri.value === item.uri.value),
+            i.id.providerTitle === item.id.providerTitle &&
+            i.id.itemId === item.id.itemId &&
+            i.uri &&
+            item.uri &&
+            i.uri.type === item.uri.type &&
+            i.uri.value === item.uri.value,
         )
       ) {
         acc.push(item);

--- a/gui/src/components/mainInput/belowMainInput/ContextItemsPeek.tsx
+++ b/gui/src/components/mainInput/belowMainInput/ContextItemsPeek.tsx
@@ -131,7 +131,7 @@ export function ContextItemsPeekItem({
         {contextItem.name}
       </span>
       <div
-        className={`group flex flex-row items-center gap-1.5 pr-1.5 text-xs text-gray-400 ${isUrl ? "hover:underline" : ""}`}
+        className={`group flex flex-row items-center gap-1.5 truncate pr-1.5 text-xs text-gray-400 ${isUrl ? "hover:underline" : ""}`}
         onClick={
           isUrl
             ? (e) => {


### PR DESCRIPTION
itemId isn't necessarily unique, so this was necessary to avoid items being removed. This was causing docs to not work for example (only one result returned)