### PR TITLE
docs: add correct title to yaml codeblocks in reference

### DIFF
--- a/docs/reference.mdx
+++ b/docs/reference.mdx
@@ -79,9 +79,7 @@ Local blocks utilizing mustache notation for secrets (`${{ secrets.SECRET_NAME }
 
 Blocks can be passed user inputs, including hub secrets and raw text values. To create a block that has an input, use mustache templating as follows:
 
-Block config.yaml
-
-```yaml
+```yaml title="config.yaml"
 name: myprofile/custom-model
 models:
   - name: My Favorite Model
@@ -91,11 +89,9 @@ models:
       temperature: ${{ inputs.TEMP }}
 ```
 
-Which can then be imported like
+Which can then be imported like this:
 
-Assistant config.yaml
-
-```yaml
+```yaml title="config.yaml"
 name: myprofile/custom-assistant
 models:
   - uses: myprofile/custom-model
@@ -110,9 +106,7 @@ Note that hub secrets can be passed as inputs, using a similar mustache format: 
 
 Block properties can be also be directly overriden using `override`. For example:
 
-Assistant config.yaml
-
-```yaml
+```yaml title="config.yaml"
 name: myprofile/custom-assistant
 models:
   - uses: myprofile/custom-model
@@ -149,9 +143,7 @@ The top-level properties in the `config.yaml` configuration file are:
 
 The `name` property specifies the name of your project or configuration.
 
-config.yaml
-
-```yaml
+```yaml title="config.yaml"
 name: MyProject
 ```
 
@@ -230,11 +222,9 @@ The `models` section defines the language models used in your configuration. Mod
     - `key`: Path to the client certificate key file.
     - `passphrase`: Optional passphrase for the client certificate key file.
 
-#### Example
+**Example:**
 
-config.yaml
-
-```yaml
+```yaml title="config.yaml"
 models:
   - name: GPT-4o
     provider: openai
@@ -279,9 +269,7 @@ More information about usage/params for each context provider can be found [here
 
 **Example:**
 
-config.yaml
-
-```yaml
+```yaml title="config.yaml"
 context:
   - provider: file
   - provider: code
@@ -310,9 +298,7 @@ Explicit rules can either be simple text or an object with the following propert
 - `rule` (**required**): The text content of the rule
 - `globs` (optional): When files are provided as context that match this glob pattern, the rule will be included. This can be either a single pattern (e.g., `"**/*.{ts,tsx}"`) or an array of patterns (e.g., `["src/**/*.ts", "tests/**/*.ts"]`).
 
-config.yaml
-
-```yaml
+```yaml title="config.yaml"l
 rules:
   - Always annotate Python functions with their parameter and return types
   - name: TypeScript best practices
@@ -334,9 +320,7 @@ rules:
 
 A list of custom prompts that can be invoked from the chat window. Each prompt has a name, description, and the actual prompt text.
 
-config.yaml
-
-```yaml
+```yaml title="config.yaml"
 prompts:
   - name: check
     description: Check for mistakes in my code
@@ -360,11 +344,9 @@ List of documentation sites to index.
 - `favicon`: URL for site favicon (default is `/favicon.ico` from `startUrl`).
 - `useLocalCrawling`: Skip the default crawler and only crawl using a local crawler.
 
-Example
+**Example:**
 
-config.yaml
-
-```yaml
+```yaml title="config.yaml"
 docs:
   - name: Continue
     startUrl: https://docs.continue.dev/intro
@@ -388,9 +370,7 @@ The [Model Context Protocol](https://modelcontextprotocol.io/introduction) is a 
 
 **Example:**
 
-config.yaml
-
-```yaml
+```yaml title="config.yaml"
 mcpServers:
   - name: My MCP Server
     command: uvx
@@ -410,27 +390,18 @@ Destinations to which [development data](/customize/overview#development-data) w
 **Properties:**
 
 - `name` (**required**): The display name of the data destination
-
 - `destination` (**required**): The destination/endpoint that will receive the data. Can be:
-
   - an HTTP endpoint that will receive a POST request with a JSON blob
   - a file URL to a directory in which events will be dumpted to `.jsonl` files
-
 - `schema` (**required**): the schema version of the JSON blobs to be sent. Options include `0.1.0` and `0.2.0`
-
 - `events`: an array of event names to include. Defaults to all events if not specified.
-
 - `level`: a pre-defined filter for event fields. Options include `all` and `noCode`; the latter excludes data like file contents, prompts, and completions. Defaults to `all`
-
 - `apiKey`: api key to be sent with request (Bearer header)
-
 - `requestOptions`: Options for event POST requests. Same format as [model requestOptions](#models).
 
-  **Example:**
+**Example:**
 
-config.yaml
-
-```yaml
+```yaml title="config.yaml"
 data:
   - name: Local Data Bank
     destination: file:///Users/dallin/Documents/code/continuedev/continue-extras/external-data
@@ -451,9 +422,7 @@ data:
 
 Putting it all together, here's a complete example of a `config.yaml` configuration file:
 
-config.yaml
-
-```yaml
+```yaml title="config.yaml"
 name: MyProject
 version: 0.0.1
 schema: v1
@@ -527,9 +496,7 @@ data:
 
 You can also use node anchors to avoid duplication of properties. To do so, adding the YAML version header `%YAML 1.1` is needed, here's an example of a `config.yaml` configuration file using anchors:
 
-config.yaml
-
-```yaml
+```yaml title="config.yaml"
 %YAML 1.1
 ---
 name: MyProject


### PR DESCRIPTION
Here is what it looks like without it:
<img width="750" height="394" alt="Screenshot 2025-07-28 at 7 42 01 PM" src="https://github.com/user-attachments/assets/698a134d-76ff-4784-acd3-b54417e5a5dd" />

Here's an example with:
<img width="746" height="210" alt="Screenshot 2025-07-28 at 7 42 39 PM" src="https://github.com/user-attachments/assets/80bb8140-a81d-40d5-9bc3-c1e8f1e9ca0d" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added correct titles to all YAML code blocks in the reference docs for better clarity and navigation.

<!-- End of auto-generated description by cubic. -->

