### PR TITLE
fix: use correct styling on truncate btn

### DIFF
--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/ToolbarButtonWithTooltip.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/ToolbarButtonWithTooltip.tsx
@@ -1,6 +1,5 @@
 import { ReactNode, useMemo } from "react";
-import { Tooltip } from "react-tooltip";
-import { getFontSize } from "../../../util";
+import { ToolTip } from "../../gui/Tooltip";
 
 interface ToolbarButtonWithTooltipProps {
   onClick: () => void;
@@ -22,20 +21,20 @@ export function ToolbarButtonWithTooltip({
 
   return (
     <>
-      <button
-        onClick={onClick}
-        style={{
-          fontSize: `${getFontSize() - 2}px`,
+      <div
+        onClick={(e) => {
+          e.stopPropagation();
+          onClick();
         }}
         data-tooltip-id={tooltipId}
         data-testid={testId}
-        className="text-foreground flex items-center border-none bg-transparent px-0.5 outline-none hover:cursor-pointer hover:brightness-125"
+        className="hover:description-muted/30 cursor-pointer select-none rounded bg-transparent px-1 py-0.5 hover:opacity-80"
       >
         {children}
-      </button>
-      <Tooltip id={tooltipId} place="top">
+      </div>
+      <ToolTip id={tooltipId} place="top">
         {tooltipContent}
-      </Tooltip>
+      </ToolTip>
     </>
   );
 }

--- a/gui/src/pages/gui/ToolCallDiv/ToolCallArgs.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/ToolCallArgs.tsx
@@ -1,6 +1,5 @@
 import { CodeBracketIcon } from "@heroicons/react/24/outline";
-import { useMemo } from "react";
-import { ToolTip } from "../../../components/gui/Tooltip";
+import { ToolbarButtonWithTooltip } from "../../../components/StyledMarkdownPreview/StepContainerPreToolbar/ToolbarButtonWithTooltip";
 
 interface ArgsToggleIconProps {
   isShowing: boolean;
@@ -13,26 +12,15 @@ export const ArgsToggleIcon = ({
   setIsShowing,
   toolCallId,
 }: ArgsToggleIconProps) => {
-  const argsTooltipId = useMemo(() => {
-    return "args-hover-" + toolCallId;
-  }, [toolCallId]);
-
   return (
-    <>
-      <div
-        data-tooltip-id={argsTooltipId}
-        onClick={(e) => {
-          e.stopPropagation();
-          setIsShowing(!isShowing);
-        }}
-        className={`hover:description-muted/30 cursor-pointer select-none rounded px-1 py-0.5 hover:opacity-80 ${isShowing ? "bg-description-muted/30" : "bg-transparent"}`}
-      >
-        <CodeBracketIcon className="h-3 w-3 flex-shrink-0 opacity-60" />
-      </div>
-      <ToolTip id={argsTooltipId}>
-        {isShowing ? "Hide args" : "Show args"}
-      </ToolTip>
-    </>
+    <ToolbarButtonWithTooltip
+      tooltipContent={isShowing ? "Hide args" : "Show args"}
+      onClick={() => {
+        setIsShowing(!isShowing);
+      }}
+    >
+      <CodeBracketIcon className="h-3 w-3 flex-shrink-0 opacity-60" />
+    </ToolbarButtonWithTooltip>
   );
 };
 

--- a/gui/src/pages/gui/ToolCallDiv/ToolTruncateHistoryIcon.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/ToolTruncateHistoryIcon.tsx
@@ -2,8 +2,8 @@ import { BarsArrowUpIcon } from "@heroicons/react/24/outline";
 import { chatMessageIsEmpty } from "core/llm/messages";
 import { findLastIndex } from "core/util/findLast";
 import { useMemo } from "react";
-import { ToolTip } from "../../../components/gui/Tooltip";
 import { useMainEditor } from "../../../components/mainInput/TipTapEditor";
+import { ToolbarButtonWithTooltip } from "../../../components/StyledMarkdownPreview/StepContainerPreToolbar/ToolbarButtonWithTooltip";
 import { useAppDispatch, useAppSelector } from "../../../redux/hooks";
 import { truncateHistoryToMessage } from "../../../redux/slices/sessionSlice";
 
@@ -20,37 +20,28 @@ export function ToolTruncateHistoryIcon({
   const dispatch = useAppDispatch();
   const { mainEditor } = useMainEditor();
 
-  const truncateTooltipId = useMemo(() => {
-    return "truncate-hover-" + historyIndex;
-  }, [historyIndex]);
-
   if (historyIndex === lastMessageIndex) {
     return null;
   }
 
   return (
-    <>
-      <div
-        data-tooltip-id={truncateTooltipId}
-        onClick={(e) => {
-          e.stopPropagation();
-          if (isStreaming) {
-            return;
-          }
-          dispatch(
-            truncateHistoryToMessage({
-              index: historyIndex,
-            }),
-          );
-          mainEditor?.commands.focus();
-        }}
-        className={`hover:description-muted/30 cursor-pointer select-none rounded px-1 py-0.5 hover:opacity-80 ${isStreaming ? "cursor-not-allowed opacity-50" : "bg-transparent"}`}
-      >
-        <BarsArrowUpIcon className="h-3 w-3 flex-shrink-0 opacity-60" />
-      </div>
-      <ToolTip id={truncateTooltipId}>
-        {isStreaming ? "" : "Trim chat to this message"}
-      </ToolTip>
-    </>
+    <ToolbarButtonWithTooltip
+      tooltipContent={isStreaming ? "" : "Trim chat to this message"}
+      onClick={() => {
+        if (isStreaming) {
+          return;
+        }
+        dispatch(
+          truncateHistoryToMessage({
+            index: historyIndex,
+          }),
+        );
+        mainEditor?.commands.focus();
+      }}
+    >
+      <BarsArrowUpIcon
+        className={`h-3 w-3 flex-shrink-0 opacity-60 ${isStreaming ? "cursor-not-allowed" : ""}`}
+      />
+    </ToolbarButtonWithTooltip>
   );
 }

--- a/gui/src/pages/gui/ToolCallDiv/ToolTruncateHistoryIcon.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/ToolTruncateHistoryIcon.tsx
@@ -2,8 +2,8 @@ import { BarsArrowUpIcon } from "@heroicons/react/24/outline";
 import { chatMessageIsEmpty } from "core/llm/messages";
 import { findLastIndex } from "core/util/findLast";
 import { useMemo } from "react";
+import { ToolTip } from "../../../components/gui/Tooltip";
 import { useMainEditor } from "../../../components/mainInput/TipTapEditor";
-import { ToolbarButtonWithTooltip } from "../../../components/StyledMarkdownPreview/StepContainerPreToolbar/ToolbarButtonWithTooltip";
 import { useAppDispatch, useAppSelector } from "../../../redux/hooks";
 import { truncateHistoryToMessage } from "../../../redux/slices/sessionSlice";
 
@@ -19,27 +19,38 @@ export function ToolTruncateHistoryIcon({
   }, [history]);
   const dispatch = useAppDispatch();
   const { mainEditor } = useMainEditor();
+
+  const truncateTooltipId = useMemo(() => {
+    return "truncate-hover-" + historyIndex;
+  }, [historyIndex]);
+
   if (historyIndex === lastMessageIndex) {
     return null;
   }
+
   return (
-    <ToolbarButtonWithTooltip
-      tooltipContent={isStreaming ? "" : "Trim chat to this message"}
-      onClick={() => {
-        if (isStreaming) {
-          return;
-        }
-        dispatch(
-          truncateHistoryToMessage({
-            index: historyIndex,
-          }),
-        );
-        mainEditor?.commands.focus();
-      }}
-    >
-      <BarsArrowUpIcon
-        className={`h-3 w-3 flex-shrink-0 ${isStreaming ? "cursor-not-allowed" : "cursor-pointer"}`}
-      />
-    </ToolbarButtonWithTooltip>
+    <>
+      <div
+        data-tooltip-id={truncateTooltipId}
+        onClick={(e) => {
+          e.stopPropagation();
+          if (isStreaming) {
+            return;
+          }
+          dispatch(
+            truncateHistoryToMessage({
+              index: historyIndex,
+            }),
+          );
+          mainEditor?.commands.focus();
+        }}
+        className={`hover:description-muted/30 cursor-pointer select-none rounded px-1 py-0.5 hover:opacity-80 ${isStreaming ? "cursor-not-allowed opacity-50" : "bg-transparent"}`}
+      >
+        <BarsArrowUpIcon className="h-3 w-3 flex-shrink-0 opacity-60" />
+      </div>
+      <ToolTip id={truncateTooltipId}>
+        {isStreaming ? "" : "Trim chat to this message"}
+      </ToolTip>
+    </>
   );
 }


### PR DESCRIPTION
Updates the args/truncate btns along with the base `ToolbarButtonWithTooltip` to have more consistent styling with the rest of the codebase.

## Old
<img width="330" alt="image" src="https://github.com/user-attachments/assets/fa569761-cd3b-4fe6-80ec-77d2e86f5333" />

## New
<img width="335" alt="image" src="https://github.com/user-attachments/assets/69c4c7a8-4786-4fc1-a03d-4fe0ba7127d3" />