### PR TITLE
fix: :bug: Fix aborts (simple Option?)

### DIFF
--- a/gui/src/redux/thunks/streamNormalInput.ts
+++ b/gui/src/redux/thunks/streamNormalInput.ts
@@ -235,9 +235,7 @@ export const streamNormalInput = createAsyncThunk<
         console.error("Failed to send dev data interaction log", e);
       }
     }
-
-    await handleToolCallExecution(dispatch, getState);
-
     dispatch(setInactive());
+    await handleToolCallExecution(dispatch, getState);
   },
 );


### PR DESCRIPTION
## Description

Main:

dispatch(setInactive());
await handleToolCallExecution(dispatch, getState);

Fix:

dispatch(setInactive());
await handleToolCallExecution(dispatch, getState);

I reviewed the somewhat complex abort funciton and the current state of main, and in thinking about what the middleware solution is accomplishing I think this is the quick fix. Since dispatch(setInactive()); is synchonous, this will guarentee the current stream is wrapped up before the tool calls fire off. With the tool calls happening first, fast tool results could attempt to start streaming before the setInactive gets fired triggering an abort. The race condition that the middleware is also solving by watching for inactive to trigger before firing off the toolCallsExecution.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

Running all existing tests to validate no changes.
