### PR TITLE
fix: longer mcp errors to show in virtual file

### DIFF
--- a/gui/src/components/mainInput/Lump/sections/mcp/MCPSection.tsx
+++ b/gui/src/components/mainInput/Lump/sections/mcp/MCPSection.tsx
@@ -7,7 +7,7 @@ import {
   WrenchScrewdriverIcon,
 } from "@heroicons/react/24/outline";
 import { MCPServerStatus } from "core";
-import { useContext, useMemo } from "react";
+import { Fragment, useContext, useMemo } from "react";
 import { useAuth } from "../../../../../context/Auth";
 import { IdeMessengerContext } from "../../../../../context/IdeMessenger";
 import { useAppDispatch, useAppSelector } from "../../../../../redux/hooks";
@@ -78,25 +78,28 @@ function MCPServerPreview({ server, serverFromYaml }: MCPServerStatusProps) {
               className="flex flex-col gap-0.5"
             >
               {server.errors.map((error, idx) => (
-                <span key={idx}>
-                  <code>
+                <Fragment key={idx}>
+                  <div>
                     {error.length > 150
                       ? error.substring(0, 150) + "..."
                       : error}
-                  </code>
+                  </div>
                   {error.length > 150 && (
                     <Button
                       className="my-0"
                       size="sm"
                       variant="ghost"
-                      onClick={() => {
-                        ideMessenger.ide.showVirtualFile(server.name, error);
-                      }}
+                      onClick={() =>
+                        void ideMessenger.ide.showVirtualFile(
+                          server.name,
+                          error,
+                        )
+                      }
                     >
-                      Know More
+                      View full error
                     </Button>
                   )}
-                </span>
+                </Fragment>
               ))}
             </ToolTip>
           </>

--- a/gui/src/components/mainInput/Lump/sections/mcp/MCPSection.tsx
+++ b/gui/src/components/mainInput/Lump/sections/mcp/MCPSection.tsx
@@ -14,6 +14,7 @@ import { useAppDispatch, useAppSelector } from "../../../../../redux/hooks";
 import { updateConfig } from "../../../../../redux/slices/configSlice";
 import { fontSize } from "../../../../../util";
 import { ToolTip } from "../../../../gui/Tooltip";
+import { Button } from "../../../../ui";
 import EditBlockButton from "../../EditBlockButton";
 import { ExploreBlocksButton } from "../ExploreBlocksButton";
 
@@ -68,9 +69,34 @@ function MCPServerPreview({ server, serverFromYaml }: MCPServerStatusProps) {
               className={`h-3 w-3 ${server.status === "error" ? "text-red-500" : "text-yellow-500"}`}
               data-tooltip-id={errorsTooltipId}
             />
-            <ToolTip id={errorsTooltipId} className="flex flex-col gap-0.5">
+            <ToolTip
+              clickable
+              id={errorsTooltipId}
+              delayHide={
+                server.errors.some((error) => error.length > 150) ? 1500 : 0
+              }
+              className="flex flex-col gap-0.5"
+            >
               {server.errors.map((error, idx) => (
-                <code key={idx}>{error}</code>
+                <span key={idx}>
+                  <code>
+                    {error.length > 150
+                      ? error.substring(0, 150) + "..."
+                      : error}
+                  </code>
+                  {error.length > 150 && (
+                    <Button
+                      className="my-0"
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => {
+                        ideMessenger.ide.showVirtualFile(server.name, error);
+                      }}
+                    >
+                      Know More
+                    </Button>
+                  )}
+                </span>
               ))}
             </ToolTip>
           </>


### PR DESCRIPTION
## Description

Open longer MCP errors in a virtual file.

closes CON-3225

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot






https://github.com/user-attachments/assets/35c8dabf-c12f-457f-8832-90146688db7a

https://github.com/user-attachments/assets/7eb019be-b605-46f7-9003-111480d8cb17



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Long MCP error messages now open in a virtual file for easier viewing.

- **New Features**
 - Added a "Know More" button to show full error details in a virtual file when errors are longer than 150 characters.

<!-- End of auto-generated description by cubic. -->

