### PR TITLE
bug fix for code snippets index in IntelliJ Plugin

### DIFF
--- a/binary/.gitignore
+++ b/binary/.gitignore
@@ -3,3 +3,4 @@ bin
 data
 out
 tmp
+tree-sitter

--- a/binary/build.js
+++ b/binary/build.js
@@ -21,6 +21,7 @@ function cleanSlate() {
   rimrafSync(out);
   rimrafSync(build);
   rimrafSync(path.join(__dirname, "tmp"));
+  rimrafSync(path.join(__dirname, "tree-sitter"));
   fs.mkdirSync(bin);
   fs.mkdirSync(out);
   fs.mkdirSync(build);
@@ -134,6 +135,25 @@ async function buildWithEsbuild() {
       (error) => {
         if (error) {
           console.warn("[error] Error copying tree-sitter-wasm files", error);
+          reject(error);
+        } else {
+          resolve();
+        }
+      },
+    );
+  });
+
+  // copy tree-sitter colder to binary folder to make it available when running in intellij debug mode
+  const treeSitterDir = path.join(__dirname, "tree-sitter");
+  fs.mkdirSync(treeSitterDir);
+  await new Promise((resolve, reject) => {
+    ncp(
+      path.join(__dirname, "..", "extensions", "vscode", "tree-sitter"),
+      treeSitterDir,
+      { dereference: true },
+      (error) => {
+        if (error) {
+          console.warn("[error] Error copying tree-sitter files", error);
           reject(error);
         } else {
           resolve();

--- a/binary/pkgJson/darwin-arm64/package.json
+++ b/binary/pkgJson/darwin-arm64/package.json
@@ -11,6 +11,7 @@
       "../../../core/node_modules/sqlite3/**/*",
       "../../out/tree-sitter.wasm",
       "../../out/tree-sitter-wasms/*",
+      "../../tree-sitter/**/*",
       "../../out/llamaTokenizer.mjs",
       "../../out/llamaTokenizerWorkerPool.mjs",
       "../../out/tiktokenWorkerPool.mjs",

--- a/binary/pkgJson/darwin-x64/package.json
+++ b/binary/pkgJson/darwin-x64/package.json
@@ -11,6 +11,7 @@
       "../../../core/node_modules/sqlite3/**/*",
       "../../out/tree-sitter.wasm",
       "../../out/tree-sitter-wasms/*",
+      "../../tree-sitter/**/*",
       "../../out/llamaTokenizer.mjs",
       "../../out/llamaTokenizerWorkerPool.mjs",
       "../../out/tiktokenWorkerPool.mjs",

--- a/binary/pkgJson/linux-arm64/package.json
+++ b/binary/pkgJson/linux-arm64/package.json
@@ -11,6 +11,7 @@
       "../../../core/node_modules/sqlite3/**/*",
       "../../out/tree-sitter.wasm",
       "../../out/tree-sitter-wasms/*",
+      "../../tree-sitter/**/*",
       "../../out/llamaTokenizer.mjs",
       "../../out/llamaTokenizerWorkerPool.mjs",
       "../../out/tiktokenWorkerPool.mjs",

--- a/binary/pkgJson/linux-x64/package.json
+++ b/binary/pkgJson/linux-x64/package.json
@@ -11,6 +11,7 @@
       "../../../core/node_modules/sqlite3/**/*",
       "../../out/tree-sitter.wasm",
       "../../out/tree-sitter-wasms/*",
+      "../../tree-sitter/**/*",
       "../../out/llamaTokenizer.mjs",
       "../../out/llamaTokenizerWorkerPool.mjs",
       "../../out/tiktokenWorkerPool.mjs",

--- a/binary/pkgJson/win32-arm64/package.json
+++ b/binary/pkgJson/win32-arm64/package.json
@@ -11,6 +11,7 @@
       "../../../core/node_modules/sqlite3/**/*",
       "../../out/tree-sitter.wasm",
       "../../out/tree-sitter-wasms/*",
+      "../../tree-sitter/**/*",
       "../../node_modules/win-ca/lib/crypt32-ia32.node",
       "../../node_modules/win-ca/lib/crypt32-x64.node",
       "../../node_modules/win-ca/lib/roots.exe",

--- a/binary/pkgJson/win32-x64/package.json
+++ b/binary/pkgJson/win32-x64/package.json
@@ -11,6 +11,7 @@
       "../../../core/node_modules/sqlite3/**/*",
       "../../out/tree-sitter.wasm",
       "../../out/tree-sitter-wasms/*",
+      "../../tree-sitter/**/*",
       "../../node_modules/win-ca/lib/crypt32-ia32.node",
       "../../node_modules/win-ca/lib/crypt32-x64.node",
       "../../node_modules/win-ca/lib/roots.exe",

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IntelliJIde.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IntelliJIde.kt
@@ -495,7 +495,7 @@ class IntelliJIDE(
 
         // Create the list of IndexTag objects
         return workspaceDirs.mapIndexed { index, directory ->
-            IndexTag(directory, branches[index], artifactId)
+            IndexTag(artifactId, branches[index], directory)
         }
     }
 
@@ -623,3 +623,4 @@ class IntelliJIDE(
     }
 
 }
+


### PR DESCRIPTION
## Description
a tiny bit of bug fix and build process adjustment to make the '@code' context provider and code snippets indexing in IntelliJ plugin work, which was mentioned in [this 6513 issue](https://github.com/continuedev/continue/issues/6513) I addressed 2 days ago.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed code snippets indexing in the IntelliJ plugin by correcting parameter order and updating the build process to include the tree-sitter folder.

- **Bug Fixes**
  - Fixed parameter order in IndexTag creation to match expected values for code snippet indexing.

- **Build Process**
  - Updated build script and package configs to copy the tree-sitter folder for IntelliJ compatibility.

<!-- End of auto-generated description by cubic. -->

