### PR TITLE
@codebase use tool calling (under experimental flag)

### DIFF
--- a/core/config/sharedConfig.ts
+++ b/core/config/sharedConfig.ts
@@ -22,6 +22,7 @@ export const sharedConfigSchema = z
     logEditingData: z.boolean(),
     optInNextEditFeature: z.boolean(),
     enableExperimentalTools: z.boolean(),
+    codebaseToolCallingOnly: z.boolean(),
 
     // `ui` in `ContinueConfig`
     showSessionTabs: z.boolean(),
@@ -186,6 +187,10 @@ export function modifyAnyConfigWithSharedConfig<
   if (sharedConfig.optInNextEditFeature !== undefined) {
     configCopy.experimental.optInNextEditFeature =
       sharedConfig.optInNextEditFeature;
+  }
+  if (sharedConfig.codebaseToolCallingOnly !== undefined) {
+    configCopy.experimental.codebaseToolCallingOnly =
+      sharedConfig.codebaseToolCallingOnly;
   }
 
   return configCopy;

--- a/core/context/retrieval/pipelines/BaseRetrievalPipeline.ts
+++ b/core/context/retrieval/pipelines/BaseRetrievalPipeline.ts
@@ -1,13 +1,44 @@
 // @ts-ignore
 import nlp from "wink-nlp-utils";
 
-import { BranchAndDir, Chunk, ContinueConfig, IDE, ILLM } from "../../../";
+import {
+  BranchAndDir,
+  Chunk,
+  ContextItem,
+  ContinueConfig,
+  IDE,
+  ILLM,
+  Tool,
+  ToolExtras,
+} from "../../../";
 import { openedFilesLruCache } from "../../../autocomplete/util/openedFilesLruCache";
 import { chunkDocument } from "../../../indexing/chunk/chunk";
 import { FullTextSearchCodebaseIndex } from "../../../indexing/FullTextSearchCodebaseIndex";
 import { LanceDbIndex } from "../../../indexing/LanceDbIndex";
+import { BuiltInToolNames } from "../../../tools/builtIn";
+import { globSearchTool } from "../../../tools/definitions/globSearch";
+import { grepSearchTool } from "../../../tools/definitions/grepSearch";
+import { lsTool } from "../../../tools/definitions/lsTool";
+import { readFileTool } from "../../../tools/definitions/readFile";
+import { viewRepoMapTool } from "../../../tools/definitions/viewRepoMap";
+import { viewSubdirectoryTool } from "../../../tools/definitions/viewSubdirectory";
+import { fileGlobSearchImpl } from "../../../tools/implementations/globSearch";
+import { grepSearchImpl } from "../../../tools/implementations/grepSearch";
+import { lsToolImpl } from "../../../tools/implementations/lsTool";
+import { readFileImpl } from "../../../tools/implementations/readFile";
+import { viewRepoMapImpl } from "../../../tools/implementations/viewRepoMap";
+import { viewSubdirectoryImpl } from "../../../tools/implementations/viewSubdirectory";
 
 const DEFAULT_CHUNK_SIZE = 384;
+
+const availableTools: Tool[] = [
+  globSearchTool,
+  grepSearchTool,
+  lsTool,
+  readFileTool,
+  viewRepoMapTool,
+  viewSubdirectoryTool,
+];
 
 export interface RetrievalPipelineOptions {
   llm: ILLM;
@@ -152,7 +183,175 @@ export default class BaseRetrievalPipeline implements IRetrievalPipeline {
     );
   }
 
