### PR TITLE
Plan (Agent) Mode

### DIFF
--- a/gui/src/components/ModeSelect/ModeIcon.tsx
+++ b/gui/src/components/ModeSelect/ModeIcon.tsx
@@ -1,8 +1,12 @@
-import { ChatBubbleLeftIcon, SparklesIcon } from "@heroicons/react/24/outline";
+import {
+  ChatBubbleLeftIcon,
+  SparklesIcon,
+  SwatchIcon,
+} from "@heroicons/react/24/outline";
 import { MessageModes } from "core";
 
 interface ModeIconProps {
-  mode: MessageModes;
+  mode: MessageModes | "plan";
   className?: string;
 }
 
@@ -13,6 +17,8 @@ export function ModeIcon({
   switch (mode) {
     case "agent":
       return <SparklesIcon className={className} />;
+    case "plan":
+      return <SwatchIcon className={className} />;
     case "chat":
       return <ChatBubbleLeftIcon className={className} />;
   }

--- a/gui/src/components/ModeSelect/ModeSelect.tsx
+++ b/gui/src/components/ModeSelect/ModeSelect.tsx
@@ -1,11 +1,16 @@
-import { CheckIcon, ChevronDownIcon } from "@heroicons/react/24/outline";
+import {
+  CheckIcon,
+  ChevronDownIcon,
+  InformationCircleIcon,
+} from "@heroicons/react/24/outline";
 import { MessageModes } from "core";
 import { modelSupportsTools } from "core/llm/autodetect";
 import { useCallback, useEffect, useMemo } from "react";
 import { useAppDispatch, useAppSelector } from "../../redux/hooks";
 import { selectSelectedChatModel } from "../../redux/slices/configSlice";
-import { setMode } from "../../redux/slices/sessionSlice";
+import { setMode, setReadOnly } from "../../redux/slices/sessionSlice";
 import { getFontSize, getMetaKeyLabel } from "../../util";
+import { ToolTip } from "../gui/Tooltip";
 import { useMainEditor } from "../mainInput/TipTapEditor";
 import { Listbox, ListboxButton, ListboxOption, ListboxOptions } from "../ui";
 import { ModeIcon } from "./ModeIcon";
@@ -32,13 +37,25 @@ export function ModeSelect() {
     }
   }, [mode, agentModeSupported, dispatch, selectedModel]);
 
