### PR TITLE
fix: show no tools available when no tools available

### DIFF
--- a/gui/src/components/mainInput/Lump/sections/tool-policies/ToolPoliciesSection.tsx
+++ b/gui/src/components/mainInput/Lump/sections/tool-policies/ToolPoliciesSection.tsx
@@ -65,6 +65,11 @@ export const ToolPoliciesSection = () => {
           </Alert>
         </div>
       )}
+      {toolsByGroup.length === 0 && (
+        <span className="text-description text-sm italic">
+          No tools available
+        </span>
+      )}
       {toolsByGroup.map(([groupName, tools]) => {
         const isGroupEnabled =
           !allToolsOff && toolGroupSettings[groupName] !== "exclude";


### PR DESCRIPTION
## Description
For longer config loading, tool policies section used to be blank, now shows a no tools available message

<img width="442" height="133" alt="image" src="https://github.com/user-attachments/assets/c8910046-6f6e-46f6-b16e-fba945ea9319" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a "No tools available" message to the tool policies section when no tools are present, so users are not shown a blank area during config loading.

<!-- End of auto-generated description by cubic. -->

