### PR TITLE
avoid garbled Chinese when call runTerminalCommandTool in windows

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -78,6 +78,7 @@
     "handlebars": "^4.7.8",
     "http-proxy-agent": "^7.0.1",
     "https-proxy-agent": "^7.0.3",
+    "iconv-lite": "^0.6.3",
     "ignore": "^5.3.1",
     "is-localhost-ip": "^2.0.0",
     "jinja-js": "0.1.8",


### PR DESCRIPTION
## Description

avoid garbled Chinese when call runTerminalCommandTool in windows

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
