### PR TITLE
fix: Attach environment type to reported exceptions

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/error/ContinueErrorService.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/error/ContinueErrorService.kt
@@ -21,6 +21,7 @@ class ContinueErrorService {
     init {
         Sentry.init { config ->
             config.dsn = SENTRY_DSN
+            config.environment = recognizeEnvironment()
             config.isSendDefaultPii = false
             config.setTag("ide_version", ApplicationInfo.getInstance().build.asString())
             config.setTag("jcef_supported", JBCefApp.isSupported().toString())
@@ -45,6 +46,12 @@ class ContinueErrorService {
         private const val PLUGIN_ID = "com.github.continuedev.continueintellijextension"
         private const val SENTRY_DSN =
             "https://fe99934dcdc537d84209893a3f96a196@o4505462064283648.ingest.us.sentry.io/4508184596054016"
-    }
 
+        private fun recognizeEnvironment() =
+            when {
+                System.getProperty("robot-server.port") != null -> "e2e"
+                System.getProperty("idea.is.internal").toBoolean() -> "dev"
+                else -> "production"
+            }
+    }
 }


### PR DESCRIPTION
Motivation:
* Everything right now goes under "production" and it's hard to distinguish exceptions that I triggered myself during development from real ones.
* In Sentry, there is an issue called JobCancellationException, which I believe is related to ci/e2e tests. I want to recognize that.
* It's a common practice to distinguish environments, and it will be easy to hide non-production issues (with query like `?environment=production`).

Introduced types:
* production (default)
* dev (when `runIde`)
* e2e (when robot enabled)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Exceptions reported to Sentry now include the environment type (production, dev, or e2e) to make it easier to filter and identify issues.

<!-- End of auto-generated description by cubic. -->

