### PR TITLE
chore: bump oai-adapters version

### DIFF
--- a/packages/openai-adapters/package-lock.json
+++ b/packages/openai-adapters/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@continuedev/openai-adapters",
-  "version": "1.0.46",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@continuedev/openai-adapters",
-      "version": "1.0.46",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.842.0",

--- a/packages/openai-adapters/package.json
+++ b/packages/openai-adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@continuedev/openai-adapters",
-  "version": "1.0.46",
+  "version": "1.1.1",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Bumped the @continuedev/openai-adapters package version from 1.0.46 to 1.1.1.

<!-- End of auto-generated description by cubic. -->

