### PR TITLE
add alpha warning to cli docs

### DIFF
--- a/docs/guides/cli.mdx
+++ b/docs/guides/cli.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Continue CLI (cn)"
-icon: book-open
 ---
 
 <Warning>Continue CLI (cn) is currently in Alpha</Warning>


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added an alpha warning to the CLI documentation to let users know the feature is still in early development.

<!-- End of auto-generated description by cubic. -->

