### PR TITLE
Update mcp.mdx

### DIFF
--- a/docs/customize/deep-dives/mcp.mdx
+++ b/docs/customize/deep-dives/mcp.mdx
@@ -104,17 +104,17 @@ server block to your [config file](./configuration.md):
 
 MCP blocks follow the established syntax for blocks, with a few additional properties specific to MCP servers.
 
-- `name` (**required**): A display name for the MCP server.
-- `command` (**required**): The command to run to start the MCP server.
-- `type` (optional): The type of the MCP server: `sse`, `stdio`, `streamable-http`
-- `args` (optional): Arguments to pass to the command.
-- `env` (optional): Secrets to be injected into the command as environment variables.
+- `name`: A display name for the MCP server.
+- `type`: The type of the MCP server: `sse`, `stdio`, `streamable-http`
+- `command`: The command to run to start the MCP server.
+- `args`: Arguments to pass to the command.
+- `env`: Secrets to be injected into the command as environment variables.
 
 ### Transport Types
 
 MCP now supports remote server connections through HTTP-based transports, expanding beyond the traditional local stdio transport method. This enables integration with cloud-hosted MCP servers and distributed architectures.
 
-#### Server-Sent Events (SSE) Transport
+#### Server-Sent Events Transport (`sse`)
 
 For real-time streaming communication, use the SSE transport:
 
@@ -125,7 +125,7 @@ mcpServers:
     url: https://....
 ```
 
-#### Standard Input/Output (stdio)
+#### Standard Input/Output (`stdio`)
 
 For local MCP servers that communicate via standard input and output:
 
@@ -139,7 +139,7 @@ mcpServers:
       - "/path/to/your/database.db"
 ```
 
-#### Streamable HTTP Transport
+#### Streamable HTTP Transport (`streamable-http`)
 
 For standard HTTP-based communication with streaming capabilities:
 


### PR DESCRIPTION
Decided to remove the required/optional args text for MCP because each transport has different required args. Eg we had `command` as required, but that is only true for `type: stdio`