-  run(args: RetrievalPipelineRunArguments): Promise<Chunk[]> {
+  run(_args: RetrievalPipelineRunArguments): Promise<Chunk[]> {
     throw new Error("Not implemented");
+  }
+
+  protected async retrieveWithTools(input: string): Promise<Chunk[]> {
+    const toolSelectionPrompt = `Given the following user input: "${input}"
+
+Available tools:
+${availableTools
+  .map((tool) => {
+    const requiredParams = tool.function.parameters?.required || [];
+    const properties = tool.function.parameters?.properties || {};
+    const paramDescriptions = requiredParams
+      .map(
+        (param: any) =>
+          `${param}: ${properties[param]?.description || "string"}`,
+      )
+      .join(", ");
+
+    return `- ${tool.function.name}: ${tool.function.description}
+  Required arguments: ${paramDescriptions || "none"}`;
+  })
+  .join("\n")}
+
+Determine which tools should be used to answer this query. You should feel free to use multiple tools when they would be helpful for comprehensive results. Respond ONLY a JSON object containing the following and nothing else:
+{
+  "tools": [
+    {
+      "name": "<tool_name>",
+      "args": { "<required_parameter_name>": "<required_parameter_value>" }
+    }
+  ]
+}`;
+
+    // Get LLM response for tool selection
+    const toolSelectionResponse = await this.options.llm.complete(
+      toolSelectionPrompt,
+      new AbortController().signal,
+    );
+
+    let toolCalls: { name: string; args: any }[] = [];
+    try {
+      const parsed = JSON.parse(toolSelectionResponse);
+      toolCalls = parsed.tools || [];
+      console.log("retrieveWithTools", toolCalls);
+    } catch (e) {
+      console.log("Failed to parse tool selection response", e);
+      return [];
+    }
+
+    // Execute tools and collect results
+    const allContextItems: ContextItem[] = [];
+
+    const toolExtras: ToolExtras = {
+      ide: this.options.ide,
+      llm: this.options.llm,
+      fetch: fetch,
+      tool: grepSearchTool,
+      config: this.options.config,
+    };
+
+    for (const toolCall of toolCalls) {
+      switch (toolCall.name) {
+        case BuiltInToolNames.FileGlobSearch:
+          toolExtras.tool = globSearchTool;
+          const globSearchContextItems = await fileGlobSearchImpl(
+            toolCall.args,
+            toolExtras,
+          );
+          allContextItems.push(...globSearchContextItems);
+          break;
+
+        case BuiltInToolNames.GrepSearch:
+          toolExtras.tool = grepSearchTool;
+          const grepContextItems = await grepSearchImpl(
+            toolCall.args,
+            toolExtras,
+          );
+          allContextItems.push(...grepContextItems);
+          break;
+
+        case BuiltInToolNames.LSTool:
+          toolExtras.tool = lsTool;
+          const lsContextItems = await lsToolImpl(toolCall.args, toolExtras);
+          allContextItems.push(...lsContextItems);
+          break;
+
+        case BuiltInToolNames.ReadFile:
+          toolExtras.tool = readFileTool;
+          const readFileImplContextItems = await readFileImpl(
+            toolCall.args,
+            toolExtras,
+          );
+          allContextItems.push(...readFileImplContextItems);
+          break;
+
+        case BuiltInToolNames.ViewRepoMap:
+          toolExtras.tool = viewRepoMapTool;
+          const repoMapContextItems = await viewRepoMapImpl(
+            toolCall.args,
+            toolExtras,
+          );
+          allContextItems.push(...repoMapContextItems);
+          break;
+
+        case BuiltInToolNames.ViewSubdirectory:
+          toolExtras.tool = viewSubdirectoryTool;
+          const viewSubdirContextItems = await viewSubdirectoryImpl(
+            toolCall.args,
+            toolExtras,
+          );
+          allContextItems.push(...viewSubdirContextItems);
+          break;
+      }
+    }
+
+    const chunks: Chunk[] = [];
+
+    // Transform ContextItem[] to Chunk[]
+    for (const contextItem of allContextItems) {
+      const content = contextItem.content;
+      const matches = [...content.matchAll(/^\.\/([^\n]+)$/gm)];
+
+      if (matches.length === 0) {
+        // single chunk content or no file path patterns found that need to be split
+        const filepath =
+          contextItem.uri?.value || contextItem.name || "unknown";
+        const cleanedFilepath = filepath.replace(/^file:\/\/\//, "");
+
+        chunks.push({
+          content: contextItem.content,
+          startLine: -1,
+          endLine: -1,
+          digest: `file:///${cleanedFilepath}`,
+          filepath: `file:///${cleanedFilepath}`,
+          index: 0,
+        });
+      } else {
+        // Split grep search results by file paths and create separate chunks
+        for (let i = 0; i < matches.length; i++) {
+          const match = matches[i];
+          const filepath = match[1];
+          const startIndex = match.index!;
+          const endIndex =
+            i < matches.length - 1 ? matches[i + 1].index! : content.length;
+
+          // Extract grepped content for this file
+          const fileContent = content
+            .substring(startIndex, endIndex)
+            .replace(/^\.\/[^\n]+\n/, "") // remove the line with file path
+            .trim();
+
+          if (fileContent) {
+            // getUriDescription expects a full file path
+            const fullFilePath = `file:///${filepath}`;
+            chunks.push({
+              content: fileContent,
+              startLine: -1,
+              endLine: -1,
+              digest: fullFilePath,
+              filepath: fullFilePath,
+              index: i,
+            });
+          }
+        }
+      }
+    }
+
+    console.log("retrieveWithTools chunks", chunks);
+    return chunks;
   }
 }

--- a/core/context/retrieval/pipelines/BaseRetrievalPipeline.ts
+++ b/core/context/retrieval/pipelines/BaseRetrievalPipeline.ts
@@ -183,7 +183,7 @@ export default class BaseRetrievalPipeline implements IRetrievalPipeline {
     );
   }
 
