### PR TITLE
add line range replacement as a fallback for search and replace

### DIFF
--- a/core/edit/searchAndReplace/findSearchMatch.test.ts
+++ b/core/edit/searchAndReplace/findSearchMatch.test.ts
@@ -1,7 +1,7 @@
 import { findSearchMatch } from "./findSearchMatch";
 
 describe("Exact matches", () => {
-  it("should find exact match at the beginning of file", () => {
+  it("should find exact match at the beginning of file", async () => {
     const fileContent = `function hello() {
   console.log("world");
 }`;
@@ -9,7 +9,7 @@ describe("Exact matches", () => {
   console.log("world");
 }`;
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     expect(result).toEqual({
       startIndex: 0,
@@ -18,7 +18,7 @@ describe("Exact matches", () => {
     });
   });
 
-  it("should find exact match in the middle of file", () => {
+  it("should find exact match in the middle of file", async () => {
     const fileContent = `const a = 1;
 function hello() {
   console.log("world");
@@ -28,7 +28,7 @@ const b = 2;`;
   console.log("world");
 }`;
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     expect(result).toEqual({
       startIndex: 13, // After "const a = 1;\n"
@@ -37,7 +37,7 @@ const b = 2;`;
     });
   });
 
-  it("should find exact match at the end of file", () => {
+  it("should find exact match at the end of file", async () => {
     const fileContent = `const a = 1;
 function hello() {
   console.log("world");
@@ -46,7 +46,7 @@ function hello() {
   console.log("world");
 }`;
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     expect(result).toEqual({
       startIndex: 13, // After "const a = 1;\n"
@@ -55,13 +55,13 @@ function hello() {
     });
   });
 
-  it("should find exact match with single line", () => {
+  it("should find exact match with single line", async () => {
     const fileContent = `const a = 1;
 const b = 2;
 const c = 3;`;
     const searchContent = `const b = 2;`;
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     expect(result).toEqual({
       startIndex: 13, // After "const a = 1;\n"
@@ -70,7 +70,7 @@ const c = 3;`;
     });
   });
 
-  it("should find exact match with whitespace preserved", () => {
+  it("should find exact match with whitespace preserved", async () => {
     const fileContent = `function test() {
     const x = 1;
     const y = 2;
@@ -78,7 +78,7 @@ const c = 3;`;
     const searchContent = `    const x = 1;
     const y = 2;`;
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     // The actual indexOf result is 18, not 17
     expect(result).toEqual({
@@ -90,7 +90,7 @@ const c = 3;`;
 });
 
 describe("Trimmed matches", () => {
-  it("should find trimmed match when exact match fails due to leading newlines", () => {
+  it("should find trimmed match when exact match fails due to leading newlines", async () => {
     const fileContent = `function hello() {
   console.log("world");
 }`;
@@ -98,7 +98,7 @@ describe("Trimmed matches", () => {
   console.log("world");
 }\n\n`;
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     expect(result).toEqual({
       startIndex: 0,
@@ -107,7 +107,7 @@ describe("Trimmed matches", () => {
     });
   });
 
-  it("should find trimmed match when exact match fails due to trailing newlines", () => {
+  it("should find trimmed match when exact match fails due to trailing newlines", async () => {
     const fileContent = `const a = 1;
 function hello() {
   return "world";
@@ -117,7 +117,7 @@ const b = 2;`;
   return "world";
 }\n`;
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     // The function finds the exact match first (at index 12), not the trimmed match
     expect(result).toEqual({
@@ -127,13 +127,13 @@ const b = 2;`;
     });
   });
 
-  it("should find trimmed match for single line with extra whitespace", () => {
+  it("should find trimmed match for single line with extra whitespace", async () => {
     const fileContent = `const a = 1;
 const b = 2;
 const c = 3;`;
     const searchContent = `\n  const b = 2;  \n`;
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     const trimmedSearchContent = searchContent.trim();
     const expectedStart = fileContent.indexOf(trimmedSearchContent);
@@ -147,13 +147,13 @@ const c = 3;`;
 });
 
 describe("Empty search content", () => {
-  it("should match at beginning for empty search content", () => {
+  it("should match at beginning for empty search content", async () => {
     const fileContent = `function hello() {
   console.log("world");
 }`;
     const searchContent = "";
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     expect(result).toEqual({
       startIndex: 0,
@@ -162,13 +162,13 @@ describe("Empty search content", () => {
     });
   });
 
-  it("should match at beginning for whitespace-only search content", () => {
+  it("should match at beginning for whitespace-only search content", async () => {
     const fileContent = `function hello() {
   console.log("world");
 }`;
     const searchContent = "\n\n  \t  \n";
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     expect(result).toEqual({
       startIndex: 0,
@@ -177,11 +177,11 @@ describe("Empty search content", () => {
     });
   });
 
-  it("should match at beginning for empty file and empty search", () => {
+  it("should match at beginning for empty file and empty search", async () => {
     const fileContent = "";
     const searchContent = "";
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     expect(result).toEqual({
       startIndex: 0,
@@ -192,7 +192,7 @@ describe("Empty search content", () => {
 });
 
 describe("No matches", () => {
-  it("should return null when search content is not found", () => {
+  it("should return null when search content is not found", async () => {
     const fileContent = `function hello() {
   console.log("world");
 }`;
@@ -200,12 +200,12 @@ describe("No matches", () => {
   console.log("world");
 }`;
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     expect(result?.strategyName).toEqual("jaroWinklerFuzzyMatch");
   });
 
-  it("should return only fuzzy result when trimmed search content is not found", () => {
+  it("should return only fuzzy result when trimmed search content is not found", async () => {
     const fileContent = `function hello() {
   console.log("world");
 }`;
@@ -213,23 +213,23 @@ describe("No matches", () => {
   console.log("world");
 }\n\n`;
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     expect(result?.strategyName).toEqual("jaroWinklerFuzzyMatch");
   });
 });
 
 describe("Edge cases", () => {
-  it("should handle empty file with non-empty search", () => {
+  it("should handle empty file with non-empty search", async () => {
     const fileContent = "";
     const searchContent = "function hello() {}";
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     expect(result).toBeNull();
   });
 
-  it("should handle very large content", () => {
+  it("should handle very large content", async () => {
     const repeatedLine = "const x = 1;\n";
     const fileContent =
       repeatedLine.repeat(1000) +
@@ -237,7 +237,7 @@ describe("Edge cases", () => {
       repeatedLine.repeat(1000);
     const searchContent = "const target = 2;";
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     const expectedStart = repeatedLine.length * 1000;
     expect(result).toEqual({
@@ -247,13 +247,13 @@ describe("Edge cases", () => {
     });
   });
 
-  it("should handle special characters and symbols", () => {
+  it("should handle special characters and symbols", async () => {
     const fileContent = `const regex = /[a-zA-Z]+/g;
 const symbols = !@#$%^&*();
 const unicode = "🚀 Hello 世界";`;
     const searchContent = `const symbols = !@#$%^&*();`;
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     const expectedStart = fileContent.indexOf(searchContent);
     expect(result).toEqual({
@@ -263,7 +263,7 @@ const unicode = "🚀 Hello 世界";`;
     });
   });
 
-  it("should prefer exact match over trimmed match", () => {
+  it("should prefer exact match over trimmed match", async () => {
     const fileContent = `function test() {
   const x = 1;
 }
@@ -275,7 +275,7 @@ function test() {
   const x = 1;
 }`;
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     // Should find the first exact match, not a trimmed version
     expect(result).toEqual({
@@ -285,13 +285,13 @@ function test() {
     });
   });
 
-  it("should handle multiple occurrences and return first match", () => {
+  it("should handle multiple occurrences and return first match", async () => {
     const fileContent = `const a = 1;
 const b = 2;
 const a = 1;`;
     const searchContent = `const a = 1;`;
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     expect(result).toEqual({
       startIndex: 0,
@@ -302,7 +302,7 @@ const a = 1;`;
 });
 
 describe("Whitespace-ignored matches", () => {
-  it("should match code with different indentation", () => {
+  it("should match code with different indentation", async () => {
     const fileContent = `function example() {
     const x = 1;
     const y = 2;
@@ -312,7 +312,7 @@ describe("Whitespace-ignored matches", () => {
 const y=2;
 return x+y;`;
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     expect(result).not.toBeNull();
     expect(result!.startIndex).toBe(20); // After "function example() {\n"
@@ -330,13 +330,13 @@ return x+y;`;
     return x + y;`);
   });
 
-  it("should match single line with different spacing", () => {
+  it("should match single line with different spacing", async () => {
     const fileContent = `const a = 1;
 const   b    =   2;
 const c = 3;`;
     const searchContent = `const b=2;`;
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     expect(result).not.toBeNull();
     expect(result!.startIndex).toBe(12); // After "const a = 1;"
@@ -352,7 +352,7 @@ const c = 3;`;
 const   b    =   2;`);
   });
 
-  it("should match with tabs vs spaces", () => {
+  it("should match with tabs vs spaces", async () => {
     const fileContent = `function test() {
 \tif (condition) {
 \t\treturn true;
@@ -362,7 +362,7 @@ const   b    =   2;`);
     return true;
 }`;
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     expect(result).not.toBeNull();
     expect(result!.startIndex).toBe(17); // After "function test() {"
@@ -380,7 +380,7 @@ const   b    =   2;`);
 \t}`);
   });
 
-  it("should match complex whitespace patterns", () => {
+  it("should match complex whitespace patterns", async () => {
     const fileContent = `const obj = {
     key1  :  'value1',
     key2    :    'value2',
@@ -390,7 +390,7 @@ const   b    =   2;`);
 key2:'value2',
 key3:'value3'`;
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     expect(result).not.toBeNull();
     expect(result!.startIndex).toBe(13); // After "const obj = {"
@@ -408,7 +408,7 @@ key3:'value3'`;
     key3 : 'value3'`);
   });
 
-  it("should handle newlines and mixed whitespace", () => {
+  it("should handle newlines and mixed whitespace", async () => {
     const fileContent = `function calc() {
 
 
@@ -421,7 +421,7 @@ key3:'value3'`;
 }`;
     const searchContent = `let result=0;result+=5;return result;`;
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     expect(result).not.toBeNull();
     expect(result!.startIndex).toBe(17); // After "function calc() {\n\n"
@@ -444,12 +444,12 @@ key3:'value3'`;
     return result;`);
   });
 
-  it("should prefer exact match over whitespace-ignored match", () => {
+  it("should prefer exact match over whitespace-ignored match", async () => {
     const fileContent = `const x=1;
 const x = 1;`;
     const searchContent = `const x=1;`;
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     // Should find the exact match first (at index 0), not the whitespace-ignored match
     expect(result).toEqual({
@@ -459,13 +459,13 @@ const x = 1;`;
     });
   });
 
-  it("should handle empty content after whitespace removal", () => {
+  it("should handle empty content after whitespace removal", async () => {
     const fileContent = `function test() {
   return 1;
 }`;
     const searchContent = `\n\n  \t  \n`;
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     // Should match at beginning for empty/whitespace-only content
     expect(result).toEqual({
@@ -475,7 +475,7 @@ const x = 1;`;
     });
   });
 
-  it("should handle complex code blocks with different formatting", () => {
+  it("should handle complex code blocks with different formatting", async () => {
     const fileContent = `class Example {
     constructor(name) {
         this.name = name;
@@ -491,7 +491,7 @@ this.name=name;
 this.value=0;
 }`;
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     expect(result).not.toBeNull();
     expect(result!.startIndex).toBe(15); // After "class Example {"
@@ -510,24 +510,24 @@ this.value=0;
     }`);
   });
 
-  it("should return null when no close match exists", () => {
+  it("should return null when no close match exists", async () => {
     const fileContent = `function hello() {
   console.log("world");
 }`;
     const searchContent = `this has nothing to do with the other option`;
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     expect(result).toBeNull();
   });
 
-  it("should handle multiple potential matches and return first", () => {
+  it("should handle multiple potential matches and return first", async () => {
     const fileContent = `const a=1;
 const   a   =   1;
 const a = 1;`;
     const searchContent = `const a=1;`;
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     // Should find the first exact match
     expect(result).toEqual({
@@ -539,7 +539,7 @@ const a = 1;`;
 });
 
 describe("Real-world scenarios", () => {
-  it("should match typical function replacement", () => {
+  it("should match typical function replacement", async () => {
     const fileContent = `class Calculator {
   constructor() {
     this.result = 0;
@@ -560,7 +560,7 @@ describe("Real-world scenarios", () => {
     return this;
   }`;
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     const expectedStart = fileContent.indexOf(searchContent);
     expect(result).toEqual({
@@ -570,7 +570,7 @@ describe("Real-world scenarios", () => {
     });
   });
 
-  it("should match import statement", () => {
+  it("should match import statement", async () => {
     const fileContent = `import React from 'react';
 import { useState, useEffect } from 'react';
 import './App.css';
@@ -580,7 +580,7 @@ function App() {
 }`;
     const searchContent = `import { useState, useEffect } from 'react';`;
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     const expectedStart = fileContent.indexOf(searchContent);
     expect(result).toEqual({
@@ -590,7 +590,7 @@ function App() {
     });
   });
 
-  it("should match comment block", () => {
+  it("should match comment block", async () => {
     const fileContent = `/**
  * This is a comment
  * that spans multiple lines
@@ -604,7 +604,7 @@ function test() {
  * that spans multiple lines
  */`;
 
-    const result = findSearchMatch(fileContent, searchContent);
+    const result = await findSearchMatch(fileContent, searchContent);
 
     expect(result).toEqual({
       startIndex: 0,
@@ -615,7 +615,7 @@ function test() {
 
   describe("Jaro-Winkler fuzzy matching", () => {
     describe("Basic fuzzy matching", () => {
-      it("should find fuzzy match for similar strings", () => {
+      it("should find fuzzy match for similar strings", async () => {
         const fileContent = `function calculateSum(a, b) {
   return a + b;
 }`;
@@ -623,33 +623,33 @@ function test() {
   return x + y;
 }`;
 
-        const result = findSearchMatch(fileContent, searchContent);
+        const result = await findSearchMatch(fileContent, searchContent);
 
         expect(result).not.toBeNull();
       });
 
-      it("should find fuzzy match with minor typos", () => {
+      it("should find fuzzy match with minor typos", async () => {
         const fileContent = `const message = "Hello World";`;
         const searchContent = `const mesage = "Hello World";`; // Missing 's' in 'message'
 
-        const result = findSearchMatch(fileContent, searchContent);
+        const result = await findSearchMatch(fileContent, searchContent);
 
         expect(result).not.toBeNull();
         expect(result?.startIndex).toBe(0);
       });
 
-      it("should find fuzzy match with different variable names", () => {
+      it("should find fuzzy match with different variable names", async () => {
         const fileContent = `let userAge = 25;
 let userName = "John";`;
         const searchContent = `let age = 25;
 let name = "John";`;
 
-        const result = findSearchMatch(fileContent, searchContent);
+        const result = await findSearchMatch(fileContent, searchContent);
 
         expect(result).not.toBeNull();
       });
 
-      it("should find fuzzy match for similar function signature", () => {
+      it("should find fuzzy match for similar function signature", async () => {
         const fileContent = `function processUserData(userData) {
   validateInput(userData);
   return formatOutput(userData);
@@ -659,14 +659,14 @@ let name = "John";`;
   return formatOutput(data);
 }`;
 
-        const result = findSearchMatch(fileContent, searchContent);
+        const result = await findSearchMatch(fileContent, searchContent);
 
         expect(result).not.toBeNull();
       });
     });
 
     describe("Multi-line fuzzy matching", () => {
-      it("should find fuzzy match for multi-line blocks", () => {
+      it("should find fuzzy match for multi-line blocks", async () => {
         const fileContent = `class Calculator {
   constructor() {
     this.result = 0;
@@ -688,12 +688,12 @@ let name = "John";`;
   }
 }`;
 
-        const result = findSearchMatch(fileContent, searchContent);
+        const result = await findSearchMatch(fileContent, searchContent);
 
         expect(result).not.toBeNull();
       });
 
-      it("should find fuzzy match for partial blocks", () => {
+      it("should find fuzzy match for partial blocks", async () => {
         const fileContent = `function processData(input) {
   const validated = validateInput(input);
   const processed = transformData(validated);
@@ -703,18 +703,18 @@ let name = "John";`;
         const searchContent = `const validated = validateInput(input);
   const processed = transformData(validated);`;
 
-        const result = findSearchMatch(fileContent, searchContent);
+        const result = await findSearchMatch(fileContent, searchContent);
 
         expect(result).not.toBeNull();
       });
     });
 
     describe("Edge cases with fuzzy matching", () => {
-      it("should handle empty search content with fuzzy matching enabled", () => {
+      it("should handle empty search content with fuzzy matching enabled", async () => {
         const fileContent = `function test() {}`;
         const searchContent = "";
 
-        const result = findSearchMatch(fileContent, searchContent);
+        const result = await findSearchMatch(fileContent, searchContent);
 
         expect(result).toEqual({
           startIndex: 0,
@@ -723,43 +723,43 @@ let name = "John";`;
         });
       });
 
-      it("should handle empty file content with fuzzy matching enabled", () => {
+      it("should handle empty file content with fuzzy matching enabled", async () => {
         const fileContent = "";
         const searchContent = "function test() {}";
 
-        const result = findSearchMatch(fileContent, searchContent);
+        const result = await findSearchMatch(fileContent, searchContent);
 
         expect(result).toBeNull();
       });
 
-      it("should prefer exact match over fuzzy match", () => {
+      it("should prefer exact match over fuzzy match", async () => {
         const fileContent = `function test() { return true; }
 function test() { return false; }`;
         const searchContent = `function test() { return true; }`;
 
-        const result = findSearchMatch(fileContent, searchContent);
+        const result = await findSearchMatch(fileContent, searchContent);
 
         expect(result).not.toBeNull();
         expect(result?.startIndex).toBe(0);
       });
 
-      it("should handle very short strings", () => {
+      it("should handle very short strings", async () => {
         const fileContent = `a b c`;
         const searchContent = `a c`;
 
-        const result = findSearchMatch(fileContent, searchContent);
+        const result = await findSearchMatch(fileContent, searchContent);
 
         // Should not match due to low similarity
         expect(result).toBeNull();
       });
 
-      it("should handle special characters in fuzzy matching", () => {
+      it("should handle special characters in fuzzy matching", async () => {
         const fileContent = `const regex = /[a-zA-Z]+/g;
 const symbols = !@#$%^&*();`;
         const searchContent = `const regex = /[a-zA-Z0-9]+/g;
 const symbols = !@#$%^&*();`;
 
-        const result = findSearchMatch(fileContent, searchContent);
+        const result = await findSearchMatch(fileContent, searchContent);
 
         expect(result).not.toBeNull();
       });

--- a/gui/src/util/clientTools/searchReplaceImpl.test.ts
+++ b/gui/src/util/clientTools/searchReplaceImpl.test.ts
@@ -139,7 +139,7 @@ describe("searchReplaceToolImpl", () => {
       const startIndex = originalContent.indexOf(searchText);
       const endIndex = startIndex + searchText.length;
 
-      mockFindSearchMatch.mockReturnValue({
+      mockFindSearchMatch.mockResolvedValue({
         startIndex,
         endIndex,
         strategyName: "exactMatch",
@@ -197,7 +197,7 @@ describe("searchReplaceToolImpl", () => {
       const startIndex = originalContent.indexOf(searchText);
       const endIndex = startIndex + searchText.length;
 
-      mockFindSearchMatch.mockReturnValue({
+      mockFindSearchMatch.mockResolvedValue({
         startIndex,
         endIndex,
         strategyName: "exactMatch",
@@ -272,12 +272,12 @@ const c = 3;`;
 
       // Mock sequential search matches
       mockFindSearchMatch
-        .mockReturnValueOnce({
+        .mockResolvedValueOnce({
           startIndex: firstStartIndex,
           endIndex: firstEndIndex,
           strategyName: "exactMatch",
         })
-        .mockReturnValueOnce({
+        .mockResolvedValueOnce({
           startIndex: secondStartIndex,
           endIndex: secondEndIndex,
           strategyName: "exactMatch",
@@ -303,11 +303,23 @@ const c = 3;`;
         1,
         originalContent,
         "const a = 1;",
+        expect.objectContaining({
+          dispatch: expect.any(Function),
+          getState: expect.any(Function),
+          ideMessenger: mockIdeMessenger,
+          selectSelectedChatModel: expect.any(Function),
+        }),
       );
       expect(mockFindSearchMatch).toHaveBeenNthCalledWith(
         2,
         contentAfterFirstReplacement,
         "const b = 2;",
+        expect.objectContaining({
+          dispatch: expect.any(Function),
+          getState: expect.any(Function),
+          ideMessenger: mockIdeMessenger,
+          selectSelectedChatModel: expect.any(Function),
+        }),
       );
       // Verify final applyToFile call
       expect(mockIdeMessenger.request).toHaveBeenCalledWith("applyToFile", {
@@ -368,12 +380,12 @@ const c = 3;`;
 
       // Mock sequential search matches
       mockFindSearchMatch
-        .mockReturnValueOnce({
+        .mockResolvedValueOnce({
           startIndex: firstStartIndex,
           endIndex: firstEndIndex,
           strategyName: "exactMatch",
         })
-        .mockReturnValueOnce({
+        .mockResolvedValueOnce({
           startIndex: secondStartIndex,
           endIndex: secondEndIndex,
           strategyName: "exactMatch",
@@ -435,7 +447,7 @@ keep this too`;
         },
       ]);
       mockIdeMessenger.ide.readFile.mockResolvedValue(originalContent);
-      mockFindSearchMatch.mockReturnValue({
+      mockFindSearchMatch.mockResolvedValue({
         startIndex: 10, // Position of "remove this line"
         endIndex: 26, // End of "remove this line"
         strategyName: "exactMatch",
@@ -475,7 +487,7 @@ keep this too`;
         },
       ]);
       mockIdeMessenger.ide.readFile.mockResolvedValue(originalContent);
-      mockFindSearchMatch.mockReturnValue({
+      mockFindSearchMatch.mockResolvedValue({
         startIndex: 6,
         endIndex: 11,
         strategyName: "exactMatch",
@@ -509,7 +521,7 @@ keep this too`;
         },
       ]);
       mockIdeMessenger.ide.readFile.mockResolvedValue("some file content");
-      mockFindSearchMatch.mockReturnValue(null); // Search content not found
+      mockFindSearchMatch.mockResolvedValue(null); // Search content not found
 
       await expect(
         searchReplaceToolImpl(
@@ -542,12 +554,12 @@ keep this too`;
 
       // First search succeeds, second fails
       mockFindSearchMatch
-        .mockReturnValueOnce({
+        .mockResolvedValueOnce({
           startIndex: 0,
           endIndex: 13,
           strategyName: "exactMatch",
         })
-        .mockReturnValueOnce(null); // Second search fails
+        .mockResolvedValueOnce(null); // Second search fails
 
       await expect(
         searchReplaceToolImpl(
@@ -582,7 +594,7 @@ keep this too`;
       ).rejects.toThrow("Failed to apply search and replace: File read error");
     });
 
-    it("should handle applyToFile errors", async () => {
+    it("should handle apply failures", async () => {
       mockResolveRelativePathInDir.mockResolvedValue("/resolved/path/test.txt");
       mockParseAllSearchReplaceBlocks.mockReturnValue([
         {
@@ -592,7 +604,7 @@ keep this too`;
         },
       ]);
       mockIdeMessenger.ide.readFile.mockResolvedValue("content");
-      mockFindSearchMatch.mockReturnValue({
+      mockFindSearchMatch.mockResolvedValue({
         startIndex: 0,
         endIndex: 7,
         strategyName: "exactMatch",
@@ -623,7 +635,7 @@ keep this too`;
         },
       ]);
       mockIdeMessenger.ide.readFile.mockResolvedValue(originalContent);
-      mockFindSearchMatch.mockReturnValue({
+      mockFindSearchMatch.mockResolvedValue({
         startIndex: 0, // Empty search matches at beginning
         endIndex: 0,
         strategyName: "exactMatch",
@@ -658,7 +670,7 @@ keep this too`;
         },
       ]);
       mockIdeMessenger.ide.readFile.mockResolvedValue(originalContent);
-      mockFindSearchMatch.mockReturnValue({
+      mockFindSearchMatch.mockResolvedValue({
         startIndex: 0,
         endIndex: originalContent.length,
         strategyName: "exactMatch",
@@ -694,7 +706,7 @@ keep this too`;
         },
       ]);
       mockIdeMessenger.ide.readFile.mockResolvedValue(originalContent);
-      mockFindSearchMatch.mockReturnValue({
+      mockFindSearchMatch.mockResolvedValue({
         startIndex: 0,
         endIndex: 4,
         strategyName: "exactMatch",
@@ -718,7 +730,16 @@ keep this too`;
       expect(mockIdeMessenger.ide.readFile).toHaveBeenCalledWith(
         "/resolved/path/test.txt",
       );
-      expect(mockFindSearchMatch).toHaveBeenCalledWith(originalContent, "test");
+      expect(mockFindSearchMatch).toHaveBeenCalledWith(
+        originalContent,
+        "test",
+        expect.objectContaining({
+          dispatch: expect.any(Function),
+          getState: expect.any(Function),
+          ideMessenger: mockIdeMessenger,
+          selectSelectedChatModel: expect.any(Function),
+        }),
+      );
       expect(mockIdeMessenger.request).toHaveBeenCalledWith("applyToFile", {
         text: "updated content",
         streamId: "test-stream-id",


### PR DESCRIPTION
Fixes CON-2773
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a fallback to the search and replace tool that uses a language model to find the best matching line range when standard matchers fail.

- **New Features**
  - If no match is found, the tool now tries a language model-based range finder to identify the correct lines for replacement.

<!-- End of auto-generated description by cubic. -->

