### PR TITLE
fix: remove reject edit diff functionality on cmd backspace

### DIFF
--- a/gui/src/pages/gui/Chat.tsx
+++ b/gui/src/pages/gui/Chat.tsx
@@ -3,7 +3,7 @@ import {
   ChatBubbleOvalLeftIcon,
 } from "@heroicons/react/24/outline";
 import { Editor, JSONContent } from "@tiptap/react";
-import { InputModifiers, ChatHistoryItem } from "core";
+import { ChatHistoryItem, InputModifiers } from "core";
 import { renderChatMessage } from "core/util/messageContent";
 import {
   useCallback,
@@ -138,7 +138,6 @@ export function Chat() {
         !e.shiftKey
       ) {
         void dispatch(cancelStream());
-        if (isInEdit) ideMessenger.post("rejectDiff", {});
       }
     };
     window.addEventListener("keydown", listener);


### PR DESCRIPTION
## Description

When cmd+backspace was pressed to delete entire words in the chat area on edit mode, the focus would transfer to the editor which in turn would delete words from the editor. This PR fixes this behavior by removing the "reject diff" shortcut functionality from edit mode.

- remove "rejectDiff" on cmd backspace event listener

resolves CON-2607

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots



https://github.com/user-attachments/assets/8862dff4-82eb-4bed-9f74-d08a30ed9365

https://github.com/user-attachments/assets/1a8c15d3-5ed5-4e33-b4e2-33e262d07c1e



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the "reject diff" shortcut from edit mode so pressing cmd+backspace in the chat area no longer deletes words in the editor.

<!-- End of auto-generated description by cubic. -->

