### PR TITLE
chore: vscode 1.1.74

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "1.1.73",
+  "version": "1.1.74",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION
## Description
VS Code version bump for prerelease

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Bumped the VS Code extension version to 1.1.74 for prerelease.

<!-- End of auto-generated description by cubic. -->

