### PR TITLE
style: prevent mention query input wrapping text

### DIFF
--- a/gui/src/components/mainInput/AtMentionDropdown/index.tsx
+++ b/gui/src/components/mainInput/AtMentionDropdown/index.tsx
@@ -32,6 +32,7 @@ import FileIcon from "../../FileIcon";
 import SafeImg from "../../SafeImg";
 import AddDocsDialog from "../../dialogs/AddDocsDialog";
 import HeaderButtonWithToolTip from "../../gui/HeaderButtonWithToolTip";
+import { Button } from "../../ui";
 import { NAMED_ICONS } from "../icons";
 import type { ComboBoxItem, ComboBoxItemType } from "../types";
 
@@ -117,6 +118,7 @@ const QueryInput = styled.textarea`
   background-color: #fff1;
   border: 1px solid ${lightGray};
   border-radius: ${defaultBorderRadius};
+  overflow: hidden;
 
   padding: 0.2rem 0.4rem;
   width: 240px;
@@ -243,7 +245,7 @@ const AtMentionDropdown = forwardRef((props: AtMentionDropdownProps, ref) => {
         .run();
 
       // Trigger warning message
-      ideMessenger.ide.showToast(
+      void ideMessenger.ide.showToast(
         "warning",
         fileSize > 0
           ? "File exceeds model's context length"
@@ -368,8 +370,9 @@ const AtMentionDropdown = forwardRef((props: AtMentionDropdownProps, ref) => {
 
     if (item) {
       if (item.type === "file" && item.query) {
-        isItemTooBig(item.type, item.query).then(([fileExceeds, fileSize]) =>
-          handleItemTooBig(fileExceeds, fileSize, item),
+        void isItemTooBig(item.type, item.query).then(
+          ([fileExceeds, fileSize]) =>
+            handleItemTooBig(fileExceeds, fileSize, item),
         );
       } else {
         props.command({ ...item, itemType: item.type });
@@ -456,34 +459,53 @@ const AtMentionDropdown = forwardRef((props: AtMentionDropdownProps, ref) => {
   return (
     <ItemsDiv>
       {querySubmenuItem ? (
-        <QueryInput
-          onClick={(e) => {
-            e.stopPropagation();
-          }}
-          rows={1}
-          ref={queryInputRef}
-          placeholder={querySubmenuItem.description}
-          onKeyDown={(e) => {
-            if (!queryInputRef.current) {
-              return;
-            }
-            if (e.key === "Enter") {
-              if (e.shiftKey) {
-                queryInputRef.current.innerText += "\n";
-              } else {
-                props.command({
-                  ...querySubmenuItem,
-                  itemType: querySubmenuItem.type,
-                  query: queryInputRef.current.value,
-                  label: `${querySubmenuItem.label}: ${queryInputRef.current.value}`,
-                });
+        <span className="flex items-center gap-x-1">
+          <QueryInput
+            wrap="off"
+            onClick={(e) => {
+              e.stopPropagation();
+            }}
+            rows={1}
+            ref={queryInputRef}
+            placeholder={querySubmenuItem.description}
+            onKeyDown={(e) => {
+              if (!queryInputRef.current) {
+                return;
               }
-            } else if (e.key === "Escape") {
-              setQuerySubmenuItem(undefined);
-              setSubMenuTitle(undefined);
+              if (e.key === "Enter") {
+                if (e.shiftKey) {
+                  queryInputRef.current.innerText += "\n";
+                } else {
+                  props.command({
+                    ...querySubmenuItem,
+                    itemType: querySubmenuItem.type,
+                    query: queryInputRef.current.value,
+                    label: `${querySubmenuItem.label}: ${queryInputRef.current.value}`,
+                  });
+                }
+              } else if (e.key === "Escape") {
+                setQuerySubmenuItem(undefined);
+                setSubMenuTitle(undefined);
+              }
+            }}
+          />
+          <Button
+            variant="secondary"
+            size="sm"
+            className="m-0"
+            disabled={!queryInputRef.current}
+            onClick={() =>
+              props.command({
+                ...querySubmenuItem,
+                itemType: querySubmenuItem.type,
+                query: queryInputRef.current!.value,
+                label: `${querySubmenuItem.label}: ${queryInputRef.current!.value}`,
+              })
             }
-          }}
-        />
+          >
+            ⏎
+          </Button>
+        </span>
       ) : (
         <>
           {subMenuTitle && <ItemDiv className="mb-2">{subMenuTitle}</ItemDiv>}


### PR DESCRIPTION
## Description

Improve the query context text field to have an enter button and prevent wrapping of text.

resolves CON-2360

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

**before**

<img width="535" height="184" alt="image" src="https://github.com/user-attachments/assets/ceae9030-de00-4ab3-9e0a-7e9cf1c3b08c" />

**after**

<img width="522" height="207" alt="image" src="https://github.com/user-attachments/assets/4b38f3dd-8bcc-4709-987d-aad367fb4a8b" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the mention query input to prevent text from wrapping and added an enter button for easier submission. This addresses CON-2360 by improving usability in the query context field.

<!-- End of auto-generated description by cubic. -->

