### PR TITLE
chore: bump to 71

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "1.1.70",
+  "version": "1.1.71",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the VS Code extension version to 1.1.71.

<!-- End of auto-generated description by cubic. -->

