### PR TITLE
chore: use icon for generate rule action

### DIFF
--- a/gui/src/components/StepContainer/ResponseActions.tsx
+++ b/gui/src/components/StepContainer/ResponseActions.tsx
@@ -1,6 +1,6 @@
 import {
   BarsArrowDownIcon,
-  PlusIcon,
+  PencilSquareIcon,
   TrashIcon,
 } from "@heroicons/react/24/outline";
 import { ChatHistoryItem } from "core";
@@ -47,18 +47,13 @@ export default function ResponseActions({
   return (
     <div className="text-description-muted mx-2 flex cursor-default items-center justify-end space-x-1 bg-transparent pb-0 text-xs">
       {isLast && ruleGenerationSupported && (
-        <div
-          className="mr-1 border-y-0 border-l-0 border-r border-solid pr-2"
+        <HeaderButtonWithToolTip
+          tabIndex={-1}
+          text="Generate rule"
           onClick={onGenerateRule}
         >
-          <span className="flex cursor-pointer items-center hover:brightness-125">
-            <PlusIcon className="mr-1 h-3 w-3" />
-            <span className="xs:block hidden whitespace-nowrap">
-              Generate rule
-            </span>
-            <span className="xs:hidden block whitespace-nowrap">Rule</span>
-          </span>
-        </div>
+          <PencilSquareIcon className="text-description-muted h-3.5 w-3.5" />
+        </HeaderButtonWithToolTip>
       )}
 
       {isTruncated && (


### PR DESCRIPTION
<img width="210" height="85" alt="Screenshot 2025-07-16 at 6 48 44 PM" src="https://github.com/user-attachments/assets/bfa7e97c-85b7-45b2-8e3b-2979a17ef0e0" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced the "Generate rule" button text with a pencil icon to simplify the action and improve the UI.

<!-- End of auto-generated description by cubic. -->

