### PR TITLE
chore: open manual testing sandbox on debug

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,8 +12,8 @@
       "cwd": "${workspaceFolder}/extensions/vscode",
       "args": [
         // Pass a directory to manually test in
-        "${workspaceFolder}/core",
-        "${workspaceFolder}/package.json",
+        "${workspaceFolder}/manual-testing-sandbox",
+        "${workspaceFolder}/manual-testing-sandbox/test.js",
         "--extensionDevelopmentPath=${workspaceFolder}/extensions/vscode"
       ],
       "pauseForSourceMap": false,


### PR DESCRIPTION
## Description

Regression: We should open the manual-testing-sandbox instead of the core folder for debugging

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the debug configuration to open the manual-testing-sandbox folder instead of the core folder for manual testing.

<!-- End of auto-generated description by cubic. -->

