### PR TITLE
Fix misformatted yaml code

### DIFF
--- a/docs/customize/custom-providers.mdx
+++ b/docs/customize/custom-providers.mdx
@@ -143,7 +143,10 @@ Reference the contents of all of your open files. Set `onlyPinned` to `true` to 
 config.yaml
 
 ```
-context:  - provider: open    params:      onlyPinned: true
+context:
+  - provider: open
+    params:
+      onlyPinned: true
 ```
 
 config.json
@@ -164,7 +167,10 @@ Optionally, set `n` to limit the number of results returned (default 6).
 config.yaml
 
 ```
-context:  - provider: web    params:      n: 5
+context:
+  - provider: web
+    params:
+      n: 5
 ```
 
 config.json
@@ -183,7 +189,8 @@ Reference the most relevant snippets from your codebase.
 config.yaml
 
 ```
-context:  - provider: codebase
+context:
+  - provider: codebase
 ```
 
 config.json
@@ -223,7 +230,10 @@ Reference the results of codebase search, just like the results you would get fr
 config.yaml
 
 ```
-context:  - provider: search    params:        maxResults: 100 # optional, defaults to 200
+context:
+  - provider: search
+    params:
+      maxResults: 100 # optional, defaults to 200
 ```
 
 config.json
@@ -244,7 +254,8 @@ Reference the markdown converted contents of a given URL.
 config.yaml
 
 ```
-context:  - provider: url
+context:
+  - provider: url
 ```
 
 config.json
@@ -263,7 +274,8 @@ Reference recent clipboard items
 config.yaml
 
 ```
-context:  - provider: clipboard
+context:
+  - provider: clipboard
 ```
 
 config.json
@@ -282,7 +294,8 @@ Reference the structure of your current workspace.
 config.yaml
 
 ```
-context:  - provider: tree
+context:
+  - provider: tree
 ```
 
 config.json
@@ -301,7 +314,8 @@ Get Problems from the current file.
 config.yaml
 
 ```
-context:  - provider: problems
+context:
+  - provider: problems
 ```
 
 config.json
@@ -320,7 +334,10 @@ Reference the contents of the local variables in the debugger. Currently only av
 config.yaml
 
 ```
-context:  - provider: debugger    params:      stackDepth: 3
+context:
+  - provider: debugger
+    params:
+      stackDepth: 3
 ```
 
 config.json
@@ -343,7 +360,10 @@ Reference the outline of your codebase. By default, signatures are included alon
 config.yaml
 
 ```
-context:  - provider: repo-map    params:      includeSignatures: false # default true
+context:
+  - provider: repo-map
+    params:
+      includeSignatures: false # default true
 ```
 
 config.json
@@ -368,7 +388,8 @@ Reference the architecture and platform of your current operating system.
 config.yaml
 
 ```
-context:  - provider: os
+context:
+  - provider: os
 ```
 
 config.json
