### PR TITLE
docs: updates docs for Slash Commands

### DIFF
--- a/docs/customize/deep-dives/configuration.mdx
+++ b/docs/customize/deep-dives/configuration.mdx
@@ -60,6 +60,10 @@ Example
 
 `config.ts` must export a `modifyConfig` function, like:
 
+<Warning>
+  The `slashCommands` array shown below is deprecated. For creating custom slash commands, use [prompt blocks or prompt files](./slash-commands) instead.
+</Warning>
+
 ```ts title="config.ts"
 export function modifyConfig(config: Config): Config {
   config.slashCommands?.push({

--- a/docs/customize/deep-dives/slash-commands.mdx
+++ b/docs/customize/deep-dives/slash-commands.mdx
@@ -11,6 +11,13 @@ Slash commands are shortcuts that can be activated by typing '/' in a chat sessi
 
 Slash commands can be combined with additional instructions, including [context providers](../custom-providers.mdx) or highlighted code.
 
+<Note>
+  **Recommended approach**: Use prompt blocks or prompt files to create slash
+  commands instead of the deprecated `config.json` approach. The methods
+  described below provide better flexibility and are the actively maintained
+  ways to add custom commands.
+</Note>
+
 ## Prompts
 
 ### Assistant prompt blocks
@@ -21,7 +28,7 @@ The easiest way to add a slash command is by adding [`prompt` blocks](../../hub/
 
 It is also possible to write your own slash command by defining a “.prompt file.” Prompt files can be as simple as a text file, but also include templating so that you can refer to files, URLs, highlighted code, and more.
 
-Learn more about prompt files [here](./prompts.md)
+Learn more about prompt files [here](./prompts.mdx).
 
 ### MCP Server prompts
 

--- a/docs/reference/json-reference.mdx
+++ b/docs/reference/json-reference.mdx
@@ -1,6 +1,14 @@
 ---
-title: "config.json Reference"
+title: "config.json Reference (Deprecated)"
+description: "Legacy configuration reference for config.json - use config.yaml instead"
+noindex: true
 ---
+
+<Warning>
+  **This page documents deprecated functionality.** For creating slash commands and customizing Continue, please use:
+  - [Prompt blocks and prompt files](/customize/deep-dives/slash-commands) for slash commands
+  - [config.yaml](/reference) for configuration
+</Warning>
 
 <Info>
   We recently introduced a new configuration format, `config.yaml`, to replace


### PR DESCRIPTION
PR generated with [cn](https://docs.continue.dev/guides/cli)

## Description

[ What changed? Feel free to be brief. ]

I noticed the slash commands docs were out of date. This PR adds a slash command as well deprioritizes makeing slash commands in json, which is how the cli recommended me do it at first. 

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
