### PR TITLE
fix: use loading state for loading indicator, better error messages

### DIFF
--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -438,7 +438,7 @@ export class ConfigHandler {
     if (!this.currentProfile) {
       return {
         config: undefined,
-        errors: [],
+        errors: [{ message: "Current profile not found", fatal: true }],
         configLoadInterrupted: true,
       };
     }
@@ -494,7 +494,7 @@ export class ConfigHandler {
     if (!this.currentProfile) {
       return {
         config: undefined,
-        errors: [],
+        errors: [{ message: "Current profile not found", fatal: true }],
         configLoadInterrupted: true,
       };
     }
@@ -507,7 +507,7 @@ export class ConfigHandler {
     if (!this.currentProfile) {
       return {
         config: undefined,
-        errors: [],
+        errors: [{ message: "Current profile not found", fatal: true }],
         configLoadInterrupted: true,
       };
     }

--- a/gui/src/components/modelSelection/ModelSelect.tsx
+++ b/gui/src/components/modelSelection/ModelSelect.tsx
@@ -11,7 +11,6 @@ import { useAuth } from "../../context/Auth";
 import { IdeMessengerContext } from "../../context/IdeMessenger";
 import { AddModelForm } from "../../forms/AddModelForm";
 import { useAppDispatch, useAppSelector } from "../../redux/hooks";
-import { EMPTY_CONFIG } from "../../redux/slices/configSlice";
 import { setDialogMessage, setShowDialog } from "../../redux/slices/uiSlice";
 import { updateSelectedModelByRole } from "../../redux/thunks/updateSelectedModelByRole";
 import {
@@ -94,6 +93,7 @@ function ModelSelect() {
 
   const isInEdit = useAppSelector((store) => store.session.isInEdit);
   const config = useAppSelector((state) => state.config.config);
+  const isConfigLoading = useAppSelector((state) => state.config.loading);
   const ideMessenger = useContext(IdeMessengerContext);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const [options, setOptions] = useState<Option[]>([]);
@@ -192,7 +192,6 @@ function ModelSelect() {
     );
   }
 
-  const isConfigLoading = config === EMPTY_CONFIG;
   const hasNoModels = allModels?.length === 0;
 
   return (

--- a/gui/src/redux/slices/configSlice.ts
+++ b/gui/src/redux/slices/configSlice.ts
@@ -68,6 +68,7 @@ export const configSlice = createSlice({
       } else {
         state.config = config;
       }
+      state.loading = false;
     },
     updateConfig: (
       state,


### PR DESCRIPTION
## Description

use loading state for loading indicator, better error messages

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved the loading indicator in model selection by using the loading state, and added clearer error messages when the current profile is missing.

- **Bug Fixes**
  - Loading indicator now accurately reflects config loading state.
  - Error messages now show when the current profile is not found.

<!-- End of auto-generated description by cubic. -->

