### PR TITLE
Disallow read file tools to add files that exceed half of context length

### DIFF
--- a/core/tools/implementations/readCurrentlyOpenFile.ts
+++ b/core/tools/implementations/readCurrentlyOpenFile.ts
@@ -1,28 +1,41 @@
 import { getUriDescription } from "../../util/uri";
 
 import { ToolImpl } from ".";
+import { throwIfFileExceedsHalfOfContext } from "./readFileLimit";
 
 export const readCurrentlyOpenFileImpl: ToolImpl = async (args, extras) => {
   const result = await extras.ide.getCurrentFile();
 
-  if (!result) {
-    return [];
-  }
+  if (result) {
+    await throwIfFileExceedsHalfOfContext(
+      result.path,
+      result.contents,
+      extras.config.selectedModelByRole.chat,
+    );
 
-  const { relativePathOrBasename, last2Parts, baseName } = getUriDescription(
-    result.path,
-    await extras.ide.getWorkspaceDirs(),
-  );
+    const { relativePathOrBasename, last2Parts, baseName } = getUriDescription(
+      result.path,
+      await extras.ide.getWorkspaceDirs(),
+    );
 
-  return [
-    {
-      name: `Current file: ${baseName}`,
-      description: last2Parts,
-      content: `\`\`\`${relativePathOrBasename}\n${result.contents}\n\`\`\``,
-      uri: {
-        type: "file",
-        value: result.path,
+    return [
+      {
+        name: `Current file: ${baseName}`,
+        description: last2Parts,
+        content: `\`\`\`${relativePathOrBasename}\n${result.contents}\n\`\`\``,
+        uri: {
+          type: "file",
+          value: result.path,
+        },
       },
-    },
-  ];
+    ];
+  } else {
+    return [
+      {
+        name: `No Current File`,
+        description: "",
+        content: "There are no files currently open.",
+      },
+    ];
+  }
 };

--- a/core/tools/implementations/readFile.ts
+++ b/core/tools/implementations/readFile.ts
@@ -2,6 +2,7 @@ import { resolveRelativePathInDir } from "../../util/ideUtils";
 import { getUriPathBasename } from "../../util/uri";
 
 import { ToolImpl } from ".";
+import { throwIfFileExceedsHalfOfContext } from "./readFileLimit";
 
 export const readFileImpl: ToolImpl = async (args, extras) => {
   const firstUriMatch = await resolveRelativePathInDir(
@@ -12,6 +13,13 @@ export const readFileImpl: ToolImpl = async (args, extras) => {
     throw new Error(`Could not find file ${args.filepath}`);
   }
   const content = await extras.ide.readFile(firstUriMatch);
+
+  await throwIfFileExceedsHalfOfContext(
+    args.filepath,
+    content,
+    extras.config.selectedModelByRole.chat,
+  );
+
   return [
     {
       name: getUriPathBasename(args.filepath),

--- a/core/tools/implementations/readFileLimit.ts
+++ b/core/tools/implementations/readFileLimit.ts
@@ -1,0 +1,18 @@
+import { ILLM } from "../..";
+import { countTokensAsync } from "../../llm/countTokens";
+
+export async function throwIfFileExceedsHalfOfContext(
+  filepath: string,
+  content: string,
+  model: ILLM | null,
+) {
+  if (model) {
+    const tokens = await countTokensAsync(content, model.title);
+    const tokenLimit = model.contextLength / 2;
+    if (tokens > tokenLimit) {
+      throw new Error(
+        `File ${filepath} is too large (${tokens} tokens vs ${tokenLimit} token limit). Try another approach`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Description

Throws a tool error if a readFile or readCurrentlyOpenFile request returns a file that exceeds half of context length.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevents read file tools from returning files that exceed half of the model's context length, throwing an error if the file is too large.

- **Bug Fixes**
  - Blocks oversized files in both readFile and readCurrentlyOpenFile tools to avoid context overflows.

<!-- End of auto-generated description by cubic. -->

