### PR TITLE
chore: remove unneeded dep in CI workflow

### DIFF
--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -478,7 +478,6 @@ jobs:
           echo "Test files: ${{ steps.vscode-get-test-file-matrix.outputs.test_file_matrix }}"
 
   vscode-package-extension:
-    needs: [install-vscode, install-core]
     uses: ./.github/workflows/build-vscode-extension.yml
     with:
       # Limited platforms for faster PR checks


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed an unnecessary dependency from the CI workflow to speed up PR checks.

<!-- End of auto-generated description by cubic. -->

