### PR TITLE
feat: make disabled tool policies more clear with tooltips

### DIFF
--- a/gui/src/components/mainInput/Lump/sections/tool-policies/ToolPolicyItem.tsx
+++ b/gui/src/components/mainInput/Lump/sections/tool-policies/ToolPolicyItem.tsx
@@ -157,10 +157,10 @@ function ToolPolicyItem(props: ToolDropdownItemProps) {
         </div>
         <Tooltip id={disabledTooltipId}>
           {mode === "chat"
-            ? "Tool cannot be enabled in chat mode"
+            ? "Tool disabled in chat mode"
             : !props.isGroupEnabled
               ? "Group is turned off"
-              : "This tool cannot be enabled in plan mode"}
+              : "Tool disabled in plan mode"}
         </Tooltip>
       </div>
       <div


### PR DESCRIPTION
## Description
Adds a tooltip that shows the reason a tool policy cannot be changed

<img width="531" height="63" alt="image" src="https://github.com/user-attachments/assets/f57ad039-0140-4e8d-b2be-2b809a413c36" />

<img width="538" height="140" alt="image" src="https://github.com/user-attachments/assets/5a189ca1-cffb-4223-9b13-01c978965133" />

<img width="432" height="45" alt="image" src="https://github.com/user-attachments/assets/c65086d7-3aa1-410b-935a-a4a9c2a1a5ca" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added tooltips to disabled tool policies to show users why a tool cannot be enabled. This makes it clearer when a tool or group is unavailable.

<!-- End of auto-generated description by cubic. -->

