### PR TITLE
fix: open the proper config file

### DIFF
--- a/core/commands/slash/customSlashCommand.ts
+++ b/core/commands/slash/customSlashCommand.ts
@@ -11,5 +11,6 @@ export function convertCustomCommandToSlashCommand(
     description: customCommand.description ?? "",
     prompt: customCommand.prompt,
     source: "json-custom-command",
+    promptFile: customCommand.sourceFile, // TODO refactor promptFile to align with sourceFile
   };
 }

--- a/core/commands/slash/promptBlockSlashCommand.ts
+++ b/core/commands/slash/promptBlockSlashCommand.ts
@@ -9,5 +9,6 @@ export function convertPromptBlockToSlashCommand(
     description: prompt.description ?? "",
     prompt: prompt.prompt,
     source: "yaml-prompt-block",
+    promptFile: prompt.sourceFile, // Align with the sourceFile property
   };
 }

--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -522,7 +522,10 @@ export class ConfigHandler {
     return config;
   }
 
-  async openConfigProfile(profileId?: string) {
+  async openConfigProfile(
+    profileId?: string,
+    element?: { sourceFile?: string },
+  ) {
     let openProfileId = profileId || this.currentProfile?.profileDescription.id;
     if (!openProfileId) {
       return;
@@ -530,8 +533,10 @@ export class ConfigHandler {
     const profile = this.currentOrg.profiles.find(
       (p) => p.profileDescription.id === openProfileId,
     );
+
     if (profile?.profileDescription.profileType === "local") {
-      await this.ide.openFile(profile.profileDescription.uri);
+      const configFile = element?.sourceFile ?? profile.profileDescription.uri;
+      await this.ide.openFile(configFile);
     } else {
       const env = await getControlPlaneEnv(this.ide.getIdeSettings());
       await this.ide.openUrl(`${env.APP_URL}${openProfileId}`);

--- a/core/config/load.ts
+++ b/core/config/load.ts
@@ -652,6 +652,7 @@ function llmToSerializedModelDescription(llm: ILLM): ModelDescription {
     configurationStatus: llm.getConfigurationStatus(),
     apiKeyLocation: llm.apiKeyLocation,
     envSecretLocations: llm.envSecretLocations,
+    sourceFile: llm.sourceFile,
   };
 }
 

--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -56,6 +56,7 @@ function convertYamlRuleToContinueRule(rule: Rule): RuleWithSource {
       rule: rule.rule,
       globs: rule.globs,
       name: rule.name,
+      ruleFile: rule.sourceFile,
     };
   }
 }
@@ -237,6 +238,7 @@ async function configYamlToContinueConfig(options: {
     faviconUrl: doc.faviconUrl,
     maxDepth: doc.maxDepth,
     useLocalCrawling: doc.useLocalCrawling,
+    sourceFile: doc.sourceFile,
   }));
 
   config.mcpServers?.forEach((mcpServer) => {
@@ -429,6 +431,7 @@ async function configYamlToContinueConfig(options: {
     (config.mcpServers ?? []).map((server) => ({
       id: server.name,
       name: server.name,
+      sourceFile: server.sourceFile,
       transport: {
         type: "stdio",
         args: [],

--- a/core/core.ts
+++ b/core/core.ts
@@ -349,7 +349,10 @@ export class Core {
     });
 
     on("config/openProfile", async (msg) => {
-      await this.configHandler.openConfigProfile(msg.data.profileId);
+      await this.configHandler.openConfigProfile(
+        msg.data.profileId,
+        msg.data?.element,
+      );
     });
 
     on("config/reload", async (msg) => {

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -237,6 +237,7 @@ export interface SiteIndexingConfig {
   maxDepth?: number;
   faviconUrl?: string;
   useLocalCrawling?: boolean;
+  sourceFile?: string;
 }
 
 export interface DocsIndexingDetails {
@@ -660,6 +661,8 @@ export interface LLMOptions {
   deploymentId?: string;
 
   env?: Record<string, string | number | boolean>;
+
+  sourceFile?: string;
 }
 
 type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<
@@ -1035,6 +1038,7 @@ export interface CustomCommand {
   name: string;
   prompt: string;
   description?: string;
+  sourceFile?: string;
 }
 
 export interface Prediction {
@@ -1152,6 +1156,8 @@ export interface ModelDescription {
   capabilities?: ModelCapability;
   roles?: ModelRole[];
   configurationStatus?: LLMConfigurationStatuses;
+
+  sourceFile?: string;
 }
 
 export interface JSONEmbedOptions {
@@ -1306,6 +1312,7 @@ export interface MCPServerStatus extends MCPOptions {
   tools: MCPTool[];
   resources: MCPResource[];
   resourceTemplates: MCPResourceTemplate[];
+  sourceFile?: string;
 }
 
 export interface ContinueUIConfig {

--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -187,6 +187,9 @@ export abstract class BaseLLM implements ILLM {
   maxEmbeddingChunkSize: number;
   maxEmbeddingBatchSize: number;
 
+  //URI to local block defining this LLM
+  sourceFile?: string;
+
   private _llmOptions: LLMOptions;
 
   protected openaiAdapter?: BaseLlmApi;
@@ -290,6 +293,7 @@ export abstract class BaseLLM implements ILLM {
     this.embeddingId = `${this.constructor.name}::${this.model}::${this.maxEmbeddingChunkSize}`;
 
     this.autocompleteOptions = options.autocompleteOptions;
+    this.sourceFile = options.sourceFile;
   }
 
   getConfigurationStatus() {

--- a/core/protocol/core.ts
+++ b/core/protocol/core.ts
@@ -102,7 +102,10 @@ export type ToCoreFromIdeOrWebviewProtocol = {
     ),
     void,
   ];
-  "config/openProfile": [{ profileId: string | undefined }, void];
+  "config/openProfile": [
+    { profileId: string | undefined; element?: { sourceFile?: string } },
+    void,
+  ];
   "config/updateSharedConfig": [SharedConfigSchema, SharedConfigSchema];
   "config/updateSelectedModel": [
     {

--- a/gui/src/components/mainInput/Lump/EditBlockButton.tsx
+++ b/gui/src/components/mainInput/Lump/EditBlockButton.tsx
@@ -13,6 +13,7 @@ interface EditBlockButtonProps<T extends SectionKey> {
   blockType: T;
   block?: NonNullable<ConfigYaml[T]>[number];
   className?: string;
+  sourceFile?: string;
 }
 
 function isUsesBlock(block: any): block is { uses: string } {
@@ -23,6 +24,7 @@ export default function EditBlockButton<T extends SectionKey>({
   block,
   blockType,
   className = "",
+  sourceFile,
 }: EditBlockButtonProps<T>) {
   const ideMessenger = useContext(IdeMessengerContext);
   const { selectedProfile } = useAuth();
@@ -37,6 +39,7 @@ export default function EditBlockButton<T extends SectionKey>({
     if (selectedProfile?.profileType === "local") {
       ideMessenger.post("config/openProfile", {
         profileId: undefined,
+        element: { sourceFile },
       });
     } else if (block && isUsesBlock(block)) {
       openUrl(`${block.uses}/new-version`);

--- a/gui/src/components/mainInput/Lump/sections/PromptsSection.tsx
+++ b/gui/src/components/mainInput/Lump/sections/PromptsSection.tsx
@@ -121,6 +121,7 @@ export function PromptsSection() {
     } else {
       ideMessenger.post("config/openProfile", {
         profileId: undefined,
+        element: { sourceFile: (prompt as any).sourceFile },
       });
     }
   };
@@ -149,7 +150,6 @@ export function PromptsSection() {
         index = index + 1;
       }
     }
-
     return promptsWithSlug.sort((a, b) => {
       const aBookmarked = isCommandBookmarked(a.name);
       const bBookmarked = isCommandBookmarked(b.name);

--- a/gui/src/components/mainInput/Lump/sections/RulesSection.tsx
+++ b/gui/src/components/mainInput/Lump/sections/RulesSection.tsx
@@ -60,6 +60,7 @@ const RuleCard: React.FC<RuleCardProps> = ({ rule }) => {
     } else {
       ideMessenger.post("config/openProfile", {
         profileId: undefined,
+        element: { sourceFile: (rule as any).sourceFile },
       });
     }
   };

--- a/gui/src/components/mainInput/Lump/sections/docs/DocsIndexingStatus.tsx
+++ b/gui/src/components/mainInput/Lump/sections/docs/DocsIndexingStatus.tsx
@@ -123,7 +123,11 @@ function DocsIndexingStatus({
               />
             )}
 
-            <EditBlockButton blockType="docs" block={docFromYaml} />
+            <EditBlockButton
+              blockType="docs"
+              block={docFromYaml}
+              sourceFile={docConfig.sourceFile}
+            />
 
             {["aborted", "complete", "failed"].includes(
               status?.status ?? "",

--- a/gui/src/components/mainInput/Lump/sections/mcp/MCPSection.tsx
+++ b/gui/src/components/mainInput/Lump/sections/mcp/MCPSection.tsx
@@ -132,7 +132,11 @@ function MCPServerPreview({ server, serverFromYaml }: MCPServerStatusProps) {
 
       {/* Refresh button */}
       <div className="flex items-center gap-2">
-        <EditBlockButton blockType={"mcpServers"} block={serverFromYaml} />
+        <EditBlockButton
+          blockType={"mcpServers"}
+          block={serverFromYaml}
+          sourceFile={server.sourceFile}
+        />
         <div
           className="text-lightgray flex cursor-pointer items-center hover:opacity-80"
           onClick={onRefresh}

--- a/gui/src/components/modelSelection/ModelSelect.tsx
+++ b/gui/src/components/modelSelection/ModelSelect.tsx
@@ -37,6 +37,7 @@ interface Option {
   value: string;
   title: string;
   apiKey?: string;
+  sourceFile?: string;
 }
 
 function modelSelectTitle(model: any): string {
@@ -56,8 +57,6 @@ function ModelOption({
   showMissingApiKeyMsg,
   isSelected,
 }: ModelOptionProps) {
-  const ideMessenger = useContext(IdeMessengerContext);
-
   function handleOptionClick(e: any) {
     if (showMissingApiKeyMsg) {
       e.preventDefault();
@@ -132,6 +131,7 @@ function ModelSelect() {
           value: model.title,
           title: modelSelectTitle(model),
           apiKey: model.apiKey,
+          sourceFile: model.sourceFile,
         };
       }),
     );
@@ -230,6 +230,7 @@ function ModelSelect() {
               onClick={() =>
                 ideMessenger.post("config/openProfile", {
                   profileId: undefined,
+                  element: { sourceFile: selectedModel?.sourceFile },
                 })
               }
             />

--- a/gui/src/pages/config/ModelRoleSelector.tsx
+++ b/gui/src/pages/config/ModelRoleSelector.tsx
@@ -48,10 +48,13 @@ const ModelRoleSelector = ({
     onSelect(models.find((m) => m.title === title) ?? null);
   }
 
-  function onClickGear(e: MouseEvent<SVGSVGElement>) {
+  function onClickGear(e: MouseEvent<SVGSVGElement>, model: ModelDescription) {
     e.stopPropagation();
     e.preventDefault();
-    ideMessenger.post("config/openProfile", { profileId: undefined });
+    ideMessenger.post("config/openProfile", {
+      profileId: undefined,
+      element: model,
+    });
   }
 
   function handleOptionClick(
@@ -169,7 +172,9 @@ const ModelRoleSelector = ({
                                 {hoveredIdx === idx && (
                                   <Cog6ToothIcon
                                     className="h-3 w-3 flex-shrink-0"
-                                    onClick={onClickGear}
+                                    onClick={(e: MouseEvent<SVGSVGElement>) =>
+                                      onClickGear(e, option)
+                                    }
                                   />
                                 )}
                                 {option.title === selectedModel?.title && (

--- a/gui/src/pages/gui/StreamError.tsx
+++ b/gui/src/pages/gui/StreamError.tsx
@@ -77,6 +77,7 @@ const StreamErrorDialog = ({ error }: StreamErrorProps) => {
       onClick={() => {
         ideMessenger.post("config/openProfile", {
           profileId: undefined,
+          element: selectedModel ?? undefined,
         });
       }}
     >

--- a/packages/config-types/src/index.ts
+++ b/packages/config-types/src/index.ts
@@ -210,6 +210,7 @@ export const siteIndexingConfigSchema = z.object({
   maxDepth: z.number().optional(),
   faviconUrl: z.string().optional(),
   useLocalCrawling: z.boolean().optional(),
+  sourceFile: z.string().optional(),
 });
 
 export const controlPlaneConfigSchema = z.object({

--- a/packages/config-yaml/src/markdown/markdownToRule.ts
+++ b/packages/config-yaml/src/markdown/markdownToRule.ts
@@ -112,5 +112,6 @@ export function markdownToRule(
     regex: frontmatter.regex,
     description: frontmatter.description,
     alwaysApply: frontmatter.alwaysApply,
+    sourceFile: id.uriType === "file" ? id.filePath : undefined,
   };
 }

--- a/packages/config-yaml/src/schemas/index.ts
+++ b/packages/config-yaml/src/schemas/index.ts
@@ -25,6 +25,7 @@ const mcpServerSchema = z.object({
   cwd: z.string().optional(),
   connectionTimeout: z.number().gt(0).optional(),
   requestOptions: requestOptionsSchema.optional(),
+  sourceFile: z.string().optional(),
 });
 
 export type MCPServer = z.infer<typeof mcpServerSchema>;
@@ -33,6 +34,7 @@ const promptSchema = z.object({
   name: z.string(),
   description: z.string().optional(),
   prompt: z.string(),
+  sourceFile: z.string().optional(),
 });
 
 export type Prompt = z.infer<typeof promptSchema>;
@@ -44,6 +46,7 @@ const docSchema = z.object({
   faviconUrl: z.string().optional(),
   maxDepth: z.number().optional(),
   useLocalCrawling: z.boolean().optional(),
+  sourceFile: z.string().optional(),
 });
 
 export type DocsConfig = z.infer<typeof docSchema>;
@@ -55,6 +58,7 @@ const ruleObjectSchema = z.object({
   globs: z.union([z.string(), z.array(z.string())]).optional(),
   regex: z.union([z.string(), z.array(z.string())]).optional(),
   alwaysApply: z.boolean().optional(),
+  sourceFile: z.string().optional(), //TODO refactor RuleWithSource.ruleFile to align with sourceFile
 });
 const ruleSchema = z.union([z.string(), ruleObjectSchema]);
 

--- a/packages/config-yaml/src/schemas/models.ts
+++ b/packages/config-yaml/src/schemas/models.ts
@@ -163,6 +163,7 @@ export const modelSchema = z.union([
   z.object({
     ...baseModelFields,
     provider: z.string().refine((val) => val !== "continue-proxy"),
+    sourceFile: z.string().optional(),
   }),
 ]);
 


### PR DESCRIPTION
The continue view currently doesn't open the proper config files, when clicking the edit button for a Model, Rule, MCP server, prompt or Doc that is not defined in the default config file, typically anything defined under the workspace's `.continue/` directory. This PR addresses this shortcoming by:

- adding a sourceFile property to the aforementioned objects
- injecting the local file path as sourceFile value, during configuration unrolling 
- passing said sourceFile value when issuing a "config/openProfile" request 

Ideally Prompts' promptfile and Rules' ruleFile should be aligned with the other sourceFile properties but I wanted to minimize the impact area of this PR.


https://github.com/user-attachments/assets/378369a2-93c4-4b4c-b17f-0789298b1845


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the edit button so it now opens the correct config file for Models, Rules, MCP servers, Prompts, and Docs, including those defined in workspace `.continue/` directories.

- **Bug Fixes**
  - Added a `sourceFile` property to config objects and passed it through the stack to ensure the right file opens when editing non-default config entries.

<!-- End of auto-generated description by cubic. -->

