### PR TITLE
fix: dont stop streaming if no tool call states found

### DIFF
--- a/gui/src/pages/gui/ToolCallDiv/SimpleToolCallUI.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/SimpleToolCallUI.tsx
@@ -89,7 +89,6 @@ export function SimpleToolCallUI({
             <ArgsToggleIcon
               isShowing={showingArgs}
               setIsShowing={setShowingArgs}
-              toolCallId={toolCallState.toolCallId}
             />
           ) : null}
         </div>

--- a/gui/src/pages/gui/ToolCallDiv/ToolCallArgs.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/ToolCallArgs.tsx
@@ -4,13 +4,11 @@ import { ToolbarButtonWithTooltip } from "../../../components/StyledMarkdownPrev
 interface ArgsToggleIconProps {
   isShowing: boolean;
   setIsShowing: (val: boolean) => void;
-  toolCallId: string;
 }
 
 export const ArgsToggleIcon = ({
   isShowing,
   setIsShowing,
-  toolCallId,
 }: ArgsToggleIconProps) => {
   return (
     <ToolbarButtonWithTooltip

--- a/gui/src/pages/gui/ToolCallDiv/ToolCallDisplay.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/ToolCallDisplay.tsx
@@ -27,7 +27,7 @@ export function ToolCallDisplay({
 
   return (
     <>
-      <div className="flex flex-col justify-center p-4 pb-1">
+      <div className="flex flex-col justify-center">
         <div className="mb-2 flex flex-col">
           <div className="flex flex-row items-center justify-between gap-1.5">
             <div className="flex min-w-0 flex-row items-center gap-2">
@@ -50,7 +50,6 @@ export function ToolCallDisplay({
                 <ArgsToggleIcon
                   isShowing={argsExpanded}
                   setIsShowing={setArgsExpanded}
-                  toolCallId={toolCallState.toolCallId}
                 />
               ) : null}
             </div>

--- a/gui/src/pages/gui/ToolCallDiv/ToolCallStatusMessage.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/ToolCallStatusMessage.tsx
@@ -53,7 +53,7 @@ export function ToolCallStatusMessage({
 
   return (
     <div
-      className="text-description line-clamp-4 min-w-0 break-words"
+      className="text-description line-clamp-4 min-w-0 break-all"
       data-testid="tool-call-title"
     >
       {`Continue ${intro} ${message}`}

--- a/gui/src/pages/gui/ToolCallDiv/index.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/index.tsx
@@ -6,7 +6,7 @@ import { useAppSelector } from "../../../redux/hooks";
 import FunctionSpecificToolCallDiv from "./FunctionSpecificToolCallDiv";
 import { GroupedToolCallHeader } from "./GroupedToolCallHeader";
 import { SimpleToolCallUI } from "./SimpleToolCallUI";
-import { ToolCallDisplay } from "./ToolCall";
+import { ToolCallDisplay } from "./ToolCallDisplay";
 import { getStatusIcon, toolCallIcons } from "./utils";
 
 interface ToolCallDivProps {
@@ -103,10 +103,7 @@ export function ToolCallDiv({
   }
 
   return toolCallStates.map((toolCallState) => (
-    <div
-      className="border-border rounded-lg border p-3"
-      key={toolCallState.toolCallId}
-    >
+    <div className="p-4 pb-1" key={toolCallState.toolCallId}>
       {renderToolCall(toolCallState)}
     </div>
   ));

--- a/gui/src/redux/thunks/streamResponseAfterToolCall.ts
+++ b/gui/src/redux/thunks/streamResponseAfterToolCall.ts
@@ -2,80 +2,32 @@ import { createAsyncThunk, unwrapResult } from "@reduxjs/toolkit";
 import { ChatMessage } from "core";
 import { renderContextItems } from "core/util/messageContent";
 import {
+  ChatHistoryItemWithMessageId,
   resetNextCodeBlockToApplyIndex,
   streamUpdate,
 } from "../slices/sessionSlice";
-import { AppThunkDispatch, RootState, ThunkApiType } from "../store";
+import { ThunkApiType } from "../store";
 import { findToolCallById } from "../util";
 import { streamNormalInput } from "./streamNormalInput";
 import { streamThunkWrapper } from "./streamThunkWrapper";
 
 /**
- * Finds the assistant message that contains the specified tool call.
- */
-function findAssistantMessageWithToolCall(
-  history: RootState["session"]["history"],
-  toolCallId: string,
-) {
-  return history.find(
-    (item) =>
-      item.message.role === "assistant" &&
-      item.toolCallStates?.some((tc) => tc.toolCallId === toolCallId),
-  );
-}
-
-/**
- * Checks if all parallel tool calls in an assistant message are complete.
- */
-function areAllToolCallsComplete(
-  toolCallStates: NonNullable<
-    ReturnType<typeof findAssistantMessageWithToolCall>
-  >["toolCallStates"],
-): boolean {
-  if (!toolCallStates) return false;
-
-  const completedToolCalls = toolCallStates.filter(
-    (tc) => tc.status === "done",
-  );
-
-  return completedToolCalls.length === toolCallStates.length;
-}
-
-/**
  * Determines if we should continue streaming based on tool call completion status.
  */
-function shouldContinueStreaming(
-  assistantMessage: ReturnType<typeof findAssistantMessageWithToolCall>,
+function areAllToolsDoneStreaming(
+  assistantMessage: ChatHistoryItemWithMessageId | undefined,
 ): boolean {
+  // This might occur because of race conditions, if so, the tools are completed
   if (!assistantMessage?.toolCallStates) {
-    return false; // No assistant message found - don't stream
-  }
-
-  const totalToolCalls = assistantMessage.toolCallStates.length;
-
-  // Single tool call - always continue streaming
-  if (totalToolCalls === 1) {
     return true;
   }
 
-  // Multiple tool calls - only continue if all are complete
-  return areAllToolCallsComplete(assistantMessage.toolCallStates);
-}
+  // Only continue if all tool calls are complete
+  const completedToolCalls = assistantMessage.toolCallStates.filter(
+    (tc) => tc.status === "done",
+  );
 
-/**
- * Creates and dispatches a tool message for the completed tool call.
- */
-function createAndDispatchToolMessage(
-  dispatch: AppThunkDispatch,
-  toolCallId: string,
-  toolOutput: any[],
-): void {
-  const newMessage: ChatMessage = {
-    role: "tool",
-    content: renderContextItems(toolOutput),
-    toolCallId,
-  };
-  dispatch(streamUpdate([newMessage]));
+  return completedToolCalls.length === assistantMessage.toolCallStates.length;
 }
 
 export const streamResponseAfterToolCall = createAsyncThunk<
@@ -104,16 +56,22 @@ export const streamResponseAfterToolCall = createAsyncThunk<
         await new Promise((resolve) => setTimeout(resolve, 0));
 
         // Create and dispatch the tool message
-        createAndDispatchToolMessage(dispatch, toolCallId, toolOutput);
+        const newMessage: ChatMessage = {
+          role: "tool",
+          content: renderContextItems(toolOutput),
+          toolCallId,
+        };
+        dispatch(streamUpdate([newMessage]));
 
         // Check if we should continue streaming based on tool call completion
         const history = getState().session.history;
-        const assistantMessage = findAssistantMessageWithToolCall(
-          history,
-          toolCallId,
+        const assistantMessage = history.find(
+          (item) =>
+            item.message.role === "assistant" &&
+            item.toolCallStates?.some((tc) => tc.toolCallId === toolCallId),
         );
 
-        if (shouldContinueStreaming(assistantMessage)) {
+        if (areAllToolsDoneStreaming(assistantMessage)) {
           unwrapResult(await dispatch(streamNormalInput({})));
         }
       }),


### PR DESCRIPTION
Resolves CON-2829

I was unable to reproduce the issue in debug mode where streaming doesn't resume after tool calls, but I'm reasonably confident this will fix it.