### PR TITLE
ci: run release on yaml change

### DIFF
--- a/.github/workflows/release-config-yaml.yml
+++ b/.github/workflows/release-config-yaml.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - "packages/config-yaml/**"
+      - ".github/workflows/release-config-yaml.yml"
+      - ".github/workflows/reusable-release.yml"
 
 permissions:
   contents: write

--- a/.github/workflows/release-fetch.yml
+++ b/.github/workflows/release-fetch.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - "packages/fetch/**"
+      - ".github/workflows/release-fetch.yml"
+      - ".github/workflows/reusable-release.yml"
 
 permissions:
   contents: write

--- a/.github/workflows/release-openai-adapters.yml
+++ b/.github/workflows/release-openai-adapters.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - "packages/openai-adapters/**"
+      - ".github/workflows/release-openai-adapters.yml"
+      - ".github/workflows/reusable-release.yml"
 
 permissions:
   contents: write


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated release workflows to trigger on changes to their own YAML files and the shared reusable-release workflow.

<!-- End of auto-generated description by cubic. -->

