### PR TITLE
run shell path async to avoid blocking config load

### DIFF
--- a/core/util/shellPath.ts
+++ b/core/util/shellPath.ts
@@ -1,7 +1,8 @@
-import { execSync } from "child_process";
-import { homedir } from "os";
+import { exec } from "child_process";
+import { promisify } from "util";
 
-export function getEnvPathFromUserShell(): string | undefined {
+const execAsync = promisify(exec);
+export async function getEnvPathFromUserShell(): Promise<string | undefined> {
   if (process.platform === "win32") {
     console.warn(`${getEnvPathFromUserShell.name} not implemented for Windows`);
     return undefined;
@@ -15,7 +16,7 @@ export function getEnvPathFromUserShell(): string | undefined {
     // Source common profile files
     const command = `${process.env.SHELL} -l -c 'for f in ~/.zprofile ~/.zshrc ~/.bash_profile ~/.bashrc; do [ -f "$f" ] && source "$f" 2>/dev/null; done; echo $PATH'`;
 
-    const stdout = execSync(command, {
+    const { stdout } = await execAsync(command, {
       encoding: "utf8",
     });
 


### PR DESCRIPTION
## Description

`getEnvPathFromUserShell` was causing unresponsive extension host when loading MCP servers (stdio). Making it async solves this

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Loading the user shell PATH is now done asynchronously to prevent blocking the extension host during MCP server startup.

- **Refactors**
  - Replaced sync shell PATH loading with async calls in MCP connection setup.
  - Updated related utility to use async execution.

<!-- End of auto-generated description by cubic. -->

