### PR TITLE
fix: :ambulance: Tool descriptions are not being added for nativeTool enabled models

### DIFF
--- a/core/llm/defaultSystemMessages.ts
+++ b/core/llm/defaultSystemMessages.ts
@@ -60,8 +60,7 @@ ${EDIT_CODE_INSTRUCTIONS}
 export const DEFAULT_AGENT_SYSTEM_MESSAGE = `\
 <important_rules>
   You are in agent mode.
-
-  If you need to use multiple tools, you can call call multiple read only tools simultaneously.
+  Make parallel tool call unless the tool description specifically states it is not supported.
 
 ${CODEBLOCK_FORMATTING_INSTRUCTIONS}
 </important_rules>`;
@@ -72,6 +71,7 @@ export const DEFAULT_PLAN_SYSTEM_MESSAGE = `\
 <important_rules>
   You are in plan mode, in which you help the user understand and construct a plan.
   Only use read-only tools. Do not use any tools that would write to non-temporary files.
+  Make parallel tool call unless the tool description specifically states it is not supported.
   If the user wants to make changes, offer that they can switch to Agent mode to give you access to write tools to make the suggested updates.
 
 ${CODEBLOCK_FORMATTING_INSTRUCTIONS}

--- a/gui/src/redux/thunks/streamNormalInput.ts
+++ b/gui/src/redux/thunks/streamNormalInput.ts
@@ -156,12 +156,13 @@ export const streamNormalInput = createAsyncThunk<
         ...tool,
         function: {
           ...tool.function,
-          description: [tool.function.description, tool.systemMessageDescription]
-            .filter(Boolean)
-            .join('\n\n') || tool.function.description
-        }
+          description:
+            [tool.function.description, tool.systemMessageDescription]
+              .filter(Boolean)
+              .join("\n\n") || tool.function.description,
+        },
       }));
-      
+
       completionOptions = {
         tools: toolsWithEnhancedDescriptions,
       };


### PR DESCRIPTION
## Description

🚨  PR: #6723 is no longer added the full tool description when the model can use native tool calling. The tool description was refactored to have a description and a systemMessageDescription. For non native models, the tool descriptions are appended to the system message. For native tool calling models the description should include all the needed information. 

This change updates the tool description for native tool calling models by concating the tool description and the systemMessgeDescription. I've noted in testing this fixes the tool calling issues that have been introduced after #6723 was merged to main. 

I'd recommend merging this fix before releasing another pre-release. Also note this fix must be bundled with #6723 in any release to not cause a broken tool calling experience.

This should be viewed as a critical hotfix to the pre-release channel.

Note, I've also updated the parallel tool calling instruction to make it more forceful. I'm willing to put that into a separate PR if it might be risky. I've noted with this change I see parallel tool calls with claude sonnet 4.

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

I've not added any new tests. I've performed inspection of the options.tools values by debugging and the system messages when nativeTool use is enabled.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where tool descriptions were missing for models with nativeTool enabled, ensuring all relevant tool information is included.

- **Bug Fixes**
  - Combined function and system message descriptions for native tools so both are shown to the model.

<!-- End of auto-generated description by cubic. -->

