### PR TITLE
docs: accessKeyId and secretAccessKey bedrock auth options

### DIFF
--- a/docs/customize/model-providers/top-level/bedrock.mdx
+++ b/docs/customize/model-providers/top-level/bedrock.mdx
@@ -186,6 +186,41 @@ aws_secret_access_key = hijklmno
 aws_session_token = pqrstuvwxyz # Optional: means short term creds.
 ```
 
+You can also use an AWS `accessKeyId` and `secretAccessKey` for authentication instead of a local credentials profile.
+
+<Tabs groupId="config-example">
+  <TabItem value="yaml" label="YAML">
+  ```yaml title="config.yaml"
+  models:
+    - name: Claude 3.7 Sonnet
+      provider: bedrock
+      model: us.anthropic.claude-3-7-sonnet-20250219-v1:0
+      env:
+        region: us-east-1
+        accessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }} # can also enter key inline here for local assistants
+        secretAccessKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }} # can also enter key inline here for local assistants
+      roles:
+        - chat
+  ```
+  </TabItem>
+  <TabItem value="json" label="JSON">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "Claude 3.7 Sonnet",
+        "provider": "bedrock",
+        "model": "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+        "region": "us-east-1",
+        "accessKeyId": "[YOUR_ACCESS_KEY_ID]",
+        "secretAccessKey": "[YOUR_SECRET_ACCESS_KEY]" 
+      }
+    ]
+  }
+  ```
+  </TabItem>
+</Tabs>
+
 ## Custom Imported Models
 
 To setup Bedrock using custom imported models, add the following to your config file:

--- a/docs/customize/model-providers/top-level/bedrock.mdx
+++ b/docs/customize/model-providers/top-level/bedrock.mdx
@@ -188,8 +188,8 @@ aws_session_token = pqrstuvwxyz # Optional: means short term creds.
 
 You can also use an AWS `accessKeyId` and `secretAccessKey` for authentication instead of a local credentials profile.
 
-<Tabs groupId="config-example">
-  <TabItem value="yaml" label="YAML">
+<Tabs>
+  <Tab title="YAML">
   ```yaml title="config.yaml"
   models:
     - name: Claude 3.7 Sonnet
@@ -202,8 +202,8 @@ You can also use an AWS `accessKeyId` and `secretAccessKey` for authentication i
       roles:
         - chat
   ```
-  </TabItem>
-  <TabItem value="json" label="JSON">
+  </Tab>
+  <Tab title="JSON">
   ```json title="config.json"
   {
     "models": [
@@ -218,7 +218,7 @@ You can also use an AWS `accessKeyId` and `secretAccessKey` for authentication i
     ]
   }
   ```
-  </TabItem>
+  </Tab>
 </Tabs>
 
 ## Custom Imported Models


### PR DESCRIPTION
Adds auth docs for secretAccessKey and accessKeyId Bedrock auth method added by #6499 
Replaces https://github.com/continuedev/continue/pull/6521
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added documentation for authenticating Bedrock model providers using AWS accessKeyId and secretAccessKey, with YAML and JSON config examples.

<!-- End of auto-generated description by cubic. -->