@@ -387,7 +408,13 @@ The [Model Context Protocol](https://modelcontextprotocol.io/introduction) is a 
 config.yaml
 
 ```
-mcpServers:  - name: My MCP Server    command: uvx    args:      - mcp-server-sqlite      - --db-path      - /Users/NAME/test.db
+mcpServers:
+  - name: My MCP Server
+    command: uvx
+    args:
+      - mcp-server-sqlite
+      - --db-path
+      - /Users/NAME/test.db
 ```
 
 config.json
@@ -420,7 +447,13 @@ Reference the conversation in a GitHub issue.
 config.yaml
 
 ```
-context:  - provider: issue    params:      repos:        - owner: continuedev          repo: continue      githubToken: ghp_xxx
+context:
+  - provider: issue
+    params:
+      repos:
+        - owner: continuedev
+          repo: continue
+      githubToken: ghp_xxx
 ```
 
 config.json
@@ -451,7 +484,29 @@ Reference table schemas from Sqlite, Postgres, MSSQL, and MySQL databases.
 config.yaml
 
 ```
-context:  - provider: database    params:      connections:        - name: examplePostgres          connection_type: postgres          connection:            user: username            host: localhost            database: exampleDB            password: yourPassword            port: 5432        - name: exampleMssql           connection_type: mssql          connection:            user: username            server: localhost            database: exampleDB            password: yourPassword        - name: exampleSqlite          connection_type: sqlite          connection:            filename: /path/to/your/sqlite/database.db
+context:
+  - provider: database
+    params:
+      connections:
+        - name: examplePostgres
+          connection_type: postgres
+          connection:
+            user: username
+            host: localhost
+            database: exampleDB
+            password: yourPassword
+            port: 5432
+        - name: exampleMssql
+          connection_type: mssql
+          connection:
+            user: username
+            server: localhost
+            database: exampleDB
+            password: yourPassword
+        - name: exampleSqlite
+          connection_type: sqlite
+          connection:
+            filename: /path/to/your/sqlite/database.db
 ```
 
 config.json
@@ -514,7 +569,16 @@ Reference the schema of a table, and some sample rows
 config.yaml
 
 ```
-context:  - provider: postgres    params:      host: localhost      port: 5436      user: myuser      password: catsarecool      database: animals      schema: public      sampleRows: 3
+context:
+  - provider: postgres
+    params:
+      host: localhost
+      port: 5436
+      user: myuser
+      password: catsarecool
+      database: animals
+      schema: public
+      sampleRows: 3
 ```
 
 config.json
@@ -554,7 +618,10 @@ Reference the results of a Google search.
 config.yaml
 
 ```
-context:  - provider: google    params:      serperApiKey: <YOUR_SERPER.DEV_API_KEY>
+context:
+  - provider: google
+    params:
+      serperApiKey: <YOUR_SERPER.DEV_API_KEY>
 ```
 
 config.json
@@ -584,7 +651,10 @@ Reference an open MR for this branch on GitLab.
 config.yaml
 
 ```
-context:  - provider: gitlab-mr    params:      token: "..."
+context:
+  - provider: gitlab-mr
+    params:
+      token: "..."
 ```
 
 config.json
@@ -605,7 +675,11 @@ You can specify the domain to communicate with by setting the `domain` parameter
 config.yaml
 
 ```
-context:  - provider: gitlab-mr    params:      token: "..."      domain: "gitlab.example.com"
+context:
+  - provider: gitlab-mr
+    params:
+      token: "..."
+      domain: "gitlab.example.com"
 ```
 
 config.json
@@ -635,7 +709,11 @@ Reference the conversation in a Jira issue.
 config.yaml
 
 ```
-context:  - provider: jira    params:      domain: company.atlassian.net      token: ATATT...
+context:
+  - provider: jira
+    params:
+      domain: company.atlassian.net
+      token: ATATT...
 ```
 
 config.json
@@ -663,7 +741,10 @@ This context provider supports both Jira API version 2 and 3. It will use versio
 config.yaml
 
 ```
-context:  - provider: jira    params:      apiVersion: "2"
+context:
+  - provider: jira
+    params:
+      apiVersion: "2"
 ```
 
 config.json
@@ -696,7 +777,16 @@ Reference the messages in a Discord channel.
 config.yaml
 
 ```
-context:  - provider: discord    params:      discordKey: "bot token"      guildId: "1234567890"       channels:        - id: "123456"          name: "example-channel"        - id: "678901"           name: "example-channel-2"
+context:
+  - provider: discord
+    params:
+      discordKey: "bot token"
+      guildId: "1234567890"
+      channels:
+        - id: "123456"
+          name: "example-channel"
+        - id: "678901"
+          name: "example-channel-2"
 ```
 
 config.json
@@ -731,7 +821,10 @@ The HttpContextProvider makes a POST request to the url passed in the configurat
 config.yaml
 
 ```
-context:  - provider: http    params:      url: "https://api.example.com/v1/users"
+context:
+  - provider: http
+    params:
+      url: "https://api.example.com/v1/users"
 ```
 
 config.json
@@ -770,7 +863,11 @@ Reference specific git commit metadata and diff or all of the recent commits.
 config.yaml
 
 ```
-context:  - provider: commit    params:      Depth: 50      LastXCommitsDepth: 10
+context:
+  - provider: commit
+    params:
+      Depth: 50
+      LastXCommitsDepth: 10
 ```
 
 config.json
@@ -795,7 +892,11 @@ Query a [Greptile](https://www.greptile.com/) index of the current repo/branch.
 config.yaml
 
 ```
-context:  - provider: greptile     params:      greptileToken: "..."      githubToken: "..."
+context:
+  - provider: greptile
+    params:
+      greptileToken: "..."
+      githubToken: "..."
 ```
 
 config.json

--- a/docs/guides/custom-code-rag.mdx
+++ b/docs/guides/custom-code-rag.mdx
@@ -79,7 +79,13 @@ After you've set up your server, you can configure Continue to use it by adding 
 config.yaml
 
 ```
-context:  - provider: http    params:      url: https://myserver.com/retrieve      name: http      description: Custom HTTP Context Provider      displayTitle: My Custom Context
+context:
+  - provider: http
+    params:
+      url: https://myserver.com/retrieve
+      name: http
+      description: Custom HTTP Context Provider
+      displayTitle: My Custom Context
 ```
 
 config.json

--- a/docs/guides/how-to-self-host-a-model.mdx
+++ b/docs/guides/how-to-self-host-a-model.mdx
@@ -25,7 +25,11 @@ Basic authentication can be done with any provider using the `apiKey` field:
 config.yaml
 
 ```
-models:  - name: Ollama    provider: ollama    model: llama2-7b    apiKey: <YOUR_CUSTOM_OLLAMA_SERVER_API_KEY>
+models:
+  - name: Ollama
+    provider: ollama
+    model: llama2-7b
+    apiKey: <YOUR_CUSTOM_OLLAMA_SERVER_API_KEY>
 ```
 
 config.json
@@ -53,7 +57,13 @@ If you need to send custom headers for authentication, you may use the `requestO
 config.yaml
 
 ```
-models:  - name: Ollama    provider: ollama    model: llama2-7b    requestOptions:      headers:        X-Auth-Token: xxx
+models:
+  - name: Ollama
+    provider: ollama
+    model: llama2-7b
+    requestOptions:
+      headers:
+        X-Auth-Token: xxx
 ```
 
 config.json
@@ -79,7 +89,15 @@ Similarly if your model requires a Certificate for authentication, you may use t
 config.yaml
 
 ```
-models:  - name: Ollama    provider: ollama    model: llama2-7b    requestOptions:      clientCertificate:        cert: C:\tempollama.pem        key: C:\tempollama.key        passphrase: c0nt!nu3
+models:
+  - name: Ollama
+    provider: ollama
+    model: llama2-7b
+    requestOptions:
+      clientCertificate:
+        cert: C:\tempollama.pem
+        key: C:\tempollama.key
+        passphrase: c0nt!nu3
 ```
 
 config.json

--- a/docs/guides/llama3.1.mdx
+++ b/docs/guides/llama3.1.mdx
@@ -21,7 +21,10 @@ Ollama is the fastest way to get up and running with local language models. We r
 config.yaml
 
 ```
-models:  - name: Llama 3.1 8b    provider: ollama    model: llama3.1-8b
+models:
+  - name: Llama 3.1 8b
+    provider: ollama
+    model: llama3.1-8b
 ```
 
 config.json
@@ -53,7 +56,11 @@ Groq provides the fastest available inference for open-source language models, i
 config.yaml
 
 ```
-models:  - name: Llama 3.3 70b Versatile    provider: groq    model: llama-3.3-70b-versatile    apiKey: <YOUR_GROQ_API_KEY>
+models:
+  - name: Llama 3.3 70b Versatile
+    provider: groq
+    model: llama-3.3-70b-versatile
+    apiKey: <YOUR_GROQ_API_KEY>
 ```
 
 config.json
@@ -85,7 +92,11 @@ Together AI provides fast and reliable inference of open-source models. You'll b
 config.yaml
 
 ```
-models:  - name: Llama 3.1 405b    provider: together    model: llama3.1-405b    apiKey: <YOUR_TOGETHER_API_KEY>
+models:
+  - name: Llama 3.1 405b
+    provider: together
+    model: llama3.1-405b
+    apiKey: <YOUR_TOGETHER_API_KEY>
 ```
 
 config.json
@@ -116,7 +127,11 @@ Replicate makes it easy to host and run open-source AI with an API.
 config.yaml
 
 ```
-models:  - name: Llama 3.1 405b    provider: replicate    model: llama3.1-405b    apiKey: <YOUR_REPLICATE_API_KEY>
+models:
+  - name: Llama 3.1 405b
+    provider: replicate
+    model: llama3.1-405b
+    apiKey: <YOUR_REPLICATE_API_KEY>
 ```
 
 config.json
@@ -148,7 +163,11 @@ SambaNova Cloud provides world record Llama3.1 70B/405B serving.
 config.yaml
 
 ```
-models:  - name: SambaNova Llama 3.1 405B    provider: sambanova    model: llama3.1-405b    apiKey: <YOUR_SAMBA_API_KEY>
+models:
+  - name: SambaNova Llama 3.1 405B
+    provider: sambanova
+    model: llama3.1-405b
+    apiKey: <YOUR_SAMBA_API_KEY>
 ```
 
 config.json
@@ -180,7 +199,11 @@ Cerebras Inference uses specialized silicon to provides fast inference for the L
 config.yaml
 
 ```
-models:  - name: Cerebras Llama 3.1 70B    provider: cerebras    model: llama3.1-70b    apiKey: <YOUR_CEREBRAS_API_KEY>
+models:
+  - name: Cerebras Llama 3.1 70B
+    provider: cerebras
+    model: llama3.1-70b
+    apiKey: <YOUR_CEREBRAS_API_KEY>
 ```
 
 config.json

--- a/docs/guides/ollama-guide.mdx
+++ b/docs/guides/ollama-guide.mdx
@@ -19,7 +19,14 @@ Before getting started, ensure your system meets these requirements:
 Choose the installation method for your operating system:
 
 ```
-# macOSbrew install ollama# Linuxcurl -fsSL https://ollama.ai/install.sh | sh# Windows# Download from ollama.ai
+# macOS
+brew install ollama
+
+# Linux
+curl -fsSL https://ollama.ai/install.sh | sh
+
+# Windows
+# Download from ollama.ai
 ```
 
 ### Step 2: Download Models
@@ -27,7 +34,10 @@ Choose the installation method for your operating system:
 After installing Ollama, download the models you want to use. Here are some popular options:
 
 ```
-# Popular models for developmentollama pull llama2ollama pull codellamaollama pull mistral
+# Popular models for development
+ollama pull llama2
+ollama pull codellama
+ollama pull mistral
 ```
 
 ## Configuration

--- a/docs/guides/set-up-codestral.mdx
+++ b/docs/guides/set-up-codestral.mdx
@@ -18,7 +18,15 @@ title: "How to Set Up Codestral"
 config.yaml
 
 ```
-models:  - name: Codestral    provider: mistral    model: codestral-latest    apiKey: <YOUR_CODESTRAL_API_KEY>    apiBase: https://codestral.mistral.ai/v1    roles:      - chat      - autocomplete
+models:
+  - name: Codestral
+    provider: mistral
+    model: codestral-latest
+    apiKey: <YOUR_CODESTRAL_API_KEY>
+    apiBase: https://codestral.mistral.ai/v1
+    roles:
+      - chat
+      - autocomplete
 ```
 
 config.json

--- a/docs/reference.mdx
+++ b/docs/reference.mdx
@@ -61,7 +61,7 @@ Blocks:
 - `.continue/models` - for models
 - `.continue/prompts` - for prompts
 - `.continue/context` - for context providers
-- `.continue/docs` - for docs~~~~
+- `.continue/docs` - for docs
 - `.continue/data` - for data
 - `.continue/mcpServers` - for MCP Servers
 

--- a/docs/reference/yaml-migration.mdx
+++ b/docs/reference/yaml-migration.mdx
@@ -88,7 +88,48 @@ config.json
 config.yaml
 
 ```
-models:  - name: GPT-4    provider: openai    model: gpt-4    apiKey: <YOUR_OPENAI_KEY>    defaultCompletionOptions:      temperature: 0.5      maxTokens: 2000    roles:      - chat      - edit  - name: My Voyage Reranker    provider: voyage    apiKey: <YOUR_VOYAGE_KEY>    roles:      - rerank  - name: My Starcoder    provider: ollama    model: starcoder2:3b    roles:      - autocomplete  - name: My Ada Embedder    provider: openai    apiKey: <YOUR_ADA_API_KEY>    roles:      - embed    embedOptions:      - maxChunkSize: 256      - maxBatchSize: 5  - name: Ollama Autodetect    provider: ollama    model: AUTODETECT  - name: My Open AI Compatible Model - Apply    provider: openai    model: my-openai-compatible-model    apiBase: http://3.3.3.3/v1    requestOptions:      headers:        X-Auth-Token: <MY_API_KEY>    roles:      - chat      - apply
+models:
+  - name: GPT-4
+    provider: openai
+    model: gpt-4
+    apiKey: <YOUR_OPENAI_KEY>
+    defaultCompletionOptions:
+      temperature: 0.5
+      maxTokens: 2000
+    roles:
+      - chat
+      - edit
+  - name: My Voyage Reranker
+    provider: voyage
+    apiKey: <YOUR_VOYAGE_KEY>
+    roles:
+      - rerank
+  - name: My Starcoder
+    provider: ollama
+    model: starcoder2:3b
+    roles:
+      - autocomplete
+  - name: My Ada Embedder
+    provider: openai
+    apiKey: <YOUR_ADA_API_KEY>
+    roles:
+      - embed
+    embedOptions:
+      - maxChunkSize: 256
+      - maxBatchSize: 5
+  - name: Ollama Autodetect
+    provider: ollama
+    model: AUTODETECT
+  - name: My Open AI Compatible Model - Apply
+    provider: openai
+    model: my-openai-compatible-model
+    apiBase: http://3.3.3.3/v1
+    requestOptions:
+      headers:
+        X-Auth-Token: <MY_API_KEY>
+    roles:
+      - chat
+      - apply
 ```
 
 Note that the `repoMapFileSelection` experimental model role has been deprecated and is only available in `config.json`.
@@ -119,7 +160,13 @@ config.json
 config.yaml
 
 ```
-context:  - provider: docs  - provider: codebase    params:      nRetrieve: 30      nFinal: 3  - provider: diff
+context:
+  - provider: docs
+  - provider: codebase
+    params:
+      nRetrieve: 30
+      nFinal: 3
+  - provider: diff
 ```
 
 ### System Message
@@ -139,7 +186,8 @@ config.json
 config.yaml
 
 ```
-rules:  - Always give concise responses
+rules:
+  - Always give concise responses
 ```
 
 ### Prompts
@@ -167,7 +215,17 @@ config.json
 config.yaml
 
 ```
-prompts:  - name: check    description: Check for mistakes in my code    prompt: |      Please read the highlighted code and check for any mistakes. You should look for the following, and be extremely vigilant:        - Syntax errors        - Logic errors        - Security vulnerabilities        - Performance issues        - Anything else that looks wrong      Once you find an error, please explain it as clearly as possible, but without using extra words. For example, instead of saying 'I think there is a syntax error on line 5', you should say 'Syntax error on line 5'. Give your answer as one bullet point per mistake found.
+prompts:
+  - name: check
+    description: Check for mistakes in my code
+    prompt: |
+      Please read the highlighted code and check for any mistakes. You should look for the following, and be extremely vigilant:
+        - Syntax errors
+        - Logic errors
+        - Security vulnerabilities
+        - Performance issues
+        - Anything else that looks wrong
+      Once you find an error, please explain it as clearly as possible, but without using extra words. For example, instead of saying 'I think there is a syntax error on line 5', you should say 'Syntax error on line 5'. Give your answer as one bullet point per mistake found.
 ```
 
 ### Documentation
@@ -192,7 +250,11 @@ config.json
 config.yaml
 
 ```
-docs:  - name: nest.js    startUrl: https://docs.nestjs.com/  - name: My site    startUrl: https://mysite.com/docs/
+docs:
+  - name: nest.js
+    startUrl: https://docs.nestjs.com/
+  - name: My site
+    startUrl: https://mysite.com/docs/
 ```
 
 ### MCP Servers
@@ -231,7 +293,15 @@ config.json
 config.yaml
 
 ```
-mcpServers:  - name: My MCP Server    command: uvx    args:      - mcp-server-sqlite      - --db-path      - /Users/NAME/test.db    env:      KEY: <VALUE>
+mcpServers:
+  - name: My MCP Server
+    command: uvx
+    args:
+      - mcp-server-sqlite
+      - --db-path
+      - /Users/NAME/test.db
+    env:
+      KEY: <VALUE>
 ```
 
 ---

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -92,7 +92,11 @@ If you're seeing a `fetch failed` error and your network requires custom certifi
 config.yaml
 
 ```
-models:  - name: My Model    ...    requestOptions:      caBundlePath: /path/to/cert.pem
+models:
+  - name: My Model
+    ...
+    requestOptions:
+      caBundlePath: /path/to/cert.pem
 ```
 
 config.json


### PR DESCRIPTION
## Description

There's a lot of misformatted yaml code showing up in the docs website. Examples on this page: https://docs.continue.dev/customize/custom-providers#%40open

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed misformatted YAML code blocks in documentation to improve readability and prevent confusion when copying examples.

<!-- End of auto-generated description by cubic. -->

