### PR TITLE
Nate/hotfix-read-file-tool

### DIFF
--- a/core/llm/countTokens.ts
+++ b/core/llm/countTokens.ts
@@ -60,7 +60,10 @@ function asyncEncoderForModel(modelName: string): AsyncEncoder {
 
   const modelType = autodetectTemplateType(modelName);
   if (!modelType || modelType === "none") {
-    return gptAsyncEncoder;
+    // Right now there is a problem packaging js-tiktoken in workers. Until then falling back
+    // Cannot find package 'js-tiktoken' imported from /Users/nate/gh/continuedev/continue/extensions/vscode/out/tiktokenWorkerPool.mjs
+    // return gptAsyncEncoder;
+    return llamaAsyncEncoder;
   }
   return llamaAsyncEncoder;
 }

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "1.1.56",
+  "version": "1.1.57",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION
## Description

The read file tool fails with:
```
Cannot find package 'js-tiktoken' imported from /Users/nate/gh/continuedev/continue/extensions/vscode/out/tiktokenWorkerPool.mjs
```

It turns out that our gptencoder was just broken this whole time I think but wasn't being used. llama was being used

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the read file tool by switching token counting to use the llama encoder instead of the broken gpt encoder. This prevents errors caused by missing the js-tiktoken package.

<!-- End of auto-generated description by cubic. -->

