### PR TITLE
fix: use JAVA_HOME instead of macOS-specific JVM

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,7 +5,7 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$/extensions/intellij" />
-        <option name="gradleJvm" value="homebrew-17" />
+        <option name="gradleJvm" value="#JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$/extensions/intellij" />


### PR DESCRIPTION
The previous `homebrew-17` is specific to macOS and requires switching to JAVA_HOME on Windows/Linux.

Workaround: `./idea/gradle.xml` can be marked as unstaged file in Git, but this is inconvenient.

`JAVA_HOME` is the most OS-agnostic value IMO.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switched Gradle JVM setting in .idea/gradle.xml from the macOS-specific "homebrew-17" to use JAVA_HOME for better cross-platform support.

<!-- End of auto-generated description by cubic. -->

