### PR TITLE
improve: add filepath in editoutcome dev data

### DIFF
--- a/extensions/vscode/src/extension/EditOutcomeTracker.ts
+++ b/extensions/vscode/src/extension/EditOutcomeTracker.ts
@@ -65,6 +65,7 @@ class EditOutcomeTracker {
         newCodeLines: pendingEdit.newCodeLines,
         lineChange: pendingEdit.lineChange,
         accepted,
+        filepath: pendingEdit.filepath,
       },
     });
 

--- a/packages/config-yaml/src/schemas/data/editOutcome/index.ts
+++ b/packages/config-yaml/src/schemas/data/editOutcome/index.ts
@@ -12,4 +12,5 @@ export const editOutcomeEventAllSchema = baseDevDataAllSchema.extend({
   newCodeLines: z.number(),
   lineChange: z.number(),
   accepted: z.boolean(),
+  filepath: z.string(),
 });

--- a/packages/config-yaml/src/schemas/data/editOutcome/v0.2.0.ts
+++ b/packages/config-yaml/src/schemas/data/editOutcome/v0.2.0.ts
@@ -20,6 +20,7 @@ export const editOutcomeEventSchema_0_2_0 = editOutcomeEventAllSchema.pick({
   previousCodeLines: true,
   newCodeLines: true,
   lineChange: true,
+  filepath: true,
 });
 
 export const editOutcomeEventSchema_0_2_0_noCode =


### PR DESCRIPTION
## Description

Add `filepath` in `editOutcome` dev data

resolves CON-2599

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
