### PR TITLE
chore: use prettierignore when formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,6 +10,11 @@ extensions/vscode/.vscode-test
 extensions/vscode/bin
 extensions/vscode/build
 extensions/vscode/out
+extensions/vscode/gui
+extensions/vscode/e2e/.test-extensions
+extensions/vscode/e2e/test-continue
+extensions/vscode/models
+extensions/intellij/src/main/resources
 gui/dist
 **/.continueignore
 CHANGELOG.md
@@ -19,7 +24,4 @@ CHANGELOG.md
 core/vendor
 coverage
 e2e
-extensions/vscode/gui
-extensions/vscode/models
-extensions/intellij/src/main/resources
 packages/continue-sdk

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "tsc:watch:vscode": "tsc --project extensions/vscode/tsconfig.json --watch --noEmit --pretty",
     "tsc:watch:core": "tsc --project core/tsconfig.json --watch --noEmit --pretty",
     "tsc:watch:binary": "tsc --project binary/tsconfig.json --watch --noEmit --pretty",
-    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,md}\" --ignore-path .gitignore",
-    "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,css,md}\" --ignore-path .gitignore"
+    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,md}\" --ignore-path .gitignore --ignore-path .prettierignore",
+    "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,css,md}\" --ignore-path .gitignore --ignore-path .prettierignore"
   },
   "devDependencies": {
     "@typescript-eslint/parser": "^7.8.0",


### PR DESCRIPTION
## Description

.prettierignore had some directory paths which could be ignored when formatting with prettier (as in the image below)

<img width="1672" height="680" alt="image" src="https://github.com/user-attachments/assets/c2b5d6b1-f51f-4485-85ad-fd593190777f" />

this PR uses prettierignore as the ignore file path

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the formatting scripts to use both .gitignore and .prettierignore, so Prettier now skips files and folders listed in .prettierignore.

<!-- End of auto-generated description by cubic. -->

