### PR TITLE
fix: don't fail tests for conventional commit check

### DIFF
--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -40,7 +40,7 @@ jobs:
           fi
 
       - name: Add PR title guidance comment
-        if: steps.pr-title-check.outputs.valid == 'false'
+        if: always() && steps.pr-title-check.outputs.valid == 'false'
         uses: actions/github-script@v7
         with:
           script: |
@@ -88,6 +88,9 @@ jobs:
                 ].join('\n')
               });
             }
+      - name: Ensure job always succeeds
+        if: always()
+        run: echo "✅ Conventional commits check completed (warning only)"
 
   security-audit:
     name: Security Audit


### PR DESCRIPTION
Remake of https://github.com/continuedev/continue/pull/6828, was having merge/test issues
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the compliance workflow so that failing the conventional commit check no longer fails the entire job. The check now only adds a warning comment if the PR title is invalid.

<!-- End of auto-generated description by cubic. -->

