### PR TITLE
docs: s/assistant/agent/g in /docs

### DIFF
--- a/docs/customization/models.mdx
+++ b/docs/customization/models.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Model Blocks"
-description: "These blocks form the foundation of the entire assistant experience, offering different specialized capabilities:"
+description: "These blocks form the foundation of the entire agent experience, offering different specialized capabilities:"
 ---
 
 - **[Chat](/customize/model-roles/chat)**: Power conversational interactions about code and provide detailed guidance

--- a/docs/customization/overview.mdx
+++ b/docs/customization/overview.mdx
@@ -9,13 +9,13 @@ description: "Continue can be deeply customized. For example you might:"
 - **Create a Slash Command**. Slash commands allow you to easily add custom functionality to Continue. You can use a slash command that allows you to generate a shell command from natural language, or perhaps generate a commit message, or create your own custom command to do whatever you want. Learn more about [slash commands](/customize/deep-dives/slash-commands).
 - **Call external tools and functions**. Unchain your LLM with the power of tools using [Agent](/features/agent/quick-start). Add custom tools using [MCP Servers](/customization/mcp-tools)
 
-Whatever you choose, you'll probably start by editing your Assistant.
+Whatever you choose, you'll probably start by editing your Agent.
 
-## Editing your assistant
+## Editing your agent
 
-You can easily access your assistant configuration from the Continue Chat sidebar. Open the sidebar by pressing `cmd/ctrl` + `L` (VS Code) or `cmd/ctrl` + `J` (JetBrains) and click the Assistant selector above the main chat input. Then, you can hover over an assistant and click the `new window` (hub assistants) or `gear` (local assistants) icon.
+You can easily access your agent configuration from the Continue Chat sidebar. Open the sidebar by pressing `cmd/ctrl` + `L` (VS Code) or `cmd/ctrl` + `J` (JetBrains) and click the Agent selector above the main chat input. Then, you can hover over an agent and click the `new window` (hub agents) or `gear` (local assistants) icon.
 
-![configure an assistant](/images/customization/images/configure-continue-a5c8c79f3304c08353f3fc727aa5da7e.png)
+![configure an agent](/images/customization/images/configure-continue-a5c8c79f3304c08353f3fc727aa5da7e.png)
 
-- See [Editing Hub Assistants](/hub/assistants/edit-an-assistant) for more details on managing your hub assistant
+- See [Editing Hub Agents](/hub/assistants/edit-an-agent) for more details on managing your hub agent
 - See the [Config Deep Dive](/reference) for more details on configuring local assistants.

--- a/docs/customization/prompts.mdx
+++ b/docs/customization/prompts.mdx
@@ -6,7 +6,7 @@ description: "These are the specialized instructions that shape how models respo
 - **Define interaction patterns** for specific tasks or frameworks
 - **Encode domain expertise** for particular technologies
 - **Ensure consistent guidance** aligned with organizational practices
-- **Can be shared and reused** across multiple assistants
+- **Can be shared and reused** across multiple agents
 - **Act as automated code reviewers** that ensure consistency across teams
 
 ![Prompt Blocks Overview](/images/customization/images/prompts-blocks-overview-17194d870840576f9a0dde548f2c70ec.png)

--- a/docs/customization/rules.mdx
+++ b/docs/customization/rules.mdx
@@ -1,18 +1,18 @@
 ---
 title: "Rules Blocks"
-description: "Rules allow you to provide specific instructions that guide how the AI assistant behaves when working with your code. Instead of the AI making assumptions about your coding standards, architecture patterns, or project-specific requirements, you can explicitly define guidelines that ensure consistent, contextually appropriate responses."
+description: "Rules allow you to provide specific instructions that guide how the AI agent behaves when working with your code. Instead of the AI making assumptions about your coding standards, architecture patterns, or project-specific requirements, you can explicitly define guidelines that ensure consistent, contextually appropriate responses."
 ---
 
-Think of these as the guardrails for your AI coding assistants:
+Think of these as the guardrails for your AI coding agents:
 
 - **Enforce company-specific coding standards** and security practices
 - **Implement quality checks** that match your engineering culture
 - **Create paved paths** for developers to follow organizational best practices
 
-By implementing rules, you transform the AI from a generic coding assistant into a knowledgeable team member that understands your project's unique requirements and constraints.
+By implementing rules, you transform the AI from a generic coding agent into a knowledgeable team member that understands your project's unique requirements and constraints.
 
 ### How Rules Work
 
