### PR TITLE
fix: :bug: Fix terminal use without a workspace

### DIFF
--- a/core/tools/implementations/runTerminalCommand.test.ts
+++ b/core/tools/implementations/runTerminalCommand.test.ts
@@ -356,10 +356,12 @@ describe("runTerminalCommandImpl", () => {
   it("should handle missing workspace directory gracefully", async () => {
     // Mock IDE to return empty workspace directories
     const mockEmptyWorkspace = jest.fn().mockReturnValue(Promise.resolve([]));
-    
+
     // Create IDE mock with empty workspace
     const mockIde = {
-      getIdeInfo: jest.fn().mockReturnValue(Promise.resolve({ remoteName: "local" })),
+      getIdeInfo: jest
+        .fn()
+        .mockReturnValue(Promise.resolve({ remoteName: "local" })),
       getWorkspaceDirs: mockEmptyWorkspace,
       runCommand: jest.fn(),
       getIdeSettings: jest.fn(),
@@ -393,7 +395,7 @@ describe("runTerminalCommandImpl", () => {
     expect(result[0].description).toBe("Terminal command output");
     expect(result[0].content).toContain("no workspace test");
     expect(result[0].status).toBe("Command completed");
-    
+
     // Verify workspace dirs was called but returned empty
     expect(mockEmptyWorkspace).toHaveBeenCalled();
   });
@@ -401,12 +403,12 @@ describe("runTerminalCommandImpl", () => {
   it("should handle case where cwd fallbacks all fail", async () => {
     // Mock IDE to return empty workspace directories
     const mockEmptyWorkspace = jest.fn().mockReturnValue(Promise.resolve([]));
-    
+
     // Save original environment variables and process.cwd
     const originalHome = process.env.HOME;
     const originalUserProfile = process.env.USERPROFILE;
     const originalCwd = process.cwd;
-    
+
     try {
       // Mock all fallbacks to fail
       delete process.env.HOME;
@@ -414,10 +416,12 @@ describe("runTerminalCommandImpl", () => {
       process.cwd = jest.fn().mockImplementation(() => {
         throw new Error("Current directory unavailable");
       });
-      
+
       // Create IDE mock with empty workspace
       const mockIde = {
-        getIdeInfo: jest.fn().mockReturnValue(Promise.resolve({ remoteName: "local" })),
+        getIdeInfo: jest
+          .fn()
+          .mockReturnValue(Promise.resolve({ remoteName: "local" })),
         getWorkspaceDirs: mockEmptyWorkspace,
         runCommand: jest.fn(),
         getIdeSettings: jest.fn(),
@@ -445,15 +449,17 @@ describe("runTerminalCommandImpl", () => {
 
       // This should now handle the case gracefully by falling back to temp directory
       const result = await runTerminalCommandImpl(args, extras);
-      
+
       // Should work using the temp directory as fallback
       expect(result).toHaveLength(1);
       expect(result[0].name).toBe("Terminal");
       expect(result[0].content).toContain("fallback test");
       expect(result[0].status).toBe("Command completed");
-      
-      console.log("Successfully handled cwd fallback to temp directory:", result[0].status);
-      
+
+      console.log(
+        "Successfully handled cwd fallback to temp directory:",
+        result[0].status,
+      );
     } finally {
       // Always restore original values
       if (originalHome !== undefined) {

--- a/core/tools/implementations/runTerminalCommand.test.ts
+++ b/core/tools/implementations/runTerminalCommand.test.ts
@@ -415,7 +415,7 @@ describe("runTerminalCommandImpl", () => {
       delete process.env.USERPROFILE;
       process.cwd = jest.fn().mockImplementation(() => {
         throw new Error("Current directory unavailable");
-      });
+      }) as jest.MockedFunction<() => string>;
 
       // Create IDE mock with empty workspace
       const mockIde = {

--- a/core/tools/implementations/runTerminalCommand.test.ts
+++ b/core/tools/implementations/runTerminalCommand.test.ts
@@ -352,4 +352,117 @@ describe("runTerminalCommandImpl", () => {
     expect(result[0].content).toBe("Command is running in the background...");
     expect(result[0].status).toBe("Command is running in the background...");
   });
+
+  it("should handle missing workspace directory gracefully", async () => {
+    // Mock IDE to return empty workspace directories
+    const mockEmptyWorkspace = jest.fn().mockReturnValue(Promise.resolve([]));
+    
+    // Create IDE mock with empty workspace
+    const mockIde = {
+      getIdeInfo: jest.fn().mockReturnValue(Promise.resolve({ remoteName: "local" })),
+      getWorkspaceDirs: mockEmptyWorkspace,
+      runCommand: jest.fn(),
+      getIdeSettings: jest.fn(),
+      getDiff: jest.fn(),
+      getClipboardContent: jest.fn(),
+      isTelemetryEnabled: jest.fn(),
+      readFile: jest.fn(),
+      writeFile: jest.fn(),
+      renameFile: jest.fn(),
+      deleteFile: jest.fn(),
+      globFiles: jest.fn(),
+      ls: jest.fn(),
+    };
+
+    const extras = {
+      ide: mockIde as unknown as IDE,
+      llm: {} as any,
+      fetch: {} as any,
+      tool: {} as any,
+      toolCallId: "test-tool-call",
+    } as ToolExtras;
+
+    const command = `node -e "console.log('no workspace test')"`;
+    const args = { command, waitForCompletion: true };
+
+    const result = await runTerminalCommandImpl(args, extras);
+
+    // Should still work - falling back to HOME or cwd
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Terminal");
+    expect(result[0].description).toBe("Terminal command output");
+    expect(result[0].content).toContain("no workspace test");
+    expect(result[0].status).toBe("Command completed");
+    
+    // Verify workspace dirs was called but returned empty
+    expect(mockEmptyWorkspace).toHaveBeenCalled();
+  });
+
+  it("should handle case where cwd fallbacks all fail", async () => {
+    // Mock IDE to return empty workspace directories
+    const mockEmptyWorkspace = jest.fn().mockReturnValue(Promise.resolve([]));
+    
+    // Save original environment variables and process.cwd
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+    const originalCwd = process.cwd;
+    
+    try {
+      // Mock all fallbacks to fail
+      delete process.env.HOME;
+      delete process.env.USERPROFILE;
+      process.cwd = jest.fn().mockImplementation(() => {
+        throw new Error("Current directory unavailable");
+      });
+      
+      // Create IDE mock with empty workspace
+      const mockIde = {
+        getIdeInfo: jest.fn().mockReturnValue(Promise.resolve({ remoteName: "local" })),
+        getWorkspaceDirs: mockEmptyWorkspace,
+        runCommand: jest.fn(),
+        getIdeSettings: jest.fn(),
+        getDiff: jest.fn(),
+        getClipboardContent: jest.fn(),
+        isTelemetryEnabled: jest.fn(),
+        readFile: jest.fn(),
+        writeFile: jest.fn(),
+        renameFile: jest.fn(),
+        deleteFile: jest.fn(),
+        globFiles: jest.fn(),
+        ls: jest.fn(),
+      };
+
+      const extras = {
+        ide: mockIde as unknown as IDE,
+        llm: {} as any,
+        fetch: {} as any,
+        tool: {} as any,
+        toolCallId: "test-tool-call",
+      } as ToolExtras;
+
+      const command = `node -e "console.log('fallback test')"`;
+      const args = { command, waitForCompletion: true };
+
+      // This should now handle the case gracefully by falling back to temp directory
+      const result = await runTerminalCommandImpl(args, extras);
+      
+      // Should work using the temp directory as fallback
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe("Terminal");
+      expect(result[0].content).toContain("fallback test");
+      expect(result[0].status).toBe("Command completed");
+      
+      console.log("Successfully handled cwd fallback to temp directory:", result[0].status);
+      
+    } finally {
+      // Always restore original values
+      if (originalHome !== undefined) {
+        process.env.HOME = originalHome;
+      }
+      if (originalUserProfile !== undefined) {
+        process.env.USERPROFILE = originalUserProfile;
+      }
+      process.cwd = originalCwd;
+    }
+  });
 });

--- a/core/tools/implementations/runTerminalCommand.ts
+++ b/core/tools/implementations/runTerminalCommand.ts
@@ -96,36 +96,27 @@ export const runTerminalCommandImpl: ToolImpl = async (args, extras) => {
         return new Promise((resolve, reject) => {
           let terminalOutput = "";
 
-              if (!waitForCompletion) {
-                const status = "Command is running in the background...";
-                if (extras.onPartialOutput) {
-                  extras.onPartialOutput({
-                    toolCallId,
-                    contextItems: [
-                      {
-                        name: "Terminal",
-                        description: "Terminal command output",
-                        content: "",
-                        status: status,
-                      },
-                    ],
-                  });
-                }
-              }
-
-              // Use spawn with color environment
-              const { shell, args } = getShellCommand(command);
-              const childProc = childProcess.spawn(shell, args, {
-                cwd,
-                env: getColorEnv(), // Add enhanced environment for colors
+          if (!waitForCompletion) {
+            const status = "Command is running in the background...";
+            if (extras.onPartialOutput) {
+              extras.onPartialOutput({
+                toolCallId,
+                contextItems: [
+                  {
+                    name: "Terminal",
+                    description: "Terminal command output",
+                    content: "",
+                    status: status,
+                  },
+                ],
               });
             }
           }
 
           // Use spawn with color environment
-          const childProc = childProcess.spawn(command, {
+          const { shell, args } = getShellCommand(command);
+          const childProc = childProcess.spawn(shell, args, {
             cwd,
-            shell: true,
             env: getColorEnv(), // Add enhanced environment for colors
           });
 

--- a/core/tools/implementations/runTerminalCommand.ts
+++ b/core/tools/implementations/runTerminalCommand.ts
@@ -78,7 +78,7 @@ export const runTerminalCommandImpl: ToolImpl = async (args, extras) => {
     if (extras.onPartialOutput) {
       try {
         const workspaceDirs = await extras.ide.getWorkspaceDirs();
-        
+
         // Handle case where no workspace is available
         let cwd: string;
         if (workspaceDirs.length > 0) {
@@ -119,58 +119,98 @@ export const runTerminalCommandImpl: ToolImpl = async (args, extras) => {
                 cwd,
                 env: getColorEnv(), // Add enhanced environment for colors
               });
+            }
+          }
 
-              childProc.stdout?.on("data", (data) => {
-                // Skip if this process has been backgrounded
-                if (isProcessBackgrounded(toolCallId)) return;
+          // Use spawn with color environment
+          const childProc = childProcess.spawn(command, {
+            cwd,
+            shell: true,
+            env: getColorEnv(), // Add enhanced environment for colors
+          });
 
-                const newOutput = getDecodedOutput(data);
-                terminalOutput += newOutput;
+          childProc.stdout?.on("data", (data) => {
+            // Skip if this process has been backgrounded
+            if (isProcessBackgrounded(toolCallId)) return;
 
-                // Send partial output to UI
-                if (extras.onPartialOutput) {
-                  const status = waitForCompletion
-                    ? ""
-                    : "Command is running in the background...";
-                  extras.onPartialOutput({
-                    toolCallId,
-                    contextItems: [
-                      {
-                        name: "Terminal",
-                        description: "Terminal command output",
-                        content: terminalOutput,
-                        status: status,
-                      },
-                    ],
-                  });
-                }
+            const newOutput = getDecodedOutput(data);
+            terminalOutput += newOutput;
+
+            // Send partial output to UI
+            if (extras.onPartialOutput) {
+              const status = waitForCompletion
+                ? ""
+                : "Command is running in the background...";
+              extras.onPartialOutput({
+                toolCallId,
+                contextItems: [
+                  {
+                    name: "Terminal",
+                    description: "Terminal command output",
+                    content: terminalOutput,
+                    status: status,
+                  },
+                ],
               });
+            }
+          });
 
-              childProc.stderr?.on("data", (data) => {
-                // Skip if this process has been backgrounded
-                if (isProcessBackgrounded(toolCallId)) return;
+          childProc.stderr?.on("data", (data) => {
+            // Skip if this process has been backgrounded
+            if (isProcessBackgrounded(toolCallId)) return;
 
-                const newOutput = getDecodedOutput(data);
-                terminalOutput += newOutput;
+            const newOutput = getDecodedOutput(data);
+            terminalOutput += newOutput;
 
-                // Send partial output to UI, status is not required
-                if (extras.onPartialOutput) {
-                  extras.onPartialOutput({
-                    toolCallId,
-                    contextItems: [
-                      {
-                        name: "Terminal",
-                        description: "Terminal command output",
-                        content: terminalOutput,
-                      },
-                    ],
-                  });
-                }
+            // Send partial output to UI, status is not required
+            if (extras.onPartialOutput) {
+              extras.onPartialOutput({
+                toolCallId,
+                contextItems: [
+                  {
+                    name: "Terminal",
+                    description: "Terminal command output",
+                    content: terminalOutput,
+                  },
+                ],
               });
+            }
+          });
 
-              // If we don't need to wait for completion, resolve immediately
-              if (!waitForCompletion) {
-                const status = "Command is running in the background...";
+          // If we don't need to wait for completion, resolve immediately
+          if (!waitForCompletion) {
+            const status = "Command is running in the background...";
+            resolve([
+              {
+                name: "Terminal",
+                description: "Terminal command output",
+                content: terminalOutput,
+                status: status,
+              },
+            ]);
+          }
+
+          childProc.on("close", (code) => {
+            // If this process has been backgrounded, clean it up from the map and return
+            if (isProcessBackgrounded(toolCallId)) {
+              removeBackgroundedProcess(toolCallId);
+              return;
+            }
+
+            if (waitForCompletion) {
+              // Normal completion, resolve now
+              if (code === 0) {
+                const status = "Command completed";
+                resolve([
+                  {
+                    name: "Terminal",
+                    description: "Terminal command output",
+                    content: terminalOutput,
+                    status: status,
+                  },
+                ]);
+              } else {
+                const status = `Command failed with exit code ${code}`;
                 resolve([
                   {
                     name: "Terminal",
@@ -180,76 +220,45 @@ export const runTerminalCommandImpl: ToolImpl = async (args, extras) => {
                   },
                 ]);
               }
+            } else {
+              // Already resolved, just update the UI with final output
+              if (extras.onPartialOutput) {
+                const status =
+                  code === 0 || !code
+                    ? "\nBackground command completed"
+                    : `\nBackground command failed with exit code ${code}`;
+                extras.onPartialOutput({
+                  toolCallId,
+                  contextItems: [
+                    {
+                      name: "Terminal",
+                      description: "Terminal command output",
+                      content: terminalOutput,
+                      status: status,
+                    },
+                  ],
+                });
+              }
+            }
+          });
 
-              childProc.on("close", (code) => {
-                // If this process has been backgrounded, clean it up from the map and return
-                if (isProcessBackgrounded(toolCallId)) {
-                  removeBackgroundedProcess(toolCallId);
-                  return;
-                }
+          childProc.on("error", (error) => {
+            // If this process has been backgrounded, clean it up from the map and return
+            if (isProcessBackgrounded(toolCallId)) {
+              removeBackgroundedProcess(toolCallId);
+              return;
+            }
 
-                if (waitForCompletion) {
-                  // Normal completion, resolve now
-                  if (code === 0) {
-                    const status = "Command completed";
-                    resolve([
-                      {
-                        name: "Terminal",
-                        description: "Terminal command output",
-                        content: terminalOutput,
-                        status: status,
-                      },
-                    ]);
-                  } else {
-                    const status = `Command failed with exit code ${code}`;
-                    resolve([
-                      {
-                        name: "Terminal",
-                        description: "Terminal command output",
-                        content: terminalOutput,
-                        status: status,
-                      },
-                    ]);
-                  }
-                } else {
-                  // Already resolved, just update the UI with final output
-                  if (extras.onPartialOutput) {
-                    const status =
-                      code === 0 || !code
-                        ? "\nBackground command completed"
-                        : `\nBackground command failed with exit code ${code}`;
-                    extras.onPartialOutput({
-                      toolCallId,
-                      contextItems: [
-                        {
-                          name: "Terminal",
-                          description: "Terminal command output",
-                          content: terminalOutput,
-                          status: status,
-                        },
-                      ],
-                    });
-                  }
-                }
-              });
-
-              childProc.on("error", (error) => {
-                // If this process has been backgrounded, clean it up from the map and return
-                if (isProcessBackgrounded(toolCallId)) {
-                  removeBackgroundedProcess(toolCallId);
-                  return;
-                }
-
-                reject(error);
-              });
-            });
+            reject(error);
+          });
+        });
       } catch (error: any) {
         throw error;
       }
     } else {
       // Fallback to non-streaming for older clients
       const workspaceDirs = await extras.ide.getWorkspaceDirs();
-      
+
       // Handle case where no workspace is available
       let cwd: string;
       if (workspaceDirs.length > 0) {


### PR DESCRIPTION
## Description

When there wasn't a workspace (you haven't opened up a project), the terminal would not work and there wasn't any kind of apparent error message. This fixes it by providing reasonable fallback options to use the users' home directory on Mac/Linux/Windows, or the process.cwd or a tempdir.

Also refactored the Promise.then into a an await model to make the code more clear.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

Tests were added to support the new fallback cases.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed terminal commands failing when no workspace is open by adding fallbacks to the user's home directory, current directory, or a temp directory. Also updated code to use async/await for clarity.

- **Bug Fixes**
  - Terminal now works even if no workspace is set, with clear fallback logic.
  - Added tests for all fallback cases.

<!-- End of auto-generated description by cubic. -->

