### PR TITLE
fix continue yaml config due to multiple config declarations

### DIFF
--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -24,8 +24,8 @@ export async function activateExtension(context: vscode.ExtensionContext) {
 
   // Load Continue configuration
   if (!context.globalState.get("hasBeenInstalled")) {
-    context.globalState.update("hasBeenInstalled", true);
-    Telemetry.capture(
+    void context.globalState.update("hasBeenInstalled", true);
+    void Telemetry.capture(
       "install",
       {
         extensionVersion: getExtensionVersion(),
@@ -38,21 +38,15 @@ export async function activateExtension(context: vscode.ExtensionContext) {
   const yamlMatcher = ".continue/**/*.yaml";
   const yamlConfig = vscode.workspace.getConfiguration("yaml");
 
-  const existingSchemas = yamlConfig.get("schemas") || {};
-  const newSchemas = Object.entries(existingSchemas).filter(
-    ([_, value]) => Array.isArray(value) && value.includes(yamlMatcher), // remove old ones
-  );
-
   const newPath = path.join(
     context.extension.extensionUri.fsPath,
     "config-yaml-schema.json",
   );
-  newSchemas.push([newPath, [yamlMatcher]]);
 
   try {
     await yamlConfig.update(
       "schemas",
-      Object.fromEntries(newSchemas),
+      { [newPath]: [yamlMatcher] },
       vscode.ConfigurationTarget.Global,
     );
   } catch (error) {


### PR DESCRIPTION
## Description

There were multiple yaml declarations. This was happening because older configs were also being preserved.
We want to only use the latest config.

- remove existing schemas when activating the extension

resolves CON-2574

related to https://discord.com/channels/1108621136150929458/1387807112117092524
related to https://discord.com/channels/1108621136150929458/1386679948038897825

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

**previous**

![Screenshot 2025-07-04 at 6 24 19 PM](https://github.com/user-attachments/assets/70b73995-f616-46be-9c6f-baa1ab6e983b)

**after**

![Screenshot 2025-07-04 at 6 25 54 PM](https://github.com/user-attachments/assets/0481e0bf-745f-4ed5-950d-7496fc6eeff8)


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

## Reproduction

1. Install the Continue extension from the marketplace
2. Launch the extension in debug mode
3. Go to a local config.yaml
4. See that yaml throws error due to multiple configurations

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where multiple YAML config declarations caused errors by ensuring only the latest config is used when activating the extension.

- **Bug Fixes**
  - Removed old YAML schemas before adding the new one to prevent duplicate config errors.

<!-- End of auto-generated description by cubic. -->

