### PR TITLE
fix: reload assistant click opens login

### DIFF
--- a/gui/src/components/AssistantAndOrgListbox/index.tsx
+++ b/gui/src/components/AssistantAndOrgListbox/index.tsx
@@ -161,18 +161,14 @@ export function AssistantAndOrgListbox() {
               </ListboxOption>
 
               <ListboxOption
-                value="new-assistant"
+                value="reload-assistant"
                 fontSizeModifier={-2}
                 className="border-border border-b px-2 py-1.5"
-                onClick={session ? onNewAssistant : () => login(false)}
+                onClick={() => refreshProfiles()}
               >
                 <span
                   className="text-description flex flex-row items-center"
                   style={{ fontSize: tinyFont }}
-                  onClick={async (e) => {
-                    e.stopPropagation();
-                    await refreshProfiles();
-                  }}
                 >
                   <ArrowPathIcon
                     className={cn(


### PR DESCRIPTION
## Description

Fix login popup when clicking on reload assistant

resolves CON-2499

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots





https://github.com/user-attachments/assets/3f489655-5d81-406e-8723-469fb0da0bfa

https://github.com/user-attachments/assets/3be1ec83-f94a-45dd-a863-0fa63a101226



## Tests



[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Clicking "reload assistant" now refreshes profiles instead of opening the login popup.

<!-- End of auto-generated description by cubic. -->

