### PR TITLE
fix: fix tool call for qwen3-ollama

### DIFF
--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -423,6 +423,8 @@ export const sessionSlice = createSlice({
               message.role === "assistant" &&
               // Last message isn't completely new
               !(!lastMessage.toolCalls?.length && !lastMessage.content) &&
+              // And make sure current message has a tool call
+              (message.toolCalls?.length ?? 0) !== 0 &&
               // And there's a difference in tool call presence
               (lastMessage.toolCalls?.length ?? 0) !==
                 (message.toolCalls?.length ?? 0))


### PR DESCRIPTION
Fix tool call broken if there are assistant messages immediately after tool call.

## Description
See https://github.com/continuedev/continue/issues/6621
If there are assistant messages without tool call immediately after tool call, we need keep using the existing message to store content. Otherwise, `findCurrentToolCall` will fail to find the message with tool call.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots

No visual changes.

## Tests

Add a new test to simulate case described in https://github.com/continuedev/continue/issues/6621.
