### PR TITLE
chore: add telemetry to config loading

### DIFF
--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -458,7 +458,7 @@ export class ConfigHandler {
       await this.currentProfile.reloadConfig(this.additionalContextProviders);
 
     this.notifyConfigListeners({ config, errors, configLoadInterrupted });
-    
+
     // Track config loading telemetry
     const endTime = performance.now();
     const duration = endTime - startTime;
@@ -468,7 +468,7 @@ export class ConfigHandler {
       totalConfigLoads: this.totalConfigLoads,
       configLoadInterrupted,
     });
-    
+
     return { config, errors, configLoadInterrupted };
   }
 

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -142,7 +142,7 @@
     },
     "../packages/config-yaml": {
       "name": "@continuedev/config-yaml",
-      "version": "1.0.95",
+      "version": "1.0.96",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",
@@ -169,9 +169,11 @@
     },
     "../packages/openai-adapters": {
       "name": "@continuedev/openai-adapters",
-      "version": "1.0.44",
+      "version": "1.0.45",
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-sdk/client-bedrock-runtime": "^3.842.0",
+        "@aws-sdk/credential-providers": "^3.840.0",
         "@continuedev/config-types": "^1.0.5",
         "@continuedev/config-yaml": "^1.0.51",
         "@continuedev/fetch": "^1.0.15",

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "1.1.59",
+  "version": "1.1.60",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "1.1.59",
+      "version": "1.1.60",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",
@@ -2544,9 +2544,10 @@
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "node_modules/@types/node": {
-      "version": "16.18.119",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.119.tgz",
-      "integrity": "sha512-ia7V9a2FnhUFfetng4/sRPBMTwHZUkPFY736rb1cg9AgG7MZdR97q7/nLR9om+sq5f1la9C857E0l/nrI0RiFQ=="
+      "version": "16.18.126",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
+      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+      "license": "MIT"
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.12",

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -220,7 +220,7 @@
     },
     "../packages/config-yaml": {
       "name": "@continuedev/config-yaml",
-      "version": "1.0.95",
+      "version": "1.0.96",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",

--- a/packages/config-yaml/package-lock.json
+++ b/packages/config-yaml/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@continuedev/config-yaml",
-  "version": "1.0.95",
+  "version": "1.0.96",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@continuedev/config-yaml",
-      "version": "1.0.95",
+      "version": "1.0.96",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",

--- a/packages/openai-adapters/package-lock.json
+++ b/packages/openai-adapters/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@continuedev/openai-adapters",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@continuedev/openai-adapters",
-      "version": "1.0.44",
+      "version": "1.0.45",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.842.0",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added telemetry to track config loading times and reasons, helping identify performance issues and reload patterns.

- **Dependencies**
  - Updated package versions in several package-lock.json files.

<!-- End of auto-generated description by cubic. -->

