### PR TITLE
Add edit history sequences to nextEdit dev data for easier processing

### DIFF
--- a/core/core.ts
+++ b/core/core.ts
@@ -722,8 +722,8 @@ export class Core {
       const EDIT_AGGREGATION_OPTIONS = {
         deltaT: 1.0,
         deltaL: 5,
-        maxEdits: 250,
-        maxDuration: 100.0,
+        maxEdits: 500,
+        maxDuration: 120.0,
         contextSize: 5,
       };
 

--- a/core/nextEdit/context/prevEditLruCache.ts
+++ b/core/nextEdit/context/prevEditLruCache.ts
@@ -1,0 +1,30 @@
+import QuickLRU from "quick-lru";
+
+export interface prevEdit {
+  unidiff: string;
+  fileUri: string;
+  workspaceUri: string;
+  timestamp: number;
+}
+const maxPrevEdits = 5;
+
+export const prevEditLruCache = new QuickLRU<string, prevEdit>({
+  maxSize: maxPrevEdits,
+});
+
+export const setPrevEdit = (edit: prevEdit): void => {
+  const uniqueSuffix = Math.random().toString(36).substring(2, 8);
+  const key = `${edit.fileUri}:${edit.timestamp}:${uniqueSuffix}`;
+  prevEditLruCache.set(key, edit);
+};
+
+export const getPrevEditsDescending = (): prevEdit[] => {
+  const edits: prevEdit[] = [];
+  for (const [_, edit] of prevEditLruCache.entriesDescending()) {
+    if (edits.length >= maxPrevEdits) {
+      break;
+    }
+    edits.push(edit);
+  }
+  return edits;
+};

--- a/core/nextEdit/context/processNextEditData.ts
+++ b/core/nextEdit/context/processNextEditData.ts
@@ -108,19 +108,22 @@ export const processNextEditData = async ({
     );
   }
 
-  void DataLogger.getInstance().logDevData({
-    name: "nextEditWithHistory",
-    data: {
-      previousEdits: filenamesAndDiffs,
-      fileURI: filePath,
-      workspaceDirURI: workspaceDir,
-      beforeContent,
-      afterContent,
-      beforeCursorPos: cursorPosBeforeEdit,
-      afterCursorPos: cursorPosAfterPrevEdit,
-      context: autocompleteContext,
-    },
-  });
+  if (filenamesAndDiffs.length > 0) {
+    // if there are previous edits, log
+    void DataLogger.getInstance().logDevData({
+      name: "nextEditWithHistory",
+      data: {
+        previousEdits: filenamesAndDiffs,
+        fileURI: filePath,
+        workspaceDirURI: workspaceDir,
+        beforeContent,
+        afterContent,
+        beforeCursorPos: cursorPosBeforeEdit,
+        afterCursorPos: cursorPosAfterPrevEdit,
+        context: autocompleteContext,
+      },
+    });
+  }
 
   // add current edit to history
   const thisEdit: prevEdit = {

--- a/packages/config-yaml/src/schemas/data/index.ts
+++ b/packages/config-yaml/src/schemas/data/index.ts
@@ -33,11 +33,11 @@ import {
   editOutcomeEventSchema_0_2_0,
   editOutcomeEventSchema_0_2_0_noCode,
 } from "./editOutcome/v0.2.0.js";
-import { nextEditEventAllSchema } from "./nextEdit/index.js";
+import { nextEditEventAllSchema } from "./nextEditWithHistory/index.js";
 import {
   nextEditEventSchema_0_2_0,
   nextEditEventSchema_0_2_0_noCode,
-} from "./nextEdit/v0.2.0.js";
+} from "./nextEditWithHistory/v0.2.0.js";
 import { quickEditEventAllSchema } from "./quickEdit/index.js";
 import {
   quickEditEventSchema_0_1_0,
@@ -88,7 +88,7 @@ const devEventAllVersionDataSchemas = z.object({
   chatInteraction: chatInteractionEventAllSchema,
   editInteraction: editInteractionEventAllSchema,
   editOutcome: editOutcomeEventAllSchema,
-  nextEdit: nextEditEventAllSchema,
+  nextEditWithHistory: nextEditEventAllSchema,
   toolUsage: toolUsageEventAllSchema,
 });
 
@@ -116,7 +116,7 @@ export const devDataVersionedSchemas = {
       chatInteraction: chatInteractionEventSchema_0_2_0,
       editInteraction: editInteractionEventSchema_0_2_0,
       editOutcome: editOutcomeEventSchema_0_2_0,
-      nextEdit: nextEditEventSchema_0_2_0,
+      nextEditWithHistory: nextEditEventSchema_0_2_0,
       toolUsage: toolUsageEventSchema_0_2_0,
     },
     noCode: {
@@ -126,7 +126,7 @@ export const devDataVersionedSchemas = {
       chatInteraction: chatInteractionEventSchema_0_2_0_noCode,
       editInteraction: editInteractionEventSchema_0_2_0_noCode,
       editOutcome: editOutcomeEventSchema_0_2_0_noCode,
-      nextEdit: nextEditEventSchema_0_2_0_noCode,
+      nextEditWithHistory: nextEditEventSchema_0_2_0_noCode,
       toolUsage: toolUsageEventSchema_0_2_0_noCode,
     },
   },

--- a/packages/config-yaml/src/schemas/data/nextEditWithHistory/index.ts
+++ b/packages/config-yaml/src/schemas/data/nextEditWithHistory/index.ts
@@ -2,6 +2,12 @@ import { z } from "zod";
 import { baseDevDataAllSchema } from "../base.js";
 
 export const nextEditEventAllSchema = baseDevDataAllSchema.extend({
+  previousEdits: z.array(
+    z.object({
+      filename: z.string(),
+      diff: z.string(),
+    }),
+  ),
   fileURI: z.string(),
   workspaceDirURI: z.string(),
   beforeContent: z.string(),

--- a/packages/config-yaml/src/schemas/data/nextEditWithHistory/v0.2.0.ts
+++ b/packages/config-yaml/src/schemas/data/nextEditWithHistory/v0.2.0.ts
@@ -10,6 +10,7 @@ export const nextEditEventSchema_0_2_0 = nextEditEventAllSchema.pick({
   schema: true,
 
   // nextedit-specific
+  previousEdits: true,
   fileURI: true,
   workspaceDirURI: true,
   beforeContent: true,
@@ -20,6 +21,7 @@ export const nextEditEventSchema_0_2_0 = nextEditEventAllSchema.pick({
 });
 
 export const nextEditEventSchema_0_2_0_noCode = nextEditEventSchema_0_2_0.omit({
+  previousEdits: true,
   fileURI: true,
   workspaceDirURI: true,
   beforeContent: true,


### PR DESCRIPTION
## Description

Logs edit history sequences in an LRU cache and updates edit logging dev data to include this.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added edit history sequences to nextEdit dev data by logging recent edits in an LRU cache for easier processing and analysis.

- **New Features**
  - Stores up to 5 recent edits with diffs and filenames.
  - Includes previous edit sequences in nextEditWithHistory dev data logs.

<!-- End of auto-generated description by cubic. -->

