### PR TITLE
Qwen3 support for autocomplete function

### DIFF
--- a/core/autocomplete/postprocessing/index.ts
+++ b/core/autocomplete/postprocessing/index.ts
@@ -103,6 +103,16 @@ export function postprocessCompletion({
     }
   }
 
+  if (llm.model.includes("qwen3")) {
+    // Qwen3 always starts from special thinking markers, and we don't want them to output these contents
+    // Remove all content from "
+    completion = completion.replace(/<think>.*?<\/think>/s, "");
+    completion = completion.replace(/<\/think>/, "");
+
+    // Remove any number of newline characters at the beginning and end
+    completion = completion.replace(/^\n+|\n+$/g, "");
+  }
+
   if (llm.model.includes("mercury") || llm.model.includes("granite")) {
     // Granite tends to repeat the start of the line in the completion output
     let prefixEnd = prefix.split("\n").pop();

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -142,7 +142,7 @@
     },
     "../packages/config-yaml": {
       "name": "@continuedev/config-yaml",
-      "version": "1.0.95",
+      "version": "1.0.96",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",
@@ -169,9 +169,11 @@
     },
     "../packages/openai-adapters": {
       "name": "@continuedev/openai-adapters",
-      "version": "1.0.44",
+      "version": "1.0.45",
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-sdk/client-bedrock-runtime": "^3.842.0",
+        "@aws-sdk/credential-providers": "^3.840.0",
         "@continuedev/config-types": "^1.0.5",
         "@continuedev/config-yaml": "^1.0.51",
         "@continuedev/fetch": "^1.0.15",

--- a/docs/customize/deep-dives/autocomplete.mdx
+++ b/docs/customize/deep-dives/autocomplete.mdx
@@ -84,6 +84,30 @@ Then, add the model to your configuration:
 
 Once the model has been downloaded, you should begin to see completions in VS Code.
 
+NOTE: Typically, thinking-type models are not recommended as they generate more slowly and are not suitable for scenarios that require speed. 
+
+However, if you use any thinking-switchable models, you can configure these models for autocomplete functions by turning off the thinking mode.
+
+For example:
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  models:
+    - name: Qwen3 without Thinking for Autocomplete
+      provider: ollama
+      model: qwen3:4b   # qwen3 is a thinking-switchable model
+      roles:
+        - autocomplete
+      requestOptions:
+        extraBodyProperties:
+          think: false  # turning off the thinking
+  ```
+  </Tab>
+</Tabs>
+
+Then, in the continue panel, select this model as the default model for autocomplete.
+
 ## Configuration Options
 
 ### Hub Autocomplete models
@@ -138,12 +162,12 @@ Yes, in VS Code, if you don't want to be shown suggestions automatically you can
 
 This is a built-in feature of VS Code, but it's just a bit hidden. Follow these settings to reassign the keyboard shortcuts in VS Code:
 
-1. Press `Ctrl+Shift+P`, type the command: `Preferences: Open Keyboard Shortcuts`, and enter the keyboard shortcuts settings page.
+1. Press <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>, type the command: `Preferences: Open Keyboard Shortcuts`, and enter the keyboard shortcuts settings page.
 2. Search for `editor.action.inlineSuggest.acceptNextLine`.
-3. Set the key binding to `Tab`.
+3. Set the key binding to <kbd>Tab</kbd>.
 4. Set the trigger condition (when) to `inlineSuggestionVisible && !editorReadonly`.
-   This will make multi-line completion (including continue and from VS Code built-in or other plugin snippets) still work, and you will see multi-line completion. However, Tab will only fill in one line at a time. Any unnecessary code can be canceled with `Esc`.
-   If you need to apply all the code, just press `Tab` multiple times.
+   This will make multi-line completion (including continue and from VS Code built-in or other plugin snippets) still work, and you will see multi-line completion. However, Tab will only fill in one line at a time. Any unnecessary code can be canceled with <kbd>Esc</kbd>.
+   If you need to apply all the code, just press <kbd>Tab</kbd> multiple times.
 
 ### How to turn off autocomplete
 

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "1.1.59",
+  "version": "1.1.60",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "1.1.59",
+      "version": "1.1.60",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -220,7 +220,7 @@
     },
     "../packages/config-yaml": {
       "name": "@continuedev/config-yaml",
-      "version": "1.0.95",
+      "version": "1.0.96",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",

--- a/packages/config-yaml/package-lock.json
+++ b/packages/config-yaml/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@continuedev/config-yaml",
-  "version": "1.0.95",
+  "version": "1.0.96",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@continuedev/config-yaml",
-      "version": "1.0.95",
+      "version": "1.0.96",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",

--- a/packages/openai-adapters/package-lock.json
+++ b/packages/openai-adapters/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@continuedev/openai-adapters",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@continuedev/openai-adapters",
-      "version": "1.0.44",
+      "version": "1.0.45",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.842.0",


### PR DESCRIPTION
## Description

Abstract:

1. Added support for the autocomplete feature for the qwen3 model.
2. The documentation has been updated to guide how to configure the autocomplete feature for models with switchable toggle-like model for the thinking function.

In the case of personal deployment models based on ollama, being able to accomplish more tasks with fewer models can significantly save GPU memory. For example, if I only need to run a `qwen3:4b` model to handle all functions such as `chat`, `autocomplete`, and `edit`, etc. There is no need to launch another `qwen2.5-coder:1.5b` model in the background.

The previous autocomplete feature in continue was not well matched with `qwen3`, often outputting tags resembling #5709 , one of the issues mentioned. This change will fix this problem, allowing the thinking process of the `qwen3` series, which can switch models, to be correctly applied to the autocomplete feature.

## Checklist

- [o] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [o] The relevant docs, if any, have been updated or created
- [o] The relevant tests, if any, have been updated or created

## Screenshots

No visual updates.

## Tests

1. Only modified the filter a bit, removing extra tags when the model name contains the `qwen3` character.
2. Use as few filtering tags as possible, theoretically not causing the filtering of content that should be output.
3. Tested on common code or text completion tasks, it performs well, can be used normally, and produces no additional output.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for Qwen3 models in the autocomplete feature, removing unwanted thinking tags from completions and updating documentation to show how to configure Qwen3 for autocomplete.

- **Bug Fixes**
  - Filters out special <think> tags from Qwen3 autocomplete output to prevent extra text.

- **Docs**
  - Added instructions for using Qwen3 models with autocomplete and disabling thinking mode.

<!-- End of auto-generated description by cubic. -->

