### PR TITLE
fix: internal permalinks with file extensions

### DIFF
--- a/docs/customize/context/codebase.mdx
+++ b/docs/customize/context/codebase.mdx
@@ -94,4 +94,4 @@ If you need to force a refresh of the index, reload the VS Code window with <kbd
 
 ## Repository map
 
-Models in the Claude 3, Llama 3.1/3.2, Gemini 1.5, and GPT-4o families will automatically use a [repository map](../custom-providers.mdx#repository-map) during codebase retrieval, which allows the model to understand the structure of your codebase and use it to answer questions. Currently, the repository map only contains the filepaths in the codebase.
+Models in the Claude 3, Llama 3.1/3.2, Gemini 1.5, and GPT-4o families will automatically use a [repository map](../custom-providers#repository-map) during codebase retrieval, which allows the model to understand the structure of your codebase and use it to answer questions. Currently, the repository map only contains the filepaths in the codebase.

--- a/docs/customize/context/documentation.mdx
+++ b/docs/customize/context/documentation.mdx
@@ -54,7 +54,7 @@ The `@Docs` context provider works by
 
 ### Hub `docs` Blocks
 
-@Docs uses [`docs` blocks](../../hub/blocks/block-types.md#docs) in Assistants from the hub. Visit the hub to [explore `docs` blocks](https://hub.continue.dev/explore/docs) or [create your own](https://hub.continue.dev/new?type=block&blockType=docs).
+@Docs uses [`docs` blocks](../../hub/blocks/block-types#docs) in Assistants from the hub. Visit the hub to [explore `docs` blocks](https://hub.continue.dev/explore/docs) or [create your own](https://hub.continue.dev/new?type=block&blockType=docs).
 
 ### Through the `@Docs` Context Provider
 

--- a/docs/customize/deep-dives/slash-commands.mdx
+++ b/docs/customize/deep-dives/slash-commands.mdx
@@ -15,7 +15,7 @@ Slash commands can be combined with additional instructions, including [context 
 
 ### Assistant prompt blocks
 
-The easiest way to add a slash command is by adding [`prompt` blocks](../../hub/blocks/block-types.md#prompts) to your assistant, which show up as slash commands in [Chat](../../features/chat/how-it-works.mdx).
+The easiest way to add a slash command is by adding [`prompt` blocks](../../hub/blocks/block-types#prompts) to your assistant, which show up as slash commands in [Chat](../../features/chat/how-it-works.mdx).
 
 ### Prompt files
 

--- a/docs/customize/model-roles/embeddings.mdx
+++ b/docs/customize/model-roles/embeddings.mdx
@@ -21,7 +21,7 @@ You can add `embed` to a model's `roles` to specify that it can be used to embed
 
 If you have the ability to use any model, we recommend `voyage-code-3`, which is listed below along with the rest of the options for embeddings models.
 
-If you want to generate embeddings locally, we recommend using `nomic-embed-text` with [Ollama](../model-providers/top-level/ollama.mdx#embeddings-model).
+If you want to generate embeddings locally, we recommend using `nomic-embed-text` with [Ollama](../model-providers/top-level/ollama#embeddings-model).
 
 ### Voyage AI
 
@@ -57,7 +57,7 @@ After obtaining an API key from [here](https://www.voyageai.com/), you can confi
 
 ### Ollama
 
-See [here](../model-providers/top-level/ollama.mdx#embeddings-model) for instructions on how to use Ollama for embeddings.
+See [here](../model-providers/top-level/ollama#embeddings-model) for instructions on how to use Ollama for embeddings.
 
 ### Transformers.js (currently VS Code only)
 
@@ -118,36 +118,36 @@ See [here](../model-providers/top-level/ollama.mdx#embeddings-model) for instruc
 
 ### OpenAI
 
-See [here](../model-providers/top-level/openai.mdx#embeddings-model) for instructions on how to use OpenAI for embeddings.
+See [here](../model-providers/top-level/openai#embeddings-model) for instructions on how to use OpenAI for embeddings.
 
 ### Cohere
 
-See [here](../model-providers/more/cohere.mdx#embeddings-model) for instructions on how to use Cohere for embeddings.
+See [here](../model-providers/more/cohere#embeddings-model) for instructions on how to use Cohere for embeddings.
 
 ### Gemini
 
-See [here](../model-providers/top-level/gemini.mdx#embeddings-model) for instructions on how to use Gemini for embeddings.
+See [here](../model-providers/top-level/gemini#embeddings-model) for instructions on how to use Gemini for embeddings.
 
 ### Vertex
 
-See [here](../model-providers/top-level/vertexai.mdx#embeddings-model) for instructions on how to use Vertex for embeddings.
+See [here](../model-providers/top-level/vertexai#embeddings-model) for instructions on how to use Vertex for embeddings.
 
 ### Mistral
 
-See [here](../model-providers/top-level/mistral.mdx#embeddings-model) for instructions on how to use Mistral for embeddings.
+See [here](../model-providers/top-level/mistral#embeddings-model) for instructions on how to use Mistral for embeddings.
 
 ### NVIDIA
 
-See [here](../model-providers/more/nvidia.mdx#embeddings-model) for instructions on how to use NVIDIA for embeddings.
+See [here](../model-providers/more/nvidia#embeddings-model) for instructions on how to use NVIDIA for embeddings.
 
 ### Bedrock
 
-See [here](../model-providers/top-level/bedrock.mdx#embeddings-model) for instructions on how to use Bedrock for embeddings.
+See [here](../model-providers/top-level/bedrock#embeddings-model) for instructions on how to use Bedrock for embeddings.
 
 ### WatsonX
 
-See [here](../model-providers/more/watsonx.mdx#embeddings-model) for instructions on how to use WatsonX for embeddings.
+See [here](../model-providers/more/watsonx#embeddings-model) for instructions on how to use WatsonX for embeddings.
 
 ### LMStudio
 
-See [here](../model-providers/more/lmstudio.mdx#embeddings-model) for instructions on how to use LMStudio for embeddings.
+See [here](../model-providers/more/lmstudio#embeddings-model) for instructions on how to use LMStudio for embeddings.


### PR DESCRIPTION
## Description

Fix internal file links ending with `.md` or `.mdx` to redirect to correct pages.

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots


https://github.com/user-attachments/assets/636d4f52-7758-4a63-96cc-27e4aa1100c4


https://github.com/user-attachments/assets/b402aa5d-f8cf-42f3-835a-c6d6dec8bdb8



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed internal documentation links ending with .md or .mdx so they now point to the correct pages.

<!-- End of auto-generated description by cubic. -->

