### PR TITLE
Less flashy truncate to tool call icon

### DIFF
--- a/gui/src/pages/gui/ToolCallDiv/ToolTruncateHistoryIcon.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/ToolTruncateHistoryIcon.tsx
@@ -19,13 +19,16 @@ export function ToolTruncateHistoryIcon({
   }, [history]);
   const dispatch = useAppDispatch();
   const { mainEditor } = useMainEditor();
-  if (isStreaming || historyIndex === lastMessageIndex) {
+  if (historyIndex === lastMessageIndex) {
     return null;
   }
   return (
     <ToolbarButtonWithTooltip
-      tooltipContent="Trim chat to this message"
+      tooltipContent={isStreaming ? "" : "Trim chat to this message"}
       onClick={() => {
+        if (isStreaming) {
+          return;
+        }
         dispatch(
           truncateHistoryToMessage({
             index: historyIndex,
@@ -34,7 +37,9 @@ export function ToolTruncateHistoryIcon({
         mainEditor?.commands.focus();
       }}
     >
-      <BarsArrowUpIcon className="h-3 w-3 flex-shrink-0" />
+      <BarsArrowUpIcon
+        className={`h-3 w-3 flex-shrink-0 ${isStreaming ? "cursor-not-allowed" : "cursor-pointer"}`}
+      />
     </ToolbarButtonWithTooltip>
   );
 }


### PR DESCRIPTION
Agent mode with many subsequent tool calls had a flashing effect caused by truncate to tool call icon appearing and disappearing with streaming.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Reduced flashing of the truncate-to-tool-call icon during streaming by hiding it until streaming ends. This makes the UI less distracting when many tool calls happen in a row.

<!-- End of auto-generated description by cubic. -->

