### PR TITLE
build: Add *-eap postfix to JetBrains Early Access releases

### DIFF
--- a/extensions/intellij/build.gradle.kts
+++ b/extensions/intellij/build.gradle.kts
@@ -9,6 +9,8 @@ fun Sync.prepareSandbox() {
 }
 
 val remoteRobotVersion = "0.11.23"
+val isEap get() = environment("RELEASE_CHANNEL").orNull == "eap"
+val pluginVersion = properties("pluginVersion").get()
 
 plugins {
     id("java")
@@ -22,17 +24,13 @@ plugins {
 }
 
 group = properties("pluginGroup").get()
+version = if (isEap) "$pluginVersion-eap" else pluginVersion
 
-version = properties("pluginVersion").get()
-
-// Configure project's dependencies
 repositories {
     mavenCentral()
     maven { url = uri("https://packages.jetbrains.team/maven/p/ij/intellij-dependencies") }
 }
 
-// Dependencies are managed with Gradle version catalog - read more:
-// https://docs.gradle.org/current/userguide/platforms.html#sub:version-catalog
 dependencies {
     implementation("com.squareup.okhttp3:okhttp:4.12.0") {
         exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
@@ -48,22 +46,6 @@ dependencies {
     testImplementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
     testImplementation("com.automation-remarks:video-recorder-junit5:2.0")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
-
-
-    // Exclude vulnerable Log4j from all dependencies
-    configurations.all {
-        resolutionStrategy {
-            eachDependency {
-                if (requested.group == "log4j" && requested.name == "log4j") {
-                    useTarget("org.slf4j:log4j-over-slf4j:1.7.36")
-                }
-            }
-        }
-    }
-
-    // Add Log4j 2.x explicitly
-    implementation("org.apache.logging.log4j:log4j-core:2.20.0")
-    implementation("org.apache.logging.log4j:log4j-api:2.20.0")
     testImplementation(kotlin("test"))
 }
 
@@ -105,7 +87,7 @@ koverReport { defaults { xml { onCheck = true } } }
 
 tasks {
     downloadRobotServerPlugin {
-        version.set(remoteRobotVersion)
+        version = remoteRobotVersion
     }
 
     prepareSandbox {
@@ -120,13 +102,14 @@ tasks {
         prepareSandbox()
     }
 
-    wrapper { gradleVersion = properties("gradleVersion").get() }
+    wrapper {
+        gradleVersion = properties("gradleVersion").get()
+    }
 
     patchPluginXml {
-        version.set(properties("pluginVersion"))
-        sinceBuild.set(properties("pluginSinceBuild"))
-        untilBuild.set(properties("pluginUntilBuild"))
-        pluginDescription.set(
+        sinceBuild = properties("pluginSinceBuild")
+        untilBuild = properties("pluginUntilBuild")
+        pluginDescription =
             providers.fileContents(layout.projectDirectory.file("README.md")).asText.map {
                 val start = "<!-- Plugin description -->"
                 val end = "<!-- Plugin description end -->"
@@ -140,7 +123,6 @@ tasks {
                     subList(indexOf(start) + 1, indexOf(end)).joinToString("\n").let(::markdownToHTML)
                 }
             }
-        )
     }
 
     // Configure UI tests plugin
@@ -167,7 +149,7 @@ tasks {
         // See ContinueExtensionSettingsService.kt for more info.
         // Currently commented out however since test fail in CI with this version
 //        intellij {
-//            version.set("2024.1")
+//            version = "2024.1"
 //        }
     }
 
@@ -178,17 +160,10 @@ tasks {
     }
 
     publishPlugin {
-        //        dependsOn("patchChangelog")
         token = environment("PUBLISH_TOKEN")
-        // The pluginVersion is based on the SemVer (https://semver.org) and supports pre-release
-        // labels, like 2.1.7-alpha.3
-        // Specify pre-release label to publish the plugin in a custom Release Channel automatically.
-        // Read more:
-        // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
-        channels.set(listOf(environment("RELEASE_CHANNEL").getOrElse("eap")))
 
-        // We always hide the stable releases until a few days of EAP have proven them stable
-        //        hidden = environment("RELEASE_CHANNEL").map { it == "stable" }.getOrElse(false)
+        val channel = if (isEap) "eap" else "default"
+        channels = listOf(channel)
     }
 
     runIde {


### PR DESCRIPTION
Motivation: https://github.com/continuedev/continue/pull/6590#discussion_r2211736481

Extra cleanup:
* Remove unused log4j dependency
  We don't have any dependency that uses it, so this dependency was unnecessarily added to the release.
* Remove explicit version in patchPluginXml
  The version is already retrieved from the project-level version / it was redundant.
* Remove commented-out publishPlugin.hidden + some noisy/redundant comments
  I removed the commented-out code which doesn't work anyway (the hidden field is not available in this version of the JetBrains Gradle plugin).

### Test

> ./gradlew buildPlugin

Outputs distributions/continue-intellij-extension-1.0.28.zip

> export RELEASE_CHANNEL=eap

> ./gradlew buildPlugin

Outputs distributions/continue-intellij-extension-1.0.28-eap.zip
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds an "-eap" postfix to JetBrains plugin builds when the Early Access release channel is used, and cleans up unused dependencies and redundant code.

- **Cleanup**
  - Removed unused log4j dependencies.
  - Simplified version handling in patchPluginXml.
  - Deleted commented-out and redundant code.

<!-- End of auto-generated description by cubic. -->

