### PR TITLE
fix: missing `alwaysApply` in local rule block

### DIFF
--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -57,6 +57,7 @@ function convertYamlRuleToContinueRule(rule: Rule): RuleWithSource {
       globs: rule.globs,
       name: rule.name,
       ruleFile: rule.sourceFile,
+      alwaysApply: rule.alwaysApply,
     };
   }
 }


### PR DESCRIPTION
## Description

Fix rules in .yaml file not applying. This was happening despite we had `alwaysApply` set to true. Because while converting it to continue config, we were dropping the alwaysApply field

resolves CON-2212

also requires https://github.com/continuedev/continue/pull/6763 to be merged

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot




https://github.com/user-attachments/assets/ef031fac-ee04-4e4d-9335-9154793e0764

https://github.com/user-attachments/assets/45bafbdf-dd60-4fc9-ba4e-96b07da54742


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where the alwaysApply field was not included when converting YAML rules, causing some rules to not apply as expected. This ensures local rules with alwaysApply set to true now work correctly.

<!-- End of auto-generated description by cubic. -->

