### PR TITLE
fix: fix tool execute abnormal when there is no tool policy data in the local cache

### DIFF
--- a/extensions/vscode/e2e/tests/GUI.test.ts
+++ b/extensions/vscode/e2e/tests/GUI.test.ts
@@ -287,7 +287,6 @@ describe("GUI Test", () => {
     }).timeout(DEFAULT_TIMEOUT.MD);
 
     it("should render tool call", async () => {
-      await GUIActions.toggleToolPolicy(view, "view_diff", 0);
       const [messageInput] = await GUISelectors.getMessageInputFields(view);
       await messageInput.sendKeys("Hello");
       await messageInput.sendKeys(Key.ENTER);

--- a/gui/src/redux/thunks/callToolById.ts
+++ b/gui/src/redux/thunks/callToolById.ts
@@ -14,6 +14,7 @@ import {
 import { ThunkApiType } from "../store";
 import { findToolCallById, logToolUsage } from "../util";
 import { streamResponseAfterToolCall } from "./streamResponseAfterToolCall";
+import { DEFAULT_TOOL_SETTING } from "../slices/uiSlice";
 
 export const callToolById = createAsyncThunk<
   void,
@@ -36,9 +37,11 @@ export const callToolById = createAsyncThunk<
 
   // Check if this is an auto-approved tool
   const toolSettings = state.ui.toolSettings;
-  const isAutoApproved =
-    toolSettings[toolCallState.toolCall.function.name] ===
-    "allowedWithoutPermission";
+  const toolPolicy =
+    toolSettings[toolCallState.toolCall.function.name] ??
+    toolCallState.tool?.defaultToolPolicy ??
+    DEFAULT_TOOL_SETTING;
+  const isAutoApproved = toolPolicy === "allowedWithoutPermission";
 
   posthog.capture("gui_tool_call_decision", {
     decision: isAutoApproved ? "auto_accept" : "accept",

--- a/gui/src/redux/thunks/streamNormalInput.ts
+++ b/gui/src/redux/thunks/streamNormalInput.ts
@@ -28,6 +28,7 @@ import { interceptSystemToolCalls } from "core/tools/systemMessageTools/intercep
 import { selectCurrentToolCalls } from "../selectors/selectToolCalls";
 import { getBaseSystemMessage } from "../util/getBaseSystemMessage";
 import { callToolById } from "./callToolById";
+import { DEFAULT_TOOL_SETTING } from "../slices/uiSlice";
 /**
  * Handles the execution of tool calls that may be automatically accepted.
  * Sets all tools as generated first, then executes auto-approved tool calls.
@@ -35,6 +36,7 @@ import { callToolById } from "./callToolById";
 async function handleToolCallExecution(
   dispatch: AppThunkDispatch,
   getState: () => RootState,
+  activeTools: Tool[],
 ): Promise<void> {
   const newState = getState();
   const toolSettings = newState.ui.toolSettings;
@@ -51,11 +53,15 @@ async function handleToolCallExecution(
   }
 
   // Check if ALL tool calls are auto-approved - if not, wait for user approval
-  const allAutoApproved = toolCallStates.every(
-    (toolCallState) =>
-      toolSettings[toolCallState.toolCall.function.name] ===
-      "allowedWithoutPermission",
-  );
+  const allAutoApproved = toolCallStates.every((toolCallState) => {
+    const toolPolicy =
+      toolSettings[toolCallState.toolCall.function.name] ??
+      activeTools.find(
+        (tool) => tool.function.name === toolCallState.toolCall.function.name,
+      )?.defaultToolPolicy ??
+      DEFAULT_TOOL_SETTING;
+    return toolPolicy == "allowedWithoutPermission";
+  });
 
   // Set all tools as generated first
   toolCallStates.forEach((toolCallState) => {
@@ -289,11 +295,16 @@ export const streamNormalInput = createAsyncThunk<
     // Check if ALL generating tool calls are auto-approved
     const allAutoApproved =
       generatingToolCalls.length > 0 &&
-      generatingToolCalls.every(
-        (toolCallState) =>
-          toolSettings[toolCallState.toolCall.function.name] ===
-          "allowedWithoutPermission",
-      );
+      generatingToolCalls.every((toolCallState) => {
+        const toolPolicy =
+          toolSettings[toolCallState.toolCall.function.name] ??
+          activeTools.find(
+            (tool) =>
+              tool.function.name === toolCallState.toolCall.function.name,
+          )?.defaultToolPolicy ??
+          DEFAULT_TOOL_SETTING;
+        return toolPolicy == "allowedWithoutPermission";
+      });
 
     // Only set inactive if:
     // 1. There are no tool calls, OR
@@ -303,6 +314,6 @@ export const streamNormalInput = createAsyncThunk<
       dispatch(setInactive());
     }
 
-    await handleToolCallExecution(dispatch, getState);
+    await handleToolCallExecution(dispatch, getState, activeTools);
   },
 );


### PR DESCRIPTION
…he local cache

## Description

fix tool execute abnormal when there is no tool policy data in the local cache
it fixed issue caused by #6852

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where tool execution failed if tool policy data was missing from the local cache. Now, the system uses default tool policy settings when local data is unavailable.

- **Bug Fixes**
  - Ensured tool calls fall back to default policy if local cache is empty.
  - Updated logic in tool execution and approval checks to handle missing policy data.

<!-- End of auto-generated description by cubic. -->

