### PR TITLE
feat: add word break for long words

### DIFF
--- a/gui/src/components/StyledMarkdownPreview/index.tsx
+++ b/gui/src/components/StyledMarkdownPreview/index.tsx
@@ -113,6 +113,10 @@ const StyledMarkdown = styled.div<{
     line-height: 1.5;
   }
 
+  * {
+    word-break: break-word;
+  }
+
   > *:last-child {
     margin-bottom: 0;
   }


### PR DESCRIPTION
## Description

add word breaks in chat area

revives https://github.com/continuedev/continue/pull/5707

resolves CON-2714

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]


https://github.com/user-attachments/assets/9acc6cfa-a47a-4614-ada3-3e1e65f16e7d



https://github.com/user-attachments/assets/4e379fc3-1c42-46d7-ab0e-4f1c6de5cbc0





## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added word-break styling to the chat area to prevent long words from overflowing and improve readability.

<!-- End of auto-generated description by cubic. -->

