### PR TITLE
chore: config-yaml v96

### DIFF
--- a/packages/config-yaml/package.json
+++ b/packages/config-yaml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@continuedev/config-yaml",
-  "version": "1.0.95",
+  "version": "1.0.96",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Description
Bump config yaml to version 96

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Bumped the @continuedev/config-yaml package version to 1.0.96.

<!-- End of auto-generated description by cubic. -->

