### PR TITLE
chore: add label-merged-prs workflow

### DIFF
--- a/.github/workflows/label-merged-prs.yml
+++ b/.github/workflows/label-merged-prs.yml
@@ -46,7 +46,6 @@ jobs:
         if: steps.check-author.outputs.should_label == 'true'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const pr = context.payload.pull_request;
             


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]
I have been working on a way to probably track features shipped and properly get them documented in release notes and announcements. 

I am introducing a Tier system (WIP) and have created labels for features shipped by the Continue team only (we can expand after we confirm this works). 

Thie PR introduces a GitHub Action that labels the merged PR in a tier. This checks the following to determine if a PR needs a label. 

- Is it a Continue team member?
- Conventional commit includes "feat"
- Size of the PR

I first created this [tier.sh script](https://gist.github.com/bdougie/b366183cfc253ac268efe9ee04883d58) to confirm it works on the last 100 PRs, and this is to start labeling PRs moving forward. There will still need to be human intervention, but the goal is to do the following. 

1. Start labeling PRs when they are merged
2. Improve our use of conventional commits in the PR titles.

_note: We may want to consider using some other than `feat:` on PRs that don't need a public announcement_

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]


https://github.com/user-attachments/assets/ec63dba5-a058-482e-b0e1-10945f0213ba



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a GitHub Action to automatically label merged PRs by tier based on author, commit type, and PR size.

- **New Features**
  - Labels merged PRs from Continue team members as tier 1, 2, or 3 using conventional commit prefixes and change size.
  - Skips labeling for PRs without a relevant commit prefix or from non-team members.

<!-- End of auto-generated description by cubic. -->

