### PR TITLE
feat: :sparkles: Introduce LLM streamChat retries

### DIFF
--- a/core/jest.config.js
+++ b/core/jest.config.js
@@ -3,14 +3,17 @@ import { fileURLToPath } from "url";
 
 export default {
   transform: {
-    "^.+\\.(ts|js)$": ["ts-jest", { 
-      useESM: true, 
-      useIsolatedModules: true,
-      tsconfig: {
-        experimentalDecorators: true,
-        emitDecoratorMetadata: true
-      }
-    }],
+    "^.+\\.(ts|js)$": [
+      "ts-jest",
+      {
+        useESM: true,
+        useIsolatedModules: true,
+        tsconfig: {
+          experimentalDecorators: true,
+          emitDecoratorMetadata: true,
+        },
+      },
+    ],
   },
   moduleNameMapper: {
     "^(\\.{1,2}/.*)\\.js$": "$1",

--- a/core/jest.config.js
+++ b/core/jest.config.js
@@ -3,7 +3,14 @@ import { fileURLToPath } from "url";
 
 export default {
   transform: {
-    "^.+\\.(ts|js)$": ["ts-jest", { useESM: true, useIsolatedModules: true }],
+    "^.+\\.(ts|js)$": ["ts-jest", { 
+      useESM: true, 
+      useIsolatedModules: true,
+      tsconfig: {
+        experimentalDecorators: true,
+        emitDecoratorMetadata: true
+      }
+    }],
   },
   moduleNameMapper: {
     "^(\\.{1,2}/.*)\\.js$": "$1",

--- a/core/llm/llms/Bedrock.ts
+++ b/core/llm/llms/Bedrock.ts
@@ -12,12 +12,7 @@ import {
 import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
 
 import type { CompletionOptions } from "../../index.js";
-import {
-  ChatMessage,
-  Chunk,
-  LLMOptions,
-  MessageContent,
-} from "../../index.js";
+import { ChatMessage, Chunk, LLMOptions, MessageContent } from "../../index.js";
 import { safeParseToolCallArgs } from "../../tools/parseArgs.js";
 import { renderChatMessage, stripImages } from "../../util/messageContent.js";
 import { BaseLLM } from "../index.js";

--- a/core/llm/llms/Bedrock.ts
+++ b/core/llm/llms/Bedrock.ts
@@ -11,10 +11,10 @@ import {
 } from "@aws-sdk/client-bedrock-runtime";
 import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
 
+import type { CompletionOptions } from "../../index.js";
 import {
   ChatMessage,
   Chunk,
-  CompletionOptions,
   LLMOptions,
   MessageContent,
 } from "../../index.js";

--- a/core/llm/utils/getSecureID.test.ts
+++ b/core/llm/utils/getSecureID.test.ts
@@ -1,4 +1,4 @@
-import { getSecureID } from "../getSecureID";
+import { getSecureID } from "./getSecureID";
 
 // Mock the crypto.randomUUID function
 const mockRandomUUID = jest.fn();

--- a/core/llm/utils/retry.test.ts
+++ b/core/llm/utils/retry.test.ts
@@ -239,7 +239,9 @@ describe("Retry Functionality", () => {
         testClass.testMethod = descriptor.value;
       }
 
-      await expect(testClass.testMethod()).rejects.toThrow("Last decorator error");
+      await expect(testClass.testMethod()).rejects.toThrow(
+        "Last decorator error",
+      );
       expect(testClass.attempts).toBe(3);
     });
   });

--- a/core/llm/utils/retry.test.ts
+++ b/core/llm/utils/retry.test.ts
@@ -1,0 +1,414 @@
+import { retryAsync, withLLMRetry, withRetry } from "./retry";
+
+// Mock console.warn to avoid noise in tests
+const consoleSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+describe("Retry Functionality", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("retryAsync", () => {
+    it("should succeed on first attempt", async () => {
+      const mockFn = jest.fn().mockResolvedValue("success");
+
+      const result = await retryAsync(mockFn);
+
+      expect(result).toBe("success");
+      expect(mockFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("should retry on retryable errors", async () => {
+      const error = new Error("ECONNRESET");
+      (error as any).code = "ECONNRESET";
+      const mockFn = jest
+        .fn()
+        .mockRejectedValueOnce(error)
+        .mockResolvedValue("success");
+
+      const result = await retryAsync(mockFn, {
+        maxAttempts: 2,
+        baseDelay: 10, // Very short delay for testing
+      });
+
+      expect(result).toBe("success");
+      expect(mockFn).toHaveBeenCalledTimes(2);
+    });
+
+    it("should not retry on non-retryable errors", async () => {
+      const error = new Error("Bad Request");
+      (error as any).status = 400;
+      const mockFn = jest.fn().mockRejectedValue(error);
+
+      await expect(retryAsync(mockFn)).rejects.toThrow("Bad Request");
+      expect(mockFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("should respect max attempts", async () => {
+      const error = new Error("ECONNRESET");
+      (error as any).code = "ECONNRESET";
+      const mockFn = jest.fn().mockRejectedValue(error);
+
+      await expect(
+        retryAsync(mockFn, {
+          maxAttempts: 3,
+          baseDelay: 10,
+        }),
+      ).rejects.toThrow("ECONNRESET");
+      expect(mockFn).toHaveBeenCalledTimes(3);
+    });
+
+    it("should handle HTTP 429 errors", async () => {
+      const error = new Error("Too Many Requests");
+      (error as any).status = 429;
+      const mockFn = jest
+        .fn()
+        .mockRejectedValueOnce(error)
+        .mockResolvedValue("success");
+
+      const result = await retryAsync(mockFn, {
+        maxAttempts: 2,
+        baseDelay: 10,
+      });
+
+      expect(result).toBe("success");
+      expect(mockFn).toHaveBeenCalledTimes(2);
+    });
+
+    it("should handle HTTP 5xx errors", async () => {
+      const error = new Error("Internal Server Error");
+      (error as any).status = 500;
+      const mockFn = jest
+        .fn()
+        .mockRejectedValueOnce(error)
+        .mockResolvedValue("success");
+
+      const result = await retryAsync(mockFn, {
+        maxAttempts: 2,
+        baseDelay: 10,
+      });
+
+      expect(result).toBe("success");
+      expect(mockFn).toHaveBeenCalledTimes(2);
+    });
+
+    it("should handle AWS SDK errors", async () => {
+      const error = new Error("Throttling");
+      error.name = "ThrottlingException";
+      (error as any).$fault = "client";
+      (error as any).$metadata = {
+        httpStatusCode: 429,
+        requestId: "test-request-id",
+      };
+      const mockFn = jest
+        .fn()
+        .mockRejectedValueOnce(error)
+        .mockResolvedValue("success");
+
+      const result = await retryAsync(mockFn, {
+        maxAttempts: 2,
+        baseDelay: 10,
+      });
+
+      expect(result).toBe("success");
+      expect(mockFn).toHaveBeenCalledTimes(2);
+    });
+
+    it("should not retry AbortError", async () => {
+      const error = new Error("Aborted");
+      error.name = "AbortError";
+      const mockFn = jest.fn().mockRejectedValue(error);
+
+      await expect(retryAsync(mockFn)).rejects.toThrow("Aborted");
+      expect(mockFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("should use custom shouldRetry function", async () => {
+      const mockFn = jest.fn().mockRejectedValue(new Error("Custom Error"));
+      const customShouldRetry = jest.fn().mockReturnValue(true);
+
+      await expect(
+        retryAsync(mockFn, {
+          maxAttempts: 2,
+          shouldRetry: customShouldRetry,
+          baseDelay: 10,
+        }),
+      ).rejects.toThrow("Custom Error");
+
+      expect(customShouldRetry).toHaveBeenCalledWith(expect.any(Error), 1);
+      expect(mockFn).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("withRetry decorator functional usage", () => {
+    it("should work when applied manually to methods", async () => {
+      const testClass = {
+        attempts: 0,
+
+        async testMethod(): Promise<string> {
+          this.attempts++;
+          if (this.attempts < 3) {
+            const error = new Error("ECONNRESET");
+            (error as any).code = "ECONNRESET";
+            throw error;
+          }
+          return "success";
+        },
+      };
+
+      // Apply decorator manually
+      const decorator = withRetry({
+        maxAttempts: 3,
+        baseDelay: 10,
+      });
+      const descriptor = decorator(testClass, "testMethod", {
+        value: testClass.testMethod,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      });
+
+      if (descriptor?.value) {
+        testClass.testMethod = descriptor.value;
+      }
+
+      const result = await testClass.testMethod();
+
+      expect(result).toBe("success");
+      expect(testClass.attempts).toBe(3);
+    });
+  });
+
+  describe("withLLMRetry decorator functional usage", () => {
+    it("should use LLM-specific defaults", async () => {
+      const testLLM = {
+        attempts: 0,
+
+        async streamChat(): Promise<string> {
+          this.attempts++;
+          if (this.attempts < 2) {
+            const error = new Error("Too Many Requests");
+            (error as any).status = 429;
+            throw error;
+          }
+          return "success";
+        },
+      };
+
+      // Apply decorator manually
+      const decorator = withLLMRetry({ baseDelay: 10 });
+      const descriptor = decorator(testLLM, "streamChat", {
+        value: testLLM.streamChat,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      });
+
+      if (descriptor?.value) {
+        testLLM.streamChat = descriptor.value;
+      }
+
+      const result = await testLLM.streamChat();
+
+      expect(result).toBe("success");
+      expect(testLLM.attempts).toBe(2);
+    });
+  });
+
+  describe("exponential backoff with jitter", () => {
+    it("should increase delay exponentially", async () => {
+      const delays: number[] = [];
+      const error = new Error("ECONNRESET");
+      (error as any).code = "ECONNRESET";
+      const mockFn = jest.fn().mockRejectedValue(error);
+
+      await expect(
+        retryAsync(mockFn, {
+          maxAttempts: 3,
+          baseDelay: 1000,
+          jitterFactor: 0, // No jitter for predictable testing
+          onRetry: (error, attempt, delay) => {
+            delays.push(delay);
+          },
+        }),
+      ).rejects.toThrow();
+
+      // First retry should be ~1000ms, second should be ~2000ms
+      expect(delays).toHaveLength(2);
+      expect(delays[0]).toBe(1000);
+      expect(delays[1]).toBe(2000);
+    });
+
+    it("should respect maxDelay", async () => {
+      const delays: number[] = [];
+      const error = new Error("ECONNRESET");
+      (error as any).code = "ECONNRESET";
+      const mockFn = jest.fn().mockRejectedValue(error);
+
+      await expect(
+        retryAsync(mockFn, {
+          maxAttempts: 4,
+          baseDelay: 1000,
+          maxDelay: 2500,
+          jitterFactor: 0,
+          onRetry: (error, attempt, delay) => {
+            delays.push(delay);
+          },
+        }),
+      ).rejects.toThrow();
+
+      // Delays should be: 1000, 2000, 2500 (capped)
+      expect(delays).toEqual([1000, 2000, 2500]);
+    });
+  });
+
+  describe("rate limiting headers", () => {
+    it("should respect retry-after header in seconds", async () => {
+      const delays: number[] = [];
+      const error = new Error("Too Many Requests");
+      (error as any).status = 429;
+      (error as any).headers = { "retry-after": "1" }; // 1 second for fast testing
+      const mockFn = jest
+        .fn()
+        .mockRejectedValueOnce(error)
+        .mockResolvedValue("success");
+
+      const result = await retryAsync(mockFn, {
+        maxAttempts: 2,
+        baseDelay: 100, // 100ms fallback
+        onRetry: (error, attempt, delay) => {
+          delays.push(delay);
+        },
+      });
+
+      expect(result).toBe("success");
+      expect(mockFn).toHaveBeenCalledTimes(2);
+      // Should use header value (1000ms) not exponential backoff (100ms)
+      expect(delays[0]).toBeGreaterThan(950); // 1000ms ±5% jitter
+      expect(delays[0]).toBeLessThan(1050);
+    });
+
+    it("should respect x-ratelimit-reset header", async () => {
+      const delays: number[] = [];
+      const error = new Error("Rate limited");
+      (error as any).status = 429;
+      (error as any).headers = { "x-ratelimit-reset": "0.5" }; // 500ms for fast testing
+      const mockFn = jest
+        .fn()
+        .mockRejectedValueOnce(error)
+        .mockResolvedValue("success");
+
+      const result = await retryAsync(mockFn, {
+        maxAttempts: 2,
+        baseDelay: 100,
+        onRetry: (error, attempt, delay) => {
+          delays.push(delay);
+        },
+      });
+
+      expect(result).toBe("success");
+      // Should use header value (500ms) not exponential backoff (100ms)
+      expect(delays[0]).toBeGreaterThan(475);
+      expect(delays[0]).toBeLessThan(525);
+    });
+
+    it("should handle HTTP date format in retry-after header", async () => {
+      const delays: number[] = [];
+      const futureDate = new Date(Date.now() + 2000); // 2 seconds from now to avoid timing issues
+      const error = new Error("Rate limited");
+      (error as any).status = 429;
+      (error as any).headers = { "retry-after": futureDate.toUTCString() };
+      const mockFn = jest
+        .fn()
+        .mockRejectedValueOnce(error)
+        .mockResolvedValue("success");
+
+      const result = await retryAsync(mockFn, {
+        maxAttempts: 2,
+        baseDelay: 100,
+        maxDelay: 300, // Cap at 300ms for fast testing
+        onRetry: (error, attempt, delay) => {
+          delays.push(delay);
+        },
+      });
+
+      expect(result).toBe("success");
+      // Should be capped at maxDelay (300ms) since original would be ~2000ms
+      expect(delays[0]).toBeGreaterThan(280);
+      expect(delays[0]).toBeLessThan(320);
+    });
+
+    it("should fallback to exponential backoff when no headers present", async () => {
+      const delays: number[] = [];
+      const error = new Error("Server Error");
+      (error as any).status = 500;
+      // No headers property
+      const mockFn = jest
+        .fn()
+        .mockRejectedValueOnce(error)
+        .mockResolvedValue("success");
+
+      const result = await retryAsync(mockFn, {
+        maxAttempts: 2,
+        baseDelay: 50, // Fast for testing
+        jitterFactor: 0,
+        onRetry: (error, attempt, delay) => {
+          delays.push(delay);
+        },
+      });
+
+      expect(result).toBe("success");
+      // Should use exponential backoff (50ms) since no headers
+      expect(delays[0]).toBe(50);
+    });
+
+    it("should respect maxDelay even with rate limit headers", async () => {
+      const delays: number[] = [];
+      const error = new Error("Rate limited");
+      (error as any).status = 429;
+      (error as any).headers = { "retry-after": "10" }; // 10 seconds requested
+      const mockFn = jest
+        .fn()
+        .mockRejectedValueOnce(error)
+        .mockResolvedValue("success");
+
+      const result = await retryAsync(mockFn, {
+        maxAttempts: 2,
+        baseDelay: 100,
+        maxDelay: 200, // Cap at 200ms for fast testing
+        onRetry: (error, attempt, delay) => {
+          delays.push(delay);
+        },
+      });
+
+      expect(result).toBe("success");
+      // Should be capped at maxDelay (200ms) not header value (10000ms)
+      expect(delays[0]).toBeGreaterThan(190);
+      expect(delays[0]).toBeLessThan(210);
+    });
+
+    it("should handle case-insensitive header names", async () => {
+      const delays: number[] = [];
+      const error = new Error("Rate limited");
+      (error as any).status = 429;
+      (error as any).headers = { "Retry-After": "0.3" }; // 300ms for fast testing
+      const mockFn = jest
+        .fn()
+        .mockRejectedValueOnce(error)
+        .mockResolvedValue("success");
+
+      const result = await retryAsync(mockFn, {
+        maxAttempts: 2,
+        baseDelay: 100,
+        onRetry: (error, attempt, delay) => {
+          delays.push(delay);
+        },
+      });
+
+      expect(result).toBe("success");
+      // Should use header value (300ms)
+      expect(delays[0]).toBeGreaterThan(285);
+      expect(delays[0]).toBeLessThan(315);
+    });
+  });
+});

--- a/core/llm/utils/retry.test.ts
+++ b/core/llm/utils/retry.test.ts
@@ -351,8 +351,8 @@ describe("Retry Functionality", () => {
       expect(result).toBe("success");
       expect(mockFn).toHaveBeenCalledTimes(2);
       // Should use header value (1000ms) not exponential backoff (100ms)
-      expect(delays[0]).toBeGreaterThan(950); // 1000ms ±5% jitter
-      expect(delays[0]).toBeLessThan(1050);
+      expect(delays[0]).toBeGreaterThan(940); // 1000ms with wider tolerance for jitter and system performance
+      expect(delays[0]).toBeLessThan(1080);
     });
 
     it("should respect x-ratelimit-reset header", async () => {
@@ -375,8 +375,8 @@ describe("Retry Functionality", () => {
 
       expect(result).toBe("success");
       // Should use header value (500ms) not exponential backoff (100ms)
-      expect(delays[0]).toBeGreaterThan(475);
-      expect(delays[0]).toBeLessThan(525);
+      expect(delays[0]).toBeGreaterThan(470); // 500ms with wider tolerance for jitter and system performance
+      expect(delays[0]).toBeLessThan(540);
     });
 
     it("should handle HTTP date format in retry-after header", async () => {

--- a/core/llm/utils/retry.ts
+++ b/core/llm/utils/retry.ts
@@ -151,7 +151,7 @@ function calculateDelay(
 
       // Respect maxDelay and add small jitter to spread requests
       const cappedDelay = Math.min(delayMs, maxDelay);
-      const jitterMultiplier = 1 + (Math.random() * 0.1 - 0.025); // Small jitter -2.5% to +7.5%
+      const jitterMultiplier = 1 + (Math.random() * 0.1 - 0.05); // Small jitter ±5%
       return Math.max(0, Math.floor(cappedDelay * jitterMultiplier));
     }
   }

--- a/core/llm/utils/retry.ts
+++ b/core/llm/utils/retry.ts
@@ -1,0 +1,457 @@
+/**
+ * Configuration options for the retry decorator
+ */
+export interface RetryOptions {
+  /** Maximum number of retry attempts (default: 3) */
+  maxAttempts?: number;
+  /** Base delay in milliseconds (default: 1000) */
+  baseDelay?: number;
+  /** Maximum delay in milliseconds (default: 30000) */
+  maxDelay?: number;
+  /** Jitter factor between 0 and 1 (default: 0.3) */
+  jitterFactor?: number;
+  /** Custom function to determine if an error should be retried */
+  shouldRetry?: (error: any, attempt: number) => boolean;
+  /** Custom function called on each retry attempt */
+  onRetry?: (error: any, attempt: number, delay: number) => void;
+}
+
+/**
+ * Default configuration for retry behavior
+ */
+const DEFAULT_RETRY_OPTIONS: Required<RetryOptions> = {
+  maxAttempts: 3,
+  baseDelay: 1000,
+  maxDelay: 30000,
+  jitterFactor: 0.3,
+  shouldRetry: defaultShouldRetry,
+  onRetry: defaultOnRetry,
+};
+
+/**
+ * Default function to determine if an error should be retried
+ * Retries on:
+ * - Network errors
+ * - HTTP 429 (Too Many Requests)
+ * - HTTP 5xx (Server errors)
+ * - Specific AWS errors
+ * - Timeout errors
+ */
+function defaultShouldRetry(error: any, attempt: number): boolean {
+  // Note: maxAttempts check is handled by the retry logic itself
+  // This function only determines if the error type is retryable
+
+  // Network/connection errors
+  if (
+    error.code === "ENOTFOUND" ||
+    error.code === "ECONNRESET" ||
+    error.code === "ECONNREFUSED" ||
+    error.code === "ETIMEDOUT"
+  ) {
+    return true;
+  }
+
+  // AWS SDK specific errors (v3 - check for AWS error structure and retryable types)
+  const isAwsError = error.$fault || error.$metadata || (error.name && error.__type);
+  const awsRetryableErrors = [
+    "ThrottlingException",
+    "ServiceUnavailableException", 
+    "InternalServerError",
+    "RequestTimeout",
+    "ModelNotReadyException",
+    "ModelTimeoutException",
+    "ResourceNotFoundException"
+  ];
+  
+  if (isAwsError && error.name && awsRetryableErrors.includes(error.name)) {
+    return true;
+  }
+
+  // HTTP status codes
+  if (error.status || error.statusCode) {
+    const status = error.status || error.statusCode;
+
+    // Rate limiting
+    if (status === 429) {
+      return true;
+    }
+
+    // Server errors (5xx)
+    if (status >= 500 && status < 600) {
+      return true;
+    }
+
+    // Don't retry client errors (4xx except 429)
+    if (status >= 400 && status < 500) {
+      return false;
+    }
+  }
+
+  // Timeout errors
+  if (
+    error.name === "TimeoutError" ||
+    error.message?.includes("timeout") ||
+    error.message?.includes("TIMEOUT")
+  ) {
+    return true;
+  }
+
+  // Abort signal errors should not be retried
+  if (error.name === "AbortError" || error.code === "ABORT_ERR") {
+    return false;
+  }
+
+  // Default to not retrying unknown errors
+  return false;
+}
+
+/**
+ * Default function called on each retry attempt
+ */
+function defaultOnRetry(error: any, attempt: number, delay: number): void {
+  console.warn(
+    `Retry attempt ${attempt} after ${delay}ms delay. Error: ${error.message || error}`,
+  );
+}
+
+/**
+ * Calculate delay with rate limit header awareness and exponential backoff fallback
+ */
+function calculateDelay(
+  attempt: number,
+  baseDelay: number,
+  maxDelay: number,
+  jitterFactor: number,
+  error?: any,
+): number {
+  // Check for rate limiting headers first (more accurate than exponential backoff)
+  if (error?.headers) {
+    const retryAfter = 
+      error.headers["retry-after"] ||
+      error.headers["x-ratelimit-reset"] ||
+      error.headers["ratelimit-reset"] ||
+      error.headers["Retry-After"] ||
+      error.headers["X-RateLimit-Reset"] ||
+      error.headers["RateLimit-Reset"];
+
+    if (retryAfter) {
+      let delayMs: number;
+      
+      // Parse retry-after header (can be seconds or HTTP date)
+      if (typeof retryAfter === 'string' && isNaN(Number(retryAfter))) {
+        // HTTP date format
+        const resetTime = new Date(retryAfter).getTime();
+        const now = Date.now();
+        delayMs = Math.max(0, resetTime - now);
+      } else {
+        // Seconds format
+        delayMs = Number(retryAfter) * 1000;
+      }
+      
+      // Respect maxDelay and add small jitter to spread requests
+      const cappedDelay = Math.min(delayMs, maxDelay);
+      const jitterMultiplier = 1 + (Math.random() * 0.1 - 0.05); // Small jitter ±5%
+      return Math.max(0, Math.floor(cappedDelay * jitterMultiplier));
+    }
+  }
+
+  // Fallback to exponential backoff if no rate limit headers
+  const exponentialDelay = baseDelay * Math.pow(2, attempt - 1);
+  const cappedDelay = Math.min(exponentialDelay, maxDelay);
+
+  // Add jitter: random value between (1 - jitterFactor) and (1 + jitterFactor)
+  const jitterMultiplier = 1 + (Math.random() * 2 - 1) * jitterFactor;
+  const jitteredDelay = cappedDelay * jitterMultiplier;
+
+  return Math.max(0, Math.floor(jitteredDelay));
+}
+
+/**
+ * Sleep for the specified number of milliseconds
+ */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Retry decorator for async functions with exponential backoff and jitter
+ *
+ * @param options Retry configuration options
+ * @returns Decorator function
+ *
+ * @example
+ * ```typescript
+ * class MyLLM {
+ *   @withRetry({ maxAttempts: 5, baseDelay: 2000 })
+ *   async streamChat(messages: ChatMessage[]): Promise<AsyncGenerator<ChatMessage>> {
+ *     // Implementation that might fail
+ *   }
+ * }
+ * ```
+ */
+export function withRetry(options: RetryOptions = {}) {
+  const config = { ...DEFAULT_RETRY_OPTIONS, ...options };
+
+  return function (...args: any[]): any {
+    // Handle different decorator calling patterns
+    const [target, propertyName, descriptor] = args;
+
+    // Get the original method
+    let originalMethod: Function;
+    if (descriptor && descriptor.value) {
+      originalMethod = descriptor.value;
+    } else {
+      // Get method from prototype
+      originalMethod = target[propertyName];
+    }
+
+    if (!originalMethod || typeof originalMethod !== "function") {
+      throw new Error(`@withRetry can only be applied to methods`);
+    }
+
+    // Check if the original method is an async generator function
+    const isAsyncGenerator = originalMethod.constructor.name === 'AsyncGeneratorFunction';
+    
+    const wrappedMethod = isAsyncGenerator 
+      ? async function* (this: any, ...methodArgs: any[]) {
+          let lastError: any;
+          
+          for (let attempt = 1; attempt <= config.maxAttempts; attempt++) {
+            try {
+              const generator = originalMethod.apply(this, methodArgs);
+              yield* createRetryableAsyncGenerator(
+                generator,
+                config,
+                originalMethod,
+                this,
+                methodArgs,
+                attempt,
+              );
+              return; // Successfully completed
+            } catch (error) {
+              lastError = error;
+
+              // Check if we should retry this error
+              if (!config.shouldRetry(error, attempt)) {
+                throw error;
+              }
+
+              // Don't delay on the last attempt
+              if (attempt === config.maxAttempts) {
+                break;
+              }
+
+              // Calculate delay and wait
+              const delay = calculateDelay(
+                attempt,
+                config.baseDelay,
+                config.maxDelay,
+                config.jitterFactor,
+                error,
+              );
+
+              config.onRetry(error, attempt, delay);
+              await sleep(delay);
+            }
+          }
+
+          // If we get here, all attempts failed
+          throw lastError;
+        }
+      : async function (this: any, ...methodArgs: any[]) {
+          let lastError: any;
+
+          for (let attempt = 1; attempt <= config.maxAttempts; attempt++) {
+            try {
+              const result = originalMethod.apply(this, methodArgs);
+              return await result;
+            } catch (error) {
+              lastError = error;
+
+              // Check if we should retry this error
+              if (!config.shouldRetry(error, attempt)) {
+                throw error;
+              }
+
+              // Don't delay on the last attempt
+              if (attempt === config.maxAttempts) {
+                break;
+              }
+
+              // Calculate delay and wait
+              const delay = calculateDelay(
+                attempt,
+                config.baseDelay,
+                config.maxDelay,
+                config.jitterFactor,
+                error,
+              );
+
+              config.onRetry(error, attempt, delay);
+
+              await sleep(delay);
+            }
+          }
+
+          // If we get here, all attempts failed
+          throw lastError;
+        };
+
+    // Apply the wrapped method based on how the decorator was called
+    if (descriptor) {
+      descriptor.value = wrappedMethod;
+      return descriptor;
+    } else {
+      // Handle case where descriptor is not provided
+      target[propertyName] = wrappedMethod;
+      return wrappedMethod;
+    }
+  };
+}
+
+/**
+ * Creates a retryable async generator that handles errors during iteration
+ */
+async function* createRetryableAsyncGenerator<T>(
+  generator: AsyncGenerator<T>,
+  config: Required<RetryOptions>,
+  originalMethod: Function,
+  context: any,
+  args: any[],
+  initialAttempt: number,
+): AsyncGenerator<T> {
+  let currentGenerator = generator;
+  let attempt = initialAttempt;
+
+  try {
+    for await (const value of currentGenerator) {
+      yield value;
+    }
+  } catch (error) {
+    // If we encounter an error during iteration, we can retry by creating a new generator
+    let lastError = error;
+
+    for (
+      let retryAttempt = attempt + 1;
+      retryAttempt <= config.maxAttempts;
+      retryAttempt++
+    ) {
+      // Check if we should retry this error
+      if (!config.shouldRetry(error, retryAttempt)) {
+        throw error;
+      }
+
+      // Don't delay on the last attempt
+      if (retryAttempt === config.maxAttempts) {
+        break;
+      }
+
+      // Calculate delay and wait
+      const delay = calculateDelay(
+        retryAttempt,
+        config.baseDelay,
+        config.maxDelay,
+        config.jitterFactor,
+        error,
+      );
+
+      config.onRetry(error, retryAttempt, delay);
+      await sleep(delay);
+
+      try {
+        // Create a new generator and continue iteration
+        const newGenerator = await originalMethod.apply(context, args);
+
+        if (
+          newGenerator &&
+          typeof newGenerator[Symbol.asyncIterator] === "function"
+        ) {
+          for await (const value of newGenerator) {
+            yield value;
+          }
+          return; // Successfully completed
+        } else {
+          throw new Error("Method did not return an async generator on retry");
+        }
+      } catch (retryError) {
+        lastError = retryError;
+        error = retryError;
+      }
+    }
+
+    // If we get here, all retry attempts failed
+    throw lastError;
+  }
+}
+
+/**
+ * Functional version of retry for use without decorators
+ *
+ * @param fn Function to retry
+ * @param options Retry configuration options
+ * @returns Promise that resolves with the function result or rejects with the last error
+ *
+ * @example
+ * ```typescript
+ * const result = await retryAsync(
+ *   () => someApiCall(),
+ *   { maxAttempts: 3, baseDelay: 1000 }
+ * );
+ * ```
+ */
+export async function retryAsync<T>(
+  fn: () => Promise<T>,
+  options: RetryOptions = {},
+): Promise<T> {
+  const config = { ...DEFAULT_RETRY_OPTIONS, ...options };
+  let lastError: any;
+
+  for (let attempt = 1; attempt <= config.maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+
+      // Check if we should retry this error
+      if (!config.shouldRetry(error, attempt)) {
+        throw error;
+      }
+
+      // Don't delay on the last attempt
+      if (attempt === config.maxAttempts) {
+        break;
+      }
+
+      // Calculate delay and wait
+      const delay = calculateDelay(
+        attempt,
+        config.baseDelay,
+        config.maxDelay,
+        config.jitterFactor,
+        error,
+      );
+
+      config.onRetry(error, attempt, delay);
+
+      await sleep(delay);
+    }
+  }
+
+  // If we get here, all attempts failed
+  throw lastError;
+}
+
+/**
+ * Retry decorator specifically configured for LLM providers
+ * Uses sensible defaults for LLM API calls, including longer delays
+ * for capacity provisioning (e.g., AWS Bedrock can require up to 59+ seconds)
+ */
+export function withLLMRetry(options: Partial<RetryOptions> = {}) {
+  return withRetry({
+    maxAttempts: 5,        // More attempts for capacity issues
+    baseDelay: 2000,       // Start with 2 seconds
+    maxDelay: 90000,       // Allow up to 90 seconds for capacity provisioning
+    jitterFactor: 0.4,     // Slightly more jitter to spread load
+    ...options,
+  });
+}

--- a/core/llm/utils/retry.ts
+++ b/core/llm/utils/retry.ts
@@ -151,7 +151,7 @@ function calculateDelay(
 
       // Respect maxDelay and add small jitter to spread requests
       const cappedDelay = Math.min(delayMs, maxDelay);
-      const jitterMultiplier = 1 + (Math.random() * 0.1 - 0.05); // Small jitter ±5%
+      const jitterMultiplier = 1 + (Math.random() * 0.1 - 0.025); // Small jitter -2.5% to +7.5%
       return Math.max(0, Math.floor(cappedDelay * jitterMultiplier));
     }
   }

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -16,6 +16,8 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "noEmitOnError": false,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
     "types": ["jest", "node"]
   },
   "include": ["./**/*.ts", "./**/*.js", "./**/*.d.ts"],


### PR DESCRIPTION
## Description

* Implement a decorator that can be used to implement intelligent retires for LLMs.
* Per recommendations from AWS this change supports exponential backoff and retries with jitter.
* Implemented common header backoff and retry patterns to make this easy to plug into other providers.
* Add that decorator to the Bedrock.ts provider to compensate for running into intermittent account quota limits.
* Moved the secureID tests to align them into the same directory as the llm utils. (cleanup)

The withLLMRetry decorator can be added to any streamChat function. Note that any try catch blocks should be updated to hand off the API errors to the decorator.

Debug is currently enabled so that retry events can be viewed.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

Added tests for the retry logic.
Updated tests for secureID to align them into the utils directory (cleanup)

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a retry decorator for LLM streamChat methods to handle intermittent API errors and quota limits, and applied it to the Bedrock provider. Also moved secureID tests for better organization.

- **New Features**
  - Introduced `withLLMRetry` decorator for automatic retries with exponential backoff and jitter.
  - Applied retry logic to Bedrock's `_streamChat` to improve reliability during quota or network issues.

- **Refactors**
  - Moved secureID tests into the llm utils directory for consistency.

<!-- End of auto-generated description by cubic. -->

