### PR TITLE
chore: Jetbrains 1.0.28

### DIFF
--- a/extensions/intellij/gradle.properties
+++ b/extensions/intellij/gradle.properties
@@ -3,7 +3,7 @@ pluginGroup=com.github.continuedev.continueintellijextension
 pluginName=continue-intellij-extension
 pluginRepositoryUrl=https://github.com/continuedev/continue
 # SemVer format -> https://semver.org
-pluginVersion=1.0.27
+pluginVersion=1.0.28
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild=223
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension


### PR DESCRIPTION
## Description
Bump jetbrains plugin version
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Bumped the JetBrains plugin version to 1.0.28 in gradle.properties.

<!-- End of auto-generated description by cubic. -->

