### PR TITLE
docs: Recommend File Expander plugin

### DIFF
--- a/extensions/intellij/CONTRIBUTING.md
+++ b/extensions/intellij/CONTRIBUTING.md
@@ -54,7 +54,7 @@ notes below).
 
 #### Recommended plugins
 
-- [Thread Access Info](https://plugins.jetbrains.com/plugin/16815-thread-access-info) - adds an extra debug panel 
+- [Thread Access Info](https://plugins.jetbrains.com/plugin/16815-thread-access-info) - adds an extra debug panel
   showing possible thread access violation (according to Intellij Platform SDK guidelines)
 - [File Expander](https://plugins.jetbrains.com/plugin/11940-file-expander) - allows you to easily preview archives as
   directories (like `build/distributions/continue-*.zip`)


### PR DESCRIPTION
Related to #6431

It just occurred to me that opening ZIP is not a built-in feature, but a separate plugin. 😅 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the JetBrains extension contribution guide to recommend the File Expander plugin for easier archive preview.

<!-- End of auto-generated description by cubic. -->

