### PR TITLE
Simplify Edit Logging

### DIFF
--- a/core/config/sharedConfig.ts
+++ b/core/config/sharedConfig.ts
@@ -19,7 +19,6 @@ export const sharedConfigSchema = z
     readResponseTTS: z.boolean(),
     promptPath: z.string(),
     useCurrentFileAsContext: z.boolean(),
-    logEditingData: z.boolean(),
     optInNextEditFeature: z.boolean(),
     enableExperimentalTools: z.boolean(),
     codebaseToolCallingOnly: z.boolean(),
@@ -180,9 +179,6 @@ export function modifyAnyConfigWithSharedConfig<
   if (sharedConfig.useCurrentFileAsContext !== undefined) {
     configCopy.experimental.useCurrentFileAsContext =
       sharedConfig.useCurrentFileAsContext;
-  }
-  if (sharedConfig.logEditingData !== undefined) {
-    configCopy.experimental.logEditingData = sharedConfig.logEditingData;
   }
   if (sharedConfig.optInNextEditFeature !== undefined) {
     configCopy.experimental.optInNextEditFeature =

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1288,7 +1288,6 @@ export interface ContinueUIConfig {
   codeWrap?: boolean;
   showSessionTabs?: boolean;
   autoAcceptEditToolDiffs?: boolean;
-  logEditingData?: boolean;
 }
 
 export interface ContextMenuConfig {
@@ -1440,11 +1439,6 @@ export interface ExperimentalConfig {
    * If enabled, will add the current file as context.
    */
   useCurrentFileAsContext?: boolean;
-
-  /**
-   * If enabled, will save data on the user's editing processes
-   */
-  logEditingData?: boolean;
 
   /**
    * If enabled, will enable next edit in place of autocomplete

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "1.1.60",
+  "version": "1.1.63",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "1.1.60",
+      "version": "1.1.63",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",

--- a/extensions/vscode/src/util/editLoggingUtils.ts
+++ b/extensions/vscode/src/util/editLoggingUtils.ts
@@ -61,7 +61,7 @@ export const handleTextDocumentChange = async (
   const editor = vscode.window.activeTextEditor;
   const { config } = await configHandler.loadConfig();
 
-  if (!config?.experimental?.logEditingData) return;
+  // if (!config?.experimental?.logEditingData) return;
   if (!editor) return;
   if (event.contentChanges.length === 0) return;
 

--- a/gui/src/pages/config/ContinueFeaturesMenu.tsx
+++ b/gui/src/pages/config/ContinueFeaturesMenu.tsx
@@ -1,14 +1,10 @@
 import ToggleSwitch from "../../components/gui/Switch";
 interface ContinueFeaturesMenuProps {
-  logEditingData: boolean;
-  handleLogEditingDataToggle: (value: boolean) => void;
   optInNextEditFeature: boolean;
   handleOptInNextEditToggle: (value: boolean) => void;
 }
 
 export function ContinueFeaturesMenu({
-  logEditingData,
-  handleLogEditingDataToggle,
   optInNextEditFeature,
   handleOptInNextEditToggle,
 }: ContinueFeaturesMenuProps) {

--- a/gui/src/pages/config/ContinueFeaturesMenu.tsx
+++ b/gui/src/pages/config/ContinueFeaturesMenu.tsx
@@ -1,6 +1,4 @@
-import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 import ToggleSwitch from "../../components/gui/Switch";
-import { ToolTip } from "../../components/gui/Tooltip";
 interface ContinueFeaturesMenuProps {
   logEditingData: boolean;
   handleLogEditingDataToggle: (value: boolean) => void;
@@ -20,23 +18,6 @@ export function ContinueFeaturesMenu({
         🚧 INTERNAL SETTINGS 🚧
       </div>
       <div className="flex w-full flex-col gap-y-4">
-        <ToggleSwitch
-          isToggled={logEditingData}
-          onToggle={() => handleLogEditingDataToggle(!logEditingData)}
-          text="Log Editing Data"
-          showIfToggled={
-            <>
-              <ExclamationTriangleIcon
-                data-tooltip-id={`auto-accept-diffs-warning-tooltip`}
-                className="h-3 w-3 text-yellow-500"
-              />
-              <ToolTip id={`auto-accept-diffs-warning-tooltip`}>
-                {`Only turn this on if you want to log your editing processes in addition to the normal dev data. Note that this will store a lot of data.`}
-              </ToolTip>
-            </>
-          }
-        />
-
         <ToggleSwitch
           isToggled={optInNextEditFeature}
           onToggle={() => handleOptInNextEditToggle(!optInNextEditFeature)}

--- a/gui/src/pages/config/UserSettingsForm.tsx
+++ b/gui/src/pages/config/UserSettingsForm.tsx
@@ -67,10 +67,6 @@ export function UserSettingsForm() {
     });
   };
 
-  const handleLogEditingDataToggle = (value: boolean) => {
-    handleUpdate({ logEditingData: value });
-  };
-
   const handleOptInNextEditToggle = (value: boolean) => {
     handleUpdate({ optInNextEditFeature: value });
   };
@@ -86,7 +82,6 @@ export function UserSettingsForm() {
   const showChatScrollbar = config.ui?.showChatScrollbar ?? false;
   const readResponseTTS = config.experimental?.readResponseTTS ?? false;
   const autoAcceptEditToolDiffs = config.ui?.autoAcceptEditToolDiffs ?? false;
-  const logEditingData = config.experimental?.logEditingData ?? false;
   const displayRawMarkdown = config.ui?.displayRawMarkdown ?? false;
   const disableSessionTitles = config.disableSessionTitles ?? false;
   const useCurrentFileAsContext =
@@ -436,8 +431,6 @@ export function UserSettingsForm() {
 
                 {hasContinueEmail && (
                   <ContinueFeaturesMenu
-                    logEditingData={logEditingData}
-                    handleLogEditingDataToggle={handleLogEditingDataToggle}
                     optInNextEditFeature={optInNextEditFeature}
                     handleOptInNextEditToggle={handleOptInNextEditToggle}
                   />


### PR DESCRIPTION
## Description

Removes toggle for logging edit data to simplify process

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the "Log Editing Data" toggle so edit logging is always enabled, making the process simpler for users.

<!-- End of auto-generated description by cubic. -->

