### PR TITLE
fix: don't use continue proxy openai adapter locally

### DIFF
--- a/core/llm/llms/stubs/ContinueProxy.ts
+++ b/core/llm/llms/stubs/ContinueProxy.ts
@@ -11,6 +11,7 @@ import OpenAI from "../OpenAI.js";
 
 import type { Chunk, LLMOptions } from "../../../index.js";
 import { LLMConfigurationStatuses } from "../../constants.js";
+import { LlmApiRequestType } from "../../openaiTypeConverters.js";
 
 class ContinueProxy extends OpenAI {
   set controlPlaneProxyInfo(value: ControlPlaneProxyInfo) {
@@ -22,6 +23,8 @@ class ContinueProxy extends OpenAI {
       ).toString();
     }
   }
+
+  protected useOpenAIAdapterFor: (LlmApiRequestType | "*")[] = [];
 
   // The apiKey and apiBase are set to the values for the proxy,
   // but we need to keep track of the actual values that the proxy will use

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "1.1.64",
+  "version": "1.1.65",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION
## Description

Don't use openai-adapter locally for Continue Proxy
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Stopped using the OpenAI adapter for Continue Proxy when running locally to avoid unnecessary proxying. Updated the VS Code extension version to 1.1.65.

<!-- End of auto-generated description by cubic. -->

