### PR TITLE
feat: edit file lint hook for claude

### DIFF
--- a/.claude/lint-check.sh
+++ b/.claude/lint-check.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Get file path from hook input
+FILE_PATH=$(cat | jq -r '.tool_input.file_path // .tool_input.edits[].file_path // empty' | head -n1)
+
+# Function to run lint and typecheck
+run_checks() {
+    local dir=$1
+    cd "$dir"
+    npm run lint >&2 && npm run tsc:check >&2
+}
+
+# Run checks based on file location
+if [[ "$FILE_PATH" == *"/core/"* ]]; then
+    run_checks core
+elif [[ "$FILE_PATH" == *"/gui/"* ]]; then
+    run_checks gui  
+elif [[ "$FILE_PATH" == *"/extensions/vscode/"* ]]; then
+    run_checks extensions/vscode
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/lint-check.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Sample output

```bash
> add a typescript error to @gui/src/App.tsx
  ⎿  Read gui/src/App.tsx (67 lines)

⏺ I'll add a TypeScript error to the App.tsx file. Here's a simple way
   to introduce a type error:

⏺ Update(gui/src/App.tsx)
  ⎿  Updated gui/src/App.tsx with 1 addition                         
       51      most of which interact with redux etc.
       52    */
       53    function App() {
       54 +    const invalidType: string = 123; // TypeScript error: 
          + Type 'number' is not assignable to type 'string'
       55      return (
       56        <VscThemeProvider>
       57          <MainEditorProvider>

> Edit operation feedback:
  - [$CLAUDE_PROJECT_DIR/.claude/lint-check.sh]: 
  > lint
  > eslint --ext ts


  > tsc:check
  > tsc -p ./ --noEmit

  src/App.tsx(54,9): error TS2322: Type 'number' is not assignable to 
  type 'string'.
  ⎿  Found 2 new diagnostic issues in 1 file (ctrl-r to expand)

⏺ Perfect! I've successfully added a TypeScript error to the App.tsx
  file. The error is on line 54 where I assigned a number value (123)
  to a variable declared as string type, which TypeScript correctly
  flags as:

  Type 'number' is not assignable to type 'string'

  The lint check confirms the TypeScript error is present and detected
   by the compiler.
```
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a post-edit hook that runs lint and type checks on edited files in core, gui, or extensions/vscode directories.

- **New Features**
  - Added a shell script to run lint and type checks based on the edited file's location.
  - Configured settings to trigger the script after file write or edit actions.

<!-- End of auto-generated description by cubic. -->

