### PR TITLE
fix: :bug: Fix CodebaseIndexer Bugs

### DIFF
--- a/core/core.ts
+++ b/core/core.ts
@@ -204,24 +204,6 @@ export class Core {
     dataLogger.ideInfoPromise = ideInfoPromise;
     dataLogger.ideSettingsPromise = ideSettingsPromise;
 
-    void ideSettingsPromise.then((ideSettings) => {
-      // Index on initialization
-      void this.ide.getWorkspaceDirs().then(async (dirs) => {
-        // Respect pauseCodebaseIndexOnStart user settings
-        if (ideSettings.pauseCodebaseIndexOnStart) {
-          this.codeBaseIndexer.paused = true;
-          void this.messenger.request("indexProgress", {
-            progress: 0,
-            desc: "Initial Indexing Skipped",
-            status: "paused",
-          });
-          return;
-        }
-
-        void this.codeBaseIndexer.refreshCodebaseIndex(dirs);
-      });
-    });
-
     const getLlm = async () => {
       const { config } = await this.configHandler.loadConfig();
       if (!config) {

--- a/core/indexing/CodebaseIndexer.ts
+++ b/core/indexing/CodebaseIndexer.ts
@@ -747,7 +747,7 @@ export class CodebaseIndexer {
     ) {
       return;
     }
-    const localController = new AbortController;
+    const localController = new AbortController();
     this.indexingCancellationController = localController;
 
     try {
@@ -817,7 +817,6 @@ export class CodebaseIndexer {
     config: newConfig,
   }: ConfigResult<ContinueConfig>) {
     if (newConfig) {
-
       const ideSettings = await this.ide.getIdeSettings();
       const pauseCodebaseIndexOnStart = ideSettings.pauseCodebaseIndexOnStart;
       if (pauseCodebaseIndexOnStart) {

--- a/core/indexing/TestCodebaseIndex.ts
+++ b/core/indexing/TestCodebaseIndex.ts
@@ -67,4 +67,10 @@ export class TestCodebaseIndex implements CodebaseIndex {
 
     return rows.map((row: any) => row.path);
   }
+
+  async clearDatabase(): Promise<void> {
+    const db = await SqliteDb.get();
+    await TestCodebaseIndex._createTables(db);
+    await db.run("DELETE FROM test_index");
+  }
 }

--- a/core/indexing/chunk/ChunkCodebaseIndex.ts
+++ b/core/indexing/chunk/ChunkCodebaseIndex.ts
@@ -77,14 +77,23 @@ export class ChunkCodebaseIndex implements CodebaseIndex {
 
     // Add tag
     for (const item of results.addTag) {
-      await db.run(
-        `
-        INSERT INTO chunk_tags (chunkId, tag)
-        SELECT id, ? FROM chunks
-        WHERE cacheKey = ?
-      `,
-        [tagString, item.cacheKey],
-      );
+      try {
+        await db.run(
+          `
+          INSERT INTO chunk_tags (chunkId, tag)
+          SELECT id, ? FROM chunks
+          WHERE cacheKey = ?
+        `,
+          [tagString, item.cacheKey],
+        );
+      } catch (e: any) {
+        if (!e.message.includes("UNIQUE constraint")) {
+          // Throw any errors other than duplicate tag
+          // Possible the changes were already added by another instance of the extension
+          // For example vscode running side by side with intellij
+          throw(e);
+        }
+      }
       await markComplete([item], IndexResultType.AddTag);
       accumulatedProgress += 1 / results.addTag.length / 4;
       yield {

--- a/core/indexing/chunk/ChunkCodebaseIndex.ts
+++ b/core/indexing/chunk/ChunkCodebaseIndex.ts
@@ -91,7 +91,7 @@ export class ChunkCodebaseIndex implements CodebaseIndex {
           // Throw any errors other than duplicate tag
           // Possible the changes were already added by another instance of the extension
           // For example vscode running side by side with intellij
-          throw(e);
+          throw e;
         }
       }
       await markComplete([item], IndexResultType.AddTag);


### PR DESCRIPTION
## Description

* Introducing codebase indexer refreshes based on configuration changes introduced a series of race condition bugs that were causing the abort signal become undefined during initalization resulting in a "signal undefined" error showing up during indexing. This was most noticible in IntelliJ but could also happen in VsCode. In IntelliJ it often had the side effect of breaking the startup causing the Chat window to never generate any LLM output.

* The pause codebase indexer on start VsCode setting no longer made much sense becaue it was tied to having a configuration and a pause request. As such I redefined it slightly and made sure that not only is it paused on start, it's also paused on configuration switches.

* There were some interesting data uniqueness issues during tag/cacheKey creation and indexing especially if you happended to swap between the intelliJ and vscode extension in the same repo. I applied a fix to the addTag function so that if the tag/cacheKey combination already exists, to ignore it as a soft error as it's likely one of the extensions already added it. This change did not affect the index content or status, and cleaned up a common indexing error I observed.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Tests

Performed the following manual tests:

* Set the VsCode pause on start setting and observe that the codebase indexing is always in a paused state on start, and on configuration changes.
* Started vscode indexing and manually paused the indexing. Stopped the extension and restarted. Noted it was still paused. Restarted an it finished sucessfully.
* Noted I had a local IntellliJ manged database in the state where a tag/cacheKey was duplicating during addTag. This was ignored and the index was updated with the soft bypass. No changes to the funcitonallity.
* Verified that during startup if the global abort signal in codeBaseIndexer gets set to undefined due to race condtions or duplicate funciton calls that the in process function continues as it's using a locally initalized version of the AbortController now in the inner loop.


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed race conditions and tag duplication bugs in the codebase indexer to prevent startup errors and improve stability in both VSCode and IntelliJ.

- **Bug Fixes**
  - Ensured the abort signal is always defined during indexing to avoid "signal undefined" errors.
  - Updated pause-on-start behavior to also pause indexing on configuration changes.
  - Handled duplicate tag/cacheKey entries gracefully to prevent errors when switching between extensions.

<!-- End of auto-generated description by cubic. -->

