### PR TITLE
feat: :zap: Improve search and release tool by supporting multiple diffs per tool call

### DIFF
--- a/core/tools/definitions/searchAndReplaceInFile.ts
+++ b/core/tools/definitions/searchAndReplaceInFile.ts
@@ -3,7 +3,7 @@ import { BUILT_IN_GROUP_NAME, BuiltInToolNames } from "../builtIn";
 
 export interface SearchAndReplaceInFileArgs {
   filepath: string;
-  diff: string;
+  diffs: string[];
 }
 
 /**
@@ -22,19 +22,22 @@ export const searchAndReplaceInFileTool: Tool = {
   function: {
     name: BuiltInToolNames.SearchAndReplaceInFile,
     description:
-      "Request to replace sections of content in an existing file using SEARCH/REPLACE blocks that define exact changes to specific parts of the file. This tool should be used when you need to make targeted changes to specific parts of a file.",
+      "Request to replace sections of content in an existing file using multiple SEARCH/REPLACE blocks that define exact changes to specific parts of the file. This tool should be used when you need to make targeted changes to specific parts of a file.",
     parameters: {
       type: "object",
-      required: ["filepath", "diff"],
+      required: ["filepath", "diffs"],
       properties: {
         filepath: {
           type: "string",
           description:
             "The path of the file to modify, relative to the root of the workspace.",
         },
-        diff: {
-          type: "string",
-          description: `One or more SEARCH/REPLACE blocks following this exact format:
+        diffs: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+          description: `An array of strings, each containing one or more SEARCH/REPLACE blocks following this exact format:
 \`\`\`
 ------- SEARCH
 [exact content to find]
@@ -51,16 +54,17 @@ Critical rules:
     * Including multiple unique SEARCH/REPLACE blocks if you need to make multiple changes.
     * Include *just* enough lines in each SEARCH section to uniquely match each set of lines that need to change.
     * When using multiple SEARCH/REPLACE blocks, list them in the order they appear in the file.
-3. Keep SEARCH/REPLACE blocks concise:
+3. **Order matters**: DIFFs in the array should be ordered from top to bottom of the file to ensure correct application.
+4. Keep SEARCH/REPLACE blocks concise:
     * Break large SEARCH/REPLACE blocks into a series of smaller blocks that each change a small portion of the file.
     * Include just the changing lines, and a few surrounding lines if needed for uniqueness.
     * Do not include long runs of unchanging lines in SEARCH/REPLACE blocks.
     * Each line must be complete. Never truncate lines mid-way through as this can cause matching failures.
-4. Splitting up tool calls:
+5. Splitting up tool calls:
     * When making multiple closely related edits to the same file, you should try to use multiple SEARCH/REPLACE blocks in a single tool call, rather than making multiple separate tool calls
     * If you need to make follow up edits or group your work into logical segments, it is okay to perform additional tool calls
     * DO NOT make back-to-back tool calls. Instead interleave with brief explanation of what each will do. For example, instead of [explanation, tool call, tool call] you should do [explanation, tool call, explanation, tool call]
-5. Special operations:
+6. Special operations:
     * To move code: Use two SEARCH/REPLACE blocks (one to delete from original + one to insert at new location)
     * To delete code: Use empty REPLACE section
     
@@ -78,7 +82,8 @@ Usage:
 [new content to replace with]
 +++++++ REPLACE
   \`\`\`
-`,
+
+Each string in the diffs array can contain multiple SEARCH/REPLACE blocks, and all will be applied sequentially in the order they appear.`,
         },
       },
     },

--- a/gui/src/pages/gui/ToolCallDiv/FunctionSpecificToolCallDiv.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/FunctionSpecificToolCallDiv.tsx
@@ -37,7 +37,7 @@ function FunctionSpecificToolCallDiv({
       return (
         <EditFile
           relativeFilePath={args.filepath ?? ""}
-          changes={args.diff ?? ""}
+          changes={args.diffs ? args.diffs.join("\n\n---\n\n") : ""}
           toolCallId={toolCall.id}
           historyIndex={historyIndex}
         />

--- a/gui/src/util/clientTools/searchReplaceImpl.test.ts
+++ b/gui/src/util/clientTools/searchReplaceImpl.test.ts
@@ -53,24 +53,58 @@ describe("searchReplaceToolImpl", () => {
 
       await expect(
         searchReplaceToolImpl(
-          { filepath: "nonexistent.txt", diff: "some diff" },
+          { filepath: "nonexistent.txt", diffs: ["some diff"] },
           "tool-call-id",
           mockExtras,
         ),
       ).rejects.toThrow("File nonexistent.txt does not exist");
     });
 
-    it("should throw error when no search/replace blocks found", async () => {
+    it("should throw error when no search/replace blocks found in first diff", async () => {
       mockResolveRelativePathInDir.mockResolvedValue("/resolved/path/test.txt");
       mockParseAllSearchReplaceBlocks.mockReturnValue([]);
 
       await expect(
         searchReplaceToolImpl(
-          { filepath: "test.txt", diff: "invalid diff content" },
+          { filepath: "test.txt", diffs: ["invalid diff content"] },
           "tool-call-id",
           mockExtras,
         ),
-      ).rejects.toThrow("No complete search/replace blocks found");
+      ).rejects.toThrow("No complete search/replace blocks found in diff 1");
+    });
+
+    it("should throw error when no search/replace blocks found in second diff", async () => {
+      mockResolveRelativePathInDir.mockResolvedValue("/resolved/path/test.txt");
+      mockParseAllSearchReplaceBlocks
+        .mockReturnValueOnce([
+          {
+            isComplete: true,
+            searchContent: "valid content",
+            replaceContent: "replacement",
+          },
+        ])
+        .mockReturnValueOnce([]);
+
+      await expect(
+        searchReplaceToolImpl(
+          { filepath: "test.txt", diffs: ["valid diff", "invalid diff content"] },
+          "tool-call-id",
+          mockExtras,
+        ),
+      ).rejects.toThrow("No complete search/replace blocks found in diff 2");
+    });
+
+    it("should throw error when all diffs are empty", async () => {
+      mockResolveRelativePathInDir.mockResolvedValue("/resolved/path/test.txt");
+      mockParseAllSearchReplaceBlocks.mockReturnValue([]);
+
+      await expect(
+        searchReplaceToolImpl(
+          { filepath: "test.txt", diffs: [] },
+          "tool-call-id",
+          mockExtras,
+        ),
+      ).rejects.toThrow("No complete search/replace blocks found in any diffs");
     });
   });
 
@@ -110,7 +144,65 @@ describe("searchReplaceToolImpl", () => {
       mockIdeMessenger.request.mockResolvedValue({ status: "success" });
 
       const result = await searchReplaceToolImpl(
-        { filepath: "test.js", diff: "mock diff content" },
+        { filepath: "test.js", diffs: ["mock diff content"] },
+        "tool-call-id",
+        mockExtras,
+      );
+
+      // Verify the result
+      expect(result).toEqual({
+        respondImmediately: false,
+        output: undefined,
+      });
+
+      // Verify applyToFile was called with correct parameters
+      expect(mockIdeMessenger.request).toHaveBeenCalledWith("applyToFile", {
+        text: expectedFinalContent,
+        streamId: "test-stream-id",
+        filepath: "/resolved/path/test.js",
+        toolCallId: "tool-call-id",
+        isSearchAndReplace: true,
+      });
+    });
+  });
+
+  describe("single diff scenarios", () => {
+    it("should successfully apply single diff with single search/replace block", async () => {
+      const originalContent = `function hello() {
+  console.log("Hello");
+  return "world";
+}`;
+
+      const expectedFinalContent = `function hello() {
+  console.log("Hi there!");
+  return "world";
+}`;
+
+      // Setup mocks
+      mockResolveRelativePathInDir.mockResolvedValue("/resolved/path/test.js");
+      mockParseAllSearchReplaceBlocks.mockReturnValue([
+        {
+          isComplete: true,
+          searchContent: 'console.log("Hello");',
+          replaceContent: 'console.log("Hi there!");',
+        },
+      ]);
+      mockIdeMessenger.ide.readFile.mockResolvedValue(originalContent);
+
+      // Calculate correct positions for 'console.log("Hello");' in the original content
+      const searchText = 'console.log("Hello");';
+      const startIndex = originalContent.indexOf(searchText);
+      const endIndex = startIndex + searchText.length;
+
+      mockFindSearchMatch.mockReturnValue({
+        startIndex,
+        endIndex,
+        strategyName: "exactMatch",
+      });
+      mockIdeMessenger.request.mockResolvedValue({ status: "success" });
+
+      const result = await searchReplaceToolImpl(
+        { filepath: "test.js", diffs: ["mock diff content"] },
         "tool-call-id",
         mockExtras,
       );
@@ -191,7 +283,7 @@ const c = 3;`;
       mockIdeMessenger.request.mockResolvedValue({ status: "success" });
 
       const result = await searchReplaceToolImpl(
-        { filepath: "test.js", diff: "mock diff content" },
+        { filepath: "test.js", diffs: ["mock diff content"] },
         "tool-call-id",
         mockExtras,
       );
@@ -214,6 +306,95 @@ const c = 3;`;
         contentAfterFirstReplacement,
         "const b = 2;",
       );
+      // Verify final applyToFile call
+      expect(mockIdeMessenger.request).toHaveBeenCalledWith("applyToFile", {
+        text: expectedFinalContent,
+        streamId: "test-stream-id",
+        filepath: "/resolved/path/test.js",
+        toolCallId: "tool-call-id",
+        isSearchAndReplace: true,
+      });
+    });
+  });
+
+  describe("multiple diff scenarios", () => {
+    it("should successfully apply multiple diffs each with single search/replace block", async () => {
+      const originalContent = `const a = 1;
+const b = 2;
+const c = 3;`;
+
+      const expectedFinalContent = `const a = 100;
+const b = 200;
+const c = 3;`;
+
+      // Setup mocks - each diff returns one block
+      mockResolveRelativePathInDir.mockResolvedValue("/resolved/path/test.js");
+      mockParseAllSearchReplaceBlocks
+        .mockReturnValueOnce([
+          {
+            isComplete: true,
+            searchContent: "const a = 1;",
+            replaceContent: "const a = 100;",
+          },
+        ])
+        .mockReturnValueOnce([
+          {
+            isComplete: true,
+            searchContent: "const b = 2;",
+            replaceContent: "const b = 200;",
+          },
+        ]);
+      mockIdeMessenger.ide.readFile.mockResolvedValue(originalContent);
+
+      // Calculate positions for sequential replacements
+      const firstSearchText = "const a = 1;";
+      const secondSearchText = "const b = 2;";
+
+      const firstStartIndex = originalContent.indexOf(firstSearchText);
+      const firstEndIndex = firstStartIndex + firstSearchText.length;
+
+      // After first replacement: "const a = 100;\nconst b = 2;\nconst c = 3;"
+      const contentAfterFirstReplacement =
+        originalContent.substring(0, firstStartIndex) +
+        "const a = 100;" +
+        originalContent.substring(firstEndIndex);
+
+      const secondStartIndex =
+        contentAfterFirstReplacement.indexOf(secondSearchText);
+      const secondEndIndex = secondStartIndex + secondSearchText.length;
+
+      // Mock sequential search matches
+      mockFindSearchMatch
+        .mockReturnValueOnce({
+          startIndex: firstStartIndex,
+          endIndex: firstEndIndex,
+          strategyName: "exactMatch",
+        })
+        .mockReturnValueOnce({
+          startIndex: secondStartIndex,
+          endIndex: secondEndIndex,
+          strategyName: "exactMatch",
+        });
+
+      mockIdeMessenger.request.mockResolvedValue({ status: "success" });
+
+      const result = await searchReplaceToolImpl(
+        { filepath: "test.js", diffs: ["first diff", "second diff"] },
+        "tool-call-id",
+        mockExtras,
+      );
+
+      // Verify the result
+      expect(result).toEqual({
+        respondImmediately: false,
+        output: undefined,
+      });
+
+      // Verify parseAllSearchReplaceBlocks was called for each diff
+      expect(mockParseAllSearchReplaceBlocks).toHaveBeenCalledTimes(2);
+      expect(mockParseAllSearchReplaceBlocks).toHaveBeenNthCalledWith(1, "first diff");
+      expect(mockParseAllSearchReplaceBlocks).toHaveBeenNthCalledWith(2, "second diff");
+
       // Verify final applyToFile call
       expect(mockIdeMessenger.request).toHaveBeenCalledWith("applyToFile", {
         text: expectedFinalContent,
@@ -253,7 +434,7 @@ keep this too`;
       mockIdeMessenger.request.mockResolvedValue({ status: "success" });
 
       const result = await searchReplaceToolImpl(
-        { filepath: "test.txt", diff: "mock diff content" },
+        { filepath: "test.txt", diffs: ["mock diff content"] },
         "tool-call-id",
         mockExtras,
       );
@@ -293,7 +474,7 @@ keep this too`;
       mockIdeMessenger.request.mockResolvedValue({ status: "success" });
 
       await searchReplaceToolImpl(
-        { filepath: "test.txt", diff: "mock diff content" },
+        { filepath: "test.txt", diffs: ["mock diff content"] },
         "tool-call-id",
         mockExtras,
       );
@@ -323,7 +504,7 @@ keep this too`;
 
       await expect(
         searchReplaceToolImpl(
-          { filepath: "test.txt", diff: "mock diff content" },
+          { filepath: "test.txt", diffs: ["mock diff content"] },
           "tool-call-id",
           mockExtras,
         ),
@@ -361,7 +542,7 @@ keep this too`;
 
       await expect(
         searchReplaceToolImpl(
-          { filepath: "test.txt", diff: "mock diff content" },
+          { filepath: "test.txt", diffs: ["mock diff content"] },
           "tool-call-id",
           mockExtras,
         ),
@@ -385,7 +566,7 @@ keep this too`;
 
       await expect(
         searchReplaceToolImpl(
-          { filepath: "test.txt", diff: "mock diff content" },
+          { filepath: "test.txt", diffs: ["mock diff content"] },
           "tool-call-id",
           mockExtras,
         ),
@@ -411,7 +592,7 @@ keep this too`;
 
       await expect(
         searchReplaceToolImpl(
-          { filepath: "test.txt", diff: "mock diff content" },
+          { filepath: "test.txt", diffs: ["mock diff content"] },
           "tool-call-id",
           mockExtras,
         ),
@@ -441,7 +622,7 @@ keep this too`;
       mockIdeMessenger.request.mockResolvedValue({ status: "success" });
 
       await searchReplaceToolImpl(
-        { filepath: "test.txt", diff: "mock diff content" },
+        { filepath: "test.txt", diffs: ["mock diff content"] },
         "tool-call-id",
         mockExtras,
       );
@@ -476,7 +657,7 @@ keep this too`;
       mockIdeMessenger.request.mockResolvedValue({ status: "success" });
 
       await searchReplaceToolImpl(
-        { filepath: "test.txt", diff: "mock diff content" },
+        { filepath: "test.txt", diffs: ["mock diff content"] },
         "tool-call-id",
         mockExtras,
       );
@@ -512,7 +693,7 @@ keep this too`;
       mockIdeMessenger.request.mockResolvedValue({ status: "success" });
 
       await searchReplaceToolImpl(
-        { filepath: "relative/test.txt", diff: "mock diff content" },
+        { filepath: "relative/test.txt", diffs: ["mock diff content"] },
         "tool-call-id",
         mockExtras,
       );


### PR DESCRIPTION
## Description

Looking at the current implementation I noted the tool definition expects the LLM to return mulltiple search and replace blocks into a single "diff" parameter. While monitoring the tool, I noted that rather than doing this, it's firing off many requests to the tool for small edits. By enhancing the tool to support an array of diffs, the tool now gets multiple search and replace blocks which are executed in sequence.

The sequence of tool calls is a pattern I've observed when testing the new tool. It's unfortunately stressing our AWS call limits as well because it's eating up the per minute call quotas. When in a tight edit loop this happens extremely rapidly across only a few users.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

I've added new tests to account for the change to the tool definition.

I've found a pretty decent way to trigger the multiple search and replace block experience in the test repo. Use the prompt "Add a double, triple and power function to @test.js, and insert them alphabetized" you seem to get multiple requests.

When attempting this same prompt without this change I noted either a single large search and replace block covering the whole file, or 3 individual back to back tool calls.
