### PR TITLE
Fix: add sanitizing process to strip off the trailing slash of the doc URL

### DIFF
--- a/core/indexing/docs/DocsCache.ts
+++ b/core/indexing/docs/DocsCache.ts
@@ -7,6 +7,15 @@ export interface SiteIndexingResults {
   title: string;
 }
 
+/**
+ * Strip off the trailing forward slash from the given URL
+ * @param url The URL of the document
+ * @returns A sanitized URL without trailing forward slash
+ */
+const stripTrailingSlash = (url: string): string => {
+  return url.replace(/\/+$/, "");
+};
+
 export class DocsCache {
   static readonly AWS_REGION: string = "us-west-1";
   static readonly BUCKET_NAME: string = "continue-preindexed-docs";
@@ -33,7 +42,8 @@ export class DocsCache {
     url: string,
   ): string {
     const normalizedEmbeddingId = DocsCache.normalizeEmbeddingId(embeddingId);
-    const normalizedUrl = encodeURIComponent(url.replace(/\//g, "_"));
+    const sanitizedUrl = stripTrailingSlash(url);
+    const normalizedUrl = encodeURIComponent(sanitizedUrl.replace(/\//g, "_"));
     return normalizedEmbeddingId + "/" + normalizedUrl;
   }
 


### PR DESCRIPTION
## Description

In this patch, we add a sanitizing process to strip off the trailing forward slash (if any) in the given URL before generating the file path for S3 bucket. Therefore, both variants (url with / and without /) in the config file can be treated the same.

https://github.com/continuedev/continue/issues/6454

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a sanitizing step to remove trailing slashes from doc URLs before generating S3 file paths, so URLs with and without a slash are treated the same.

<!-- End of auto-generated description by cubic. -->

