### PR TITLE
fix: :bug: Use login shell and powershell

### DIFF
--- a/core/tools/definitions/runTerminalCommand.ts
+++ b/core/tools/definitions/runTerminalCommand.ts
@@ -11,7 +11,7 @@ export function getPreferredShell(): string {
   const platform = os.platform();
 
   if (platform === "win32") {
-    return process.env.COMSPEC || "cmd.exe";
+    return "powershell.exe";
   } else if (platform === "darwin") {
     return process.env.SHELL || "/bin/zsh";
   } else {

--- a/core/tools/implementations/runTerminalCommand.ts
+++ b/core/tools/implementations/runTerminalCommand.ts
@@ -245,15 +245,40 @@ export const runTerminalCommandImpl: ToolImpl = async (args, extras) => {
       if (waitForCompletion) {
         // Standard execution, waiting for completion
         try {
-          // Use color environment for exec as well
-          const { shell: execShell, args: execArgs } = getShellCommand(command);
-          const output = await asyncExec(
-            `"${execShell}" ${execArgs.map((arg) => `"${arg}"`).join(" ")}`,
-            {
+          // Use spawn approach for consistency with streaming version
+          const { shell: nonStreamingShell, args: nonStreamingArgs } = getShellCommand(command);
+          const output = await new Promise<{stdout: string, stderr: string}>((resolve, reject) => {
+            const childProc = childProcess.spawn(nonStreamingShell, nonStreamingArgs, {
               cwd,
               env: getColorEnv(),
-            },
-          );
+            });
+            
+            let stdout = '';
+            let stderr = '';
+            
+            childProc.stdout?.on('data', (data) => {
+              stdout += getDecodedOutput(data);
+            });
+            
+            childProc.stderr?.on('data', (data) => {
+              stderr += getDecodedOutput(data);
+            });
+            
+            childProc.on('close', (code) => {
+              if (code === 0) {
+                resolve({ stdout, stderr });
+              } else {
+                const error = new Error(`Command failed with exit code ${code}`);
+                (error as any).stderr = stderr;
+                reject(error);
+              }
+            });
+            
+            childProc.on('error', (error) => {
+              reject(error);
+            });
+          });
+          
           const status = "Command completed";
           return [
             {
@@ -274,6 +299,7 @@ export const runTerminalCommandImpl: ToolImpl = async (args, extras) => {
             },
           ];
         }
+        
       } else {
         // For non-streaming but also not waiting for completion, use spawn
         // but don't attach any listeners other than error

--- a/core/tools/implementations/runTerminalCommand.ts
+++ b/core/tools/implementations/runTerminalCommand.ts
@@ -16,6 +16,19 @@ function getDecodedOutput(data: Buffer): string {
   } else {
     return data.toString();
   }
+} // Simple helper function to use login shell on Unix/macOS and PowerShell on Windows
+function getShellCommand(command: string): { shell: string; args: string[] } {
+  if (process.platform === "win32") {
+    // Windows: Use PowerShell
+    return {
+      shell: "powershell.exe",
+      args: ["-NoLogo", "-ExecutionPolicy", "Bypass", "-Command", command],
+    };
+  } else {
+    // Unix/macOS: Use login shell to source .bashrc/.zshrc etc.
+    const userShell = process.env.SHELL || "/bin/bash";
+    return { shell: userShell, args: ["-l", "-c", command] };
+  }
 }
 
 import { fileURLToPath } from "node:url";
@@ -88,9 +101,9 @@ export const runTerminalCommandImpl: ToolImpl = async (args, extras) => {
               }
 
               // Use spawn with color environment
-              const childProc = childProcess.spawn(command, {
+              const { shell, args } = getShellCommand(command);
+              const childProc = childProcess.spawn(shell, args, {
                 cwd,
-                shell: true,
                 env: getColorEnv(), // Add enhanced environment for colors
               });
 
@@ -233,10 +246,14 @@ export const runTerminalCommandImpl: ToolImpl = async (args, extras) => {
         // Standard execution, waiting for completion
         try {
           // Use color environment for exec as well
-          const output = await asyncExec(command, {
-            cwd,
-            env: getColorEnv(),
-          });
+          const { shell: execShell, args: execArgs } = getShellCommand(command);
+          const output = await asyncExec(
+            `"${execShell}" ${execArgs.map((arg) => `"${arg}"`).join(" ")}`,
+            {
+              cwd,
+              env: getColorEnv(),
+            },
+          );
           const status = "Command completed";
           return [
             {
@@ -262,9 +279,10 @@ export const runTerminalCommandImpl: ToolImpl = async (args, extras) => {
         // but don't attach any listeners other than error
         try {
           // Use spawn with color environment
-          const childProc = childProcess.spawn(command, {
+          const { shell: detachedShell, args: detachedArgs } =
+            getShellCommand(command);
+          const childProc = childProcess.spawn(detachedShell, detachedArgs, {
             cwd,
-            shell: true,
             env: getColorEnv(), // Add color environment
             // Detach the process so it's not tied to the parent
             detached: true,


### PR DESCRIPTION
## Description

* Use -l -c so that we get a login shell which gives us PATH and other .zshrc / .bashrc setup things in IntelliJ where we don't have the vscode wrapper envirionment for node.
* Switch to powershell for windows. Using cmd.exe seemed a bit ancient.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

* Performed tests in MacOS Vscode (Passed)
* Performed tests in MacOS IntellJ CE (Passed)
* Performed tests in Windows 11 VsCode (Pending)

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated terminal command execution to use a login shell on macOS/Linux and PowerShell on Windows. This ensures environment variables like PATH are set correctly and improves compatibility in IntelliJ.

- **Bug Fixes**
  - Uses user shell with login mode on Unix systems to source shell profiles.
  - Switches from cmd.exe to powershell.exe on Windows for modern shell support.

<!-- End of auto-generated description by cubic. -->

