### PR TITLE
Feat-collapsed-terminal

### DIFF
--- a/gui/src/pages/gui/ToolCallDiv/IndicatorBar.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/IndicatorBar.tsx
@@ -1,0 +1,29 @@
+import { ChevronDownIcon } from "@heroicons/react/24/outline";
+
+interface IndicatorBarProps {
+  text: string;
+  isExpanded: boolean;
+}
+
+export function IndicatorBar({ 
+  text,
+  isExpanded
+}: IndicatorBarProps) {
+  return (
+    <div className="absolute top-0 left-0 right-0 flex items-start justify-center pt-1 h-8 z-10">
+      <div 
+        className="flex items-center gap-2 rounded px-2 py-1 shadow-sm text-[11px]"
+        style={{
+          backgroundColor: 'var(--vscode-editor-background, #1e1e1e)',
+          border: '1px solid var(--vscode-widget-border, #454545)',
+          color: 'var(--vscode-descriptionForeground, #cccccc88)'
+        }}
+      >
+        <span>{text}</span>
+        <ChevronDownIcon 
+          className={`h-3 w-3 text-gray-500 ${isExpanded ? '' : 'rotate-180'}`} 
+        />
+      </div>
+    </div>
+  );
+}

--- a/gui/src/pages/gui/ToolCallDiv/TerminalCollapsibleContainer.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/TerminalCollapsibleContainer.tsx
@@ -1,0 +1,123 @@
+import { ChevronDownIcon } from "@heroicons/react/24/outline";
+import { useState } from "react";
+import { defaultBorderRadius } from "../../../components";
+
+interface TerminalCollapsibleContainerProps {
+  collapsedContent: React.ReactNode;
+  expandedContent: React.ReactNode;
+  className?: string;
+  collapsible?: boolean;
+  hiddenLinesCount?: number;
+}
+
+export function TerminalCollapsibleContainer({
+  collapsedContent,
+  expandedContent,
+  className = "",
+  collapsible = false,
+  hiddenLinesCount = 0,
+}: TerminalCollapsibleContainerProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  if (!collapsible) {
+    return <div className={className}>{collapsedContent}</div>;
+  }
+
+  return (
+    <div className={`relative ${className}`}>
+      {/* Collapsed State - Top indicator bar */}
+      {!isExpanded && hiddenLinesCount > 0 && (
+        <div
+          className="absolute top-0 left-0 right-0 flex items-start justify-center pt-1"
+          style={{
+            height: '32px',
+            zIndex: 10
+          }}
+        >
+          <div
+            className="flex items-center gap-2 rounded px-2 py-1 text-xs shadow-sm"
+            style={{
+              backgroundColor: 'var(--vscode-editor-background, #1e1e1e)',
+              border: '1px solid var(--vscode-widget-border, #454545)',
+              fontSize: '11px'
+            }}
+          >
+            <span style={{ color: 'var(--vscode-descriptionForeground, #cccccc88)' }}>
+              +{hiddenLinesCount} more lines
+            </span>
+            <ChevronDownIcon className="h-3 w-3" style={{ transform: 'rotate(180deg)', color: '#888888' }} />
+          </div>
+        </div>
+      )}
+
+      {/* Expanded State - Top indicator bar */}
+      {isExpanded && collapsible && (
+        <div
+          className="absolute top-0 left-0 right-0 flex items-start justify-center pt-1"
+          style={{
+            height: '32px',
+            zIndex: 10
+          }}
+        >
+          <div
+            className="flex items-center gap-2 rounded px-2 py-1 text-xs shadow-sm"
+            style={{
+              backgroundColor: 'var(--vscode-editor-background, #1e1e1e)',
+              border: '1px solid var(--vscode-widget-border, #454545)',
+              fontSize: '11px'
+            }}
+          >
+            <span style={{ color: 'var(--vscode-descriptionForeground, #cccccc88)' }}>
+              Collapse
+            </span>
+            <ChevronDownIcon className="h-3 w-3" style={{ color: '#888888' }} />
+          </div>
+        </div>
+      )}
+
+      {/* Clickable overlay covering the entire content area */}
+      {collapsible && (
+        <div
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setIsExpanded(!isExpanded);
+          }}
+          className="absolute inset-0 cursor-pointer"
+          style={{
+            zIndex: 20
+          }}
+        />
+      )}
+
+      {/* Content container with proper constraint for gradient */}
+      <div
+        className={`relative ${collapsible ? 'cursor-pointer' : ''}`}
+        style={{
+          borderRadius: defaultBorderRadius,
+          overflow: 'hidden'
+        }}
+      >
+        {/* Gradient overlay on top of content - only when collapsed */}
+        {!isExpanded && hiddenLinesCount > 0 && (
+          <div
+            className="absolute pointer-events-none"
+            style={{
+              top: '16px', // Move further down from the top
+              left: '9px', // 1px border + 8px padding from Ansi pre element
+              right: '9px', // 1px border + 8px padding from Ansi pre element
+              height: '100px',
+              background: 'linear-gradient(to bottom, var(--vscode-editor-background, #1e1e1e), transparent)',
+              borderTopLeftRadius: 'calc(' + defaultBorderRadius + ' - 1px)', // Slightly smaller radius to fit inside border
+              borderTopRightRadius: 'calc(' + defaultBorderRadius + ' - 1px)',
+              zIndex: 5
+            }}
+          />
+        )}
+
+        {isExpanded ? expandedContent : collapsedContent}
+      </div>
+
+    </div>
+  );
+}

