### PR TITLE
Add config schema review rule documentation

### DIFF
--- a/packages/config-yaml/src/schemas/review.rule.md
+++ b/packages/config-yaml/src/schemas/review.rule.md
@@ -1,0 +1,3 @@
+No new additions to the ConfigYaml schema should be made for features that are experimental. This is because anything added to config.yaml can't easily be taken away without causing backward-compatibility issues for users that chose to use the setting.
+
+You can tell whether a feature is experimental based off of whether anything was added to the "Experimental Settings" section of `UserSettingsForm.tsx`.


### PR DESCRIPTION
This happened for basePlanSystemMessage, which isn't that big a deal but just thought this might be an interesting PR review rule. Wouldn't be triggered super often