### PR TITLE
build: Fix jetbrains-release/bump-version CI job

### DIFF
--- a/.github/workflows/jetbrains-release.yaml
+++ b/.github/workflows/jetbrains-release.yaml
@@ -63,7 +63,6 @@ jobs:
 
       - name: Bump version in gradle.properties
         run: |
-          cd extensions/intellij
           awk '/pluginVersion=/{split($0,a,"="); split(a[2],b,"."); b[3]+=1; printf "%s=%s.%s.%s\n",a[1],b[1],b[2],b[3];next}1' gradle.properties > tmp && mv tmp gradle.properties
           rm -rf tmp
           NEW_VERSION=$(grep 'pluginVersion=' gradle.properties | cut -d'=' -f2)


### PR DESCRIPTION
This `cd` was failing because `extensions/intellij` is the default working directory.

Can be reproduced with:

`act push -j bump-version -W .github/workflows/jetbrains-release.yaml`

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the bump-version CI job by removing an unnecessary cd command, since the workflow already runs in the correct directory.

<!-- End of auto-generated description by cubic. -->

