### PR TITLE
chore: remove is too big check

### DIFF
--- a/core/protocol/core.ts
+++ b/core/protocol/core.ts
@@ -243,7 +243,6 @@ export type ToCoreFromIdeOrWebviewProtocol = {
     { vsCodeUriScheme?: string },
     { url: string } | null,
   ];
-  isItemTooBig: [{ item: ContextItemWithId }, boolean];
   didChangeControlPlaneSessionInfo: [
     { sessionInfo: ControlPlaneSessionInfo | undefined },
     void,

--- a/core/protocol/passThrough.ts
+++ b/core/protocol/passThrough.ts
@@ -67,7 +67,6 @@ export const WEBVIEW_TO_CORE_PASS_THROUGH: (keyof ToCoreFromWebviewProtocol)[] =
     "tools/call",
     "controlPlane/openUrl",
     "controlPlane/getModelsAddOnUpgradeUrl",
-    "isItemTooBig",
     "process/markAsBackgrounded",
     "process/isBackgrounded",
     "controlPlane/getFreeTrialStatus",

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/MessageTypes.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/MessageTypes.kt
@@ -133,7 +133,6 @@ class MessageTypes {
             "didChangeSelectedOrg",
             "tools/call",
             "controlPlane/openUrl",
-            "isItemTooBig",
             "process/markAsBackgrounded",
             "process/isBackgrounded",
         )


### PR DESCRIPTION
## Description
Removes the item is too big check, https://github.com/continuedev/continue/pull/4790, feedback has been that it's a bit noisy
Pruning message warnings will address part of the original reason for this
   
Draft, looking into updating the error message etc. instead of removing

<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the "is item too big" check from core logic and UI to reduce noise and simplify context item handling. Pruning message warnings will now handle related errors earlier.

<!-- End of auto-generated description by cubic. -->

