### PR TITLE
fix rules deep dive docs link

### DIFF
--- a/docs/customization/rules.mdx
+++ b/docs/customization/rules.mdx
@@ -15,6 +15,4 @@ By implementing rules, you transform the AI from a generic coding assistant into
 
 Your assistant detects rule blocks and applies the specified rules while in [Agent](/features/agent/quick-start), [Chat](/features/chat/quick-start), and [Edit](/features/edit/quick-start) modes.
 
-## Learn More
-
-Learn more in the [rules deep dive](/customization/rules), and view [`rules`](/reference#rules) in the YAML Reference for more details.
+Learn more in the [rules deep dive](/customize/deep-dives/rules), and view [`rules`](/reference#rules) in the YAML Reference for more details.


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed the "rules deep dive" link in the rules documentation to point to the correct page.

<!-- End of auto-generated description by cubic. -->

