### PR TITLE
feat: relocate the codebase indexing tab

### DIFF
--- a/gui/src/components/mainInput/Lump/LumpToolbar/BlockSettingsTopToolbar.tsx
+++ b/gui/src/components/mainInput/Lump/LumpToolbar/BlockSettingsTopToolbar.tsx
@@ -2,6 +2,7 @@ import {
   BookOpenIcon,
   ChatBubbleLeftIcon,
   ChevronLeftIcon,
+  CircleStackIcon,
   CubeIcon,
   EllipsisHorizontalIcon,
   ExclamationTriangleIcon,
@@ -48,6 +49,12 @@ const sections: Section[] = [
   { id: "models", title: "Models", tooltip: "Models", icon: CubeIcon },
   { id: "rules", title: "Rules", tooltip: "Rules", icon: PencilIcon },
   { id: "docs", title: "Docs", tooltip: "Docs", icon: BookOpenIcon },
+  {
+    id: "codebase",
+    title: "Codebase",
+    tooltip: "Codebase",
+    icon: CircleStackIcon,
+  },
   {
     id: "prompts",
     title: "Prompts",

--- a/gui/src/components/mainInput/Lump/sections/CodebaseSection.tsx
+++ b/gui/src/components/mainInput/Lump/sections/CodebaseSection.tsx
@@ -1,0 +1,26 @@
+import IndexingProgress from "../../../../pages/config/IndexingProgress";
+import { useAppSelector } from "../../../../redux/hooks";
+
+export function CodebaseSection() {
+  const config = useAppSelector((state) => state.config.config);
+  return (
+    <div className="py-5">
+      <div>
+        <h3 className="mx-auto mb-1 mt-0 text-xl">@codebase index</h3>
+        <span className="text-lightgray w-3/4 text-xs">
+          Local embeddings of your codebase
+        </span>
+      </div>
+      {config.disableIndexing ? (
+        <div className="pb-2 pt-5">
+          <p className="py-1 text-center font-semibold">Indexing is disabled</p>
+          <p className="text-lightgray cursor-pointer text-center text-xs">
+            Open settings and toggle <code>Enable Indexing</code> to re-enable
+          </p>
+        </div>
+      ) : (
+        <IndexingProgress />
+      )}
+    </div>
+  );
+}

--- a/gui/src/components/mainInput/Lump/sections/SelectedSection.tsx
+++ b/gui/src/components/mainInput/Lump/sections/SelectedSection.tsx
@@ -1,4 +1,5 @@
 import { useLump } from "../LumpContext";
+import { CodebaseSection } from "./CodebaseSection";
 import { ContextSection } from "./ContextSection";
 import DocsSection from "./docs/DocsSection";
 import { ErrorSection } from "./errors/ErrorSection";
@@ -21,6 +22,8 @@ export function SelectedSection() {
       return <RulesSection />;
     case "docs":
       return <DocsSection />;
+    case "codebase":
+      return <CodebaseSection />;
     case "prompts":
       return <PromptsSection />;
     case "context":

--- a/gui/src/pages/config/CodebaseSettingsSection.tsx
+++ b/gui/src/pages/config/CodebaseSettingsSection.tsx
@@ -1,7 +1,7 @@
 import { useAppSelector } from "../../redux/hooks";
 import IndexingProgress from "./IndexingProgress";
 
-export function IndexingSettingsSection() {
+export function CodebaseSettingsSection() {
   const config = useAppSelector((state) => state.config.config);
   return (
     <div className="py-5">
@@ -15,7 +15,7 @@ export function IndexingSettingsSection() {
         <div className="pb-2 pt-5">
           <p className="py-1 text-center font-semibold">Indexing is disabled</p>
           <p className="text-lightgray cursor-pointer text-center text-xs">
-            Open settings and toggle <code>Disable Indexing</code> to re-enable
+            Open settings and toggle <code>Enable Indexing</code> to re-enable
           </p>
         </div>
       ) : (

--- a/gui/src/pages/config/index.tsx
+++ b/gui/src/pages/config/index.tsx
@@ -11,7 +11,6 @@ import { useNavigationListener } from "../../hooks/useNavigationListener";
 import { fontSize } from "../../util";
 import { AccountButton } from "./AccountButton";
 import { HelpCenterSection } from "./HelpCenterSection";
-import { IndexingSettingsSection } from "./IndexingSettingsSection";
 import KeyboardShortcuts from "./KeyboardShortcuts";
 import { UserSettingsForm } from "./UserSettingsForm";
 
@@ -33,12 +32,6 @@ function ConfigPage() {
       label: "Settings",
       component: <UserSettingsForm />,
       icon: <Cog6ToothIcon className="xs:h-4 xs:w-4 h-3 w-3 flex-shrink-0" />,
-    },
-    {
-      id: "indexing",
-      label: "Indexing",
-      component: <IndexingSettingsSection />,
-      icon: <CircleStackIcon className="xs:h-4 xs:w-4 h-3 w-3 flex-shrink-0" />,
     },
     {
       id: "help",


### PR DESCRIPTION
## Description

This moves the codebase indexing status from its current location underneath the Settings icon, to a new tab next to the Docs tab, inline with the others.

This improves the accessibility of the codebase index tab, making it easier to find and requiring only one click to reach. This also brings it in line with the docs indexing tab so that they are providing a more similar experience.

Additionally, this fixes the text on the disabled state to show "Enable Indexing", matching the text on the toggle in the Settings tab.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Settings view looks correct with Indexing tab removed:

<img width="362" height="771" alt="Screenshot_20250803_032116" src="https://github.com/user-attachments/assets/dc7af278-be07-4451-9592-7e8c9bb5e2ef" />

Codebase tab displays, and has a tooltip when hovered:

<img width="359" height="359" alt="Screenshot_20250803_032133" src="https://github.com/user-attachments/assets/8c52a5eb-ac14-4663-96f9-d8a0e24f75cc" />

When opened, the Codebase tab displays the same contents as the current Indexing tab:

<img width="356" height="477" alt="Screenshot_20250803_032145" src="https://github.com/user-attachments/assets/f7283380-d11a-4649-9fdd-4692eb9b416e" />

The disabled state also displays correctly and the text matches the settings toggle:

<img width="349" height="343" alt="Screenshot_20250803_032558" src="https://github.com/user-attachments/assets/1563c40b-103f-47c2-b846-73761ea07d9d" />


## Tests

All existing tests pass, and manual verification was done (see screenshots).

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Moved the codebase indexing status to a new tab next to the Docs tab for easier access and updated the disabled state text to say "Enable Indexing".

<!-- End of auto-generated description by cubic. -->

