### PR TITLE
Suppress stderr output from Windows registry queries

### DIFF
--- a/core/control-plane/mdm/mdm.ts
+++ b/core/control-plane/mdm/mdm.ts
@@ -132,7 +132,10 @@ function readMdmKeysWindows(): MdmKeys | undefined {
     try {
       // Use REG QUERY command to read registry values
       const licenseKeyCmd = `reg query "${regPath}" /v licenseKey`;
-      const licenseKeyOutput = execSync(licenseKeyCmd, { encoding: "utf8" });
+      const licenseKeyOutput = execSync(licenseKeyCmd, {
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
       // Extract values from command output
       const licenseKey = extractRegValue(licenseKeyOutput);
       if (licenseKey) {
@@ -145,7 +148,10 @@ function readMdmKeysWindows(): MdmKeys | undefined {
     // Try HKEY_CURRENT_USER if not found in HKEY_LOCAL_MACHINE
     try {
       const licenseKeyCmd = `reg query "${userRegPath}" /v licenseKey`;
-      const licenseKeyOutput = execSync(licenseKeyCmd, { encoding: "utf8" });
+      const licenseKeyOutput = execSync(licenseKeyCmd, {
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
       // Extract values from command output
       const licenseKey = extractRegValue(licenseKeyOutput);
       if (licenseKey) {


### PR DESCRIPTION
This appears to have been the cause of

```
ERROR: The system was unable to find the specified registry key or value.ERROR: The system was unable to find the specified registry key or value.ERROR: The system was unable to find the specified registry key or value.ERROR: The system was unable to find the specified registry key or value.ERROR: The system was unable to find the specified registry key or value.ERROR: The system was unable to find the specified registry key or value.ERROR: The system was unable to find the specified registry key or value.ERROR: The system was unable to find the specified registry key or value.ERROR: The system was unable to find the specified registry key or value.ERROR: The system was unable to find the specified registry key or value.
```

which was leading to core exits in JetBrains