### PR TITLE
fix: allow prompts starting with `/`

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor/extensions/SlashCommand.ts
+++ b/gui/src/components/mainInput/TipTapEditor/extensions/SlashCommand.ts
@@ -15,6 +15,9 @@ export const SlashCommand = Node.create<SlashCommandOptions>({
   addOptions() {
     return {
       suggestion: {
+        allow: ({ editor }) =>
+          // the first character is "/". we want to avoid slash commands when there is a space after it
+          editor.getText().at(1) !== " ",
         char: "/",
         pluginKey: new PluginKey(this.name),
         startOfLine: true,


### PR DESCRIPTION
## Description

Allow prompts starting with `/` at the beginning to be submitted.

- check for space after first slash and disallow popup if present

resolves CON-2605

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots



https://github.com/user-attachments/assets/5ceff035-8eaa-4a35-8b42-51f91a0c5ce0


https://github.com/user-attachments/assets/052169df-145e-44ec-bb4a-1fd69104560c


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
