### PR TITLE
Codebase/Colocated Rules Cache

### DIFF
--- a/core/config/markdown/loadCodebaseRules.ts
+++ b/core/config/markdown/loadCodebaseRules.ts
@@ -7,6 +7,40 @@ import { walkDirs } from "../../indexing/walkDir";
 import { RULES_MARKDOWN_FILENAME } from "../../llm/rules/constants";
 import { getUriPathBasename } from "../../util/uri";
 
+export class CodebaseRulesCache {
+  private static instance: CodebaseRulesCache | null = null;
+  private constructor() {}
+
+  public static getInstance(): CodebaseRulesCache {
+    if (CodebaseRulesCache.instance === null) {
+      CodebaseRulesCache.instance = new CodebaseRulesCache();
+    }
+    return CodebaseRulesCache.instance;
+  }
+  rules: RuleWithSource[] = [];
+  errors: ConfigValidationError[] = [];
+  async refresh(ide: IDE) {
+    const { rules, errors } = await loadCodebaseRules(ide);
+    this.rules = rules;
+    this.errors = errors;
+  }
+  async update(ide: IDE, uri: string) {
+    const content = await ide.readFile(uri);
+    const rule = markdownToRule(content, { uriType: "file", filePath: uri });
+    const ruleWithSource: RuleWithSource = {
+      ...rule,
+      source: "colocated-markdown",
+      ruleFile: uri,
+    };
+    const matchIdx = this.rules.findIndex((r) => r.ruleFile === uri);
+    if (matchIdx === -1) {
+      this.rules.push(ruleWithSource);
+    } else {
+      this.rules[matchIdx] = ruleWithSource;
+    }
+  }
+}
+
 /**
  * Loads rules from rules.md files colocated in the codebase
  */
