### PR TITLE
fix: autocomplete dev data timestamp as iso string

### DIFF
--- a/core/autocomplete/CompletionProvider.ts
+++ b/core/autocomplete/CompletionProvider.ts
@@ -254,7 +254,7 @@ export class CompletionProvider {
         completionId: helper.input.completionId,
         gitRepo: await this.ide.getRepoName(helper.filepath),
         uniqueId: await this.ide.getUniqueId(),
-        timestamp: Date.now(),
+        timestamp: new Date().toISOString(),
         ...helper.options,
       };
 

--- a/core/autocomplete/util/types.ts
+++ b/core/autocomplete/util/types.ts
@@ -41,5 +41,5 @@ export interface AutocompleteOutcome extends TabAutocompleteOptions {
   gitRepo?: string;
   completionId: string;
   uniqueId: string;
-  timestamp: number;
+  timestamp: string;
 }

--- a/packages/config-yaml/src/schemas/data/autocomplete/index.ts
+++ b/packages/config-yaml/src/schemas/data/autocomplete/index.ts
@@ -34,7 +34,7 @@ export const autocompleteEventAllSchema = baseDevDataAllSchema.extend({
   gitRepo: z.string().optional(),
   completionId: z.string(),
   uniqueId: z.string(),
-  timestamp: z.number(),
+  timestamp: z.string(),
 
   // DEPRECATED - no more nested objects after v0.1.0, all flat values
   completionOptions: completionOptionsSchema.optional(),


### PR DESCRIPTION
## Description

Fix autocomplete timestamp as ISO string instead of Date.now number.

- fix types in config yaml and CompletionProvider

Resolves CON-2221

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

**Previous**

https://webhook.site/#!/view/064c1893-d710-4e1d-9713-a3cda0cc4b17/44c59738-48bd-495b-875c-c516ebe901dd/1

![Screenshot 2025-07-08 at 10 04 53 PM](https://github.com/user-attachments/assets/09b55383-0f89-4530-8d2f-443c431eb9c8)



**After**

https://webhook.site/#!/view/03ed0403-9a91-449c-b5db-af15ba0c3190/eca8e7ae-1b18-4582-873d-e95c4f292329/1

![Screenshot 2025-07-08 at 9 56 32 PM](https://github.com/user-attachments/assets/8c51f1ed-beef-4c15-9411-48a1565eaacb)



## Tests


