### PR TITLE
feat: allow Cmd+L / Cmd+I on empty selection to select the entire line

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -505,13 +505,12 @@
       "continue.continueSubMenu": [
         {
           "command": "continue.focusContinueInputWithoutClear",
-          "group": "Continue",
-          "when": "editorHasSelection"
+          "group": "Continue"
         },
         {
           "command": "continue.focusEdit",
           "group": "Continue",
-          "when": "editorHasSelection && !editorReadonly"
+          "when": "!editorReadonly"
         },
         {
           "command": "continue.writeCommentsForCode",

--- a/extensions/vscode/src/util/addCode.ts
+++ b/extensions/vscode/src/util/addCode.ts
@@ -40,18 +40,34 @@ export function getRangeInFileWithContents(
       return null;
     }
 
-    let selectionRange = new vscode.Range(selection.start, selection.end);
-    const document = editor.document;
-    // Select the context from the beginning of the selection start line to the selection start position
-    const beginningOfSelectionStartLine = selection.start.with(undefined, 0);
-    const textBeforeSelectionStart = document.getText(
-      new vscode.Range(beginningOfSelectionStartLine, selection.start),
-    );
-    // If there are only whitespace before the start of the selection, include the indentation
-    if (textBeforeSelectionStart.trim().length === 0) {
-      selectionRange = selectionRange.with({
-        start: beginningOfSelectionStartLine,
-      });
+    let selectionRange: vscode.Range | undefined;
+    // if the selection is empty and the line is not, then use the entire line
+    if (selection.isEmpty) {
+      const startLine = editor.document.lineAt(selection.start.line);
+      if (startLine.isEmptyOrWhitespace) {
+        // Empty selection on an empty line, nothing else to do here
+        return null;
+      }
+      // Select the whole line
+      selectionRange = new vscode.Range(
+        selection.start.with(undefined, 0),
+        selection.end.with(undefined, startLine.range.end.character),
+      );
+    }
+    if (!selectionRange) {
+      selectionRange = new vscode.Range(selection.start, selection.end);
+      const document = editor.document;
+      // Select the context from the beginning of the selection start line to the selection start position
+      const beginningOfSelectionStartLine = selection.start.with(undefined, 0);
+      const textBeforeSelectionStart = document.getText(
+        new vscode.Range(beginningOfSelectionStartLine, selection.start),
+      );
+      // If there are only whitespace before the start of the selection, include the indentation
+      if (textBeforeSelectionStart.trim().length === 0) {
+        selectionRange = selectionRange.with({
+          start: beginningOfSelectionStartLine,
+        });
+      }
     }
 
     const contents = editor.document.getText(selectionRange);
@@ -78,7 +94,7 @@ export function getRangeInFileWithContents(
 export async function addHighlightedCodeToContext(
   webviewProtocol: VsCodeWebviewProtocol | undefined,
 ) {
-  const rangeInFileWithContents = getRangeInFileWithContents();
+  const rangeInFileWithContents = getRangeInFileWithContents(true);
   if (rangeInFileWithContents) {
     webviewProtocol?.request("highlightedCode", {
       rangeInFileWithContents,


### PR DESCRIPTION
This PR makes it simpler to add code to the Chat context: if no code is selected, the entire line is added to the context by Cmd+I or Cmd+L. This behaviour is similar to what Github Copilot offers.

https://github.com/user-attachments/assets/d89add3b-5515-4b34-a2d1-4ab9327a6397


