### PR TITLE
improve: tool call spacing and margins

### DIFF
--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/index.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/index.tsx
@@ -263,7 +263,7 @@ export function StepContainerPreToolbar({
   }
 
   return (
-    <div className="outline-command-border -outline-offset-0.5 rounded-default bg-editor mb-2 mt-2 flex min-w-0 flex-col outline outline-1">
+    <div className="outline-command-border -outline-offset-0.5 rounded-default bg-editor !my-2 flex min-w-0 flex-col outline outline-1">
       <div
         className={`find-widget-skip bg-editor sticky -top-2 z-10 m-0 flex items-center justify-between gap-3 px-1.5 py-1 ${isExpanded ? "rounded-t-default border-command-border border-b" : "rounded-default"}`}
         style={{ fontSize: `${getFontSize() - 2}px` }}

--- a/gui/src/pages/gui/ToolCallDiv/index.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/index.tsx
@@ -80,7 +80,7 @@ export function ToolCallDiv({
 
   if (shouldShowGroupedUI) {
     return (
-      <div className="border-border rounded-lg border p-3">
+      <div className="border-border rounded-lg border p-3 pb-0">
         <GroupedToolCallHeader
           toolCallStates={toolCallStates}
           activeCalls={activeCalls}
@@ -103,7 +103,7 @@ export function ToolCallDiv({
   }
 
   return toolCallStates.map((toolCallState) => (
-    <div className="p-4 pb-1" key={toolCallState.toolCallId}>
+    <div className="px-4 py-1" key={toolCallState.toolCallId}>
       {renderToolCall(toolCallState)}
     </div>
   ));


### PR DESCRIPTION
## Description

Reduce the blank space and margins in tool call divs

resolves CON-3328

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot


| before | now |
| --- | --- |
| <img width="471" height="217" alt="image" src="https://github.com/user-attachments/assets/39894b09-a503-4b91-b924-0c497a8a0ee2" /> | <img width="478" height="199" alt="image" src="https://github.com/user-attachments/assets/29f96024-a88c-49d4-ad6e-44497ca81715" /> |
| <img width="460" height="295" alt="image" src="https://github.com/user-attachments/assets/952e245b-2305-462e-934e-f8322e48322c" />| <img width="473" height="284" alt="image" src="https://github.com/user-attachments/assets/4c69fad9-effb-4c6d-9a52-b6405b977c23" /> |
| <img width="483" height="100" alt="image" src="https://github.com/user-attachments/assets/d4e787c9-06a9-4cb8-bc65-1ee6fdfd91e9" /> | <img width="472" height="135" alt="image" src="https://github.com/user-attachments/assets/93bce42e-71b7-403b-944f-3b041d47382d" /> |




## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Reduced extra spacing and margins in tool call components for a cleaner, more compact layout.

<!-- End of auto-generated description by cubic. -->

