### PR TITLE
fix: only set inactive when conversation isn't continuing

### DIFF
--- a/gui/src/redux/thunks/callCurrentTool.ts
+++ b/gui/src/redux/thunks/callCurrentTool.ts
@@ -8,6 +8,7 @@ import { selectSelectedChatModel } from "../slices/configSlice";
 import {
   acceptToolCall,
   errorToolCall,
+  setInactive,
   setToolCallCalling,
   updateToolCallOutput,
 } from "../slices/sessionSlice";
@@ -145,6 +146,8 @@ export const callCurrentTool = createAsyncThunk<void, undefined, ThunkApiType>(
         }),
       );
       unwrapResult(wrapped);
+    } else {
+      dispatch(setInactive());
     }
   },
 );

--- a/gui/src/redux/thunks/streamNormalInput.ts
+++ b/gui/src/redux/thunks/streamNormalInput.ts
@@ -213,6 +213,8 @@ export const streamNormalInput = createAsyncThunk<
       } else {
         dispatch(setInactive());
       }
+    } else {
+      dispatch(setInactive());
     }
   },
 );

--- a/gui/src/redux/thunks/streamNormalInput.ts
+++ b/gui/src/redux/thunks/streamNormalInput.ts
@@ -154,8 +154,6 @@ export const streamNormalInput = createAsyncThunk<
       next = await gen.next();
     }
 
-    dispatch(setInactive());
-
     // Attach prompt log and end thinking for reasoning models
     if (next.done && next.value) {
       dispatch(addPromptCompletionPair([next.value]));
@@ -212,6 +210,8 @@ export const streamNormalInput = createAsyncThunk<
       ) {
         const response = await dispatch(callCurrentTool());
         unwrapResult(response);
+      } else {
+        dispatch(setInactive());
       }
     }
   },


### PR DESCRIPTION
## Description
On a previous PR I moved it from the stream wrapper to prevent a bug where it would stop isStreaming prematurely
Caused another bug where streaming wasn't active while tool call was ocurring
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a bug where conversations were marked as inactive during tool calls, causing streaming to stop too early. Now, the inactive state is only set when the conversation is not continuing.

<!-- End of auto-generated description by cubic. -->

