### PR TITLE
fix: :ambulance: hotfix-bedrock-provider

### DIFF
--- a/core/llm/llms/Bedrock.ts
+++ b/core/llm/llms/Bedrock.ts
@@ -54,7 +54,6 @@ class Bedrock extends BaseLLM {
     profile: "bedrock",
   };
 
-  private _currentToolResponse: Partial<ToolUseState> | null = null;
   private _promptCachingMetrics: PromptCachingMetrics = {
     cacheReadInputTokens: 0,
     cacheWriteInputTokens: 0,


### PR DESCRIPTION
## Description

An alternate hotfix for the duplicated tool argument issue. This aligns the Bedrock provider with the Anthropic and OpenAI providers in that tool delta messages aren't aggreated in the provider but are instead streamed to the client where they are aggreated.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

Manual testing has been performed.
TODO: Evaluating impacts to tests.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed duplicated tool argument issue in the Bedrock provider by streaming tool delta messages to the client for aggregation, matching the behavior of Anthropic and OpenAI providers.

<!-- End of auto-generated description by cubic. -->

