### PR TITLE
fix: show save dialog when creating new files (issue 6309)

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1395,6 +1395,7 @@ export interface ApplyToFilePayload {
   text: string;
   toolCallId?: string;
   isSearchAndReplace?: boolean;
+  showSaveDialog?: boolean;
 }
 
 export interface RangeInFileWithContents {

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/index.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/index.tsx
@@ -150,7 +150,11 @@ export function StepContainerPreToolbar({
 
   async function onClickApply() {
     const fileUri = await getFileUriToApplyTo();
-    if (!fileUri) {
+    
+    // Check if we're creating a new file (when fileExists is false or when we don't have a specific file)
+    const isCreatingNewFile = !fileExists && relativeFilepath;
+    
+    if (!fileUri && !isCreatingNewFile) {
       void ideMessenger.ide.showToast(
         "error",
         "Could not resolve filepath to apply changes",
@@ -163,12 +167,15 @@ export function StepContainerPreToolbar({
       streamId: codeBlockStreamId,
       filepath: fileUri,
       text: codeBlockContent,
+      showSaveDialog: !!isCreatingNewFile,
+      toolCallId: forceToolCallId,
     });
 
-    setAppliedFileUri(fileUri);
-    void refreshFileExists();
+    if (fileUri) {
+      setAppliedFileUri(fileUri);
+      void refreshFileExists();
+    }
   }
-
   function onClickInsertAtCursor() {
     ideMessenger.post("insertAtCursor", { text: codeBlockContent });
   }


### PR DESCRIPTION
## Description

This PR fixes issue #6309 where the "Create File" command always created files in the workspace root instead of allowing users to choose the location.

## Related Issue

Fixes #6309 - Files created in workspace root instead of chosen directory

## Changes

- Added `showSaveDialog?: boolean` property to `ApplyToFilePayload` interface for backward compatibility
- Updated VS Code extension message handler to show a native save dialog when `showSaveDialog` flag is set
- Modified frontend to set `showSaveDialog: true` when creating new files (when `fileExists` is false)

## Testing

### Manual Testing Performed
- ✅ Creating new files shows the save dialog
- ✅ Dialog suggests correct filename from relative path (e.g., `utils/helper.js` suggests `helper.js`)
- ✅ User can choose any location to save the file
- ✅ Existing files still apply changes without dialog
- ✅ User can cancel file creation
- ✅ Nested directories work correctly (e.g., `src/components/Button.tsx`)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project (Prettier formatted)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] The fix is focused on the specific issue without unrelated changes
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective (can be added in follow-up PR)

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where creating a new file always placed it in the workspace root by showing a save dialog so users can choose the file location.

- **Bug Fixes**
  - Added a save dialog when creating new files, allowing users to pick the directory and filename.
  - Existing files are updated without showing the dialog.

<!-- End of auto-generated description by cubic. -->

