### PR TITLE
feat: lock indexing until completion

### DIFF
--- a/core/core.ts
+++ b/core/core.ts
@@ -11,7 +11,6 @@ import { ConfigHandler } from "./config/ConfigHandler";
 import { SYSTEM_PROMPT_DOT_FILE } from "./config/getWorkspaceContinueRuleDotFiles";
 import { addModel, deleteModel } from "./config/util";
 import CurrentFileContextProvider from "./context/providers/CurrentFileContextProvider";
-import { ContinueServerClient } from "./continueServer/stubs/client";
 import { getAuthUrlForTokenPage } from "./control-plane/auth/index";
 import { getControlPlaneEnv } from "./control-plane/env";
 import { DevDataSqliteDb } from "./data/devdataSqlite";
@@ -202,11 +201,6 @@ export class Core {
     dataLogger.ideSettingsPromise = ideSettingsPromise;
 
     void ideSettingsPromise.then((ideSettings) => {
-      const continueServerClient = new ContinueServerClient(
-        ideSettings.remoteConfigServerUrl,
-        ideSettings.userToken,
-      );
-
       // Index on initialization
       void this.ide.getWorkspaceDirs().then(async (dirs) => {
         // Respect pauseCodebaseIndexOnStart user settings

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -50,6 +50,7 @@ export interface IndexingProgressUpdate {
   shouldClearIndexes?: boolean;
   status:
     | "loading"
+    | "waiting"
     | "indexing"
     | "done"
     | "failed"

--- a/core/indexing/CodebaseIndexer.ts
+++ b/core/indexing/CodebaseIndexer.ts
@@ -664,7 +664,7 @@ export class CodebaseIndexer {
     for await (const update of this.waitForDBIndex()) {
       this.updateProgress(update);
     }
-    IndexLock.lock(paths.join(", ")); // acquire the index lock to prevent multiple windows to start indexing
+    await IndexLock.lock(paths.join(", ")); // acquire the index lock to prevent multiple windows to start indexing
     try {
       for await (const update of this.refreshDirs(
         paths,
@@ -680,7 +680,7 @@ export class CodebaseIndexer {
       console.log(`Failed refreshing codebase index directories: ${e}`);
       await this.handleIndexingError(e);
     }
-    IndexLock.unlock(); // release the index lock
+    await IndexLock.unlock(); // release the index lock
     // Directly refresh submenu items
     if (this.messenger) {
       this.messenger.send("refreshSubmenuItems", {

--- a/gui/src/pages/config/IndexingProgress/IndexingProgress.tsx
+++ b/gui/src/pages/config/IndexingProgress/IndexingProgress.tsx
@@ -111,7 +111,7 @@ function IndexingProgress() {
     <div className="mt-4 flex flex-col">
       <div className="mb-0 flex justify-between text-sm">
         <IndexingProgressTitleText update={update} />
-        {update.status !== "loading" && (
+        {["loading", "waiting"].includes(update.status) && (
           <IndexingProgressIndicator update={update} />
         )}
       </div>

--- a/gui/src/pages/config/IndexingProgress/IndexingProgress.tsx
+++ b/gui/src/pages/config/IndexingProgress/IndexingProgress.tsx
@@ -111,7 +111,7 @@ function IndexingProgress() {
     <div className="mt-4 flex flex-col">
       <div className="mb-0 flex justify-between text-sm">
         <IndexingProgressTitleText update={update} />
-        {["loading", "waiting"].includes(update.status) && (
+        {!["loading", "waiting"].includes(update.status) && (
           <IndexingProgressIndicator update={update} />
         )}
       </div>

--- a/gui/src/pages/config/IndexingProgress/IndexingProgressIndicator.tsx
+++ b/gui/src/pages/config/IndexingProgress/IndexingProgressIndicator.tsx
@@ -13,6 +13,7 @@ export interface IndexingProgressIndicatorProps {
 const STATUS_TO_ICON: Record<IndexingProgressUpdate["status"], any> = {
   disabled: null,
   loading: null,
+  waiting: null,
   indexing: ArrowPathIcon,
   paused: PauseCircleIcon,
   done: CheckCircleIcon,

--- a/gui/src/pages/config/IndexingProgress/IndexingProgressSubtext.tsx
+++ b/gui/src/pages/config/IndexingProgress/IndexingProgressSubtext.tsx
@@ -11,6 +11,7 @@ const STATUS_TO_SUBTITLE_TEXT: Record<
 > = {
   done: "Click to re-index",
   loading: "",
+  waiting: "",
   indexing: "Click to pause",
   paused: "Click to resume",
   failed: "Click to retry",

--- a/gui/src/pages/config/IndexingProgress/IndexingProgressTitleText.tsx
+++ b/gui/src/pages/config/IndexingProgress/IndexingProgressTitleText.tsx
@@ -8,6 +8,7 @@ export interface IndexingProgressTitleTextProps {
 const STATUS_TO_TEXT: Record<IndexingProgressUpdate["status"], string> = {
   done: "Indexing complete",
   loading: "Initializing",
+  waiting: "Indexing other workspace",
   indexing: "Indexing in-progress",
   paused: "Indexing paused",
   failed: "Indexing failed",


### PR DESCRIPTION
## Description

Add an index locking to prevent sqlite errors on multiple windows. The indexing on the second window will wait until the indexing on the first window finishes.

- add a new indexing_lock table into index.sqlite
- add waiting status in IndexingProgressUpdate
- show user feedback similar to "waiting" in gui
- update the indexing_lock timestamp at interval to prevent a deadlock

closes https://github.com/continuedev/continue/issues/2060
closes https://github.com/continuedev/continue/issues/6460

resolves CON-2260
resolves CON-2682

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots



https://github.com/user-attachments/assets/66f5863d-1ab7-47e8-83f5-e2dcf86e41d5



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added an indexing lock to prevent SQLite errors when multiple windows try to index at the same time. Now, if one window is indexing, others will wait until it finishes, with clear feedback shown in the UI.

- **New Features**
  - Introduced an indexing_lock table to manage lock state and prevent concurrent indexing.
  - Added a "waiting" status and UI feedback when a window is waiting for the lock.
  - Updated lock timestamp regularly to avoid deadlocks if a window closes unexpectedly.

<!-- End of auto-generated description by cubic. -->

