### PR TITLE
docs: move capabilities reference to clearer location

### DIFF
--- a/docs/reference.mdx
+++ b/docs/reference.mdx
@@ -175,11 +175,11 @@ The `models` section defines the language models used in your configuration. Mod
 
 - `roles`: An array specifying the roles this model can fulfill, such as `chat`, `autocomplete`, `embed`, `rerank`, `edit`, `apply`, `summarize`. The default value is `[chat, edit, apply, summarize]`. Note that the `summarize` role is not currently used.
 
-- `capabilities`: Array of strings denoting model capabilities, which will overwrite Continue's autodetection based on provider and model. Supported capabilities include:
+- `capabilities`: Array of strings denoting model capabilities, which will overwrite Continue's autodetection based on provider and model. See the [Model Capabilities guide](/customize/deep-dives/model-capabilities) for detailed information. Supported capabilities include:
   - `tool_use`: Enables function/tool calling support (required for Agent mode)
   - `image_input`: Enables image upload and processing support
   
-  Continue automatically detects these capabilities for most models, but you can override this when using custom deployments or if autodetection isn't working correctly. See the [Model Capabilities guide](/customize/deep-dives/model-capabilities) for detailed information.
+  Continue automatically detects these capabilities for most models, but you can override this when using custom deployments or if autodetection isn't working correctly.
 
 - `maxStopWords`: Maximum number of stop words allowed, to avoid API errors with extensive lists.
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Moved the model capabilities reference link to a clearer location in the docs for easier access and better guidance.

<!-- End of auto-generated description by cubic. -->

