### PR TITLE
fix: (do not merge) kimi-k2 on openrouter should not support tools

### DIFF
--- a/core/llm/toolSupport.ts
+++ b/core/llm/toolSupport.ts
@@ -217,9 +217,14 @@ export const PROVIDER_TOOL_SUPPORT: Record<string, (model: string) => boolean> =
     openrouter: (model) => {
       // https://openrouter.ai/models?fmt=cards&supported_parameters=tools
       if (
-        ["vision", "math", "guard", "mistrallite", "mistral-openorca"].some(
-          (part) => model.toLowerCase().includes(part),
-        )
+        [
+          "vision",
+          "math",
+          "guard",
+          "mistrallite",
+          "mistral-openorca",
+          "kimi-k2",
+        ].some((part) => model.toLowerCase().includes(part))
       ) {
         return false;
       }


### PR DESCRIPTION
## Description

kimi k2 on open router does not support tool use

<img width="901" height="503" alt="image" src="https://github.com/user-attachments/assets/cf92e071-e1d4-4085-b760-4e09bcba7d2c" />


closes https://github.com/continuedev/continue/issues/6619
resolves CON-2854

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
