### PR TITLE
build: Remove buildPlugin from jetbrains-release/build

### DIFF
--- a/.github/workflows/jetbrains-release.yaml
+++ b/.github/workflows/jetbrains-release.yaml
@@ -224,10 +224,6 @@ jobs:
       #     apple-product-id: dev.continue.continue-binary
       #     options: --options runtime --entitlements entitlements.xml
 
-      # Build plugin
-      - name: Build plugin
-        run: ./gradlew buildPlugin
-
       # Publish the plugin to JetBrains Marketplace
       - name: Publish EAP Plugin
         if: github.event_name == 'release' || github.event.inputs.publish_build == 'true'


### PR DESCRIPTION
It is redundant because `publishPlugin` depends on `buildPlugin` Gradle task.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the separate buildPlugin step from the JetBrains release workflow since publishPlugin already runs it automatically.

<!-- End of auto-generated description by cubic. -->

