### PR TITLE
Document existing autocompleteOptions in YAML configuration and add experimental options to schema

### DIFF
--- a/docs/customize/deep-dives/autocomplete.mdx
+++ b/docs/customize/deep-dives/autocomplete.mdx
@@ -84,7 +84,7 @@ Then, add the model to your configuration:
 
 Once the model has been downloaded, you should begin to see completions in VS Code.
 
-NOTE: Typically, thinking-type models are not recommended as they generate more slowly and are not suitable for scenarios that require speed. 
+NOTE: Typically, thinking-type models are not recommended as they generate more slowly and are not suitable for scenarios that require speed.
 
 However, if you use any thinking-switchable models, you can configure these models for autocomplete functions by turning off the thinking mode.
 
@@ -92,17 +92,10 @@ For example:
 
 <Tabs>
   <Tab title="YAML">
-  ```yaml title="config.yaml"
-  models:
-    - name: Qwen3 without Thinking for Autocomplete
-      provider: ollama
-      model: qwen3:4b   # qwen3 is a thinking-switchable model
-      roles:
-        - autocomplete
-      requestOptions:
-        extraBodyProperties:
-          think: false  # turning off the thinking
-  ```
+    ```yaml title="config.yaml" models: - name: Qwen3 without Thinking for
+    Autocomplete provider: ollama model: qwen3:4b # qwen3 is a
+    thinking-switchable model roles: - autocomplete requestOptions:
+    extraBodyProperties: think: false # turning off the thinking ```
   </Tab>
 </Tabs>
 
@@ -122,9 +115,32 @@ The following settings can be configured for autocompletion in the IDE extension
 - `Multiline Autocompletions`: Controls multiline completions for autocomplete. Can be set to `always`, `never`, or `auto`. Defaults to `auto`
 - `Disable autocomplete in files`: List of comma-separated glob pattern to disable autocomplete in matching files. E.g., "\_/.md, \*/.txt"
 
-### `config.json` Configuration
+### Autocomplete Configuration
 
