### PR TITLE
fix: Nvidia Agent and handle different arg streaming styles

### DIFF
--- a/core/llm/autodetect.ts
+++ b/core/llm/autodetect.ts
@@ -46,7 +46,8 @@ import { PROVIDER_TOOL_SUPPORT } from "./toolSupport.js";
 const PROVIDER_HANDLES_TEMPLATING: string[] = [
   "lmstudio",
   "openai",
-  "ollama",
+  "nvidia",
+  "ollama", 
   "together",
   "novita",
   "msty",

--- a/core/llm/autodetect.ts
+++ b/core/llm/autodetect.ts
@@ -47,7 +47,7 @@ const PROVIDER_HANDLES_TEMPLATING: string[] = [
   "lmstudio",
   "openai",
   "nvidia",
-  "ollama", 
+  "ollama",
   "together",
   "novita",
   "msty",

--- a/gui/src/util/toolCallState.test.ts
+++ b/gui/src/util/toolCallState.test.ts
@@ -479,4 +479,104 @@ describe("addToolCallDeltaToState", () => {
     );
     expect(currentState.parsedArgs).toEqual({ location: "Paris, France" });
   });
+
+  it("should handle arguments streamed in full progressive chunks", () => {
+    // Test case where model streams args progressively but includes full prefix each time
+    // e.g. '{"query":"te' -> '{"query":"tes' -> '{"query":"test"}'
+    const currentState: ToolCallState = {
+      status: "generating",
+      toolCall: {
+        id: "call123",
+        type: "function",
+        function: {
+          name: "searchFiles",
+          arguments: '{"query":"te',
+        },
+      },
+      toolCallId: "call123",
+      parsedArgs: { query: "te" },
+    };
+
+    const delta: ToolCallDelta = {
+      function: {
+        arguments: '{"query":"tes',
+      },
+    };
+
+    const result = addToolCallDeltaToState(delta, currentState);
+    expect(result.toolCall.function.arguments).toBe('{"query":"tes');
+    expect(result.parsedArgs).toEqual({ query: "tes" });
+
+    // Continue the streaming
+    const nextDelta: ToolCallDelta = {
+      function: {
+        arguments: '{"query":"test"}',
+      },
+    };
+
+    const finalResult = addToolCallDeltaToState(nextDelta, result);
+    expect(finalResult.toolCall.function.arguments).toBe('{"query":"test"}');
+    expect(finalResult.parsedArgs).toEqual({ query: "test" });
+  });
+
+  it("should handle when args delta is a superset of current args", () => {
+    // Test case where model sends a subset of the current arguments
+    // This can happen in certain LLM implementations
+    const currentState: ToolCallState = {
+      status: "generating",
+      toolCall: {
+        id: "call123",
+        type: "function",
+        function: {
+          name: "searchFiles",
+          arguments: '{"query":"test"',
+        },
+      },
+      toolCallId: "call123",
+      parsedArgs: { query: "test" },
+    };
+
+    const delta: ToolCallDelta = {
+      function: {
+        arguments: '{"query":"test","limit":10}',
+      },
+    };
+
+    // The subset should be ignored, keeping the current state
+    const result = addToolCallDeltaToState(delta, currentState);
+    expect(result.toolCall.function.arguments).toBe(
+      '{"query":"test","limit":10}',
+    );
+    expect(result.parsedArgs).toEqual({ query: "test", limit: 10 });
+  });
+
+  it("should handle when args are complete JSON and new deltas arrive", () => {
+    // When args are already a valid JSON object, new deltas should not modify it
+    const currentState: ToolCallState = {
+      status: "generating",
+      toolCall: {
+        id: "call123",
+        type: "function",
+        function: {
+          name: "searchFiles",
+          arguments: '{"query":"test","limit":10}',
+        },
+      },
+      toolCallId: "call123",
+      parsedArgs: { query: "test", limit: 10 },
+    };
+
+    const delta: ToolCallDelta = {
+      function: {
+        arguments: ',"sort":"asc"}',
+      },
+    };
+
+    // The complete JSON should not be modified
+    const result = addToolCallDeltaToState(delta, currentState);
+    expect(result.toolCall.function.arguments).toBe(
+      '{"query":"test","limit":10}',
+    );
+    expect(result.parsedArgs).toEqual({ query: "test", limit: 10 });
+  });
 });

--- a/gui/src/util/toolCallState.ts
+++ b/gui/src/util/toolCallState.ts
@@ -34,15 +34,24 @@ export function addToolCallDeltaToState(
   if (nameDelta.startsWith(currentName)) {
     // Case where model progresssively streams name but full name each time e.g. "readFi" -> "readFil" -> "readFile"
     mergedName = nameDelta;
-  } else if (currentName.startsWith(nameDelta)) {
-    // Case where model streams in full name each time e.g. readFile -> readFile -> readFile
-    // do nothing
-  } else {
-    // Case where model streams in name in parts e.g. "read" -> "File"
+  } else if (!currentName.startsWith(nameDelta)) {
     mergedName = currentName + nameDelta;
   }
 
-  const mergedArgs = currentArgs + argsDelta;
+  // Similar logic for args, with an extra JSON check
+  let mergedArgs = currentArgs;
+  try {
+    // If args is JSON parseable, it is complete, don't add to it
+    JSON.parse(currentArgs);
+  } catch (e) {
+    if (argsDelta.startsWith(currentArgs)) {
+      // Case where model progresssively streams args but full args each time e.g. "{"file": "file1"}" -> "{"file": "file1", "line": 1}"
+      mergedArgs = argsDelta;
+    } else if (!currentArgs.startsWith(argsDelta)) {
+      // Case where model streams in args in parts e.g. "{"file": "file1"" -> ", "line": 1}"
+      mergedArgs = currentArgs + argsDelta;
+    }
+  }
 
   const [_, parsedArgs] = incrementalParseJson(mergedArgs || "{}");
 


### PR DESCRIPTION
## Description
- Adds nvidia to the list of providers that handle templating (allows non-completion calls)
- Handles different styles of args streaming, similar to how different name styles are currently handled

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added Nvidia to the list of providers that support templating and improved handling of different argument streaming styles for tool calls.

- **Bug Fixes**
  - Correctly merges streamed argument chunks, supporting both progressive and full-prefix styles.
  - Added tests for various argument streaming scenarios.

<!-- End of auto-generated description by cubic. -->

