### PR TITLE
fix: jetbrains release action

### DIFF
--- a/.github/workflows/jetbrains-release.yaml
+++ b/.github/workflows/jetbrains-release.yaml
@@ -504,7 +504,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ needs.build.outputs.pluginVerifierHomeDir }}/ides
-          key: plugin-verifier-${{ hashFiles('build/listProductsReleases.txt') }}
+          key: plugin-verifier-${{ hashFiles('build/printProductsReleases.txt') }}
 
       # Run Verify Plugin task and IntelliJ Plugin Verifier tool
       - name: Run Plugin Verification tasks

--- a/.github/workflows/jetbrains-release.yaml
+++ b/.github/workflows/jetbrains-release.yaml
@@ -140,7 +140,7 @@ jobs:
           echo "$CHANGELOG" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-          ./gradlew listProductsReleases # prepare list of IDEs for Plugin Verifier
+          ./gradlew printProductsReleases # prepare list of IDEs for Plugin Verifier
 
       # # Setup Node.js
       - name: Use Node.js from .nvmrc


### PR DESCRIPTION
## Description
Fixes mis-named gradle action caused by updating intellij plugin version (listProductsReleases became silent)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the JetBrains release workflow by updating the Gradle command to use the correct property for listing IDE releases.

<!-- End of auto-generated description by cubic. -->

