### PR TITLE
Add Ollama OpenAI adapter support

### DIFF
--- a/packages/openai-adapters/src/apis/OpenAI.ts
+++ b/packages/openai-adapters/src/apis/OpenAI.ts
@@ -28,7 +28,8 @@ export class OpenAIApi implements BaseLlmApi {
   constructor(protected config: z.infer<typeof OpenAIConfigSchema>) {
     this.apiBase = config.apiBase ?? this.apiBase;
     this.openai = new OpenAI({
-      apiKey: config.apiKey,
+      // Necessary because `new OpenAI()` will throw an error if there is no API Key
+      apiKey: config.apiKey ?? "",
       baseURL: this.apiBase,
       fetch: customFetch(config.requestOptions),
     });

--- a/packages/openai-adapters/src/index.ts
+++ b/packages/openai-adapters/src/index.ts
@@ -28,7 +28,6 @@ function openAICompatible(
   return new OpenAIApi({
     ...config,
     apiBase: config.apiBase ?? apiBase,
-    apiKey: config.apiKey ?? "api-key",
   });
 }
 

--- a/packages/openai-adapters/src/index.ts
+++ b/packages/openai-adapters/src/index.ts
@@ -28,6 +28,7 @@ function openAICompatible(
   return new OpenAIApi({
     ...config,
     apiBase: config.apiBase ?? apiBase,
+    apiKey: config.apiKey ?? "api-key",
   });
 }
 
@@ -113,6 +114,8 @@ export function constructLlmApi(config: LLMConfig): BaseLlmApi | undefined {
       return openAICompatible("http://localhost:8000/", config);
     case "lmstudio":
       return openAICompatible("http://localhost:1234/", config);
+    case "ollama":
+      return openAICompatible("http://localhost:11434/v1/", config);
     case "mock":
       return new MockApi();
     default:

--- a/packages/openai-adapters/src/types.ts
+++ b/packages/openai-adapters/src/types.ts
@@ -46,6 +46,7 @@ export const OpenAIConfigSchema = BasePlusConfig.extend({
     z.literal("llama.cpp"),
     z.literal("llamafile"),
     z.literal("lmstudio"),
+    z.literal("ollama"),
     z.literal("cerebras"),
     z.literal("kindo"),
     z.literal("msty"),


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for Ollama as an OpenAI-compatible adapter, allowing connections to Ollama's API using the existing interface.

- **New Features**
  - Added "ollama" as a valid provider in the config schema.
  - Configured Ollama to use the correct local API endpoint.

<!-- End of auto-generated description by cubic. -->

