### PR TITLE
docs: reorder agent to be first

### DIFF
--- a/docs/customize/deep-dives/rules.mdx
+++ b/docs/customize/deep-dives/rules.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Rules"
-description: "Rules are used to provide instructions to the model for Chat, Edit, and Agent requests."
+description: "Rules are used to provide instructions to the model for Agent, Chat, and Edit requests."
 keywords: [rules, .continuerules, system, prompt, message]
 ---
 
-Rules provide instructions to the model for [Chat](../../features/chat/quick-start), [Edit](../../features/edit/quick-start), and [Agent](../../features/agent/quick-start) requests.
+Rules provide instructions to the model for [Agent](../../features/agent/quick-start), [Chat](../../features/chat/quick-start), and [Edit](../../features/edit/quick-start) requests.
 
 <Info>
   Rules are not included in [autocomplete](./autocomplete.mdx) or
@@ -151,7 +151,7 @@ globs: ["**/*.ts", "**/*.tsx"]
 
 ### Chat System Message
 
-Continue includes a simple default system message for [Chat](../../features/chat/quick-start) and [Agent](../../features/agent/quick-start) requests, to help the model provide reliable codeblock formats in its output.
+Continue includes a simple default system message for [Agent](../../features/agent/quick-start) and [Chat](../../features/chat/quick-start) requests, to help the model provide reliable codeblock formats in its output.
 
 This can be viewed in the rules section of the toolbar (see above), or in the source code [here](https://github.com/continuedev/continue/blob/main/core/llm/constructMessages.ts#L4).
 

--- a/docs/customize/deep-dives/rules.mdx.backup
+++ b/docs/customize/deep-dives/rules.mdx.backup
@@ -1,10 +1,10 @@
 ---
 title: "Rules"
-description: Rules are used to provide instructions to the model for Chat, Edit, and Agent requests.
+description: Rules are used to provide instructions to the model for Agent, Chat, and Edit requests.
 keywords: [rules, .continuerules, system, prompt, message]
 ---
 
-Rules provide instructions to the model for [Chat](../../features/chat/quick-start), [Edit](../../features/edit/quick-start), and [Agent](../../features/agent/quick-start) requests.
+Rules provide instructions to the model for [Agent](../../features/agent/quick-start), [Chat](../../features/chat/quick-start), and [Edit](../../features/edit/quick-start) requests.
 
 <Info> Rules are not included in [autocomplete](./autocomplete.mdx) or [apply](../model-roles/apply.mdx).
 </Info>
@@ -166,7 +166,7 @@ Whenever you are writing React code, make sure to
 
 ### Chat System Message
 
-Continue includes a simple default system message for [Chat](../../features/chat/quick-start) and [Agent](../../features/agent/quick-start) requests, to help the model provide reliable codeblock formats in its output.
+Continue includes a simple default system message for [Agent](../../features/agent/quick-start) and [Chat](../../features/chat/quick-start) requests, to help the model provide reliable codeblock formats in its output.
 
 This can be viewed in the rules section of the toolbar (see above), or in the source code [here](https://github.com/continuedev/continue/blob/main/core/llm/constructMessages.ts#L4).
 

--- a/docs/features/plan/quick-start.mdx
+++ b/docs/features/plan/quick-start.mdx
@@ -56,5 +56,5 @@ Plan mode will analyze the existing code, understand the current implementation,
 When you're ready to implement your plan, simply switch to Agent mode using the mode selector or keyboard shortcut (`Cmd/Ctrl + .`). The conversation context carries over, so Agent mode can immediately start implementing the plan you developed.
 
 <Tip>
-  Use the keyboard shortcut `Cmd/Ctrl + .` to quickly cycle between Chat, Plan, and Agent modes.
+  Use the keyboard shortcut `Cmd/Ctrl + .` to quickly cycle between Agent, Chat, and Plan modes.
 </Tip>

--- a/docs/getting-started/overview.mdx
+++ b/docs/getting-started/overview.mdx
@@ -4,6 +4,16 @@ description: "To quickly understand what you can do with Continue, check out eac
 ---
 
 <Tabs>
+<Tab title="Agent">
+[Agent](/features/agent/quick-start) equips the Chat model with the tools needed to handle a wide range of coding tasks
+
+![agent](/images/agent-9ef792cfc196a3b5faa984fb072c4400.gif)
+
+<Info>
+  Learn more about [Agent](/features/agent/quick-start)
+</Info>
+</Tab>
+
 <Tab title="Chat">
 [Chat](/features/chat/quick-start) makes it easy to ask for help from an LLM without needing to leave the IDE
 
@@ -14,13 +24,13 @@ description: "To quickly understand what you can do with Continue, check out eac
 </Info>
 </Tab>
 
-<Tab title="Autocomplete">
-[Autocomplete](/features/autocomplete/quick-start) provides inline code suggestions as you type
+<Tab title="Plan">
+[Plan](/features/agent/plan-mode) provides a safe environment with read-only tools for exploring code and planning changes
 
-![autocomplete](/images/autocomplete-9d4e3f7658d3e65b8e8b20f2de939675.gif)
+![plan](/images/plan-mode.gif)
 
 <Info>
-  Learn more about [Autocomplete](/features/autocomplete/quick-start)
+  Learn more about [Plan](/features/agent/plan-mode)
 </Info>
 </Tab>
 
@@ -34,23 +44,13 @@ description: "To quickly understand what you can do with Continue, check out eac
 </Info>
 </Tab>
 
-<Tab title="Agent">
-[Agent](/features/agent/quick-start) equips the Chat model with the tools needed to handle a wide range of coding tasks
+<Tab title="Autocomplete">
+[Autocomplete](/features/autocomplete/quick-start) provides inline code suggestions as you type
 
-![agent](/images/agent-9ef792cfc196a3b5faa984fb072c4400.gif)
-
-<Info>
-  Learn more about [Agent](/features/agent/quick-start)
-</Info>
-</Tab>
-
-<Tab title="Plan">
-[Plan](/features/agent/plan-mode) provides a safe environment with read-only tools for exploring code and planning changes
-
-![plan](/images/plan-mode.gif)
+![autocomplete](/images/autocomplete-9d4e3f7658d3e65b8e8b20f2de939675.gif)
 
 <Info>
-  Learn more about [Plan](/features/agent/plan-mode)
+  Learn more about [Autocomplete](/features/autocomplete/quick-start)
 </Info>
 </Tab>
 </Tabs>

--- a/docs/reference.mdx
+++ b/docs/reference.mdx
@@ -181,7 +181,7 @@ The `models` section defines the language models used in your configuration. Mod
 
 - `promptTemplates`: Can be used to override the default prompt templates for different model roles. Valid values are `chat`, [`edit`](/customize/model-roles#edit-prompt-templating), [`apply`](/customize/model-roles#apply-prompt-templating) and [`autocomplete`](/customize/model-roles#autocomplete-prompt-templating). The `chat` property must be a valid template name, such as `llama3` or `anthropic`.
 
-- `chatOptions`: If the model includes role `chat`, these settings apply for Chat and Agent mode:
+- `chatOptions`: If the model includes role `chat`, these settings apply for Agent and Chat mode:
 
   - `baseSystemMessage`: Can be used to override the default system prompt for **Chat** mode.
 
@@ -290,7 +290,7 @@ context:
 
 ### `rules`
 
-List of rules that the LLM should follow. These are concatenated into the system message for all [Chat](/features/chat/quick-start), [Edit](/features/edit/quick-start), and [Agent](/features/agent/quick-start) requests. See the [rules deep dive](/customization/rules) for details.
+List of rules that the LLM should follow. These are concatenated into the system message for all [Agent](/features/agent/quick-start), [Chat](/features/chat/quick-start), and [Edit](/features/edit/quick-start) requests. See the [rules deep dive](/customization/rules) for details.
 
 Explicit rules can either be simple text or an object with the following properties:
 


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

Agent appears first in docs always.



## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

<img width="1090" height="462" alt="Screenshot 2025-07-29 at 7 05 44 PM" src="https://github.com/user-attachments/assets/2ee8af91-6f42-4217-b058-fa38293c1296" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
