### PR TITLE
feat: add editOutcome logging for Agent Mode

### DIFF
--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -1057,6 +1057,7 @@ declare global {
     numDiffs?: number;
     filepath?: string;
     fileContent?: string;
+    originalFileContent?: string;
   }
   
   export interface RangeInFileWithContents {

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1360,6 +1360,7 @@ export interface ApplyState {
   numDiffs?: number;
   filepath?: string;
   fileContent?: string;
+  originalFileContent?: string;
   toolCallId?: string;
 }
 

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/ApplyToFileHandler.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/ApplyToFileHandler.kt
@@ -29,6 +29,9 @@ class ApplyToFileHandler(
     private val diffStreamService: DiffStreamService
 ) {
 
+    // Store the original file content before applying changes
+    private val originalFileContent: String? = editorUtils?.getDocumentText()
+
     suspend fun handleApplyToFile() {
         // Notify webview that we're starting to stream
         notifyStreamStarted()
@@ -111,6 +114,7 @@ class ApplyToFileHandler(
             numDiffs = numDiffs,
             filepath = params.filepath,
             fileContent = params.text,
+            originalFileContent = originalFileContent,
             toolCallId = params.toolCallId.toString()
         )
 

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IntelliJIde.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IntelliJIde.kt
@@ -342,9 +342,10 @@ class IntelliJIDE(
                         val buffer = ByteArray(sizeToRead)
                         val bytesRead = fis.read(buffer, 0, sizeToRead)
                         if (bytesRead <= 0) return@use ""
-                        String(buffer, 0, bytesRead, Charset.forName("UTF-8"))
-                            // `\r` takes up unnecessary tokens
-                            .lineSequence().joinToString("\n")
+                        val content = String(buffer, 0, bytesRead, Charset.forName("UTF-8"))
+                        // Remove `\r` characters but preserve trailing newlines to prevent line count discrepancies
+                        val contentWithoutCR = content.replace("\r\n", "\n").replace("\r", "\n")
+                        contentWithoutCR
                     }
                 }
             }

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/types.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/types.kt
@@ -290,6 +290,7 @@ data class ApplyState(
     val numDiffs: Int? = null,
     val filepath: String? = null,
     val fileContent: String? = null,
+    val originalFileContent: String? = null,
     val toolCallId: String? = null
 )
 

--- a/extensions/vscode/src/apply/ApplyManager.ts
+++ b/extensions/vscode/src/apply/ApplyManager.ts
@@ -29,13 +29,6 @@ export class ApplyManager {
     toolCallId,
     isSearchAndReplace,
   }: ApplyToFilePayload) {
-    await this.webviewProtocol.request("updateApplyState", {
-      streamId,
-      status: "streaming",
-      fileContent: text,
-      toolCallId,
-    });
-
     if (filepath) {
       await this.ensureFileOpen(filepath);
     }
@@ -45,6 +38,17 @@ export class ApplyManager {
       void vscode.window.showErrorMessage("No active editor to apply edits to");
       return;
     }
+
+    // Capture the original file content before applying changes
+    const originalFileContent = activeTextEditor.document.getText();
+
+    await this.webviewProtocol.request("updateApplyState", {
+      streamId,
+      status: "streaming",
+      fileContent: text,
+      originalFileContent,
+      toolCallId,
+    });
 
     const hasExistingDocument = !!activeTextEditor.document.getText().trim();
 

--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -784,6 +784,9 @@ export const sessionSlice = createSlice({
         applyState.status = payload.status ?? applyState.status;
         applyState.numDiffs = payload.numDiffs ?? applyState.numDiffs;
         applyState.filepath = payload.filepath ?? applyState.filepath;
+        applyState.fileContent = payload.fileContent ?? applyState.fileContent;
+        applyState.originalFileContent =
+          payload.originalFileContent ?? applyState.originalFileContent;
       }
 
       if (payload.status === "done") {

--- a/gui/src/util/editOutcomeLogger.ts
+++ b/gui/src/util/editOutcomeLogger.ts
@@ -1,0 +1,206 @@
+import { ApplyState, ToolCallState } from "core";
+import { IIdeMessenger } from "../context/IdeMessenger";
+import { store } from "../redux/store";
+
+interface EditOutcomeData {
+  streamId: string;
+  timestamp: string;
+  modelProvider: string;
+  modelTitle: string;
+  prompt: string;
+  completion: string;
+  previousCode: string;
+  newCode: string;
+  filepath: string;
+  previousCodeLines: number;
+  newCodeLines: number;
+  lineChange: number;
+  accepted: boolean;
+}
+
+/**
+ * Extract model information from tool call state
+ */
+function extractModelInfo(toolCallState: ToolCallState): {
+  modelProvider: string;
+  modelTitle: string;
+} {
+  // Get the conversation history to find the model info
+  const history = store.getState().session.history;
+
+  // Find the assistant message that contains this tool call
+  const assistantMessage = history.find(
+    (item) =>
+      item.message.role === "assistant" &&
+      item.message.toolCalls?.some((tc) => tc.id === toolCallState.toolCallId),
+  );
+
+  if (
+    assistantMessage?.message.role === "assistant" &&
+    "model" in assistantMessage.message &&
+    assistantMessage.message.model
+  ) {
+    // Extract provider from model string (e.g., "anthropic::claude-3-5-sonnet" -> "anthropic")
+    const modelParts = String(assistantMessage.message.model).split("::");
+    return {
+      modelProvider: modelParts[0] || "unknown",
+      modelTitle: modelParts[1] || String(assistantMessage.message.model),
+    };
+  }
+
+  // Fallback to config if not found in message
+  const config = store.getState().config.config;
+  const chatModel = config?.selectedModelByRole?.chat;
+
+  return {
+    modelProvider: chatModel?.provider || "unknown",
+    modelTitle: chatModel?.model || "unknown",
+  };
+}
+
+/**
+ * Extract prompt and completion from tool call state
+ */
+function extractPromptAndCompletion(toolCallState: ToolCallState): {
+  prompt: string;
+  completion: string;
+} {
+  const history = store.getState().session.history;
+
+  // Find the assistant message with this tool call
+  const assistantMessageIndex = history.findIndex(
+    (item) =>
+      item.message.role === "assistant" &&
+      item.message.toolCalls?.some((tc) => tc.id === toolCallState.toolCallId),
+  );
+
+  if (assistantMessageIndex >= 0) {
+    const assistantMessage = history[assistantMessageIndex];
+
+    // Look for the most recent user message before this assistant message
+    let userMessage = null;
+    for (let i = assistantMessageIndex - 1; i >= 0; i--) {
+      if (history[i].message.role === "user") {
+        userMessage = history[i];
+        break;
+      }
+    }
+
+    const promptContent = userMessage
+      ? Array.isArray(userMessage.message.content)
+        ? userMessage.message.content
+            .map((part) =>
+              typeof part === "string"
+                ? part
+                : part.type === "text"
+                  ? part.text || ""
+                  : "",
+            )
+            .join("")
+        : userMessage.message.content || ""
+      : "";
+
+    const completionContent = Array.isArray(assistantMessage.message.content)
+      ? assistantMessage.message.content
+          .map((part) =>
+            typeof part === "string"
+              ? part
+              : part.type === "text"
+                ? part.text || ""
+                : "",
+          )
+          .join("")
+      : assistantMessage.message.content || "";
+
+    return {
+      prompt: promptContent,
+      completion: completionContent,
+    };
+  }
+
+  return {
+    prompt: "Unknown prompt",
+    completion: "Unknown completion",
+  };
+}
+
+/**
+ * Extract code changes from apply state
+ */
+function extractCodeChanges(applyState: ApplyState): {
+  previousCode: string;
+  newCode: string;
+  previousCodeLines: number;
+  newCodeLines: number;
+  lineChange: number;
+} {
+  // Use the original file content if provided, otherwise empty string
+  const previousCode = applyState.originalFileContent || "";
+  const newCode = applyState.fileContent || "";
+
+  // Calculate line counts properly - empty string should be 0 lines, not 1
+  const previousCodeLines =
+    previousCode === "" ? 0 : previousCode.split("\n").length;
+  const newCodeLines = newCode === "" ? 0 : newCode.split("\n").length;
+  const lineChange = newCodeLines - previousCodeLines;
+
+  return {
+    previousCode,
+    newCode,
+    previousCodeLines,
+    newCodeLines,
+    lineChange,
+  };
+}
+
+/**
+ * Assemble complete edit outcome data from tool call and apply state
+ */
+function assembleCompleteEditData(
+  toolCallState: ToolCallState,
+  applyState: ApplyState,
+  accepted: boolean,
+): EditOutcomeData {
+  const modelInfo = extractModelInfo(toolCallState);
+  const promptAndCompletion = extractPromptAndCompletion(toolCallState);
+  const codeChanges = extractCodeChanges(applyState);
+
+  return {
+    streamId: applyState.streamId,
+    timestamp: new Date().toISOString(),
+    modelProvider: modelInfo.modelProvider,
+    modelTitle: modelInfo.modelTitle,
+    prompt: promptAndCompletion.prompt,
+    completion: promptAndCompletion.completion,
+    previousCode: codeChanges.previousCode,
+    newCode: codeChanges.newCode,
+    filepath: applyState.filepath || "",
+    previousCodeLines: codeChanges.previousCodeLines,
+    newCodeLines: codeChanges.newCodeLines,
+    lineChange: codeChanges.lineChange,
+    accepted,
+  };
+}
+
+/**
+ * Log Agent Mode edit outcome to editOutcome.jsonl
+ */
+export async function logAgentModeEditOutcome(
+  toolCallState: ToolCallState,
+  applyState: ApplyState,
+  accepted: boolean,
+  ideMessenger: IIdeMessenger,
+): Promise<void> {
+  // Use the original file content stored in applyState, captured before edits were applied
+
+  const completeData = assembleCompleteEditData(
+    toolCallState,
+    applyState,
+    accepted,
+  );
+
+  ideMessenger.post("devdata/log", {
+    name: "editOutcome",
+    data: completeData,
+  });
+}


### PR DESCRIPTION
## Description

• Add editOutcome.jsonl logging for Agent Mode accept / rejects 
• Capture original file content before applying changes to enable proper diff tracking 
• Fix newline handling in IntelliJ and VS Code to prevent line count discrepancies, was causing lineChange count to be off by one

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

https://github.com/user-attachments/assets/fe3b4ba7-d697-42f2-8381-86a8394fd094

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
