### PR TITLE
fix: :lipstick: Fix the enter button foreground color

### DIFF
--- a/gui/src/components/ui/Button.tsx
+++ b/gui/src/components/ui/Button.tsx
@@ -11,7 +11,7 @@ type ButtonProps = React.ComponentProps<"button"> & {
 
 const buttonVariants = {
   primary:
-    "border-none text-foreground bg-primary hover:enabled:brightness-125",
+    "border-none text-primary-foreground bg-primary hover:enabled:brightness-125",
   secondary:
     "border-none text-foreground bg-border hover:enabled:brightness-125",
   outline:


### PR DESCRIPTION
## Description

Update the enter button so that it is white on blue in visual studio light modes, and dark modes to make it more readable.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Before:
<img width="728" height="119" alt="image" src="https://github.com/user-attachments/assets/a49ab7d2-baec-493c-82f8-049cfbf6e807" />

After:
<img width="728" height="119" alt="image" src="https://github.com/user-attachments/assets/afd7befd-1b47-4570-8405-b033b0ae6b08" />

After Dark:
<img width="728" height="119" alt="image" src="https://github.com/user-attachments/assets/1788b492-67b4-4b77-9e3b-7d7d2300fd19" />

## Tests

Tested by visual inspection.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the enter button text color to ensure it is readable on both light and dark backgrounds.

<!-- End of auto-generated description by cubic. -->

