### PR TITLE
fix: prevent UI freeze when ⌘I pressed without active editor

### DIFF
--- a/gui/src/components/mainInput/Lump/LumpToolbar/EditToolbar.tsx
+++ b/gui/src/components/mainInput/Lump/LumpToolbar/EditToolbar.tsx
@@ -30,9 +30,7 @@ export function EditToolbar() {
       <span className="truncate">
         Editing:{" "}
         <span className="italic">
-          {codeToEdit
-            ? getEditFilenameAndRangeText(codeToEdit)
-            : "⚠️ No file selected"}
+          {getEditFilenameAndRangeText(codeToEdit)}
         </span>
       </span>
     </div>

--- a/gui/src/redux/thunks/edit.ts
+++ b/gui/src/redux/thunks/edit.ts
@@ -133,6 +133,14 @@ export const enterEdit = createAsyncThunk<
       return;
     }
 
+    if (!state.editModeState.codeToEdit[0]) {
+      extra.ideMessenger.post("showToast", [
+        "info",
+        "Please open a file to use Edit mode",
+      ]);
+      return;
+    }
+
     dispatch(setMainEditorContentTrigger({}));
     dispatch(setPreviousModeEditorContent(editorContent));
 
@@ -148,9 +156,5 @@ export const enterEdit = createAsyncThunk<
     );
 
     dispatch(setIsInEdit(true));
-
-    if (!state.editModeState.codeToEdit[0]) {
-      extra.ideMessenger.post("edit/addCurrentSelection", undefined);
-    }
   },
 );


### PR DESCRIPTION
## Description

fixes #6494 

pressing ⌘I in chat mode to switch to edit mode when no editor is focused previously led to an unrecoverable error state in the secondary sidebar.

this commit ensures that ⌘I action does nothing unless an editor is focused, preventing the ui from freezing and allowing normal interaction with the panel.

## Screenshots

<img width="443" alt="Screenshot 2025-07-07 at 2 53 55 PM" src="https://github.com/user-attachments/assets/170408e0-f6b6-4d38-b184-fbccabf83739" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Stops the UI from freezing when ⌘I is pressed without an active editor by making the shortcut do nothing in that case. This keeps the sidebar and panel working normally.

<!-- End of auto-generated description by cubic. -->

