### PR TITLE
fix: model should now recompute outcome at each next edit location

### DIFF
--- a/extensions/vscode/src/autocomplete/completionProvider.ts
+++ b/extensions/vscode/src/autocomplete/completionProvider.ts
@@ -432,9 +432,28 @@ export class ContinueCompletionProvider
               0 &&
             !jumpSuccessful
           ) {
+            // NOTE: Outcome has to be re-computed for each next editable location.
             const nextRegion =
-              this.nextEditProvider.shiftNextEditableRegionsInTheCurrentChain();
+              this.nextEditProvider.getNextEditableRegionsInTheCurrentChain()[0];
             if (!nextRegion) continue;
+
+            // Getting the outcome shifts the next editable region queue,
+            // deleting the item denoted by nextRegion above.
+            outcome =
+              await this.nextEditProvider.provideInlineCompletionItemsWithChain(
+                {
+                  completionId,
+                  manuallyPassFileContents,
+                  manuallyPassPrefix,
+                  selectedCompletionInfo,
+                  isUntitledFile: document.isUntitled,
+                  recentlyVisitedRanges,
+                  recentlyEditedRanges,
+                },
+                signal,
+              );
+
+            if (!outcome) continue;
 
             const jumpPosition = new vscode.Position(
               nextRegion.range.start.line,


### PR DESCRIPTION
## Description

Closes CON-3129.

Fix a bug where model was using a stale output for next editable locations instead of re-computing predictions.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a bug where the model used outdated predictions for next edit locations by ensuring it now recomputes the outcome at each step. This addresses the issue in CON-3129 and improves prediction accuracy during multi-step edits.

<!-- End of auto-generated description by cubic. -->

