### PR TITLE
feat: make the reasoning btn solid when active

### DIFF
--- a/gui/src/components/gui/Alert.tsx
+++ b/gui/src/components/gui/Alert.tsx
@@ -3,7 +3,7 @@ import {
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
   InformationCircleIcon,
-} from "@heroicons/react/24/solid";
+} from "@heroicons/react/16/solid";
 import { ReactNode } from "react";
 import { vscBackground } from "..";
 

--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -1,8 +1,9 @@
 import {
   AtSymbolIcon,
-  LightBulbIcon,
+  LightBulbIcon as LightBulbIconOutline,
   PhotoIcon,
 } from "@heroicons/react/24/outline";
+import { LightBulbIcon as LightBulbIconSolid } from "@heroicons/react/24/solid";
 import { InputModifiers } from "core";
 import { modelSupportsImages, modelSupportsTools } from "core/llm/autodetect";
 import { useContext, useRef } from "react";
@@ -13,7 +14,6 @@ import { selectSelectedChatModel } from "../../redux/slices/configSlice";
 import { setHasReasoningEnabled } from "../../redux/slices/sessionSlice";
 import { exitEdit } from "../../redux/thunks/edit";
 import { getAltKeyLabel, isMetaEquivalentKeyPressed } from "../../util";
-import { cn } from "../../util/cn";
 import { ToolTip } from "../gui/Tooltip";
 import ModelSelect from "../modelSelection/ModelSelect";
 import { ModeSelect } from "../ModeSelect";
@@ -141,19 +141,23 @@ function InputToolbar(props: InputToolbarProps) {
                 </ToolTip>
               </HoverItem>
             )}
-            {defaultModel?.provider === "anthropic" && (
+            {defaultModel?.underlyingProviderName === "anthropic" && (
               <HoverItem
                 onClick={() =>
                   dispatch(setHasReasoningEnabled(!hasReasoningEnabled))
                 }
               >
-                <LightBulbIcon
-                  data-tooltip-id="model-reasoning-tooltip"
-                  className={cn(
-                    "h-3 w-3 hover:brightness-150",
-                    hasReasoningEnabled && "brightness-200",
-                  )}
-                />
+                {hasReasoningEnabled ? (
+                  <LightBulbIconSolid
+                    data-tooltip-id="model-reasoning-tooltip"
+                    className="h-3 w-3 brightness-200 hover:brightness-150"
+                  />
+                ) : (
+                  <LightBulbIconOutline
+                    data-tooltip-id="model-reasoning-tooltip"
+                    className="h-3 w-3 hover:brightness-150"
+                  />
+                )}
 
                 <ToolTip id="model-reasoning-tooltip" place="top">
                   {hasReasoningEnabled


### PR DESCRIPTION
<img width="72" height="28" alt="image" src="https://github.com/user-attachments/assets/717d64d9-61e0-4193-9b87-918d860757da" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
The reasoning button now shows a solid lightbulb icon when active, making it easier to see when reasoning is enabled.

- **UI Improvements**
  - Switched to a solid icon for the active state of the reasoning button.
  - Imported a smaller set of icons for the Alert component

<!-- End of auto-generated description by cubic. -->

