### PR TITLE
docs: fix broken links in the customization overview page

### DIFF
--- a/docs/customization/overview.mdx
+++ b/docs/customization/overview.mdx
@@ -18,4 +18,4 @@ You can easily access your assistant configuration from the Continue Chat sideba
 ![configure an assistant](/images/customization/images/configure-continue-a5c8c79f3304c08353f3fc727aa5da7e.png)
 
 - See [Editing Hub Assistants](/hub/assistants/edit-an-assistant) for more details on managing your hub assistant
-- See the [Config Deep Dive](/reference/json-reference) for more details on configuring local assistants.
+- See the [Config Deep Dive](/reference) for more details on configuring local assistants.

--- a/docs/customization/overview.mdx
+++ b/docs/customization/overview.mdx
@@ -3,10 +3,10 @@ title: "Overview"
 description: "Continue can be deeply customized. For example you might:"
 ---
 
-- **Change your Model Provider**. Continue allows you to choose your favorite or even add multiple model providers. This allows you to use different models for different tasks, or to try another model if you're not happy with the results from your current model. Continue supports all of the popular model providers, including OpenAI, Anthropic, Microsoft/Azure, Mistral, and more. You can even self host your own model provider if you'd like. Learn more about [model providers](/customization/models#openai).
+- **Change your Model Provider**. Continue allows you to choose your favorite or even add multiple model providers. This allows you to use different models for different tasks, or to try another model if you're not happy with the results from your current model. Continue supports all of the popular model providers, including OpenAI, Anthropic, Microsoft/Azure, Mistral, and more. You can even self host your own model provider if you'd like. Learn more about [model providers](/customize/model-providers/top-level/openai).
 - **Select different models for specific tasks**. Different Continue features can use different models. We call these _model roles_. For example, you can use a different model for chat than you do for autocomplete. Learn more about [model roles](/customize/model-roles).
 - **Add a Context Provider**. Context providers allow you to add information to your prompts, giving your LLM additional context to work with. Context providers allow you to reference snippets from your codebase, or lookup relevant documentation, or use a search engine to find information and much more. Learn more about [context providers](/customize/custom-providers).
-- **Create a Slash Command**. Slash commands allow you to easily add custom functionality to Continue. You can use a slash command that allows you to generate a shell command from natural language, or perhaps generate a commit message, or create your own custom command to do whatever you want. Learn more about [slash commands](/customization/overview#slash-commands).
+- **Create a Slash Command**. Slash commands allow you to easily add custom functionality to Continue. You can use a slash command that allows you to generate a shell command from natural language, or perhaps generate a commit message, or create your own custom command to do whatever you want. Learn more about [slash commands](/customize/deep-dives/slash-commands).
 - **Call external tools and functions**. Unchain your LLM with the power of tools using [Agent](/features/agent/quick-start). Add custom tools using [MCP Servers](/customization/mcp-tools)
 
 Whatever you choose, you'll probably start by editing your Assistant.
@@ -18,4 +18,4 @@ You can easily access your assistant configuration from the Continue Chat sideba
 ![configure an assistant](/images/customization/images/configure-continue-a5c8c79f3304c08353f3fc727aa5da7e.png)
 
 - See [Editing Hub Assistants](/hub/assistants/edit-an-assistant) for more details on managing your hub assistant
-- See the [Config Deep Dive](/customization/overview#configuration) for more details on configuring local assistants.
+- See the [Config Deep Dive](/reference/json-reference) for more details on configuring local assistants.


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

There were a few broken links I found while working on #6877 

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

Visit https://continue-docs-bdougie-customization-links.mintlify.app/customization/overview to confirm all links work.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed broken links in the customization overview page to ensure all documentation references work correctly.

<!-- End of auto-generated description by cubic. -->

