### PR TITLE
feat: System Message tools

### DIFF
--- a/core/config/sharedConfig.ts
+++ b/core/config/sharedConfig.ts
@@ -21,6 +21,7 @@ export const sharedConfigSchema = z
     useCurrentFileAsContext: z.boolean(),
     optInNextEditFeature: z.boolean(),
     enableExperimentalTools: z.boolean(),
+    onlyUseSystemMessageTools: z.boolean(),
     codebaseToolCallingOnly: z.boolean(),
 
     // `ui` in `ContinueConfig`
@@ -184,6 +185,11 @@ export function modifyAnyConfigWithSharedConfig<
     configCopy.experimental.optInNextEditFeature =
       sharedConfig.optInNextEditFeature;
   }
+  if (sharedConfig.onlyUseSystemMessageTools !== undefined) {
+    configCopy.experimental.onlyUseSystemMessageTools =
+      sharedConfig.onlyUseSystemMessageTools;
+  }
+
   if (sharedConfig.codebaseToolCallingOnly !== undefined) {
     configCopy.experimental.codebaseToolCallingOnly =
       sharedConfig.codebaseToolCallingOnly;

--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -1122,7 +1122,6 @@ declare global {
      * This is needed to crawl a large number of documentation sites that are dynamically rendered.
      */
     useChromiumForDocsCrawling?: boolean;
-    useTools?: boolean;
     modelContextProtocolServers?: MCPOptions[];
   }
   

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1443,6 +1443,7 @@ export interface ExperimentalConfig {
   defaultContext?: DefaultContextProvider[];
   promptPath?: string;
   enableExperimentalTools?: boolean;
+  onlyUseSystemMessageTools?: boolean;
 
   /**
    * Quick actions are a way to add custom commands to the Code Lens of

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1080,6 +1080,7 @@ export interface Tool {
   faviconUrl?: string;
   group: string;
   originalFunctionName?: string;
+  systemMessageDescription?: string;
 }
 
 interface ToolChoice {

--- a/core/llm/autodetect.ts
+++ b/core/llm/autodetect.ts
@@ -1,9 +1,4 @@
-import {
-  ChatMessage,
-  ModelCapability,
-  ModelDescription,
-  TemplateType,
-} from "../index.js";
+import { ChatMessage, ModelCapability, TemplateType } from "../index.js";
 
 import {
   anthropicTemplateMessages,
@@ -41,7 +36,6 @@ import {
   xWinCoderEditPrompt,
   zephyrEditPrompt,
 } from "./templates/edit.js";
-import { PROVIDER_TOOL_SUPPORT } from "./toolSupport.js";
 
 const PROVIDER_HANDLES_TEMPLATING: string[] = [
   "lmstudio",
@@ -106,17 +100,6 @@ const MODEL_SUPPORTS_IMAGES: string[] = [
   "llama4",
   "granite-vision",
 ];
-
-function modelSupportsTools(modelDescription: ModelDescription) {
-  if (modelDescription.capabilities?.tools !== undefined) {
-    return modelDescription.capabilities.tools;
-  }
-  const providerSupport = PROVIDER_TOOL_SUPPORT[modelDescription.provider];
-  if (!providerSupport) {
-    return false;
-  }
-  return providerSupport(modelDescription.model) ?? false;
-}
 
 function modelSupportsImages(
   provider: string,
@@ -400,5 +383,4 @@ export {
   autodetectTemplateType,
   llmCanGenerateInParallel,
   modelSupportsImages,
-  modelSupportsTools,
 };

--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -524,7 +524,7 @@ export abstract class BaseLLM implements ILLM {
     let contentToShow = "";
     if (msg.role === "tool") {
       contentToShow = msg.content;
-    } else if (msg.role === "assistant" && msg.toolCalls) {
+    } else if (msg.role === "assistant" && msg.toolCalls?.length) {
       contentToShow = msg.toolCalls
         ?.map(
           (toolCall) =>
@@ -532,10 +532,7 @@ export abstract class BaseLLM implements ILLM {
         )
         .join("\n");
     } else if ("content" in msg) {
-      if (Array.isArray(msg.content)) {
-        msg.content = renderChatMessage(msg);
-      }
-      contentToShow = msg.content;
+      contentToShow = renderChatMessage(msg);
     }
 
     return `<${msg.role}>\n${contentToShow}\n\n`;

--- a/core/llm/toolSupport.ts
+++ b/core/llm/toolSupport.ts
@@ -1,4 +1,5 @@
 import { parseProxyModelName } from "@continuedev/config-yaml";
+import { ModelDescription } from "..";
 
 export const PROVIDER_TOOL_SUPPORT: Record<string, (model: string) => boolean> =
   {
@@ -287,3 +288,31 @@ export const PROVIDER_TOOL_SUPPORT: Record<string, (model: string) => boolean> =
       return false;
     },
   };
+
+export function isRecommendedAgentModel(modelName: string): boolean {
+  // AND behavior
+  const recs: RegExp[][] = [
+    [/o[134]/],
+    [/deepseek/, /r1|reasoner/],
+    [/gemini/, /2\.5/, /pro/],
+    [/gpt/, /4/],
+    [/claude/, /sonnet/, /3\.5|3\.7|3-5|3-7|-4/],
+    [/claude/, /opus/, /-4/],
+  ];
+  for (const combo of recs) {
+    if (combo.every((regex) => modelName.toLowerCase().match(regex))) {
+      return true;
+    }
+  }
+  return false;
+}
+export function modelSupportsNativeTools(modelDescription: ModelDescription) {
+  if (modelDescription.capabilities?.tools !== undefined) {
+    return modelDescription.capabilities.tools;
+  }
+  const providerSupport = PROVIDER_TOOL_SUPPORT[modelDescription.provider];
+  if (!providerSupport) {
+    return false;
+  }
+  return providerSupport(modelDescription.model) ?? false;
+}

--- a/core/tools/constants.ts
+++ b/core/tools/constants.ts
@@ -1,0 +1,2 @@
+export const NO_TOOL_CALL_OUTPUT_MESSAGE = "No tool output";
+export const CANCELLED_TOOL_CALL_MESSAGE = "The user cancelled this tool call.";

--- a/core/tools/systemMessageTools/buildToolsSystemMessage.ts
+++ b/core/tools/systemMessageTools/buildToolsSystemMessage.ts
@@ -1,0 +1,157 @@
+import { Tool } from "../..";
+import { closeTag } from "./systemToolUtils";
+
+export const TOOL_INSTRUCTIONS_TAG = "<tool_use_instructions>";
+export const TOOL_DEFINITION_TAG = "TOOL_DEFINITION";
+export const TOOL_DESCRIPTION_TAG = "DESCRIPTION";
+
+const EXAMPLE_DYNAMIC_TOOL = `
+\`\`\`tool_definition
+TOOL_NAME: example_tool
+TOOL_ARG: arg_1 (string, required)
+Description of the first argument
+END_ARG
+TOOL_ARG: arg_2 (number, optional)
+END_ARG
+\`\`\``.trim();
+
+const EXAMPLE_DYNAMIC_TOOL_CALL = `
+\`\`\`tool
+TOOL_NAME: example_tool
+BEGIN_ARG: arg_1
+The value
+of arg 1
+END_ARG
+BEGIN_ARG: arg_2
+3
+END_ARG
+\`\`\``.trim();
+
+export function createSystemMessageExampleCall(
+  name: string,
+  instructions: string,
+  args: Array<[string, string]> = [],
+) {
+  let callExample = `\`\`\`tool
+TOOL_NAME: ${name}`;
+
+  // Add each argument dynamically
+  for (const [argName, argValue] of args) {
+    callExample += `
+BEGIN_ARG: ${argName}
+${argValue}
+END_ARG`;
+  }
+
+  callExample += `
+\`\`\``;
+
+  return `${instructions.trim()}
+${callExample}`;
+}
+
+function toolToSystemToolDefinition(tool: Tool): string {
+  let toolDefinition = `\`\`\`tool_definition\nTOOL_NAME: ${tool.function.name}\n`;
+
+  if (tool.function.description) {
+    toolDefinition += `TOOL_DESCRIPTION:\n${tool.function.description}\n`;
+  }
+
+  if (tool.function.parameters && "properties" in tool.function.parameters) {
+    for (const [key, value] of Object.entries(
+      tool.function.parameters.properties as object,
+    )) {
+      const isRequired = tool.function.parameters.required?.includes(key);
+      const requiredText = isRequired ? "required" : "optional";
+
+      let argType = "string";
+      if ("type" in value) {
+        argType = value.type;
+      }
+      let argDescription = "";
+      if ("description" in value) {
+        argDescription = value.argDescription;
+      }
+
+      toolDefinition += `TOOL_ARG: ${key} (${argType}, ${requiredText})\n`;
+      if (argDescription) {
+        toolDefinition += argDescription + "\n";
+      }
+      toolDefinition += `END_ARG\n`;
+    }
+  }
+
+  toolDefinition += `\`\`\``;
+  return toolDefinition.trim();
+}
+
+export const generateToolsSystemMessage = (tools: Tool[]) => {
+  if (tools.length === 0) {
+    return undefined;
+  }
+  const withPredefinedMessage = tools.filter(
+    (tool) => !!tool.systemMessageDescription,
+  );
+
+  const withDynamicMessage = tools.filter(
+    (tool) => !tool.systemMessageDescription,
+  );
+
+  let prompt = `${TOOL_INSTRUCTIONS_TAG}\n`;
+  prompt += `You have access to several "tools" that you can use at any time to retrieve information and/or perform tasks for the User.`;
+  prompt += `\nTo use a tool, respond with a tool code block (\`\`\`tool) using the syntax shown in the examples below:`;
+
+  if (withPredefinedMessage.length > 0) {
+    prompt += `\n\nThe following tools are available to you:`;
+    for (const tool of withPredefinedMessage) {
+      prompt += "\n\n";
+      prompt += tool.systemMessageDescription;
+    }
+  }
+
+  if (withDynamicMessage.length > 0) {
+    prompt += `\n\nAlso, these additional tool definitions show other tools you can call with the same syntax:`;
+
+    for (const tool of tools) {
+      try {
+        const definition = toolToSystemToolDefinition(tool);
+        prompt += "\n\n";
+        prompt += definition;
+      } catch (e) {
+        console.error(
+          "Failed to convert tool to system message tool:\n" +
+            JSON.stringify(tool),
+        );
+      }
+    }
+
+    prompt += `\n\nFor example, this tool definition:\n\n`;
+
+    prompt += EXAMPLE_DYNAMIC_TOOL;
+
+    prompt += "\n\nCan be called like this:\n";
+
+    prompt += EXAMPLE_DYNAMIC_TOOL_CALL;
+  }
+
+  prompt += `\n\nIf it seems like the User's request could be solved with one of the tools, choose the BEST one for the job based on the user's request and the tool descriptions`;
+  prompt += `\nThen send the \`\`\`tool codeblock (YOU call the tool, not the user). Always start the codeblock on a new line.`;
+  prompt += `\nDo not perform actions with/for hypothetical files. Ask the user or use tools to deduce which files are relevant.`;
+  prompt += `\nYou can only call ONE tool at at time. The tool codeblock should be the last thing you say; stop your response after the tool codeblock.`;
+
+  prompt += `\n${closeTag(TOOL_INSTRUCTIONS_TAG)}`;
+  return prompt;
+};
+
+export function addSystemMessageToolsToSystemMessage(
+  baseSystemMessage: string,
+  systemMessageTools: Tool[],
+): string {
+  let systemMessage = baseSystemMessage;
+  if (systemMessageTools.length > 0) {
+    const toolsSystemMessage = generateToolsSystemMessage(systemMessageTools);
+    systemMessage += `\n\n${toolsSystemMessage}`;
+  }
+
+  return systemMessage;
+}

--- a/core/tools/systemMessageTools/detectToolCallStart.ts
+++ b/core/tools/systemMessageTools/detectToolCallStart.ts
@@ -1,0 +1,37 @@
+let boundaryTypeIndex = 0;
+
+// Poor models are really bad at following instructions
+// Give some leeway in how the initiate
+const acceptedToolStarts: [string, string][] = [
+  ["```tool\n", "```tool\n"],
+  ["tool_name:", "```tool\ntool_name:"],
+];
+
+export function detectToolCallStart(buffer: string) {
+  let modifiedBuffer = buffer;
+  let isInToolCall = false;
+  let isInPartialStart = false;
+  const lowerCaseBuffer = buffer.toLowerCase();
+  for (let i = 0; i < acceptedToolStarts.length; i++) {
+    const [start, _] = acceptedToolStarts[i];
+    if (lowerCaseBuffer.startsWith(start)) {
+      boundaryTypeIndex = i;
+      // for non-standard cases like no ```tool codeblock, etc, replace before adding to buffer, case insensitive
+      if (boundaryTypeIndex !== 0) {
+        modifiedBuffer = buffer.replace(
+          new RegExp(start, "i"),
+          acceptedToolStarts[boundaryTypeIndex][1],
+        );
+      }
+      isInToolCall = true;
+      break;
+    } else if (start.startsWith(lowerCaseBuffer)) {
+      isInPartialStart = true;
+    }
+  }
+  return {
+    isInToolCall,
+    isInPartialStart,
+    modifiedBuffer,
+  };
+}

--- a/core/tools/systemMessageTools/interceptSystemToolCalls.ts
+++ b/core/tools/systemMessageTools/interceptSystemToolCalls.ts
@@ -1,0 +1,126 @@
+import { ChatMessage, PromptLog, TextMessagePart } from "../..";
+import { normalizeToMessageParts } from "../../util/messageContent";
+import { detectToolCallStart } from "./detectToolCallStart";
+import { generateOpenAIToolCallId } from "./openAiToolCallId";
+import {
+  getInitialTooLCallParseState,
+  handleToolCallBuffer,
+  ToolCallParseState,
+} from "./parseSystemToolCall";
+import { splitAtCodeblocksAndNewLines } from "./systemToolUtils";
+
+/*
+    Function to intercept tool calls in markdown code blocks format from a chat message stream
+    1. Skips non-assistant messages
+    2. Intercepts text that looks like a tool call in a markdown code block format:
+    ```tool
+    TOOL_NAME: example_tool
+    BEGIN_ARG: arg1
+    value
+    END_ARG
+    ```
+    3. Parses tool calls line by line and generates proper tool call deltas
+    4. Once the tool call is complete, resets state for potential future tool calls
+*/
+export async function* interceptSystemToolCalls(
+  messageGenerator: AsyncGenerator<ChatMessage[], PromptLog | undefined>,
+  abortController: AbortController,
+): AsyncGenerator<ChatMessage[], PromptLog | undefined> {
+  let hasSeenToolCall = false;
+  let inToolCall = false;
+  let currentToolCallId: string | undefined = undefined;
+  let buffer = "";
+
+  let parseState: ToolCallParseState | undefined;
+
+  while (true) {
+    const result = await messageGenerator.next();
+    if (result.done) {
+      return result.value;
+    } else {
+      for await (const message of result.value) {
+        if (abortController.signal.aborted || parseState?.done) {
+          break;
+        }
+        // Skip non-assistant messages or messages with native tool calls
+        if (message.role !== "assistant" || message.toolCalls) {
+          yield [message];
+          continue;
+        }
+
+        const parts = normalizeToMessageParts(message);
+
+        // Image output cannot be combined with tools
+        if (parts.find((part) => part.type === "imageUrl")) {
+          yield [message];
+          continue;
+        }
+
+        const chunks = (parts as TextMessagePart[])
+          .map((part) => splitAtCodeblocksAndNewLines(part.text))
+          .flat();
+
+        for (const chunk of chunks) {
+          buffer += chunk;
+          if (!inToolCall) {
+            const { isInPartialStart, isInToolCall, modifiedBuffer } =
+              detectToolCallStart(buffer);
+
+            if (isInPartialStart) {
+              continue;
+            }
+            if (isInToolCall) {
+              inToolCall = true;
+              buffer = modifiedBuffer;
+            }
+          }
+
+          if (inToolCall) {
+            if (!currentToolCallId) {
+              currentToolCallId = generateOpenAIToolCallId();
+            }
+            if (!parseState) {
+              parseState = getInitialTooLCallParseState();
+            }
+
+            const delta = handleToolCallBuffer(
+              buffer,
+              currentToolCallId,
+              parseState,
+            );
+            if (delta) {
+              hasSeenToolCall = true;
+              yield [
+                {
+                  ...message,
+                  content: "",
+                  toolCalls: [delta],
+                },
+              ];
+            }
+
+            if (parseState.done) {
+              inToolCall = false;
+              currentToolCallId = undefined;
+              parseState = undefined;
+            }
+          } else {
+            // Prevent content after tool calls for now
+            if (hasSeenToolCall) {
+              continue;
+            }
+
+            // Yield normal assistant message
+            yield [
+              {
+                ...message,
+                content: [{ type: "text", text: buffer }],
+              },
+            ];
+          }
+          buffer = "";
+        }
+      }
+    }
+  }
+}

--- a/core/tools/systemMessageTools/openAiToolCallId.ts
+++ b/core/tools/systemMessageTools/openAiToolCallId.ts
@@ -1,0 +1,13 @@
+function randomLettersAndNumbers(length: number): string {
+  const characters =
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  let result = "";
+  for (let i = 0; i < length; i++) {
+    result += characters.charAt(Math.floor(Math.random() * characters.length));
+  }
+  return result;
+}
+
+export function generateOpenAIToolCallId(): string {
+  return `call_${randomLettersAndNumbers(24)}`;
+}

--- a/core/tools/systemMessageTools/parseSystemToolCall.ts
+++ b/core/tools/systemMessageTools/parseSystemToolCall.ts
@@ -1,0 +1,128 @@
+import { ToolCallDelta } from "../..";
+
+export type ToolCallParseState = {
+  isOnArgBeginLine: boolean;
+  currentArgName: string | undefined;
+  currentArgLines: string[];
+  processedArgNames: Set<string>;
+  currentLineIndex: number;
+  lineChunks: string[][];
+  done: boolean;
+};
+
+export const getInitialTooLCallParseState = (): ToolCallParseState => ({
+  isOnArgBeginLine: false,
+  currentArgName: undefined,
+  currentArgLines: [],
+  currentLineIndex: 0,
+  processedArgNames: new Set(),
+  lineChunks: [],
+  done: false,
+});
+
+function createDelta(name: string, args: string, id: string): ToolCallDelta {
+  return {
+    type: "function",
+    function: {
+      name,
+      arguments: args,
+    },
+    id,
+  };
+}
+
+/*
+  Efficiently applies chunks to a tool call state as they come in
+  Expects chunks to be broken so that new lines and codeblocks are alone
+  For now, this parser collects entire arg before
+  This is because support for JSON booleans is tricky otherwise
+
+*/
+export function handleToolCallBuffer(
+  chunk: string,
+  toolCallId: string,
+  state: ToolCallParseState,
+): ToolCallDelta | undefined {
+  // Add chunks
+  const lineIndex = state.currentLineIndex;
+  if (!state.lineChunks[lineIndex]) {
+    state.lineChunks[lineIndex] = [];
+  }
+  state.lineChunks[lineIndex].push(chunk);
+
+  const isNewLine = chunk === "\n";
+  if (isNewLine) {
+    state.currentLineIndex++;
+  }
+
+  const line = state.lineChunks[lineIndex].join("");
+
+  switch (lineIndex) {
+    // The first line will be skipped (e.g. ```tool\n)
+    case 0:
+      state.currentLineIndex = 1;
+      if (!line.toLowerCase().includes("name")) {
+        return;
+      }
+    // tool_name alternate start case
+    // Tool name line - process once line 2 is reached
+    case 1:
+      if (isNewLine) {
+        const name = (line.split(/tool_?name:/i)[1] ?? "").trim();
+        if (!name) {
+          throw new Error("Invalid tool name");
+        }
+        return createDelta(name, "", toolCallId);
+      }
+      return;
+    default:
+      if (state.isOnArgBeginLine) {
+        if (isNewLine) {
+          const argName = (line.split(/begin_?arg:/i)[1] ?? "").trim();
+          if (!argName) {
+            throw new Error("Invalid begin arg line");
+          }
+          state.currentArgName = argName;
+          state.isOnArgBeginLine = false;
+          const argPrefix = state.processedArgNames.size === 0 ? "{" : ",";
+          return createDelta("", `${argPrefix}"${argName}":`, toolCallId);
+        }
+      } else if (state.currentArgName) {
+        if (isNewLine) {
+          const isEndArgTag = line.match(/end_?arg/i);
+          if (isEndArgTag) {
+            const trimmedValue = state.currentArgLines.join("").trim();
+            state.currentArgLines.length = 0;
+            state.processedArgNames.add(state.currentArgName);
+            state.currentArgName = undefined;
+
+            try {
+              const parsed = JSON.parse(trimmedValue);
+              const stringifiedArg = JSON.stringify(parsed);
+              return createDelta("", stringifiedArg, toolCallId);
+            } catch (e) {
+              const stringifiedArg = JSON.stringify(trimmedValue);
+              return createDelta("", stringifiedArg, toolCallId);
+            }
+          } else {
+            state.currentArgLines.push(line);
+          }
+        }
+      } else {
+        // Check for entry into arg
+        const isBeginArgLine = line.match(/begin_?arg:/i);
+        if (isBeginArgLine) {
+          state.isOnArgBeginLine = true;
+        }
+
+        // Check for exit
+        if (line === "```" || isNewLine) {
+          state.done = true;
+          // finish args JSON if applicable
+          if (state.processedArgNames.size > 0) {
+            return createDelta("", "}", toolCallId);
+          }
+        }
+      }
+  }
+}

--- a/core/tools/systemMessageTools/systemToolUtils.ts
+++ b/core/tools/systemMessageTools/systemToolUtils.ts
@@ -1,0 +1,17 @@
+export function closeTag(openingTag: string): string {
+  return `</${openingTag.slice(1)}`;
+}
+
+export function getStringDelta(original: string, updated: string): string {
+  if (!updated.startsWith(original)) {
+    console.warn(
+      `Original string "${original}" is not a prefix of updated string "${updated}"`,
+    );
+    return updated;
+  }
+  return updated.slice(original.length);
+}
+
+export function splitAtCodeblocksAndNewLines(content: string) {
+  return content.split(/(```|\n)/g).filter(Boolean);
+}

--- a/core/tools/systemMessageTools/systemToolUtils.vitest.ts
+++ b/core/tools/systemMessageTools/systemToolUtils.vitest.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+import { closeTag, splitAtCodeblocksAndNewLines } from "./systemToolUtils";
+
+describe("closeTag", () => {
+  const testCases = [
+    {
+      input: "<div>",
+      expectedOutput: "</div>",
+    },
+    {
+      input: "<p>",
+      expectedOutput: "</p>",
+    },
+    // Add more test cases as needed
+  ];
+
+  testCases.forEach((testCase) => {
+    test(`closes tag "${testCase.input}" to "</${testCase.input.slice(1)}"`, () => {
+      const result = closeTag(testCase.input);
+      expect(result).toEqual(testCase.expectedOutput);
+    });
+  });
+});
+
+describe("splitAtCodeblocks", () => {
+  test("doesn't split plain text without codeblocks", () => {
+    expect(splitAtCodeblocksAndNewLines("hello world")).toEqual([
+      "hello world",
+    ]);
+  });
+
+  test("splits at codeblocks", () => {
+    expect(splitAtCodeblocksAndNewLines("```<one>middle```<two>")).toEqual([
+      "```",
+      "<one>middle",
+      "```",
+      "<two>",
+    ]);
+  });
+
+  test("splits at new lines", () => {
+    expect(splitAtCodeblocksAndNewLines("hello\nhoware\n you\n")).toEqual([
+      "hello",
+      "\n",
+      "howare",
+      "\n",
+      " you",
+      "\n",
+    ]);
+  });
+
+  test("splits at both codeblocks and new lines", () => {
+    expect(splitAtCodeblocksAndNewLines("hello```\nho```ware\n you\n")).toEqual(
+      ["hello", "```", "\n", "ho", "```", "ware", "\n", " you", "\n"],
+    );
+  });
+});

