### PR TITLE
build: Remove test dependencies from the release

### DIFF
--- a/extensions/intellij/build.gradle.kts
+++ b/extensions/intellij/build.gradle.kts
@@ -46,7 +46,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.2")
     testImplementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
-    implementation("com.automation-remarks:video-recorder-junit5:2.0")
+    testImplementation("com.automation-remarks:video-recorder-junit5:2.0")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
 
 


### PR DESCRIPTION
I noticed that `video-recorder-junit5` dependency was probably mistakenly added as a non-test dependency. As a result, the `buildPlugin` artifact included a lot of unnecessary dependencies including an old, vulnerable Apache Commons IO ([CVE-2021-29425](https://www.mend.io/vulnerability-database/CVE-2021-29425)).

List of dependencies before fix:

```
annotations-13.0.jar
apiguardian-api-1.0.0.jar
awaitility-3.1.6.jar
commons-io-1.4.jar
commons-lang3-3.8.1.jar
hamcrest-core-1.3.jar
hamcrest-library-1.3.jar
instrumented-continue-intellij-extension-1.0.27.jar
junit-jupiter-api-5.4.1.jar
junit-platform-commons-1.4.1.jar
kotlin-stdlib-1.8.10.jar
kotlin-stdlib-common-1.9.10.jar
kotlin-stdlib-jdk7-1.9.24.jar
kotlin-stdlib-jdk8-1.9.24.jar
kotlinx-serialization-core-jvm-1.5.0.jar
kotlinx-serialization-json-jvm-1.5.0.jar
log4j-api-2.20.0.jar
log4j-core-2.20.0.jar
log4j-over-slf4j-1.7.36.jar
objenesis-2.6.jar
okhttp-4.12.0.jar
okio-jvm-3.6.0.jar
opentest4j-1.1.1.jar
owner-1.0.10.jar
owner-java8-1.0.10.jar
posthog-1.2.0.jar
searchableOptions-1.0.27.jar
sentry-8.14.0.jar
sentry-log4j2-8.14.0.jar
sentry-okhttp-8.14.0.jar
slf4j-api-1.7.36.jar
video-recorder-core-2.0.jar
video-recorder-junit5-2.0.jar
zt-exec-1.10.jar
```

After:

```
annotations-13.0.jar
instrumented-continue-intellij-extension-1.0.27.jar
kotlin-stdlib-1.8.10.jar
kotlin-stdlib-common-1.9.10.jar
kotlin-stdlib-jdk7-1.9.24.jar
kotlin-stdlib-jdk8-1.9.24.jar
kotlinx-serialization-core-jvm-1.5.0.jar
kotlinx-serialization-json-jvm-1.5.0.jar
log4j-api-2.20.0.jar
log4j-core-2.20.0.jar
okhttp-4.12.0.jar
okio-jvm-3.6.0.jar
posthog-1.2.0.jar
searchableOptions-1.0.27.jar
sentry-8.14.0.jar
sentry-log4j2-8.14.0.jar
sentry-okhttp-8.14.0.jar
```