### PR TITLE
fix: Remove redundant jcef.out-of-process=false from run configs

### DIFF
--- a/extensions/intellij/.run/Run Extension.run.xml
+++ b/extensions/intellij/.run/Run Extension.run.xml
@@ -20,7 +20,6 @@
                     <option value="runIde"/>
                 </list>
             </option>
-             <option name="vmOptions" value="-Dide.browser.jcef.out-of-process.enabled=false"/>
         </ExternalSystemSettings>
         <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
         <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>

--- a/extensions/intellij/.run/Run Qodana.run.xml
+++ b/extensions/intellij/.run/Run Qodana.run.xml
@@ -19,7 +19,6 @@
 <!--          <option value="runInspections" />-->
 <!--        </list>-->
 <!--      </option>-->
-<!--       <option name="vmOptions" value="-Dide.browser.jcef.out-of-process.enabled=false"/>-->
 <!--    </ExternalSystemSettings>-->
 <!--    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>-->
 <!--    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>-->

--- a/extensions/intellij/.run/Run Test IDE.run.xml
+++ b/extensions/intellij/.run/Run Test IDE.run.xml
@@ -13,7 +13,6 @@
                     <option value="runIdeForUiTests"/>
                 </list>
             </option>
-             <option name="vmOptions" value="-Dide.browser.jcef.out-of-process.enabled=false"/>
         </ExternalSystemSettings>
         <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
         <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>

--- a/extensions/intellij/.run/Run Tests.run.xml
+++ b/extensions/intellij/.run/Run Tests.run.xml
@@ -13,7 +13,6 @@
           <option value="test" />
         </list>
       </option>
-       <option name="vmOptions" value="-Dide.browser.jcef.out-of-process.enabled=false"/>
     </ExternalSystemSettings>
     <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
     <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>


### PR DESCRIPTION
Related to #6611
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the redundant -Dide.browser.jcef.out-of-process.enabled=false VM option from all IntelliJ run configurations to simplify setup.

<!-- End of auto-generated description by cubic. -->

