### PR TITLE
don't fail workflow on non-conventional commit

### DIFF
--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -36,7 +36,7 @@ jobs:
         continue-on-error: true
 
       - name: Add commit message guidance comment
-        if: steps.commitlint.outcome == 'failure'
+        if: always() && steps.commitlint.outcome == 'failure'
         uses: actions/github-script@v7
         with:
           script: |
@@ -88,6 +88,10 @@ jobs:
                 ].join('\n')
               });
             }
+
+      - name: Ensure job always succeeds
+        if: always()
+        run: echo "✅ Conventional commits check completed (warning only)"
 
   security-audit:
     name: Security Audit


### PR DESCRIPTION
## Description

Shouldn't show red X. This is just intended as a reminder

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the compliance workflow so that non-conventional commit messages no longer cause the workflow to fail. The check now only adds a warning and guidance comment.

<!-- End of auto-generated description by cubic. -->

