### PR TITLE
Fix JCEF. NullPointerException: Cannot read field "objId" because "robj" is null

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinuePluginToolWindowFactory.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/toolWindow/ContinuePluginToolWindowFactory.kt
@@ -46,6 +46,7 @@ class ContinuePluginToolWindowFactory : ToolWindowFactory, DumbAware {
     init {
       System.setProperty("ide.browser.jcef.jsQueryPoolSize", JS_QUERY_POOL_SIZE)
       System.setProperty("ide.browser.jcef.contextMenu.devTools.enabled", "true")
+      System.setProperty("ide.browser.jcef.out-of-process.enabled", "false")
     }
 
     val browser: ContinueBrowser by lazy {


### PR DESCRIPTION
fix JCEF. NullPointerException: Cannot read field "objId" because "robj" is null

## Description

[ What changed? Feel free to be brief. ]

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
