### PR TITLE
docs: remove unnecessary anchor tags

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -52,5 +52,6 @@
   "conventionalCommits.promptBody": false,
   "conventionalCommits.promptFooter": false,
   "conventionalCommits.promptScopes": true,
-  "conventionalCommits.scopes": ["reg"]
+  "conventionalCommits.scopes": ["reg"],
+  "java.compile.nullAnalysis.mode": "disabled"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -52,6 +52,5 @@
   "conventionalCommits.promptBody": false,
   "conventionalCommits.promptFooter": false,
   "conventionalCommits.promptScopes": true,
-  "conventionalCommits.scopes": ["reg"],
-  "java.compile.nullAnalysis.mode": "disabled"
+  "conventionalCommits.scopes": ["reg"]
 }

--- a/docs/customization/mcp-tools.mdx
+++ b/docs/customization/mcp-tools.mdx
@@ -11,6 +11,6 @@ description: "Model Context Protocol servers provide specialized functionality:"
 
 ![MCP Blocks Overview](/images/customization/images/mcp-blocks-overview-c9a104f9b586779c156f9cf34da197c2.png)
 
-## Learn More[​](#learn-more "Direct link to Learn More")
+## Learn More
 
 Learn more in the [MCP deep dive](/customization/mcp-tools), and view [`mcpServers`](/reference#mcpservers) in the YAML Reference for more details.

--- a/docs/customization/models.mdx
+++ b/docs/customization/models.mdx
@@ -12,7 +12,7 @@ description: "These blocks form the foundation of the entire assistant experienc
 
 ![Model Blocks Overview](/images/customization/images/model-blocks-overview-36c30e7e01928d7a9b5b26ff1639c34b.png)
 
-## Learn More[​](#learn-more "Direct link to Learn More")
+## Learn More
 
 Continue supports [many model providers](/customization/models#openai), including Anthropic, OpenAI, Gemini, Ollama, Amazon Bedrock, Azure, xAI, DeepSeek, and more. Models can have various roles like `chat`, `edit`, `apply`, `autocomplete`, `embed`, and `rerank`.
 

--- a/docs/customization/overview.mdx
+++ b/docs/customization/overview.mdx
@@ -11,7 +11,7 @@ description: "Continue can be deeply customized. For example you might:"
 
 Whatever you choose, you'll probably start by editing your Assistant.
 
-## Editing your assistant[​](#editing-your-assistant "Direct link to Editing your assistant")
+## Editing your assistant
 
 You can easily access your assistant configuration from the Continue Chat sidebar. Open the sidebar by pressing `cmd/ctrl` + `L` (VS Code) or `cmd/ctrl` + `J` (JetBrains) and click the Assistant selector above the main chat input. Then, you can hover over an assistant and click the `new window` (hub assistants) or `gear` (local assistants) icon.
 

--- a/docs/customization/prompts.mdx
+++ b/docs/customization/prompts.mdx
@@ -11,6 +11,6 @@ description: "These are the specialized instructions that shape how models respo
 
 ![Prompt Blocks Overview](/images/customization/images/prompts-blocks-overview-17194d870840576f9a0dde548f2c70ec.png)
 
-## Learn More[​](#learn-more "Direct link to Learn More")
+## Learn More
 
 Prompt blocks have the same syntax as [prompt files](/customization/prompts). The `config.yaml` spec for `prompts` can be found [here](/reference#prompts).

--- a/docs/customization/rules.mdx
+++ b/docs/customization/rules.mdx
@@ -11,10 +11,10 @@ Think of these as the guardrails for your AI coding assistants:
 
 By implementing rules, you transform the AI from a generic coding assistant into a knowledgeable team member that understands your project's unique requirements and constraints.
 
-### How Rules Work[​](#how-rules-work "Direct link to How Rules Work")
+### How Rules Work
 
 Your assistant detects rule blocks and applies the specified rules while in [Agent](/features/agent/quick-start), [Chat](/features/chat/quick-start), and [Edit](/features/edit/quick-start) modes.
 
-## Learn More[​](#learn-more "Direct link to Learn More")
+## Learn More
 
 Learn more in the [rules deep dive](/customization/rules), and view [`rules`](/reference#rules) in the YAML Reference for more details.

--- a/docs/customize/custom-providers.mdx
+++ b/docs/customize/custom-providers.mdx
@@ -7,15 +7,15 @@ As an example, say you are working on solving a new GitHub Issue. You type '@Iss
 
 ![Context Items](/images/customize/images/context-provider-example-0c96ff77286fa970b23dddfdc1fa986a.png)
 
-## Context blocks[​](#context-blocks "Direct link to Context blocks")
+## Context blocks
 
 You can add context providers to assistants using [`context` blocks](/hub/blocks/block-types#context). Explore available context blocks in [the hub](https://hub.continue.dev/explore/context).
 
-## Built-in Context Providers[​](#built-in-context-providers "Direct link to Built-in Context Providers")
+## Built-in Context Providers
 
 You can add any built-in context-providers in your config file as shown below:
 
-### `@File`[​](#file "Direct link to file")
+### `@File`
 
 Reference any file in your current workspace.
 
@@ -34,7 +34,7 @@ config.json
 { "contextProviders": [{ "name": "file" }] }
 ```
 
-### `@Code`[​](#code "Direct link to code")
+### `@Code`
 
 Reference specific functions or classes from throughout your project.
 
@@ -53,7 +53,7 @@ config.json
 { "contextProviders": [{ "name": "code" }] }
 ```
 
-### `@Git Diff`[​](#git-diff "Direct link to git-diff")
+### `@Git Diff`
 
 Reference all of the changes you've made to your current branch. This is useful if you want to summarize what you've done or ask for a general review of your work before committing.
 
@@ -72,7 +72,7 @@ config.json
 { "contextProviders": [{ "name": "diff" }] }
 ```
 
-### `@Current File`[​](#current-file "Direct link to current-file")
+### `@Current File`
 
 Reference the currently open file.
 
@@ -91,7 +91,7 @@ config.json
 { "contextProviders": [{ "name": "currentFile" }] }
 ```
 
-### `@Terminal`[​](#terminal "Direct link to terminal")
+### `@Terminal`
 
 Reference the last command you ran in your IDE's terminal and its output.
 
@@ -110,7 +110,7 @@ config.json
 { "contextProviders": [{ "name": "terminal" }] }
 ```
 
-### `@Docs`[​](#docs "Direct link to docs")
+### `@Docs`
 
 Reference the contents from any documentation site.
 
@@ -133,7 +133,7 @@ Note that this will only enable the `@Docs` context provider.
 
 To use it, you need to add a documentation site to your config file. See the [docs](/customization/overview#documentation-context) page for more information.
 
-### `@Open`[​](#open "Direct link to open")
+### `@Open`
 
 Reference the contents of all of your open files. Set `onlyPinned` to `true` to only reference pinned files.
 
@@ -152,7 +152,7 @@ config.json
 { "contextProviders": [{ "name": "open", "params": { "onlyPinned": true } }] }
 ```
 
-### `@Web`[​](#web "Direct link to web")
+### `@Web`
 
 Reference relevant pages from across the web, automatically determined from your input.
 
@@ -173,7 +173,7 @@ config.json
 { "contextProviders": [{ "name": "web", "params": { "n": 5 } }] }
 ```
 
-### `@Codebase`[​](#codebase "Direct link to codebase")
+### `@Codebase`
 
 Reference the most relevant snippets from your codebase.
 
@@ -194,7 +194,7 @@ config.json
 
 Read more about indexing and retrieval [here](/customization/overview#codebase-context).
 
-### `@Folder`[​](#folder "Direct link to folder")
+### `@Folder`
 
 Uses the same retrieval mechanism as `@Codebase`, but only on a single folder.
 
@@ -213,7 +213,7 @@ config.json
 { "contextProviders": [{ "name": "folder" }] }
 ```
 
-### `@Search`[​](#search "Direct link to search")
+### `@Search`
 
 Reference the results of codebase search, just like the results you would get from VS Code search.
 
@@ -234,7 +234,7 @@ config.json
 
 This context provider is powered by [ripgrep](https://github.com/BurntSushi/ripgrep).
 
-### `@Url`[​](#url "Direct link to url")
+### `@Url`
 
 Reference the markdown converted contents of a given URL.
 
@@ -253,7 +253,7 @@ config.json
 { "contextProviders": [{ "name": "url" }] }
 ```
 
-### `@Clipboard`[​](#clipboard "Direct link to clipboard")
+### `@Clipboard`
 
 Reference recent clipboard items
 
@@ -272,7 +272,7 @@ config.json
 { "contextProviders": [{ "name": "clipboard" }] }
 ```
 
-### `@Tree`[​](#tree "Direct link to tree")
+### `@Tree`
 
 Reference the structure of your current workspace.
 
@@ -291,7 +291,7 @@ config.json
 { "contextProviders": [{ "name": "tree" }] }
 ```
 
-### `@Problems`[​](#problems "Direct link to problems")
+### `@Problems`
 
 Get Problems from the current file.
 
@@ -310,7 +310,7 @@ config.json
 { "contextProviders": [{ "name": "problems" }] }
 ```
 
-### `@Debugger`[​](#debugger "Direct link to debugger")
+### `@Debugger`
 
 Reference the contents of the local variables in the debugger. Currently only available in VS Code.
 
@@ -331,7 +331,7 @@ config.json
 
 Uses the top _n_ levels (defaulting to 3) of the call stack for that thread.
 
-### `@Repository Map`[​](#repository-map "Direct link to repository-map")
+### `@Repository Map`
 
 Reference the outline of your codebase. By default, signatures are included along with file in the repo map.
 
@@ -358,7 +358,7 @@ In the submenu that appears, you can select either `Entire codebase`, or specify
 
 This context provider is inpsired by [Aider's repository map](https://aider.chat/2023/10/22/repomap.html).
 
-### `@Operating System`[​](#operating-system "Direct link to operating-system")
+### `@Operating System`
 
 Reference the architecture and platform of your current operating system.
 
@@ -377,7 +377,7 @@ config.json
 { "contextProviders": [{ "name": "os" }] }
 ```
 
-### Model Context Protocol[​](#model-context-protocol "Direct link to Model Context Protocol")
+### Model Context Protocol
 
 The [Model Context Protocol](https://modelcontextprotocol.io/introduction) is a standard proposed by Anthropic to unify prompts, context, and tool use. Continue supports any MCP server with the MCP context provider. Read their [quickstart](https://modelcontextprotocol.io/quickstart) to learn how to set up a local server and then set up your configuration like this:
 
@@ -410,7 +410,7 @@ config.json
 
 You'll then be able to type "@" and see "MCP" in the context providers dropdown.
 
-### `@Issue`[​](#issue "Direct link to issue")
+### `@Issue`
 
 Reference the conversation in a GitHub issue.
 
@@ -441,7 +441,7 @@ config.json
 
 Make sure to include your own [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) to avoid being rate-limited.
 
-### `@Database`[​](#database "Direct link to database")
+### `@Database`
 
 Reference table schemas from Sqlite, Postgres, MSSQL, and MySQL databases.
 
@@ -504,7 +504,7 @@ Available connection types:
 - `mysql`
 - `sqlite`
 
-### `@Postgres`[​](#postgres "Direct link to postgres")
+### `@Postgres`
 
 Reference the schema of a table, and some sample rows
 
@@ -544,7 +544,7 @@ By default, the `schema` filter is set to `public`, and the `sampleRows` is set 
 
 [Here is a short demo.](https://github.com/continuedev/continue/pull/859)
 
-### `@Google`[​](#google "Direct link to google")
+### `@Google`
 
 Reference the results of a Google search.
 
@@ -574,7 +574,7 @@ For example, type "@Google python tutorial" if you want to search and discuss wa
 
 Note: You can get an API key for free at [serper.dev](https://serper.dev).
 
-### `@Gitlab Merge Request`[​](#gitlab-merge-request "Direct link to gitlab-merge-request")
+### `@Gitlab Merge Request`
 
 Reference an open MR for this branch on GitLab.
 
@@ -595,7 +595,7 @@ config.json
 
 You will need to create a [personal access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) with the `read_api` scope.
 
-#### Using Self-Hosted GitLab[​](#using-self-hosted-gitlab "Direct link to Using Self-Hosted GitLab")
+#### Using Self-Hosted GitLab
 
 You can specify the domain to communicate with by setting the `domain` parameter in your configurtion. By default this is set to `gitlab.com`.
 
@@ -621,11 +621,11 @@ config.json
 }
 ```
 
-#### Filtering Comments[​](#filtering-comments "Direct link to Filtering Comments")
+#### Filtering Comments
 
 If you select some code to be edited, you can have the context provider filter out comments for other files. To enable this feature, set `filterComments` to `true`.
 
-### `@Jira`[​](#jira "Direct link to jira")
+### `@Jira`
 
 Reference the conversation in a Jira issue.
 
@@ -653,7 +653,7 @@ config.json
 
 Make sure to include your own [Atlassian API Token](https://id.atlassian.com/manage-profile/security/api-tokens), or use your `email` and `token`, with token set to your password for basic authentication. If you use your own Atlassian API Token, don't configure your email.
 
-#### Jira Datacenter Support[​](#jira-datacenter-support "Direct link to Jira Datacenter Support")
+#### Jira Datacenter Support
 
 This context provider supports both Jira API version 2 and 3. It will use version 3 by default since that's what the cloud version uses, but if you have the datacenter version of Jira, you'll need to set the API Version to 2 using the `apiVersion` property.
 
@@ -672,7 +672,7 @@ config.json
 { "contextProviders": [{ "name": "jira", "params": { "apiVersion": "2" } }] }
 ```
 
-#### Issue Query[​](#issue-query "Direct link to Issue Query")
+#### Issue Query
 
 By default, the following query will be used to find issues:
 
@@ -682,11 +682,11 @@ assignee = currentUser() AND resolution = Unresolved order by updated DESC
 
 You can override this query by setting the `issueQuery` parameter.
 
-#### Max results[​](#max-results "Direct link to Max results")
+#### Max results
 
 You can set the `maxResults` parameter to limit the number of results returned. The default is `50`.
 
-### `@Discord`[​](#discord "Direct link to discord")
+### `@Discord`
 
 Reference the messages in a Discord channel.
 
@@ -721,7 +721,7 @@ config.json
 
 Make sure to include your own [Bot Token](https://discord.com/developers/applications), and join it to your related server . If you want more granular control over which channels are searched, you can specify a list of channel IDs to search in. If you don't want to specify any channels, just include the guild id(Server ID) and all channels will be included. The provider only reads text channels.
 
-### `@HTTP`[​](#http "Direct link to http")
+### `@HTTP`
 
 The HttpContextProvider makes a POST request to the url passed in the configuration. The server must return 200 OK with a ContextItem object or an array of ContextItems.
 
@@ -760,7 +760,7 @@ Response
 [  {    "name": "",    "description": "",    "content": ""  }]// OR{  "name": "",  "description": "",  "content": ""}
 ```
 
-### `@Commits`[​](#commits "Direct link to commits")
+### `@Commits`
 
 Reference specific git commit metadata and diff or all of the recent commits.
 
@@ -785,7 +785,7 @@ config.json
 
 The depth is how many commits will be loaded into the submenu, defaults to 50. The LastXCommitsDepth is how many recent commits will be included, defaults to 10.
 
-### `@Greptile`[​](#greptile "Direct link to greptile")
+### `@Greptile`
 
 Query a [Greptile](https://www.greptile.com/) index of the current repo/branch.
 
@@ -811,6 +811,6 @@ config.json
 }
 ```
 
-### Requesting Context Providers[​](#requesting-context-providers "Direct link to Requesting Context Providers")
+### Requesting Context Providers
 
 Not seeing what you want? Create an issue [here](https://github.com/continuedev/continue/issues/new?assignees=TyDunn&labels=enhancement&projects=&template=feature-request-%F0%9F%92%AA.md&title=) to request a new Context Provider.

--- a/docs/customize/overview.mdx
+++ b/docs/customize/overview.mdx
@@ -3,43 +3,43 @@ title: "Overview"
 description: "Explore Continue's advanced capabilities for power users and complex development scenarios."
 ---
 
-## Context Providers[​](#context-providers "Direct link to Context Providers")
+## Context Providers
 
 Master how Continue understands your codebase with powerful context providers for code, documentation, and more.
 
 [Explore Context Providers →](/customize/custom-providers)
 
-## Context Integration[​](#context-integration "Direct link to Context Integration")
+## Context Integration
 
 Specialized context features for codebase understanding and documentation integration.
 
 [Browse Context Features →](/customization/overview#codebase-context)
 
-## Deep Dives[​](#deep-dives "Direct link to Deep Dives")
+## Deep Dives
 
 Detailed technical explanations of Continue's internal workings and advanced configuration options.
 
 [Read Deep Dives →](/customization/overview#configuration)
 
-## Model Providers[​](#model-providers "Direct link to Model Providers")
+## Model Providers
 
 Configure and optimize different AI model providers for your specific needs and infrastructure.
 
 [Configure Providers →](/customization/models#openai)
 
-## Model Roles[​](#model-roles "Direct link to Model Roles")
+## Model Roles
 
 Understand how different models can be assigned specific roles in your development workflow.
 
 [Learn Model Roles →](/customize/model-roles)
 
-## Reference[​](#reference "Direct link to Reference")
+## Reference
 
 Complete configuration reference and API documentation.
 
 [View Reference →](/reference)
 
-## Troubleshooting[​](#troubleshooting "Direct link to Troubleshooting")
+## Troubleshooting
 
 Solutions to common issues and debugging techniques.
 

--- a/docs/customize/telemetry.mdx
+++ b/docs/customize/telemetry.mdx
@@ -2,17 +2,17 @@
 title: "Telemetry"
 ---
 
-## Overview[​](#overview "Direct link to Overview")
+## Overview
 
 The open-source Continue Extensions collect and report **anonymous** usage information to help us improve our product. This data enables us to understand user interactions and optimize the user experience effectively. You can opt out of telemetry collection at any time if you prefer not to share your usage information.
 
 We utilize [Posthog](https://posthog.com/), an open-source platform for product analytics, to gather and store this data. For transparency, you can review the implementation code [here](https://github.com/continuedev/continue/blob/main/gui/src/hooks/CustomPostHogProvider.tsx) or read our [official privacy policy](https://continue.dev/privacy).
 
-## Tracking Policy[​](#tracking-policy "Direct link to Tracking Policy")
+## Tracking Policy
 
 All data collected by the open-source Continue extensions is anonymized and stripped of personally identifiable information (PII) before being sent to PostHog. We are committed to maintaining the privacy and security of your data.
 
-## What We Track[​](#what-we-track "Direct link to What We Track")
+## What We Track
 
 The following usage information is collected and reported:
 
@@ -22,7 +22,7 @@ The following usage information is collected and reported:
 - **System Information:** The name of your operating system (OS) and integrated development environment (IDE).
 - **Pageviews:** General pageview statistics.
 
-## How to Opt Out[​](#how-to-opt-out "Direct link to How to Opt Out")
+## How to Opt Out
 
 You can disable anonymous telemetry by visiting the [User Settings Page](/customize/settings) and toggling "Allow Anonymous Telemetry" off.
 

--- a/docs/features/agent/how-it-works.mdx
+++ b/docs/features/agent/how-it-works.mdx
@@ -3,7 +3,7 @@ title: "How Agent Works"
 description: "Agent offers the same functionality as Chat, while also including tools in the request to the model and an interface for handling tool calls and responses."
 ---
 
-## The tool handshake[​](#the-tool-handshake "Direct link to The tool handshake")
+## The tool handshake
 
 Tools provide a flexible, powerful way for models to interface with the external world. They are provided to the model as a JSON object with a name and an arguments schema. For example, a `read_file` tool with a `filepath` argument will give the model the ability to request the contents of a specific file.
 
@@ -21,7 +21,7 @@ The following handshake describes how Agent uses tools:
   request to the model.
 </Info>
 
-## Built-in tools[​](#built-in-tools "Direct link to Built-in tools")
+## Built-in tools
 
 Continue includes several built-in tools which provide the model access to IDE functionality:
 

--- a/docs/features/agent/quick-start.mdx
+++ b/docs/features/agent/quick-start.mdx
@@ -2,11 +2,11 @@
 title: "Quick Start"
 ---
 
-## How to use it[​](#how-to-use-it "Direct link to How to use it")
+## How to use it
 
 Agent equips the Chat model with the tools needed to handle a wide range of coding tasks, allowing the model to make decisions and save you the work of manually finding context and performing actions.
 
-### Use Agent[​](#use-agent "Direct link to Use Agent")
+### Use Agent
 
 You can switch to `Agent` in the mode selector below the chat input box.
 
@@ -18,11 +18,11 @@ You can switch to `Agent` in the mode selector below the chat input box.
   See [Model Blocks](/customization/models) for more information.
 </Info>
 
-### Chat with Agent[​](#chat-with-agent "Direct link to Chat with Agent")
+### Chat with Agent
 
 Agent lives within the same interface as [Chat](/features/chat/how-it-works), so the same [input](/features/chat/quick-start#1-start-a-conversation) is used to send messages and you can still use the same manual methods of providing context, such as [`@` context providers](/features/chat/quick-start#3-use--for-additional-context) or adding [highlighted code from the editor](/features/chat/quick-start#2-include-code-context).
 
-#### Use natural language[​](#use-natural-language "Direct link to Use natural language")
+#### Use natural language
 
 With Agent, you can provide natural language instruction and let the model do the work. As an example, you might say
 
@@ -30,7 +30,7 @@ With Agent, you can provide natural language instruction and let the model do th
 
 Agent will then decide which tools to use to get the job done.
 
-## Give Agent permission[​](#give-agent-permission "Direct link to Give Agent permission")
+## Give Agent permission
 
 By default, Agent will ask permission when it wants to use a tool. Click `Continue` to allow Agent mode to proceed with the tool call or `Cancel` to reject it.
 
@@ -38,7 +38,7 @@ By default, Agent will ask permission when it wants to use a tool. Click `Contin
 
 You can use tool policies to exclude or make usage automatic for specific tools. See [MCP Tools](/customization/mcp-tools) for more background.
 
-## View Tool Responses[​](#view-tool-responses "Direct link to View Tool Responses")
+## View Tool Responses
 
 Any data returned from a tool call is automatically fed back into the model as a context item. Most errors are also caught and returned, so that Agent mode can decide how to proceed.
 

--- a/docs/features/autocomplete/how-it-works.mdx
+++ b/docs/features/autocomplete/how-it-works.mdx
@@ -3,18 +3,18 @@ title: "How Autocomplete Works"
 description: "Autocomplete is a  that uses a combination of retrieval methods and response processing techniques. The system can be understood in roughly three parts."
 ---
 
-## Timing[​](#timing "Direct link to Timing")
+## Timing
 
 In order to display suggestions quickly, without sending too many requests, we do the following:
 
 - Debouncing: If you are typing quickly, we won't make a request on each keystroke. Instead, we wait until you have finished.
 - Caching: If your cursor is in a position that we've already generated a completion for, this completion is reused. For example, if you backspace, we'll be able to immediately show the suggestion you saw before.
 
-## Context[​](#context "Direct link to Context")
+## Context
 
 Continue uses a number of retrieval methods to find relevant snippets from your codebase to include in the prompt.
 
-## Filtering[​](#filtering "Direct link to Filtering")
+## Filtering
 
 Language models aren't perfect, but can be made much closer by adjusting their output. We do extensive post-processing on responses before displaying a suggestion, including:
 

--- a/docs/features/autocomplete/quick-start.mdx
+++ b/docs/features/autocomplete/quick-start.mdx
@@ -2,22 +2,22 @@
 title: "Quick Start"
 ---
 
-## How to use it[​](#how-to-use-it "Direct link to How to use it")
+## How to use it
 
 Autocomplete provides inline code suggestions as you type. To enable it, simply click the "Continue" button in the status bar at the bottom right of your IDE or ensure the "Enable Tab Autocomplete" option is checked in your IDE settings.
 
-### Accepting a full suggestion[​](#accepting-a-full-suggestion "Direct link to Accepting a full suggestion")
+### Accepting a full suggestion
 
 Accept a full suggestion by pressing `Tab`
 
-### Rejecting a full suggestion[​](#rejecting-a-full-suggestion "Direct link to Rejecting a full suggestion")
+### Rejecting a full suggestion
 
 Reject a full suggestion with `Esc`
 
-### Partially accepting a suggestion[​](#partially-accepting-a-suggestion "Direct link to Partially accepting a suggestion")
+### Partially accepting a suggestion
 
 For more granular control, use `cmd/ctrl` + `→` to accept parts of the suggestion word-by-word.
 
-### Forcing a suggestion (VS Code)[​](#forcing-a-suggestion-vs-code "Direct link to Forcing a suggestion (VS Code)")
+### Forcing a suggestion (VS Code)
 
 If you want to trigger a suggestion immediately without waiting, or if you've dismissed a suggestion and want a new one, you can force it by using the keyboard shortcut **`cmd/ctrl` + `alt` + `space`**.

--- a/docs/features/chat/how-it-works.mdx
+++ b/docs/features/chat/how-it-works.mdx
@@ -3,7 +3,7 @@ title: "How Chat Works"
 description: "Continue's Chat feature provides a conversational interface with AI models directly in your IDE sidebar."
 ---
 
-## Core Functionality[​](#core-functionality "Direct link to Core Functionality")
+## Core Functionality
 
 When you start a chat conversation, Continue:
 
@@ -12,22 +12,22 @@ When you start a chat conversation, Continue:
 3. **Sends to Model**: Prompts the configured AI model for a response
 4. **Streams Response**: Returns the AI response in real-time to the sidebar
 
-## Context Management[​](#context-management "Direct link to Context Management")
+## Context Management
 
-### Automatic Context[​](#automatic-context "Direct link to Automatic Context")
+### Automatic Context
 
 - Selected code in your editor
 - Current file context when relevant
 - Previous conversation history in the session
 
-### Manual Context[​](#manual-context "Direct link to Manual Context")
+### Manual Context
 
 - `@Codebase` - Search and include relevant code from your project
 - `@Docs` - Include documentation context
 - `@Files` - Reference specific files
 - Custom context providers
 
-## Response Handling[​](#response-handling "Direct link to Response Handling")
+## Response Handling
 
 Each code section in the AI response includes action buttons:
 
@@ -35,19 +35,19 @@ Each code section in the AI response includes action buttons:
 - **Insert at cursor** - Add code at cursor position
 - **Copy** - Copy code to clipboard
 
-## Session Management[​](#session-management "Direct link to Session Management")
+## Session Management
 
 - Use `Cmd/Ctrl + L` (VS Code) or `Cmd/Ctrl + J` (JetBrains) to start a new session
 - Clears all previous context for a fresh start
 - Helpful for switching between different tasks
 
-## Advanced Features[​](#advanced-features "Direct link to Advanced Features")
+## Advanced Features
 
-### Prompt Inspection[​](#prompt-inspection "Direct link to Prompt Inspection")
+### Prompt Inspection
 
 View the exact prompt sent to the AI model in the [prompt logs](/troubleshooting) for debugging and optimization.
 
-### Context Providers[​](#context-providers "Direct link to Context Providers")
+### Context Providers
 
 Learn more about how context providers work:
 

--- a/docs/features/chat/quick-start.mdx
+++ b/docs/features/chat/quick-start.mdx
@@ -4,9 +4,9 @@ title: "Quick Start"
 
 Chat makes it easy to ask for help from an AI without leaving your IDE. Get explanations, generate code, and iterate on solutions conversationally.
 
-## Basic Usage[​](#basic-usage "Direct link to Basic Usage")
+## Basic Usage
 
-### 1. Start a Conversation[​](#1-start-a-conversation "Direct link to 1. Start a Conversation")
+### 1. Start a Conversation
 
 Type your question or request in the chat input and press Enter.
 
@@ -16,7 +16,7 @@ Type your question or request in the chat input and press Enter.
 - "How do I handle errors in this code?"
 - "Generate a test for this component"
 
-### 2. Include Code Context[​](#2-include-code-context "Direct link to 2. Include Code Context")
+### 2. Include Code Context
 
 Select code in your editor, then use the keyboard shortcut to include it in your chat:
 
@@ -27,7 +27,7 @@ Press `Cmd/Ctrl + L` to send selected code to chat
 
 Press `Cmd/Ctrl + J` to send selected code to chat
 
-### 3. Use @ for Additional Context[​](#3-use--for-additional-context "Direct link to 3. Use @ for Additional Context")
+### 3. Use @ for Additional Context
 
 Type `@` to include specific context:
 
@@ -36,7 +36,7 @@ Type `@` to include specific context:
 - `@Files` - Reference specific files
 - `@Terminal` - Include terminal output
 
-## Working with Responses[​](#working-with-responses "Direct link to Working with Responses")
+## Working with Responses
 
 When the AI provides code in its response, you'll see action buttons:
 
@@ -44,13 +44,13 @@ When the AI provides code in its response, you'll see action buttons:
 - **Insert at cursor** - Add code at your cursor position
 - **Copy** - Copy code to clipboard
 
-## Pro Tips[​](#pro-tips "Direct link to Pro Tips")
+## Pro Tips
 
-### Start Fresh[​](#start-fresh "Direct link to Start Fresh")
+### Start Fresh
 
 Press `Cmd/Ctrl + L` (VS Code) or `Cmd/Ctrl + J` (JetBrains) in an empty chat to start a new session.
 
-### Be Specific[​](#be-specific "Direct link to Be Specific")
+### Be Specific
 
 Include details about:
 
@@ -58,7 +58,7 @@ Include details about:
 - Any constraints or requirements
 - Your preferred coding style or patterns
 
-### Iterate[​](#iterate "Direct link to Iterate")
+### Iterate
 
 If the first response isn't perfect:
 
@@ -66,21 +66,21 @@ If the first response isn't perfect:
 - Request modifications
 - Provide additional context
 
-## Common Use Cases[​](#common-use-cases "Direct link to Common Use Cases")
+## Common Use Cases
 
-### Code Explanation[​](#code-explanation "Direct link to Code Explanation")
+### Code Explanation
 
 Select confusing code and ask "What does this code do?"
 
-### Bug Fixing[​](#bug-fixing "Direct link to Bug Fixing")
+### Bug Fixing
 
 Include error messages and ask "How do I fix this error?"
 
-### Code Generation[​](#code-generation "Direct link to Code Generation")
+### Code Generation
 
 Describe what you want: "Create a React component that displays a user profile"
 
-### Refactoring[​](#refactoring "Direct link to Refactoring")
+### Refactoring
 
 Select code and ask "How can I make this more efficient?"
 

--- a/docs/features/edit/quick-start.mdx
+++ b/docs/features/edit/quick-start.mdx
@@ -2,7 +2,7 @@
 title: "Quick Start"
 ---
 
-## How to use it[​](#how-to-use-it "Direct link to How to use it")
+## How to use it
 
 Edit is a convenient way to make quick changes to specific code and files. Select code, describe your code changes, and a diff will be streamed inline to your file which you can accept or reject.
 
@@ -12,15 +12,15 @@ Edit is recommended for small, targeted changes, such as
 - Generating unit tests
 - Refactoring functions or methods
 
-## Highlight code and activate[​](#highlight-code-and-activate "Direct link to Highlight code and activate")
+## Highlight code and activate
 
 Highlight the block of code you would like to modify and press `cmd/ctrl` + `i` to active Edit mode. You can also enter Edit mode by pressing `cmd/ctrl` + `i` with no code highlighted, which will default to editing the current file.
 
-## Describe code changes[​](#describe-code-changes "Direct link to Describe code changes")
+## Describe code changes
 
 Describe the changes you would like the model to make to your highlighted code. For edits, a good prompt should be relatively short and concise. For longer, more complex tasks, we recommend using [Chat](/features/chat/quick-start).
 
-## Accept or reject changes[​](#accept-or-reject-changes "Direct link to Accept or reject changes")
+## Accept or reject changes
 
 Proposed changes appear as inline diffs within your highlighted text.
 
@@ -30,7 +30,7 @@ You can also accept or reject all changes at once using `cmd/ctrl` + `shift` + `
 
 If you want to request a new suggestion for the same highlighted code section, you can use `cmd/ctrl` + `i` to re-prompt the model.
 
-## VS Code[​](#vs-code "Direct link to VS Code")
+## VS Code
 
 In VS Code, Edit is implemented in the extension sidebar with a similar interface to [Chat](/features/chat/how-it-works), and you can also enter Edit mode by using the Mode Selector below the main Chat input to select `Edit`.
 
@@ -38,10 +38,10 @@ In VS Code, Edit is implemented in the extension sidebar with a similar interfac
 
 You can also reject and accept diffs using the `Reject All` and `Accept All` buttons that show up in the Chat when diffs are present (see examples below).
 
-### Adding Code to Edit[​](#adding-code-to-edit "Direct link to Adding Code to Edit")
+### Adding Code to Edit
 
 Along with adding highlighted code, you can also manually add files to edit using the `Add file` combobox or by clicking the dropdown and selecting `Add all open files` to add all files that are currently open in the editor.
 
-## Jetbrains[​](#jetbrains "Direct link to Jetbrains")
+## Jetbrains
 
 In Jetbrains, Edit is implemented as an inline popup. See the header GIF example.

--- a/docs/guides/build-your-own-context-provider.mdx
+++ b/docs/guides/build-your-own-context-provider.mdx
@@ -3,7 +3,7 @@ title: "Build Your Own Context Provider"
 description: "Continue offers several way to provide your custom context to the extension."
 ---
 
-## HTTP Context Provider[​](#http-context-provider "Direct link to HTTP Context Provider")
+## HTTP Context Provider
 
 Continue can retrieve context from a custom HTTP server that you create and serve. Add the `@HTTP` context provider to your configuration like this:
 
@@ -46,7 +46,7 @@ The `"options"` property can be used to send additional parameters to your endpo
   where possible.
 </Info>
 
-## Using CustomContextProvider[​](#using-customcontextprovider "Direct link to Using CustomContextProvider")
+## Using CustomContextProvider
 
 Custom context providers can be implemented in a `config.ts` placed in your Continue global directory (`~/.continue` for MacOS, `%USERPROFILE%/.continue` for Windows). You can implement the `CustomContextProvider` interface in your `config.ts`
 
@@ -76,7 +76,7 @@ export function modifyConfig(config: Config): Config {  if (!config.contextProvi
 
 This is automatically appended to your configuration.
 
-### Custom Context Providers with Submenu or Query[​](#custom-context-providers-with-submenu-or-query "Direct link to Custom Context Providers with Submenu or Query")
+### Custom Context Providers with Submenu or Query
 
 There are 3 types of context providers: "normal", "query", and "submenu". The "normal" type is the default, and is what we've seen so far.
 
@@ -97,13 +97,13 @@ The flow of information in the above example is as follows:
 3. The `id` of the chosen `ContextSubmenuItem` is passed to `getContextItems` as the `query` argument. In this case it is the filepath of the README.
 4. The `getContextItems` function can then use the `query` to retrieve the full contents of the README and format the content before returning the context item which will be included in the prompt.
 
-### Importing outside modules[​](#importing-outside-modules "Direct link to Importing outside modules")
+### Importing outside modules
 
 To include outside Node modules in your config.ts, run `npm install <module_name>` from the `~/.continue` directory, and then import them in config.ts.
 
 Continue will use [esbuild](https://esbuild.github.io/) to bundle your `config.ts` and any dependencies into a single Javascript file. The exact configuration used can be found [here](https://github.com/continuedev/continue/blob/5c9874400e223bbc9786a8823614a2e501fbdaf7/extensions/vscode/src/ideProtocol.ts#L45-L52).
 
-### `CustomContextProvider` Reference[​](#customcontextprovider-reference "Direct link to customcontextprovider-reference")
+### `CustomContextProvider` Reference
 
 - `title`: An identifier for the context provider
 
@@ -124,7 +124,7 @@ Continue will use [esbuild](https://esbuild.github.io/) to bundle your `config.t
 
 - `loadSubmenuItems` (optional): A function that returns a list of `ContextSubmenuItem`s to display in a submenu. It is given access to an `IDE`, the same that is passed to `getContextItems`. .
 
-## Extension API for VSCode[​](#extension-api-for-vscode "Direct link to Extension API for VSCode")
+## Extension API for VSCode
 
 Continue exposes an API for registering context providers from a 3rd party VSCode extension. This is useful if you have a VSCode extension that provides some additional context that you would like to use in Continue. To use this API, add the following to your `package.json`:
 

--- a/docs/guides/custom-code-rag.mdx
+++ b/docs/guides/custom-code-rag.mdx
@@ -3,17 +3,17 @@ title: "Custom code RAG"
 description: "While Continue comes with  out of the box, you might wish to set up your own vector database and build a custom retrieval-augmented generation (RAG) system. This can allow you to access code that is not available locally, to index code a single time across all users, or to include custom logic. In this guide, we'll walk you through the steps it takes to build this."
 ---
 
-## Step 1: Choose an embeddings model[​](#step-1-choose-an-embeddings-model "Direct link to Step 1: Choose an embeddings model")
+## Step 1: Choose an embeddings model
 
 If possible, we recommend using [`voyage-code-3`](https://docs.voyageai.com/docs/embeddings), which will give the most accurate answers of any existing embeddings model for code. You can obtain an API key [here](https://dash.voyageai.com/api-keys). Because their API is [OpenAI-compatible](https://docs.voyageai.com/reference/embeddings-api), you can use any OpenAI client by swapping out the URL.
 
-## Step 2: Choose a vector database[​](#step-2-choose-a-vector-database "Direct link to Step 2: Choose a vector database")
+## Step 2: Choose a vector database
 
 There are a number of available vector databases, but because most vector databases will be able to performantly handle large codebases, we would recommend choosing one for ease of setup and experimentation.
 
 [LanceDB](https://lancedb.github.io/lancedb/basic/) is a good choice for this because it can run in-memory with libraries for both Python and Node.js. This means that in the beginning you can focus on writing code rather than setting up infrastructure. If you have already chosen a vector database, then using this instead of LanceDB is also a fine choice.
 
-## Step 3: Choose a "chunking" strategy[​](#step-3-choose-a-chunking-strategy 'Direct link to Step 3: Choose a "chunking" strategy')
+## Step 3: Choose a "chunking" strategy
 
 Most embeddings models can only handle a limited amount of text at once. To get around this, we "chunk" our code into smaller pieces.
 
@@ -25,7 +25,7 @@ If you use `voyage-code-3`, it has a maximum context length of 16,000 tokens, wh
 
 As usual in this guide, we recommend starting with the strategy that gives 80% of the benefit with 20% of the effort.
 
-## Step 4: Put together an indexing script[​](#step-4-put-together-an-indexing-script "Direct link to Step 4: Put together an indexing script")
+## Step 4: Put together an indexing script
 
 Indexing, in which we will insert your code into the vector database in a retrievable format, happens in three steps:
 
@@ -48,7 +48,7 @@ from lancedb.pydantic import LanceModel, Vectorfrom lancedb.embeddings import ge
 
 Regardless of which database or model you have chosen, your script should iterate over all of the files that you wish to index, chunk them, generate embeddings for each chunk, and then insert all of the chunks into your vector database.
 
-## Step 5: Run your indexing script[​](#step-5-run-your-indexing-script "Direct link to Step 5: Run your indexing script")
+## Step 5: Run your indexing script
 
 <Check>
   In a perfect production version, you would want to build "automatic, incremental indexing", so that you whenever a file changes, that file and nothing else is automatically re-indexed. This has the benefits of perfectly up-to-date embeddings and lower cost.
@@ -61,7 +61,7 @@ At this point, you've written your indexing script and tested that you can make 
 
 In the beginning, you should probably run it by hand. Once you are confident that your custom RAG is providing value and is ready for the long-term, then you can set up a cron job to run it periodically. Because codebases are largely unchanged in short time frames, you won't want to re-index more than once a day. Once per week or month is probably even sufficient.
 
-## Step 6: Set up your server[​](#step-6-set-up-your-server "Direct link to Step 6: Set up your server")
+## Step 6: Set up your server
 
 In order for the Continue extension to access your custom RAG system, you'll need to set up a server. This server is responsible for recieving a query from the extension, querying the vector database, and returning the results in the format expected by Continue.
 
@@ -100,7 +100,7 @@ config.json
 }
 ```
 
-## Step 7 (Bonus): Set up reranking[​](#step-7-bonus-set-up-reranking "Direct link to Step 7 (Bonus): Set up reranking")
+## Step 7 (Bonus): Set up reranking
 
 If you'd like to improve the quality of your results, a great first step is to add reranking. This involves retrieving a larger initial pool of results from the vector database, and then using a reranking model to order them from most to least relevant. This works because the reranking model can perform a slightly more expensive calculation on the small set of top results, and so can give a more accurate ordering than similarity search, which has to search over all entries in the database.
 

--- a/docs/guides/how-to-self-host-a-model.mdx
+++ b/docs/guides/how-to-self-host-a-model.mdx
@@ -9,13 +9,13 @@ description: "You can deploy a model in your , , , , or  using:"
 - [Anyscale Private Endpoints](https://github.com/continuedev/deploy-os-code-llm#anyscale-private-endpoints) (OpenAI compatible API)
 - [Lambda](https://github.com/continuedev/deploy-os-code-llm#lambda)
 
-## Self-hosting an open-source model[​](#self-hosting-an-open-source-model "Direct link to Self-hosting an open-source model")
+## Self-hosting an open-source model
 
 For many cases, either Continue will have a built-in provider or the API you use will be OpenAI-compatible, in which case you can use the "openai" provider and change the "baseUrl" to point to the server.
 
 However, if neither of these are the case, you will need to wire up a new LLM object.
 
-## Authentication[​](#authentication "Direct link to Authentication")
+## Authentication
 
 Basic authentication can be done with any provider using the `apiKey` field:
 

--- a/docs/guides/llama3.1.mdx
+++ b/docs/guides/llama3.1.mdx
@@ -7,7 +7,7 @@ If you haven't already installed Continue, you can do that [here for VS Code](ht
 
 Below we share some of the easiest ways to get up and running, depending on your use-case.
 
-## Ollama[​](#ollama "Direct link to Ollama")
+## Ollama
 
 Ollama is the fastest way to get up and running with local language models. We recommend trying Llama 3.1 8b, which is impressive for its size and will perform well on most hardware.
 
@@ -34,7 +34,7 @@ config.json
 }
 ```
 
-## Groq[​](#groq "Direct link to Groq")
+## Groq
 
 <Info>
   Check if your chosen model is still supported by referring to the [model
@@ -71,7 +71,7 @@ config.json
 }
 ```
 
-## Together AI[​](#together-ai "Direct link to Together AI")
+## Together AI
 
 Together AI provides fast and reliable inference of open-source models. You'll be able to run the 405b model with good speed.
 
@@ -103,7 +103,7 @@ config.json
 }
 ```
 
-## Replicate[​](#replicate "Direct link to Replicate")
+## Replicate
 
 Replicate makes it easy to host and run open-source AI with an API.
 
@@ -134,7 +134,7 @@ config.json
 }
 ```
 
-## SambaNova[​](#sambanova "Direct link to SambaNova")
+## SambaNova
 
 SambaNova Cloud provides world record Llama3.1 70B/405B serving.
 
@@ -166,7 +166,7 @@ config.json
 }
 ```
 
-## Cerebras Inference[​](#cerebras-inference "Direct link to Cerebras Inference")
+## Cerebras Inference
 
 Cerebras Inference uses specialized silicon to provides fast inference for the Llama3.1 8B/70B.
 

--- a/docs/guides/ollama-guide.mdx
+++ b/docs/guides/ollama-guide.mdx
@@ -3,7 +3,7 @@ title: "Using Ollama with Continue: A Developer's Guide"
 description: "This comprehensive guide will walk you through setting up Ollama with Continue for powerful local AI development. Ollama allows you to run large language models locally on your machine, providing privacy, control, and offline capabilities for AI-assisted coding."
 ---
 
-## Prerequisites[​](#prerequisites "Direct link to Prerequisites")
+## Prerequisites
 
 Before getting started, ensure your system meets these requirements:
 
@@ -12,9 +12,9 @@ Before getting started, ensure your system meets these requirements:
 - Storage: At least 10GB free space
 - Continue extension installed
 
-## Installation Steps[​](#installation-steps "Direct link to Installation Steps")
+## Installation Steps
 
-### Step 1: Install Ollama[​](#step-1-install-ollama "Direct link to Step 1: Install Ollama")
+### Step 1: Install Ollama
 
 Choose the installation method for your operating system:
 
@@ -22,7 +22,7 @@ Choose the installation method for your operating system:
 # macOSbrew install ollama# Linuxcurl -fsSL https://ollama.ai/install.sh | sh# Windows# Download from ollama.ai
 ```
 
-### Step 2: Download Models[​](#step-2-download-models "Direct link to Step 2: Download Models")
+### Step 2: Download Models
 
 After installing Ollama, download the models you want to use. Here are some popular options:
 
@@ -30,11 +30,11 @@ After installing Ollama, download the models you want to use. Here are some popu
 # Popular models for developmentollama pull llama2ollama pull codellamaollama pull mistral
 ```
 
-## Configuration[​](#configuration "Direct link to Configuration")
+## Configuration
 
 Configure Continue to work with your local Ollama instance:
 
-### Continue Configuration[​](#continue-configuration "Direct link to Continue Configuration")
+### Continue Configuration
 
 ```json
 {
@@ -49,7 +49,7 @@ Configure Continue to work with your local Ollama instance:
 }
 ```
 
-### Advanced Settings[​](#advanced-settings "Direct link to Advanced Settings")
+### Advanced Settings
 
 For optimal performance, consider these advanced configuration options:
 
@@ -58,9 +58,9 @@ For optimal performance, consider these advanced configuration options:
 - Custom model parameters
 - Performance tuning
 
-## Best Practices[​](#best-practices "Direct link to Best Practices")
+## Best Practices
 
-### Model Selection[​](#model-selection "Direct link to Model Selection")
+### Model Selection
 
 Choose models based on your specific needs:
 
@@ -68,7 +68,7 @@ Choose models based on your specific needs:
 2. **Chat**: Llama2 or Mistral
 3. **Specialized Tasks**: Domain-specific models
 
-### Performance Optimization[​](#performance-optimization "Direct link to Performance Optimization")
+### Performance Optimization
 
 To get the best performance from Ollama:
 
@@ -77,25 +77,25 @@ To get the best performance from Ollama:
 - Use appropriate model sizes
 - Enable GPU acceleration when available
 
-## Troubleshooting[​](#troubleshooting "Direct link to Troubleshooting")
+## Troubleshooting
 
-### Common Issues[​](#common-issues "Direct link to Common Issues")
+### Common Issues
 
 Here are solutions to common problems you might encounter:
 
-#### Connection Problems[​](#connection-problems "Direct link to Connection Problems")
+#### Connection Problems
 
 - Check Ollama service status
 - Verify port availability
 - Review firewall settings
 
-#### Performance Issues[​](#performance-issues "Direct link to Performance Issues")
+#### Performance Issues
 
 - Insufficient RAM
 - Model too large for system
 - GPU compatibility
 
-### Solutions[​](#solutions "Direct link to Solutions")
+### Solutions
 
 Try these solutions in order:
 
@@ -104,15 +104,15 @@ Try these solutions in order:
 3. Update to latest version
 4. Check system requirements
 
-## Example Workflows[​](#example-workflows "Direct link to Example Workflows")
+## Example Workflows
 
-### Code Generation[​](#code-generation "Direct link to Code Generation")
+### Code Generation
 
 ```
 # Example: Generate a FastAPI endpointdef create_user_endpoint():    # Continue will help generate the implementation    pass
 ```
 
-### Code Review[​](#code-review "Direct link to Code Review")
+### Code Review
 
 Use Continue with Ollama to:
 
@@ -121,7 +121,7 @@ Use Continue with Ollama to:
 - Identify potential bugs
 - Generate documentation
 
-## Conclusion[​](#conclusion "Direct link to Conclusion")
+## Conclusion
 
 Ollama with Continue provides a powerful local development environment for AI-assisted coding. You now have complete control over your AI models, ensuring privacy and enabling offline development workflows.
 

--- a/docs/guides/overview.mdx
+++ b/docs/guides/overview.mdx
@@ -2,7 +2,7 @@
 title: "Overview"
 ---
 
-## Model & Setup Guides[​](#model--setup-guides "Direct link to Model & Setup Guides")
+## Model & Setup Guides
 
 - [Using Ollama with Continue](/guides/ollama-guide) - Local AI development with Ollama
 - [Setting up Codestral](/guides/set-up-codestral) - Configure Mistral's Codestral model
@@ -10,11 +10,11 @@ title: "Overview"
 - [Running Continue Without Internet](/guides/running-continue-without-internet) - Offline development setup
 - [Llama 3.1 Setup](/guides/llama3.1) - Getting started with Llama 3.1
 
-## Advanced Tutorials[​](#advanced-tutorials "Direct link to Advanced Tutorials")
+## Advanced Tutorials
 
 - [Build Your Own Context Provider](/guides/build-your-own-context-provider) - Create custom context providers
 - [Custom Code RAG](/guides/custom-code-rag) - Implement custom retrieval-augmented generation
 
-## Contributing[​](#contributing "Direct link to Contributing")
+## Contributing
 
 Have a guide idea or found an issue? We welcome contributions! Check our [GitHub repository](https://github.com/continuedev/continue) to get involved.

--- a/docs/hub/assistants/create-an-assistant.mdx
+++ b/docs/hub/assistants/create-an-assistant.mdx
@@ -2,7 +2,7 @@
 title: "Create an assistant"
 ---
 
-## Remix an assistant[​](#remix-an-assistant "Direct link to Remix an assistant")
+## Remix an assistant
 
 You should remix an assistant if you want to use it after some modifications.
 
@@ -17,7 +17,7 @@ Once here, you’ll be able to
 
 Clicking “Create assistant” will make this assistant available for use.
 
-## Create an assistant from scratch[​](#create-an-assistant-from-scratch "Direct link to Create an assistant from scratch")
+## Create an assistant from scratch
 
 To create an assistant from scratch, select “New assistant” in the top bar.
 

--- a/docs/hub/blocks/block-types.mdx
+++ b/docs/hub/blocks/block-types.mdx
@@ -2,43 +2,43 @@
 title: "Block Types"
 ---
 
-## Models[​](#models "Direct link to Models")
+## Models
 
 Models are blocks that let you specify Large Language Models (LLMs) and other deep learning models to be used for various roles in the open-source IDE extension like Chat, Autocomplete, Edit, Embed, Rerank, etc. You can explore available models on [the hub](https://hub.continue.dev/explore/models).
 
 Continue supports [many model providers](/customization/models#openai), including Anthropic, OpenAI, Gemini, Ollama, Amazon Bedrock, Azure, xAI, DeepSeek, and more. Models can have one or more of the following roles depending on its capabilities, including `chat`, `edit`, `apply`, `autocomplete`, `embed`, and `rerank`. Read more about roles [here](/customize/model-roles). View [`models`](/reference#models) in the YAML Reference for more details.
 
-## Context[​](#context "Direct link to Context")
+## Context
 
 Context blocks define a context provider which can be referenced in Chat with `@` to pull in data from external sources such as files and folders, a URL, Jira or Confluence, and GitHub issues, among others. [Explore context provider blocks](https://hub.continue.dev/explore/context) on the hub.
 
 Learn more about context providers [here](/reference#context), and check out [this guide](/guides/build-your-own-context-provider) to creating your own custom context provider. The `config.yaml` spec for context can be found [`here`](/reference#context).
 
-## Docs[​](#docs "Direct link to Docs")
+## Docs
 
 Docs are blocks that point to documentation sites, which will be indexed locally and then can be referenced as context using @Docs in Chat. [Explore docs](https://hub.continue.dev/explore/docs) on the hub.
 
 Learn more in the [@Docs deep dive](/customization/overview#documentation-context), and view [`docs`](/reference#docs) in the YAML Reference for more details.
 
-## MCP Servers[​](#mcp-servers "Direct link to MCP Servers")
+## MCP Servers
 
 Model Context Protocol (MCP) is a standard way of building and sharing tools for language models. MCP Servers can be defined in `mcpServers` blocks. [Explore MCP Servers](https://hub.continue.dev/explore/mcp) on the hub.
 
 Learn more in the [MCP deep dive](/customization/mcp-tools), and view [`mcpServers`](/reference#mcpservers) in the YAML Reference for more details.
 
-## Rules[​](#rules "Direct link to Rules")
+## Rules
 
 Rules blocks are instructions that your custom AI code assistant will always keep in mind - the contents of rules are inserted into the system message for all Chat requests. [Explore rules](https://hub.continue.dev/explore/rules) on the hub.
 
 Learn more in the [rules deep dive](/customization/rules), and view [`rules`](/reference#rules) in the YAML Reference for more details.
 
-## Prompts[​](#prompts "Direct link to Prompts")
+## Prompts
 
 Prompts blocks are pre-written, reusable prompts that can be referenced at any time during chat. They are especially useful as context for repetitive and/or complex tasks. [Explore prompts](https://hub.continue.dev/explore/prompts) on the hub.
 
 Prompt blocks have the same syntax as [prompt files](/customization/prompts). The `config.yaml` spec for `prompts` can be found [here](/reference#prompts).
 
-## Data[​](#data "Direct link to Data")
+## Data
 
 Data blocks allow you send your development data to custom destinations of your choice. Development data can be used for a variety of purposes, including analyzing usage, gathering insights, or fine-tuning models. You can read more about development data [here](/customize/overview#development-data). Explore data block examples [here](https://hub.continue.dev/explore/data).
 

--- a/docs/hub/blocks/bundles.mdx
+++ b/docs/hub/blocks/bundles.mdx
@@ -3,7 +3,7 @@ title: "Bundles"
 description: "Bundles are collections of blocks that are commonly used together. You can use them to add multiple building blocks to your custom AI code assistants at once. They are only a concept on , so they are not represented in ."
 ---
 
-## Use a bundle[​](#use-a-bundle "Direct link to Use a bundle")
+## Use a bundle
 
 Once you know which bundle you want to use, you’ll need to
 
@@ -14,7 +14,7 @@ Once you know which bundle you want to use, you’ll need to
 
 After this, you can then go to your IDE extension using the "Open VS Code" or "Open Jetbrains" buttons and begin using the new blocks.
 
-## Create a bundle[​](#create-a-bundle "Direct link to Create a bundle")
+## Create a bundle
 
 To create a bundle, click “New bundle” in the header.
 
@@ -28,6 +28,6 @@ Then, search blocks using the "Search blocks" input and add them to your bundle.
 
 Once you have added all the blocks you want in your bundle, click "Create Bundle" to save it and make it available for use.
 
-## Remix a bundle[​](#remix-a-bundle "Direct link to Remix a bundle")
+## Remix a bundle
 
 It is not currently possible to remix a bundle.

--- a/docs/hub/blocks/create-a-block.mdx
+++ b/docs/hub/blocks/create-a-block.mdx
@@ -2,7 +2,7 @@
 title: "Create a block"
 ---
 
-## Remix a block[​](#remix-a-block "Direct link to Remix a block")
+## Remix a block
 
 You should remix a block if you want to use it after some modifications.
 
@@ -12,7 +12,7 @@ By clicking the “remix” button, you’ll be taken to the “Create a remix�
 
 Once here, you’ll be able to 1) edit YAML configuration for the block and 2) change name, description, icon, etc. Clicking “Create block” will make this block available for use in an assistant.
 
-## Create a block from scratch[​](#create-a-block-from-scratch "Direct link to Create a block from scratch")
+## Create a block from scratch
 
 To create a block from scratch, you will need to click “New block” in the top bar.
 
@@ -22,6 +22,6 @@ After filling out information on the block, you will want to create a block foll
 
 ![New block page](/images/hub/blocks/images/block-new-page-2d7faf71739d0f062d555b5d7257fb56.png)
 
-### Block inputs[​](#block-inputs "Direct link to Block inputs")
+### Block inputs
 
 Blocks can receive values, including secrets, as inputs through templating. For values that the user of the block needs to set, you can use template variables (e.g. `${{ inputs.API_KEY}}`). Then, the user can set `API_KEY: ${{ secrets.MY_API_KEY }}` in the `with` clause of their assistant.

--- a/docs/hub/governance/pricing.mdx
+++ b/docs/hub/governance/pricing.mdx
@@ -2,30 +2,30 @@
 title: "Pricing"
 ---
 
-## Solo[​](#solo "Direct link to Solo")
+## Solo
 
 **Solo** is best suited for individuals and small teams with "single-player" problems.
 
 You can read more about what **Solo** includes [here](https://hub.continue.dev/pricing).
 
-## Teams[​](#teams "Direct link to Teams")
+## Teams
 
 **Teams** is best suited for growing teams with "multiplayer" problems.
 
 You can read more about what **Teams** includes [here](https://hub.continue.dev/pricing).
 
-## Enterprise[​](#enterprise "Direct link to Enterprise")
+## Enterprise
 
 **Enterprise** is best suited for large teams with enterprise-grade requirements.
 
 You can read more about what **Enterprise** includes [here](https://hub.continue.dev/pricing).
 
-## Models Add-On[​](#models-add-on "Direct link to Models Add-On")
+## Models Add-On
 
 The **Models Add-On** allows you to use a variety of frontier models for a flat monthly fee. It’s designed to cover the usage of most developers.
 
 You can read more about usage limits and what models are included [here](https://hub.continue.dev/pricing).
 
-### Free Trial[​](#free-trial "Direct link to Free Trial")
+### Free Trial
 
 To try out Continue, we offer a free trial of the **Models Add-On** that allows you to use 50 Chat requests and 2,000 autocomplete requests.

--- a/docs/hub/secrets/secret-types.mdx
+++ b/docs/hub/secrets/secret-types.mdx
@@ -3,13 +3,13 @@ title: "Secret Types"
 description: "The Continue Hub comes with secrets management built-in. Secrets are values such as API keys or endpoints that can be shared across assistants and within organizations."
 ---
 
-## User secrets[​](#user-secrets "Direct link to User secrets")
+## User secrets
 
 User secrets are defined by the user for themselves. This means that user secrets are available only to the user that created them. User secrets are assumed to be safe for the user to know, so they will be sent to the IDE extensions alongside the assistant `config.yaml`.
 
 This allows API requests to be made directly from the IDE extensions. You can use user secrets with [Solo](/hub/governance/pricing#solo), [Teams](/hub/governance/pricing#teams), and [Enterprise](/hub/governance/pricing#enterprise). User secrets can be managed [here](https://hub.continue.dev/settings/secrets) in the hub.
 
-## Org secrets[​](#org-secrets "Direct link to Org secrets")
+## Org secrets
 
 Org secrets are defined by admins for their organization. Org secrets are available to anyone in the organization to use with assistants in that organization. Org secrets are assumed to not be shareable with the user (e.g. you are a team lead who wants to give team members access to models without passing out API keys).
 

--- a/docs/hub/sharing.mdx
+++ b/docs/hub/sharing.mdx
@@ -3,25 +3,25 @@ title: "Sharing"
 description: "Connect with the Continue community to discover, share, and collaborate on AI development tools."
 ---
 
-## Community[​](#community "Direct link to Community")
+## Community
 
 Join thousands of developers using Continue. Share experiences, get help, and contribute to the ecosystem.
 
 [Join our Discord Community →](https://discord.gg/continue)
 
-## Publishing[​](#publishing "Direct link to Publishing")
+## Publishing
 
 Share your custom assistants, blocks, and configurations with the Continue community.
 
 [Visit the Hub →](https://hub.continue.dev)
 
-## Browse Assistants[​](#browse-assistants "Direct link to Browse Assistants")
+## Browse Assistants
 
 Explore assistants created by the community for specific use cases and workflows.
 
 [Browse Assistants →](https://hub.continue.dev)
 
-## Using Assistants[​](#using-assistants "Direct link to Using Assistants")
+## Using Assistants
 
 Learn how to discover, install, and use community-created assistants in your projects.
 

--- a/docs/hub/source-control.mdx
+++ b/docs/hub/source-control.mdx
@@ -3,21 +3,21 @@ title: "Source Control"
 description: "When managing your custom assistants within an organization, you might want to take advantage of your usual source control workflows. Continue makes this easy with a  that automatically syncs your YAML files with hub.continue.dev. We are also planning on adding automations for GitLab, BitBucket, Gitee, and others. If you are interested, please reach out to us on ."
 ---
 
-## Quickstart[​](#quickstart "Direct link to Quickstart")
+## Quickstart
 
 This quickstart uses a template repository, but you can also follow these steps 2-4 from an existing repository.
 
-### 1. Create a new repository from the template[​](#1-create-a-new-repository-from-the-template "Direct link to 1. Create a new repository from the template")
+### 1. Create a new repository from the template
 
 As shown in the image below, start by creating a new repository from [the template](https://github.com/continuedev/continue-hub-template). Click "Use Template" and then "Create a new repository".
 
 ![Use the template repository](/images/hub/images/template-repo-65ccd7537b6fba3bbb202ee3e83e1953.png)
 
-### 2. Obtain a deploy key[​](#2-obtain-a-deploy-key "Direct link to 2. Obtain a deploy key")
+### 2. Obtain a deploy key
 
 Deploy keys allow the GitHub Action to authenticate with hub.continue.dev. [Obtain your deploy key here](https://hub.continue.dev/settings/api-keys) and then [create a secret](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository) named `CONTINUE_API_KEY` in your GitHub repository.
 
-### 3. Configure the GitHub Action[​](#3-configure-the-github-action "Direct link to 3. Configure the GitHub Action")
+### 3. Configure the GitHub Action
 
 <Check>
   This step assumes you have already created an organization on
@@ -32,7 +32,7 @@ env:  OWNER_SLUG: my-org-slug # <-- TODO
 
 This is the only configuration necessary, but you can view the full list of options [here](https://github.com/continuedev/continue-publish-action/blob/main/README.md).
 
-### 4. Commit and push[​](#4-commit-and-push "Direct link to 4. Commit and push")
+### 4. Commit and push
 
 Add the [YAML for your assistants and blocks](/reference) to the appropriate directories:
 

--- a/docs/reference.mdx
+++ b/docs/reference.mdx
@@ -2,7 +2,7 @@
 title: "config.yaml Reference"
 ---
 
-## Introduction[​](#introduction "Direct link to Introduction")
+## Introduction
 
 Continue hub assistants are defined using the `config.yaml` specification. Assistants can be loaded from [the Hub](https://hub.continue.dev/explore/assistants) or locally
 
@@ -28,7 +28,7 @@ Examples of blocks and assistants can be found on the [Continue hub](https://hub
 
 Assistants can either explicitly define blocks - see [Properties](#properties) below - or import and configure existing hub blocks.
 
-### Using Blocks[​](#using-blocks "Direct link to Using Blocks")
+### Using Blocks
 
 Hub blocks and assistants are identified with a slug in the format `owner-slug/block-or-assistant-slug`, where an owner can be a user or organization (For example, if you want to use the [OpenAI 4o Model block](https://hub.continue.dev/openai/gpt-4o), your slug would be `openai/gpt-4o`). These blocks are pulled from [https://hub.continue.dev](https://hub.continue.dev).
 
@@ -45,7 +45,7 @@ models:
     provider: ollama
 ```
 
-### Local Blocks[​](#local-blocks "Direct link to Local Blocks")
+### Local Blocks
 
 It is also possible to define blocks locally in a `.continue` folder. This folder can be located at either the root of your workspace (these will automatically be applied to all assistants when you are in that workspace) or in your home directory at `~/.continue` (these will automatically be applied globally).
 
@@ -61,7 +61,7 @@ Blocks:
 - `.continue/models` - for models
 - `.continue/prompts` - for prompts
 - `.continue/context` - for context providers
-- `.continue/docs` - for docs
+- `.continue/docs` - for docs~~~~
 - `.continue/data` - for data
 - `.continue/mcpServers` - for MCP Servers
 
@@ -75,7 +75,7 @@ Local blocks utilizing mustache notation for secrets (`${{ secrets.SECRET_NAME }
 
 </Info>
 
-### Inputs[​](#inputs "Direct link to Inputs")
+### Inputs
 
 Blocks can be passed user inputs, including hub secrets and raw text values. To create a block that has an input, use mustache templating as follows:
 
@@ -106,7 +106,7 @@ models:
 
 Note that hub secrets can be passed as inputs, using a similar mustache format: `secrets.SECRET_NAME`.
 
-### Overrides[​](#overrides "Direct link to Overrides")
+### Overrides
 
 Block properties can be also be directly overriden using `override`. For example:
 
@@ -124,7 +124,7 @@ models:
         - chat
 ```
 
-## Properties[​](#properties "Direct link to Properties")
+## Properties
 
 Below are details for each property that can be set in `config.yaml`.
 
@@ -145,7 +145,7 @@ The top-level properties in the `config.yaml` configuration file are:
 
 ---
 
-### `name`[​](#name "Direct link to name")
+### `name`
 
 The `name` property specifies the name of your project or configuration.
 
@@ -157,17 +157,17 @@ name: MyProject
 
 ---
 
-### `version`[​](#version "Direct link to version")
+### `version`
 
 The `version` property specifies the version of your project or configuration.
 
-### `schema`[​](#schema "Direct link to schema")
+### `schema`
 
 The `schema` property specifies the schema version used for the `config.yaml`, e.g. `v1`
 
 ---
 
-### `models`[​](#models "Direct link to models")
+### `models`
 
 The `models` section defines the language models used in your configuration. Models are used for functionalities such as chat, editing, and summarizing.
 
@@ -190,13 +190,16 @@ The `models` section defines the language models used in your configuration. Mod
 - `promptTemplates`: Can be used to override the default prompt templates for different model roles. Valid values are `chat`, [`edit`](/customize/model-roles#edit-prompt-templating), [`apply`](/customize/model-roles#apply-prompt-templating) and [`autocomplete`](/customize/model-roles#autocomplete-prompt-templating). The `chat` property must be a valid template name, such as `llama3` or `anthropic`.
 
 - `chatOptions`: If the model includes role `chat`, these settings apply for Chat and Agent mode:
+
   - `baseSystemMessage`: Can be used to override the default system prompt for **Chat** mode.
 
 - `embedOptions`: If the model includes role `embed`, these settings apply for embeddings:
+
   - `maxChunkSize`: Maximum tokens per document chunk. Minimum is 128 tokens.
   - `maxBatchSize`: Maximum number of chunks per request. Minimum is 1 chunk.
 
 - `defaultCompletionOptions`: Default completion options for model settings.
+
   - `contextLength`: Maximum context length of the model, typically in tokens.
   - `maxTokens`: Maximum number of tokens to generate in a completion.
   - `temperature`: Controls the randomness of the completion. Values range from `0.0` (deterministic) to `1.0` (random).
@@ -207,6 +210,7 @@ The `models` section defines the language models used in your configuration. Mod
   - `reasoningBudgetTokens`: Budget tokens for thinking/reasoning in Anthropic Claude 3.7+ models.
 
 - `requestOptions`: HTTP request options specific to the model.
+
   - `timeout`: Timeout for each request to the language model.
 
   - `verifySsl`: Whether to verify SSL certificates for requests.
@@ -226,7 +230,7 @@ The `models` section defines the language models used in your configuration. Mod
     - `key`: Path to the client certificate key file.
     - `passphrase`: Optional passphrase for the client certificate key file.
 
-#### Example[​](#example "Direct link to Example")
+#### Example
 
 config.yaml
 
@@ -261,7 +265,7 @@ models:
 
 ---
 
-### `context`[​](#context "Direct link to context")
+### `context`
 
 The `context` section defines context providers, which supply additional information or context to the language models. Each context provider can be configured with specific parameters.
 
@@ -296,7 +300,7 @@ context:
 
 ---
 
-### `rules`[​](#rules "Direct link to rules")
+### `rules`
 
 List of rules that the LLM should follow. These are concatenated into the system message for all [Chat](/features/chat/quick-start), [Edit](/features/edit/quick-start), and [Agent](/features/agent/quick-start) requests. See the [rules deep dive](/customization/rules) for details.
 
@@ -326,7 +330,7 @@ rules:
 
 ---
 
-### `prompts`[​](#prompts "Direct link to prompts")
+### `prompts`
 
 A list of custom prompts that can be invoked from the chat window. Each prompt has a name, description, and the actual prompt text.
 
@@ -345,7 +349,7 @@ prompts:
 
 ---
 
-### `docs`[​](#docs "Direct link to docs")
+### `docs`
 
 List of documentation sites to index.
 
@@ -371,7 +375,7 @@ docs:
 
 ---
 
-### `mcpServers`[​](#mcpservers "Direct link to mcpservers")
+### `mcpServers`
 
 The [Model Context Protocol](https://modelcontextprotocol.io/introduction) is a standard proposed by Anthropic to unify prompts, context, and tool use. Continue supports any MCP server with the MCP context provider.
 
@@ -401,7 +405,7 @@ mcpServers:
       NODE_ENV: production
 ```
 
-### `data`[​](#data "Direct link to data")
+### `data`
 
 Destinations to which [development data](/customize/overview#development-data) will be sent.
 
@@ -410,6 +414,7 @@ Destinations to which [development data](/customize/overview#development-data) w
 - `name` (**required**): The display name of the data destination
 
 - `destination` (**required**): The destination/endpoint that will receive the data. Can be:
+
   - an HTTP endpoint that will receive a POST request with a JSON blob
   - a file URL to a directory in which events will be dumpted to `.jsonl` files
 
@@ -444,7 +449,7 @@ data:
 
 ---
 
-## Complete YAML Config Example[​](#complete-yaml-config-example "Direct link to Complete YAML Config Example")
+## Complete YAML Config Example
 
 Putting it all together, here's a complete example of a `config.yaml` configuration file:
 
@@ -521,7 +526,7 @@ data:
       - chatInteraction
 ```
 
-## Using YAML anchors to avoid config duplication[​](#using-yaml-anchors-to-avoid-config-duplication "Direct link to Using YAML anchors to avoid config duplication")
+## Using YAML anchors to avoid config duplication
 
 You can also use node anchors to avoid duplication of properties. To do so, adding the YAML version header `%YAML 1.1` is needed, here's an example of a `config.yaml` configuration file using anchors:
 

--- a/docs/reference/json-reference.mdx
+++ b/docs/reference/json-reference.mdx
@@ -12,7 +12,7 @@ Below are details for each property that can be set in `config.json`. The config
 
 **All properties at all levels are optional unless explicitly marked required**
 
-### `models`[​](#models "Direct link to models")
+### `models`
 
 Your **chat** models are defined here, which are used for [Chat](/features/chat/how-it-works), [Edit](/features/edit/how-it-works) and [VS Code actions](/customization/overview#vscode-actions).
 
@@ -79,7 +79,7 @@ config.json
 }
 ```
 
-### `tabAutocompleteModel`[​](#tabautocompletemodel "Direct link to tabautocompletemodel")
+### `tabAutocompleteModel`
 
 Specifies the model or models for tab autocompletion, defaulting to an Ollama instance. This property uses the same format as `models`. Can be an array of models or an object for one model.
 
@@ -97,7 +97,7 @@ config.json
 }
 ```
 
-### `tabAutocompleteOptions`[​](#tabautocompleteoptions "Direct link to tabautocompleteoptions")
+### `tabAutocompleteOptions`
 
 Specifies options for tab autocompletion behavior.
 
@@ -125,7 +125,7 @@ config.json
 }
 ```
 
-### `embeddingsProvider`[​](#embeddingsprovider "Direct link to embeddingsprovider")
+### `embeddingsProvider`
 
 Embeddings model settings - the model used for @Codebase and @docs.
 
@@ -160,7 +160,7 @@ config.json
 }
 ```
 
-### `completionOptions`[​](#completionoptions "Direct link to completionoptions")
+### `completionOptions`
 
 Parameters that control the behavior of text generation and completion settings. Top-level `completionOptions` apply to all models, _unless overridden at the model level_.
 
@@ -190,7 +190,7 @@ config.json
 { "completionOptions": { "stream": false, "temperature": 0.5 } }
 ```
 
-### `requestOptions`[​](#requestoptions "Direct link to requestoptions")
+### `requestOptions`
 
 Default HTTP request options that apply to all models and context providers, unless overridden at the model level.
 
@@ -223,7 +223,7 @@ config.json
 { "requestOptions": { "headers": { "X-Auth-Token": "xxx" } } }
 ```
 
-### `reranker`[​](#reranker "Direct link to reranker")
+### `reranker`
 
 Configuration for the reranker model used in response ranking.
 
@@ -249,7 +249,7 @@ config.json
 }
 ```
 
-### `docs`[​](#docs "Direct link to docs")
+### `docs`
 
 List of documentation sites to index.
 
@@ -270,7 +270,7 @@ config.json
 "docs": [    {    "title": "Continue",    "startUrl": "https://docs.continue.dev/intro",    "faviconUrl": "https://docs.continue.dev/favicon.ico",  }]
 ```
 
-### `slashCommands`[​](#slashcommands "Direct link to slashcommands")
+### `slashCommands`
 
 Custom commands initiated by typing "/" in the sidebar. Commands include predefined functionality or may be user-defined.
 
@@ -283,7 +283,7 @@ Custom commands initiated by typing "/" in the sidebar. Commands include predefi
 
 The following commands are built-in and can be added to `config.json` to make them visible:
 
-#### `/share`[​](#share "Direct link to share")
+#### `/share`
 
 Generate a shareable markdown transcript of your current chat history.
 
@@ -303,7 +303,7 @@ config.json
 
 Use the `outputDir` parameter to specify where you want to the markdown file to be saved.
 
-#### `/cmd`[​](#cmd "Direct link to cmd")
+#### `/cmd`
 
 Generate a shell command from natural language and (only in VS Code) automatically paste it into the terminal.
 
@@ -317,7 +317,7 @@ config.json
 }
 ```
 
-#### `/commit`[​](#commit "Direct link to commit")
+#### `/commit`
 
 Shows the LLM your current git diff and asks it to generate a commit message.
 
@@ -334,7 +334,7 @@ config.json
 }
 ```
 
-#### `/http`[​](#http "Direct link to http")
+#### `/http`
 
 Write a custom slash command at your own HTTP endpoint. Set 'url' in the params object for the endpoint you have setup. The endpoint should return a sequence of string updates, which will be streamed to the Continue sidebar. See our basic [FastAPI example](https://github.com/continuedev/continue/blob/74002369a5e435735b83278fb965e004ae38a97d/core/context/providers/context_provider_server.py#L34-L45) for reference.
 
@@ -352,7 +352,7 @@ config.json
 }
 ```
 
-#### `/issue`[​](#issue "Direct link to issue")
+#### `/issue`
 
 Describe the issue you'd like to generate, and Continue will turn into a well-formatted title and body, then give you a link to the draft so you can submit. Make sure to set the URL of the repository you want to generate issues for.
 
@@ -370,7 +370,7 @@ config.json
 }
 ```
 
-#### `/onboard`[​](#onboard "Direct link to onboard")
+#### `/onboard`
 
 The onboard slash command helps to familiarize yourself with a new project by analyzing the project structure, READMEs, and dependency files. It identifies key folders, explains their purpose, and highlights popular packages used. Additionally, it offers insights into the project's architecture.
 
@@ -401,7 +401,7 @@ config.json
 }
 ```
 
-### `customCommands`[​](#customcommands "Direct link to customcommands")
+### `customCommands`
 
 User-defined commands for prompt shortcuts in the sidebar, allowing quick access to common actions.
 
@@ -427,7 +427,7 @@ config.json
 }
 ```
 
-### `contextProviders`[​](#contextproviders "Direct link to contextproviders")
+### `contextProviders`
 
 List of the pre-defined context providers that will show up as options while typing in the chat, and their customization with `params`.
 
@@ -451,15 +451,15 @@ config.json
 }
 ```
 
-### `userToken`[​](#usertoken "Direct link to usertoken")
+### `userToken`
 
 An optional token that identifies the user, primarily for authenticated services.
 
-### `systemMessage`[​](#systemmessage "Direct link to systemmessage")
+### `systemMessage`
 
 Defines a system message that appears before every response from the language model, providing guidance or context.
 
-### `experimental`[​](#experimental "Direct link to experimental")
+### `experimental`
 
 Several experimental config parameters are available, as described below:
 
@@ -516,7 +516,7 @@ config.json
 }
 ```
 
-### Fully deprecated settings[​](#fully-deprecated-settings "Direct link to Fully deprecated settings")
+### Fully deprecated settings
 
 Some deprecated `config.json` settings are no longer stored in config and have been moved to be editable through the [User Settings Page](/customize/settings). If found in `config.json`, they will be auto-migrated to User Settings and removed from `config.json`.
 

--- a/docs/reference/yaml-migration.mdx
+++ b/docs/reference/yaml-migration.mdx
@@ -9,7 +9,7 @@ See also
 - [JSON Continue Config Reference](/reference)
 - [YAML Continue Config Reference](/reference)
 
-## Create YAML file[​](#create-yaml-file "Direct link to Create YAML file")
+## Create YAML file
 
 Create a `config.yaml` file in your Continue Global Directory (`~/.continue` on Mac, `%USERPROFILE%\.continue`) alongside your current `config.json` file. If a `config.yaml` file is present, it will be loaded instead of `config.json`.
 
@@ -21,7 +21,7 @@ config.yaml
 name: my-configurationversion: 0.0.1schema: v1
 ```
 
-### Models[​](#models "Direct link to Models")
+### Models
 
 Add all model configurations in `config.json`, including models in `models`, `tabAutocompleteModel`, `embeddingsProvider`, and `reranker`, to the `models` section of your new YAML config file. A new `roles` YAML field specifies which roles a model can be used for, with possible values `chat`, `autocomplete`, `embed`, `rerank`, `edit`, `apply`, `summarize`.
 
@@ -93,7 +93,7 @@ models:  - name: GPT-4    provider: openai    model: gpt-4    apiKey: <YOUR_OPEN
 
 Note that the `repoMapFileSelection` experimental model role has been deprecated and is only available in `config.json`.
 
-### Context Providers[​](#context-providers "Direct link to Context Providers")
+### Context Providers
 
 The JSON `contextProviders` field is replaced by the YAML `context` array.
 
@@ -122,7 +122,7 @@ config.yaml
 context:  - provider: docs  - provider: codebase    params:      nRetrieve: 30      nFinal: 3  - provider: diff
 ```
 
-### System Message[​](#system-message "Direct link to System Message")
+### System Message
 
 The `systemMessage` property has been replaced with a `rules` property that takes an array of strings.
 
@@ -142,7 +142,7 @@ config.yaml
 rules:  - Always give concise responses
 ```
 
-### Prompts[​](#prompts "Direct link to Prompts")
+### Prompts
 
 Rather than with `customCommands`, you can now use the `prompts` field to define custom prompts.
 
@@ -170,7 +170,7 @@ config.yaml
 prompts:  - name: check    description: Check for mistakes in my code    prompt: |      Please read the highlighted code and check for any mistakes. You should look for the following, and be extremely vigilant:        - Syntax errors        - Logic errors        - Security vulnerabilities        - Performance issues        - Anything else that looks wrong      Once you find an error, please explain it as clearly as possible, but without using extra words. For example, instead of saying 'I think there is a syntax error on line 5', you should say 'Syntax error on line 5'. Give your answer as one bullet point per mistake found.
 ```
 
-### Documentation[​](#documentation "Direct link to Documentation")
+### Documentation
 
 Documentation is largely the same, but the `title` property has been replaced with `name`. The `startUrl`, `rootUrl`, and `faviconUrl` properties remain.
 
@@ -195,7 +195,7 @@ config.yaml
 docs:  - name: nest.js    startUrl: https://docs.nestjs.com/  - name: My site    startUrl: https://mysite.com/docs/
 ```
 
-### MCP Servers[​](#mcp-servers "Direct link to MCP Servers")
+### MCP Servers
 
 **Properties:**
 
@@ -236,7 +236,7 @@ mcpServers:  - name: My MCP Server    command: uvx    args:      - mcp-server-sq
 
 ---
 
-## Deprecated configuration options[​](#deprecated-configuration-options "Direct link to Deprecated configuration options")
+## Deprecated configuration options
 
 Some deprecated `config.json` settings are no longer stored in config and have been moved to be editable through the [User Settings Page](/customize/settings) (Gear Icon). If found in `config.json`, they will be auto-migrated to User Settings and removed from `config.json`.
 
@@ -267,6 +267,6 @@ The following top-level fields from `config.json` have been deprecated. Most UI-
 - `experimental`
 - `userToken`
 
-## New Configuration options[​](#new-configuration-options "Direct link to New Configuration options")
+## New Configuration options
 
 The YAML configuration format offers new configuration options not available in the JSON format. See the [YAML Config Reference](/reference) for more information.

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -8,13 +8,13 @@ title: "Troubleshooting"
 4. [Resolve keyboard shortcut issues](#keyboard-shortcuts-not-resolving)
 5. [Check FAQs for common issues](#faqs)
 
-## Check the logs[​](#check-the-logs "Direct link to Check the logs")
+## Check the logs
 
 To solve many problems, the first step is reading the logs to find the relevant error message. To do this, follow these steps:
 
-### VS Code[​](#vs-code "Direct link to VS Code")
+### VS Code
 
-#### Console logs[​](#console-logs "Direct link to Console logs")
+#### Console logs
 
 <Info>
   In order to view debug logs, which contain extra information, click the
@@ -28,7 +28,7 @@ To solve many problems, the first step is reading the logs to find the relevant 
 4. Select the `Console` tab
 5. Read the console logs
 
-#### Prompt Logs (Continue Console)[​](#prompt-logs-continue-console "Direct link to Prompt Logs (Continue Console)")
+#### Prompt Logs (Continue Console)
 
 To view prompt logs/analytics, you can enable the Continue Console.
 
@@ -39,21 +39,21 @@ To view prompt logs/analytics, you can enable the Continue Console.
 
 ![Continue Console](/images/images/continue-console-d387a10c2918c117c6c253a3b5f18c22.png)
 
-### JetBrains[​](#jetbrains "Direct link to JetBrains")
+### JetBrains
 
 Open `~/.continue/logs/core.log` to view the logs for the Continue plugin. The most recent logs are found at the bottom of the file.
 
 Some JetBrains-related logs may also be found by clicking "Help" > "Show Log in Explorer/Finder".
 
-## Download the latest pre-release[​](#download-the-latest-pre-release "Direct link to Download the latest pre-release")
+## Download the latest pre-release
 
-### VS Code[​](#vs-code-1 "Direct link to VS Code")
+### VS Code
 
 We are constantly making fixes and improvements to Continue, but the latest changes remain in a "pre-release" version for roughly a week so that we can test their stability. If you are experiencing issues, you can try the pre-release by going to the Continue extension page in VS Code and selecting "Switch to Pre-Release" as shown below.
 
 ![Pre-Release](/images/images/prerelease-9bed93e846914165d30a3b227a680d9b.png)
 
-### JetBrains[​](#jetbrains-1 "Direct link to JetBrains")
+### JetBrains
 
 On JetBrains, the "pre-release" happens through their Early Access Program (EAP) channel. To download the latest EAP version, enable the EAP channel:
 
@@ -63,7 +63,7 @@ On JetBrains, the "pre-release" happens through their Early Access Program (EAP)
 4. Add "[https://plugins.jetbrains.com/plugins/eap/list](https://plugins.jetbrains.com/plugins/eap/list)" to the list
 5. You'll now always be able to download the latest EAP version from the marketplace
 
-## Download an Older Version[​](#download-an-older-version "Direct link to Download an Older Version")
+## Download an Older Version
 
 If you've tried everything, reported an error, know that a previous version was working for you, and are waiting to hear back, you can try downloading an older version of the extension.
 
@@ -71,18 +71,18 @@ For VS Code, All versions are hosted on the Open VSX Registry [here](https://ope
 
 You can find older versions of the JetBrains extension on their [marketplace](https://plugins.jetbrains.com/plugin/22707-continue), which will walk you through installing from disk.
 
-## Keyboard shortcuts not resolving[​](#keyboard-shortcuts-not-resolving "Direct link to Keyboard shortcuts not resolving")
+## Keyboard shortcuts not resolving
 
 If your keyboard shortcuts are not resolving, you may have other commands that are taking precedence over the Continue shortcuts. You can see if this is the case, and change your shortcut mappings, in the configuration of your IDE.
 
 - [VSCode keyboard shortcuts docs](https://code.visualstudio.com/docs/getstarted/keybindings)
 - [IntelliJ keyboard shortcut docs](https://www.jetbrains.com/help/idea/configuring-keyboard-and-mouse-shortcuts.html)
 
-## FAQs[​](#faqs "Direct link to FAQs")
+## FAQs
 
-### Networking Issues[​](#networking-issues "Direct link to Networking Issues")
+### Networking Issues
 
-#### Configure Certificates[​](#configure-certificates "Direct link to Configure Certificates")
+#### Configure Certificates
 
 If you're seeing a `fetch failed` error and your network requires custom certificates, you will need to configure them in your config file. In each of the objects in the `"models"` array, add `requestOptions.caBundlePath` like this:
 
@@ -105,37 +105,37 @@ You may also set `requestOptions.caBundlePath` to an array of paths to multiple 
 
 **_Windows VS Code Users_**: Installing the [win-ca](https://marketplace.visualstudio.com/items?itemName=ukoloff.win-ca) extension should also correct this issue.
 
-#### VS Code Proxy Settings[​](#vs-code-proxy-settings "Direct link to VS Code Proxy Settings")
+#### VS Code Proxy Settings
 
 If you are using VS Code and require requests to be made through a proxy, you are likely already set up through VS Code's [Proxy Server Support](https://code.visualstudio.com/docs/setup/network#_proxy-server-support). To double-check that this is enabled, use `cmd/ctrl` + `,` to open settings and search for "Proxy Support". Unless it is set to "off", then VS Code is responsible for making the request to the proxy.
 
-#### code-server[​](#code-server "Direct link to code-server")
+#### code-server
 
 Continue can be used in [code-server](https://coder.com/), but if you are running across an error in the logs that includes "This is likely because the editor is not running in a secure context", please see [their documentation on securely exposing code-server](https://coder.com/docs/code-server/latest/guide#expose-code-server).
 
-### I installed Continue, but don't see the sidebar window[​](#i-installed-continue-but-dont-see-the-sidebar-window "Direct link to I installed Continue, but don't see the sidebar window")
+### I installed Continue, but don't see the sidebar window
 
 By default the Continue window is on the left side of VS Code, but it can be dragged to right side as well, which we recommend in our tutorial. In the situation where you have previously installed Continue and moved it to the right side, it may still be there. You can reveal Continue either by using cmd/ctrl+L or by clicking the button in the top right of VS Code to open the right sidebar.
 
-### I'm getting a 404 error from OpenAI[​](#im-getting-a-404-error-from-openai "Direct link to I'm getting a 404 error from OpenAI")
+### I'm getting a 404 error from OpenAI
 
 If you have entered a valid API key and model, but are still getting a 404 error from OpenAI, this may be because you need to add credits to your billing account. You can do so from the [billing console](https://platform.openai.com/settings/organization/billing/overview). If you just want to check that this is in fact the cause of the error, you can try adding $1 to your account and checking whether the error persists.
 
-### I'm getting a 404 error from OpenRouter[​](#im-getting-a-404-error-from-openrouter "Direct link to I'm getting a 404 error from OpenRouter")
+### I'm getting a 404 error from OpenRouter
 
 If you have entered a valid API key and model, but are still getting a 404 error from OpenRouter, this may be because models that do not support function calling will return an error to Continue when a request is sent. Example error: `HTTP 404 Not Found from https://openrouter.ai/api/v1/chat/completions`
 
-### Indexing issues[​](#indexing-issues "Direct link to Indexing issues")
+### Indexing issues
 
 If you are having persistent errors with indexing, our recommendation is to rebuild your index from scratch. Note that for large codebases this may take some time.
 
 This can be accomplished using the following command: `Continue: Rebuild codebase index`.
 
-### Android Studio - "Nothing to show" in Chat[​](#android-studio---nothing-to-show-in-chat 'Direct link to Android Studio - "Nothing to show" in Chat')
+### Android Studio - "Nothing to show" in Chat
 
 This can be fixed by selecting `Actions > Choose Boot runtime for the IDE` then selecting the latest version, and then restarting Android Studio. [See this thread](https://github.com/continuedev/continue/issues/596#issuecomment-1789327178) for details.
 
-### I received a "Codebase indexing disabled - Your Linux system lacks required CPU features (AVX2, FMA)" notification[​](#i-received-a-codebase-indexing-disabled---your-linux-system-lacks-required-cpu-features-avx2-fma-notification 'Direct link to I received a "Codebase indexing disabled - Your Linux system lacks required CPU features (AVX2, FMA)" notification')
+### I received a "Codebase indexing disabled - Your Linux system lacks required CPU features (AVX2, FMA)" notification
 
 We use LanceDB as our vector database for codebase search features. On x64 Linux systems, LanceDB requires specific CPU features (FMA and AVX2) which may not be available on older processors.
 
@@ -143,12 +143,12 @@ Most Continue features will work normally, including autocomplete and chat. Howe
 
 For more details about this requirement, see the [LanceDB issue #2195](https://github.com/lancedb/lance/issues/2195).
 
-### How do I reset the state of the extension?[​](#how-do-i-reset-the-state-of-the-extension "Direct link to How do I reset the state of the extension?")
+### How do I reset the state of the extension?
 
 Continue stores it's data in the `~/.continue` directory (%USERPROFILE%.continue\` on Windows).
 
 If you'd like to perform a clean reset of the extension, including removing all configuration files, indices, etc, you can remove this directory, uninstall, and then reinstall.
 
-## Still having trouble?[​](#still-having-trouble "Direct link to Still having trouble?")
+## Still having trouble?
 
 You can also join our Discord community [here](https://discord.gg/vapESyrFmJ) for additional support and discussions. Alternatively, you can create a GitHub issue [here](https://github.com/continuedev/continue/issues/new?assignees=&labels=bug&projects=&template=bug-report-%F0%9F%90%9B.md&title=), providing details of your problem, and we'll be able to help you out more quickly.


### PR DESCRIPTION
## Description
Removed unnecessary anchor tags from documentation headings. This was causing `%E2%80%8B` to be appended to all anchor tag URLs when clicking on them in the UI, e.g. https://docs.continue.dev/customize/custom-providers#%40file%E2%80%8B

