### PR TITLE
fix: use rules when `alwaysApply` is absent

### DIFF
--- a/core/llm/rules/getSystemMessageWithRules.ts
+++ b/core/llm/rules/getSystemMessageWithRules.ts
@@ -132,7 +132,7 @@ const isFileInDirectory = (
  * Checks if a rule is a root-level rule (.continue directory or no file path)
  */
 const isRootLevelRule = (rule: RuleWithSource): boolean => {
-  return !rule.ruleFile || rule.ruleFile.startsWith(".continue/");
+  return !rule.ruleFile || rule.ruleFile.includes(".continue/"); // ruleFile path is absolute - hence we need to check for it in between
 };
 
 /**

--- a/core/llm/rules/getSystemMessageWithRules.vitest.ts
+++ b/core/llm/rules/getSystemMessageWithRules.vitest.ts
@@ -69,7 +69,7 @@ describe("Rule colocation glob matching", () => {
       name: "Root Rule",
       rule: "Follow project standards",
       source: "rules-block",
-      ruleFile: ".continue/rules.md",
+      ruleFile: "/path/to/repo/.continue/rules.md",
       // No restriction, should apply to all files
     };
 
@@ -212,7 +212,7 @@ describe("Rule policies", () => {
       name: "Root Rule",
       rule: "Follow project standards",
       source: "rules-block",
-      ruleFile: ".continue/rules.md",
+      ruleFile: "/my/project/.continue/rules.md",
     };
 
     // Off policy should override even global rules


### PR DESCRIPTION
## Description

`alwaysApply: undefined` was not working because the rule file path is always absolute

- use `.includes` instead of `.startsWith` to search for the `.continue` folder
- update tests

resolves CON-2955

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot


https://github.com/user-attachments/assets/c7790569-6796-422d-8dd1-90e294460273


https://github.com/user-attachments/assets/662cfe2c-3561-47be-9f55-195707b85c69



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
