### PR TITLE
fix: skip analytics capture calls if workspaceId is undefined

### DIFF
--- a/core/config/profile/doLoadConfig.ts
+++ b/core/config/profile/doLoadConfig.ts
@@ -358,6 +358,9 @@ export default async function doLoadConfig(options: {
   };
 
   if (newConfig.analytics) {
+    // FIXME before re-enabling TeamAnalytics.setup() populate workspaceId in
+    //   controlPlaneProxyInfo to prevent /proxy/analytics/undefined/capture calls
+    //   where undefined is :workspaceId
     // await TeamAnalytics.setup(
     //   newConfig.analytics,
     //   uniqueId,

--- a/core/control-plane/analytics/ContinueProxyAnalyticsProvider.ts
+++ b/core/control-plane/analytics/ContinueProxyAnalyticsProvider.ts
@@ -20,8 +20,12 @@ export default class ContinueProxyAnalyticsProvider
     event: string,
     properties: { [key: string]: any },
   ): Promise<void> {
+    if (!this.controlPlaneProxyInfo?.workspaceId) {
+      return;
+    }
+
     const url = new URL(
-      `proxy/analytics/${this.controlPlaneProxyInfo?.workspaceId}/capture`,
+      `proxy/analytics/${this.controlPlaneProxyInfo.workspaceId}/capture`,
       this.controlPlaneProxyInfo?.controlPlaneProxyUrl,
     ).toString();
     void fetch(url, {


### PR DESCRIPTION
While `TeamAnalytics.setup()` is still commented out let's return early if workspaceId is undefined 