--- a/core/tools/systemMessageTools/textifySystemTools.ts
+++ b/core/tools/systemMessageTools/textifySystemTools.ts
@@ -1,0 +1,95 @@
+import {
+  AssistantChatMessage,
+  MessagePart,
+  ToolCallState,
+  UserChatMessage,
+} from "../..";
+import {
+  normalizeToMessageParts,
+  renderContextItems,
+} from "../../util/messageContent";
+import {
+  CANCELLED_TOOL_CALL_MESSAGE,
+  NO_TOOL_CALL_OUTPUT_MESSAGE,
+} from "../constants";
+function toolCallStateToSystemToolCall(state: ToolCallState): string {
+  let parts = ["```tool"];
+  parts.push(`TOOL_NAME: ${state.toolCall.function.name}`);
+  try {
+    for (const arg in state.parsedArgs) {
+      parts.push(`BEGIN_ARG: ${arg}`);
+      parts.push(JSON.stringify(state.parsedArgs[arg]));
+      parts.push(`END_ARG`);
+    }
+  } catch (e) {
+    console.log("Failed to stringify json args", state.parsedArgs);
+  }
+  // TODO - include tool call id for parallel. Confuses dumb models
+  parts.push("```");
+  return parts.join("\n");
+}
+
+function toolCallStateToSystemToolOutput(state: ToolCallState): string {
+  let output = `Tool output for ${state.toolCall.function.name} tool call:\n\n`;
+  // TODO - include tool call id for parallel. Confuses dumb models
+  // let output = `Tool output for tool call ${state.toolCallId} (${state.toolCall.function.name}):\n\n`;
+  if (state.status === "canceled") {
+    output += CANCELLED_TOOL_CALL_MESSAGE;
+  } else if (state.output?.length) {
+    output += renderContextItems(state.output);
+  } else {
+    output += NO_TOOL_CALL_OUTPUT_MESSAGE;
+  }
+  return output;
+}
+
+export function convertToolCallStatesToSystemCallsAndOutput(
+  originalAssistantMessage: AssistantChatMessage,
+  toolCallStates: ToolCallState[],
+): {
+  assistantMessage: AssistantChatMessage;
+  userMessage: UserChatMessage;
+} {
+  const parts = normalizeToMessageParts(originalAssistantMessage);
+  if (originalAssistantMessage.toolCalls) {
+    parts.push(
+      ...toolCallStates.map((state) => ({
+        type: "text" as const,
+        text: toolCallStateToSystemToolCall(state),
+      })),
+    );
+  }
+
+  // new message with tool calls moved to content
+  const assistantMessage: AssistantChatMessage = {
+    ...originalAssistantMessage,
+    content: parts,
+    toolCalls: undefined, // remove tool calls from the assistant message
+  };
+
+  const userParts: MessagePart[] = [];
+  if (toolCallStates) {
+    for (const state of toolCallStates) {
+      userParts.push({
+        type: "text",
+        text: toolCallStateToSystemToolOutput(state),
+      });
+    }
+  }
+  if (userParts.length === 0) {
+    userParts.push({
+      type: "text",
+      text: "Error: no tool output for tool calls",
+    });
+  }
+
+  const userMessage: UserChatMessage = {
+    role: "user",
+    content: userParts,
+  };
+
+  return {
+    assistantMessage,
+    userMessage,
+  };
+}

