### PR TITLE
feat: create `oneper` util script

### DIFF
--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -701,15 +701,24 @@ jobs:
           path: packages/openai-adapters/node_modules
           key: ${{ runner.os }}-openai-adapters-node-modules-${{ hashFiles('packages/openai-adapters/package-lock.json') }}
 
-      - name: Build config-yaml
+      - name: Install and build config-yaml
         run: |
           cd packages/config-yaml
+          if [ ! -d node_modules ]; then npm ci; fi
           npm run build
 
-      - name: Build openai-adapters
+      - name: Install and build openai-adapters
         run: |
           cd packages/openai-adapters
+          if [ ! -d node_modules ]; then npm ci; fi
           npm run build
+
+      - name: Install vscode dependencies if needed
+        run: |
+          cd extensions/vscode
+          if [ ! -d node_modules ]; then npm ci; fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
 
       - name: Package extension
         run: |

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -659,7 +659,10 @@ jobs:
           echo "Test files: ${{ steps.vscode-get-test-file-matrix.outputs.test_file_matrix }}"
 
   vscode-package-extension:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     needs:
       [
         install-vscode,
@@ -716,7 +719,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: vscode-extension-build
+          name: vscode-extension-build-${{ runner.os }}
           path: extensions/vscode/build
 
   vscode-download-e2e-dependencies:
@@ -812,7 +815,7 @@ jobs:
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:
-          name: vscode-extension-build
+          name: vscode-extension-build-Linux
           path: extensions/vscode/build
 
       - name: Download e2e dependencies

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -50,7 +50,10 @@ jobs:
 
   install-config-yaml:
     needs: install-root
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -77,7 +80,10 @@ jobs:
 
   install-openai-adapters:
     needs: install-root
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -133,7 +139,10 @@ jobs:
 
   install-core:
     needs: install-root
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -381,7 +390,10 @@ jobs:
   install-vscode:
     needs:
       [install-root, install-core, install-config-yaml, install-openai-adapters]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -701,24 +713,15 @@ jobs:
           path: packages/openai-adapters/node_modules
           key: ${{ runner.os }}-openai-adapters-node-modules-${{ hashFiles('packages/openai-adapters/package-lock.json') }}
 
-      - name: Install and build config-yaml
+      - name: Build config-yaml
         run: |
           cd packages/config-yaml
-          if [ ! -d node_modules ]; then npm ci; fi
           npm run build
 
-      - name: Install and build openai-adapters
+      - name: Build openai-adapters
         run: |
           cd packages/openai-adapters
-          if [ ! -d node_modules ]; then npm ci; fi
           npm run build
-
-      - name: Install vscode dependencies if needed
-        run: |
-          cd extensions/vscode
-          if [ ! -d node_modules ]; then npm ci; fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
 
       - name: Package extension
         run: |

--- a/scripts/oneper
+++ b/scripts/oneper
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+set -e
+
+# oneper - Install Continue VS Code extension from PR builds or latest pre-release
+# Usage: 
+#   oneper install --pr X     - Install VSIX from PR number X
+#   oneper install --latest   - Install latest pre-release from marketplace
+
+REPO="continuedev/continue"
+ONEPER_DIR="$HOME/.continue/.utils/oneper"
+
+show_help() {
+    echo "oneper - Install Continue VS Code extension from PR builds or latest pre-release"
+    echo ""
+    echo "Usage: oneper <command> [options]"
+    echo "       oneper -h | --help"
+    echo ""
+    echo "Commands:"
+    echo "  install --pr <number>    Download and install VSIX from specified PR number"
+    echo "  install --latest         Install latest pre-release from VS Code marketplace"
+    echo "  clean                    Remove all downloaded VSIX files from oneper cache"
+    echo ""
+    echo "Options:"
+    echo "  -h, --help              Show this help message"
+    echo ""
+    echo "Examples:"
+    echo "  oneper install --pr 123     # Install VSIX from PR #123"
+    echo "  oneper install --latest     # Install latest pre-release"
+    echo "  oneper clean                # Clear cached VSIX files"
+    echo "  oneper -h                   # Show help"
+    echo ""
+    echo "VSIX files are cached in: ~/.continue/.utils/oneper/"
+}
+
+check_dependencies() {
+    if ! command -v gh &> /dev/null; then
+        echo "❌ GitHub CLI (gh) is required but not installed."
+        echo "   Install with: brew install gh"
+        exit 1
+    fi
+
+    if ! command -v code &> /dev/null; then
+        echo "❌ VS Code CLI (code) is required but not installed."
+        echo "   Install VS Code and ensure 'code' command is in PATH"
+        exit 1
+    fi
+
+    if ! command -v unzip &> /dev/null; then
+        echo "❌ unzip is required but not installed."
+        exit 1
+    fi
+}
+
+ensure_oneper_dir() {
+    if [ ! -d "$ONEPER_DIR" ]; then
+        echo "📁 Creating oneper directory: $ONEPER_DIR"
+        mkdir -p "$ONEPER_DIR"
+    fi
+}
+
+install_from_pr() {
+    local pr_number=$1
+    
+    if [ -z "$pr_number" ]; then
+        echo "❌ PR number is required"
+        show_help
+        exit 1
+    fi
+
+    echo "🔍 Getting branch name for PR #$pr_number..."
+    
+    # First get the branch name for the PR
+    local branch_name=$(gh pr view "$pr_number" --repo "$REPO" --json headRefName --jq '.headRefName')
+    
+    if [ -z "$branch_name" ]; then
+        echo "❌ Could not find PR #$pr_number"
+        exit 1
+    fi
+    
+    echo "🔍 Finding latest workflow run for branch: $branch_name..."
+    
+    # Get the latest successful workflow run for the branch
+    local run_id=$(gh run list \
+        --repo "$REPO" \
+        --workflow="pr_checks.yaml" \
+        --branch="$branch_name" \
+        --json databaseId,status,conclusion \
+        --jq ".[] | select(.status == \"completed\" and .conclusion == \"success\") | .databaseId" \
+        | head -1)
+    
+    if [ -z "$run_id" ]; then
+        echo "❌ No successful workflow run found for PR #$pr_number"
+        echo "   Make sure the PR exists and has a successful CI run"
+        exit 1
+    fi
+
+    echo "✅ Found workflow run: $run_id"
+    echo "📥 Downloading vscode-extension-build artifact..."
+    
+    # Create temporary directory for download
+    local temp_dir=$(mktemp -d)
+    
+    # Download the artifact
+    if ! gh run download "$run_id" \
+        --repo "$REPO" \
+        --name "vscode-extension-build" \
+        --dir "$temp_dir"; then
+        echo "❌ Failed to download artifact"
+        rm -rf "$temp_dir"
+        exit 1
+    fi
+
+    # Find the VSIX file
+    local vsix_file=$(find "$temp_dir" -name "*.vsix" | head -1)
+    
+    if [ -z "$vsix_file" ]; then
+        echo "❌ No VSIX file found in artifact"
+        rm -rf "$temp_dir"
+        exit 1
+    fi
+
+    # Create standardized VSIX name with PR number
+    local target_path="$ONEPER_DIR/continue-${pr_number}.vsix"
+    
+    # Check if file already exists and notify about overwrite
+    if [ -f "$target_path" ]; then
+        echo "⚠️  Overwriting existing VSIX: $target_path"
+    fi
+    
+    echo "📦 Moving VSIX to: $target_path"
+    mv "$vsix_file" "$target_path"
+    
+    # Clean up temp directory
+    rm -rf "$temp_dir"
+    
+    # Install the extension
+    echo "🚀 Installing VS Code extension..."
+    if code --install-extension "$target_path"; then
+        echo "✅ Successfully installed Continue extension from PR #$pr_number"
+        echo "📄 VSIX file saved to: $target_path"
+    else
+        echo "❌ Failed to install extension"
+        exit 1
+    fi
+}
+
+install_latest() {
+    echo "🚀 Installing latest pre-release Continue extension..."
+    if code --install-extension --pre-release Continue.continue; then
+        echo "✅ Successfully installed latest pre-release Continue extension"
+    else
+        echo "❌ Failed to install extension"
+        exit 1
+    fi
+}
+
+clean_cache() {
+    if [ ! -d "$ONEPER_DIR" ]; then
+        echo "📁 Oneper cache directory doesn't exist: $ONEPER_DIR"
+        return 0
+    fi
+    
+    local file_count=$(find "$ONEPER_DIR" -name "*.vsix" | wc -l | tr -d ' ')
+    
+    if [ "$file_count" -eq 0 ]; then
+        echo "✨ Oneper cache is already empty"
+        return 0
+    fi
+    
+    echo "🧹 Removing $file_count VSIX file(s) from oneper cache..."
+    rm -f "$ONEPER_DIR"/*.vsix
+    
+    echo "✅ Oneper cache cleared successfully"
+    echo "📁 Cache directory: $ONEPER_DIR"
+}
+
+main() {
+    if [ $# -eq 0 ]; then
+        show_help
+        exit 1
+    fi
+
+    # Handle help flags first
+    case "$1" in
+        "-h"|"--help")
+            show_help
+            exit 0
+            ;;
+    esac
+
+    check_dependencies
+    ensure_oneper_dir
+
+    case "$1" in
+        "install")
+            case "$2" in
+                "--pr")
+                    install_from_pr "$3"
+                    ;;
+                "--latest")
+                    install_latest
+                    ;;
+                *)
+                    echo "❌ Unknown install option: $2"
+                    show_help
+                    exit 1
+                    ;;
+            esac
+            ;;
+        "clean")
+            clean_cache
+            ;;
+        *)
+            echo "❌ Unknown command: $1"
+            show_help
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/scripts/oneper
+++ b/scripts/oneper
@@ -180,6 +180,11 @@ install_latest() {
     echo "🚀 Installing latest pre-release Continue extension..."
     if code --install-extension --pre-release Continue.continue; then
         echo "✅ Successfully installed latest pre-release Continue extension"
+        echo ""
+        echo "💡 To use the new extension version, reload your VS Code window:"
+        echo "   • Press Ctrl+Shift+P (Cmd+Shift+P on Mac)"
+        echo "   • Type 'Developer: Reload Window' and press Enter"
+        echo "   • Or restart VS Code entirely"
     else
         echo "❌ Failed to install extension"
         exit 1

--- a/scripts/oneper
+++ b/scripts/oneper
@@ -45,10 +45,6 @@ check_dependencies() {
         exit 1
     fi
 
-    if ! command -v unzip &> /dev/null; then
-        echo "❌ unzip is required but not installed."
-        exit 1
-    fi
 }
 
 ensure_oneper_dir() {

--- a/scripts/oneper
+++ b/scripts/oneper
@@ -16,18 +16,22 @@ show_help() {
     echo "       oneper -h | --help"
     echo ""
     echo "Commands:"
-    echo "  install --pr <number>    Download and install VSIX from specified PR number"
+    echo "  install --pr <number> [--platform <platform>]"
+    echo "                           Download and install VSIX from specified PR number"
+    echo "                           Platform options: macos, linux (default: macos)"
     echo "  install --latest         Install latest pre-release from VS Code marketplace"
     echo "  clean                    Remove all downloaded VSIX files from oneper cache"
     echo ""
     echo "Options:"
     echo "  -h, --help              Show this help message"
+    echo "  --platform <platform>   Specify platform for PR builds (macos, linux)"
     echo ""
     echo "Examples:"
-    echo "  oneper install --pr 123     # Install VSIX from PR #123"
-    echo "  oneper install --latest     # Install latest pre-release"
-    echo "  oneper clean                # Clear cached VSIX files"
-    echo "  oneper -h                   # Show help"
+    echo "  oneper install --pr 123              # Install macOS VSIX from PR #123"
+    echo "  oneper install --pr 123 --platform linux   # Install Linux VSIX from PR #123"
+    echo "  oneper install --latest              # Install latest pre-release"
+    echo "  oneper clean                         # Clear cached VSIX files"
+    echo "  oneper -h                            # Show help"
     echo ""
     echo "VSIX files are cached in: ~/.continue/.utils/oneper/"
 }
@@ -56,12 +60,29 @@ ensure_oneper_dir() {
 
 install_from_pr() {
     local pr_number=$1
+    local platform=${2:-"macos"}  # Default to macOS
     
     if [ -z "$pr_number" ]; then
         echo "❌ PR number is required"
         show_help
         exit 1
     fi
+
+    # Map platform names to GitHub runner OS names
+    local artifact_suffix
+    case "$platform" in
+        "macos")
+            artifact_suffix="macOS"
+            ;;
+        "linux")
+            artifact_suffix="Linux"
+            ;;
+        *)
+            echo "❌ Unknown platform: $platform"
+            echo "   Supported platforms: macos, linux"
+            exit 1
+            ;;
+    esac
 
     echo "🔍 Getting branch name for PR #$pr_number..."
     
@@ -91,7 +112,7 @@ install_from_pr() {
     fi
 
     echo "✅ Found workflow run: $run_id"
-    echo "📥 Downloading vscode-extension-build artifact..."
+    echo "📥 Downloading vscode-extension-build-$artifact_suffix artifact..."
     
     # Create temporary directory for download
     local temp_dir=$(mktemp -d)
@@ -99,14 +120,15 @@ install_from_pr() {
     # Download the artifact
     if ! gh run download "$run_id" \
         --repo "$REPO" \
-        --name "vscode-extension-build" \
+        --name "vscode-extension-build-$artifact_suffix" \
         --dir "$temp_dir"; then
-        echo "❌ Failed to download artifact"
+        echo "❌ Failed to download artifact vscode-extension-build-$artifact_suffix"
+        echo "   Make sure the workflow run completed successfully for $platform"
         rm -rf "$temp_dir"
         exit 1
     fi
 
-    # Find the VSIX file
+    # Find the VSIX file in the downloaded artifact
     local vsix_file=$(find "$temp_dir" -name "*.vsix" | head -1)
     
     if [ -z "$vsix_file" ]; then
@@ -115,8 +137,17 @@ install_from_pr() {
         exit 1
     fi
 
-    # Create standardized VSIX name with PR number
-    local target_path="$ONEPER_DIR/continue-${pr_number}.vsix"
+    # Extract version from the original VSIX filename (e.g., continue-1.1.66.vsix -> 1.1.66)
+    local original_filename=$(basename "$vsix_file")
+    local version=$(echo "$original_filename" | sed 's/continue-\(.*\)\.vsix/\1/')
+    
+    if [ -z "$version" ]; then
+        echo "⚠️  Could not extract version from filename: $original_filename"
+        version="unknown"
+    fi
+
+    # Create new VSIX name with version and PR number
+    local target_path="$ONEPER_DIR/continue-${version}-${pr_number}.vsix"
     
     # Check if file already exists and notify about overwrite
     if [ -f "$target_path" ]; then
@@ -196,7 +227,16 @@ main() {
         "install")
             case "$2" in
                 "--pr")
-                    install_from_pr "$3"
+                    # Parse PR number and optional platform
+                    local pr_number="$3"
+                    local platform="macos"  # default
+                    
+                    # Check if --platform is specified
+                    if [ "$4" = "--platform" ] && [ -n "$5" ]; then
+                        platform="$5"
+                    fi
+                    
+                    install_from_pr "$pr_number" "$platform"
                     ;;
                 "--latest")
                     install_latest

--- a/scripts/oneper
+++ b/scripts/oneper
@@ -138,6 +138,11 @@ install_from_pr() {
     if code --install-extension "$target_path"; then
         echo "✅ Successfully installed Continue extension from PR #$pr_number"
         echo "📄 VSIX file saved to: $target_path"
+        echo ""
+        echo "💡 To use the new extension version, reload your VS Code window:"
+        echo "   • Press Ctrl+Shift+P (Cmd+Shift+P on Mac)"
+        echo "   • Type 'Developer: Reload Window' and press Enter"
+        echo "   • Or restart VS Code entirely"
     else
         echo "❌ Failed to install extension"
         exit 1


### PR DESCRIPTION
Closes CON-3004

 Added the `oneper` Bash utility to install the Continue VS Code extension from a PR build or the latest pre-release, and to manage cached VSIX files.

Also updates our `pr_checks.yaml` workflow to build a `macOS` artifact for us to install using the script. Previously we only built on `ubuntu-latest`.

Sample usage of the script against this PR: 

```bash
❯ ./scripts/oneper install --pr 6783
🔍 Getting branch name for PR #6783...
🔍 Finding latest workflow run for branch: pe/oneper...
✅ Found workflow run: 16509218350
📥 Downloading vscode-extension-build-macOS artifact...
📦 Moving VSIX to: /Users/patrickerichsen/.continue/.utils/oneper/continue-1.1.67-6783.vsix
🚀 Installing VS Code extension...
Installing extensions...
Extension 'continue-1.1.67-6783.vsix' was successfully installed.
✅ Successfully installed Continue extension from PR #6783
📄 VSIX file saved to: /Users/patrickerichsen/.continue/.utils/oneper/continue-1.1.67-6783.vsix

💡 To use the new extension version, reload your VS Code window:
   • Press Ctrl+Shift+P (Cmd+Shift+P on Mac)
   • Type 'Developer: Reload Window' and press Enter
   • Or restart VS Code entirely
```