-Your assistant detects rule blocks and applies the specified rules while in [Agent](/features/agent/quick-start), [Chat](/features/chat/quick-start), and [Edit](/features/edit/quick-start) modes.
+Your agent detects rule blocks and applies the specified rules while in [Agent](/features/agent/quick-start), [Chat](/features/chat/quick-start), and [Edit](/features/edit/quick-start) modes.
 
 Learn more in the [rules deep dive](/customize/deep-dives/rules), and view [`rules`](/reference#rules) in the YAML Reference for more details.

--- a/docs/customize/context/documentation.mdx
+++ b/docs/customize/context/documentation.mdx
@@ -54,7 +54,7 @@ The `@Docs` context provider works by
 
 ### Hub `docs` Blocks
 
-@Docs uses [`docs` blocks](../../hub/blocks/block-types#docs) in Assistants from the hub. Visit the hub to [explore `docs` blocks](https://hub.continue.dev/explore/docs) or [create your own](https://hub.continue.dev/new?type=block&blockType=docs).
+@Docs uses [`docs` blocks](../../hub/blocks/block-types#docs) in Agents from the hub. Visit the hub to [explore `docs` blocks](https://hub.continue.dev/explore/docs) or [create your own](https://hub.continue.dev/new?type=block&blockType=docs).
 
 ### Through the `@Docs` Context Provider
 

--- a/docs/customize/custom-providers.mdx
+++ b/docs/customize/custom-providers.mdx
@@ -9,7 +9,7 @@ As an example, say you are working on solving a new GitHub Issue. You type '@Iss
 
 ## Context blocks
 
-You can add context providers to assistants using [`context` blocks](/hub/blocks/block-types#context). Explore available context blocks in [the hub](https://hub.continue.dev/explore/context).
+You can add context providers to agents using [`context` blocks](/hub/blocks/block-types#context). Explore available context blocks in [the hub](https://hub.continue.dev/explore/context).
 
 ## Built-in Context Providers
 

--- a/docs/customize/deep-dives/configuration.mdx
+++ b/docs/customize/deep-dives/configuration.mdx
@@ -1,16 +1,16 @@
 ---
 title: "Configuration"
-description: Learn how to access and manage Continue assistant configurations through Hub or local YAML files
+description: Learn how to access and manage Continue agent configurations through Hub or local YAML files
 keywords: [config, settings, customize]
 ---
 
-You can easily access your assistant configuration from the Continue Chat sidebar. Open the sidebar by pressing <kbd>cmd/ctrl</kbd> + <kbd>L</kbd> (VS Code) or <kbd>cmd/ctrl</kbd> + <kbd>J</kbd> (JetBrains) and click the Assistant selector above the main chat input. Then, you can hover over an assistant and click the `new window` (hub assistants) or `gear` (local assistants) icon.
+You can easily access your agent configuration from the Continue Chat sidebar. Open the sidebar by pressing <kbd>cmd/ctrl</kbd> + <kbd>L</kbd> (VS Code) or <kbd>cmd/ctrl</kbd> + <kbd>J</kbd> (JetBrains) and click the Agent selector above the main chat input. Then, you can hover over an agent and click the `new window` (hub agents) or `gear` (local assistants) icon.
 
-![configure an assistant](/images/configure-continue.png)
+![configure an agent](/images/configure-continue.png)
 
-## Hub Assistants
+## Hub Agents
 
-Hub Assistants can be managed in [the Hub](https://hub.continue.dev). See [Editing an Assistant](../../hub/assistants/edit-an-assistant.md)
+Hub Agents can be managed in [the Hub](https://hub.continue.dev). See [Editing an Agent](../../hub/assistants/edit-an-agent.md)
 
 ## YAML Config
 
@@ -19,7 +19,7 @@ Local user-level configuration is stored and can be edited in your home director
 - `~/.continue/config.yaml` (MacOS / Linux)
 - `%USERPROFILE%\.continue\config.yaml` (Windows)
 
-To open this `config.yaml`, you need to open the assistants dropdown in the top-right portion of the chat input. On that dropdown beside the "Local Assistant" option, select the cog icon. It will open the local `config.yaml`.
+To open this `config.yaml`, you need to open the agents dropdown in the top-right portion of the chat input. On that dropdown beside the "Local Assistant" option, select the cog icon. It will open the local `config.yaml`.
 
 ![local-config-open-steps](/images/local-config-open-steps.png)
 

--- a/docs/customize/deep-dives/development-data.mdx
+++ b/docs/customize/deep-dives/development-data.mdx
@@ -12,7 +12,7 @@ You can read more about how development data is generated as a byproduct of LLM-
 
 You can also configure custom destinations for your data, including remote HTTP endpoints and local file directories.
 
-For hub assistants, data destinations are configured in `data` blocks. Visit the hub to [explore example data blocks](https://hub.continue.dev/explore/data) or [create your own](https://hub.continue.dev/new?type=block&blockType=data).
+For hub agents, data destinations are configured in `data` blocks. Visit the hub to [explore example data blocks](https://hub.continue.dev/explore/data) or [create your own](https://hub.continue.dev/new?type=block&blockType=data).
 
 See more details about adding `data` blocks to your configuration files in the [YAML specification](/reference#data)
 

--- a/docs/customize/deep-dives/mcp.mdx
+++ b/docs/customize/deep-dives/mcp.mdx
@@ -18,7 +18,7 @@ that can be set up with custom tools.
 Currently custom tools can be configured using the Model Context
 Protocol standard to unify prompts, context, and tool use.
 
-MCP Servers can be added to hub Assistants using `mcpServers` blocks. You can
+MCP Servers can be added to hub Agents using `mcpServers` blocks. You can
 explore available MCP server blocks
 [here](https://hub.continue.dev/explore/mcp).
 
@@ -26,7 +26,7 @@ explore available MCP server blocks
 
 ## Quick Start
 
-Below is a quick example of setting up a new MCP server for use in your assistant:
+Below is a quick example of setting up a new MCP server for use in your agent:
 
 1. Create a folder called `.continue/mcpServers` at the top level of your workspace
 2. Add a file called `playwright-mcp.yaml` to this folder.

--- a/docs/customize/deep-dives/rules.mdx
+++ b/docs/customize/deep-dives/rules.mdx
@@ -52,7 +52,7 @@ For example, you can say "Create a rule for this", and a rule will be created fo
 
 </Info>
 
-Rules can also be added to an Assistant on the Continue Hub.
+Rules can also be added to an Agent on the Continue Hub.
 
 Explore available rules [here](https://hub.continue.dev), or [create your own](https://hub.continue.dev/new?type=block&blockType=rules) in the Hub.
 

--- a/docs/customize/deep-dives/slash-commands.mdx
+++ b/docs/customize/deep-dives/slash-commands.mdx
@@ -13,9 +13,9 @@ Slash commands can be combined with additional instructions, including [context 
 
 ## Prompts
 
-### Assistant prompt blocks
+### Agent prompt blocks
 
-The easiest way to add a slash command is by adding [`prompt` blocks](../../hub/blocks/block-types#prompts) to your assistant, which show up as slash commands in [Chat](../../features/chat/how-it-works.mdx).
+The easiest way to add a slash command is by adding [`prompt` blocks](../../hub/blocks/block-types#prompts) to your agent, which show up as slash commands in [Chat](../../features/chat/how-it-works.mdx).
 
 ### Prompt files
 

--- a/docs/customize/model-roles/00-intro.mdx
+++ b/docs/customize/model-roles/00-intro.mdx
@@ -19,7 +19,7 @@ These roles can be specified for a `config.yaml` model block using `roles`. See 
 
 ## Selecting model roles
 
-You can control which of the models in your assistant for a given role will be currently used for that role. Above the main input, click the 3 dots and then the cube icon to expand the `Models` section. Then you can use the dropdowns to select an active model for each role.
+You can control which of the models in your agent for a given role will be currently used for that role. Above the main input, click the 3 dots and then the cube icon to expand the `Models` section. Then you can use the dropdowns to select an active model for each role.
 
 ![Settings Active Models Section](/images/settings-model-roles.png)
 

--- a/docs/customize/model-roles/intro.mdx
+++ b/docs/customize/model-roles/intro.mdx
@@ -16,7 +16,7 @@ These roles can be specified for a `config.yaml` model block using `roles`. See 
 
 ## Selecting model roles
 
-You can control which of the models in your assistant for a given role will be currently used for that role. Above the main input, click the 3 dots and then the cube icon to expand the `Models` section. Then you can use the dropdowns to select an active model for each role.
+You can control which of the models in your agent for a given role will be currently used for that role. Above the main input, click the 3 dots and then the cube icon to expand the `Models` section. Then you can use the dropdowns to select an active model for each role.
 
 <Frame>
   <img src="/images/settings-model-roles-5e5f8a6bd9137b70cf94178a7e45847c.png" />

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -191,13 +191,13 @@
             "pages": [
               "hub/introduction",
               {
-                "group": "Assistants",
+                "group": "Agents",
                 "icon": "robot",
                 "pages": [
-                  "hub/assistants/intro",
-                  "hub/assistants/use-an-assistant",
-                  "hub/assistants/create-an-assistant",
-                  "hub/assistants/edit-an-assistant"
+                  "hub/agents/intro",
+                  "hub/agents/use-an-agent",
+                  "hub/agents/create-an-agent",
+                  "hub/agents/edit-an-agent"
                 ]
               },
               {
@@ -241,7 +241,7 @@
             "group": "Guides",
             "pages": [
               "guides/overview",
-              "guides/understanding-assistants",
+              "guides/understanding-agents",
               "guides/cli",
               "guides/plan-mode-guide",
               "guides/ollama-guide",
@@ -351,7 +351,7 @@
       "destination": "/hub/secrets/secret-types"
     },
     {
-      "source": "/hub/assistants",
+      "source": "/hub/agents",
       "destination": "/hub/assistants/intro"
     },
     {

--- a/docs/features/agent/how-to-customize.mdx
+++ b/docs/features/agent/how-to-customize.mdx
@@ -1,6 +1,6 @@
 ## Add Rules Blocks
 
-Adding Rules can be done in your assistant locally or in the Hub. You can explore Rules on the Continue Hub and refer to the [Rules deep dive](/customize/deep-dives/rules) for more details.
+Adding Rules can be done in your agent locally or in the Hub. You can explore Rules on the Continue Hub and refer to the [Rules deep dive](/customize/deep-dives/rules) for more details.
 
 ## Customize System Messages
 
@@ -12,14 +12,14 @@ models:
     provider: openai
     model: gpt-4o
     chatOptions:
-      baseSystemMessage: "You are a helpful coding assistant."
-      baseAgentSystemMessage: "You are a systematic coding assistant. Break down problems methodically."
-      basePlanSystemMessage: "You are a planning assistant. Create clear, actionable steps."
+      baseSystemMessage: "You are a helpful coding agent."
+      baseAgentSystemMessage: "You are a systematic coding agent. Break down problems methodically."
+      basePlanSystemMessage: "You are a planning agent. Create clear, actionable steps."
 ```
 
 ## Add MCP Tools
 
-You can add MCP servers to your assistant to give Agent access to more tools. Explore [MCP Servers on the Hub](https://hub.continue.dev) and consult the [MCP guide](/customize/deep-dives/mcp) for more details.
+You can add MCP servers to your agent to give Agent access to more tools. Explore [MCP Servers on the Hub](https://hub.continue.dev) and consult the [MCP guide](/customize/deep-dives/mcp) for more details.
 
 ## Tool Policies
 

--- a/docs/features/autocomplete/model-setup.mdx
+++ b/docs/features/autocomplete/model-setup.mdx
@@ -11,9 +11,9 @@ This model is specifically designed for code completion and offers excellent per
 **Codestral Quick Setup:**
 
 1. Get your API key from [Mistral AI](https://console.mistral.ai)
-2. Add [Codestral](https://hub.continue.dev/mistral/codestral) to your assistant on Continue Hub
+2. Add [Codestral](https://hub.continue.dev/mistral/codestral) to your agent on Continue Hub
 3. Add `MISTRAL_API_KEY` as a [User Secret](https://docs.continue.dev/hub/secrets/secret-types#user-secrets) on Continue Hub [here](https://hub.continue.dev/settings/secrets)
-4. Click `Reload config` in the assistant selector in the Continue IDE extension
+4. Click `Reload config` in the agent selector in the Continue IDE extension
 
 ### Hosted (Best Speed/Quality Tradeoff)
 
@@ -24,9 +24,9 @@ This model is specifically designed for code completion and is particularly fast
 **Mercury Coder Small Quick Setup:**
 
 1. Get your API key from [Inception Labs](https://platform.inceptionlabs.ai/)
-2. Add [Mercury Coder Small](https://hub.continue.dev/inceptionlabs/mercury-coder-small) to your assistant on Continue Hub
+2. Add [Mercury Coder Small](https://hub.continue.dev/inceptionlabs/mercury-coder-small) to your agent on Continue Hub
 3. Add `INCEPTION_API_KEY` as a [User Secret](https://docs.continue.dev/hub/secrets/secret-types#user-secrets) on Continue Hub [here](https://hub.continue.dev/settings/secrets)
-4. Click `Reload config` in the assistant selector in the Continue IDE extension
+4. Click `Reload config` in the agent selector in the Continue IDE extension
 
 ### Local (Offline / Privacy First)
 
@@ -37,8 +37,8 @@ This model provides good suggestions while keeping your code completely private.
 **Quick Setup:**
 
 1. Install [Ollama](https://ollama.ai/)
-2. Add [Qwen 2.5 Coder 1.5B](https://hub.continue.dev/ollama/qwen2.5-coder-1.5b) to your assistant on Continue Hub
-3. Click `Reload config` in the assistant selector in the Continue IDE extension
+2. Add [Qwen 2.5 Coder 1.5B](https://hub.continue.dev/ollama/qwen2.5-coder-1.5b) to your agent on Continue Hub
+3. Click `Reload config` in the agent selector in the Continue IDE extension
 
 ## Need Help?
 

--- a/docs/features/chat/model-setup.mdx
+++ b/docs/features/chat/model-setup.mdx
@@ -10,9 +10,9 @@ Our strong recommendation is to use [Claude Sonnet 4](https://hub.continue.dev/a
 Its strong tool calling and reasoning capabilities make it the best model for Agent mode.
 
 1. Get your API key from [Anthropic](https://console.anthropic.com/)
-2. Add [Claude Sonnet 4](https://hub.continue.dev/anthropic/claude-4-sonnet) to your assistant on Continue Hub
+2. Add [Claude Sonnet 4](https://hub.continue.dev/anthropic/claude-4-sonnet) to your agent on Continue Hub
 3. Add `ANTHROPIC_API_KEY` as a [User Secret](https://docs.continue.dev/hub/secrets/secret-types#user-secrets) on Continue Hub [here](https://hub.continue.dev/settings/secrets)
-4. Click `Reload config` in the assistant selector in the Continue IDE extension
+4. Click `Reload config` in the agent selector in the Continue IDE extension
 
 #### Other hosted models
 
@@ -21,51 +21,51 @@ These models have varying tool calling and reasoning capabilities.
 [Kimi K2](https://hub.continue.dev/openrouter/kimi-k2) from Moonshot AI
 
 1. Get your API key from [OpenRouter](https://openrouter.ai/settings/keys)
-2. Add [Kimi K2](https://hub.continue.dev/openrouter/kimi-k2) to your assistant on Continue Hub
+2. Add [Kimi K2](https://hub.continue.dev/openrouter/kimi-k2) to your agent on Continue Hub
 3. Add `OPENROUTER_API_KEY` as a [User Secret](https://docs.continue.dev/hub/secrets/secret-types#user-secrets) on Continue Hub [here](https://hub.continue.dev/settings/secrets)
-4. Click `Reload config` in the assistant selector in the Continue IDE extension
+4. Click `Reload config` in the agent selector in the Continue IDE extension
 
 [Qwen Coder 3 480B](https://hub.continue.dev/openrouter/qwen3-coder) from Qwen
 
 1. Get your API key from [OpenRouter](https://openrouter.ai/settings/keys)
-2. Add [Qwen Coder 3 480B](https://hub.continue.dev/openrouter/qwen3-coder) to your assistant on Continue Hub
+2. Add [Qwen Coder 3 480B](https://hub.continue.dev/openrouter/qwen3-coder) to your agent on Continue Hub
 3. Add `OPENROUTER_API_KEY` as a [User Secret](https://docs.continue.dev/hub/secrets/secret-types#user-secrets) on Continue Hub [here](https://hub.continue.dev/settings/secrets)
-4. Click `Reload config` in the assistant selector in the Continue IDE extension
+4. Click `Reload config` in the agent selector in the Continue IDE extension
 
 [Gemini 2.5 Pro](https://hub.continue.dev/google/gemini-2.5-pro) from Google
 
 1. Get your API key from [Google AI Studio](https://aistudio.google.com)
-2. Add [Gemini 2.5 Pro](https://hub.continue.dev/google/gemini-2.5-pro) to your assistant on Continue Hub
+2. Add [Gemini 2.5 Pro](https://hub.continue.dev/google/gemini-2.5-pro) to your agent on Continue Hub
 3. Add `GEMINI_API_KEY` as a [User Secret](https://docs.continue.dev/hub/secrets/secret-types#user-secrets) on Continue Hub [here](https://hub.continue.dev/settings/secrets)
-4. Click `Reload config` in the assistant selector in the Continue IDE extension
+4. Click `Reload config` in the agent selector in the Continue IDE extension
 
 [o3](https://hub.continue.dev/openai/o3) from OpenAI
 
 1. Get your API key from [OpenAI](https://platform.openai.com)
-2. Add [o3](https://hub.continue.dev/openai/o3) to your assistant on Continue Hub
+2. Add [o3](https://hub.continue.dev/openai/o3) to your agent on Continue Hub
 3. Add `OPENAI_API_KEY` as a [User Secret](https://docs.continue.dev/hub/secrets/secret-types#user-secrets) on Continue Hub [here](https://hub.continue.dev/settings/secrets)
-4. Click `Reload config` in the assistant selector in the Continue IDE extension
+4. Click `Reload config` in the agent selector in the Continue IDE extension
 
 [Grok 4](https://hub.continue.dev/xai/grok-4) from xAI
 
 1. Get your API key from [xAI](https://console.x.ai/)
-2. Add [Grok 4](https://hub.continue.dev/xai/grok-4) to your assistant on Continue Hub
+2. Add [Grok 4](https://hub.continue.dev/xai/grok-4) to your agent on Continue Hub
 3. Add `XAI_API_KEY` as a [User Secret](https://docs.continue.dev/hub/secrets/secret-types#user-secrets) on Continue Hub [here](https://hub.continue.dev/settings/secrets)
-4. Click `Reload config` in the assistant selector in the Continue IDE extension
+4. Click `Reload config` in the agent selector in the Continue IDE extension
 
 [Devstral Medium](https://hub.continue.dev/mistral/devstral-medium) from Mistral AI
 
 1. Get your API key from [Mistral AI](https://console.mistral.ai/)
-2. Add [Devstral Medium](https://hub.continue.dev/mistral/devstral-medium) to your assistant on Continue Hub
+2. Add [Devstral Medium](https://hub.continue.dev/mistral/devstral-medium) to your agent on Continue Hub
 3. Add `MISTRAL_API_KEY` as a [User Secret](https://docs.continue.dev/hub/secrets/secret-types#user-secrets) on Continue Hub [here](https://hub.continue.dev/settings/secrets)
-4. Click `Reload config` in the assistant selector in the Continue IDE extension
+4. Click `Reload config` in the agent selector in the Continue IDE extension
 
 [DeepSeek-V3](https://hub.continue.dev/togetherai/deepseek-v3) from DeepSeek
 
 1. Get your API key from [Together AI](https://api.together.ai)
-2. Add [DeepSeek-V3](https://hub.continue.dev/togetherai/deepseek-v3) to your assistant on Continue Hub
+2. Add [DeepSeek-V3](https://hub.continue.dev/togetherai/deepseek-v3) to your agent on Continue Hub
 3. Add `TOGETHER_API_KEY` as a [User Secret](https://docs.continue.dev/hub/secrets/secret-types#user-secrets) on Continue Hub [here](https://hub.continue.dev/settings/secrets)
-4. Click `Reload config` in the assistant selector in the Continue IDE extension
+4. Click `Reload config` in the agent selector in the Continue IDE extension
 
 #### Local models
 
@@ -75,27 +75,27 @@ Their limited tool calling and reasoning capabilities will make it challenging t
 
 [Qwen2.5-Coder 32B](https://hub.continue.dev/ollama/qwen2.5-coder-32b)
 
-1. Add [Qwen2.5-Coder 32B](https://hub.continue.dev/ollama/qwen2.5-coder-32b) to your assistant on Continue Hub
+1. Add [Qwen2.5-Coder 32B](https://hub.continue.dev/ollama/qwen2.5-coder-32b) to your agent on Continue Hub
 2. Run the model with [Ollama](https://docs.continue.dev/guides/ollama-guide#using-ollama-with-continue-a-developers-guide)
-3. Click `Reload config` in the assistant selector in the Continue IDE extension
+3. Click `Reload config` in the agent selector in the Continue IDE extension
 
 [Devstral Small 27B](https://hub.continue.dev/ollama/devstral)
 
-1. Add [Devstral Small](https://hub.continue.dev/ollama/devstral) to your assistant on Continue Hub
+1. Add [Devstral Small](https://hub.continue.dev/ollama/devstral) to your agent on Continue Hub
 2. Run the model with [Ollama](https://docs.continue.dev/guides/ollama-guide#using-ollama-with-continue-a-developers-guide)
-3. Click `Reload config` in the assistant selector in the Continue IDE extension
+3. Click `Reload config` in the agent selector in the Continue IDE extension
 
 [Qwen2.5-Coder 7B](https://hub.continue.dev/ollama/qwen2.5-coder-7b) from Qwen
 
-1. Add [Qwen2.5-Coder 7B](https://hub.continue.dev/ollama/qwen2.5-coder-7b) to your assistant on Continue Hub
+1. Add [Qwen2.5-Coder 7B](https://hub.continue.dev/ollama/qwen2.5-coder-7b) to your agent on Continue Hub
 2. Run the model with [Ollama](https://docs.continue.dev/guides/ollama-guide#using-ollama-with-continue-a-developers-guide)
-3. Click `Reload config` in the assistant selector in the Continue IDE extension
+3. Click `Reload config` in the agent selector in the Continue IDE extension
 
 [Gemma 3 4B](https://hub.continue.dev/ollama/gemma3-4b) from Google
 
-1. Add [Gemma 3 4B](https://hub.continue.dev/ollama/gemma3-4b) to your assistant on Continue Hub
+1. Add [Gemma 3 4B](https://hub.continue.dev/ollama/gemma3-4b) to your agent on Continue Hub
 2. Run the model with [Ollama](https://docs.continue.dev/guides/ollama-guide#using-ollama-with-continue-a-developers-guide)
-3. Click `Reload config` in the assistant selector in the Continue IDE extension
+3. Click `Reload config` in the agent selector in the Continue IDE extension
 
 For more detailed setup instructions, see [here](/getting-started/install#setup-your-first-model).
 

--- a/docs/features/edit/how-to-customize.mdx
+++ b/docs/features/edit/how-to-customize.mdx
@@ -1,6 +1,6 @@
 ## Setting active Edit/Apply model
 
-You can configure particular models from your Assistant to be used for Edit and Apply requests.
+You can configure particular models from your Agent to be used for Edit and Apply requests.
 
 1. Click the 3 dots above the main input
 2. Click the cube icon to expand the "Models" section

--- a/docs/getting-started/extensions.mdx
+++ b/docs/getting-started/extensions.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Understanding Assistants"
-description: "Continue offers two ways to configure your AI assistants"
+title: "Understanding Agents"
+description: "Continue offers two ways to configure your AI agents"
 ---
 
-This content has moved to our comprehensive guide: [Understanding Assistants: Hub vs Local Configuration](/guides/understanding-assistants)
+This content has moved to our comprehensive guide: [Understanding Agents: Hub vs Local Configuration](/guides/understanding-assistants)

--- a/docs/getting-started/install.mdx
+++ b/docs/getting-started/install.mdx
@@ -24,7 +24,7 @@ The Continue logo will appear on the left sidebar. For a better experience, move
 </Step>
 
 <Step title="Sign In">
-[Sign in to the hub](https://auth.continue.dev/) to get started with your first assistant
+[Sign in to the hub](https://auth.continue.dev/) to get started with your first agent
 </Step>
 </Steps>
 
@@ -54,7 +54,7 @@ Click `Install`, which will cause the Continue logo to show up on the right tool
 </Step>
 
 <Step title="Sign In">
-[Sign in to the hub](https://auth.continue.dev/) to get started with your first assistant
+[Sign in to the hub](https://auth.continue.dev/) to get started with your first agent
 </Step>
 </Steps>
 
@@ -68,6 +68,6 @@ Click `Install`, which will cause the Continue logo to show up on the right tool
 
 ## Signing in
 
-Click "Get started" to sign in to the hub and start using assistants.
+Click "Get started" to sign in to the hub and start using agents.
 
 ![Hub Onboarding in the Extension](/images/getting-started/images/hub-onboarding-card-81abd457b6d131c4b0aa89a5a6d647d3.png)

--- a/docs/getting-started/overview.mdx
+++ b/docs/getting-started/overview.mdx
@@ -58,6 +58,6 @@ description: "To quickly understand what you can do with Continue, check out eac
 </Tabs>
 
 
-## AI Coding Assistants
+## AI Coding Agents
 
-Continue offers flexible AI assistants that enhance your development workflow. You can choose between cloud-managed **Hub Assistants** for easy setup and synchronization, or **Local Assistants** for complete control and privacy. Learn more about [understanding and configuring assistants](/guides/understanding-assistants).
+Continue offers flexible AI agents that enhance your development workflow. You can choose between cloud-managed **Hub Agents** for easy setup and synchronization, or **Local Assistants** for complete control and privacy. Learn more about [understanding and configuring agents](/guides/understanding-assistants).

--- a/docs/guides/understanding-assistants.mdx
+++ b/docs/guides/understanding-assistants.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Understanding Assistants: Hub vs Local Configuration"
-description: "Master the two approaches to configuring AI assistants in Continue - choosing the right path for your development workflow"
+title: "Understanding Agents: Hub vs Local Configuration"
+description: "Master the two approaches to configuring AI agents in Continue - choosing the right path for your development workflow"
 ---
 
 Every developer has unique needs when it comes to AI assistance. Some prefer the convenience of cloud-managed configurations, while others need the control and privacy of local setups. Continue offers both paths, and this guide will help you choose the right one for your workflow.
@@ -9,50 +9,50 @@ Every developer has unique needs when it comes to AI assistance. Some prefer the
 
 Think of Continue's configuration options like choosing between a managed service and self-hosting. Both get you to the same destination—powerful AI assistance in your IDE—but the journey and control level differ significantly.
 
-### Accessing Your Assistant Configuration
+### Accessing Your Agent Configuration
 
 Before we dive into the specifics, let's understand how to access your configuration:
 
 1. Open the Continue Chat sidebar by pressing <kbd>cmd/ctrl</kbd> + <kbd>L</kbd> (VS Code) or <kbd>cmd/ctrl</kbd> + <kbd>J</kbd> (JetBrains)
-2. Click the Assistant selector above the main chat input
-3. Hover over an assistant and click:
-   - `new window` icon for Hub assistants
+2. Click the Agent selector above the main chat input
+3. Hover over an agent and click:
+   - `new window` icon for Hub agents
    - `gear` icon for Local assistants
 
-![configure an assistant](/images/configure-continue.png)
+![configure an agent](/images/configure-continue.png)
 
-## Hub Assistants: The Managed Experience
+## Hub Agents: The Managed Experience
 
-Hub Assistants represent the "it just works" philosophy. When you [sign in to Continue Hub](https://auth.continue.dev/), you gain access to a curated ecosystem of pre-configured assistants that sync seamlessly across all your development environments.
+Hub Agents represent the "it just works" philosophy. When you [sign in to Continue Hub](https://auth.continue.dev/), you gain access to a curated ecosystem of pre-configured agents that sync seamlessly across all your development environments.
 
-### Why Choose Hub Assistants?
+### Why Choose Hub Agents?
 
 **The Power of Simplicity**
-- **Instant Setup**: Browse the [assistant marketplace](https://hub.continue.dev/explore/assistants) and add any assistant to your account with a single click
+- **Instant Setup**: Browse the [agent marketplace](https://hub.continue.dev/explore/assistants) and add any agent to your account with a single click
 - **Web-Based Management**: Configure models, add secrets, and customize settings through an intuitive web interface—no JSON editing required
 - **Automatic Synchronization**: Make a change on the hub, and it reflects immediately across all your IDE instances
-- **Team Collaboration**: Share custom assistants with your team, ensuring everyone uses the same optimized configurations
+- **Team Collaboration**: Share custom agents with your team, ensuring everyone uses the same optimized configurations
 
-![nextjs assistant](/images/nextjs-assistant.png)
+![nextjs agent](/images/nextjs-agent.png)
 
-### Getting Started with Hub Assistants
+### Getting Started with Hub Agents
 
 The journey from zero to AI-powered coding takes just four steps:
 
-1. **Select Your Assistant**: Click the assistant selector in your IDE's Continue panel
-2. **Explore or Create**: Browse community assistants or craft your own specialized helper
+1. **Select Your Agent**: Click the agent selector in your IDE's Continue panel
+2. **Explore or Create**: Browse community agents or craft your own specialized helper
 3. **Secure Your Keys**: Add API keys as [User Secrets](https://hub.continue.dev/settings/secrets) in the hub—they're encrypted and never exposed
 4. **Sync and Code**: Click "Reload config" to pull your latest settings
 
-Pro tip: Hub Assistants are perfect for teams. Create a custom assistant with your team's coding standards, preferred models, and context sources, then share it with a simple link.
+Pro tip: Hub Agents are perfect for teams. Create a custom agent with your team's coding standards, preferred models, and context sources, then share it with a simple link.
 
-### Managing Hub Assistants
+### Managing Hub Agents
 
-All Hub Assistant management happens through [the Hub](https://hub.continue.dev). For detailed customization, see our guide on [Editing an Assistant](/hub/assistants/edit-an-assistant).
+All Hub Agent management happens through [the Hub](https://hub.continue.dev). For detailed customization, see our guide on [Editing an Agent](/hub/assistants/edit-an-agent).
 
 ## Local Assistants: The Power User's Choice
 
-Local Assistants put you in the driver's seat. Using a `config.yaml` file, you have complete control over every aspect of your AI assistant's behavior, with all configuration stored directly on your machine.
+Local Assistants put you in the driver's seat. Using a `config.yaml` file, you have complete control over every aspect of your AI agent's behavior, with all configuration stored directly on your machine.
 
 ### Why Choose Local Assistants?
 
@@ -71,7 +71,7 @@ Local configuration lives in a single YAML file in your home directory:
 - Windows: `%USERPROFILE%\.continue\config.yaml`
 
 **Quick Access Method:**
-1. Open the assistants dropdown in your IDE
+1. Open the agents dropdown in your IDE
 2. Click the gear icon next to "Local Assistant"
 3. The `config.yaml` file opens in your editor
 
@@ -89,7 +89,7 @@ For the complete configuration reference, see our [config.yaml documentation](/r
 
 The decision between Hub and Local assistants often comes down to your specific needs and constraints. Here's a framework to help you decide:
 
-### Choose Hub Assistants When You:
+### Choose Hub Agents When You:
 
 **Value Convenience Over Control**
 - Want to start coding with AI assistance in under 60 seconds
@@ -98,7 +98,7 @@ The decision between Hub and Local assistants often comes down to your specific 
 - Work in a team that needs standardized AI assistance
 
 **Need Advanced Collaboration**
-- Want to share custom assistants with teammates
+- Want to share custom agents with teammates
 - Need centralized API key management
 - Require quick updates across your entire organization
 
@@ -128,18 +128,18 @@ The decision between Hub and Local assistants often comes down to your specific 
 
 Here's a secret: you don't have to choose just one. Many developers use both approaches:
 
-- **Hub Assistants** for general development and experimentation
+- **Hub Agents** for general development and experimentation
 - **Local Assistants** for production work or client projects with specific requirements
 
-You can switch between them seamlessly using the assistant selector in your IDE.
+You can switch between them seamlessly using the agent selector in your IDE.
 
 ## Common Patterns and Best Practices
 
-### For Hub Assistant Users
+### For Hub Agent Users
 
-1. **Start with Community Assistants**: Before creating your own, explore what others have built
+1. **Start with Community Agents**: Before creating your own, explore what others have built
 2. **Use Secrets Properly**: Never hardcode API keys—always use the User Secrets feature
-3. **Create Specialized Assistants**: Make different assistants for different contexts (frontend, backend, DevOps)
+3. **Create Specialized Agents**: Make different agents for different contexts (frontend, backend, DevOps)
 4. **Share Liberally**: If you create something useful, share it with the community
 
 ### For Local Assistant Users
@@ -151,14 +151,14 @@ You can switch between them seamlessly using the assistant selector in your IDE.
 
 ## Troubleshooting and Tips
 
-### Hub Assistant Issues
+### Hub Agent Issues
 
 **Changes Not Reflecting?**
 - Click "Reload config" in your IDE
 - Check your internet connection
 - Ensure you're signed in to the correct account
 
-**Assistant Not Available?**
+**Agent Not Available?**
 - Verify it's added to your account on the hub
 - Check if it requires specific API keys
 
@@ -177,7 +177,7 @@ You can switch between them seamlessly using the assistant selector in your IDE.
 
 Now that you understand both configuration approaches, you're ready to dive deeper:
 
-- **For Hub Users**: [Create Your First Assistant](/hub/assistants/create-an-assistant)
+- **For Hub Users**: [Create Your First Agent](/hub/assistants/create-an-agent)
 - **For Local Users**: [Explore the Config Reference](/reference)
 - **For Everyone**: [Discover Available Models](/customize/model-providers/overview)
 

--- a/docs/home.mdx
+++ b/docs/home.mdx
@@ -2,7 +2,7 @@
 title: "Introduction"
 ---
 
-**Continue enables developers to create, share, and use custom AI code assistants with our open-source [VS Code](https://marketplace.visualstudio.com/items?itemName=Continue.continue) and [JetBrains](https://plugins.jetbrains.com/plugin/22707-continue-extension) extensions and [hub of models, rules, prompts, docs, and other building blocks](https://hub.continue.dev)**
+**Continue enables developers to create, share, and use custom AI code agents with our open-source [VS Code](https://marketplace.visualstudio.com/items?itemName=Continue.continue) and [JetBrains](https://plugins.jetbrains.com/plugin/22707-continue-extension) extensions and [hub of models, rules, prompts, docs, and other building blocks](https://hub.continue.dev)**
 
 - [Chat](/features/chat/quick-start) to understand and iterate on code in the sidebar
 - [Autocomplete](/features/autocomplete/quick-start) to receive inline code suggestions as you type

--- a/docs/hub/assistants/create-an-assistant.mdx
+++ b/docs/hub/assistants/create-an-assistant.mdx
@@ -1,32 +1,32 @@
 ---
-title: "Create an assistant"
+title: "Create an agent"
 ---
 
-## Remix an assistant
+## Remix an agent
 
-You should remix an assistant if you want to use it after some modifications.
+You should remix an agent if you want to use it after some modifications.
 
 By clicking the “remix” button, you’ll be taken to the “Create a remix” page.
 
-![Remix Assistant Button](/images/hub/assistants/images/assistant-remix-button-728ececa73983140eeab42e33cc3903b.png)
+![Remix Agent Button](/images/hub/assistants/images/agent-remix-button-728ececa73983140eeab42e33cc3903b.png)
 
 Once here, you’ll be able to
 
 1. add or remove blocks in YAML configuration
 2. change the name, description, icon, etc.
 
-Clicking “Create assistant” will make this assistant available for use.
+Clicking “Create agent” will make this agent available for use.
 
-## Create an assistant from scratch
+## Create an agent from scratch
 
-To create an assistant from scratch, select “New assistant” in the top bar.
+To create an agent from scratch, select “New agent” in the top bar.
 
-![New assistant button](/images/hub/assistants/images/assistant-new-button-16070e2cff9ce25ec9ebfeecb0e2f2b5.png)
+![New agent button](/images/hub/assistants/images/agent-new-button-16070e2cff9ce25ec9ebfeecb0e2f2b5.png)
 
-Choose a name, slug, description, and icon for your assistant.
+Choose a name, slug, description, and icon for your agent.
 
-The easiest way to create an assistant is to click "Create assistant" with the default configuration and then add / remove blocks using the sidebar.
+The easiest way to create an agent is to click "Create agent" with the default configuration and then add / remove blocks using the sidebar.
 
-Alternatively, you can edit the assistant YAML directly before clicking "Create assistant". Refer to examples of assistants on [hub.continue.dev](https://hub.continue.dev/explore/assistants) and visit the [YAML Reference](/reference#complete-yaml-config-example) docs for more details.
+Alternatively, you can edit the agent YAML directly before clicking "Create agent". Refer to examples of agents on [hub.continue.dev](https://hub.continue.dev/explore/assistants) and visit the [YAML Reference](/reference#complete-yaml-config-example) docs for more details.
 
-![New assistant YAML](/images/hub/assistants/images/assistant-create-yaml-a991e5a81506f1c3ba611a664a50734c.png)
+![New agent YAML](/images/hub/assistants/images/agent-create-yaml-a991e5a81506f1c3ba611a664a50734c.png)

--- a/docs/hub/assistants/edit-an-assistant.mdx
+++ b/docs/hub/assistants/edit-an-assistant.mdx
@@ -1,13 +1,13 @@
 ---
-title: "Edit an Assistant"
-description: "New versions of an assistant can be created and published using the sidebar."
+title: "Edit an Agent"
+description: "New versions of an agent can be created and published using the sidebar."
 ---
 
-![Remix Assistant Button](/images/hub/assistants/images/assistant-create-sidebar-608be49973f2a7723212adeb52dbcafb.png)
+![Remix Agent Button](/images/hub/assistants/images/agent-create-sidebar-608be49973f2a7723212adeb52dbcafb.png)
 
-First, select an assistant from the dropdown at the top.
+First, select an agent from the dropdown at the top.
 
-While editing an assistant, you can explore the hub and click "Add Block" from a block page to add it to your assistant.
+While editing an agent, you can explore the hub and click "Add Block" from a block page to add it to your agent.
 
 For blocks that require secret values like API keys, you will see a small notification on the block's tile in the sidebar that will indicate if action is needed.
 
@@ -15,6 +15,6 @@ To delete a block, click the trash icon.
 
 If a block you want to use does not exist yet, you can [create a new block](/hub/blocks/create-a-block).
 
-When you are done editing, click "Publish" to publish a new version of the assistant.
+When you are done editing, click "Publish" to publish a new version of the agent.
 
-Click "Open VS Code" or "Open JetBrains" to open your IDE for using the assistant.
+Click "Open VS Code" or "Open JetBrains" to open your IDE for using the agent.

--- a/docs/hub/assistants/intro.mdx
+++ b/docs/hub/assistants/intro.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Introduction to Assistants"
-description: "Custom AI code assistants are configurations of building blocks that enable a coding experience tailored to your specific use cases."
+title: "Introduction to Agents"
+description: "Custom AI code agents are configurations of building blocks that enable a coding experience tailored to your specific use cases."
 ---
 
-`config.yaml` is a format for defining custom AI code assistants. An assistant has some top-level properties (e.g. `name`, `version`), but otherwise consists of composable lists of **blocks** such as `models` and `rules`, which are the atomic building blocks of an assistant.
+`config.yaml` is a format for defining custom AI code agents. An agent has some top-level properties (e.g. `name`, `version`), but otherwise consists of composable lists of **blocks** such as `models` and `rules`, which are the atomic building blocks of an agent.
 
-The `config.yaml` is parsed by the open-source Continue IDE extensions to create custom assistant experiences. When you log in to [hub.continue.dev](https://hub.continue.dev/), your assistants will automatically be synced with the IDE extensions.
+The `config.yaml` is parsed by the open-source Continue IDE extensions to create custom agent experiences. When you log in to [hub.continue.dev](https://hub.continue.dev/), your agents will automatically be synced with the IDE extensions.

--- a/docs/hub/assistants/use-an-assistant.mdx
+++ b/docs/hub/assistants/use-an-assistant.mdx
@@ -1,14 +1,14 @@
 ---
-title: "Use an assistant"
-description: "To use an existing assistant, you can explore other assistants ."
+title: "Use an agent"
+description: "To use an existing agent, you can explore other agents ."
 ---
 
-Once you've found the assistant you want to use
+Once you've found the agent you want to use
 
-1. Click “Add Assistant” on its page
+1. Click “Add Agent” on its page
 2. Add any required inputs (e.g. secrets like API keys)
-3. Select “Save changes” in assistant sidebar on the right hand side
+3. Select “Save changes” in agent sidebar on the right hand side
 
-After this, you can then go to your IDE extension and begin using the assistant by selecting it from the assistant dropdown.
+After this, you can then go to your IDE extension and begin using the agent by selecting it from the agent dropdown.
 
-[Extension Assistant Selector](/images/assistant-extension-select-319492a06d6249e5389747687341dfdb.png)
+[Extension Agent Selector](/images/agent-extension-select-319492a06d6249e5389747687341dfdb.png)

--- a/docs/hub/blocks/block-types.mdx
+++ b/docs/hub/blocks/block-types.mdx
@@ -28,7 +28,7 @@ Learn more in the [MCP deep dive](/customize/deep-dives/mcp), and view [`mcpServ
 
 ## Rules
 
-Rules blocks are instructions that your custom AI code assistant will always keep in mind - the contents of rules are inserted into the system message for all Chat requests. [Explore rules](https://hub.continue.dev/explore/rules) on the hub.
+Rules blocks are instructions that your custom AI code agent will always keep in mind - the contents of rules are inserted into the system message for all Chat requests. [Explore rules](https://hub.continue.dev/explore/rules) on the hub.
 
 Learn more in the [rules deep dive](/customize/deep-dives/rules), and view [`rules`](/reference#rules) in the YAML Reference for more details.
 

--- a/docs/hub/blocks/bundles.mdx
+++ b/docs/hub/blocks/bundles.mdx
@@ -1,16 +1,16 @@
 ---
 title: "Bundles"
-description: "Bundles are collections of blocks that are commonly used together. You can use them to add multiple building blocks to your custom AI code assistants at once. They are only a concept on , so they are not represented in ."
+description: "Bundles are collections of blocks that are commonly used together. You can use them to add multiple building blocks to your custom AI code agents at once. They are only a concept on , so they are not represented in ."
 ---
 
 ## Use a bundle
 
 Once you know which bundle you want to use, you’ll need to
 
-1. Make sure the correct assistant is in the sidebar
-2. Click “Add all blocks". This adds the individual blocks to your assistant.
+1. Make sure the correct agent is in the sidebar
+2. Click “Add all blocks". This adds the individual blocks to your agent.
 3. Add any required inputs (e.g. secrets) for each block.
-4. Select “Save changes” in assistant sidebar on the right hand side
+4. Select “Save changes” in agent sidebar on the right hand side
 
 After this, you can then go to your IDE extension using the "Open VS Code" or "Open Jetbrains" buttons and begin using the new blocks.
 

--- a/docs/hub/blocks/create-a-block.mdx
+++ b/docs/hub/blocks/create-a-block.mdx
@@ -10,7 +10,7 @@ By clicking the “remix” button, you’ll be taken to the “Create a remix�
 
 ![Remix block button](/images/hub/blocks/images/block-remix-button-913beb80672662855acc7013561c78d0.png)
 
-Once here, you’ll be able to 1) edit YAML configuration for the block and 2) change name, description, icon, etc. Clicking “Create block” will make this block available for use in an assistant.
+Once here, you’ll be able to 1) edit YAML configuration for the block and 2) change name, description, icon, etc. Clicking “Create block” will make this block available for use in an agent.
 
 ## Create a block from scratch
 
@@ -24,4 +24,4 @@ After filling out information on the block, you will want to create a block foll
 
 ### Block inputs
 
-Blocks can receive values, including secrets, as inputs through templating. For values that the user of the block needs to set, you can use template variables (e.g. `${{ inputs.API_KEY}}`). Then, the user can set `API_KEY: ${{ secrets.MY_API_KEY }}` in the `with` clause of their assistant.
+Blocks can receive values, including secrets, as inputs through templating. For values that the user of the block needs to set, you can use template variables (e.g. `${{ inputs.API_KEY}}`). Then, the user can set `API_KEY: ${{ secrets.MY_API_KEY }}` in the `with` clause of their agent.

--- a/docs/hub/blocks/intro.mdx
+++ b/docs/hub/blocks/intro.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Introduction"
-description: "Blocks are the components you use to build a custom AI code assistant. These include , , , , , , and ."
+description: "Blocks are the components you use to build a custom AI code agent. These include , , , , , , and ."
 ---
 
-Blocks follow the [`config.yaml`](/reference) format. When combined with other blocks into a complete `config.yaml`, they form a custom AI code assistant.
+Blocks follow the [`config.yaml`](/reference) format. When combined with other blocks into a complete `config.yaml`, they form a custom AI code agent.

--- a/docs/hub/blocks/use-a-block.mdx
+++ b/docs/hub/blocks/use-a-block.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Use a block"
-description: "Blocks can be used by adding them to assistants:"
+description: "Blocks can be used by adding them to agents:"
 ---
 
-- [Create an assistant](/hub/assistants/create-an-assistant)
-- [Edit an assistant](/hub/assistants/edit-an-assistant)
+- [Create an agent](/hub/assistants/create-an-agent)
+- [Edit an agent](/hub/assistants/edit-an-agent)
 
 Some blocks require inputs. If you are missing an input for a block, a notification icon will show up in the sidebar next to the block. Click the notification to select which secret to use for the block input:
 

--- a/docs/hub/governance/creating-an-org.mdx
+++ b/docs/hub/governance/creating-an-org.mdx
@@ -6,7 +6,7 @@ description: "To Create an Organization, click the organization selector in the 
 ![create an org selector](/images/hub/governance/images/org-selector-4ea627afc7c0765633780920a0fbe16e.png)
 
 1. Choose a name, which will be used as the display name for your organization throughout the hub
-2. Add a slug, which will be used for your org URL and as the prefix to all organization blocks and assistant slugs
+2. Add a slug, which will be used for your org URL and as the prefix to all organization blocks and agent slugs
 3. Select an icon for your organization using the image uploader
 4. Finally, add a Biography, which will be displayed on your org Home Page
 

--- a/docs/hub/governance/org-permissions.mdx
+++ b/docs/hub/governance/org-permissions.mdx
@@ -3,8 +3,8 @@ title: "Organization Permissions"
 description: "Users can have the following roles within an organization:"
 ---
 
-1. Admins are users who can manage members, secrets, blocks, assistants, etc.
-2. Members are users who can use assistants, blocks, secrets, etc.
+1. Admins are users who can manage members, secrets, blocks, agents, etc.
+2. Members are users who can use agents, blocks, secrets, etc.
 
 **User permissions for each role depend on the pricing plan:**
 

--- a/docs/hub/introduction.mdx
+++ b/docs/hub/introduction.mdx
@@ -2,8 +2,8 @@
 title: "Introduction"
 ---
 
-[Continue Hub](https://hub.continue.dev) makes it simple to create custom AI code [assistants](/hub/assistants/intro), providing a registry for defining, managing, and sharing assistant [building blocks](/hub/blocks/intro).
+[Continue Hub](https://hub.continue.dev) makes it simple to create custom AI code [agents](/hub/assistants/intro), providing a registry for defining, managing, and sharing agent [building blocks](/hub/blocks/intro).
 
-Assistants can contain several types of blocks, including [models](/hub/blocks/block-types#models), [rules](/hub/blocks/block-types#rules), [context providers](/hub/blocks/block-types#context), [prompts](/hub/blocks/block-types#prompts), [docs](/hub/blocks/block-types#docs), [data destinations](/hub/blocks/block-types#data), and [MCP servers](/hub/blocks/block-types#mcp-servers).
+Agents can contain several types of blocks, including [models](/hub/blocks/block-types#models), [rules](/hub/blocks/block-types#rules), [context providers](/hub/blocks/block-types#context), [prompts](/hub/blocks/block-types#prompts), [docs](/hub/blocks/block-types#docs), [data destinations](/hub/blocks/block-types#data), and [MCP servers](/hub/blocks/block-types#mcp-servers).
 
-Continue Hub also makes it easy for engineering leaders to centrally [configure](/hub/secrets/secret-types) and [govern](/hub/governance/org-permissions) blocks and assistants for their organization.
+Continue Hub also makes it easy for engineering leaders to centrally [configure](/hub/secrets/secret-types) and [govern](/hub/governance/org-permissions) blocks and agents for their organization.

--- a/docs/hub/secrets/secret-resolution.mdx
+++ b/docs/hub/secrets/secret-resolution.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Secret Resolution"
-description: "User or Org secrets should be used depending on how users want them to be shared within their organization and assistants."
+description: "User or Org secrets should be used depending on how users want them to be shared within their organization and agents."
 ---
 
 For individual users and [Solo](/hub/governance/pricing#solo) organizations, secret resolution is performed in the following order:

--- a/docs/hub/secrets/secret-types.mdx
+++ b/docs/hub/secrets/secret-types.mdx
@@ -1,16 +1,16 @@
 ---
 title: "Secret Types"
-description: "The Continue Hub comes with secrets management built-in. Secrets are values such as API keys or endpoints that can be shared across assistants and within organizations."
+description: "The Continue Hub comes with secrets management built-in. Secrets are values such as API keys or endpoints that can be shared across agents and within organizations."
 ---
 
 ## User secrets
 
-User secrets are defined by the user for themselves. This means that user secrets are available only to the user that created them. User secrets are assumed to be safe for the user to know, so they will be sent to the IDE extensions alongside the assistant `config.yaml`.
+User secrets are defined by the user for themselves. This means that user secrets are available only to the user that created them. User secrets are assumed to be safe for the user to know, so they will be sent to the IDE extensions alongside the agent `config.yaml`.
 
 This allows API requests to be made directly from the IDE extensions. You can use user secrets with [Solo](/hub/governance/pricing#solo), [Teams](/hub/governance/pricing#teams), and [Enterprise](/hub/governance/pricing#enterprise). User secrets can be managed [here](https://hub.continue.dev/settings/secrets) in the hub.
 
 ## Org secrets
 
-Org secrets are defined by admins for their organization. Org secrets are available to anyone in the organization to use with assistants in that organization. Org secrets are assumed to not be shareable with the user (e.g. you are a team lead who wants to give team members access to models without passing out API keys).
+Org secrets are defined by admins for their organization. Org secrets are available to anyone in the organization to use with agents in that organization. Org secrets are assumed to not be shareable with the user (e.g. you are a team lead who wants to give team members access to models without passing out API keys).
 
 This is why LLM requests are proxied through api.continue.dev / on-premise proxy and secrets are never sent to the IDE extensions. You can only use org secrets on [Teams](/hub/governance/pricing#teams) and [Enterprise](/hub/governance/pricing#enterprise). If you are an admin, you can manage secrets for your organization from the org settings page.

--- a/docs/hub/sharing.mdx
+++ b/docs/hub/sharing.mdx
@@ -11,21 +11,21 @@ Join thousands of developers using Continue. Share experiences, get help, and co
 
 ## Publishing
 
-Share your custom assistants, blocks, and configurations with the Continue community.
+Share your custom agents, blocks, and configurations with the Continue community.
 
 [Visit the Hub →](https://hub.continue.dev)
 
-## Browse Assistants
+## Browse Agents
 
-Explore assistants created by the community for specific use cases and workflows.
+Explore agents created by the community for specific use cases and workflows.
 
-[Browse Assistants →](https://hub.continue.dev)
+[Browse Agents →](https://hub.continue.dev)
 
-## Using Assistants
+## Using Agents
 
-Learn how to discover, install, and use community-created assistants in your projects.
+Learn how to discover, install, and use community-created agents in your projects.
 
-[Learn About Assistants →](/hub/assistants/intro)
+[Learn About Agents →](/hub/assistants/intro)
 
 ---
 

--- a/docs/hub/source-control.mdx
+++ b/docs/hub/source-control.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Source Control"
-description: "When managing your custom assistants within an organization, you might want to take advantage of your usual source control workflows. Continue makes this easy with a  that automatically syncs your YAML files with hub.continue.dev. We are also planning on adding automations for GitLab, BitBucket, Gitee, and others. If you are interested, please reach out to us on ."
+description: "When managing your custom agents within an organization, you might want to take advantage of your usual source control workflows. Continue makes this easy with a  that automatically syncs your YAML files with hub.continue.dev. We are also planning on adding automations for GitLab, BitBucket, Gitee, and others. If you are interested, please reach out to us on ."
 ---
 
 ## Quickstart
@@ -34,11 +34,11 @@ This is the only configuration necessary, but you can view the full list of opti
 
 ### 4. Commit and push
 
-Add the [YAML for your assistants and blocks](/reference) to the appropriate directories. The name of the file will be the slug of the assistant/block.
+Add the [YAML for your agents and blocks](/reference) to the appropriate directories. The name of the file will be the slug of the agent/block.
 
-- `assistants/public` for public assistants
-- `assistants/private` for private (visible only within your organization) assistants
+- `agents/public` for public agents
+- `agents/private` for private (visible only within your organization) agents
 - `blocks/public` for public blocks
 - `blocks/private` for private blocks
 
-Then, commit and push your changes. Once the GitHub Action has completed running, you should be able to view the assistants within your organization on hub.continue.dev. For subsequent changes, make sure to increment the `version` property of your updated YAML file(s).
+Then, commit and push your changes. Once the GitHub Action has completed running, you should be able to view the agents within your organization on hub.continue.dev. For subsequent changes, make sure to increment the `version` property of your updated YAML file(s).

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -7,7 +7,7 @@ icon: book-open
   <img src="/images/intro-0c302b9c15b890c251b1ad04586c880f.png" />
 </Frame>
 
-**Continue enables developers to create, share, and use custom AI code assistants with our open-source [VS Code](https://marketplace.visualstudio.com/items?itemName=Continue.continue) and [JetBrains](https://plugins.jetbrains.com/plugin/22707-continue-extension) extensions and [hub of models, rules, prompts, docs, and other building blocks](https://hub.continue.dev)**
+**Continue enables developers to create, share, and use custom AI code agents with our open-source [VS Code](https://marketplace.visualstudio.com/items?itemName=Continue.continue) and [JetBrains](https://plugins.jetbrains.com/plugin/22707-continue-extension) extensions and [hub of models, rules, prompts, docs, and other building blocks](https://hub.continue.dev)**
 
 <CardGroup cols={2}>
   <Card

--- a/docs/reference.mdx
+++ b/docs/reference.mdx
@@ -4,39 +4,39 @@ title: "config.yaml Reference"
 
 ## Introduction
 
-Continue hub assistants are defined using the `config.yaml` specification. Assistants can be loaded from [the Hub](https://hub.continue.dev/explore/assistants) or locally
+Continue hub agents are defined using the `config.yaml` specification. Agents can be loaded from [the Hub](https://hub.continue.dev/explore/assistants) or locally
 
 - [Continue Hub](https://hub.continue.dev/explore/assistants) - YAML is stored on the hub and automatically synced to the extension
 
 - Locally
-  - in your global `.continue` folder (`~/.continue` on Mac, `%USERPROFILE%\.continue`) within `.continue/assistants`. The name of the file will be used as the display name of the assistant, e.g. `My Assistant.yaml`
-  - in your workspace in a `/.continue/assistants` folder, with the same naming convention
+  - in your global `.continue` folder (`~/.continue` on Mac, `%USERPROFILE%\.continue`) within `.continue/agents`. The name of the file will be used as the display name of the agent, e.g. `My Agent.yaml`
+  - in your workspace in a `/.continue/agents` folder, with the same naming convention
 
 <Info>
   Config YAML replaces `config.json`, which is deprecated. View the **[Migration
   Guide](/customize/yaml-migration)**.
 </Info>
 
-An assistant is made up of:
+An agent is made up of:
 
-1. **Top level properties**, which specify the `name`, `version`, and `config.yaml` `schema` for the assistant
-2. **Block lists**, which are composable arrays of coding assistant building blocks available to the assistant, such as models, docs, and context providers.
+1. **Top level properties**, which specify the `name`, `version`, and `config.yaml` `schema` for the agent
+2. **Block lists**, which are composable arrays of coding agent building blocks available to the agent, such as models, docs, and context providers.
 
-A block is a single standalone building block of a coding assistants, e.g., one model or one documentation source. In `config.yaml` syntax, a block consists of the same top-level properties as assistants (`name`, `version`, and `schema`), but only has **ONE** item under whichever block type it is.
+A block is a single standalone building block of a coding agents, e.g., one model or one documentation source. In `config.yaml` syntax, a block consists of the same top-level properties as agents (`name`, `version`, and `schema`), but only has **ONE** item under whichever block type it is.
 
-Examples of blocks and assistants can be found on the [Continue hub](https://hub.continue.dev/explore/assistants).
+Examples of blocks and agents can be found on the [Continue hub](https://hub.continue.dev/explore/assistants).
 
-Assistants can either explicitly define blocks - see [Properties](#properties) below - or import and configure existing hub blocks.
+Agents can either explicitly define blocks - see [Properties](#properties) below - or import and configure existing hub blocks.
 
 ### Using Blocks
 
-Hub blocks and assistants are identified with a slug in the format `owner-slug/block-or-assistant-slug`, where an owner can be a user or organization (For example, if you want to use the [OpenAI 4o Model block](https://hub.continue.dev/openai/gpt-4o), your slug would be `openai/gpt-4o`). These blocks are pulled from [https://hub.continue.dev](https://hub.continue.dev).
+Hub blocks and agents are identified with a slug in the format `owner-slug/block-or-agent-slug`, where an owner can be a user or organization (For example, if you want to use the [OpenAI 4o Model block](https://hub.continue.dev/openai/gpt-4o), your slug would be `openai/gpt-4o`). These blocks are pulled from [https://hub.continue.dev](https://hub.continue.dev).
 
-Blocks can be imported into an assistant by adding a `uses` clause under the block type. This can be alongside other `uses` clauses or explicit blocks of that type.
+Blocks can be imported into an agent by adding a `uses` clause under the block type. This can be alongside other `uses` clauses or explicit blocks of that type.
 
-For example, the following assistant imports an Anthropic model and defines an Ollama DeepSeek one.
+For example, the following agent imports an Anthropic model and defines an Ollama DeepSeek one.
 
-Assistant models section
+Agent models section
 
 ```yaml
 models:
@@ -47,13 +47,13 @@ models:
 
 ### Local Blocks
 
-It is also possible to define blocks locally in a `.continue` folder. This folder can be located at either the root of your workspace (these will automatically be applied to all assistants when you are in that workspace) or in your home directory at `~/.continue` (these will automatically be applied globally).
+It is also possible to define blocks locally in a `.continue` folder. This folder can be located at either the root of your workspace (these will automatically be applied to all agents when you are in that workspace) or in your home directory at `~/.continue` (these will automatically be applied globally).
 
 Place your YAML files in the following folders:
 
-Assistants:
+Agents:
 
-- `.continue/assistants` - for assistants
+- `.continue/agents` - for agents
 
 Blocks:
 
@@ -92,7 +92,7 @@ models:
 Which can then be imported like this:
 
 ```yaml title="config.yaml"
-name: myprofile/custom-assistant
+name: myprofile/custom-agent
 models:
   - uses: myprofile/custom-model
     with:
@@ -107,7 +107,7 @@ Note that hub secrets can be passed as inputs, using a similar mustache format: 
 Block properties can be also be directly overriden using `override`. For example:
 
 ```yaml title="config.yaml"
-name: myprofile/custom-assistant
+name: myprofile/custom-agent
 models:
   - uses: myprofile/custom-model
     with:

--- a/docs/reference/continue-mcp.mdx
+++ b/docs/reference/continue-mcp.mdx
@@ -45,7 +45,7 @@ What context providers are available in Continue?
 ### Customization
 
 ```
-How do I add custom rules to my assistant in Continue?
+How do I add custom rules to my agent in Continue?
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

To align with what is on the home page. I've rename instances of assistant to agent. 

QUESTION: Do we want to keep it "Local Assistants" or should we update the name of the feature in app to "Local Agents" cc @TyDunn - This PR does not update it yet.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

n/a

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Renamed all instances of "assistant" to "agent" in the documentation to match the terminology used on the home page.

<!-- End of auto-generated description by cubic. -->

