### PR TITLE
chore: ignore docusaurus build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,8 +67,9 @@ instance/
 # Scrapy stuff:
 .scrapy
 
-# Sphinx documentation
+# docusaurus
 docs/_build/
+docs/.docusaurus
 
 # PyBuilder
 target/


### PR DESCRIPTION
## Description

ignore `.docusaurus` build files

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

these files need to be ignored

<img width="473" height="1024" alt="image" src="https://github.com/user-attachments/assets/8b9c7248-3b71-4fb5-844d-3c94330de7f3" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
