### PR TITLE
fix: indexing toggle copy

### DIFF
--- a/gui/src/pages/config/IndexingSettingsSection.tsx
+++ b/gui/src/pages/config/IndexingSettingsSection.tsx
@@ -15,7 +15,7 @@ export function IndexingSettingsSection() {
         <div className="pb-2 pt-5">
           <p className="py-1 text-center font-semibold">Indexing is disabled</p>
           <p className="text-lightgray cursor-pointer text-center text-xs">
-            Open settings and toggle <code>Disable Indexing</code> to re-enable
+            Open settings and toggle <code>Enable Indexing</code> to re-enable
           </p>
         </div>
       ) : (


### PR DESCRIPTION
## Description
Credit/Coauthor @shssoichiro 
Name was updated to `Enable Indexing`, text elsewhere was outdated
from https://github.com/continuedev/continue/pull/6939
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the settings text to say "Enable Indexing" instead of "Disable Indexing" for clarity.

<!-- End of auto-generated description by cubic. -->

