### PR TITLE
fix: :bug: Fix autoscrolling terminal output

### DIFF
--- a/gui/src/pages/gui/ToolCallDiv/RunTerminalCommand.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/RunTerminalCommand.tsx
@@ -1,4 +1,5 @@
 import { ToolCallState } from "core";
+import { useEffect, useRef } from "react";
 import styled from "styled-components";
 import { vscForeground } from "../../../components";
 import Ansi from "../../../components/ansiTerminal/Ansi";
@@ -73,6 +74,8 @@ const TerminalContainer = styled.div`
 
 export function RunTerminalCommand(props: RunTerminalCommandToolCallProps) {
   const dispatch = useAppDispatch();
+  const ansiWrapperRef = useRef<HTMLDivElement>(null);
+  const terminalContainerRef = useRef<HTMLDivElement>(null);
 
   // Find the terminal output from context items if available
   const terminalItem = props.toolCallState.output?.find(
@@ -83,6 +86,19 @@ export function RunTerminalCommand(props: RunTerminalCommandToolCallProps) {
   const statusMessage = terminalItem?.status || "";
   const isRunning = props.toolCallState.status === "calling";
   const hasOutput = terminalContent.length > 0;
+
+  // Add data attributes to help with autoscroll detection
+  useEffect(() => {
+    if (ansiWrapperRef.current) {
+      ansiWrapperRef.current.setAttribute("data-terminal-output", "true");
+    }
+    if (terminalContainerRef.current) {
+      terminalContainerRef.current.setAttribute(
+        "data-terminal-container",
+        "true",
+      );
+    }
+  }, []);
 
   // Determine status type
   let statusType: "running" | "completed" | "failed" | "background" =
@@ -96,7 +112,7 @@ export function RunTerminalCommand(props: RunTerminalCommandToolCallProps) {
   }
 
   return (
-    <TerminalContainer>
+    <TerminalContainer ref={terminalContainerRef}>
       {/* Command */}
       <StyledMarkdownPreview
         isRenderingInStepContainer
@@ -108,7 +124,7 @@ export function RunTerminalCommand(props: RunTerminalCommandToolCallProps) {
         <WaitingMessage>Waiting for output...</WaitingMessage>
       )}
       {hasOutput && (
-        <AnsiWrapper>
+        <AnsiWrapper ref={ansiWrapperRef}>
           <Ansi>{terminalContent}</Ansi>
         </AnsiWrapper>
       )}

--- a/gui/src/pages/gui/useAutoScroll.ts
+++ b/gui/src/pages/gui/useAutoScroll.ts
@@ -1,12 +1,30 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { ChatHistoryItemWithMessageId } from "../../redux/slices/sessionSlice";
 
 /**
- * Only reset scroll state when a new user message is added to the chat.
- * We don't want to auto-scroll on new tool response messages.
+ * Reset scroll state when a new user message is added to the chat.
+ * Also track tool call updates for auto-scrolling during streaming.
  */
 function getNumUserMsgs(history: ChatHistoryItemWithMessageId[]) {
   return history.filter((msg) => msg.message.role === "user").length;
+}
+
+/**
+ * Get a hash of tool call states to detect when tool outputs change
+ */
+function getToolCallHash(history: ChatHistoryItemWithMessageId[]) {
+  return history
+    .filter((item) => item.toolCallState)
+    .map((item) => {
+      const state = item.toolCallState!;
+      const outputLength =
+        state.output?.reduce(
+          (acc, item) => acc + (item.content?.length || 0),
+          0,
+        ) || 0;
+      return `${state.toolCallId}-${state.status}-${outputLength}`;
+    })
+    .join("|");
 }
 
 export const useAutoScroll = (
@@ -15,47 +33,114 @@ export const useAutoScroll = (
 ) => {
   const [userHasScrolled, setUserHasScrolled] = useState(false);
   const numUserMsgs = useMemo(() => getNumUserMsgs(history), [history.length]);
+  const toolCallHash = useMemo(() => getToolCallHash(history), [history]);
 
+  // Reset scroll state when new user messages are added
   useEffect(() => {
     setUserHasScrolled(false);
   }, [numUserMsgs]);
 
+  const scrollToBottom = useCallback(() => {
+    const elem = ref.current;
+    if (!elem) return;
+    elem.scrollTop = elem.scrollHeight;
+  }, [ref]);
+
+  const handleScroll = useCallback(() => {
+    const elem = ref.current;
+    if (!elem) return;
+
+    const isAtBottom =
+      Math.abs(elem.scrollHeight - elem.scrollTop - elem.clientHeight) < 5;
+
+    /**
+     * We stop auto scrolling if a user manually scrolled up.
+     * We resume auto scrolling if a user manually scrolled to the bottom.
+     */
+    setUserHasScrolled(!isAtBottom);
+  }, []);
+  // Auto-scroll when history changes (including tool call outputs)
+  useEffect(() => {
+    if (!userHasScrolled) {
+      // Small delay to ensure DOM has updated
+      const timeoutId = setTimeout(scrollToBottom, 10);
+      return () => clearTimeout(timeoutId);
+    }
+  }, [history, userHasScrolled, scrollToBottom]);
+
   useEffect(() => {
     if (!ref.current || history.length === 0) return;
 
-    const handleScroll = () => {
-      const elem = ref.current;
-      if (!elem) return;
+    const elem = ref.current;
 
-      const isAtBottom =
-        Math.abs(elem.scrollHeight - elem.scrollTop - elem.clientHeight) < 1;
+    const resizeObserver = new ResizeObserver((entries) => {
+      if (userHasScrolled) return;
 
-      /**
-       * We stop auto scrolling if a user manually scrolled up.
-       * We resume auto scrolling if a user manually scrolled to the bottom.
-       */
-      setUserHasScrolled(!isAtBottom);
-    };
+      // Check if any observed element has grown in height
+      let shouldScroll = false;
+      entries.forEach((entry) => {
+        const target = entry.target as HTMLElement;
+        const currentHeight = entry.contentRect.height;
 
-    const resizeObserver = new ResizeObserver(() => {
-      const elem = ref.current;
-      if (!elem || userHasScrolled) return;
-      elem.scrollTop = elem.scrollHeight;
+        // Store previous height on the element for comparison
+        const prevHeight = target.dataset.prevHeight
+          ? parseInt(target.dataset.prevHeight, 10)
+          : 0;
+
+        // Only scroll if the element has actually grown
+        if (currentHeight > prevHeight && currentHeight > 0) {
+          shouldScroll = true;
+        }
+
+        // Update stored height
+        target.dataset.prevHeight = currentHeight.toString();
+      });
+
+      if (shouldScroll) {
+        // Use requestAnimationFrame for smoother scrolling
+        requestAnimationFrame(() => {
+          scrollToBottom();
+        });
+      }
     });
 
-    ref.current.addEventListener("scroll", handleScroll);
+    elem.addEventListener("scroll", handleScroll, { passive: true });
 
     // Observe the container
-    resizeObserver.observe(ref.current);
+    resizeObserver.observe(elem);
 
-    // Observe all immediate children
-    Array.from(ref.current.children).forEach((child) => {
-      resizeObserver.observe(child);
+    // Observe all immediate children and their nested content
+    const observeElement = (element: Element) => {
+      resizeObserver.observe(element);
+      // Also observe terminal/tool output containers that can grow dynamically
+      const toolElements = element.querySelectorAll(
+        '[class*="terminal"], [class*="ansi"], pre, code, [class*="TerminalContainer"], [class*="AnsiWrapper"], [class*="Terminal"]',
+      );
+      toolElements.forEach((toolEl) => resizeObserver.observe(toolEl));
+    };
+
+    Array.from(elem.children).forEach(observeElement);
+
+    // Set up a mutation observer to catch new elements being added
+    const mutationObserver = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        mutation.addedNodes.forEach((node) => {
+          if (node.nodeType === Node.ELEMENT_NODE) {
+            observeElement(node as Element);
+          }
+        });
+      });
+    });
+
+    mutationObserver.observe(elem, {
+      childList: true,
+      subtree: true,
     });
 
     return () => {
       resizeObserver.disconnect();
-      ref.current?.removeEventListener("scroll", handleScroll);
+      mutationObserver.disconnect();
+      elem.removeEventListener("scroll", handleScroll);
     };
-  }, [ref, history.length, userHasScrolled]);
+  }, [ref, history.length, userHasScrolled, handleScroll, scrollToBottom]);
 };


### PR DESCRIPTION
## Description

A previous change to auto-scroll behavior broke the autoscroll when terminal tools became taller due to streaming output. 

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

Visual inspection of auto scroll working. I've used a prompts like running vite or jest tests that steam output over time, and then also using terminal output like echo commands in a foreground loop.