### PR TITLE
docs: Add apiBase to remote instance config and standardize LM Studio page content

### DIFF
--- a/docs/customize/model-providers/more/lmstudio.mdx
+++ b/docs/customize/model-providers/more/lmstudio.mdx
@@ -4,13 +4,17 @@ title: "LM Studio"
 
 [LM Studio](https://lmstudio.ai) is an application for Mac, Windows, and Linux that makes it easy to locally run open-source models and comes with a great UI. To get started with LM Studio, download from the website, use the UI to download a model, and then start the local inference server. Continue can then be configured to use the `LMStudio` LLM class:
 
+## Chat model
+
+We recommend configuring **Llama3.1 8B** as your chat model.
+
 <Tabs>
   <Tab title="YAML">
   ```yaml title="config.yaml"
   models:
-    - name: LM Studio
+    - name: Llama3.1 8B Instruct
       provider: lmstudio
-      model: llama2-7b
+      model: meta-llama-3.1-8b-instruct
   ```
   </Tab>
   <Tab title="JSON">
@@ -18,9 +22,9 @@ title: "LM Studio"
   {
     "models": [
       {
-        "title": "LM Studio",
+        "title": "Llama3.1 8B Instruct",
         "provider": "lmstudio",
-        "model": "llama2-7b"
+        "model": "meta-llama-3.1-8b-instruct"
       }
     ]
   }
@@ -28,7 +32,7 @@ title: "LM Studio"
   </Tab>
 </Tabs>
 
-### Embeddings model
+## Embeddings model
 
 LMStudio supports embeddings endpoints, and comes with the `nomic-ai/nomic-embed-text-v1.5-GGUF` model (as of Nov 2024, check your models)
 
@@ -71,16 +75,16 @@ To configure a remote instance of LM Studio, add the `"apiBase"` property to you
   </Tab>
   <Tab title="JSON">
   ```json title="config.json"
-  {
+    {
       "models": [
         {
           "title": "Llama3.1 8B Instruct",
-      "provider": "lmstudio",
+          "provider": "lmstudio",
           "model": "meta-llama-3.1-8b-instruct",
           "apiBase": "http://<MY ENDPOINT>/v1"
-    }
+        }
       ]
-  }
+    }
   ```
   </Tab>
 </Tabs>

--- a/docs/customize/model-providers/more/lmstudio.mdx
+++ b/docs/customize/model-providers/more/lmstudio.mdx
@@ -63,20 +63,23 @@ To configure a remote instance of LM Studio, add the `"apiBase"` property to you
   <Tab title="YAML">
   ```yaml title="config.yaml"
   models:
-    - name: Nomic Embed Text
+    - name: Llama3.1 8B Instruct
       provider: lmstudio
-      model: nomic-ai/nomic-embed-text-v1.5-GGUF
-      roles:
-        - embed
+      model: meta-llama-3.1-8b-instruct
+      apiBase: http://<MY ENDPOINT>/v1
   ```
   </Tab>
   <Tab title="JSON">
   ```json title="config.json"
   {
-    "embeddingsProvider": {
+      "models": [
+        {
+          "title": "Llama3.1 8B Instruct",
       "provider": "lmstudio",
-      "model": "nomic-ai/nomic-embed-text-v1.5-GGUF"
+          "model": "meta-llama-3.1-8b-instruct",
+          "apiBase": "http://<MY ENDPOINT>/v1"
     }
+      ]
   }
   ```
   </Tab>


### PR DESCRIPTION
## Description

- Fixed Remote instance configuration in LM Studio documentation page
- Standardized content to follow same idea as Ollama documentation page

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Before:
<img width="988" height="660" alt="image" src="https://github.com/user-attachments/assets/b416c189-6fa9-4aee-aa3c-f5eaff27bd66" />

After:
<img width="972" height="637" alt="image" src="https://github.com/user-attachments/assets/e806fad0-a2ad-4c95-bf24-6673b64317b7" />

## Tests

No tests required.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the LM Studio documentation to add the apiBase option for remote instance configuration and to match the structure and style of the Ollama docs.

- **Docs Updates**
  - Added apiBase example for remote LM Studio setup.
  - Standardized model config examples and page layout.

<!-- End of auto-generated description by cubic. -->

