### PR TITLE
feat: continue mcp server

### DIFF
--- a/.continue/mcpServers/continue-docs-mcp.yaml
+++ b/.continue/mcpServers/continue-docs-mcp.yaml
@@ -1,0 +1,8 @@
+name: Continue Documentation MCP
+version: 0.0.1
+schema: v1
+mcpServers:
+  - name: Continue Docs Search
+    command: node
+    args:
+      - /Users/briandouglas/.mcp/continue-docs/src/index.js

--- a/docs/docs/customize/deep-dives/mcp.mdx
+++ b/docs/docs/customize/deep-dives/mcp.mdx
@@ -140,7 +140,7 @@ mcpServers:
       - "@modelcontextprotocol/server-sqlite"
       - "./database.db"
     cwd: "/path/to/project"
-  
+
   - name: Local Project Server
     command: npm
     args:

--- a/docs/docs/features/agent/context-selection.mdx
+++ b/docs/docs/features/agent/context-selection.mdx
@@ -1,0 +1,3 @@
+You can use the same methods to manually add context as [Chat](/features/chat/context-selection).
+
+Tool call responses are automatically included as context items. This enables Agent mode to see the result of the previous action and decide what to do next.

--- a/docs/docs/features/agent/how-to-customize.mdx
+++ b/docs/docs/features/agent/how-to-customize.mdx
@@ -1,0 +1,27 @@
+## Add Rules Blocks
+
+Adding Rules can be done in your assistant locally or in the Hub. You can explore Rules on the Continue Hub and refer to the [Rules deep dive](/customize/deep-dives/rules) for more details.
+
+## Add MCP Tools
+
+You can add MCP servers to your assistant to give Agent access to more tools. Explore [MCP Servers on the Hub](https://hub.continue.dev) and consult the [MCP guide](/customize/deep-dives/mcp) for more details.
+
+## Tool Policies
+
+You can adjust the Agent's tool usage behavior to three options:
+
+- **Ask First (default)**: Request user permission with "Cancel" and "Continue" buttons
+- **Automatic**: Automatically call the tool without requesting permission
+- **Excluded**: Do not send the tool to the model
+
+:::warning
+Be careful setting tools to "automatic" if their behavior is not read-only.
+:::
+
+To manage tool policies:
+
+1. Click the tools icon in the input toolbar
+2. View and change policies by clicking on the policy text
+3. You can also toggle groups of tools on/off
+
+Tool policies are stored locally per user.

--- a/docs/docs/features/agent/model-setup.mdx
+++ b/docs/docs/features/agent/model-setup.mdx
@@ -1,0 +1,14 @@
+We recommend **Claude 3.5 Sonnet** from Anthropic for the best Agent experience.
+
+- [Add Claude 3.5 Sonnet to your assistant from the hub](https://hub.continue.dev/anthropic/claude-3-5-sonnet-20241022)
+- Get your API key from the [Anthropic console](https://console.anthropic.com/)
+
+## Other recommended models
+
+- [Claude Sonnet 4 from Anthropic](https://hub.continue.dev/anthropic)
+- [GPT-4o from OpenAI](https://hub.continue.dev/openai/gpt-4o)
+- [Gemini 2.0 Pro from Google](https://hub.continue.dev/google/gemini-2.0-pro)
+
+Agent can be used with models that support tool use through Continue. The best chat models generally support tool use.
+
+For more information on models, check out [our recommended chat models](/features/chat/model-setup).

--- a/docs/docs/features/autocomplete/context-selection.mdx
+++ b/docs/docs/features/autocomplete/context-selection.mdx
@@ -1,0 +1,19 @@
+# Context Selection
+
+Autocomplete will automatically determine context based on the current cursor position. We use the following techniques to determine what to include in the prompt:
+
+## File prefix/suffix
+
+We will always include the code from your file prior to and after the cursor position.
+
+## Definitions from the Language Server Protocol
+
+Similar to how you can use cmd/ctrl + click in your editor, we use the same tool (the LSP) to power "go to definition". For example, if you are typing out a function call, we will include the function definition. Or, if you are writing code inside of a method, we will include the type definitions for any parameters or the return type.
+
+## Imported files
+
+Because there are often many imports, we can't include all of them. Instead, we look for symbols around your cursor that have matching imports and use that as context.
+
+## Recent files
+
+We automatically consider recently opened or edited files and include snippets that are relevant to the current completion.

--- a/docs/docs/features/autocomplete/how-to-customize.mdx
+++ b/docs/docs/features/autocomplete/how-to-customize.mdx
@@ -1,5 +1,5 @@
 # How to Customize Autocomplete
 
-Continue offers a handful of settings to customize autocomplete behavior. Visit the [User Settings Page](/customize/deep-dives/settings/) to manage these settings.
+Continue offers a handful of settings to customize autocomplete behavior. Visit the [User Settings Page](/customize/settings) to manage these settings.
 
 For a comprehensive guide on all configuration options and their impacts, see the [Autocomplete deep dive](/customize/deep-dives/autocomplete).

--- a/docs/docs/features/autocomplete/how-to-customize.mdx
+++ b/docs/docs/features/autocomplete/how-to-customize.mdx
@@ -1,0 +1,5 @@
+# How to Customize Autocomplete
+
+Continue offers a handful of settings to customize autocomplete behavior. Visit the [User Settings Page](/customize/deep-dives/settings/) to manage these settings.
+
+For a comprehensive guide on all configuration options and their impacts, see the [Autocomplete deep dive](/customize/deep-dives/autocomplete).

--- a/docs/docs/features/autocomplete/model-setup.mdx
+++ b/docs/docs/features/autocomplete/model-setup.mdx
@@ -1,0 +1,29 @@
+# Autocomplete Model Setup
+
+Setting up the right model for autocomplete is crucial for a smooth coding experience. Here are our top recommendations:
+
+## Recommended Models
+
+### Hosted-Based (Best Performance)
+
+For the highest quality autocomplete suggestions, we recommend **[Codestral](https://hub.continue.dev/mistral/codestral)** from Mistral. This model is specifically designed for code completion and offers excellent performance across multiple programming languages.
+
+**Quick Setup:**
+
+1. [Add Codestral from the hub](https://hub.continue.dev/mistral/codestral)
+2. Get your API key from the [Mistral Platform](https://console.mistral.ai/codestral)
+3. Configure it in your Continue settings
+
+### Local/Offline (Privacy First)
+
+For a fully local autocomplete experience that doesn't send your code to external servers, we recommend **[Qwen 2.5 Coder 1.5B](https://hub.continue.dev/ollama/qwen2.5-coder-1.5b)** running on Ollama. This model provides good suggestions while keeping your code completely private.
+
+**Quick Setup:**
+
+1. Install [Ollama](https://ollama.ai/)
+2. [Add Qwen 2.5 Coder from the hub](https://hub.continue.dev/ollama/qwen2.5-coder-1.5b)
+3. Configure it in your Continue settings
+
+## Need Help?
+
+If you're not seeing any completions or need more detailed configuration options, check out our comprehensive [autocomplete deep dive guide](/customize/deep-dives/autocomplete).

--- a/docs/docs/features/chat/context-selection.mdx
+++ b/docs/docs/features/chat/context-selection.mdx
@@ -36,4 +36,4 @@ You can include all of the changes you've made to your current branch by typing 
 
 ## Other Context
 
-You can see a full list of built-in context providers [here](/customize/context-providers) and learn about how to create your own context provider [here](/customize/deep-dives/custom-context-providers).
+You can see a full list of built-in context providers [here](/customize/custom-providers) and learn about how to create your own context provider [here](/guides/build-your-own-context-provider).

--- a/docs/docs/features/chat/context-selection.mdx
+++ b/docs/docs/features/chat/context-selection.mdx
@@ -1,0 +1,39 @@
+## Input
+
+Typing a question or instructions into the input box is the only required context.
+
+## Highlighted Code
+
+The highlighted code you've selected by pressing cmd/ctrl + L (VS Code) or cmd/ctrl + J (JetBrains) will be included in your prompt.
+
+## Active File
+
+You can include the currently open file as context by pressing opt/alt + enter when you send your request.
+
+## Specific File
+
+You can include a specific file in your current workspace by typing '@Files' and selecting the file.
+
+## Specific Folder
+
+You can include a folder in your current workspace by typing '@Folder' and selecting the directory.
+
+## Codebase Search
+
+You can automatically include relevant files from your codebase by typing '@Codebase'.
+
+## Documentation Site
+
+You can include a documentation site as context by typing '@Docs' and selecting the site.
+
+## Terminal Contents
+
+You can include the contents of the terminal in your IDE by typing '@Terminal'.
+
+## Git Diff
+
+You can include all of the changes you've made to your current branch by typing '@Git Diff'.
+
+## Other Context
+
+You can see a full list of built-in context providers [here](/customize/context-providers) and learn about how to create your own context provider [here](/customize/deep-dives/custom-context-providers).

--- a/docs/docs/features/chat/how-to-customize.mdx
+++ b/docs/docs/features/chat/how-to-customize.mdx
@@ -3,5 +3,5 @@ There are a number of different ways to customize Chat:
 - Add a `rules` block to give the model persistent instructions through the system prompt
 - Configure `@Codebase`
 - Configure `@Docs`
-- [Build your own context provider](/customize/deep-dives/build-your-own-context-provider)
+- [Build your own context provider](/guides/build-your-own-context-provider)
 - [Create a custom code RAG](/guides/custom-code-rag)

--- a/docs/docs/features/chat/how-to-customize.mdx
+++ b/docs/docs/features/chat/how-to-customize.mdx
@@ -1,0 +1,7 @@
+There are a number of different ways to customize Chat:
+
+- Add a `rules` block to give the model persistent instructions through the system prompt
+- Configure `@Codebase`
+- Configure `@Docs`
+- [Build your own context provider](/customize/deep-dives/build-your-own-context-provider)
+- [Create a custom code RAG](/guides/custom-code-rag)

--- a/docs/docs/features/chat/model-setup.mdx
+++ b/docs/docs/features/chat/model-setup.mdx
@@ -1,0 +1,19 @@
+We recommend setting up a model for the best experience.
+
+## Recommended Models
+
+Here's our primary model recommendation:
+
+**Claude 3.5 Sonnet** from Anthropic
+
+- [Add Claude 3.5 Sonnet to your assistant from the hub](https://hub.continue.dev/anthropic/claude-3-5-sonnet-20241022)
+- Get your API key from the [Anthropic console](https://console.anthropic.com/)
+
+Other top models to consider:
+
+- [GPT-4o from OpenAI](https://hub.continue.dev/openai/gpt-4o)
+- [Grok-2 from xAI](https://hub.continue.dev/xai/grok-2)
+- [Gemini 2.0 Flash from Google](https://hub.continue.dev/google/gemini-2.0-flash)
+- [Llama 3.1 8b from Meta (local)](https://hub.continue.dev/ollama/llama3.1)
+
+For more detailed setup instructions, see [here](/getting-started/install#setup-your-first-model).

--- a/docs/docs/features/edit/context-selection.mdx
+++ b/docs/docs/features/edit/context-selection.mdx
@@ -8,4 +8,4 @@ The **entire contents** of each file (the current file for Jetbrains inline Edit
 
 ## Context Providers
 
-In VS Code Edit mode, you can use `@` to add context using [Context Providers](/customize/context-providers), similar to [Chat](/features/chat/context-selection). Some context providers may be disabled in Edit mode.
+In VS Code Edit mode, you can use `@` to add context using [Context Providers](/customize/custom-providers), similar to [Chat](/features/chat/context-selection). Some context providers may be disabled in Edit mode.

--- a/docs/docs/features/edit/context-selection.mdx
+++ b/docs/docs/features/edit/context-selection.mdx
@@ -1,0 +1,11 @@
+## Input
+
+The input you provide is included in the prompt.
+
+## Code to Edit
+
+The **entire contents** of each file (the current file for Jetbrains inline Edit, the `Code to Edit` item for VS Code Edit mode) are included in the prompt for context. The model will only attempt to edit the highlighted/specified ranges.
+
+## Context Providers
+
+In VS Code Edit mode, you can use `@` to add context using [Context Providers](/customize/context-providers), similar to [Chat](/features/chat/context-selection). Some context providers may be disabled in Edit mode.

--- a/docs/docs/features/edit/how-to-customize.mdx
+++ b/docs/docs/features/edit/how-to-customize.mdx
@@ -1,0 +1,9 @@
+## Setting active Edit/Apply model
+
+You can configure particular models from your Assistant to be used for Edit and Apply requests.
+
+1. Click the 3 dots above the main input
+2. Click the cube icon to expand the "Models" section
+3. Use the dropdowns to select models for Edit and Apply
+
+Learn more about the [Edit role](/customize/model-roles/edit) and [Apply role](/customize/model-roles/apply).

--- a/docs/docs/features/edit/model-setup.mdx
+++ b/docs/docs/features/edit/model-setup.mdx
@@ -1,0 +1,14 @@
+By default, Edit uses the same model as Chat. We recommend **Claude 3.5 Sonnet** from Anthropic.
+
+[Explore other Edit models on the Continue Hub →](https://hub.continue.dev)
+
+## Apply Model
+
+We also recommend setting up an Apply model for the best Edit experience.
+
+**Recommended Apply models:**
+
+- [Morph v0 Fast Apply](https://hub.continue.dev)
+- [Relace Instant Apply](https://hub.continue.dev)
+
+[Explore other Apply models on the Continue Hub →](https://hub.continue.dev)

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -637,6 +637,18 @@ const config = {
             from: "/autocomplete/how-it-works",
           },
           {
+            to: "/features/autocomplete/model-setup",
+            from: "/autocomplete/model-setup",
+          },
+          {
+            to: "/features/autocomplete/how-to-customize",
+            from: "/autocomplete/how-to-customize",
+          },
+          {
+            to: "/features/autocomplete/context-selection",
+            from: "/autocomplete/context-selection",
+          },
+          {
             to: "/features/edit/how-it-works",
             from: "/edit/how-it-works",
           },

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -668,6 +668,43 @@ const config = {
             to: "/customize/json-reference",
             from: ["/json-reference", "/advanced/json-reference"],
           },
+          // New feature page redirects
+          {
+            to: "/features/chat/model-setup",
+            from: "/chat/model-setup",
+          },
+          {
+            to: "/features/chat/how-to-customize",
+            from: "/chat/how-to-customize",
+          },
+          {
+            to: "/features/chat/context-selection",
+            from: "/chat/context-selection",
+          },
+          {
+            to: "/features/edit/model-setup",
+            from: "/edit/model-setup",
+          },
+          {
+            to: "/features/edit/how-to-customize",
+            from: "/edit/how-to-customize",
+          },
+          {
+            to: "/features/edit/context-selection",
+            from: "/edit/context-selection",
+          },
+          {
+            to: "/features/agent/model-setup",
+            from: "/agent/model-setup",
+          },
+          {
+            to: "/features/agent/how-to-customize",
+            from: "/agent/how-to-customize",
+          },
+          {
+            to: "/features/agent/context-selection",
+            from: "/agent/context-selection",
+          },
         ],
       },
     ],


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

In conjunction with #6500, I generated an MCP server based on the continue docs. The goal will be providing context on continue from chat. 

```yml
    name: Continue Documentation MCP
     version: 0.0.1
     schema: v1
     mcpServers:
       - name: Continue Docs Search
         command: node
         args:
           - /Users/YOUR-USER/.mcp/continue-docs/src/index.js # I think we can use "cwd ." in prerelease now
```

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

TBD - I will grab shots of it working

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

 Test Plan

  Prerequisites

  - Ensure Continue extension is installed and running
  - Switch to agent mode (MCP only works in agent mode)
  - Verify the MCP server configuration is loaded

  Test Cases

  1. Basic Documentation Search

  - Objective: Verify the MCP server can search Continue documentation
  - Steps:
    a. Open Continue agent mode
    b. Ask: "Search the Continue docs for information about model setup"
    c. Verify it returns relevant documentation about configuring models
  - Expected Result: Returns structured information from Continue docs about model configuration

  4. MCP Server Integration

  - Objective: Test search for MCP-related documentation
  - Steps:
    a. Ask: "Search for MCP server setup instructions"
    b. Verify it finds the MCP documentation section
  - Expected Result: Returns MCP setup and configuration information

  Verification Checklist

  - MCP server starts without errors
  - Search tool is available in agent mode
  - Documentation searches return relevant results
  - Search results include proper citations/links
  - Error handling works for invalid queries
  - Performance is acceptable (< 5 seconds for searches)

  Configuration Verification

  - .continue/mcpServers/continue-docs-mcp.yaml exists
  - MCP server path is correct: /Users/[username]/.mcp/continue-docs/src/index.js
  - Agent mode is enabled in Continue settings
