### PR TITLE
don't expand edit tool codeblocks by default

### DIFF
--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/CollapsibleContainer.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/CollapsibleContainer.tsx
@@ -24,10 +24,10 @@ export function CollapsibleContainer({
         <div className="from-editor absolute bottom-0 left-0 right-0 h-12 bg-gradient-to-t to-transparent">
           <div
             onClick={() => setIsExpanded(true)}
-            className="flex h-full cursor-pointer items-end justify-center pb-2"
+            className="group flex h-full cursor-pointer items-end justify-center pb-2"
           >
             <span title="Expand to show full content">
-              <ChevronDownIcon className="text-lightgray h-4 w-4" />
+              <ChevronDownIcon className="text-lightgray group-hover:text-foreground h-4 w-4" />
             </span>
           </div>
         </div>
@@ -36,10 +36,10 @@ export function CollapsibleContainer({
       {isExpanded && (
         <div
           onClick={() => setIsExpanded(false)}
-          className="mt-2 flex cursor-pointer justify-center"
+          className="group mt-2 flex cursor-pointer justify-center"
         >
           <span title="Collapse to compact view">
-            <ChevronDownIcon className="text-lightgray h-4 w-4 rotate-180" />
+            <ChevronDownIcon className="text-lightgray group-hover:text-foreground h-4 w-4 rotate-180" />
           </span>
         </div>
       )}

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/CollapsibleContainer.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/CollapsibleContainer.tsx
@@ -1,0 +1,48 @@
+import { ChevronDownIcon } from "@heroicons/react/24/outline";
+import { useState } from "react";
+
+interface CollapsibleContainerProps {
+  children: React.ReactNode;
+  maxHeight?: string;
+  className?: string;
+}
+
+export function CollapsibleContainer({
+  children,
+  maxHeight = "max-h-40",
+  className = "",
+}: CollapsibleContainerProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <div className={`relative ${className}`}>
+      <div className={`overflow-hidden ${isExpanded ? "" : maxHeight}`}>
+        {children}
+      </div>
+
+      {!isExpanded && (
+        <div className="from-editor absolute bottom-0 left-0 right-0 h-12 bg-gradient-to-t to-transparent">
+          <div
+            onClick={() => setIsExpanded(true)}
+            className="flex h-full cursor-pointer items-end justify-center pb-2"
+          >
+            <span title="Expand to show full content">
+              <ChevronDownIcon className="text-lightgray h-4 w-4" />
+            </span>
+          </div>
+        </div>
+      )}
+
+      {isExpanded && (
+        <div
+          onClick={() => setIsExpanded(false)}
+          className="mt-2 flex cursor-pointer justify-center"
+        >
+          <span title="Collapse to compact view">
+            <ChevronDownIcon className="text-lightgray h-4 w-4 rotate-180" />
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/CollapsibleContainer.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/CollapsibleContainer.tsx
@@ -5,14 +5,21 @@ interface CollapsibleContainerProps {
   children: React.ReactNode;
   maxHeight?: string;
   className?: string;
+  collapsible?: boolean;
 }
 
 export function CollapsibleContainer({
   children,
   maxHeight = "max-h-40",
   className = "",
+  collapsible = false,
 }: CollapsibleContainerProps) {
   const [isExpanded, setIsExpanded] = useState(false);
+
+  // If not collapsible, just render children without any collapsible behavior
+  if (!collapsible) {
+    return <div className={className}>{children}</div>;
+  }
 
   return (
     <div className={`relative ${className}`}>

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/index.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/index.tsx
@@ -33,6 +33,7 @@ export interface StepContainerPreToolbarProps {
   children: any;
   expanded?: boolean;
   disableManualApply?: boolean;
+  collapsible?: boolean;
 }
 
 export function StepContainerPreToolbar({
@@ -48,6 +49,7 @@ export function StepContainerPreToolbar({
   children,
   expanded,
   disableManualApply,
+  collapsible,
 }: StepContainerPreToolbarProps) {
   const ideMessenger = useContext(IdeMessengerContext);
   const history = useAppSelector((state) => state.session.history);
@@ -299,8 +301,11 @@ export function StepContainerPreToolbar({
           {renderActionButtons()}
         </div>
       </div>
-
-      {isExpanded && <CollapsibleContainer>{children}</CollapsibleContainer>}
+      {isExpanded && (
+        <CollapsibleContainer collapsible={collapsible}>
+          {children}
+        </CollapsibleContainer>
+      )}
     </div>
   );
 }

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/index.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/index.tsx
@@ -13,6 +13,7 @@ import { getFontSize } from "../../../util";
 import Spinner from "../../gui/Spinner";
 import { isTerminalCodeBlock } from "../utils";
 import { ApplyActions } from "./ApplyActions";
+import { CollapsibleContainer } from "./CollapsibleContainer";
 import { CopyButton } from "./CopyButton";
 import { CreateFileButton } from "./CreateFileButton";
 import { FileInfo } from "./FileInfo";
@@ -299,9 +300,7 @@ export function StepContainerPreToolbar({
         </div>
       </div>
 
-      {isExpanded && (
-        <div className="overflow-hidden overflow-y-auto">{children}</div>
-      )}
+      {isExpanded && <CollapsibleContainer>{children}</CollapsibleContainer>}
     </div>
   );
 }

--- a/gui/src/components/StyledMarkdownPreview/index.tsx
+++ b/gui/src/components/StyledMarkdownPreview/index.tsx
@@ -127,6 +127,7 @@ interface StyledMarkdownPreviewProps {
   disableManualApply?: boolean;
   toolCallId?: string;
   expandCodeblocks?: boolean;
+  collapsible?: boolean;
 }
 
 const HLJS_LANGUAGE_CLASSNAME_PREFIX = "language-";
@@ -305,6 +306,7 @@ const StyledMarkdownPreview = memo(function StyledMarkdownPreview(
               forceToolCallId={props.toolCallId}
               expanded={props.expandCodeblocks}
               disableManualApply={props.disableManualApply}
+              collapsible={props.collapsible}
             >
               <SyntaxHighlightedPre {...preProps} />
             </StepContainerPreToolbar>

--- a/gui/src/pages/gui/ToolCallDiv/EditFile.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/EditFile.tsx
@@ -18,7 +18,7 @@ export function EditFile(props: EditToolCallProps) {
 
   return (
     <StyledMarkdownPreview
-      expandCodeblocks={props.expandCodeblocks ?? false}
+      expandCodeblocks={false}
       isRenderingInStepContainer
       disableManualApply
       source={src}

--- a/gui/src/pages/gui/ToolCallDiv/EditFile.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/EditFile.tsx
@@ -24,6 +24,7 @@ export function EditFile(props: EditToolCallProps) {
       source={src}
       toolCallId={props.toolCallId}
       itemIndex={props.historyIndex}
+      collapsible={true}
     />
   );
 }


### PR DESCRIPTION
## Description

Improving the UI for edit tool call UI
- Collapsed code blocks by default (diff automatically shows up in the editor)
- Max height with ability to toggle if you do expand it

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Code blocks in the edit tool are now collapsed by default to reduce clutter and make the UI cleaner. The diff still appears in the editor, and users can expand code blocks if needed.

<!-- End of auto-generated description by cubic. -->

