### PR TITLE
fix: don't stringify os methods in terminal tool definition

### DIFF
--- a/core/tools/definitions/runTerminalCommand.ts
+++ b/core/tools/definitions/runTerminalCommand.ts
@@ -20,7 +20,7 @@ export function getPreferredShell(): string {
   }
 }
 
-export const PLATFORM_INFO = `Choose terminal commands and scripts optimized for ${os.platform} and ${os.arch} and shell ${getPreferredShell()}.`;
+export const PLATFORM_INFO = `Choose terminal commands and scripts optimized for ${os.platform()} and ${os.arch()} and shell ${getPreferredShell()}.`;
 
 export const runTerminalCommandTool: Tool = {
   type: "function",


### PR DESCRIPTION
## Description
Hotfix, os methods were being tried on the GUI and causing it not to load