--- a/gui/src/pages/gui/ToolCallDiv/TerminalCollapsibleContainer.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/TerminalCollapsibleContainer.tsx
@@ -1,6 +1,6 @@
-import { ChevronDownIcon } from "@heroicons/react/24/outline";
 import { useState } from "react";
 import { defaultBorderRadius } from "../../../components";
+import { IndicatorBar } from "./IndicatorBar";
 
 interface TerminalCollapsibleContainerProps {
   collapsedContent: React.ReactNode;
@@ -25,54 +25,12 @@ export function TerminalCollapsibleContainer({
 
   return (
     <div className={`relative ${className}`}>
-      {/* Collapsed State - Top indicator bar */}
-      {!isExpanded && hiddenLinesCount > 0 && (
-        <div
-          className="absolute top-0 left-0 right-0 flex items-start justify-center pt-1"
-          style={{
-            height: '32px',
-            zIndex: 10
-          }}
-        >
-          <div
-            className="flex items-center gap-2 rounded px-2 py-1 text-xs shadow-sm"
-            style={{
-              backgroundColor: 'var(--vscode-editor-background, #1e1e1e)',
-              border: '1px solid var(--vscode-widget-border, #454545)',
-              fontSize: '11px'
-            }}
-          >
-            <span style={{ color: 'var(--vscode-descriptionForeground, #cccccc88)' }}>
-              +{hiddenLinesCount} more lines
-            </span>
-            <ChevronDownIcon className="h-3 w-3" style={{ transform: 'rotate(180deg)', color: '#888888' }} />
-          </div>
-        </div>
-      )}
-
-      {/* Expanded State - Top indicator bar */}
-      {isExpanded && collapsible && (
-        <div
-          className="absolute top-0 left-0 right-0 flex items-start justify-center pt-1"
-          style={{
-            height: '32px',
-            zIndex: 10
-          }}
-        >
-          <div
-            className="flex items-center gap-2 rounded px-2 py-1 text-xs shadow-sm"
-            style={{
-              backgroundColor: 'var(--vscode-editor-background, #1e1e1e)',
-              border: '1px solid var(--vscode-widget-border, #454545)',
-              fontSize: '11px'
-            }}
-          >
-            <span style={{ color: 'var(--vscode-descriptionForeground, #cccccc88)' }}>
-              Collapse
-            </span>
-            <ChevronDownIcon className="h-3 w-3" style={{ color: '#888888' }} />
-          </div>
-        </div>
+      {/* Indicator bar - shows for both collapsed and expanded states */}
+      {((!isExpanded && hiddenLinesCount > 0) || (isExpanded && collapsible)) && (
+        <IndicatorBar 
+          text={isExpanded ? 'Collapse' : `+${hiddenLinesCount} more lines`}
+          isExpanded={isExpanded}
+        />
       )}
 
       {/* Clickable overlay covering the entire content area */}
@@ -83,34 +41,23 @@ export function TerminalCollapsibleContainer({
             e.stopPropagation();
             setIsExpanded(!isExpanded);
           }}
-          className="absolute inset-0 cursor-pointer"
-          style={{
-            zIndex: 20
-          }}
+          className="absolute inset-0 cursor-pointer z-20"
         />
       )}
 
       {/* Content container with proper constraint for gradient */}
       <div
-        className={`relative ${collapsible ? 'cursor-pointer' : ''}`}
-        style={{
-          borderRadius: defaultBorderRadius,
-          overflow: 'hidden'
-        }}
+        className={`relative overflow-hidden ${collapsible ? 'cursor-pointer' : ''}`}
+        style={{ borderRadius: defaultBorderRadius }}
       >
         {/* Gradient overlay on top of content - only when collapsed */}
         {!isExpanded && hiddenLinesCount > 0 && (
           <div
-            className="absolute pointer-events-none"
+            className="absolute pointer-events-none top-4 left-[9px] right-[9px] h-[100px] z-[5]"
             style={{
-              top: '16px', // Move further down from the top
-              left: '9px', // 1px border + 8px padding from Ansi pre element
-              right: '9px', // 1px border + 8px padding from Ansi pre element
-              height: '100px',
               background: 'linear-gradient(to bottom, var(--vscode-editor-background, #1e1e1e), transparent)',
-              borderTopLeftRadius: 'calc(' + defaultBorderRadius + ' - 1px)', // Slightly smaller radius to fit inside border
-              borderTopRightRadius: 'calc(' + defaultBorderRadius + ' - 1px)',
-              zIndex: 5
+              borderTopLeftRadius: `calc(${defaultBorderRadius} - 1px)`,
+              borderTopRightRadius: `calc(${defaultBorderRadius} - 1px)`
             }}
           />
         )}


### PR DESCRIPTION
## Description

When the terminal streams a large amount of output the chat window can get overwhelmed with content making scrolling difficult. This change automatically collapses the terminal output display when 20 lines are displayed. The collapsed view can easily be expanded and then collapsed by clicking in the component. This makes it easy to expand it, review the content and then click it to collapse it regardless of how far you have scrolled.

The top of the component when collapsed shows how many lines are above the fold, and I've added a blur to indicate content above is hidden.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

No new tests have been added. Visual inspection and manual testing perfored using the sandbox and running a variety of commends including jest tests, and long running terminal commands including echos in loops.