### PR TITLE
[QoL] Add Collapse Button to Sidebar History Panel (#6222)

### DIFF
--- a/gui/src/components/History/index.tsx
+++ b/gui/src/components/History/index.tsx
@@ -1,6 +1,6 @@
 import { SessionMetadata } from "core";
 import MiniSearch from "minisearch";
-import React, {
+import {
   Fragment,
   useContext,
   useEffect,
@@ -10,7 +10,11 @@ import React, {
 } from "react";
 import Shortcut from "../gui/Shortcut";
 
-import { XMarkIcon } from "@heroicons/react/24/solid";
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/solid";
 import { useNavigate } from "react-router-dom";
 import { IdeMessengerContext } from "../../context/IdeMessenger";
 import { useAppDispatch, useAppSelector } from "../../redux/hooks";
@@ -39,10 +43,11 @@ const HEADER_CLASS =
 export function History() {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
-  const searchInputRef = React.useRef<HTMLInputElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const ideMessenger = useContext(IdeMessengerContext);
 
   const [searchTerm, setSearchTerm] = useState("");
+  const [collapsed, setCollapsed] = useState(false);
 
   const minisearch = useRef<MiniSearch>(
     new MiniSearch({
@@ -76,30 +81,25 @@ export function History() {
   const platform = useMemo(() => getPlatform(), []);
 
   const filteredAndSortedSessions: SessionMetadata[] = useMemo(() => {
-    // 1. Exact phrase matching
     const exactResults = minisearch.search(searchTerm, {
       fuzzy: false,
     });
 
-    // 2. Fuzzy matching with higher tolerance
     const fuzzyResults = minisearch.search(searchTerm, {
       fuzzy: 0.3,
     });
 
-    // 3. Prefix matching for partial words
     const prefixResults = minisearch.search(searchTerm, {
       prefix: true,
       fuzzy: 0.2,
     });
 
-    // Combine results, with exact matches having higher priority
     const allResults = [
       ...exactResults.map((r) => ({ ...r, priority: 3 })),
       ...fuzzyResults.map((r) => ({ ...r, priority: 2 })),
       ...prefixResults.map((r) => ({ ...r, priority: 1 })),
     ];
 
-    // Remove duplicates while preserving highest priority
     const uniqueResultsMap = new Map<string, any>();
     allResults.forEach((result) => {
       const existing = uniqueResultsMap.get(result.id);
@@ -107,16 +107,15 @@ export function History() {
         uniqueResultsMap.set(result.id, result);
       }
     });
-    const uniqueResults = Array.from(uniqueResultsMap.values());
 
-    const sessionIds = uniqueResults
+    const sessionIds = Array.from(uniqueResultsMap.values())
       .sort((a, b) => b.priority - a.priority || b.score - a.score)
       .map((result) => result.id);
 
     return allSessionMetadata
-      .filter((session) => {
-        return searchTerm === "" || sessionIds.includes(session.sessionId);
-      })
+      .filter(
+        (session) => searchTerm === "" || sessionIds.includes(session.sessionId),
+      )
       .sort(
         (a, b) =>
           parseDate(b.dateCreated).getTime() -
@@ -136,14 +135,9 @@ export function History() {
           title={`Clear sessions`}
           text={`Are you sure you want to permanently delete all chat sessions, including the current chat session?`}
           onConfirm={async () => {
-            // optimistic update
             dispatch(setAllSessionMetadata([]));
-
-            // actual update + refresh
             await ideMessenger.request("history/clear", undefined);
             void dispatch(refreshSessionMetadata({}));
-
-            // start a new session
             dispatch(newSession());
             navigate(ROUTES.HOME);
           }}
@@ -156,11 +150,27 @@ export function History() {
   return (
     <div
       style={{ fontSize: getFontSize() }}
-      className="flex flex-1 flex-col overflow-auto px-1"
+      className={`flex flex-1 flex-col overflow-auto px-1 transition-all duration-300 ${
+        collapsed ? "w-10" : "w-full"
+      }`}
     >
       <div className="relative my-2 flex justify-center space-x-2">
+        {/* Collapse Button */}
+        <button
+          onClick={() => setCollapsed(!collapsed)}
+          className="absolute left-2 top-1/2 -translate-y-1/2 transform bg-vsc-background text-vsc-foreground hover:bg-vsc-editor-background p-1 rounded-md"
+          title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+        >
+          {collapsed ? (
+            <ChevronRightIcon className="h-5 w-5" />
+          ) : (
+            <ChevronLeftIcon className="h-5 w-5" />
+          )}
+        </button>
+
+        {/* Search Input */}
         <input
-          className="bg-vsc-input-background text-vsc-foreground flex-1 rounded-md border border-none py-1 pl-2 pr-8 text-base outline-none focus:outline-none"
+          className="bg-vsc-input-background text-vsc-foreground flex-1 rounded-md border border-none py-1 pl-8 pr-8 text-base outline-none focus:outline-none"
           ref={searchInputRef}
           placeholder="Search past sessions"
           type="text"
@@ -179,79 +189,88 @@ export function History() {
           />
         )}
       </div>
-      <div className="thin-scrollbar flex flex-1 flex-col overflow-y-auto pr-4">
-        {filteredAndSortedSessions.length === 0 && (
-          <div className="m-3 text-center">
-            {isSessionMetadataLoading ? (
-              "Loading Sessions..."
-            ) : (
-              <>
-                No past sessions found. To start a new session, either click the
-                "+" button or use the keyboard shortcut:{" "}
-                <Shortcut>meta L</Shortcut>
-              </>
+
+      {!collapsed && (
+        <>
+          <div className="thin-scrollbar flex flex-1 flex-col overflow-y-auto pr-4">
+            {filteredAndSortedSessions.length === 0 && (
+              <div className="m-3 text-center">
+                {isSessionMetadataLoading ? (
+                  "Loading Sessions..."
+                ) : (
+                  <>
+                    No past sessions found. To start a new session, either click the
+                    "+" button or use the keyboard shortcut: <Shortcut>meta L</Shortcut>
+                  </>
+                )}
+              </div>
             )}
+
+            <table className="flex flex-1 flex-col">
+              <tbody>
+                {filteredAndSortedSessions.map((session, index) => {
+                  const prevDate =
+                    index > 0
+                      ? parseDate(filteredAndSortedSessions[index - 1].dateCreated)
+                      : earlier;
+                  const date = parseDate(session.dateCreated);
+
+                  return (
+                    <Fragment key={index}>
+                      {index === 0 && date > yesterday && (
+                        <tr className={HEADER_CLASS}>
+                          <td colSpan={3}>Today</td>
+                        </tr>
+                      )}
+                      {date < yesterday &&
+                        date > lastWeek &&
+                        prevDate > yesterday && (
+                          <tr className={HEADER_CLASS}>
+                            <td colSpan={3}>This Week</td>
+                          </tr>
+                        )}
+                      {date < lastWeek &&
+                        date > lastMonth &&
+                        prevDate > lastWeek && (
+                          <tr className={HEADER_CLASS}>
+                            <td colSpan={3}>This Month</td>
+                          </tr>
+                        )}
+                      {date < lastMonth && prevDate > lastMonth && (
+                        <tr className={HEADER_CLASS}>
+                          <td colSpan={3}>Older</td>
+                        </tr>
+                      )}
+
+                      <HistoryTableRow
+                        sessionMetadata={session}
+                        date={date}
+                        index={index}
+                      />
+                    </Fragment>
+                  );
+                })}
+              </tbody>
+            </table>
           </div>
-        )}
 
-        <table className="flex flex-1 flex-col">
-          <tbody className="">
-            {filteredAndSortedSessions.map((session, index) => {
-              const prevDate =
-                index > 0
-                  ? parseDate(filteredAndSortedSessions[index - 1].dateCreated)
-                  : earlier;
-              const date = parseDate(session.dateCreated);
-              return (
-                <Fragment key={index}>
-                  {index === 0 && date > yesterday && (
-                    <tr className={HEADER_CLASS}>
-                      <td colSpan={3}>Today</td>
-                    </tr>
-                  )}
-                  {date < yesterday &&
-                    date > lastWeek &&
-                    prevDate > yesterday && (
-                      <div className={HEADER_CLASS}>
-                        <td colSpan={3}>This Week</td>
-                      </div>
-                    )}
-                  {date < lastWeek &&
-                    date > lastMonth &&
-                    prevDate > lastWeek && (
-                      <div className={HEADER_CLASS}>
-                        <td colSpan={3}>This Month</td>
-                      </div>
-                    )}
-                  {date < lastMonth && prevDate > lastMonth && (
-                    <div className={HEADER_CLASS}>
-                      <td colSpan={3}>Older</td>
-                    </div>
-                  )}
-
-                  <HistoryTableRow
-                    sessionMetadata={session}
-                    date={date}
-                    index={index}
-                  />
-                </Fragment>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
-      <div className="flex flex-col items-end justify-center border-0 border-t border-solid border-gray-400 px-2 py-1.5 text-sm">
-        <i
-          className=""
-          data-testid="history-sessions-note"
-        >{`Data is saved in ${platform === "windows" ? "%USERPROFILE%/.continue" : "~/.continue/sessions"}`}</i>
-        <span
-          className="cursor-pointer text-xs text-gray-400 hover:underline"
-          onClick={showClearSessionsDialog}
-        >
-          Clear session history
-        </span>
-      </div>
+          <div className="flex flex-col items-end justify-center border-0 border-t border-solid border-gray-400 px-2 py-1.5 text-sm">
+            <i data-testid="history-sessions-note">
+              {`Data is saved in ${
+                platform === "windows"
+                  ? "%USERPROFILE%/.continue"
+                  : "~/.continue/sessions"
+              }`}
+            </i>
+            <span
+              className="cursor-pointer text-xs text-gray-400 hover:underline"
+              onClick={showClearSessionsDialog}
+            >
+              Clear session history
+            </span>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/gui/src/components/History/index.tsx
+++ b/gui/src/components/History/index.tsx
@@ -114,7 +114,8 @@ export function History() {
 
     return allSessionMetadata
       .filter(
-        (session) => searchTerm === "" || sessionIds.includes(session.sessionId),
+        (session) =>
+          searchTerm === "" || sessionIds.includes(session.sessionId),
       )
       .sort(
         (a, b) =>
@@ -158,7 +159,7 @@ export function History() {
         {/* Collapse Button */}
         <button
           onClick={() => setCollapsed(!collapsed)}
-          className="absolute left-2 top-1/2 -translate-y-1/2 transform bg-vsc-background text-vsc-foreground hover:bg-vsc-editor-background p-1 rounded-md"
+          className="bg-vsc-background text-vsc-foreground hover:bg-vsc-editor-background absolute left-2 top-1/2 -translate-y-1/2 transform rounded-md p-1"
           title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
         >
           {collapsed ? (
@@ -199,8 +200,9 @@ export function History() {
                   "Loading Sessions..."
                 ) : (
                   <>
-                    No past sessions found. To start a new session, either click the
-                    "+" button or use the keyboard shortcut: <Shortcut>meta L</Shortcut>
+                    No past sessions found. To start a new session, either click
+                    the "+" button or use the keyboard shortcut:{" "}
+                    <Shortcut>meta L</Shortcut>
                   </>
                 )}
               </div>
@@ -211,7 +213,9 @@ export function History() {
                 {filteredAndSortedSessions.map((session, index) => {
                   const prevDate =
                     index > 0
-                      ? parseDate(filteredAndSortedSessions[index - 1].dateCreated)
+                      ? parseDate(
+                          filteredAndSortedSessions[index - 1].dateCreated,
+                        )
                       : earlier;
                   const date = parseDate(session.dateCreated);
 


### PR DESCRIPTION
Hi @sestinj, I noticed this issue and found it a good fit to contribute.
I went ahead and implemented the collapse/expand functionality for the history sidebar.

Let me know if any changes are needed. Happy to tweak things as required.  
Thanks! 🙌

Fixes #6222

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a collapse/expand button to the history sidebar, letting users hide or show the panel as needed. This makes the sidebar more flexible and saves screen space.

<!-- End of auto-generated description by cubic. -->

