### PR TITLE
fix: :bug: When a terminal command is moved to the background preserve existing output

### DIFF
--- a/gui/src/redux/thunks/moveTerminalProcessToBackground.ts
+++ b/gui/src/redux/thunks/moveTerminalProcessToBackground.ts
@@ -10,9 +10,10 @@ import { streamResponseAfterToolCall } from "./streamResponseAfterToolCall";
 
 /**
  * This thunk is used to move a terminal command to the background
- * when the user clicks the "Continue" button in the UI
+ * when the user clicks the "Move to background" link in the UI
  *
- * It marks the command as visually complete without stopping
+ * It preserves all existing terminal output, marks the command as
+ * visually complete, and stops listening to further output from
  * the already running process
  */
 export const moveTerminalProcessToBackground = createAsyncThunk<
@@ -39,6 +40,12 @@ export const moveTerminalProcessToBackground = createAsyncThunk<
       return;
     }
 
+    // Find existing terminal output to preserve it
+    const existingOutput = toolCall.output?.find(
+      (item) => item.name === "Terminal",
+    );
+    const existingContent = existingOutput?.content || "";
+
     const status =
       "Command moved to background. Further output will be ignored.";
 
@@ -46,7 +53,7 @@ export const moveTerminalProcessToBackground = createAsyncThunk<
       {
         name: "Terminal",
         description: "Terminal command output",
-        content: "\n" + status,
+        content: existingContent + (existingContent ? "\n\n" : "") + status,
         status: status,
       },
     ];


### PR DESCRIPTION
## Description

When a terminal command was moved to the background the existing output was lost. This confused the next call to the LLM because if that output was useful to make decisions then the LLM would proceed without that information.

This fixes that issue by preserving the output captured before the command is moved to the background for the LLM.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

No changes to tests. Testing was performed manually.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Terminal commands moved to the background now keep all previous output, so no information is lost when switching modes. This ensures the LLM can access the full command output even after backgrounding.

<!-- End of auto-generated description by cubic. -->

