### PR TITLE
fix: only update on session change when needed

### DIFF
--- a/core/control-plane/client.ts
+++ b/core/control-plane/client.ts
@@ -36,9 +36,7 @@ export const TRIAL_PROXY_URL =
 
 export class ControlPlaneClient {
   constructor(
-    private readonly sessionInfoPromise: Promise<
-      ControlPlaneSessionInfo | undefined
-    >,
+    readonly sessionInfoPromise: Promise<ControlPlaneSessionInfo | undefined>,
     private readonly ideSettingsPromise: Promise<IdeSettings>,
     private readonly ideInfoPromise: Promise<IdeInfo>,
   ) {}


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved session handling so updates only trigger when the session actually changes, reducing unnecessary reloads.

- **Bug Fixes**
  - Only reloads the control plane client on real session changes, login, or logout.

<!-- End of auto-generated description by cubic. -->

