### PR TITLE
style: make the thinking icon distinguishable when it is enabled

### DIFF
--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -150,7 +150,7 @@ function InputToolbar(props: InputToolbarProps) {
                 {hasReasoningEnabled ? (
                   <LightBulbIconSolid
                     data-tooltip-id="model-reasoning-tooltip"
-                    className="h-3 w-3 brightness-200 hover:brightness-150"
+                    className="h-3 w-3 text-yellow-300 brightness-200 hover:brightness-150"
                   />
                 ) : (
                   <LightBulbIconOutline


### PR DESCRIPTION
## Description

This updates the Thinking icon so that it is clearer when thinking is enabled vs disabled.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Disabled state:

<img width="350" height="117" alt="image" src="https://github.com/user-attachments/assets/3f553e25-d491-42e4-8c7c-ee100d37d2f5" />


Before, enabled state. It is barely distinguishable from the disabled state:

<img width="350" height="117" alt="image" src="https://github.com/user-attachments/assets/6f8d6ec0-51f0-4d62-94ef-7fbfcec3e928" />

After, enabled state:

<img width="346" height="101" alt="image" src="https://github.com/user-attachments/assets/c8d48b14-af22-4fc7-bcf7-a7bad6ae18ec" />


## Tests

N/A (no tests cover this functionality, and it is a style change)

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the Thinking icon to use a yellow color when enabled, making it easier to see when thinking is active.

<!-- End of auto-generated description by cubic. -->

