### PR TITLE
fix: jetbrains release script

### DIFF
--- a/.github/workflows/jetbrains-release.yaml
+++ b/.github/workflows/jetbrains-release.yaml
@@ -249,7 +249,7 @@ jobs:
           CERTIFICATE_CHAIN: ${{ secrets.JETBRAINS_CERTIFICATE_CHAIN }}
           PRIVATE_KEY: ${{ secrets.JETBRAINS_PRIVATE_KEY }}
           PRIVATE_KEY_PASSWORD: ${{ secrets.JETBRAINS_PRIVATE_KEY_PASSWORD }}
-          RELEASE_CHANNEL: eap
+          RELEASE_CHANNEL: default
         run: ./gradlew buildPlugin --info --stacktrace
 
       # Publish the plugin to JetBrains Marketplace


### PR DESCRIPTION
## Description
Build plugin was removed from jetbrains release because it is a dependency of publish plugin https://github.com/continuedev/continue/pull/6760

But this means when not publishing there was no artifact to save, disabling non-release CI builds
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the JetBrains release workflow so that non-publish builds correctly generate and save plugin artifacts. Added options to control building and publishing for EAP and Stable channels.

<!-- End of auto-generated description by cubic. -->

