### PR TITLE
Update GitHub issue auto-assignment workflow: replace sestinj with tingwai

### DIFF
--- a/.github/workflows/auto-assign-issue.yaml
+++ b/.github/workflows/auto-assign-issue.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: pozil/auto-assign-issue@v2
         with:
           repo-token: ${{ secrets.CI_GITHUB_TOKEN }}
-          assignees: sestinj,Patrick-Erichsen,tomasz-stefaniak,RomneyDa
+          assignees: Patrick-Erichsen,tomasz-stefaniak,RomneyDa,tingwai
           numOfAssignee: 1
       # - name: "Add default labels"
       #   uses: actions-ecosystem/action-add-labels@v1


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the GitHub issue auto-assignment workflow to remove sestinj and add tingwai as an assignee.

<!-- End of auto-generated description by cubic. -->

