### PR TITLE
feat: set capabilities for next edit

### DIFF
--- a/core/config/yaml/models.ts
+++ b/core/config/yaml/models.ts
@@ -68,6 +68,7 @@ async function modelConfigToBaseLLM({
     capabilities: {
       tools: model.capabilities?.includes("tool_use"),
       uploadImage: model.capabilities?.includes("image_input"),
+      nextEdit: model.capabilities?.includes("next_edit"),
     },
     autocompleteOptions: model.autocompleteOptions,
   };

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1138,6 +1138,7 @@ export interface BaseCompletionOptions {
 export interface ModelCapability {
   uploadImage?: boolean;
   tools?: boolean;
+  nextEdit?: boolean;
 }
 
 export interface ModelDescription {

--- a/core/llm/autodetect.ts
+++ b/core/llm/autodetect.ts
@@ -173,6 +173,35 @@ function isProviderHandlesTemplatingOrNoTemplateTypeRequired(
   );
 }
 
+// NOTE: When updating this list,
+// update core/nextEdit/templating/NextEditPromptEngine.ts as well.
+const MODEL_SUPPORTS_NEXT_EDIT: string[] = [
+  "mercury-coder-nextedit",
+  "model-1",
+  "this field is not used",
+];
+
+function modelSupportsNextEdit(
+  model: string,
+  title: string | undefined,
+  capabilities: ModelCapability | undefined,
+): boolean {
+  if (capabilities?.nextEdit !== undefined) {
+    return capabilities.nextEdit;
+  }
+
+  const lower = model.toLowerCase();
+  if (
+    MODEL_SUPPORTS_NEXT_EDIT.some(
+      (modelName) => lower.includes(modelName) || title?.includes(modelName),
+    )
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
 function autodetectTemplateType(model: string): TemplateType | undefined {
   const lower = model.toLowerCase();
 
@@ -391,4 +420,5 @@ export {
   autodetectTemplateType,
   llmCanGenerateInParallel,
   modelSupportsImages,
+  modelSupportsNextEdit,
 };

--- a/core/nextEdit/NextEditProvider.ts
+++ b/core/nextEdit/NextEditProvider.ts
@@ -18,6 +18,7 @@ import { AutocompleteDebouncer } from "../autocomplete/util/AutocompleteDebounce
 import AutocompleteLruCache from "../autocomplete/util/AutocompleteLruCache.js";
 import { HelperVars } from "../autocomplete/util/HelperVars.js";
 import { AutocompleteInput } from "../autocomplete/util/types.js";
+import { modelSupportsNextEdit } from "../llm/autodetect.js";
 import { localPathOrUriToPath } from "../util/pathToUri.js";
 import { replaceEscapedCharacters } from "../util/text.js";
 import {
@@ -283,6 +284,14 @@ export class NextEditProvider {
 
       const llm = await this._prepareLlm();
       if (!llm) {
+        return undefined;
+      }
+
+      // In vscode, this check is done in extensions/vscode/src/extension/VsCodeExtension.ts.
+      // For other editors, this check should be done in their respective config reloaders.
+      // This is left for a final check.
+      if (!modelSupportsNextEdit(llm.model, llm.title, llm.capabilities)) {
+        console.error(`${llm.model} is not capable of next edit.`);
         return undefined;
       }
 

--- a/core/nextEdit/templating/NextEditPromptEngine.ts
+++ b/core/nextEdit/templating/NextEditPromptEngine.ts
@@ -33,6 +33,7 @@ import {
 
 type TemplateRenderer = (vars: TemplateVars) => string;
 
+// NOTE: When updating this union, update core/llm/autodetect.ts as well.
 export type NextEditModelName =
   | "mercury-coder-nextedit"
   | "model-1"

--- a/core/nextEdit/utils.ts
+++ b/core/nextEdit/utils.ts
@@ -1,15 +1,13 @@
-type NextEditModelName = "mercury-coder-nextedit";
+export function isNextEditTest(): boolean {
+  const enabled = process.env.NEXT_EDIT_TEST_ENABLED;
 
-export function isModelCapableOfNextEdit(modelName: string): boolean {
-  // In test mode, we can control whether next edit is enabled via environment variable.
-  if (process.env.NEXT_EDIT_TEST_ENABLED === "false") {
+  if (enabled === "false") {
     return false;
   }
 
-  if (process.env.NEXT_EDIT_TEST_ENABLED === "true") {
+  if (enabled === "true") {
     return true;
   }
 
-  const supportedModels: NextEditModelName[] = ["mercury-coder-nextedit"];
-  return supportedModels.some((supported) => modelName.includes(supported));
+  return false;
 }

--- a/extensions/vscode/src/extension/VsCodeExtension.ts
+++ b/extensions/vscode/src/extension/VsCodeExtension.ts
@@ -43,13 +43,14 @@ import { ConfigYamlDocumentLinkProvider } from "./ConfigYamlDocumentLinkProvider
 import { VsCodeMessenger } from "./VsCodeMessenger";
 
 import { getAst } from "core/autocomplete/util/ast";
+import { modelSupportsNextEdit } from "core/llm/autodetect";
 import { DocumentHistoryTracker } from "core/nextEdit/DocumentHistoryTracker";
 import {
   EditableRegionStrategy,
   getNextEditableRegion,
 } from "core/nextEdit/NextEditEditableRegionCalculator";
 import { NextEditProvider } from "core/nextEdit/NextEditProvider";
-import { isModelCapableOfNextEdit } from "core/nextEdit/utils";
+import { isNextEditTest } from "core/nextEdit/utils";
 import { localPathOrUriToPath } from "core/util/pathToUri";
 import { JumpManager } from "../activation/JumpManager";
 import setupNextEditWindowManager, {
@@ -190,8 +191,13 @@ export class VsCodeExtension {
       async ({ config: newConfig, configLoadInterrupted }) => {
         const autocompleteModel = newConfig?.selectedModelByRole.autocomplete;
         if (
-          autocompleteModel &&
-          isModelCapableOfNextEdit(autocompleteModel.model)
+          (autocompleteModel &&
+            modelSupportsNextEdit(
+              autocompleteModel.model,
+              autocompleteModel.title,
+              autocompleteModel.capabilities,
+            )) ||
+          isNextEditTest()
         ) {
           // Set up next edit window manager only for Continue team members
           await setupNextEditWindowManager(context);

--- a/packages/config-yaml/src/schemas/models.ts
+++ b/packages/config-yaml/src/schemas/models.ts
@@ -36,6 +36,7 @@ export type ModelRole = z.infer<typeof modelRolesSchema>;
 export const modelCapabilitySchema = z.union([
   z.literal("tool_use"),
   z.literal("image_input"),
+  z.literal("next_edit"),
 ]);
 export type ModelCapability = z.infer<typeof modelCapabilitySchema>;
 


### PR DESCRIPTION
## Description

Closes CON-3283.

Users can now set `next_edit` as a per-model capability.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

`core/llm/autodetect.vitest.ts`
