### PR TITLE
docs: Fix broken screenshots on @docs page

### DIFF
--- a/docs/customize/context/documentation.mdx
+++ b/docs/customize/context/documentation.mdx
@@ -77,7 +77,7 @@ Documentation sources may be suggested based on package files in your repo. This
 - Packages with partial information (with a pen icon) can be clicked to fill the form with the available information
 - Note that you can hover over the information icon to see where the package suggestion was found.
 
-![Add documentation form](/img/docs-form.png)
+![Add documentation form](/images/docs-form.png)
 
 ### In a configuration file
 
@@ -230,11 +230,11 @@ You can view indexing statuses and manage your documentation sites from the `@do
 - Failed indexing attempts will show an error status bar and icon
 - Delete a documentation site from your configuration using the trash icon
 
-![More Page @docs indexes section](/img/docs-indexes.png)
+![More Page @docs indexes section](/images/docs-indexes.png)
 
 You can also view the overall status of currently indexing docs from a hideable progress bar at the bottom of the chat page
 
-![Documentation indexing peek](/img/docs-indexing-peek.png)
+![Documentation indexing peek](/images/docs-indexing-peek.png)
 
 You can also use the following IDE command to force a re-index of all docs: `Continue: Docs Force Re-Index`.
 

--- a/docs/customize/context/documentation.mdx
+++ b/docs/customize/context/documentation.mdx
@@ -212,8 +212,9 @@ If your documentation is private, you can skip the default crawler and use a loc
 </Tabs>
 
 <Info>
-  Chromium crawling has been deprecated
-  {/* The default local crawler is a lightweight tool that cannot render sites that are dynamically generated using JavaScript. If your sites need to be rendered, you can enable the experimental `Use Chromium for Docs Crawling` feature from your [User Settings Page](../deep-dives/settings.md) This will download and install Chromium to `~/.continue/.utils`, and use it as the local crawler. */}
+  The default local crawler is a lightweight tool that cannot render sites that are dynamically generated using JavaScript. If your sites need to be rendered, you can enable the experimental `Use Chromium for Docs Crawling` feature from your [User Settings Page](../settings) This will download and install Chromium to `~/.continue/.utils`, and use it as the local crawler.
+  
+  **Note:** Chromium crawling support is being deprecated and may be removed in future versions.
 </Info>
 
 Further notes:
@@ -400,4 +401,4 @@ The following configuration example includes:
   </Tab>
 </Tabs>
 
-{/* This could also involve enabling Chromium as a backup for local documentation the [User Settings Page](../deep-dives/settings.md). */}
+This setup could also involve enabling Chromium as a backup for local documentation through the [User Settings Page](../settings).

--- a/docs/customize/model-roles/00-intro.mdx
+++ b/docs/customize/model-roles/00-intro.mdx
@@ -21,7 +21,7 @@ These roles can be specified for a `config.yaml` model block using `roles`. See 
 
 You can control which of the models in your assistant for a given role will be currently used for that role. Above the main input, click the 3 dots and then the cube icon to expand the `Models` section. Then you can use the dropdowns to select an active model for each role.
 
-![Settings Active Models Section](/img/settings-model-roles.png)
+![Settings Active Models Section](/images/settings-model-roles.png)
 
 <Info>
   `roles` are not explicitly defined within `config.json` (deprecated) - they


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

Screenshots on the @ docs page were broken. This PR fixes those and uncomments the Chromium details.  

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