@@ -33,7 +67,11 @@ export async function loadCodebaseRules(ide: IDE): Promise<{
         const content = await ide.readFile(filePath);
         const rule = markdownToRule(content, { uriType: "file", filePath });
 
-        rules.push({ ...rule, source: "rules-block", ruleFile: filePath });
+        rules.push({
+          ...rule,
+          source: "colocated-markdown",
+          ruleFile: filePath,
+        });
       } catch (e) {
         errors.push({
           fatal: false,

--- a/core/config/markdown/loadCodebaseRules.vitest.ts
+++ b/core/config/markdown/loadCodebaseRules.vitest.ts
@@ -45,27 +45,27 @@ describe("loadCodebaseRules", () => {
     "src/rules.md": {
       name: "General Rules",
       rule: "Follow coding standards",
-      source: "rules-block",
+      source: "colocated-markdown",
       ruleFile: "src/rules.md",
     },
     "src/redux/rules.md": {
       name: "Redux Rules",
       rule: "Use Redux Toolkit",
       globs: "**/*.{ts,tsx}",
-      source: "rules-block",
+      source: "colocated-markdown",
       ruleFile: "src/redux/rules.md",
     },
     "src/components/rules.md": {
       name: "Component Rules",
       rule: "Use functional components",
       globs: ["**/*.tsx", "**/*.jsx"],
-      source: "rules-block",
+      source: "colocated-markdown",
       ruleFile: "src/components/rules.md",
     },
     ".continue/rules.md": {
       name: "Global Rules",
       rule: "Follow project guidelines",
-      source: "rules-block",
+      source: "colocated-markdown",
       ruleFile: ".continue/rules.md",
     },
   };

--- a/core/config/markdown/ruleCollocationApplication.vitest.ts
+++ b/core/config/markdown/ruleCollocationApplication.vitest.ts
@@ -16,7 +16,7 @@ describe("Rule Colocation Application", () => {
     {
       name: "Root Rule",
       rule: "Follow project standards",
-      source: "rules-block",
+      source: "colocated-markdown",
       ruleFile: ".continue/rules.md",
     },
 
@@ -24,7 +24,7 @@ describe("Rule Colocation Application", () => {
     {
       name: "React Components Rule",
       rule: "Use functional components with hooks",
-      source: "rules-block",
+      source: "colocated-markdown",
       ruleFile: "src/components/rules.md",
       // No explicit globs - should implicitly only apply to files in that directory
     },
@@ -34,7 +34,7 @@ describe("Rule Colocation Application", () => {
       name: "Redux Rule",
       rule: "Use Redux Toolkit for state management",
       globs: "src/redux/**/*.{ts,tsx}",
-      source: "rules-block",
+      source: "colocated-markdown",
       ruleFile: "src/redux/rules.md",
     },
 
@@ -43,7 +43,7 @@ describe("Rule Colocation Application", () => {
       name: "TypeScript Components Rule",
       rule: "Use TypeScript with React components",
       globs: "**/*.tsx", // Only apply to .tsx files
-      source: "rules-block",
+      source: "colocated-markdown",
       ruleFile: "src/components/rules.md",
     },
 
@@ -52,7 +52,7 @@ describe("Rule Colocation Application", () => {
       name: "API Utils Rule",
       rule: "Follow API utility conventions",
       globs: "**/*.ts", // Only TypeScript files in this directory
-      source: "rules-block",
+      source: "colocated-markdown",
       ruleFile: "src/utils/api/rules.md",
     },
   ];
@@ -183,7 +183,7 @@ describe("Rule Colocation Application", () => {
       const impliedComponentRule: RuleWithSource = {
         name: "Implied Components Rule",
         rule: "Use React component best practices",
-        source: "rules-block",
+        source: "colocated-markdown",
         ruleFile: "src/components/rules.md",
         // No explicit globs - should infer from directory
       };
@@ -233,7 +233,7 @@ describe("Rule Colocation Application", () => {
         name: "TypeScript Component Rule",
         rule: "Use TypeScript with React components",
         globs: "**/*.tsx", // Only apply to .tsx files
-        source: "rules-block",
+        source: "colocated-markdown",
         ruleFile: "src/components/rules.md",
       };
 
@@ -280,7 +280,7 @@ describe("Rule Colocation Application", () => {
         name: "API Utils Rule",
         rule: "Follow API utility conventions",
         globs: "**/*.ts", // Only TypeScript files in this directory
-        source: "rules-block",
+        source: "colocated-markdown",
         ruleFile: "src/utils/api/rules.md",
       };
 
@@ -323,7 +323,7 @@ describe("Rule Colocation Application", () => {
         return {
           name: `Inferred Rule for ${directory}`,
           rule: `Follow standards for ${directory}`,
-          source: "rules-block",
+          source: "colocated-markdown",
           ruleFile: ruleFilePath,
           // In a fixed implementation, these globs would be automatically inferred
           // globs: expectedGlob,

--- a/core/config/profile/doLoadConfig.ts
+++ b/core/config/profile/doLoadConfig.ts
@@ -37,7 +37,7 @@ import { Telemetry } from "../../util/posthog";
 import { TTS } from "../../util/tts";
 import { getWorkspaceContinueRuleDotFiles } from "../getWorkspaceContinueRuleDotFiles";
 import { loadContinueConfigFromJson } from "../load";
-import { loadCodebaseRules } from "../markdown/loadCodebaseRules";
+import { CodebaseRulesCache } from "../markdown/loadCodebaseRules";
 import { loadMarkdownRules } from "../markdown/loadMarkdownRules";
 import { migrateJsonSharedConfig } from "../migrateSharedConfig";
 import { rectifySelectedModelsFromGlobalContext } from "../selectedModels";
@@ -165,10 +165,9 @@ export default async function doLoadConfig(options: {
   }
 
   // Add rules from colocated rules.md files in the codebase
-  const { rules: codebaseRules, errors: codebaseRulesErrors } =
-    await loadCodebaseRules(ide);
-  newConfig.rules.unshift(...codebaseRules);
-  errors.push(...codebaseRulesErrors);
+  const codebaseRulesCache = CodebaseRulesCache.getInstance();
+  newConfig.rules.unshift(...codebaseRulesCache.rules);
+  errors.push(...codebaseRulesCache.errors);
 
   // Rectify model selections for each role
   newConfig = rectifySelectedModelsFromGlobalContext(newConfig, profileId);

--- a/core/core.ts
+++ b/core/core.ts
@@ -985,8 +985,13 @@ export class Core {
         ) {
           await this.configHandler.reloadConfig();
         } else if (uri.endsWith(RULES_MARKDOWN_FILENAME)) {
-          const codebaseRulesCache = CodebaseRulesCache.getInstance();
-          void codebaseRulesCache.update(this.ide, uri);
+          try {
+            const codebaseRulesCache = CodebaseRulesCache.getInstance();
+            await codebaseRulesCache.update(this.ide, uri);
+            this.configHandler.reloadConfig();
+          } catch (e) {
+            console.error("Failed to update codebase rule", e);
+          }
         } else if (
           uri.endsWith(".continueignore") ||
           uri.endsWith(".gitignore")

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1650,6 +1650,7 @@ export type RuleSource =
   | "model-options-plan"
   | "model-options-agent"
   | "rules-block"
+  | "colocated-markdown"
   | "json-systemMessage"
   | ".continuerules";
 

--- a/core/llm/rules/ruleColocation.vitest.ts
+++ b/core/llm/rules/ruleColocation.vitest.ts
@@ -9,7 +9,7 @@ describe("Rule colocation - glob pattern matching", () => {
     generalRule: {
       name: "General Rule",
       rule: "Follow coding standards",
-      source: "rules-block",
+      source: "colocated-markdown",
       ruleFile: "src/rules.md",
     },
 
@@ -18,7 +18,7 @@ describe("Rule colocation - glob pattern matching", () => {
       name: "Redux Rule",
       rule: "Use Redux Toolkit",
       globs: "src/redux/**/*.{ts,tsx}",
-      source: "rules-block",
+      source: "colocated-markdown",
       ruleFile: "src/redux/rules.md",
     },
 
@@ -27,7 +27,7 @@ describe("Rule colocation - glob pattern matching", () => {
       name: "Component Rule",
       rule: "Use functional components",
       globs: ["src/components/**/*.tsx", "src/components/**/*.jsx"],
-      source: "rules-block",
+      source: "colocated-markdown",
       ruleFile: "src/components/rules.md",
     },
 
@@ -37,7 +37,7 @@ describe("Rule colocation - glob pattern matching", () => {
       rule: "Follow these guidelines always",
       alwaysApply: true,
       globs: "src/specific/**/*.ts", // Should be ignored since alwaysApply is true
-      source: "rules-block",
+      source: "colocated-markdown",
       ruleFile: ".continue/rules.md",
     },
 
@@ -47,7 +47,7 @@ describe("Rule colocation - glob pattern matching", () => {
       rule: "This rule should only apply to matching files",
       alwaysApply: false,
       // No globs, so should never apply
-      source: "rules-block",
+      source: "colocated-markdown",
       ruleFile: ".continue/rules.md",
     },
 
@@ -57,7 +57,7 @@ describe("Rule colocation - glob pattern matching", () => {
       rule: "Apply only to matching files",
       alwaysApply: false,
       globs: "src/utils/**/*.ts",
-      source: "rules-block",
+      source: "colocated-markdown",
       ruleFile: "src/utils/rules.md",
     },
   };
@@ -127,7 +127,7 @@ describe("Rule colocation - glob pattern matching", () => {
       rule: "Follow nested module standards",
       // Fix: Specify the exact path prefix to restrict to this directory structure
       globs: "src/features/auth/utils/**/*.ts",
-      source: "rules-block",
+      source: "colocated-markdown",
       ruleFile: "src/features/auth/utils/rules.md",
     };
 
@@ -157,7 +157,7 @@ describe("Rule colocation - glob pattern matching", () => {
       // Note: Negative globs may not be supported by the current implementation
       // Testing with standard pattern instead
       globs: "src/**/[!.]*.ts",
-      source: "rules-block",
+      source: "colocated-markdown",
       ruleFile: "src/rules.md",
     };
 
@@ -174,7 +174,7 @@ describe("Rule colocation - glob pattern matching", () => {
         // Use a pattern that doesn't match test files
         globs: ["src/**/*.ts", "!src/**/*.test.ts", "!src/**/*.spec.ts"],
         alwaysApply: false,
-        source: "rules-block",
+        source: "colocated-markdown",
         ruleFile: "src/rules.md",
       };
 

--- a/core/protocol/core.ts
+++ b/core/protocol/core.ts
@@ -89,7 +89,7 @@ export type ToCoreFromIdeOrWebviewProtocol = {
     },
   ];
   "config/deleteModel": [{ title: string }, void];
-  "config/reload": [undefined, ConfigResult<BrowserSerializedContinueConfig>];
+  "config/reload": [undefined, void];
   "config/refreshProfiles": [
     (
       | undefined

--- a/gui/src/components/mainInput/belowMainInput/RulesPeek.tsx
+++ b/gui/src/components/mainInput/belowMainInput/RulesPeek.tsx
@@ -27,6 +27,8 @@ const getSourceLabel = (source: RuleSource): string => {
       return "Model Agent Options";
     case "rules-block":
       return "Rules Block";
+    case "colocated-markdown":
+      return "Codebase Rule";
     case "json-systemMessage":
       return "System Message";
     case ".continuerules":


### PR DESCRIPTION
## Description

A major source of slow config loading is walk dir to find colocated rules.md files. This PR adds a codebase/colocated rules cache that initializes on startup and then updates and triggers a config reload when a rules.md file is edited. This way it's not doing a full walk dir for any config reload.