### PR TITLE
Todo lists and suggestions

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -262,6 +262,7 @@ export interface Session {
   title: string;
   workspaceDirectory: string;
   history: ChatHistoryItem[];
+  // TODO: todo state maybe goes here
 }
 
 export interface SessionMetadata {

--- a/core/llm/defaultSystemMessages.ts
+++ b/core/llm/defaultSystemMessages.ts
@@ -61,6 +61,22 @@ export const DEFAULT_AGENT_SYSTEM_MESSAGE = `\
 <important_rules>
   You are in agent mode.
 
+Use TodoRead and TodoWrite extremely often to manage and plan tasks. The user will review the todo list frequently, so keep it updated. Always break down non-trivial tasks into subtasks. Always update the todo list immediately when task status changes, like from planned to in progress to done. Never mark tasks in batches, always mark them one by one as they are completed. The todo list should be append only, though editing is also ok. In general you add tasks, then complete them, maybe add more, complete those, etc. You can also re-order tasks as needed. Do not wipe earlier tasks when writing later ones, as we need the entire task history to audit.
+
+IMPORTANT: The user will send the <suggestion> tag to provide more information. Always consider the suggestion, respond to the user, and incorporate it into your plans.
+
+Workflow:
+- Read: read the prompt and read source code until you understand the work to be done
+- Ask: if anything is not clear, stop and ask the user
+- Plan: consider several approaches to the problem, then choose one and proceed. Mark them all as todos with the chosen one in progress and the others cancelled.
+- Execute: do the plan
+- Check: does it work?
+- Refactor: dry and simplify if possible
+- Verify: run tests, linters, etc; fix any issues reported
+- Report: output a brief report (up to 100 words) discussing work done, not done, and any thoughts or feedback
+
+If at any point during workflow you make discoveries should change the plan, start workflow over.
+
 ${CODEBLOCK_FORMATTING_INSTRUCTIONS}
 </important_rules>`;
 

--- a/core/tools/builtIn.ts
+++ b/core/tools/builtIn.ts
@@ -14,6 +14,8 @@ export enum BuiltInToolNames {
   RequestRule = "request_rule",
   FetchUrlContent = "fetch_url_content",
   CodebaseTool = "codebase",
+  TodoRead = "todo_read",
+  TodoWrite = "todo_write",
 
   // excluded from allTools for now
   ViewRepoMap = "view_repo_map",

--- a/core/tools/callTool.ts
+++ b/core/tools/callTool.ts
@@ -15,6 +15,8 @@ import { readFileImpl } from "./implementations/readFile";
 import { requestRuleImpl } from "./implementations/requestRule";
 import { runTerminalCommandImpl } from "./implementations/runTerminalCommand";
 import { searchWebImpl } from "./implementations/searchWeb";
+import { todoReadImpl } from "./implementations/todoRead";
+import { todoWriteImpl } from "./implementations/todoWrite";
 import { viewDiffImpl } from "./implementations/viewDiff";
 import { viewRepoMapImpl } from "./implementations/viewRepoMap";
 import { viewSubdirectoryImpl } from "./implementations/viewSubdirectory";
@@ -173,6 +175,10 @@ export async function callBuiltInTool(
       return await viewRepoMapImpl(args, extras);
     case BuiltInToolNames.ViewSubdirectory:
       return await viewSubdirectoryImpl(args, extras);
+    case BuiltInToolNames.TodoRead:
+      return await todoReadImpl(args, extras);
+    case BuiltInToolNames.TodoWrite:
+      return await todoWriteImpl(args, extras);
     default:
       throw new Error(`Tool "${functionName}" not found`);
   }

--- a/core/tools/definitions/todoRead.ts
+++ b/core/tools/definitions/todoRead.ts
@@ -1,0 +1,30 @@
+// Tool definition for reading the current markdown todo list. Returns the full
+// markdown content with legend: [ ] planned, [x] done, [*] in progress, [~]
+// cancelled.
+import { Tool } from "../..";
+import { BUILT_IN_GROUP_NAME, BuiltInToolNames } from "../builtIn";
+
+export const todoReadTool: Tool = {
+  type: "function",
+  displayTitle: "TodoRead",
+  wouldLikeTo: "read the todo list",
+  isCurrently: "reading the todo list",
+  hasAlready: "viewed the todo list",
+  readonly: true,
+  isInstant: true,
+  group: BUILT_IN_GROUP_NAME,
+  function: {
+    name: BuiltInToolNames.TodoRead,
+    description:
+      "Read the current markdown todo list. Returns the full markdown content. " +
+      "Use at the beginning of conversations, before starting new tasks, when " +
+      "uncertain about next steps, or after completing tasks to track remaining " +
+      "work. Format: [ ] planned, [x] done, [*] in progress, [~] cancelled. " +
+      "Legend is included in HTML comments (<!-- ... -->).",
+    parameters: {
+      type: "object",
+      required: [],
+      properties: {},
+    },
+  },
+};

--- a/core/tools/definitions/todoWrite.ts
+++ b/core/tools/definitions/todoWrite.ts
@@ -1,0 +1,37 @@
+// Tool definition for writing markdown todo lists. Accepts the full markdown
+// content and stores it in history. Format: [ ] planned, [x] done, [*] in
+// progress, [~] cancelled.
+import { Tool } from "../..";
+import { BUILT_IN_GROUP_NAME, BuiltInToolNames } from "../builtIn";
+
+export const todoWriteTool: Tool = {
+  type: "function",
+  displayTitle: "TodoWrite",
+  wouldLikeTo: "update the todo list",
+  isCurrently: "updating the todo list",
+  hasAlready: "updated the todo list",
+  readonly: false,
+  isInstant: true,
+  group: BUILT_IN_GROUP_NAME,
+  function: {
+    name: BuiltInToolNames.TodoWrite,
+    description:
+      "CRITICAL: You MUST update todo status right away as a todo CHANGES from PLANNED to IN PROGRESS to COMPLETED, or is CANCELLED. " +
+      "Write the full markdown todo list. Use for complex multi-step tasks, non-trivial " +
+      "operations, when user provides multiple tasks, or after receiving new instructions. " +
+      "Use subtask todos to break down complex todos, indented 2 spaces under the parent todo. " +
+      "Format: - [ ] planned, - [x] done, - [*] in progress, - [~] cancelled. " +
+      "Always include the format legend at top in HTML comments (<!-- ... -->).",
+    parameters: {
+      type: "object",
+      required: ["markdown"],
+      properties: {
+        markdown: {
+          type: "string",
+          description:
+            "The full markdown content for the todo list including HTML-commented legend and all tasks",
+        },
+      },
+    },
+  },
+};

--- a/core/tools/implementations/todoRead.ts
+++ b/core/tools/implementations/todoRead.ts
@@ -1,0 +1,44 @@
+// Implementation for reading markdown todo list from global state. Returns the
+// current markdown content with legend: [ ] planned, [x] done, [*] in progress,
+// [~] cancelled.
+import { ToolImpl } from ".";
+import { getTodoMarkdown, countTodos, getTodoSummary } from "./todoState";
+
+export const todoReadImpl: ToolImpl = async (_args, _extras) => {
+  const markdown = getTodoMarkdown();
+
+  if (!markdown) {
+    const defaultContent = `# Todo List
+
+<!-- 
+Legend:
+- [ ] planned
+- [x] done  
+- [*] in progress
+- [~] cancelled
+-->
+
+## Tasks
+`;
+
+    return [
+      {
+        name: "Todo List (empty)",
+        description: "Current todo list",
+        content: defaultContent,
+      },
+    ];
+  }
+
+  // Count todos for summary
+  const counts = countTodos(markdown);
+  const summary = getTodoSummary(counts);
+
+  return [
+    {
+      name: `Todo List (${summary})`,
+      description: "Current todo list",
+      content: markdown,
+    },
+  ];
+};

--- a/core/tools/implementations/todoState.ts
+++ b/core/tools/implementations/todoState.ts
@@ -1,0 +1,75 @@
+// In-memory state management for markdown todo lists with full history. Todo
+// format: [ ] planned, [x] done, [*] in progress, [~] cancelled. Each history
+// item stores the complete markdown content at that point in time.
+
+interface TodoState {
+  history: string[];
+  currentIndex: number;
+}
+
+// In-memory state storage
+let todoState: TodoState = {
+  history: [],
+  currentIndex: -1,
+};
+
+export function getTodoMarkdown(): string {
+  if (todoState.currentIndex < 0 || todoState.history.length === 0) {
+    return "";
+  }
+  return todoState.history[todoState.currentIndex];
+}
+
+export function setTodoMarkdown(markdown: string): void {
+  // Add new state to history
+  todoState.history.push(markdown);
+  todoState.currentIndex = todoState.history.length - 1;
+}
+
+export function getTodoHistory(): string[] {
+  return [...todoState.history];
+}
+
+export function clearTodoState(): void {
+  todoState = {
+    history: [],
+    currentIndex: -1,
+  };
+}
+
+export interface TodoCounts {
+  planned: number;
+  done: number;
+  inProgress: number;
+  cancelled: number;
+  total: number;
+}
+
+export function countTodos(markdown: string): TodoCounts {
+  const lines = markdown.split("\n");
+  let planned = 0;
+  let done = 0;
+  let inProgress = 0;
+  let cancelled = 0;
+
+  for (const line of lines) {
+    if (line.includes("- [ ]")) planned++;
+    else if (line.includes("- [x]")) done++;
+    else if (line.includes("- [*]")) inProgress++;
+    else if (line.includes("- [~]")) cancelled++;
+  }
+
+  return {
+    planned,
+    done,
+    inProgress,
+    cancelled,
+    total: planned + done + inProgress + cancelled,
+  };
+}
+
+export function getTodoSummary(counts: TodoCounts): string {
+  return counts.total > 0
+    ? `${counts.planned} planned, ${counts.inProgress} in progress, ${counts.done} done`
+    : "empty";
+}

--- a/core/tools/implementations/todoWrite.ts
+++ b/core/tools/implementations/todoWrite.ts
@@ -1,0 +1,24 @@
+// Implementation for writing markdown todo list to global state. Accepts the
+// full markdown content and stores it in history. Format: [ ] planned, [x]
+// done, [*] in progress, [~] cancelled.
+import { ToolImpl } from ".";
+import { setTodoMarkdown, countTodos, getTodoSummary } from "./todoState";
+
+export const todoWriteImpl: ToolImpl = async (args, _extras) => {
+  const markdown: string = args.markdown || "";
+
+  // Store the markdown content
+  setTodoMarkdown(markdown);
+
+  // Count todos for summary
+  const counts = countTodos(markdown);
+  const summary = getTodoSummary(counts);
+
+  return [
+    {
+      name: `Todo List Updated (${summary})`,
+      description: "Todo list has been updated",
+      content: markdown,
+    },
+  ];
+};

--- a/core/tools/index.ts
+++ b/core/tools/index.ts
@@ -13,6 +13,8 @@ import { requestRuleTool } from "./definitions/requestRule";
 import { runTerminalCommandTool } from "./definitions/runTerminalCommand";
 import { searchAndReplaceInFileTool } from "./definitions/searchAndReplaceInFile";
 import { searchWebTool } from "./definitions/searchWeb";
+import { todoReadTool } from "./definitions/todoRead";
+import { todoWriteTool } from "./definitions/todoWrite";
 import { viewDiffTool } from "./definitions/viewDiff";
 import { viewRepoMapTool } from "./definitions/viewRepoMap";
 import { viewSubdirectoryTool } from "./definitions/viewSubdirectory";
@@ -33,6 +35,8 @@ const getBaseToolDefinitions = () => [
   lsTool,
   createRuleBlock,
   fetchUrlContentTool,
+  todoReadTool,
+  todoWriteTool,
 ];
 
 export const getConfigDependentToolDefinitions = (

--- a/gui/src/components/FileIcon.tsx
+++ b/gui/src/components/FileIcon.tsx
@@ -2,6 +2,7 @@
 import DOMPurify from "dompurify";
 import { useMemo } from "react";
 import { themeIcons } from "seti-file-icons";
+import { Bars3BottomLeftIcon } from "@heroicons/react/24/outline";
 
 export interface FileIconProps {
   height: `${number}px`;
@@ -19,6 +20,20 @@ export default function FileIcon({ filename, height, width }: FileIconProps) {
       return filename;
     }
   }, [filename]);
+
+  // Special case for TODO.md files
+  if (file.endsWith("TODO.md") || file === "TODO.md") {
+    return (
+      <Bars3BottomLeftIcon
+        style={{
+          width: width,
+          height: height,
+          flexShrink: 0,
+          display: "flex",
+        }}
+      />
+    );
+  }
 
   const getIcon = themeIcons({
     blue: "#268bd2",

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/index.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/index.tsx
@@ -265,7 +265,7 @@ export function StepContainerPreToolbar({
   return (
     <div className="outline-command-border -outline-offset-0.5 rounded-default bg-editor mb-2 mt-2 flex min-w-0 flex-col outline outline-1">
       <div
-        className={`find-widget-skip bg-editor sticky -top-2 z-10 m-0 flex items-center justify-between gap-3 px-1.5 py-1 ${isExpanded ? "border-command-border border-b" : ""}`}
+        className={`find-widget-skip bg-editor sticky -top-2 z-10 m-0 flex items-center justify-between gap-3 rounded-lg px-1.5 py-1 ${isExpanded ? "border-command-border border-b" : ""}`}
         style={{ fontSize: `${getFontSize() - 2}px` }}
       >
         <div className="flex max-w-[50%] flex-row items-center">

--- a/gui/src/components/StyledMarkdownPreview/SyntaxHighlightedPre.tsx
+++ b/gui/src/components/StyledMarkdownPreview/SyntaxHighlightedPre.tsx
@@ -15,19 +15,26 @@ const generateThemeStyles = (theme: any) => {
     .join("");
 };
 
-const StyledPre = styled.pre<{ theme: any }>`
+const StyledPre = styled.pre<{ theme: any; hasHeader?: boolean }>`
   & .hljs {
     color: ${vscForeground};
   }
 
   margin-top: 0;
   margin-bottom: 0;
-  border-radius: 0 0 ${defaultBorderRadius} ${defaultBorderRadius} !important;
+  border-radius: ${(props) =>
+    props.hasHeader
+      ? `0 0 ${defaultBorderRadius} ${defaultBorderRadius}`
+      : defaultBorderRadius} !important;
 
   ${(props) => generateThemeStyles(props.theme)}
 `;
 
 export const SyntaxHighlightedPre = (props: any) => {
   const currentTheme = useContext(VscThemeContext);
-  return <StyledPre {...props} theme={currentTheme.theme} />;
+  // Check if this pre is inside a container with header by looking for parent with border
+  const hasHeader = props.className?.includes("has-toolbar-header") ?? true;
+  return (
+    <StyledPre {...props} theme={currentTheme.theme} hasHeader={hasHeader} />
+  );
 };

--- a/gui/src/components/mainInput/TipTapEditor/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor/TipTapEditor.tsx
@@ -7,6 +7,7 @@ import useIsOSREnabled from "../../../hooks/useIsOSREnabled";
 import useUpdatingRef from "../../../hooks/useUpdatingRef";
 import { useAppDispatch, useAppSelector } from "../../../redux/hooks";
 import { selectSelectedChatModel } from "../../../redux/slices/configSlice";
+import { addSuggestion } from "../../../redux/slices/sessionSlice";
 import InputToolbar, { ToolbarOptions } from "../InputToolbar";
 import { ComboBoxItem } from "../types";
 import { DragOverlay } from "./components/DragOverlay";
@@ -49,6 +50,9 @@ export function TipTapEditor(props: TipTapEditorProps) {
   const isStreaming = useAppSelector((state) => state.session.isStreaming);
   const historyLength = useAppSelector((store) => store.session.history.length);
   const isInEdit = useAppSelector((store) => store.session.isInEdit);
+  const suggestionQueue = useAppSelector(
+    (state) => state.session.suggestionQueue,
+  );
 
   const { editor, onEnterRef } = createEditorConfig({
     props,
@@ -71,7 +75,12 @@ export function TipTapEditor(props: TipTapEditorProps) {
     if (!editor) {
       return;
     }
-    const placeholder = getPlaceholderText(props.placeholder, historyLength);
+    const placeholder = getPlaceholderText(
+      props.placeholder,
+      historyLength,
+      isStreaming,
+      props.isMainInput,
+    );
 
     editor.extensionManager.extensions.filter(
       (extension) => extension.name === "placeholder",
@@ -266,6 +275,12 @@ export function TipTapEditor(props: TipTapEditorProps) {
           }}
           disabled={isStreaming}
         />
+        {isStreaming && suggestionQueue.length > 0 && props.isMainInput && (
+          <div className="px-2 py-1 text-xs text-gray-500">
+            {suggestionQueue.length} suggestion
+            {suggestionQueue.length > 1 ? "s" : ""} queued
+          </div>
+        )}
       </div>
 
       {showDragOverMsg &&

--- a/gui/src/pages/gui/ToolCallDiv/FunctionSpecificToolCallDiv.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/FunctionSpecificToolCallDiv.tsx
@@ -1,8 +1,10 @@
 import { ToolCallState } from "core";
 import { BuiltInToolNames } from "core/tools/builtIn";
+import { useAppSelector } from "../../../redux/hooks";
 import { CreateFile } from "./CreateFile";
 import { EditFile } from "./EditFile";
 import { RunTerminalCommand } from "./RunTerminalCommand";
+import { TodoCard } from "./TodoCard";
 
 function FunctionSpecificToolCallDiv({
   toolCallState,
@@ -13,6 +15,41 @@ function FunctionSpecificToolCallDiv({
 }) {
   const args = toolCallState.parsedArgs;
   const toolCall = toolCallState.toolCall;
+  const history = useAppSelector((state) => state.session.history);
+
+  // Find previous markdown content by looking back through history
+  const findPreviousMarkdown = (): string | undefined => {
+    // Look backwards through history from current position
+    for (let i = historyIndex - 1; i >= 0; i--) {
+      const item = history[i];
+      if (item.toolCallStates) {
+        // Check each tool call state in reverse order (most recent first)
+        for (let j = item.toolCallStates.length - 1; j >= 0; j--) {
+          const prevToolCall = item.toolCallStates[j];
+          const funcName = prevToolCall.toolCall.function?.name;
+
+          // Look for TodoWrite calls which have markdown in args
+          if (
+            funcName === BuiltInToolNames.TodoWrite &&
+            prevToolCall.parsedArgs?.markdown
+          ) {
+            return prevToolCall.parsedArgs.markdown;
+          }
+
+          // Look for TodoRead calls which have markdown in output
+          if (funcName === BuiltInToolNames.TodoRead) {
+            const todoItem = prevToolCall.output?.find((item) =>
+              item.name?.includes("Todo List"),
+            );
+            if (todoItem?.content) {
+              return todoItem.content;
+            }
+          }
+        }
+      }
+    }
+    return undefined;
+  };
 
   switch (toolCall.function?.name) {
     case BuiltInToolNames.CreateNewFile:
@@ -46,6 +83,29 @@ function FunctionSpecificToolCallDiv({
         <RunTerminalCommand
           command={args.command}
           toolCallState={toolCallState}
+          toolCallId={toolCall.id}
+        />
+      );
+    case BuiltInToolNames.TodoWrite:
+      return (
+        <TodoCard
+          markdown={args.markdown || ""}
+          previousMarkdown={findPreviousMarkdown()}
+          historyIndex={historyIndex}
+          toolCallId={toolCall.id}
+        />
+      );
+    case BuiltInToolNames.TodoRead:
+      // For TodoRead, the markdown is in the output content
+      const todoItem = toolCallState.output?.find((item) =>
+        item.name?.includes("Todo List"),
+      );
+      const markdown = todoItem?.content || "";
+      return (
+        <TodoCard
+          markdown={markdown}
+          previousMarkdown={findPreviousMarkdown()}
+          historyIndex={historyIndex}
           toolCallId={toolCall.id}
         />
       );

--- a/gui/src/pages/gui/ToolCallDiv/TodoCard.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/TodoCard.tsx
@@ -1,0 +1,222 @@
+// TodoCard component for displaying markdown todo lists. Parses markdown format
+// with legend: [ ] planned, [x] done, [*] in progress, [~] cancelled. Shows
+// changes between versions and supports expanding/collapsing view.
+import {
+  CheckCircleIcon,
+  ClockIcon,
+  XCircleIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+  PlusCircleIcon,
+} from "@heroicons/react/24/outline";
+import { useEffect, useState, useMemo } from "react";
+import { FileInfo } from "../../../components/StyledMarkdownPreview/StepContainerPreToolbar/FileInfo";
+
+interface ParsedTodo {
+  content: string;
+  status: "planned" | "done" | "in_progress" | "cancelled";
+  line: string;
+  indentLevel: number;
+}
+
+interface TodoCardProps {
+  markdown: string;
+  previousMarkdown?: string;
+  historyIndex: number;
+  toolCallId?: string;
+}
+
+export function TodoCard({
+  markdown,
+  previousMarkdown,
+  historyIndex,
+  toolCallId,
+}: TodoCardProps) {
+  const [viewMode, setViewMode] = useState<"changes" | "all">("changes");
+  const [changedLines, setChangedLines] = useState<Set<string>>(new Set());
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  // Parse markdown to extract todos
+  const parseTodos = (md: string): ParsedTodo[] => {
+    if (!md) return [];
+
+    const lines = md.split("\n");
+    const todos: ParsedTodo[] = [];
+    let inComment = false;
+
+    for (const line of lines) {
+      // Track HTML comment blocks
+      if (line.includes("<!--")) {
+        inComment = true;
+      }
+      if (line.includes("-->")) {
+        inComment = false;
+        continue;
+      }
+
+      // Skip lines inside comments
+      if (inComment) {
+        continue;
+      }
+
+      // Calculate indentation level by counting leading spaces
+      const leadingSpaces = line.match(/^(\s*)/)?.[0].length || 0;
+      const indentLevel = Math.floor(leadingSpaces / 2); // 2 spaces per indent level
+
+      if (line.includes("- [ ]")) {
+        todos.push({
+          content: line.replace(/^\s*- \[ \]\s*/, "").trim(),
+          status: "planned",
+          line: line,
+          indentLevel: indentLevel,
+        });
+      } else if (line.includes("- [x]")) {
+        todos.push({
+          content: line.replace(/^\s*- \[x\]\s*/, "").trim(),
+          status: "done",
+          line: line,
+          indentLevel: indentLevel,
+        });
+      } else if (line.includes("- [*]")) {
+        todos.push({
+          content: line.replace(/^\s*- \[\*\]\s*/, "").trim(),
+          status: "in_progress",
+          line: line,
+          indentLevel: indentLevel,
+        });
+      } else if (line.includes("- [~]")) {
+        todos.push({
+          content: line.replace(/^\s*- \[~\]\s*/, "").trim(),
+          status: "cancelled",
+          line: line,
+          indentLevel: indentLevel,
+        });
+      }
+    }
+
+    return todos;
+  };
+
+  const todos = useMemo(() => parseTodos(markdown), [markdown]);
+
+  useEffect(() => {
+    if (markdown) {
+      setIsInitialized(true);
+
+      const changed = new Set<string>();
+      if (previousMarkdown) {
+        const prevLines = new Set(previousMarkdown.split("\n"));
+        const currLines = markdown.split("\n");
+
+        // Find changed or new lines
+        currLines.forEach((line) => {
+          if (line.includes("- [") && !prevLines.has(line)) {
+            changed.add(line);
+          }
+        });
+      } else {
+        // First time - all todo lines are "changed"
+        todos.forEach((todo) => changed.add(todo.line));
+      }
+
+      setChangedLines(changed);
+    }
+  }, [markdown, previousMarkdown, todos]);
+
+  const getStatusIcon = (status: ParsedTodo["status"]) => {
+    switch (status) {
+      case "done":
+        return (
+          <CheckCircleIcon className="h-4 w-4 text-green-500" title="Done" />
+        );
+      case "in_progress":
+        return (
+          <ClockIcon className="h-4 w-4 text-blue-500" title="In Progress" />
+        );
+      case "cancelled":
+        return (
+          <XCircleIcon className="h-4 w-4 text-red-500" title="Cancelled" />
+        );
+      case "planned":
+        return (
+          <PlusCircleIcon className="h-4 w-4 text-gray-400" title="Planned" />
+        );
+      default:
+        return (
+          <PlusCircleIcon className="h-4 w-4 text-gray-400" title="Planned" />
+        );
+    }
+  };
+
+  const plannedCount = todos.filter((t) => t.status === "planned").length;
+  const inProgressCount = todos.filter(
+    (t) => t.status === "in_progress",
+  ).length;
+  const doneCount = todos.filter((t) => t.status === "done").length;
+
+  // Don't render until we have real data
+  if (!isInitialized || !markdown) {
+    return null;
+  }
+
+  // Determine which todos to show
+  const todosToShow =
+    viewMode === "all"
+      ? todos
+      : todos.filter((todo) => changedLines.has(todo.line));
+
+  const hasHiddenTodos =
+    viewMode === "changes" && todosToShow.length < todos.length;
+
+  return (
+    <div className="outline-command-border -outline-offset-0.5 rounded-default bg-editor mt-2 flex min-w-0 flex-col outline outline-1">
+      <div className="bg-editor border-command-border sticky -top-2 z-10 m-0 flex items-center justify-between gap-3 rounded-lg border-b px-3 py-2">
+        <div className="flex items-center gap-2">
+          <ChevronDownIcon
+            data-testid="toggle-todo-card"
+            onClick={() => {
+              setViewMode(viewMode === "changes" ? "all" : "changes");
+            }}
+            className={`text-lightgray h-3.5 w-3.5 flex-shrink-0 cursor-pointer hover:brightness-125 ${
+              viewMode === "all" ? "rotate-0" : "-rotate-90"
+            }`}
+          />
+          <FileInfo filepath="TODO.md" />
+          <span className="text-description text-sm">
+            ({plannedCount} planned, {inProgressCount} in progress, {doneCount}{" "}
+            done)
+          </span>
+        </div>
+      </div>
+
+      <div className="space-y-1 p-3">
+        {todosToShow.map((todo, index) => (
+          <div
+            key={`${todo.line}-${index}`}
+            className={`flex items-start gap-2 rounded p-1 ${
+              changedLines.has(todo.line)
+                ? "bg-warning/10 border-warning/30 border"
+                : "bg-secondary/10"
+            }`}
+            style={{ marginLeft: `${todo.indentLevel * 20}px` }}
+          >
+            {getStatusIcon(todo.status)}
+            <div className="flex-1">
+              <span
+                className={
+                  todo.status === "done"
+                    ? "text-description"
+                    : todo.status === "cancelled"
+                      ? "text-description-muted"
+                      : ""
+                }
+              >
+                {todo.content}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/gui/src/pages/gui/ToolCallDiv/index.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/index.tsx
@@ -39,6 +39,20 @@ export function ToolCallDiv({
     const functionName = toolCallState.toolCall.function?.name;
     const icon = functionName && toolCallIcons[functionName];
 
+    // Check for specific function names first, before checking for icons
+    if (
+      functionName === BuiltInToolNames.SearchAndReplaceInFile ||
+      functionName === BuiltInToolNames.TodoWrite ||
+      functionName === BuiltInToolNames.TodoRead
+    ) {
+      return (
+        <FunctionSpecificToolCallDiv
+          toolCallState={toolCallState}
+          historyIndex={historyIndex}
+        />
+      );
+    }
+
     if (icon) {
       return (
         <SimpleToolCallUI

--- a/gui/src/pages/gui/ToolCallDiv/utils.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/utils.tsx
@@ -82,6 +82,8 @@ export const toolCallIcons: Record<string, ComponentType> = {
   [BuiltInToolNames.ViewRepoMap]: MapIcon,
   [BuiltInToolNames.ViewSubdirectory]: FolderOpenIcon,
   [BuiltInToolNames.CreateRuleBlock]: PencilIcon,
+  [BuiltInToolNames.TodoRead]: DocumentTextIcon,
+  [BuiltInToolNames.TodoWrite]: PencilIcon,
 };
 
 export function getStatusIcon(state: ToolStatus) {

--- a/gui/src/redux/slices/sessionSlice.test.ts
+++ b/gui/src/redux/slices/sessionSlice.test.ts
@@ -75,6 +75,7 @@ describe("sessionSlice streamUpdate", () => {
     },
     newestToolbarPreviewForInput: {},
     isSessionMetadataLoading: false,
+    suggestionQueue: [],
   });
 
   describe("Basic Chat Message", () => {

--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -225,6 +225,7 @@ type SessionState = {
   newestToolbarPreviewForInput: Record<string, string>;
   hasReasoningEnabled?: boolean;
   warningMessage?: WarningMessage;
+  suggestionQueue: string[];
 };
 
 const initialState: SessionState = {
@@ -244,6 +245,7 @@ const initialState: SessionState = {
   },
   lastSessionId: undefined,
   newestToolbarPreviewForInput: {},
+  suggestionQueue: [],
 };
 
 export const sessionSlice = createSlice({
@@ -272,6 +274,12 @@ export const sessionSlice = createSlice({
     },
     setActive: (state) => {
       state.isStreaming = true;
+    },
+    addSuggestion: (state, { payload }: PayloadAction<string>) => {
+      state.suggestionQueue.push(payload);
+    },
+    clearSuggestionQueue: (state) => {
+      state.suggestionQueue = [];
     },
     setIsGatheringContext: (state, { payload }: PayloadAction<boolean>) => {
       const curMessage = state.history.at(-1);
@@ -982,6 +990,8 @@ export const {
   setIsInEdit,
   setHasReasoningEnabled,
   setWarningMessage,
+  addSuggestion,
+  clearSuggestionQueue,
 } = sessionSlice.actions;
 
 export const { selectIsGatheringContext } = sessionSlice.selectors;

--- a/gui/src/redux/slices/uiSlice.ts
+++ b/gui/src/redux/slices/uiSlice.ts
@@ -64,6 +64,8 @@ export const uiSlice = createSlice({
       [BuiltInToolNames.CreateRuleBlock]: "allowedWithPermission",
       [BuiltInToolNames.RequestRule]: "disabled",
       [BuiltInToolNames.SearchAndReplaceInFile]: "allowedWithPermission",
+      [BuiltInToolNames.TodoRead]: "allowedWithoutPermission",
+      [BuiltInToolNames.TodoWrite]: "allowedWithoutPermission",
     },
     toolGroupSettings: {
       [BUILT_IN_GROUP_NAME]: "include",


### PR DESCRIPTION
Fixes CON-2772

This is likely not merge ready, but opening anyway for visibility. There may be some state management issues left that I haven't quite understood yet.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added built-in todo list tools and UI to help users and the agent plan, track, and update tasks, including support for user suggestions during streaming.

- **New Features**
  - Introduced TodoRead and TodoWrite tools for reading and updating markdown todo lists.
  - Added in-memory todo state management with full history.
  - Implemented a TodoCard UI to display, diff, and summarize todos in the chat.
  - Enabled users to queue suggestions while streaming, which are injected into the next message.

<!-- End of auto-generated description by cubic. -->