-  run(_args: RetrievalPipelineRunArguments): Promise<Chunk[]> {
+  run(args: RetrievalPipelineRunArguments): Promise<Chunk[]> {
     throw new Error("Not implemented");
   }
 

--- a/core/context/retrieval/pipelines/NoRerankerRetrievalPipeline.ts
+++ b/core/context/retrieval/pipelines/NoRerankerRetrievalPipeline.ts
@@ -64,12 +64,22 @@ export default class NoRerankerRetrievalPipeline extends BaseRetrievalPipeline {
       console.error("Error retrieving repo map chunks:", error);
     }
 
-    retrievalResults.push(
-      ...recentlyEditedFilesChunks,
-      ...ftsChunks,
-      ...embeddingsChunks,
-      ...repoMapChunks,
-    );
+    if (this.options.config.experimental?.codebaseToolCallingOnly) {
+      let toolBasedChunks: Chunk[] = [];
+      try {
+        toolBasedChunks = await this.retrieveWithTools(input);
+      } catch (error) {
+        console.error("Error retrieving tool based chunks:", error);
+      }
+      retrievalResults.push(...toolBasedChunks);
+    } else {
+      retrievalResults.push(
+        ...recentlyEditedFilesChunks,
+        ...ftsChunks,
+        ...embeddingsChunks,
+        ...repoMapChunks,
+      );
+    }
 
     if (filterDirectory) {
       // Backup if the individual retrieval methods don't listen

--- a/core/context/retrieval/pipelines/RerankerRetrievalPipeline.ts
+++ b/core/context/retrieval/pipelines/RerankerRetrievalPipeline.ts
@@ -58,12 +58,22 @@ export default class RerankerRetrievalPipeline extends BaseRetrievalPipeline {
       console.error("Error retrieving repo map chunks:", error);
     }
 
-    retrievalResults.push(
-      ...recentlyEditedFilesChunks,
-      ...ftsChunks,
-      ...embeddingsChunks,
-      ...repoMapChunks,
-    );
+    if (config.experimental?.codebaseToolCallingOnly) {
+      let toolBasedChunks: Chunk[] = [];
+      try {
+        toolBasedChunks = await this.retrieveWithTools(input);
+      } catch (error) {
+        console.error("Error retrieving tool based chunks:", error);
+      }
+      retrievalResults.push(...toolBasedChunks);
+    } else {
+      retrievalResults.push(
+        ...recentlyEditedFilesChunks,
+        ...ftsChunks,
+        ...embeddingsChunks,
+        ...repoMapChunks,
+      );
+    }
 
     if (filterDirectory) {
       // Backup if the individual retrieval methods don't listen

--- a/core/context/retrieval/retrieval.ts
+++ b/core/context/retrieval/retrieval.ts
@@ -91,7 +91,7 @@ export async function retrieveContextItemsFromEmbeddings(
     return [];
   }
 
-  const result = [
+  return [
     {
       ...INSTRUCTIONS_BASE_ITEM,
       content:
@@ -122,6 +122,4 @@ export async function retrieveContextItemsFromEmbeddings(
         };
       }),
   ];
-
-  return result;
 }

--- a/core/context/retrieval/retrieval.ts
+++ b/core/context/retrieval/retrieval.ts
@@ -91,7 +91,7 @@ export async function retrieveContextItemsFromEmbeddings(
     return [];
   }
 
-  return [
+  const result = [
     {
       ...INSTRUCTIONS_BASE_ITEM,
       content:
@@ -108,7 +108,11 @@ export async function retrieveContextItemsFromEmbeddings(
         }
 
         return {
-          name: `${baseName} (${r.startLine + 1}-${r.endLine + 1})`,
+          // Don't show line numbers for tool calls where startLine = -1
+          name:
+            r.startLine === -1
+              ? baseName
+              : `${baseName} (${r.startLine + 1}-${r.endLine + 1})`,
           description: last2Parts,
           content: `\`\`\`${relativePathOrBasename}\n${r.content}\n\`\`\``,
           uri: {
@@ -118,4 +122,6 @@ export async function retrieveContextItemsFromEmbeddings(
         };
       }),
   ];
+
+  return result;
 }

--- a/core/core.ts
+++ b/core/core.ts
@@ -45,7 +45,6 @@ import {
   RangeInFile,
   ToolCall,
   type ContextItem,
-  type ContextItemId,
   type IDE,
 } from ".";
 
@@ -1102,11 +1101,6 @@ export class Core {
     }
 
     try {
-      const id: ContextItemId = {
-        providerTitle: provider.description.title,
-        itemId: uuidv4(),
-      };
-
       void Telemetry.capture("context_provider_get_context_items", {
         name: provider.description.title,
       });
@@ -1133,7 +1127,10 @@ export class Core {
 
       return items.map((item) => ({
         ...item,
-        id,
+        id: {
+          providerTitle: provider.description.title,
+          itemId: item.uri?.value ?? uuidv4(),
+        },
       }));
     } catch (e) {
       let knownError = false;

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1420,6 +1420,12 @@ export interface ExperimentalConfig {
    * If enabled, will enable next edit in place of autocomplete
    */
   optInNextEditFeature?: boolean;
+
+  /**
+   * If enabled, @codebase will only use tool calling
+   * instead of embeddings, FTS, recently edited files, etc.
+   */
+  codebaseToolCallingOnly?: boolean;
 }
 
 export interface AnalyticsConfig {

--- a/core/tools/callTool.ts
+++ b/core/tools/callTool.ts
@@ -17,6 +17,8 @@ import { requestRuleImpl } from "./implementations/requestRule";
 import { runTerminalCommandImpl } from "./implementations/runTerminalCommand";
 import { searchWebImpl } from "./implementations/searchWeb";
 import { viewDiffImpl } from "./implementations/viewDiff";
+import { viewRepoMapImpl } from "./implementations/viewRepoMap";
+import { viewSubdirectoryImpl } from "./implementations/viewSubdirectory";
 import { safeParseToolCallArgs } from "./parseArgs";
 
 async function callHttpTool(
@@ -136,7 +138,7 @@ async function callToolFromUri(
   }
 }
 
-async function callBuiltInTool(
+export async function callBuiltInTool(
   functionName: string,
   args: any,
   extras: ToolExtras,
@@ -168,6 +170,10 @@ async function callBuiltInTool(
       return await requestRuleImpl(args, extras);
     case BuiltInToolNames.CodebaseTool:
       return await codebaseToolImpl(args, extras);
+    case BuiltInToolNames.ViewRepoMap:
+      return await viewRepoMapImpl(args, extras);
+    case BuiltInToolNames.ViewSubdirectory:
+      return await viewSubdirectoryImpl(args, extras);
     default:
       throw new Error(`Tool "${functionName}" not found`);
   }

--- a/core/tools/definitions/globSearch.ts
+++ b/core/tools/definitions/globSearch.ts
@@ -13,7 +13,7 @@ export const globSearchTool: Tool = {
   function: {
     name: BuiltInToolNames.FileGlobSearch,
     description:
-      "Search for files in the project. Output may be truncated; use targeted patterns",
+      "Search for files recursively in the project using glob patterns. Supports ** for recursive directory search. Output may be truncated; use targeted patterns",
     parameters: {
       type: "object",
       required: ["pattern"],

--- a/core/tools/implementations/grepSearch.ts
+++ b/core/tools/implementations/grepSearch.ts
@@ -5,6 +5,41 @@ import { formatGrepSearchResults } from "../../util/grepSearch";
 const DEFAULT_GREP_SEARCH_RESULTS_LIMIT = 100;
 const DEFAULT_GREP_SEARCH_CHAR_LIMIT = 5000; // ~1000 tokens, will keep truncation simply for now
 
+function splitGrepResultsByFile(content: string): ContextItem[] {
+  const matches = [...content.matchAll(/^\.\/([^\n]+)$/gm)];
+
+  if (matches.length === 0) {
+    return [];
+  }
+
+  const contextItems: ContextItem[] = [];
+
+  for (let i = 0; i < matches.length; i++) {
+    const match = matches[i];
+    const filepath = match[1];
+    const startIndex = match.index!;
+    const endIndex =
+      i < matches.length - 1 ? matches[i + 1].index! : content.length;
+
+    // Extract grepped content for this file
+    const fileContent = content
+      .substring(startIndex, endIndex)
+      .replace(/^\.\/[^\n]+\n/, "") // remove the line with file path
+      .trim();
+
+    if (fileContent) {
+      contextItems.push({
+        name: `Search results in ${filepath}`,
+        description: `Grep search results from ${filepath}`,
+        content: fileContent,
+        uri: { type: "file", value: filepath },
+      });
+    }
+  }
+
+  return contextItems;
+}
+
 export const grepSearchImpl: ToolImpl = async (args, extras) => {
   const results = await extras.ide.getSearchResults(
     args.query,
@@ -26,13 +61,21 @@ export const grepSearchImpl: ToolImpl = async (args, extras) => {
     );
   }
 
-  const contextItems: ContextItem[] = [
-    {
-      name: "Search results",
-      description: "Results from grep search",
-      content: formatted,
-    },
-  ];
+  let contextItems: ContextItem[] = [];
+
+  const splitByFile: boolean = args.splitByFile || false;
+  if (splitByFile) {
+    contextItems = splitGrepResultsByFile(formatted);
+  } else {
+    contextItems = [
+      {
+        name: "Search results",
+        description: "Results from grep search",
+        content: formatted,
+      },
+    ];
+  }
+
   if (truncationReasons.length > 0) {
     contextItems.push({
       name: "Search truncation warning",

--- a/gui/src/pages/config/UserSettingsForm.tsx
+++ b/gui/src/pages/config/UserSettingsForm.tsx
@@ -95,6 +95,8 @@ export function UserSettingsForm() {
     config.experimental?.enableExperimentalTools ?? false;
   const optInNextEditFeature =
     config.experimental?.optInNextEditFeature ?? false;
+  const codebaseToolCallingOnly =
+    config.experimental?.codebaseToolCallingOnly ?? false;
 
   const allowAnonymousTelemetry = config.allowAnonymousTelemetry ?? true;
   const disableIndexing = config.disableIndexing ?? false;
@@ -420,6 +422,16 @@ export function UserSettingsForm() {
                     })
                   }
                   text="Enable experimental tools"
+                />
+
+                <ToggleSwitch
+                  isToggled={codebaseToolCallingOnly}
+                  onToggle={() =>
+                    handleUpdate({
+                      codebaseToolCallingOnly: !codebaseToolCallingOnly,
+                    })
+                  }
+                  text="@Codebase: use tool calling only"
                 />
 
                 {hasContinueEmail && (


### PR DESCRIPTION
## Description

Experiment: @codebase context provider to use built in tools to see how it compares with indexing

Here's some example queries to play around to trigger tool calls
| Query                                | Tools used                  |
|--------------------------------------|-----------------------------|
| @codebase what files are here        | ls                          |
| @codebase find all the add functions | grep                        |
| @codebase look inside test.js        | read_file                   |
| @codebase where are my .ts files     | glob_search                 |
| @codebase tell me about this repo    | repo_map + ls + glob_search |

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots


https://github.com/user-attachments/assets/5bbdfb85-846d-4aaf-af24-24c816864775



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added an experimental option for @codebase to use tool calling instead of traditional retrieval methods like embeddings or full-text search.

- **New Features**
  - Introduced a "tool calling only" toggle in user settings.
  - When enabled, context retrieval uses built-in tools to answer queries.

<!-- End of auto-generated description by cubic. -->