--- a/gui/src/components/ModeSelect/ModeSelect.tsx
+++ b/gui/src/components/ModeSelect/ModeSelect.tsx
@@ -1,10 +1,12 @@
 import {
   CheckIcon,
   ChevronDownIcon,
+  ExclamationCircleIcon,
   InformationCircleIcon,
 } from "@heroicons/react/24/outline";
 import { MessageModes } from "core";
-import { modelSupportsTools } from "core/llm/autodetect";
+import { isRecommendedAgentModel } from "core/llm/toolSupport";
+import { capitalize } from "lodash";
 import { useCallback, useEffect, useMemo } from "react";
 import { useAppDispatch, useAppSelector } from "../../redux/hooks";
 import { selectSelectedChatModel } from "../../redux/slices/configSlice";
@@ -19,23 +21,16 @@ export function ModeSelect() {
   const dispatch = useAppDispatch();
   const mode = useAppSelector((store) => store.session.mode);
   const selectedModel = useAppSelector(selectSelectedChatModel);
-  const agentModeSupported = useMemo(() => {
-    return selectedModel && modelSupportsTools(selectedModel);
+  const showAgentModeWarning = useMemo(() => {
+    if (!selectedModel || isRecommendedAgentModel(selectedModel.model)) {
+      return false; // no need to show warning if no model is selected
+    }
+    return true;
   }, [selectedModel]);
   const { mainEditor } = useMainEditor();
   const metaKeyLabel = useMemo(() => {
     return getMetaKeyLabel();
   }, []);
-
-  // Switch to chat mode if agent mode is selected but not supported
-  useEffect(() => {
-    if (!selectedModel) {
-      return;
-    }
-    if (mode !== "chat" && !agentModeSupported) {
-      dispatch(setMode("chat"));
-    }
-  }, [mode, agentModeSupported, dispatch, selectedModel]);
 
   const cycleMode = useCallback(() => {
     if (mode === "chat") {
@@ -75,6 +70,37 @@ export function ModeSelect() {
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [cycleMode]);
+
+  const agentWarning = (
+    <>
+      <ExclamationCircleIcon
+        data-tooltip-id="bad-at-agent-mode-tooltip"
+        className="text-warning h-3 w-3"
+      />
+      <ToolTip
+        id="bad-at-agent-mode-tooltip"
+        style={{
+          zIndex: 200001, // in front of listbox
+        }}
+        className="flex items-center gap-1"
+      >
+        {`${capitalize(mode)} might not work well with this model.`}
+        {/* can't seem to make link in tooltip clickable. globalCloseEvents or closeEvents? */}
+        {/* <a
+                    href=""
+                    onClick={() => {
+                      ideMessenger.post(
+                        "openUrl",
+                        "https://docs.continue.dev/agent/model-setup",
+                      );
+                    }}
+                    className="text-link cursor-pointer"
+                  >
+                    See docs
+                  </a> */}
+      </ToolTip>
+    </>
+  );
 
   return (
     <Listbox value={mode} onChange={selectMode}>
@@ -117,11 +143,7 @@ export function ModeSelect() {
             </div>
             {mode === "chat" && <CheckIcon className="ml-auto h-3 w-3" />}
           </ListboxOption>
-          <ListboxOption
-            value="plan"
-            disabled={!agentModeSupported}
-            className={"gap-1"}
-          >
+          <ListboxOption value="plan" className={"gap-1"}>
             <div className="flex flex-row items-center gap-1.5">
               <ModeIcon mode="plan" />
               <span className="">Plan</span>
@@ -138,19 +160,13 @@ export function ModeSelect() {
                 Read-only/MCP tools available
               </ToolTip>
             </div>
-            {agentModeSupported ? (
-              <CheckIcon
-                className={`ml-auto h-3 w-3 ${mode === "plan" ? "" : "opacity-0"}`}
-              />
-            ) : (
-              <span>(Not supported)</span>
-            )}
+            {showAgentModeWarning && agentWarning}
+            <CheckIcon
+              className={`ml-auto h-3 w-3 ${mode === "plan" ? "" : "opacity-0"}`}
+            />
           </ListboxOption>
-          <ListboxOption
-            value="agent"
-            disabled={!agentModeSupported}
-            className={"gap-1"}
-          >
+
+          <ListboxOption value="agent" className={"gap-1"}>
             <div className="flex flex-row items-center gap-1.5">
               <ModeIcon mode="agent" />
               <span className="">Agent</span>
@@ -167,13 +183,10 @@ export function ModeSelect() {
                 All tools available
               </ToolTip>
             </div>
-            {agentModeSupported ? (
-              <CheckIcon
-                className={`ml-auto h-3 w-3 ${mode === "agent" ? "" : "opacity-0"}`}
-              />
-            ) : (
-              <span>(Not supported)</span>
-            )}
+            {showAgentModeWarning && agentWarning}
+            <CheckIcon
+              className={`ml-auto h-3 w-3 ${mode === "agent" ? "" : "opacity-0"}`}
+            />
           </ListboxOption>
 
           <div className="text-description-muted px-2 py-1">

--- a/gui/src/components/StepContainer/ResponseActions.tsx
+++ b/gui/src/components/StepContainer/ResponseActions.tsx
@@ -5,7 +5,7 @@ import {
   TrashIcon,
 } from "@heroicons/react/24/outline";
 import { ChatHistoryItem } from "core";
-import { modelSupportsTools } from "core/llm/autodetect";
+import { modelSupportsNativeTools } from "core/llm/toolSupport";
 import { renderChatMessage } from "core/util/messageContent";
 import { useMemo } from "react";
 import { useAppDispatch, useAppSelector } from "../../redux/hooks";
@@ -41,7 +41,7 @@ export default function ResponseActions({
   );
   const isPruned = useAppSelector((state) => state.session.isPruned);
   const ruleGenerationSupported = useMemo(() => {
-    return selectedModel && modelSupportsTools(selectedModel);
+    return selectedModel && modelSupportsNativeTools(selectedModel);
   }, [selectedModel]);
 
   const percent = Math.round((contextPercentage ?? 0) * 100);

--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -4,7 +4,7 @@ import {
   PhotoIcon,
 } from "@heroicons/react/24/outline";
 import { InputModifiers } from "core";
-import { modelSupportsImages, modelSupportsTools } from "core/llm/autodetect";
+import { modelSupportsImages } from "core/llm/autodetect";
 import { useContext, useRef } from "react";
 import { IdeMessengerContext } from "../../context/IdeMessenger";
 import { useAppDispatch, useAppSelector } from "../../redux/hooks";
@@ -56,8 +56,6 @@ function InputToolbar(props: InputToolbarProps) {
 
   const isEnterDisabled =
     props.disabled || (isInEdit && codeToEdit.length === 0);
-
-  const toolsSupported = defaultModel && modelSupportsTools(defaultModel);
 
   const supportsImages =
     defaultModel &&
@@ -174,7 +172,7 @@ function InputToolbar(props: InputToolbarProps) {
           {!isInEdit && <ContextStatus />}
           {!props.toolbarOptions?.hideUseCodebase && !isInEdit && (
             <div
-              className={`${toolsSupported ? "md:flex" : "int:flex"} hover:underline" hidden transition-colors duration-200`}
+              className={`hover:underline" hidden transition-colors duration-200 md:flex`}
             >
               <HoverItem
                 className={props.activeKey === "Alt" ? "underline" : ""}

--- a/gui/src/pages/config/UserSettingsForm.tsx
+++ b/gui/src/pages/config/UserSettingsForm.tsx
@@ -88,6 +88,8 @@ export function UserSettingsForm() {
     config.experimental?.useCurrentFileAsContext ?? false;
   const enableExperimentalTools =
     config.experimental?.enableExperimentalTools ?? false;
+  const onlyUseSystemMessageTools =
+    config.experimental?.onlyUseSystemMessageTools ?? false;
   const optInNextEditFeature =
     config.experimental?.optInNextEditFeature ?? false;
   const codebaseToolCallingOnly =
@@ -417,6 +419,16 @@ export function UserSettingsForm() {
                     })
                   }
                   text="Enable experimental tools"
+                />
+
+                <ToggleSwitch
+                  isToggled={onlyUseSystemMessageTools}
+                  onToggle={() =>
+                    handleUpdate({
+                      onlyUseSystemMessageTools: !onlyUseSystemMessageTools,
+                    })
+                  }
+                  text="Only use system message tools"
                 />
 
                 <ToggleSwitch

--- a/gui/src/pages/gui/StreamError.tsx
+++ b/gui/src/pages/gui/StreamError.tsx
@@ -246,8 +246,6 @@ const StreamErrorDialog = ({ error }: StreamErrorProps) => {
     );
   }
 
-  console.log({ message });
-
   return (
     <div className="flex flex-col gap-4 px-3 pb-3 pt-3">
       {/* Concise error title */}

--- a/gui/src/redux/thunks/streamNormalInput.ts
+++ b/gui/src/redux/thunks/streamNormalInput.ts
@@ -18,13 +18,11 @@ import {
   streamUpdate,
 } from "../slices/sessionSlice";
 import { AppThunkDispatch, RootState, ThunkApiType } from "../store";
-import {
-  constructMessages,
-  getBaseSystemMessage,
-} from "../util/constructMessages";
+import { constructMessages } from "../util/constructMessages";
 
 import { modelSupportsNativeTools } from "core/llm/toolSupport";
 import { selectCurrentToolCalls } from "../selectors/selectToolCalls";
+import { getBaseSystemMessage } from "../util/getBaseSystemMessage";
 import { callToolById } from "./callToolById";
 
 /**

--- a/gui/src/redux/thunks/streamNormalInput.ts
+++ b/gui/src/redux/thunks/streamNormalInput.ts
@@ -1,6 +1,5 @@
 import { createAsyncThunk, unwrapResult } from "@reduxjs/toolkit";
 import { LLMFullCompletionOptions, ModelDescription, Tool } from "core";
-import { modelSupportsTools } from "core/llm/autodetect";
 import { getRuleId } from "core/llm/rules/getSystemMessageWithRules";
 import { ToCoreProtocol } from "core/protocol";
 import { BuiltInToolNames } from "core/tools/builtIn";
@@ -24,6 +23,7 @@ import {
   getBaseSystemMessage,
 } from "../util/constructMessages";
 
+import { modelSupportsNativeTools } from "core/llm/toolSupport";
 import { selectCurrentToolCalls } from "../selectors/selectToolCalls";
 import { callToolById } from "./callToolById";
 
@@ -141,7 +141,7 @@ export const streamNormalInput = createAsyncThunk<
     // Get tools and filter them based on the selected model
     const allActiveTools = selectActiveTools(state);
     const activeTools = filterToolsForModel(allActiveTools, selectedChatModel);
-    const toolsSupported = modelSupportsTools(selectedChatModel);
+    const toolsSupported = modelSupportsNativeTools(selectedChatModel);
 
     // Construct completion options
     let completionOptions: LLMFullCompletionOptions = {};

--- a/gui/src/redux/util/constructMessages.test.ts
+++ b/gui/src/redux/util/constructMessages.test.ts
@@ -3,23 +3,16 @@ import {
   ChatHistoryItem,
   ChatMessage,
   ContextItemWithId,
-  ModelDescription,
   RuleWithSource,
   ThinkingChatMessage,
   ToolResultChatMessage,
   UserChatMessage,
 } from "core";
-import {
-  DEFAULT_AGENT_SYSTEM_MESSAGE,
-  DEFAULT_CHAT_SYSTEM_MESSAGE,
-  DEFAULT_PLAN_SYSTEM_MESSAGE,
-} from "core/llm/defaultSystemMessages";
 import { renderChatMessage } from "core/util/messageContent";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import {
   CANCELLED_TOOL_CALL_MESSAGE,
   constructMessages,
-  getBaseSystemMessage,
   NO_TOOL_CALL_OUTPUT_MESSAGE,
 } from "./constructMessages";
 
@@ -87,44 +80,6 @@ vi.mock("core/llm/rules/getSystemMessageWithRules", async (importOriginal) => {
       return { systemMessage, appliedRules };
     },
   };
-});
-
-test("getBaseSystemMessage should return the correct system message based on mode", () => {
-  const mockModel = {
-    baseChatSystemMessage: "Custom Chat System Message",
-    basePlanSystemMessage: "Custom Plan System Message",
-    baseAgentSystemMessage: "Custom Agent System Message",
-  } as ModelDescription;
-
-  // Test agent mode with custom message
-  expect(getBaseSystemMessage("agent", mockModel)).toBe(
-    "Custom Agent System Message",
-  );
-
-  // Test plan mode with custom message
-  expect(getBaseSystemMessage("plan", mockModel)).toBe(
-    "Custom Plan System Message",
-  );
-
-  // Test chat mode with custom message
-  expect(getBaseSystemMessage("chat", mockModel)).toBe(
-    "Custom Chat System Message",
-  );
-
-  // Test agent mode with default message
-  expect(getBaseSystemMessage("agent", {} as ModelDescription)).toBe(
-    DEFAULT_AGENT_SYSTEM_MESSAGE,
-  );
-
-  // Test agent mode with default message
-  expect(getBaseSystemMessage("plan", {} as ModelDescription)).toBe(
-    DEFAULT_PLAN_SYSTEM_MESSAGE,
-  );
-
-  // Test chat mode with default message
-  expect(getBaseSystemMessage("chat", {} as ModelDescription)).toBe(
-    DEFAULT_CHAT_SYSTEM_MESSAGE,
-  );
 });
 
 describe("constructMessages", () => {

--- a/gui/src/redux/util/constructMessages.ts
+++ b/gui/src/redux/util/constructMessages.ts
@@ -2,17 +2,11 @@ import {
   ChatHistoryItem,
   ChatMessage,
   ContextItemWithId,
-  ModelDescription,
   RuleWithSource,
   TextMessagePart,
   ToolResultChatMessage,
   UserChatMessage,
 } from "core";
-import {
-  DEFAULT_AGENT_SYSTEM_MESSAGE,
-  DEFAULT_CHAT_SYSTEM_MESSAGE,
-  DEFAULT_PLAN_SYSTEM_MESSAGE,
-} from "core/llm/defaultSystemMessages";
 import { chatMessageIsEmpty } from "core/llm/messages";
 import { getSystemMessageWithRules } from "core/llm/rules/getSystemMessageWithRules";
 import { RulePolicies } from "core/llm/rules/types";
@@ -198,17 +192,4 @@ export function constructMessages(
     appliedRules,
     appliedRuleIndex,
   };
-}
-
-export function getBaseSystemMessage(
-  messageMode: string,
-  model: ModelDescription,
-): string {
-  if (messageMode === "agent") {
-    return model.baseAgentSystemMessage ?? DEFAULT_AGENT_SYSTEM_MESSAGE;
-  } else if (messageMode === "plan") {
-    return model.basePlanSystemMessage ?? DEFAULT_PLAN_SYSTEM_MESSAGE;
-  } else {
-    return model.baseChatSystemMessage ?? DEFAULT_CHAT_SYSTEM_MESSAGE;
-  }
 }

--- a/gui/src/redux/util/constructMessages.ts
+++ b/gui/src/redux/util/constructMessages.ts
@@ -1,9 +1,11 @@
 import {
+  AssistantChatMessage,
   ChatHistoryItem,
   ChatMessage,
   ContextItemWithId,
   RuleWithSource,
   TextMessagePart,
+  ToolCallState,
   ToolResultChatMessage,
   UserChatMessage,
 } from "core";
@@ -29,6 +31,7 @@ export function constructMessages(
   baseSystemMessage: string | undefined,
   availableRules: RuleWithSource[],
   rulePolicies: RulePolicies,
+  useSystemMessageTools: Boolean,
 ): {
   messages: ChatMessage[];
   appliedRules: RuleWithSource[];
@@ -92,6 +95,24 @@ export function constructMessages(
         message: item.message,
       });
     } else if (item.message.role === "assistant") {
+      // When using system message tools, convert tool calls/states to text content
+      if (item.toolCallStates?.length && useSystemMessageTools) {
+        const { userMessage, assistantMessage } =
+          convertToolCallStatesToSystemCallsAndOutput(
+            item.message,
+            item.toolCallStates ?? [],
+          );
+        msgs.push({
+          message: assistantMessage,
+          ctxItems: [],
+        });
+        msgs.push({
+          message: userMessage,
+          ctxItems: [],
+        });
+        continue;
+      }
+
       msgs.push({
         ctxItems: item.contextItems,
         message: item.message,
@@ -192,4 +213,10 @@ export function constructMessages(
     appliedRules,
     appliedRuleIndex,
   };
+}
+function convertToolCallStatesToSystemCallsAndOutput(
+  message: AssistantChatMessage,
+  arg1: ToolCallState[],
+): { userMessage: any; assistantMessage: any } {
+  throw new Error("Function not implemented.");
 }

--- a/gui/src/redux/util/getBaseSystemMessage.test.ts
+++ b/gui/src/redux/util/getBaseSystemMessage.test.ts
@@ -1,0 +1,45 @@
+import { ModelDescription } from "core";
+import {
+  DEFAULT_AGENT_SYSTEM_MESSAGE,
+  DEFAULT_CHAT_SYSTEM_MESSAGE,
+  DEFAULT_PLAN_SYSTEM_MESSAGE,
+} from "core/llm/defaultSystemMessages";
+import { getBaseSystemMessage } from "./getBaseSystemMessage";
+
+test("getBaseSystemMessage should return the correct system message based on mode", () => {
+  const mockModel = {
+    baseChatSystemMessage: "Custom Chat System Message",
+    basePlanSystemMessage: "Custom Plan System Message",
+    baseAgentSystemMessage: "Custom Agent System Message",
+  } as ModelDescription;
+
+  // Test agent mode with custom message
+  expect(getBaseSystemMessage("agent", mockModel)).toBe(
+    "Custom Agent System Message",
+  );
+
+  // Test plan mode with custom message
+  expect(getBaseSystemMessage("plan", mockModel)).toBe(
+    "Custom Plan System Message",
+  );
+
+  // Test chat mode with custom message
+  expect(getBaseSystemMessage("chat", mockModel)).toBe(
+    "Custom Chat System Message",
+  );
+
+  // Test agent mode with default message
+  expect(getBaseSystemMessage("agent", {} as ModelDescription)).toBe(
+    DEFAULT_AGENT_SYSTEM_MESSAGE,
+  );
+
+  // Test plan mode with default message
+  expect(getBaseSystemMessage("plan", {} as ModelDescription)).toBe(
+    DEFAULT_PLAN_SYSTEM_MESSAGE,
+  );
+
+  // Test chat mode with default message
+  expect(getBaseSystemMessage("chat", {} as ModelDescription)).toBe(
+    DEFAULT_CHAT_SYSTEM_MESSAGE,
+  );
+});

--- a/gui/src/redux/util/getBaseSystemMessage.ts
+++ b/gui/src/redux/util/getBaseSystemMessage.ts
@@ -1,0 +1,19 @@
+import { ModelDescription } from "core";
+import {
+  DEFAULT_AGENT_SYSTEM_MESSAGE,
+  DEFAULT_CHAT_SYSTEM_MESSAGE,
+  DEFAULT_PLAN_SYSTEM_MESSAGE,
+} from "core/llm/defaultSystemMessages";
+
+export function getBaseSystemMessage(
+  messageMode: string,
+  model: ModelDescription,
+): string {
+  if (messageMode === "agent") {
+    return model.baseAgentSystemMessage ?? DEFAULT_AGENT_SYSTEM_MESSAGE;
+  } else if (messageMode === "plan") {
+    return model.basePlanSystemMessage ?? DEFAULT_PLAN_SYSTEM_MESSAGE;
+  } else {
+    return model.baseChatSystemMessage ?? DEFAULT_CHAT_SYSTEM_MESSAGE;
+  }
+}


### PR DESCRIPTION
A remake of https://github.com/continuedev/continue/pull/5809 and https://github.com/continuedev/continue/pull/6395/

Adds support for tools in the form of system message instructions and response content parsing + tests
Tools are parsed as they come in, converted to ToolCalls, and on the way out converted back to text. Switching between native and non-native tools is interchangeable with this approach.
For now, this applies only to models that are NOT known to support native tools
Adds a warning to the Agent mode dropdown that shows for any models not known to be great with tools (including models that support native tools)
All models can now be used in Agent mode