### PR TITLE
fix: double slash on opening hub urls

### DIFF
--- a/core/core.ts
+++ b/core/core.ts
@@ -359,7 +359,10 @@ export class Core {
 
     on("controlPlane/openUrl", async (msg) => {
       const env = await getControlPlaneEnv(this.ide.getIdeSettings());
-      let url = `${env.APP_URL}${msg.data.path}`;
+      const urlPath = msg.data.path.startsWith("/")
+        ? msg.data.path.slice(1)
+        : msg.data.path;
+      let url = `${env.APP_URL}${urlPath}`;
       if (msg.data.orgSlug) {
         url += `?org=${msg.data.orgSlug}`;
       }


### PR DESCRIPTION
## Description

Fix double slash in hub urls

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots



https://github.com/user-attachments/assets/6fb372a2-8469-4588-a5f7-56b036a09cee




https://github.com/user-attachments/assets/e6bc51b4-0939-43c6-b702-f2f050daa8ae

## Tests


[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where opening hub URLs could result in double slashes, ensuring URLs are now formatted correctly.

<!-- End of auto-generated description by cubic. -->

