### PR TITLE
docs: fix broken link to context in chat docs

### DIFF
--- a/docs/features/chat/how-it-works.mdx
+++ b/docs/features/chat/how-it-works.mdx
@@ -51,8 +51,8 @@ View the exact prompt sent to the AI model in the [prompt logs](/troubleshooting
 
 Learn more about how context providers work:
 
-- [Codebase Context](/customization/overview#codebase-context)
-- [Documentation Context](/customization/overview#documentation-context)
+- [Codebase Context](/customize/context/codebase)
+- [Documentation Context](/customize/context/documentation)
 
 ---
 


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

User reported a broken link in the https://docs.continue.dev/features/chat/how-it-works docs. 

 
<img width="1206" height="822" alt="Screenshot 2025-07-28 at 5 50 02 PM" src="https://github.com/user-attachments/assets/4749a083-2344-4e52-8569-527e1a226f8a" />


## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
