### PR TITLE
docs: fix image path in `/customize/model-roles/00-intro#selecting-model-roles`

### DIFF
--- a/docs/customize/model-roles/00-intro.mdx
+++ b/docs/customize/model-roles/00-intro.mdx
@@ -21,7 +21,7 @@ These roles can be specified for a `config.yaml` model block using `roles`. See 
 
 You can control which of the models in your assistant for a given role will be currently used for that role. Above the main input, click the 3 dots and then the cube icon to expand the `Models` section. Then you can use the dropdowns to select an active model for each role.
 
-![Settings Active Models Section](/img/settings-model-roles.png)
+![Settings Active Models Section](/images/settings-model-roles.png)
 
 <Info>
   `roles` are not explicitly defined within `config.json` (deprecated) - they


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

Image path broken image.

<img width="720" height="310" alt="Screenshot 2025-07-29 at 5 25 41 PM" src="https://github.com/user-attachments/assets/38da18bb-b518-4bb9-a0ad-6f08939e4fe1" />


## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

<img width="1624" height="1056" alt="Screenshot 2025-07-29 at 5 25 12 PM" src="https://github.com/user-attachments/assets/876feed4-1503-4280-8553-801a28111b47" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
