### PR TITLE
fix: remove redundant `call` word from the default agent system prompt

### DIFF
--- a/core/llm/defaultSystemMessages.ts
+++ b/core/llm/defaultSystemMessages.ts
@@ -61,7 +61,7 @@ export const DEFAULT_AGENT_SYSTEM_MESSAGE = `\
 <important_rules>
   You are in agent mode.
 
-  If you need to use multiple tools, you can call call multiple read only tools simultaneously.
+  If you need to use multiple tools, you can call multiple read only tools simultaneously.
 
 ${CODEBLOCK_FORMATTING_INSTRUCTIONS}
 </important_rules>`;


### PR DESCRIPTION
## Description

It seems there was a typo in the agent system prompt

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed a duplicate "call" from the default agent system prompt to fix a typo.

<!-- End of auto-generated description by cubic. -->

