### PR TITLE
improve: open conversation summary be default

### DIFF
--- a/gui/src/components/StepContainer/ConversationSummary.tsx
+++ b/gui/src/components/StepContainer/ConversationSummary.tsx
@@ -1,12 +1,12 @@
-import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/solid";
 import { TrashIcon } from "@heroicons/react/24/outline";
+import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/solid";
 import { ChatHistoryItem } from "core";
 import { useState } from "react";
-import { AnimatedEllipsis } from "../AnimatedEllipsis";
 import { useAppSelector } from "../../redux/hooks";
-import StyledMarkdownPreview from "../StyledMarkdownPreview";
 import { useDeleteCompaction } from "../../util/compactConversation";
+import { AnimatedEllipsis } from "../AnimatedEllipsis";
 import HeaderButtonWithToolTip from "../gui/HeaderButtonWithToolTip";
+import StyledMarkdownPreview from "../StyledMarkdownPreview";
 
 interface ConversationSummaryProps {
   item: ChatHistoryItem;
@@ -14,7 +14,7 @@ interface ConversationSummaryProps {
 }
 
 export default function ConversationSummary(props: ConversationSummaryProps) {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(true);
   const isLoading = useAppSelector(
     (state) => state.session.compactionLoading[props.index] || false,
   );


### PR DESCRIPTION
## Description

Open the conversation summary when it is done generating

resolves CON-2966

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot


https://github.com/user-attachments/assets/ab0a08a5-c80e-4696-a549-d61a22ce1916



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
The conversation summary now opens by default once it finishes generating, making it easier to view results without extra clicks.

<!-- End of auto-generated description by cubic. -->

