### PR TITLE
Add debug configuration for core binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ __pycache__/
 # C extensions
 *.so
 
+.cursor/
+
 # Distribution / packaging
 .Python
 build/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -44,6 +44,23 @@
       }
     },
     {
+      "type": "node",
+      "request": "launch",
+      "name": "Core Binary (Debug)",
+      "skipFiles": ["<node_internals>/**"],
+      "program": "${workspaceFolder}/binary/out/index.js",
+      "outFiles": ["${workspaceFolder}/binary/out/**/*.js"],
+      "sourceMaps": true,
+      "smartStep": true,
+      "internalConsoleOptions": "openOnSessionStart",
+      "cwd": "${workspaceFolder}/binary",
+      "preLaunchTask": "binary:rebuild",
+      "env": {
+        "CONTINUE_DEVELOPMENT": "true",
+        "CONTINUE_GLOBAL_DIR": "${workspaceFolder}/extensions/.continue-debug"
+      }
+    },
+    {
       "name": "Debug Jest Tests",
       "type": "node",
       "request": "launch",
@@ -55,7 +72,6 @@
         "--config",
         "${workspaceRoot}/core/jest.config.js"
       ],
-
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
     },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -159,6 +159,16 @@
       }
     },
     {
+      "label": "binary:rebuild",
+      "type": "shell",
+      "command": "npm",
+      "args": ["run", "rebuild"],
+      "problemMatcher": [],
+      "options": {
+        "cwd": "binary"
+      }
+    },
+    {
       "label": "docs:start",
       "type": "shell",
       "command": "npm",

--- a/extensions/intellij/CONTRIBUTING.md
+++ b/extensions/intellij/CONTRIBUTING.md
@@ -85,7 +85,7 @@ Select the `Run Continue` task in the top right corner of the IDE and then selec
 > In community edition, use `Run Continue (CE)` instead, which uses shell scripts instead of Ultimate-only node configs.
 > If you want to debug the core in CE, you'll need to quit the `Start Core Dev Server (CE)` process and run the core in
 > a
-> different environment that supports debugging, such as VS Code (Launch "Core Binary").
+> different environment that supports debugging, such as VS Code (Launch "Core Binary (Debug)").
 
 ![run-extension-screenshot](../../media/run-continue-intellij.png)
 
@@ -107,9 +107,10 @@ When using the `Run Continue` task, we automatically tail both prompt logs and I
   _Run | Debugging Actions | Reload Changed Classes`_
   - This will often fail on new imports, schema changes etc. In that case, you need to stop and restart the extension
 - `gui`: Changes will be reloaded automatically
-- `core`: Run `npm run build -- --os [darwin | linux | win32]` from the `binary` directory (requires
-  restarting the
-  `Start Core Dev Server` task)
+- `core`:
+  - In IntelliJ: run `npm run build -- --os [darwin | linux | win32]` from the `binary` directory and restart the `Start Core Dev Server` task.
+  - In VS Code: restart the `Core Binary (Debug)` launch configuration. Its preLaunch task `binary:rebuild` will automatically rebuild the binary before starting.
+  - After rebuilding the core binary, stop and restart the `Run Continue` (or `Run Continue (CE)` in Community Edition) task so that the IntelliJ extension picks up the updated binary.
 
 ### Setting breakpoints
 
@@ -117,7 +118,7 @@ When using the `Run Continue` task, we automatically tail both prompt logs and I
 - `gui`: You'll need to set explicit `debugger` statements in the source code, or through the browser dev tools
 - `core`: Breakpoints can be set in Intellij (requires restarting the `Start Core Dev Server` task)
   - If you have Community Edition installed, you won't be able to use breakpoints in IntelliJ. Instead, you can start
-    the `Core Binary` task in VS Code and set breakpoints in that IDE.
+    the `Core Binary (Debug)` launch configuration in VS Code and set breakpoints there.
 
 ### Available Gradle tasks
 


### PR DESCRIPTION
Adds a new "Core Binary (Debug)" launch configuration to VS Code. This allows for direct debugging of the Node.js binary.

- Creates a `binary:rebuild` task to build the binary before launching.
- Sets development-specific environment variables for the debug session.
- Ignores the `.cursor` directory.

## Description  
This change introduces a dedicated “Core Binary (Debug)” launch configuration for VS Code, allowing developers to debug the Node.js core binary directly inside the IDE with full source-map support.  
Key points:  
• Automatically rebuilds the binary before each session via the new `binary:rebuild` task, ensuring the debugger always runs the latest code.  
• Sets development-specific environment variables so the binary behaves the same way it does when launched by the Extension.  
• Updates documentation to reflect the new workflow and clarifies how to use it from both IntelliJ and VS Code.  
• Adds `.cursor/` to `.gitignore` to keep editor metadata out of version control.  

Together, these updates streamline the developer workflow, enable breakpoint debugging without manual setup, and keep the repository clean of transient files.

## Checklist

- [v] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [v] The relevant docs, if any, have been updated or created
- [v] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a "Core Binary (Debug)" launch configuration to VS Code for direct debugging of the Node.js binary, with automatic rebuilds and development environment variables.

- **New Features**
  - New debug config runs the latest binary build and sets up the correct environment.
  - Added a `binary:rebuild` task to automate building before debugging.
  - Updated `.gitignore` to exclude `.cursor` directory.

<!-- End of auto-generated description by cubic. -->

