### PR TITLE
Fix cmd backspace for pending tool calls

### DIFF
--- a/gui/src/components/mainInput/Lump/LumpToolbar/LumpToolbar.tsx
+++ b/gui/src/components/mainInput/Lump/LumpToolbar/LumpToolbar.tsx
@@ -18,6 +18,7 @@ import { TtsActiveToolbar } from "./TtsActiveToolbar";
 
 export function LumpToolbar() {
   const dispatch = useAppDispatch();
+  const ideMessenger = useContext(IdeMessengerContext);
   const ttsActive = useAppSelector((state) => state.ui.ttsActive);
   const isStreaming = useAppSelector((state) => state.session.isStreaming);
   const isInEdit = useAppSelector((state) => state.session.isInEdit);
@@ -52,7 +53,6 @@ export function LumpToolbar() {
       } else if ((jetbrains ? altKey : metaKey) && event.key === "Backspace") {
         event.preventDefault();
         event.stopPropagation();
-        const ideMessenger = useContext(IdeMessengerContext);
         logToolUsage(toolCallState, false, true, ideMessenger);
         void dispatch(
           cancelToolCall({


### PR DESCRIPTION
## Description
React hook was in the wrong place
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where the cmd+backspace shortcut did not work for pending tool calls by moving the React hook to the correct place.

<!-- End of auto-generated description by cubic. -->

