### PR TITLE
Update available Cerebras models + handling functions

### DIFF
--- a/core/llm/llms/Cerebras.ts
+++ b/core/llm/llms/Cerebras.ts
@@ -1,4 +1,5 @@
-import { LLMOptions } from "../../index.js";
+import { ChatCompletionCreateParams } from "openai/resources/index";
+import { ChatMessage, CompletionOptions, LLMOptions } from "../../index.js";
 
 import OpenAI from "./OpenAI.js";
 
@@ -9,10 +10,63 @@ class Cerebras extends OpenAI {
   };
   maxStopWords: number | undefined = 4;
 
+  constructor(options: LLMOptions) {
+    super(options);
+    
+    // Set context length based on whether the model is the free version
+    if (options.model === "qwen-3-coder-480b-free") {
+      this._contextLength = 64000;
+    } else if (options.model === "qwen-3-coder-480b") {
+      this._contextLength = 128000;
+    }
+  }
+
+  private filterThinkingTags(content: string): string {
+    // Remove <thinking>...</thinking> tags (including multiline)
+    return content.replace(/<thinking>[\s\S]*?<\/thinking>/gi, '').trim();
+  }
+
+  private filterThinkingFromMessages(messages: ChatMessage[]): ChatMessage[] {
+    return messages.map(message => {
+      if (typeof message.content === 'string') {
+        return {
+          ...message,
+          content: this.filterThinkingTags(message.content)
+        } as ChatMessage;
+      } else if (Array.isArray(message.content)) {
+        return {
+          ...message,
+          content: message.content.map(part => {
+            if (part.type === 'text' && typeof part.text === 'string') {
+              return {
+                ...part,
+                text: this.filterThinkingTags(part.text)
+              };
+            }
+            return part;
+          })
+        } as ChatMessage;
+      }
+      return message;
+    });
+  }
+
+  protected _convertArgs(
+    options: CompletionOptions,
+    messages: ChatMessage[],
+  ): ChatCompletionCreateParams {
+    // Filter thinking tags from messages before processing
+    const filteredMessages = this.filterThinkingFromMessages(messages);
+    return super._convertArgs(options, filteredMessages);
+  }
+
   private static modelConversion: { [key: string]: string } = {
-    "llama3.1-8b": "llama3.1-8b",
-    "llama3.1-70b": "llama3.1-70b",
-    "llama-4-scout-17b-16e-instruct": "llama-4-scout-17b-16e-instruct",
+    "qwen-3-coder-480b-free": "qwen-3-coder-480b", // Maps free version to base model
+    "qwen-3-coder-480b": "qwen-3-coder-480b",
+    "qwen-3-235b-a22b-instruct-2507": "qwen-3-235b-a22b-instruct-2507",
+    "llama-3.3-70b": "llama-3.3-70b",
+    "qwen-3-32b": "qwen-3-32b",
+    "qwen-3-235b-a22b-thinking-2507": "qwen-3-235b-a22b-thinking-2507",
   };
   protected _convertModelName(model: string): string {
     return Cerebras.modelConversion[model] ?? model;

--- a/core/llm/llms/Cerebras.ts
+++ b/core/llm/llms/Cerebras.ts
@@ -12,7 +12,7 @@ class Cerebras extends OpenAI {
 
   constructor(options: LLMOptions) {
     super(options);
-    
+
     // Set context length based on whether the model is the free version
     if (options.model === "qwen-3-coder-480b-free") {
       this._contextLength = 64000;
@@ -23,28 +23,28 @@ class Cerebras extends OpenAI {
 
   private filterThinkingTags(content: string): string {
     // Remove <thinking>...</thinking> tags (including multiline)
-    return content.replace(/<thinking>[\s\S]*?<\/thinking>/gi, '').trim();
+    return content.replace(/<thinking>[\s\S]*?<\/thinking>/gi, "").trim();
   }
 
   private filterThinkingFromMessages(messages: ChatMessage[]): ChatMessage[] {
-    return messages.map(message => {
-      if (typeof message.content === 'string') {
+    return messages.map((message) => {
+      if (typeof message.content === "string") {
         return {
           ...message,
-          content: this.filterThinkingTags(message.content)
+          content: this.filterThinkingTags(message.content),
         } as ChatMessage;
       } else if (Array.isArray(message.content)) {
         return {
           ...message,
-          content: message.content.map(part => {
-            if (part.type === 'text' && typeof part.text === 'string') {
+          content: message.content.map((part) => {
+            if (part.type === "text" && typeof part.text === "string") {
               return {
                 ...part,
-                text: this.filterThinkingTags(part.text)
+                text: this.filterThinkingTags(part.text),
               };
             }
             return part;
-          })
+          }),
         } as ChatMessage;
       }
       return message;


### PR DESCRIPTION
## Description

Added most recent Cerebras models, as well as distinction between allowed context lengths for Qwen coder paid/free plans. Also added helper function to strip thinking tags from Cerebras model inputs to avoid confusion.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Tests

Updated Cerebras provider tests to use Qwen 3 32B instead of llama 3.1 8B, which isn't included in Continue through Cerebras anymore.
