### PR TITLE
feat: add 'uri' for context items for http context provider

### DIFF
--- a/core/context/providers/HttpContextProvider.ts
+++ b/core/context/providers/HttpContextProvider.ts
@@ -72,6 +72,10 @@ class HttpContextProvider extends BaseContextProvider {
         description: item.description ?? "HTTP Context Item",
         content: item.content ?? "",
         name: item.name ?? this.options.title ?? "HTTP",
+        uri: {
+          type: item.uri.type,
+          value: item.uri.value,
+        },
       });
 
       return Array.isArray(json)

--- a/docs/docs/customize/custom-providers.mdx
+++ b/docs/docs/customize/custom-providers.mdx
@@ -987,6 +987,33 @@ The response 200 OK should be a JSON object with the following structure:
   "description": "",
   "content": ""
 }
+
+// For response context items with hyperlinks
+
+[
+  {
+    "name": "",
+    "description": "",
+    "content": "",
+    "uri": {
+      "type": "file" or "url",
+      "value": "file:///path/to/file" or "https://example.com",
+    }
+  }
+]
+
+// OR
+
+{
+  "name": "",
+  "description": "",
+  "content": "",
+  "uri": {
+    "type": "file" or "url",
+    "value": "file:///path/to/file" or "https://example.com",
+  }
+}
+
 ```
 
 ### `@Commits`


### PR DESCRIPTION
## Description

Added 'uri' property to Http context provider. This allows context items to have filepaths or hyperlinks

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots

N/A

## Tests

N/A

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a 'uri' property to HTTP context provider items so they can include file paths or hyperlinks.

- **Docs**
  - Updated custom provider docs with examples showing how to use the new 'uri' field.

<!-- End of auto-generated description by cubic. -->

