### PR TITLE
fix: race condition for this.lanceDbIndex being loaded and retrieveEmbeddings accessing it

### DIFF
--- a/core/context/retrieval/pipelines/BaseRetrievalPipeline.ts
+++ b/core/context/retrieval/pipelines/BaseRetrievalPipeline.ts
@@ -60,12 +60,13 @@ export interface IRetrievalPipeline {
 export default class BaseRetrievalPipeline implements IRetrievalPipeline {
   private ftsIndex = new FullTextSearchCodebaseIndex();
   private lanceDbIndex: LanceDbIndex | null = null;
+  private lanceDbInitPromise: Promise<void> | null = null;
 
   constructor(protected readonly options: RetrievalPipelineOptions) {
     void this.initLanceDb();
   }
 
-  private async initLanceDb() {
+  protected async initLanceDb() {
     const embedModel = this.options.config.selectedModelByRole.embed;
 
     if (!embedModel) {
@@ -75,6 +76,23 @@ export default class BaseRetrievalPipeline implements IRetrievalPipeline {
     this.lanceDbIndex = await LanceDbIndex.create(embedModel, (uri) =>
       this.options.ide.readFile(uri),
     );
+  }
+
+  protected async ensureLanceDbInitialized(): Promise<boolean> {
+    if (this.lanceDbIndex) {
+      return true;
+    }
+
+    if (this.lanceDbInitPromise) {
+      await this.lanceDbInitPromise;
+      return this.lanceDbIndex !== null;
+    }
+
+    this.lanceDbInitPromise = this.initLanceDb();
+    await this.lanceDbInitPromise;
+    this.lanceDbInitPromise = null; // clear after init
+
+    return this.lanceDbIndex !== null;
   }
 
   private getCleanedTrigrams(
@@ -163,7 +181,9 @@ export default class BaseRetrievalPipeline implements IRetrievalPipeline {
     input: string,
     n: number,
   ): Promise<Chunk[]> {
-    if (!this.lanceDbIndex) {
+    const initialized = await this.ensureLanceDbInitialized();
+
+    if (!initialized || !this.lanceDbIndex) {
       console.warn(
         "LanceDB index not available, skipping embeddings retrieval",
       );


### PR DESCRIPTION
## Description

Closes CON-2848.

I noticed that we never really wait for `this.lanceDbIndex` to be properly initialized. The constructor makes a void call, which actually doesn't wait for `initLanceDb` to finish. Unless this is an intentional design choice, or that I'm misunderstanding this. Which, in case, feel free to close this PR.

This introduces a race condition, which potentially explains why I see `retrieveEmbeddings` failing sometimes. `this.lanceDbIndex` is not loaded yet.

I added a simple check to ensure that `this.lanceDbIndex` is properly initialized.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
