### PR TITLE
fix(config-yaml): Handle api_key field in config.yaml

### DIFF
--- a/packages/config-yaml/src/schemas/models.ts
+++ b/packages/config-yaml/src/schemas/models.ts
@@ -134,6 +134,7 @@ const baseModelFields = {
   name: z.string(),
   model: z.string(),
   apiKey: z.string().optional(),
+  api_key: z.string().optional(),
   apiBase: z.string().optional(),
   maxStopWords: z.number().optional(),
   roles: modelRolesSchema.array().optional(),
@@ -151,37 +152,53 @@ const baseModelFields = {
   autocompleteOptions: autocompleteOptionsSchema.optional(),
 };
 
-export const modelSchema = z.union([
-  z.object({
-    ...baseModelFields,
-    provider: z.literal("continue-proxy"),
-    apiKeyLocation: z.string().optional(),
-    envSecretLocations: z.record(z.string(), z.string()).optional(),
-    orgScopeId: z.string().nullable(),
-    onPremProxyUrl: z.string().nullable(),
-  }),
-  z.object({
-    ...baseModelFields,
-    provider: z.string().refine((val) => val !== "continue-proxy"),
-    sourceFile: z.string().optional(),
-  }),
-]);
-
-export const partialModelSchema = z.union([
-  z
-    .object({
+export const modelSchema = z
+  .union([
+    z.object({
       ...baseModelFields,
       provider: z.literal("continue-proxy"),
       apiKeyLocation: z.string().optional(),
       envSecretLocations: z.record(z.string(), z.string()).optional(),
-    })
-    .partial(),
-  z
-    .object({
+      orgScopeId: z.string().nullable(),
+      onPremProxyUrl: z.string().nullable(),
+    }),
+    z.object({
       ...baseModelFields,
       provider: z.string().refine((val) => val !== "continue-proxy"),
-    })
-    .partial(),
-]);
+      sourceFile: z.string().optional(),
+    }),
+  ])
+  .transform((val) => {
+    if (val.api_key && !val.apiKey) {
+      val.apiKey = val.api_key;
+    }
+    delete val.api_key;
+    return val;
+  });
+
+export const partialModelSchema = z
+  .union([
+    z
+      .object({
+        ...baseModelFields,
+        provider: z.literal("continue-proxy"),
+        apiKeyLocation: z.string().optional(),
+        envSecretLocations: z.record(z.string(), z.string()).optional(),
+      })
+      .partial(),
+    z
+      .object({
+        ...baseModelFields,
+        provider: z.string().refine((val) => val !== "continue-proxy"),
+      })
+      .partial(),
+  ])
+  .transform((val) => {
+    if (val.api_key && !val.apiKey) {
+      val.apiKey = val.api_key;
+    }
+    delete val.api_key;
+    return val;
+  });
 
 export type ModelConfig = z.infer<typeof modelSchema>;


### PR DESCRIPTION
This fixes a bug where the config.yaml parser would not correctly handle the 'api_key' field, causing authentication failures for providers like OpenRouter and Groq. The Zod schema has been updated to transform 'api_key' to 'apiKey', ensuring that the API key is correctly passed to the request headers. This change is backward compatible and improves the user experience by allowing for more flexible configuration.

## Description
fix [Issue 6191](https://github.com/continuedev/continue/issues/6191)

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a bug where the config.yaml parser did not handle the api_key field, which caused authentication failures for some providers. The parser now maps api_key to apiKey, allowing both formats in config files.

<!-- End of auto-generated description by cubic. -->

