### PR TITLE
fix: :mute: The safeParseToolCallArgs function is logging excessively

### DIFF
--- a/core/tools/parseArgs.ts
+++ b/core/tools/parseArgs.ts
@@ -6,9 +6,9 @@ export function safeParseToolCallArgs(
   try {
     return JSON.parse(toolCall.function?.arguments?.trim() || "{}");
   } catch (e) {
-    console.error(
-      `Failed to parse tool call arguments:\nTool call: ${toolCall.function?.name + " " + toolCall.id}\nArgs:${toolCall.function?.arguments}\n`,
-    );
+    //console.error(
+    //  `Failed to parse tool call arguments:\nTool call: ${toolCall.function?.name + " " + toolCall.id}\nArgs:${toolCall.function?.arguments}\n`,
+    //);
     return {};
   }
 }


### PR DESCRIPTION
## Description

The console.error statement in this function is getting triggered on every delta reutrn that is incomplete as it won't parse as valid Json. This is filling the logs full of parsing errors.

Recommend removing this code entirely as the catch block is expected up until the point the full argument is returned as valid JSON.

I'm curious if there are issues here, if the arguments parse at some interim point and the tool call proceeds too early. We aren't using stop messages from the provdiers to detect when when the toolCall is full generated and this might be causing premature tool exeuction?

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed excessive error logging from safeParseToolCallArgs to prevent log spam when parsing incomplete tool call arguments.

<!-- End of auto-generated description by cubic. -->

