### PR TITLE
fix: use reasoning budget tokens when available

### DIFF
--- a/gui/src/redux/thunks/streamNormalInput.ts
+++ b/gui/src/redux/thunks/streamNormalInput.ts
@@ -155,7 +155,8 @@ export const streamNormalInput = createAsyncThunk<
       completionOptions = {
         ...completionOptions,
         reasoning: true,
-        reasoningBudgetTokens: completionOptions.reasoningBudgetTokens ?? 2048,
+        reasoningBudgetTokens:
+          selectedChatModel.completionOptions?.reasoningBudgetTokens ?? 2048,
       };
     }
 


### PR DESCRIPTION
## Description

Reasoning budget tokens was not sent in core request. This PR fixes it

closes https://github.com/continuedev/continue/issues/6270

resolves CON-2940

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

https://github.com/user-attachments/assets/cbddce48-0c13-4f34-aa8a-73f587997cd4

https://github.com/user-attachments/assets/0106ec71-6f61-4780-b113-1679e355489b




## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where reasoning budget tokens were not used in core requests by ensuring the correct token value is sent when available. This addresses the requirements in CON-2940.

<!-- End of auto-generated description by cubic. -->

