### PR TITLE
fix: :ambulance: Tool arguments are getting duplicated as they are already aggregated by the provider

### DIFF
--- a/gui/src/util/toolCallState.ts
+++ b/gui/src/util/toolCallState.ts
@@ -31,7 +31,11 @@ export function addToolCallDeltaToState(
   const argsDelta = toolCallDelta.function?.arguments ?? "";
 
   let mergedName = currentName;
-  if (nameDelta.startsWith(currentName)) {
+  if (currentName === nameDelta) {
+    mergedName = currentName;
+    // Case where provider aggregates Tool Calls already (Bedrock.ts)
+    // TODO: Maybe we want to undo this complexity from the provider?
+  } else if (nameDelta.startsWith(currentName)) {
     // Case where model progresssively streams name but full name each time e.g. "readFi" -> "readFil" -> "readFile"
     mergedName = nameDelta;
   } else if (currentName.startsWith(nameDelta)) {
@@ -42,7 +46,15 @@ export function addToolCallDeltaToState(
     mergedName = currentName + nameDelta;
   }
 
-  const mergedArgs = currentArgs + argsDelta;
+  let mergedArgs = currentArgs;
+  if (currentArgs === argsDelta) {
+    mergedArgs = currentArgs;
+    // Case where provider aggregates Tool Calls already (Bedrock.ts)
+    // TODO: Maybe we want to undo this complexity from the provider?
+  } else {
+    mergedArgs = currentArgs + argsDelta;
+    // Case build up the args from the deltas.
+  }
 
   const [_, parsedArgs] = incrementalParseJson(mergedArgs || "{}");
 


### PR DESCRIPTION
## Description

A change to the toolCallState to solve for streaming Tool Names and Arguments has broken the Bedrock provider. This fixes that issue.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

No tests. Manual testing and debugging was performed to validate the fix works. I'd recommend testing with OpenAI models prior to merging.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a bug where tool arguments were duplicated when using the Bedrock provider, ensuring arguments are only aggregated once.

<!-- End of auto-generated description by cubic. -->

