### PR TITLE
feat: VertexAI keyFile, keyJson, and express/apiKey support

### DIFF
--- a/core/llm/llms/VertexAI.ts
+++ b/core/llm/llms/VertexAI.ts
@@ -58,7 +58,7 @@ class VertexAI extends BaseLLM {
     if (apiKey) {
       if (this.vertexProvider !== "gemini") {
         throw new Error(
-          "VertexAI: only gemini models are supported in express (apiKey) mode. See       https://cloud.google.com/vertex-ai/generative-ai/docs/start/express-mode/overview#models",
+          "VertexAI: only gemini models are supported in express (apiKey) mode. See https://cloud.google.com/vertex-ai/generative-ai/docs/start/express-mode/overview#models",
         );
       }
       if (region || projectId) {

--- a/docs/docs/customize/model-providers/top-level/vertexai.mdx
+++ b/docs/docs/customize/model-providers/top-level/vertexai.mdx
@@ -114,3 +114,33 @@ We recommend configuring **text-embedding-004** as your embeddings model.
 Vertex AI currently does not offer any reranking models.
 
 [Click here](../../model-roles/reranking.mdx) to see a list of reranking model providers.
+
+## Express mode
+
+You can use VertexAI in [express mode](https://cloud.google.com/vertex-ai/generative-ai/docs/start/express-mode/overview) by only providing an API Key. Only some Gemini models are supported in express mode for now.
+
+<Tabs groupId="config-example">
+    <TabItem value="yaml" label="YAML">
+    ```yaml title="config.yaml"
+    models:
+      - name: Gemini 2.5 Flash - VertexAI
+        provider: vertexai
+        model: gemini-2.5-flash
+        apiKey: ${{ secrets.GOOGLE_CLOUD_API_KEY }}
+    ```
+    </TabItem>
+    <TabItem value="json" label="JSON">
+    ```json title="config.json"
+    {
+      "models": [
+        {
+          "title": "Gemini 2.5 Flash - VertexAI",
+          "provider": "vertexai",
+          "model": "gemini-2.5-flash",
+          "apiKey": "[YOUR_GOOGLE_CLOUD_API_KEY]",
+        }
+      ]
+    }
+    ```
+    </TabItem>
+</Tabs>


### PR DESCRIPTION
## Description

Adds support for additional authentication methods for VertexAI
- Path to keys json file using `env.keyFile` (YAML only)
- Inline keys json using `env.keyJson` (YAML only)
- [Express mode](https://cloud.google.com/vertex-ai/generative-ai/docs/start/express-mode/overview) using `apiKey` (JSON and YAML)

Adds docs for the express mode case. 
TODO add docs for `keyFile` and `keyJson` methods
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for VertexAI Express mode, allowing users to authenticate with an API key instead of Google Cloud credentials. Updated documentation with setup instructions and examples.

- **New Features**
  - Accepts apiKey for Gemini models using Express mode.
  - Ignores region and projectId when apiKey is provided.
  - Added docs with YAML and JSON config examples for Express mode.

<!-- End of auto-generated description by cubic. -->