-The `config.json` configuration format (deprecated) offers further configuration options through `tabAutocompleteOptions`. See the [JSON Reference](/reference) for more details.
+Autocomplete options can be configured in two ways:
+
+#### YAML Configuration (Recommended)
+
+In the YAML configuration format, autocomplete options can be specified per model under the `autocompleteOptions` property:
+
+```yaml
+models:
+  - name: Codestral
+    provider: mistral
+    model: codestral-latest
+    roles:
+      - autocomplete
+    autocompleteOptions:
+      debounceDelay: 500
+      maxPromptTokens: 1500
+      onlyMyCode: true
+```
+
+See the [YAML Reference](/reference#models) for all available options.
+
+#### JSON Configuration (Deprecated)
+
+The `config.json` configuration format offers configuration through `tabAutocompleteOptions`. See the [JSON Reference](/reference/json-reference#tabautocomplete-options) for more details.
 
 ## FAQs
 

--- a/docs/reference.mdx
+++ b/docs/reference.mdx
@@ -251,6 +251,10 @@ models:
     model: codestral-latest
     roles:
       - autocomplete
+    autocompleteOptions:
+      debounceDelay: 500
+      maxPromptTokens: 1500
+      onlyMyCode: true
   - name: My Model - OpenAI-Compatible
     provider: openai
     apiBase: http://my-endpoint/v1
@@ -425,6 +429,17 @@ Destinations to which [development data](/customize/overview#development-data) w
 - `apiKey`: api key to be sent with request (Bearer header)
 
 - `requestOptions`: Options for event POST requests. Same format as [model requestOptions](#models).
+
+- `autocompleteOptions`: If the model includes role `autocomplete`, these settings apply for tab autocompletion:
+
+  - `disable`: If `true`, disables tab autocomplete for this model (default: `false`).
+  - `maxPromptTokens`: Maximum number of tokens for the autocomplete prompt.
+  - `debounceDelay`: Delay (in ms) before triggering autocomplete.
+  - `modelTimeout`: Timeout (in ms) for autocomplete requests.
+  - `maxSuffixPercentage`: Maximum percentage of prompt allocated for suffix context.
+  - `prefixPercentage`: Percentage of input allocated for prefix context.
+  - `template`: Template string for autocomplete prompts, using Mustache templating. You can use the `{{{ prefix }}}`, `{{{ suffix }}}`, `{{{ filename }}}`, `{{{ reponame }}}`, and `{{{ language }}}` variables.
+  - `onlyMyCode`: If `true`, only includes code within the repository for context.
 
   **Example:**
 

--- a/docs/reference/json-reference.mdx
+++ b/docs/reference/json-reference.mdx
@@ -101,6 +101,8 @@ config.json
 
 Specifies options for tab autocompletion behavior.
 
+> **Note**: These options can also be configured in the YAML format under each model's `autocompleteOptions` property. See the [YAML Reference](/reference#models) for details.
+
 **Properties:**
 
 - `disable`: If `true`, disables tab autocomplete (default: `false`).
@@ -468,16 +470,19 @@ Several experimental config parameters are available, as described below:
 - `defaultContext`: Defines the default context for the LLM. Uses the same format as `contextProviders` but includes an additional `query` property to specify custom query parameters.=
 
 - `modelRoles`:
+
   - `inlineEdit`: Model title for inline edits.
   - `applyCodeBlock`: Model title for applying code blocks.
   - `repoMapFileSelection`: Model title for repo map selections.
 
 - `quickActions`: Array of custom quick actions
+
   - `title` (**required**): Display title for the quick action.
   - `prompt` (**required**): Prompt for quick action.
   - `sendToChat`: If `true`, sends result to chat; else inserts in document. Default is `false`.
 
 - `contextMenuPrompts`:
+
   - `comment`: Prompt for commenting code.
   - `docstring`: Prompt for adding docstrings.
   - `fix`: Prompt for fixing code.
@@ -529,15 +534,18 @@ Some deprecated `config.json` settings are no longer stored in config and have b
 - `disableSessionTitles`/`ui.getChatTitles`: This value will be migrated to the safest merged value (`true` if either are `true`). `getChatTitles` takes precedence if set to false
 
 - `tabAutocompleteOptions`
+
   - `useCache`: This value will override during migration.
   - `disableInFiles`: This value will be migrated to the safest merged value (arrays of file matches merged/deduplicated)
   - `multilineCompletions`: This value will override during migration.
 
 - `experimental`
+
   - `useChromiumForDocsCrawling`: This value will override during migration.
   - `readResponseTTS`: This value will override during migration.
 
 - `ui` - all will override during migration
+
   - `codeBlockToolbarPosition`
   - `fontSize`
   - `codeWrap`

--- a/packages/config-types/src/index.ts
+++ b/packages/config-types/src/index.ts
@@ -151,6 +151,12 @@ export const tabAutocompleteOptionsSchema = z.object({
   useRecentlyEdited: z.boolean(),
   disableInFiles: z.array(z.string()).optional(),
   useImports: z.boolean().optional(),
+  // true = enabled, false = disabled, number = enabled with priority
+  experimental_includeClipboard: z.union([z.boolean(), z.number()]),
+  experimental_includeRecentlyVisitedRanges: z.union([z.boolean(), z.number()]),
+  experimental_includeRecentlyEditedRanges: z.union([z.boolean(), z.number()]),
+  experimental_includeDiff: z.union([z.boolean(), z.number()]),
+  experimental_enableStaticContextualization: z.boolean(),
 });
 export type TabAutocompleteOptions = z.infer<
   typeof tabAutocompleteOptionsSchema

--- a/packages/config-yaml/src/schemas/models.ts
+++ b/packages/config-yaml/src/schemas/models.ts
@@ -118,7 +118,18 @@ export const autocompleteOptionsSchema = z.object({
   maxSuffixPercentage: z.number().optional(),
   prefixPercentage: z.number().optional(),
   template: z.string().optional(),
+  useCache: z.boolean().optional(),
   onlyMyCode: z.boolean().optional(),
+  useRecentlyEdited: z.boolean().optional(),
+  useRecentlyOpened: z.boolean().optional(),
+  disableInFiles: z.array(z.string()).optional(),
+  useImports: z.boolean().optional(),
+  // true = enabled, false = disabled, number = enabled with priority
+  experimental_includeClipboard: z.union([z.boolean(), z.number()]).optional(),
+  experimental_includeRecentlyVisitedRanges: z.union([z.boolean(), z.number()]).optional(),
+  experimental_includeRecentlyEditedRanges: z.union([z.boolean(), z.number()]).optional(),
+  experimental_includeDiff: z.union([z.boolean(), z.number()]).optional(),
+  experimental_enableStaticContextualization: z.boolean().optional(),
 });
 
 /** Prompt templates use Handlebars syntax */


### PR DESCRIPTION
## Description

This PR adds comprehensive documentation for the existing `autocompleteOptions` configuration in YAML format and extends the YAML schema to include experimental autocomplete options.

### Main Changes:

1. **Documentation Updates**:
   - Added detailed documentation for `autocompleteOptions` in YAML configuration format
   - Updated the autocomplete deep-dive guide to recommend YAML configuration over the deprecated JSON format
   - Added examples showing how to configure autocomplete options per model in YAML
   - Updated reference documentation with complete list of available autocomplete options

2. **Schema Enhancements**:
   - Extended the YAML schema to include all existing autocomplete options that were previously only available in JSON
   - Added experimental autocomplete options to both config-types and YAML schemas:
     - `experimental_includeClipboard`
     - `experimental_includeRecentlyVisitedRanges`
     - `experimental_includeRecentlyEditedRanges`
     - `experimental_includeDiff`
     - `experimental_enableStaticContextualization`

The changes make autocomplete configuration more accessible and consistent across configuration formats, while maintaining backward compatibility with the existing JSON configuration.

Related issue:
https://github.com/continuedev/continue/issues/6853

## Checklist
- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created

## Screen recording or screenshot
[ Documentation changes - no UI changes to demonstrate ]

## Tests
[ Schema validation tests should automatically cover the new YAML schema options. No additional functional tests needed as this primarily adds documentation and schema definitions for existing functionality. ]
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Documented all existing autocompleteOptions for YAML configuration and updated the schema to support experimental autocomplete options, making configuration clearer and more consistent.

- **Documentation**
  - Added YAML examples and a full list of autocomplete options to the docs.
  - Updated guides to recommend YAML over the deprecated JSON format.

- **Schema**
  - Extended the YAML schema to include all current and experimental autocomplete options.

<!-- End of auto-generated description by cubic. -->

