### PR TITLE
Revert "chore: terminate all tasks after debug"

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,6 @@
       "pauseForSourceMap": false,
       "outFiles": ["${workspaceFolder}/extensions/vscode/out/extension.js"],
       "preLaunchTask": "vscode-extension:build",
-      "postDebugTask": "Terminate All Tasks",
       "env": {
         // "CONTROL_PLANE_ENV": "local",
         "CONTINUE_GLOBAL_DIR": "${workspaceFolder}/extensions/.continue-debug"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -223,19 +223,6 @@
       ],
       "type": "shell",
       "problemMatcher": []
-    },
-    {
-      "label": "Terminate All Tasks",
-      "command": "${input:terminate}",
-      "type": "shell"
-    }
-  ],
-  "inputs": [
-    {
-      "id": "terminate",
-      "type": "command",
-      "command": "workbench.action.tasks.terminate",
-      "args": "terminateAll"
     }
   ]
 }


### PR DESCRIPTION
Reverts continuedev/continue#6405

This is causing an issue where every time you reload the debug window, all the processes are terminated.