### PR TITLE
fix: spacing between divs on tool calls

### DIFF
--- a/gui/src/components/StepContainer/StepContainer.tsx
+++ b/gui/src/components/StepContainer/StepContainer.tsx
@@ -110,21 +110,18 @@ export default function StepContainer(props: StepContainerProps) {
         {props.isLast && <ThinkingIndicator historyItem={props.item} />}
       </div>
 
-      {shouldRenderResponseAction() && (
-        // We want to occupy space in the DOM regardless of whether the actions are visible to avoid jank on stream complete
+      {shouldRenderResponseAction() && !isStreaming && (
         <div
           className={`mt-2 h-7 transition-opacity duration-300 ease-in-out ${isBeforeLatestSummary ? "opacity-35" : ""}`}
         >
-          {!isStreaming && (
-            <ResponseActions
-              isTruncated={isTruncated}
-              onDelete={onDelete}
-              onContinueGeneration={onContinueGeneration}
-              index={props.index}
-              item={props.item}
-              isLast={props.isLast}
-            />
-          )}
+          <ResponseActions
+            isTruncated={isTruncated}
+            onDelete={onDelete}
+            onContinueGeneration={onContinueGeneration}
+            index={props.index}
+            item={props.item}
+            isLast={props.isLast}
+          />
         </div>
       )}
 

--- a/gui/src/components/mainInput/GradientBorder.tsx
+++ b/gui/src/components/mainInput/GradientBorder.tsx
@@ -35,4 +35,5 @@ export const GradientBorder = styled.div<{
   display: flex;
   flex-direction: row;
   align-items: center;
+  margin-top: ${(props) => (props.loading ? "8px" : "")};
 `;


### PR DESCRIPTION
## Description

Fix spacing between divs when tool call is the last response.

- adding marginTop in mainInput when streaming/loading
- remove empty area caused due to response actions div

resolves CON-2951

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

https://github.com/user-attachments/assets/f7ea5a97-0d9e-4b09-bd95-aac3d751abbe


https://github.com/user-attachments/assets/50d789e8-1880-43d9-8f34-b30cac9c074c


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed spacing issues between divs when a tool call is the last response, removing extra empty space and improving layout during loading.

- **Bug Fixes**
  - Added margin above the main input when streaming or loading.
  - Removed empty area caused by the response actions div when not needed.

<!-- End of auto-generated description by cubic. -->

