### PR TITLE
feat: add rootUrl param to docs and improve page selection

### DIFF
--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -220,8 +220,11 @@ declare global {
   export interface SiteIndexingConfig {
     title: string;
     startUrl: string;
+    rootUrl?: string;
     maxDepth?: number;
     faviconUrl?: string;
+    useLocalCrawling?: boolean;
+    sourceFile?: string;
   }
   
   export interface IContextProvider {

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -234,6 +234,7 @@ export interface ContextSubmenuItemWithProvider extends ContextSubmenuItem {
 export interface SiteIndexingConfig {
   title: string;
   startUrl: string;
+  rootUrl?: string;
   maxDepth?: number;
   faviconUrl?: string;
   useLocalCrawling?: boolean;

--- a/core/indexing/docs/crawlers/CheerioCrawler.ts
+++ b/core/indexing/docs/crawlers/CheerioCrawler.ts
@@ -20,6 +20,7 @@ export default class CheerioCrawler {
 
   constructor(
     private readonly startUrl: URL,
+    private readonly rootUrl: URL,
     private readonly maxRequestsPerCrawl: number,
     private readonly maxDepth: number,
   ) {}
@@ -113,6 +114,9 @@ export default class CheerioCrawler {
     const html = await response.text();
     let links: string[] = [];
 
+    // FIXME: Why do we have this special case?
+    // This method will also catch subdomains such as `docs.github.com`,
+    // so we should clarify the intent and make the `includes` more specific if needed.
     if (url.includes("github.com")) {
       return { html, links };
     }
@@ -126,7 +130,10 @@ export default class CheerioCrawler {
       }
 
       const parsedUrl = new URL(href, location);
-      if (parsedUrl.hostname === baseUrl.hostname) {
+      if (
+        parsedUrl.hostname === this.rootUrl.hostname &&
+        parsedUrl.pathname.startsWith(this.rootUrl.pathname)
+      ) {
         links.push(parsedUrl.pathname);
       }
     });

--- a/core/indexing/docs/crawlers/ChromiumCrawler.ts
+++ b/core/indexing/docs/crawlers/ChromiumCrawler.ts
@@ -21,6 +21,7 @@ export class ChromiumCrawler {
 
   constructor(
     private readonly startUrl: URL,
+    private readonly rootUrl: URL,
     private readonly maxRequestsPerCrawl: number,
     private readonly maxDepth: number,
   ) {}
@@ -155,9 +156,10 @@ export class ChromiumCrawler {
     }
   }
 
-  private isValidHostAndPath(newUrl: URL, curUrl: URL) {
+  private isValidHostAndPath(parsedUrl: URL) {
     return (
-      newUrl.pathname.startsWith(curUrl.pathname) && newUrl.host === curUrl.host
+      parsedUrl.hostname === this.rootUrl.hostname &&
+      parsedUrl.pathname.startsWith(this.rootUrl.pathname)
     );
   }
 
@@ -169,7 +171,7 @@ export class ChromiumCrawler {
       .filter(
         (newUrl) =>
           newUrl !== null &&
-          this.isValidHostAndPath(newUrl, curUrl) &&
+          this.isValidHostAndPath(newUrl) &&
           newUrl !== curUrl,
       )
       .map((newUrl) => (newUrl as URL).href);

--- a/core/indexing/docs/crawlers/DefaultCrawler.ts
+++ b/core/indexing/docs/crawlers/DefaultCrawler.ts
@@ -7,11 +7,14 @@ import { PageData } from "./DocsCrawler";
 export class DefaultCrawler {
   constructor(
     private readonly startUrl: URL,
+    private readonly rootUrl: URL,
     private readonly maxRequestsPerCrawl: number,
     private readonly maxDepth: number,
   ) {}
 
   async crawl(): Promise<PageData[]> {
+    // TODO: How do we edit the remote crawler? I see there is a `control-plane` folder
+    // but I don't see any reference to "startUrl" in there.
     const resp = await fetch(new URL("crawl", TRIAL_PROXY_URL).toString(), {
       method: "POST",
       headers: {
@@ -20,6 +23,7 @@ export class DefaultCrawler {
       },
       body: JSON.stringify({
         startUrl: this.startUrl.toString(),
+        rootUrl: this.rootUrl.toString(),
         maxDepth: this.maxDepth,
         limit: this.maxRequestsPerCrawl,
       }),

--- a/docs/reference.mdx
+++ b/docs/reference.mdx
@@ -347,6 +347,7 @@ List of documentation sites to index.
 
 - `name` (**required**): Name of the documentation site, displayed in dropdowns, etc.
 - `startUrl` (**required**): Start page for crawling - usually root or intro page for docs
+- `rootUrl`: Specify the base URL to match for crawling subpages of a site. If not provided, this is inferred from `startUrl`.
 - `favicon`: URL for site favicon (default is `/favicon.ico` from `startUrl`).
 - `useLocalCrawling`: Skip the default crawler and only crawl using a local crawler.
 
@@ -356,6 +357,7 @@ List of documentation sites to index.
 docs:
   - name: Continue
     startUrl: https://docs.continue.dev/intro
+    rootUrl: https://docs.continue.dev/
     favicon: https://docs.continue.dev/favicon.ico
 ```
 


### PR DESCRIPTION
## Description

- Readds the `rootUrl` param (optional) to docs sites to match against for selecting subpages when crawling
- If `rootUrl` is not specified, infer it from the `startUrl`
- Use the `rootUrl` when crawling to include the correct pages that are part of the desired documentation

Fixes #3823

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A

## Tests

TODO

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added an optional rootUrl parameter for docs sites to improve how subpages are selected during crawling. If rootUrl is not set, it is now inferred from startUrl for more accurate page inclusion.

- **New Features**
  - rootUrl can be specified in docs config to control which pages are crawled.
  - Crawlers use rootUrl to match and include only relevant subpages.

<!-- End of auto-generated description by cubic. -->

