### PR TITLE
chore: remove submit message listener

### DIFF
--- a/core/protocol/ideWebview.ts
+++ b/core/protocol/ideWebview.ts
@@ -52,7 +52,6 @@ export type ToIdeFromWebviewProtocol = ToIdeFromWebviewOrCoreProtocol & {
 
 export type ToWebviewFromIdeProtocol = ToWebviewFromIdeOrCoreProtocol & {
   setInactive: [undefined, void];
-  submitMessage: [{ message: any }, void]; // any -> JSONContent from TipTap
   newSessionWithPrompt: [{ prompt: string }, void];
   userInput: [{ input: string }, void];
   focusContinueInput: [undefined, void];

--- a/gui/src/hooks/ParallelListeners.tsx
+++ b/gui/src/hooks/ParallelListeners.tsx
@@ -30,7 +30,6 @@ import { streamResponseAfterToolCall } from "../redux/thunks/streamResponseAfter
 import { store } from "../redux/store";
 import { cancelStream } from "../redux/thunks/cancelStream";
 import { refreshSessionMetadata } from "../redux/thunks/session";
-import { streamResponseThunk } from "../redux/thunks/streamResponse";
 import { updateFileSymbolsFromHistory } from "../redux/thunks/updateFileSymbols";
 import { findToolCallById, logToolUsage } from "../redux/util";
 import {
@@ -218,16 +217,6 @@ function ParallelListeners() {
 
   useWebviewListener("setTTSActive", async (status) => {
     dispatch(setTTSActive(status));
-  });
-
-  // TODO - remove?
-  useWebviewListener("submitMessage", async (data) => {
-    void dispatch(
-      streamResponseThunk({
-        editorState: data.message,
-        modifiers: { useCodebase: false, noContext: true },
-      }),
-    );
   });
 
   useWebviewListener("addContextItem", async (data) => {


### PR DESCRIPTION
## Description

Remove the `submitMessage` listener since it was unused.

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the unused submitMessage listener and related type definition to clean up the codebase.

<!-- End of auto-generated description by cubic. -->

