### PR TITLE
Config loading fixes

### DIFF
--- a/core/config/ConfigHandler.vitest.ts
+++ b/core/config/ConfigHandler.vitest.ts
@@ -32,7 +32,7 @@ describe.skip("Test the ConfigHandler and E2E config loading", () => {
 }`;
     fs.writeFileSync(getConfigTsPath(), configTs);
     await new Promise((resolve) => setTimeout(resolve, 1000));
-    const config = await testConfigHandler.reloadConfig();
+    const config = await testConfigHandler.reloadConfig("test");
     /**
      * @ts-ignore is applied because this test is skipped
      */
@@ -45,7 +45,7 @@ describe.skip("Test the ConfigHandler and E2E config loading", () => {
       path.join(TEST_DIR, ".continuerc.json"),
       JSON.stringify({ systemMessage: "SYSTEM2" }),
     );
-    const config = await testConfigHandler.reloadConfig();
+    const config = await testConfigHandler.reloadConfig("test");
     /**
      * @ts-ignore is applied because this test is skipped
      */

--- a/core/control-plane/client.ts
+++ b/core/control-plane/client.ts
@@ -45,6 +45,7 @@ export class ControlPlaneClient {
   async resolveFQSNs(
     fqsns: FQSN[],
     orgScopeId: string | null,
+    signal?: AbortSignal,
   ): Promise<(SecretResult | undefined)[]> {
     if (!(await this.isSignedIn())) {
       return fqsns.map((fqsn) => ({
@@ -60,6 +61,7 @@ export class ControlPlaneClient {
     const resp = await this.request("ide/sync-secrets", {
       method: "POST",
       body: JSON.stringify({ fqsns, orgScopeId }),
+      signal,
     });
     return (await resp.json()) as any;
   }
@@ -103,7 +105,10 @@ export class ControlPlaneClient {
     return resp;
   }
 
-  public async listAssistants(organizationId: string | null): Promise<
+  public async listAssistants(
+    organizationId: string | null,
+    signal?: AbortSignal,
+  ): Promise<
     {
       configResult: ConfigResult<AssistantUnrolled>;
       ownerSlug: string;
@@ -123,6 +128,7 @@ export class ControlPlaneClient {
 
       const resp = await this.request(url, {
         method: "GET",
+        signal,
       });
       return (await resp.json()) as any;
     } catch (e) {
@@ -130,7 +136,9 @@ export class ControlPlaneClient {
     }
   }
 
-  public async listOrganizations(): Promise<Array<OrganizationDescription>> {
+  public async listOrganizations(
+    signal?: AbortSignal,
+  ): Promise<Array<OrganizationDescription>> {
     if (!(await this.isSignedIn())) {
       return [];
     }
@@ -138,6 +146,7 @@ export class ControlPlaneClient {
     try {
       const resp = await this.request("ide/list-organizations", {
         method: "GET",
+        signal,
       });
       const { organizations } = (await resp.json()) as any;
       return organizations;
@@ -148,6 +157,7 @@ export class ControlPlaneClient {
 
   public async listAssistantFullSlugs(
     organizationId: string | null,
+    signal?: AbortSignal,
   ): Promise<FullSlug[] | null> {
     if (!(await this.isSignedIn())) {
       return null;
@@ -160,6 +170,7 @@ export class ControlPlaneClient {
     try {
       const resp = await this.request(url, {
         method: "GET",
+        signal,
       });
       const { fullSlugs } = (await resp.json()) as any;
       return fullSlugs;
@@ -168,7 +179,9 @@ export class ControlPlaneClient {
     }
   }
 
-  public async getFreeTrialStatus(): Promise<FreeTrialStatus | null> {
+  public async getFreeTrialStatus(
+    signal?: AbortSignal,
+  ): Promise<FreeTrialStatus | null> {
     if (!(await this.isSignedIn())) {
       return null;
     }
@@ -176,6 +189,7 @@ export class ControlPlaneClient {
     try {
       const resp = await this.request("ide/free-trial-status", {
         method: "GET",
+        signal,
       });
       return (await resp.json()) as FreeTrialStatus;
     } catch (e) {
@@ -190,6 +204,7 @@ export class ControlPlaneClient {
    */
   public async getModelsAddOnCheckoutUrl(
     vsCodeUriScheme?: string,
+    signal?: AbortSignal,
   ): Promise<{ url: string } | null> {
     if (!(await this.isSignedIn())) {
       return null;
@@ -209,6 +224,7 @@ export class ControlPlaneClient {
         `ide/get-models-add-on-checkout-url?${params.toString()}`,
         {
           method: "GET",
+          signal,
         },
       );
       return (await resp.json()) as { url: string };

--- a/core/core.ts
+++ b/core/core.ts
@@ -150,7 +150,7 @@ export class Core {
     );
 
     MCPManagerSingleton.getInstance().onConnectionsRefreshed = () => {
-      void this.configHandler.reloadConfig();
+      void this.configHandler.reloadConfig("MCP Connections refreshed");
 
       // Refresh @mention dropdown submenu items for MCP providers
       const mcpManager = MCPManagerSingleton.getInstance();
@@ -299,23 +299,31 @@ export class Core {
     on("config/addModel", (msg) => {
       const model = msg.data.model;
       addModel(model, msg.data.role);
-      void this.configHandler.reloadConfig();
+      void this.configHandler.reloadConfig(
+        "Model added (config/addModel message)",
+      );
     });
 
     on("config/deleteModel", (msg) => {
       deleteModel(msg.data.title);
-      void this.configHandler.reloadConfig();
+      void this.configHandler.reloadConfig(
+        "Model removed (config/deleteModel message)",
+      );
     });
 
     on("config/newPromptFile", async (msg) => {
       const { config } = await this.configHandler.loadConfig();
       await createNewPromptFileV2(this.ide, config?.experimental?.promptPath);
-      await this.configHandler.reloadConfig();
+      await this.configHandler.reloadConfig(
+        "Prompt file created (config/newPromptFile message)",
+      );
     });
 
     on("config/addLocalWorkspaceBlock", async (msg) => {
       await createNewWorkspaceBlockFile(this.ide, msg.data.blockType);
-      await this.configHandler.reloadConfig();
+      await this.configHandler.reloadConfig(
+        "Local block created (config/addLocalWorkspaceBlock message)",
+      );
     });
 
     on("config/openProfile", async (msg) => {
@@ -323,7 +331,9 @@ export class Core {
     });
 
     on("config/reload", async (msg) => {
-      void this.configHandler.reloadConfig();
+      void this.configHandler.reloadConfig(
+        "Force reloaded (config/reload message)",
+      );
       return await this.configHandler.getSerializedConfig();
     });
 
@@ -343,7 +353,9 @@ export class Core {
 
     on("config/updateSharedConfig", async (msg) => {
       const newSharedConfig = this.globalContext.updateSharedConfig(msg.data);
-      await this.configHandler.reloadConfig();
+      await this.configHandler.reloadConfig(
+        "Shared config update (config/updateSharedConfig message)",
+      );
       return newSharedConfig;
     });
 
@@ -353,7 +365,9 @@ export class Core {
         msg.data.role,
         msg.data.title,
       );
-      await this.configHandler.reloadConfig();
+      await this.configHandler.reloadConfig(
+        "Selected model update (config/updateSelectedModel message)",
+      );
       return newSelectedModels;
     });
 
@@ -630,7 +644,7 @@ export class Core {
         void refreshIfNotIgnored(data.uris);
 
         if (hasRulesFiles(data.uris)) {
-          await this.configHandler.reloadConfig();
+          await this.configHandler.reloadConfig("Rules file created");
         }
 
         // If it's a local assistant being created, we want to reload all assistants so it shows up in the list
@@ -652,7 +666,7 @@ export class Core {
         void refreshIfNotIgnored(data.uris);
 
         if (hasRulesFiles(data.uris)) {
-          await this.configHandler.reloadConfig();
+          await this.configHandler.reloadConfig("Rules file deleted");
         }
       }
     });
@@ -928,7 +942,7 @@ export class Core {
         ],
       }),
     );
-    void this.configHandler.reloadConfig();
+    void this.configHandler.reloadConfig("Autocomplete model added");
   }
 
   private async handleFilesChanged({
@@ -958,7 +972,9 @@ export class Core {
               this.globalContext.update("showConfigUpdateToast", false);
             }
           }
-          await this.configHandler.reloadConfig();
+          await this.configHandler.reloadConfig(
+            "Current profile config file updated",
+          );
           continue;
         }
 
@@ -974,7 +990,9 @@ export class Core {
               uri.includes(`.continue\\${blockType}`),
           )
         ) {
-          await this.configHandler.reloadConfig();
+          await this.configHandler.reloadConfig(
+            "Config-related file updated: continuerc, prompt, local block, etc",
+          );
         } else if (
           uri.endsWith(".continueignore") ||
           uri.endsWith(".gitignore")
@@ -1056,7 +1074,7 @@ export class Core {
 
     editConfigFile((c) => c, editConfigYamlCallback);
 
-    void this.configHandler.reloadConfig();
+    void this.configHandler.reloadConfig("Onboarding completed");
   }
 
   private getContextItems = async (

--- a/extensions/vscode/src/ContinueGUIWebviewViewProvider.ts
+++ b/extensions/vscode/src/ContinueGUIWebviewViewProvider.ts
@@ -1,4 +1,3 @@
-import { ConfigHandler } from "core/config/ConfigHandler";
 import * as vscode from "vscode";
 
 import { getTheme } from "./util/getTheme";
@@ -58,16 +57,10 @@ export class ContinueGUIWebviewViewProvider
   }
 
   constructor(
-    private readonly configHandlerPromise: Promise<ConfigHandler>,
     private readonly windowId: string,
     private readonly extensionContext: vscode.ExtensionContext,
   ) {
-    this.webviewProtocol = new VsCodeWebviewProtocol(
-      (async () => {
-        const configHandler = await this.configHandlerPromise;
-        return configHandler.reloadConfig();
-      }).bind(this),
-    );
+    this.webviewProtocol = new VsCodeWebviewProtocol();
   }
 
   getSidebarContent(

--- a/extensions/vscode/src/extension/VsCodeExtension.ts
+++ b/extensions/vscode/src/extension/VsCodeExtension.ts
@@ -100,7 +100,6 @@ export class VsCodeExtension {
       resolveConfigHandler = resolve;
     });
     this.sidebar = new ContinueGUIWebviewViewProvider(
-      configHandlerPromise,
       this.windowId,
       this.extensionContext,
     );
@@ -147,7 +146,7 @@ export class VsCodeExtension {
     );
     resolveVerticalDiffManager?.(this.verticalDiffManager);
 
-    void setupRemoteConfigSync(
+    void setupRemoteConfigSync(() =>
       this.configHandler.reloadConfig.bind(this.configHandler),
     );
 
@@ -284,7 +283,9 @@ export class VsCodeExtension {
       if (stats.size === 0) {
         return;
       }
-      await this.configHandler.reloadConfig();
+      await this.configHandler.reloadConfig(
+        "Global JSON config updated - fs file watch",
+      );
     });
 
     fs.watchFile(
@@ -294,7 +295,9 @@ export class VsCodeExtension {
         if (stats.size === 0) {
           return;
         }
-        await this.configHandler.reloadConfig();
+        await this.configHandler.reloadConfig(
+          "Global YAML config updated - fs file watch",
+        );
       },
     );
 
@@ -302,7 +305,7 @@ export class VsCodeExtension {
       if (stats.size === 0) {
         return;
       }
-      void this.configHandler.reloadConfig();
+      void this.configHandler.reloadConfig("config.ts updated - fs file watch");
     });
 
     vscode.workspace.onDidChangeTextDocument(async (event) => {
@@ -363,7 +366,7 @@ export class VsCodeExtension {
         );
 
         if (e.provider.id === "github") {
-          this.configHandler.reloadConfig();
+          this.configHandler.reloadConfig("Github sign-in status changed");
         }
       }
     });

--- a/extensions/vscode/src/webviewProtocol.ts
+++ b/extensions/vscode/src/webviewProtocol.ts
@@ -152,7 +152,7 @@ export class VsCodeWebviewProtocol
     this._webviewListener = this._webview.onDidReceiveMessage(handleMessage);
   }
 
-  constructor(private readonly reloadConfig: () => void) {}
+  constructor() {}
 
   invoke<T extends keyof FromWebviewProtocol>(
     messageType: T,

--- a/gui/src/components/AssistantAndOrgListbox/ScopeSelect.tsx
+++ b/gui/src/components/AssistantAndOrgListbox/ScopeSelect.tsx
@@ -10,6 +10,7 @@ import { useAppDispatch, useAppSelector } from "../../redux/hooks";
 import {
   selectCurrentOrg,
   setSelectedOrgId,
+  setSelectedProfile,
 } from "../../redux/slices/profilesSlice";
 import {
   Listbox,
@@ -44,8 +45,14 @@ export function ScopeSelect({ onSelect }: ScopeSelectProps) {
   const dispatch = useAppDispatch();
 
   const handleChange = (newValue: string) => {
+    const org = organizations.find((o) => o.id === newValue);
+    if (!org) {
+      return;
+    }
+
     // optimisitic update
-    dispatch(setSelectedOrgId(newValue));
+    dispatch(setSelectedOrgId(org.id));
+    dispatch(setSelectedProfile(org.selectedProfileId));
     ideMessenger.post("didChangeSelectedOrg", {
       id: newValue,
     });

--- a/gui/src/components/AssistantAndOrgListbox/index.tsx
+++ b/gui/src/components/AssistantAndOrgListbox/index.tsx
@@ -166,7 +166,7 @@ export function AssistantAndOrgListbox() {
                 className="border-border border-b px-2 py-1.5"
               >
                 <span
-                  className="text-description flex flex-row items-center"
+                  className="text-description flex flex-1 flex-row items-center"
                   style={{ fontSize: tinyFont }}
                   onClick={async (e) => {
                     e.stopPropagation();

--- a/gui/src/components/AssistantAndOrgListbox/index.tsx
+++ b/gui/src/components/AssistantAndOrgListbox/index.tsx
@@ -161,10 +161,9 @@ export function AssistantAndOrgListbox() {
               </ListboxOption>
 
               <ListboxOption
-                value="new-assistant"
+                value="reload-config"
                 fontSizeModifier={-2}
                 className="border-border border-b px-2 py-1.5"
-                onClick={session ? onNewAssistant : () => login(false)}
               >
                 <span
                   className="text-description flex flex-row items-center"

--- a/gui/src/context/Auth.tsx
+++ b/gui/src/context/Auth.tsx
@@ -95,7 +95,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     "sessionUpdate",
     async (data) => {
       setSession(data.sessionInfo);
-      void refreshProfiles();
     },
     [],
   );

--- a/gui/src/context/Auth.tsx
+++ b/gui/src/context/Auth.tsx
@@ -1,6 +1,6 @@
 import {
-  OrganizationDescription,
   ProfileDescription,
+  SerializedOrgWithProfiles,
 } from "core/config/ProfileLifecycleManager";
 import { ControlPlaneSessionInfo } from "core/control-plane/AuthTypes";
 import React, {
@@ -28,7 +28,7 @@ interface AuthContextType {
   selectedProfile: ProfileDescription | null;
   profiles: ProfileDescription[] | null;
   refreshProfiles: () => Promise<void>;
-  organizations: OrganizationDescription[];
+  organizations: SerializedOrgWithProfiles[];
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);

--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -36,8 +36,6 @@ import { RootState } from "../store";
 import { streamResponseThunk } from "../thunks/streamResponse";
 import { findCurrentToolCall, findToolCall, findToolOutput } from "../util";
 
-const getIdeMessenger = () => (window as any).ideMessenger;
-
 // We need this to handle reorderings (e.g. a mid-array deletion) of the messages array.
 // The proper fix is adding a UUID to all chat messages, but this is the temp workaround.
 export type ChatHistoryItemWithMessageId = ChatHistoryItem & {

--- a/packages/hub/src/ContinueHubClient.ts
+++ b/packages/hub/src/ContinueHubClient.ts
@@ -57,16 +57,19 @@ export class ContinueHubClient implements IContinueHubClient {
   async resolveFQSNs(
     fqsns: FQSN[],
     orgScopeId: string | null,
+    signal?: AbortSignal,
   ): Promise<(SecretResult | undefined)[]> {
     const resp = await this.request("ide/sync-secrets", {
       method: "POST",
       body: JSON.stringify({ fqsns, orgScopeId }),
+      signal,
     });
     return (await resp.json()) as any;
   }
   async listAssistants(options: {
     organizationId: string | null;
     alwaysUseProxy?: boolean;
+    signal?: AbortSignal;
   }): Promise<
     {
       configResult: ConfigResult<AssistantUnrolled>;
@@ -94,6 +97,7 @@ export class ContinueHubClient implements IContinueHubClient {
 
       const resp = await this.request(url, {
         method: "GET",
+        signal: options.signal,
       });
       return (await resp.json()) as any;
     } catch (e) {
@@ -103,6 +107,7 @@ export class ContinueHubClient implements IContinueHubClient {
 
   async listAssistantFullSlugs(
     organizationId: string | null,
+    signal?: AbortSignal,
   ): Promise<FullSlug[] | null> {
     const url = organizationId
       ? `ide/list-assistant-full-slugs?organizationId=${organizationId}`
@@ -111,6 +116,7 @@ export class ContinueHubClient implements IContinueHubClient {
     try {
       const resp = await this.request(url, {
         method: "GET",
+        signal,
       });
       const { fullSlugs } = (await resp.json()) as any;
       return fullSlugs;


### PR DESCRIPTION
- Awaits initial refresh attempt when getting sessions (vs code) - fixes duplicate cascade caused by immediate session update from refreshing
- Fixes laggy assistant dropdown updating when changing assistants - adds optimistic selected profile update
- Abort current cascade init when ideSettings/session is changed - adds signals to control plane client methods
- Remove duplicate profiles refresh in gui Auth Provider on `sessionUpdate`
- Add "reason" logs for all config reloads (log line commented out for now)
- When loading config, wait till cascade init has been initialized/completed once
  - this prevents potentially useless initial load AND reload caused by its MCP server followup reload
- Await config handler cascade init initialized when loading config
  - this cancels auth-dependent calls when auth changes - better security
- Fix reload config button styling that caused it to open hub when clicked
