### PR TITLE
Add middle mouse button click handling to close tabs in TabBar component

### DIFF
--- a/gui/src/components/TabBar/TabBar.tsx
+++ b/gui/src/components/TabBar/TabBar.tsx
@@ -237,6 +237,13 @@ export const TabBar = React.forwardRef<HTMLDivElement>((_, ref) => {
           key={tab.id}
           isActive={tab.isActive}
           onClick={() => handleTabClick(tab.id)}
+          onAuxClick={(e) => {
+            // Middle mouse button
+            if (e.button === 1) {
+              e.preventDefault();
+              handleTabClose(tab.id);
+            }
+          }}
         >
           <TabTitle>{tab.title}</TabTitle>
           <CloseButton


### PR DESCRIPTION
## Description

This PR adds an option to close tabs using the middle mouse button.

This is a simple UX improvement of these original issue and PR:
https://github.com/continuedev/continue/issues/4030
https://github.com/continuedev/continue/pull/4051

## Checklist

- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Testing instructions

1. Enable "Session Tabs"
2. Create new tabs
3. Close with the middle button
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for closing tabs in the TabBar with a middle mouse button click for faster tab management.

<!-- End of auto-generated description by cubic. -->

