### PR TITLE
Fix: improved Documentation Indexing and Submenu Updates

### DIFF
--- a/core/context/providers/DocsContextProvider.ts
+++ b/core/context/providers/DocsContextProvider.ts
@@ -145,6 +145,11 @@ class DocsContextProvider extends BaseContextProvider {
   async loadSubmenuItems(
     args: LoadSubmenuItemsArgs,
   ): Promise<ContextSubmenuItem[]> {
+    const { config } = args;
+    // This set is used to filter out the docs that is not in docs config but exist in sqlite metadata
+    const configDocsSet = new Set(
+      config.docs?.map((doc) => doc.startUrl) || [],
+    );
     // Get docs service
     const docsService = DocsService.getSingleton();
     if (!docsService) {
@@ -159,12 +164,14 @@ class DocsContextProvider extends BaseContextProvider {
     // Get all indexed docs from the database
     const docs = (await docsService.listMetadata()) ?? [];
     for (const { startUrl, title, favicon } of docs) {
-      submenuItems.push({
-        title,
-        id: startUrl,
-        description: new URL(startUrl).hostname,
-        icon: favicon,
-      });
+      if (configDocsSet.has(startUrl)) {
+        submenuItems.push({
+          title,
+          id: startUrl,
+          description: new URL(startUrl).hostname,
+          icon: favicon,
+        });
+      }
     }
 
     // Sort alphabetically


### PR DESCRIPTION
## Description

This patch significantly enhances how Continue responds to changes in the documentation configuration, providing a more consistent and user-friendly experience.

Previously, Continue's handling of documentation configuration changes could lead to inconsistencies, requiring users to relaunch the application to see updates. This PR addresses these issues by improving the caching, indexing, and display of the documentation.

Key Improvements:
  1. Submenu items for the documentation now refresh automatically after retrieving the cache from S3. Before this fix, it won't show up in the submenu until we relaunch Continue.
  2. The titles and favicons for cached documentation now correctly reflect the values defined in the docs configuration, rather than defaulting to the URL.
  3. Deleting or commenting out a documentation entry in the configuration file will now automatically remove it from the submenu, ensuring consistency between the configuration and the displayed options.
  4. If only the title or favicon of a document changes, Continue now efficiently updates the metadata in the SQLite database instead of performing a full reindexing.
  5. Continue can now catch and apply changes to documentation titles and favicons even when the application is not actively running.

Future Considerations:
  1. The doc schema in the config-yaml should be updated to include maxDepth and useLocalCrawling parameters if we're planing to keep these parameters. Their values are always undefined now no matter what users set in config file.
  2. If we do keep maxDepth and useLocalCrawling, we should consider adding maxDepth and useLocalCrawling to the SQLite metadata. This would allow the SQLite database to serve as a persistent store for each document's parameters, preventing edge cases where changes to the documentation configuration are missed when Continue is inactive.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [ ] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created

## Tests

After each improvement, confirm it performs as expected.


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved how documentation submenu items update after changes to the docs configuration, so updates appear right away without needing to restart Continue.

- **Bug Fixes**
  - Submenu now refreshes automatically after docs config changes or cache updates.
  - Titles and favicons in the submenu match the docs config.
  - Removing a doc from the config removes it from the submenu.
  - Title or favicon changes update instantly in the database without full reindexing.

<!-- End of auto-generated description by cubic. -->