+  const readOnlyMode = useAppSelector((store) => store.session.readOnlyMode);
+  const pseudoMode = useMemo(() => {
+    return mode === "chat" ? "chat" : readOnlyMode ? "plan" : "agent";
+  }, [mode, readOnlyMode]);
   const cycleMode = useCallback(() => {
-    dispatch(setMode(mode === "chat" ? "agent" : "chat"));
+    if (pseudoMode === "chat") {
+      dispatch(setMode("agent"));
+      dispatch(setReadOnly(true));
+    } else if (pseudoMode === "plan") {
+      dispatch(setReadOnly(false));
+    } else {
+      dispatch(setReadOnly(true));
+      dispatch(setMode("chat"));
+    }
     // Only focus main editor if another one doesn't already have focus
     if (!document.activeElement?.classList?.contains("ProseMirror")) {
       mainEditor?.commands.focus();
     }
-  }, [mode, mainEditor]);
+  }, [pseudoMode, mainEditor]);
 
   const selectMode = useCallback(
     (newMode: MessageModes) => {
@@ -72,9 +89,13 @@ export function ModeSelect() {
           data-testid="mode-select-button"
           className="xs:px-2 text-description bg-lightgray/20 gap-1 rounded-full border-none px-1.5 py-0.5 transition-colors duration-200 hover:brightness-110"
         >
-          <ModeIcon mode={mode} />
+          <ModeIcon mode={pseudoMode} />
           <span className="hidden sm:block">
-            {mode.charAt(0).toUpperCase() + mode.slice(1)}
+            {pseudoMode === "chat"
+              ? "Chat"
+              : pseudoMode === "agent"
+                ? "Agent"
+                : "Plan"}
           </span>
           <ChevronDownIcon
             className="h-2 w-2 flex-shrink-0"
@@ -92,20 +113,68 @@ export function ModeSelect() {
                 {getMetaKeyLabel()}L
               </span>
             </div>
-            {mode === "chat" && <CheckIcon className="ml-auto h-3 w-3" />}
+            {pseudoMode === "chat" && <CheckIcon className="ml-auto h-3 w-3" />}
           </ListboxOption>
-
           <ListboxOption
             value="agent"
             disabled={!agentModeSupported}
             className={"gap-1"}
+            onClick={() => {
+              dispatch(setReadOnly(true));
+            }}
+          >
+            <div className="flex flex-row items-center gap-1.5">
+              <ModeIcon mode="plan" />
+              <span className="">Agent (Plan)</span>
+              <InformationCircleIcon
+                data-tooltip-id="plan-tip"
+                className="h-2.5 w-2.5 flex-shrink-0"
+              />
+              <ToolTip
+                id="plan-tip"
+                style={{
+                  zIndex: 200001,
+                }}
+              >
+                In Plan mode, the Agent can only use read-only tools
+              </ToolTip>
+            </div>
+            {agentModeSupported ? (
+              <CheckIcon
+                className={`ml-auto h-3 w-3 ${pseudoMode === "plan" ? "" : "opacity-0"}`}
+              />
+            ) : (
+              <span>(Not supported)</span>
+            )}
+          </ListboxOption>
+          <ListboxOption
+            value="agent"
+            disabled={!agentModeSupported}
+            className={"gap-1"}
+            onClick={() => {
+              dispatch(setReadOnly(false));
+            }}
           >
             <div className="flex flex-row items-center gap-1.5">
               <ModeIcon mode="agent" />
-              <span className="">Agent</span>
+              <span className="">Agent (Act)</span>
+              <InformationCircleIcon
+                data-tooltip-id="act-tip"
+                className="h-2.5 w-2.5 flex-shrink-0"
+              />
+              <ToolTip
+                id="act-tip"
+                style={{
+                  zIndex: 200001,
+                }}
+              >
+                In Act mode, the Agent can use create/edit tools
+              </ToolTip>
             </div>
             {agentModeSupported ? (
-              mode === "agent" && <CheckIcon className="ml-auto h-3 w-3" />
+              <CheckIcon
+                className={`ml-auto h-3 w-3 ${pseudoMode === "agent" ? "" : "opacity-0"}`}
+              />
             ) : (
               <span>(Not supported)</span>
             )}

--- a/gui/src/components/gui/Switch.tsx
+++ b/gui/src/components/gui/Switch.tsx
@@ -7,6 +7,7 @@ type ToggleSwitchProps = {
   text: string;
   size?: number;
   showIfToggled?: ReactNode;
+  disabled?: boolean;
 };
 
 const ToggleSwitch: React.FC<ToggleSwitchProps> = ({
@@ -15,15 +16,18 @@ const ToggleSwitch: React.FC<ToggleSwitchProps> = ({
   text,
   size = 16,
   showIfToggled,
+  disabled = false,
 }) => {
   return (
-    <div className="flex cursor-pointer select-none items-center justify-between gap-3">
+    <div
+      className={`flex select-none items-center justify-between gap-3 ${disabled ? "cursor-not-allowed" : "cursor-pointer"}`}
+    >
       <span className="truncate-right">{text}</span>
       <div className="flex flex-row items-center gap-1">
         {isToggled && !!showIfToggled && showIfToggled}
         <div
           className={`border-vsc-input-border bg-vsc-input-background flex items-center rounded-full border border-solid`}
-          onClick={onToggle}
+          onClick={disabled ? undefined : onToggle}
           style={{
             height: size,
             width: size * 2,

--- a/gui/src/components/mainInput/Lump/sections/tool-policies/ToolPoliciesSection.tsx
+++ b/gui/src/components/mainInput/Lump/sections/tool-policies/ToolPoliciesSection.tsx
@@ -1,3 +1,4 @@
+import { InformationCircleIcon } from "@heroicons/react/24/outline";
 import { Tool } from "core";
 import { useMemo } from "react";
 import { useAppDispatch, useAppSelector } from "../../../../../redux/hooks";
@@ -6,7 +7,27 @@ import { fontSize } from "../../../../../util";
 import ToggleSwitch from "../../../../gui/Switch";
 import ToolPolicyItem from "./ToolPolicyItem";
 
+interface ModeBadgeProps {
+  text: string;
+  icon: React.ReactNode;
+  onClick: () => void;
+  isSelected: boolean;
+}
+const ModeBadge = ({ text, onClick, isSelected, icon }: ModeBadgeProps) => {
+  return (
+    <div
+      className="flex flex-1 items-center justify-center gap-1.5 text-sm"
+      onClick={isSelected ? undefined : onClick}
+    >
+      {icon}
+      {text}
+    </div>
+  );
+};
+
 export const ToolPoliciesSection = () => {
+  const mode = useAppSelector((state) => state.session.mode);
+  const readOnlyMode = useAppSelector((state) => state.session.readOnlyMode);
   const availableTools = useAppSelector((state) => state.config.config.tools);
   const toolGroupSettings = useAppSelector(
     (store) => store.ui.toolGroupSettings,
@@ -39,38 +60,57 @@ export const ToolPoliciesSection = () => {
     );
   }, [availableTools]);
 
+  const allToolsOff = mode === "chat";
+
+  const pseudoMode = mode === "chat" ? "chat" : readOnlyMode ? "plan" : "act";
+  const message =
+    pseudoMode === "chat"
+      ? "All tools are disabled in Chat mode"
+      : pseudoMode === "plan"
+        ? "Plan mode: only MCP and read-only tools"
+        : "Act mode: all tool policies apply";
+
   return (
     <>
-      {toolsByGroup.map(([groupName, tools]) => (
-        <div key={groupName} className="mt-2 flex flex-col pr-1">
-          <div className="flex flex-row items-center justify-between px-1">
-            <h3
-              className="m-0 p-0 font-bold"
-              style={{
-                fontSize: fontSize(-2),
-              }}
-            >
-              {groupName}
-            </h3>
-            <ToggleSwitch
-              isToggled={toolGroupSettings[groupName] !== "exclude"}
-              onToggle={() => dispatch(toggleToolGroupSetting(groupName))}
-              text=""
-              size={10}
-            />
-          </div>
-          <div className={`relative flex flex-col p-1`}>
-            {tools.map((tool) => (
-              <ToolPolicyItem
-                key={tool.uri + tool.function.name}
-                tool={tool}
-                duplicatesDetected={duplicateDetection[tool.function.name]}
-                excluded={toolGroupSettings[groupName] === "exclude"}
+      <div className="mb-3 px-1">
+        <InformationCircleIcon className="text-description-muted mr-1.5 inline-block h-2.5 w-2.5 flex-shrink-0" />
+        <span className="text-description text-xs italic">{message}</span>
+      </div>
+      {toolsByGroup.map(([groupName, tools]) => {
+        const isGroupEnabled =
+          !allToolsOff && toolGroupSettings[groupName] !== "exclude";
+        return (
+          <div key={groupName} className="mt-2 flex flex-col pr-1">
+            <div className="flex flex-row items-center justify-between px-1">
+              <h3
+                className="m-0 p-0 font-bold"
+                style={{
+                  fontSize: fontSize(-2),
+                }}
+              >
+                {groupName}
+              </h3>
+              <ToggleSwitch
+                isToggled={isGroupEnabled}
+                onToggle={() => dispatch(toggleToolGroupSetting(groupName))}
+                text=""
+                size={10}
+                disabled={allToolsOff}
               />
-            ))}
+            </div>
+            <div className={`relative flex flex-col p-1`}>
+              {tools.map((tool) => (
+                <ToolPolicyItem
+                  key={tool.uri + tool.function.name}
+                  tool={tool}
+                  duplicatesDetected={duplicateDetection[tool.function.name]}
+                  isGroupEnabled={isGroupEnabled}
+                />
+              ))}
+            </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
     </>
   );
 };

--- a/gui/src/components/mainInput/Lump/sections/tool-policies/ToolPolicyItem.tsx
+++ b/gui/src/components/mainInput/Lump/sections/tool-policies/ToolPolicyItem.tsx
@@ -3,6 +3,7 @@ import {
   InformationCircleIcon,
 } from "@heroicons/react/24/outline";
 import { Tool } from "core";
+import { BUILT_IN_GROUP_NAME } from "core/tools/builtIn";
 import { useEffect, useMemo, useState } from "react";
 import { useDispatch } from "react-redux";
 import { useAppSelector } from "../../../../../redux/hooks";
@@ -16,7 +17,7 @@ import { useFontSize } from "../../../../ui/font";
 interface ToolDropdownItemProps {
   tool: Tool;
   duplicatesDetected: boolean;
-  excluded: boolean;
+  isGroupEnabled: boolean;
 }
 
 function ToolPolicyItem(props: ToolDropdownItemProps) {
@@ -25,6 +26,7 @@ function ToolPolicyItem(props: ToolDropdownItemProps) {
     (state) => state.ui.toolSettings[props.tool.function.name],
   );
   const [isExpanded, setIsExpanded] = useState(false);
+  const readOnlyMode = useAppSelector((state) => state.session.readOnlyMode);
 
   useEffect(() => {
     if (!policy) {
@@ -43,6 +45,12 @@ function ToolPolicyItem(props: ToolDropdownItemProps) {
   }, [props.tool.function.parameters]);
 
   const fontSize = useFontSize(-2);
+
+  const disabled =
+    !props.isGroupEnabled ||
+    (readOnlyMode &&
+      props.tool.group === BUILT_IN_GROUP_NAME &&
+      !props.tool.readonly);
 
   if (!policy) {
     return null;
@@ -106,8 +114,9 @@ function ToolPolicyItem(props: ToolDropdownItemProps) {
             </span>
           </div>
         </div>
+
         <div
-          className={`flex w-8 flex-row items-center justify-end gap-2 px-2 py-0.5 sm:w-16 ${props.excluded ? "cursor-not-allowed" : "hover:bg-list-active hover:text-list-active-foreground cursor-pointer"}`}
+          className={`flex w-8 flex-row items-center justify-end gap-2 px-2 py-0.5 sm:w-16 ${disabled ? "cursor-not-allowed" : "hover:bg-list-active hover:text-list-active-foreground cursor-pointer"}`}
           data-testid={`tool-policy-item-${props.tool.function.name}`}
           onClick={(e) => {
             dispatch(toggleToolSetting(props.tool.function.name));
@@ -115,7 +124,7 @@ function ToolPolicyItem(props: ToolDropdownItemProps) {
             e.preventDefault();
           }}
         >
-          {props.excluded || policy === "disabled" ? (
+          {disabled || policy === "disabled" ? (
             <>
               <span className="text-lightgray sm:hidden">Off</span>
               <span className="text-lightgray hidden sm:inline-block">

--- a/gui/src/pages/gui/chat-tests/Chat.test.tsx
+++ b/gui/src/pages/gui/chat-tests/Chat.test.tsx
@@ -27,7 +27,19 @@ test("should be able to toggle modes", async () => {
     );
   });
 
-  // Check that it switched to Agent mode
+  // Check that it switched to Plan mode
+  await getElementByText("Plan");
+
+  act(() => {
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: ".",
+        metaKey: true, // cmd key on Mac
+      }),
+    );
+  });
+
+  // Check that it switched to Plan mode
   await getElementByText("Agent");
 
   act(() => {

--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -54,6 +54,7 @@ type SessionState = {
   mainEditorContentTrigger?: JSONContent | undefined;
   symbols: FileSymbolMap;
   mode: MessageModes;
+  readOnlyMode: boolean;
   isInEdit: boolean;
   codeBlockApplyStates: {
     states: ApplyState[];
@@ -73,6 +74,7 @@ const initialState: SessionState = {
   streamAborter: new AbortController(),
   symbols: {},
   mode: "chat",
+  readOnlyMode: false,
   isInEdit: false,
   codeBlockApplyStates: {
     states: [],
@@ -668,6 +670,9 @@ export const sessionSlice = createSlice({
     setMode: (state, action: PayloadAction<MessageModes>) => {
       state.mode = action.payload;
     },
+    setReadOnly: (state, action: PayloadAction<boolean>) => {
+      state.readOnlyMode = action.payload;
+    },
     setIsInEdit: (state, action: PayloadAction<boolean>) => {
       state.isInEdit = action.payload;
     },
@@ -768,6 +773,7 @@ export const {
   setToolGenerated,
   updateToolCallOutput,
   setMode,
+  setReadOnly,
   setIsSessionMetadataLoading,
   setAllSessionMetadata,
   addSessionMetadata,

--- a/gui/src/redux/store.ts
+++ b/gui/src/redux/store.ts
@@ -42,6 +42,7 @@ const saveSubsetFilters = [
 
     // Persist edit mode in case closes in middle
     "mode",
+    "readOnlyMode",
 
     // higher risk to persist
     // codeBlockApplyStates

--- a/gui/src/redux/thunks/streamNormalInput.ts
+++ b/gui/src/redux/thunks/streamNormalInput.ts
@@ -40,12 +40,16 @@ export const streamNormalInput = createAsyncThunk<
     // Get tools
     const activeTools = selectActiveTools(state);
     const toolsSupported = modelSupportsTools(selectedChatModel);
+    const readOnlyMode = state.session.readOnlyMode;
+    const filteredTools = readOnlyMode
+      ? activeTools.filter((t) => t.readonly)
+      : activeTools;
 
     // Construct completion options
     let completionOptions: LLMFullCompletionOptions = {};
-    if (toolsSupported && activeTools.length > 0) {
+    if (toolsSupported && filteredTools.length > 0) {
       completionOptions = {
-        tools: activeTools,
+        tools: filteredTools,
       };
     }
 
@@ -125,7 +129,7 @@ export const streamNormalInput = createAsyncThunk<
               modelTitle: selectedChatModel.title,
               sessionId: state.session.id,
               ...(state.session.mode === "agent" && {
-                tools: activeTools.map((tool) => tool.function.name),
+                tools: filteredTools.map((tool) => tool.function.name),
               }),
             },
           });


### PR DESCRIPTION
## Description

Adds a "Plan" mode which disables any tools that are not read only
Is available as "Plan" in mode dropdown, and included in cmd + . toggling
Under the hood, just adds a readOnlyMode boolean rather than adding a third "mode"

<img width="385" alt="plan-mode-2" src="https://github.com/user-attachments/assets/d328cdd5-5ed7-49da-86bd-7072abe7423c" />

<img width="395" alt="plan-mode-3" src="https://github.com/user-attachments/assets/f80a5d42-cb7e-4a0b-b0a5-4f77ad13f9e8" />

<img width="396" alt="plan-mode-4" src="https://github.com/user-attachments/assets/38124504-d1ea-479f-b70c-6f0317306e5a" />

## Tests

Updates toggle test to account for plan mode