### PR TITLE
docs: fix broken Docs deep dive link

### DIFF
--- a/docs/hub/blocks/block-types.mdx
+++ b/docs/hub/blocks/block-types.mdx
@@ -18,7 +18,7 @@ Learn more about context providers [here](/reference#context), and check out [th
 
 Docs are blocks that point to documentation sites, which will be indexed locally and then can be referenced as context using @Docs in Chat. [Explore docs](https://hub.continue.dev/explore/docs) on the hub.
 
-Learn more in the [@Docs deep dive](/customization/overview#documentation-context), and view [`docs`](/reference#docs) in the YAML Reference for more details.
+Learn more in the [@Docs context provider documentation](/customize/context/documentation), and view [`docs`](/reference#docs) in the YAML Reference for more details.
 
 ## MCP Servers
 


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

The @ Docs context was previously in the deep dive section but now moved. This updates the link.

<img width="750" height="207" alt="Screenshot 2025-07-29 at 5 48 37 PM" src="https://github.com/user-attachments/assets/e70b8446-2a51-48bf-b8ef-f7ed1d926e83" />

Now links to https://continue-docs-bdougie-con-2824.mintlify.app/customize/context/documentation

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

Visit - https://continue-docs-bdougie-con-2824.mintlify.app/hub/blocks/block-types
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a broken link in the Docs block types documentation to point to the correct @Docs context provider page.

<!-- End of auto-generated description by cubic. -->

