### PR TITLE
feat: :sparkles: MCP Prompts now display when inserted

### DIFF
--- a/core/config/profile/doLoadConfig.ts
+++ b/core/config/profile/doLoadConfig.ts
@@ -18,6 +18,7 @@ import {
   SlashCommandDescWithSource,
   Tool,
 } from "../../";
+import { stringifyMcpPrompt } from "../../commands/slash/mcpSlashCommand";
 import { MCPManagerSingleton } from "../../context/mcp/MCPManagerSingleton";
 import CurrentFileContextProvider from "../../context/providers/CurrentFileContextProvider";
 import MCPContextProvider from "../../context/providers/MCPContextProvider";
@@ -216,15 +217,39 @@ export default async function doLoadConfig(options: {
       }));
       newConfig.tools.push(...serverTools);
 
+      // Fetch MCP prompt content during config load
       const serverSlashCommands: SlashCommandDescWithSource[] =
-        server.prompts.map((prompt) => ({
-          name: prompt.name,
-          description: prompt.description ?? "MCP Prompt",
-          source: "mcp-prompt",
-          isLegacy: false,
-          mcpServerName: server.name, // Used in client to retrieve prompt
-          mcpArgs: prompt.arguments,
-        }));
+        await Promise.all(
+          server.prompts.map(async (prompt) => {
+            let promptContent: string | undefined;
+
+            try {
+              // Fetch the actual prompt content from the MCP server
+              const mcpPromptResponse = await mcpManager.getPrompt(
+                server.name,
+                prompt.name,
+                {}, // Empty args for now - TODO: handle prompt arguments
+              );
+              promptContent = stringifyMcpPrompt(mcpPromptResponse);
+            } catch (error) {
+              console.warn(
+                `Failed to fetch MCP prompt content for ${prompt.name} from server ${server.name}:`,
+                error,
+              );
+              // Keep promptContent as undefined so the UI can show a fallback
+            }
+
+            return {
+              name: prompt.name,
+              description: prompt.description ?? "MCP Prompt",
+              source: "mcp-prompt",
+              isLegacy: false,
+              prompt: promptContent, // Store the actual prompt content
+              mcpServerName: server.name, // Used in client to retrieve prompt
+              mcpArgs: prompt.arguments,
+            };
+          }),
+        );
       newConfig.slashCommands.push(...serverSlashCommands);
 
       const submenuItems = server.resources

--- a/gui/src/redux/selectors/index.ts
+++ b/gui/src/redux/selectors/index.ts
@@ -10,11 +10,18 @@ export const selectSlashCommandComboBoxInputs = createSelector(
   (slashCommands) => {
     return (
       slashCommands?.map((cmd) => {
+        let content = cmd.prompt;
+
+        // For MCP prompts without content, show that it failed to load
+        if (cmd.source === "mcp-prompt" && !content) {
+          content = "[MCP Prompt - failed to load content during startup]";
+        }
+
         return {
           title: cmd.name,
           description: cmd.description,
           type: "slashCommand" as ComboBoxItemType,
-          content: cmd.prompt,
+          content: content,
         } as ComboBoxItem;
       }) || []
     );


### PR DESCRIPTION
## Description

Using /slash commands to insert MCP prompts now displays the prompt content consistent with other prompts like /init

MCP prompt content is loaded at config change at the same time we are loading the MCP prompt definition and are cached.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

<img width="728" height="258" alt="image" src="https://github.com/user-attachments/assets/a249107c-7c22-484a-b851-8035813ce291" />

## Tests

Manual verification performed.