### PR TITLE
fix: fix /auth/refresh string value

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/auth/ContinueAuthService.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/auth/ContinueAuthService.kt
@@ -112,8 +112,10 @@ class ContinueAuthService {
         val jsonBody = gson.toJson(mapOf("refreshToken" to refreshToken))
         val url = getControlPlaneUrl() + "/auth/refresh"
         val response = HttpRequests.post(url, HttpRequests.JSON_CONTENT_TYPE)
-            .connect { connection -> connection.write(jsonBody.toByteArray()) }
-            .toString()
+            .connect {
+                connection -> connection.write(jsonBody.toByteArray())
+                connection.readString()
+            }
         return gson.fromJson(response, RefreshTokenResponse::class.java)
     }
 


### PR DESCRIPTION
Fix regression introduced in https://github.com/continuedev/continue/pull/6531

Fortunately, this change hasn't been published yet on stable channel.

We need to hide [1.0.31-eap](https://plugins.jetbrains.com/plugin/22707-continue/versions/eap/803584) + probably the stable 1.0.31 if it's still being verified by Marketplace.

1.0.30 is OK.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the /auth/refresh endpoint response handling to correctly read the response string, resolving a regression in token refresh logic.

<!-- End of auto-generated description by cubic. -->

