### PR TITLE
fix: Add logging of Continue binary IO

### DIFF
--- a/extensions/intellij/CONTRIBUTING.md
+++ b/extensions/intellij/CONTRIBUTING.md
@@ -101,6 +101,14 @@ allow for changes to your `config.json` and other files during development, with
 
 When using the `Run Continue` task, we automatically tail both prompt logs and IDE logs.
 
+#### Viewing more IDE logs
+
+You can selectively increase the log granularity (e.g., debug-level logs) as follows:
+* Navigate to `Help | Diagnostic Tools | Debug Log Settings...`
+* Add a line in the format: `com.intellij.diagnostic:debug`
+
+You can find more information about this feature in [official docs](https://youtrack.jetbrains.com/articles/SUPPORT-A-43/How-to-enable-debug-logging-in-IntelliJ-IDEA).
+
 ### Reloading changes
 
 - `extensions/intellij`: Attempt to reload changed classes by selecting

--- a/extensions/intellij/CONTRIBUTING.md
+++ b/extensions/intellij/CONTRIBUTING.md
@@ -104,8 +104,9 @@ When using the `Run Continue` task, we automatically tail both prompt logs and I
 #### Viewing more IDE logs
 
 You can selectively increase the log granularity (e.g., debug-level logs) as follows:
-* Navigate to `Help | Diagnostic Tools | Debug Log Settings...`
-* Add a line in the format: `com.intellij.diagnostic:debug`
+
+- Navigate to `Help | Diagnostic Tools | Debug Log Settings...`
+- Add a line in the format: `com.intellij.diagnostic:debug`
 
 You can find more information about this feature in [official docs](https://youtrack.jetbrains.com/articles/SUPPORT-A-43/How-to-enable-debug-logging-in-IntelliJ-IDEA).
 


### PR DESCRIPTION
Minor fix/feature for developers

I used this recently in a situation where I wasn’t connecting to the binary with `USE_TCP` (it wasn’t straightforward due to the remote host)