### PR TITLE
fix: :ambulance: Put back agent mode system edit instructions

### DIFF
--- a/core/llm/defaultSystemMessages.ts
+++ b/core/llm/defaultSystemMessages.ts
@@ -65,4 +65,5 @@ export const DEFAULT_AGENT_SYSTEM_MESSAGE = `\
   You are in agent mode.
 
 ${CODEBLOCK_FORMATTING_INSTRUCTIONS}
+${EDIT_CODE_INSTRUCTIONS}
 </important_rules>`;


### PR DESCRIPTION
## Description

A recent change appears to have lost the lazy edit instructions for edit mode. This restores those instructions.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Restored the missing edit instructions in agent mode to ensure users see the correct guidance when editing code.

<!-- End of auto-generated description by cubic. -->

