### PR TITLE
fix: :green_heart: Remove clean on build

### DIFF
--- a/scripts/build-packages.js
+++ b/scripts/build-packages.js
@@ -86,7 +86,7 @@ async function main() {
     await buildPackagesInParallel(["fetch", "config-yaml", "llm-info"]);
 
     // Phase 3: Build packages that depend on other local packages
-    await buildPackagesInParallel(["openai-adapters", "continue-sdk"], true);
+    await buildPackagesInParallel(["openai-adapters", "continue-sdk"]);
 
     console.log("🎉 All packages built successfully!");
   } catch (error) {


### PR DESCRIPTION
## Description

Before

    // Phase 3: Build packages that depend on other local packages
    await buildPackagesInParallel(["openai-adapters", "continue-sdk"], true);

After

    // Phase 3: Build packages that depend on other local packages
    await buildPackagesInParallel(["openai-adapters", "continue-sdk"]);

I'm not clear why we would need to clear node_modules before building these two packages.

In the local debug build the other stages don't wait for this Continue Build to complete, and as such when the cleanup runs it can sometimes break downstream build steps when things are running in parallel.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
