### PR TITLE
fix: sqlite migrations should ran after the table is created

### DIFF
--- a/core/indexing/docs/DocsService.ts
+++ b/core/indexing/docs/DocsService.ts
@@ -968,7 +968,6 @@ export default class DocsService {
 
       await db.exec("PRAGMA busy_timeout = 3000;");
 
-      await runSqliteMigrations(db);
       // First create the table if it doesn't exist
       await db.exec(`CREATE TABLE IF NOT EXISTS ${DocsService.sqlitebTableName} (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -977,6 +976,8 @@ export default class DocsService {
             favicon STRING,
             embeddingsProviderId STRING
         )`);
+
+      await runSqliteMigrations(db);
 
       this.sqliteDb = db;
     }


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
