### PR TITLE
ci: don't try to push to main

### DIFF
--- a/packages/shared-release.config.js
+++ b/packages/shared-release.config.js
@@ -21,13 +21,7 @@ export default function createReleaseConfig(packageName) {
       "@semantic-release/release-notes-generator",
       "@semantic-release/changelog",
       "@semantic-release/npm",
-      [
-        "@semantic-release/git",
-        {
-          assets: ["CHANGELOG.md", "package.json"],
-          message: `chore(release): @continuedev/${packageName}@\${nextRelease.version} [skip ci]`,
-        },
-      ],
+      // Removed @semantic-release/git plugin to avoid pushing to main
       "@semantic-release/github",
     ],
   };


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed the @semantic-release/git plugin from the release config to prevent CI from pushing changes to the main branch.

<!-- End of auto-generated description by cubic. -->

