### PR TITLE
Fix: Remove duplicate blocks and provide config warnings

### DIFF
--- a/packages/config-yaml/src/__tests__/index.test.ts
+++ b/packages/config-yaml/src/__tests__/index.test.ts
@@ -93,9 +93,11 @@ describe("E2E Scenarios", () => {
   const registry: Registry = {
     getContent: async function (id: PackageIdentifier): Promise<string> {
       const slug = packageIdentifierToShorthandSlug(id);
-      return fs
-        .readFileSync(`./src/__tests__/packages/${slug}.yaml`)
-        .toString();
+      const filePath =
+        id.uriType === "slug"
+          ? `./src/__tests__/packages/${slug}.yaml`
+          : id.filePath;
+      return fs.readFileSync(filePath).toString();
     },
   };
 
@@ -230,7 +232,7 @@ describe("E2E Scenarios", () => {
         orgScopeId: "test-org",
         currentUserSlug: "test-user",
         onPremProxyUrl: null,
-        // Add an injected block
+        // Add injected blocks
         injectBlocks: [
           {
             uriType: "slug",
@@ -240,11 +242,16 @@ describe("E2E Scenarios", () => {
               versionSlug: "latest",
             },
           },
+          {
+            uriType: "file",
+            filePath: "./src/__tests__/local-files/rules.yaml",
+          },
         ],
       },
     );
 
     const config = unrolledConfig.config;
+    const errors = unrolledConfig.errors;
 
     // The original rules array should have two items
     expect(config?.rules?.length).toBe(3); // Now 3 with the injected block
@@ -255,7 +262,72 @@ describe("E2E Scenarios", () => {
     );
 
     // Check the injected doc block was added
-    expect(config?.rules?.[2]).toBe("Be kind");
+    expect(
+      typeof config?.rules?.[2] !== "string" &&
+        config?.rules?.[2]?.rule === "Be humble",
+    );
+
+    // Check if we receive one error that is caused by duplicate rules
+    expect(errors?.length).toBe(1);
+    expect(errors?.[0].message.includes("Duplicate rules detected"));
+  });
+
+  it("duplicate detection should happen in the assistant config first and then the intected blocks", async () => {
+    const unrolledConfig = await unrollAssistant(
+      {
+        uriType: "file",
+        filePath: "./src/__tests__/local-files/duplicate-test-assistant.yaml",
+      },
+      registry,
+      {
+        renderSecrets: true,
+        platformClient,
+        orgScopeId: "test-org",
+        currentUserSlug: "test-user",
+        onPremProxyUrl: null,
+        // Add injected blocks
+        injectBlocks: [
+          {
+            uriType: "file",
+            filePath: "./src/__tests__/local-files/rules.yaml",
+          },
+          {
+            uriType: "file",
+            filePath: "./src/__tests__/local-files/mcpServer.yaml",
+          },
+          {
+            uriType: "file",
+            filePath: "./src/__tests__/local-files/prompt.yaml",
+          },
+        ],
+      },
+    );
+
+    const config = unrolledConfig.config;
+    const errors = unrolledConfig.errors;
+
+    // Check if all the duplicate blocks get removed
+    expect(config?.models?.length).toBe(1);
+    expect(config?.context?.length).toBe(1);
+    expect(config?.mcpServers?.length).toBe(1);
+    expect(config?.rules?.length).toBe(1);
+    expect(config?.prompts?.length).toBe(1);
+    expect(config?.docs?.length).toBe(1);
+
+    // Check if there are 8 duplication detected
+    expect(errors?.length).toBe(8);
+
+    // Beginning of the assistant config duplication check
+    expect(
+      errors?.[0].message.includes("Duplicate models named gpt-5 detected"),
+    ).toBe(true);
+    // Beginning of the injected blocks duplication check
+    expect(errors?.[4].message.includes("Duplicate rules detected")).toBe(true);
+    expect(
+      errors?.[6].message.includes(
+        "Duplicate mcpServers named Browser search detected",
+      ),
+    ).toBe(true);
   });
 
   it.skip("should prioritize org over user / package secrets", () => {});

--- a/packages/config-yaml/src/__tests__/local-files/duplicate-test-assistant.yaml
+++ b/packages/config-yaml/src/__tests__/local-files/duplicate-test-assistant.yaml
@@ -1,0 +1,39 @@
+name: Duplicate Test Assistant
+version: 0.0.1
+schema: v1
+
+docs:
+  - name: React
+    startUrl: https://react.dev
+  - name: React
+    startUrl: https://react.dev
+
+rules:
+  - Be humble
+  - uses: ./src/__tests__/local-files/rules.yaml
+
+models:
+  - name: gpt-5
+    provider: openai
+    model: gpt-5
+    apiKey: ${{ secrets.OPENAI_API_KEY }}
+    roles:
+      - chat
+
+  - name: gpt-5
+    provider: openai
+    model: gpt-5
+    apiKey: ${{ secrets.OPENAI_API_KEY }}
+    roles:
+      - chat
+
+mcpServers:
+  - uses: ./src/__tests__/local-files/mcpServer.yaml
+
+prompts:
+  - uses: ./src/__tests__/local-files/prompt.yaml
+  - uses: ./src/__tests__/local-files/prompt.yaml
+
+context:
+  - provider: doc
+  - provider: doc

--- a/packages/config-yaml/src/__tests__/local-files/mcpServer.yaml
+++ b/packages/config-yaml/src/__tests__/local-files/mcpServer.yaml
@@ -1,0 +1,8 @@
+name: Local MCP Server
+version: 0.0.1
+schema: v1
+mcpServers:
+  - name: Browser search
+    command: npx
+    args:
+      - "@playwright/mcp@latest"

--- a/packages/config-yaml/src/__tests__/local-files/prompt.yaml
+++ b/packages/config-yaml/src/__tests__/local-files/prompt.yaml
@@ -1,0 +1,7 @@
+name: Local prompt
+version: 0.0.1
+schema: v1
+prompts:
+  - name: duplication test
+    description: test purpose
+    prompt: Please check that this prompt should only appear once

--- a/packages/config-yaml/src/__tests__/local-files/rules.yaml
+++ b/packages/config-yaml/src/__tests__/local-files/rules.yaml
@@ -1,0 +1,6 @@
+name: Rules
+version: 0.0.1
+schema: v1
+
+rules:
+  - Be humble

--- a/packages/config-yaml/src/load/blockDuplicationDetector.ts
+++ b/packages/config-yaml/src/load/blockDuplicationDetector.ts
@@ -1,0 +1,76 @@
+import { BLOCK_TYPES, BlockType } from "./getBlockType.js";
+
+export class BlockDuplicationDetector {
+  private records: Map<string, Set<string>>;
+
+  constructor() {
+    this.records = new Map();
+    for (const blockType of BLOCK_TYPES) {
+      this.records.set(blockType, new Set());
+    }
+  }
+
+  private isRuleDuplicated(rule: any): boolean {
+    if (typeof rule === "string") {
+      return this.check(rule, "rules");
+    } else {
+      return this.check(rule.name, "rules");
+    }
+  }
+
+  private isContextDuplicated(context: any): boolean {
+    return this.check(context.provider, "context");
+  }
+
+  private isCommonBlockDuplicated(block: any, blockType: BlockType): boolean {
+    return this.check(block.name, blockType);
+  }
+
+  private check(identifier: string, blockType: BlockType): boolean {
+    if (this.records.get(blockType)!.has(identifier)) {
+      return true;
+    } else {
+      this.records.get(blockType)!.add(identifier);
+      return false;
+    }
+  }
+
+  // Check if the name is duplicated within the same blockType
+  isDuplicated(
+    block: any,
+    blockType: BlockType,
+    injectError?: (errorMsg: string) => void,
+  ): boolean {
+    // Not checking any null or undefined object
+    if (block === null || block === undefined) {
+      return false;
+    }
+
+    switch (blockType) {
+      case "rules":
+        if (this.isRuleDuplicated(block)) {
+          injectError?.(
+            `Duplicate rules${typeof block === "string" ? "" : ` named ${block.name}`} detected. The duplicate one has been deleted for preventing unexpected behavior.`,
+          );
+          return true;
+        }
+        return false;
+      case "context":
+        if (this.isContextDuplicated(block)) {
+          injectError?.(
+            `Duplicate ${block.provider} context providers detected. The duplicate one has been deleted for preventing unexpected behavior.`,
+          );
+          return true;
+        }
+        return false;
+      default:
+        if (this.isCommonBlockDuplicated(block, blockType)) {
+          injectError?.(
+            `Duplicate ${blockType} named ${block.name} detected. The duplicate one has been deleted for preventing unexpected behavior.`,
+          );
+          return true;
+        }
+        return false;
+    }
+  }
+}


### PR DESCRIPTION
## Description

This patch is to address the following cases that duplicate blocks appear in the UI and confuse users:

  1. When users refer to a local block with "- uses", if the block is already in the default directories (e.g. ~/.continue/models or \<workspace\>/.continue/models) and users don't override its name attribute, the duplicate block will appear in the UI.

  2. When users have duplicate block names among each block type in their assistant config.

  3. When the injected blocks have duplicate names with the assistant config for the corresponding block type.

The duplicate blocks in the UI is confusing, especially in the model selection.

This patch add a blockDuplicationDetector to detect duplication. When a duplication is detected, we remove the duplicate item and push a config error to the result to warn the users that having duplicate names is not the best practice to set up their config.

The detecting order: assistant config -> injected blocks

To detect duplication, all block types use "name" as the identifier except for rules and context. For rules, if it's an rule object, we use the "name" attribute. Otherwise, we use its string content as the identifier. For context, the "provider" attribute is used as the identifier.

The detection only happens under assistant level, which means you can have assistants with duplicate names.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

### Before this patch

https://github.com/user-attachments/assets/d27117c1-b8f4-485e-b1e7-3d39a147dd19

### After this patch

https://github.com/user-attachments/assets/1cdcc4a6-e951-4ca9-935f-846efc3514f9


## Tests

Add a few duplicate blocks and see if they get removed with the corresponding config errors.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed duplicate blocks from assistant configs and injected blocks, and added config warnings when duplicates are detected to prevent confusion in the UI.

- **Bug Fixes**
  - Blocks with duplicate names are now filtered out based on block type.
  - Config errors are shown to warn users about duplicates.

<!-- End of auto-generated description by cubic. -->

