### PR TITLE
feat: add more prompt templates

### DIFF
--- a/.continue/rules/comment-periods.md
+++ b/.continue/rules/comment-periods.md
@@ -1,0 +1,5 @@
+---
+alwaysApply: true
+---
+
+End your comments with a period.

--- a/.continue/rules/comment-periods.md
+++ b/.continue/rules/comment-periods.md
@@ -1,5 +1,0 @@
----
-alwaysApply: true
----
-
-End your comments with a period.

--- a/core/nextEdit/NextEditProvider.ts
+++ b/core/nextEdit/NextEditProvider.ts
@@ -559,11 +559,30 @@ export class NextEditProvider {
         currentFilePath: helper.filepath,
       };
     } else if (modelName.includes("model-1")) {
+      // Calculate the window around the cursor position (25 lines above and below).
+      const windowStart = Math.max(0, helper.pos.line - 25);
+      const windowEnd = Math.min(
+        helper.fileLines.length - 1,
+        helper.pos.line + 25,
+      );
+
+      // The editable region is defined as: cursor line - 1 to cursor line + 5 (inclusive).
+      const actualEditableStart = Math.max(0, helper.pos.line - 1);
+      const actualEditableEnd = Math.min(
+        helper.fileLines.length - 1,
+        helper.pos.line + 5,
+      );
+
+      // Ensure editable region boundaries are within the window.
+      const adjustedEditableStart = Math.max(windowStart, actualEditableStart);
+      const adjustedEditableEnd = Math.min(windowEnd, actualEditableEnd);
       ctx = {
         contextSnippets: this.autocompleteContext,
         currentFileContent: helper.fileContents,
-        editableRegionStartLine,
-        editableRegionEndLine,
+        windowStart,
+        windowEnd,
+        adjustedEditableStart,
+        adjustedEditableEnd,
         editDiffHistory: this.diffContext,
         currentFilePath: helper.filepath,
         languageShorthand: helper.lang.name,

--- a/core/nextEdit/NextEditProvider.ts
+++ b/core/nextEdit/NextEditProvider.ts
@@ -545,9 +545,17 @@ export class NextEditProvider {
       };
     } else if (modelName.includes("model-1")) {
       ctx = {
-        userEdits: historyDiff ?? this.diffContext,
+        recentlyViewedCodeSnippets:
+          snippetPayload.recentlyVisitedRangesSnippets.map((snip) => ({
+            filepath: snip.filepath,
+            content: snip.content,
+          })) ?? [],
+        currentFileContent: helper.fileContents,
+        editableRegionStartLine,
+        editableRegionEndLine,
+        editDiffHistory: this.diffContext,
+        currentFilePath: helper.filepath,
         languageShorthand: helper.lang.name,
-        userExcerpts: helper.fileContents,
       };
     } else {
       ctx = {};

--- a/core/nextEdit/NextEditProvider.ts
+++ b/core/nextEdit/NextEditProvider.ts
@@ -37,6 +37,7 @@ import { replaceEscapedCharacters } from "../util/text.js";
 import {
   MERCURY_CODE_TO_EDIT_OPEN,
   MERCURY_SYSTEM_PROMPT,
+  MODEL_1_SYSTEM_PROMPT,
   NEXT_EDIT_EDITABLE_REGION_BOTTOM_MARGIN,
   NEXT_EDIT_EDITABLE_REGION_TOP_MARGIN,
 } from "./constants.js";
@@ -60,8 +61,6 @@ import {
   PromptMetadata,
   RecentlyEditedRange,
 } from "./types.js";
-import { getAutocompleteContext } from "./context/autocompleteContextFetching.js";
-import { EditAggregator } from "./context/aggregateEdits.js";
 
 const autocompleteCache = AutocompleteLruCache.get();
 
@@ -578,7 +577,9 @@ export class NextEditProvider {
 
     const systemPrompt: Prompt = {
       role: "system",
-      content: MERCURY_SYSTEM_PROMPT,
+      content: modelName.includes("mercury-coder-nextedit")
+        ? MERCURY_SYSTEM_PROMPT
+        : MODEL_1_SYSTEM_PROMPT,
     };
 
     return [systemPrompt, promptMetadata.prompt];

--- a/core/nextEdit/constants.ts
+++ b/core/nextEdit/constants.ts
@@ -8,6 +8,31 @@ export const MODEL_1_EDITABLE_REGION_START_TOKEN = "<|editable_region_start|>";
 export const MODEL_1_EDITABLE_REGION_END_TOKEN = "<|editable_region_end|>";
 export const MODEL_1_CONTEXT_FILE_TOKEN = "<|context_file|>";
 export const MODEL_1_SNIPPET_TOKEN = "<|snippet|>";
+export const MODEL_1_SYSTEM_PROMPT = `You are Instinct, an intelligent next-edit predictor developed by Continue.dev. Your role as an AI assistant is to help developers complete their code tasks by predicting the next edit that they will make within the section of code marked by <|editable_region_start|> and <|editable_region_end|> tags.
+
+You have access to the following information to help you make informed suggestions:
+
+- Context: In the section marked "### Context", there are context items from potentially relevant files in the developer's codebase. Each context item consists of a <|context_file|> marker, the filepath, a <|snippet|> marker, and then some content from that file, in that order. Keep in mind that not all of the context information may be relevant to the task, so use your judgement to determine which parts to consider.
+- User Edits: In the section marked "### User Edits:", there is a record of the most recent changes made to the code, helping you understand the evolution of the code and the developer's intentions. These changes are listed from most recent to least recent. It's possible that some of the edit diff history is entirely irrelevant to the developer's change. The changes are provided in a unified line-diff format, i.e. with pluses and minuses for additions and deletions to the code.
+- User Excerpt: In the section marked "### User Excerpt:", there is a filepath to the developer's current file, and then an excerpt from that file. The <|editable_region_start|> and <|editable_region_end|> markers are within this excerpt. Your job is to rewrite only this editable region, not the whole excerpt. The excerpt provides additional context on the surroundings of the developer's edit.
+- Cursor Position: Within the user excerpt's editable region, the <|user_cursor_is_here|> flag indicates where the developer's cursor is currently located, which can be crucial for understanding what part of the code they are focusing on. Do not produce this marker in your output; simply take it into account.
+
+Your task is to predict and complete the changes the developer would have made next in the editable region. The developer may have stopped in the middle of typing. Your goal is to keep the developer on the path that you think they're following. Some examples include further implementing a class, method, or variable, or improving the quality of the code. Make sure the developer doesn't get distracted by ensuring your suggestion is relevant. Consider what changes need to be made next, if any. If you think changes should be made, ask yourself if this is truly what needs to happen. If you are confident about it, then proceed with the changes.
+
+# Steps
+
+1. **Review Context**: Analyze the context from the resources provided, such as recently viewed snippets, edit history, surrounding code, and cursor location.
+2. **Evaluate Current Code**: Determine if the current code within the tags requires any corrections or enhancements.
+3. **Suggest Edits**: If changes are required, ensure they align with the developer's patterns and improve code quality.
+4. **Maintain Consistency**: Ensure indentation and formatting follow the existing code style.
+
+# Output Format
+
+- Provide only the revised code within the tags. Do not include the tags in your output.
+- Ensure that you do not output duplicate code that exists outside of these tags.
+- Avoid undoing or reverting the developer's last change unless there are obvious typos or errors.`;
+export const MODEL_1_USER_PROMPT_PREFIX =
+  "Reference the user excerpt, user edits, and the snippets to understand the developer's intent. Update the editable region of the user excerpt by predicting and completing the changes they would have made next. This may be a deletion, addition, or modification of code.";
 
 // Mercury Coder Next Edit-specific tokens.
 export const MERCURY_RECENTLY_VIEWED_CODE_SNIPPETS_OPEN =

--- a/core/nextEdit/constants.ts
+++ b/core/nextEdit/constants.ts
@@ -6,6 +6,8 @@ export const NEXT_EDIT_EDITABLE_REGION_BOTTOM_MARGIN = 5;
 export const MODEL_1_USER_CURSOR_IS_HERE_TOKEN = "<|user_cursor_is_here|>";
 export const MODEL_1_EDITABLE_REGION_START_TOKEN = "<|editable_region_start|>";
 export const MODEL_1_EDITABLE_REGION_END_TOKEN = "<|editable_region_end|>";
+export const MODEL_1_CONTEXT_FILE_TOKEN = "<|context_file|>";
+export const MODEL_1_SNIPPET_TOKEN = "<|snippet|>";
 
 // Mercury Coder Next Edit-specific tokens.
 export const MERCURY_RECENTLY_VIEWED_CODE_SNIPPETS_OPEN =

--- a/core/nextEdit/context/diffFormatting.ts
+++ b/core/nextEdit/context/diffFormatting.ts
@@ -95,3 +95,98 @@ const createTokenLineDiff = (
   // TODO: Implement token line diff
   return "";
 };
+
+export interface DiffMetadata {
+  oldFilename?: string; // Filename in the original version
+  newFilename?: string; // Filename in the modified version
+  oldTimestamp?: string; // Timestamp of the original file
+  newTimestamp?: string; // Timestamp of the modified file
+  hunks?: Array<{
+    // Information about each change hunk
+    oldStart: number; // Starting line in original file
+    oldCount: number; // Number of lines in original file
+    newStart: number; // Starting line in modified file
+    newCount: number; // Number of lines in modified file
+    header?: string; // Optional section header
+  }>;
+  isBinary?: boolean; // Whether this is a binary file diff
+  isNew?: boolean; // Whether this is a new file
+  isDeleted?: boolean; // Whether this file was deleted
+  isRename?: boolean; // Whether this file was renamed
+}
+
+export function extractMetadataFromUnifiedDiff(
+  unifiedDiff: string,
+): DiffMetadata {
+  const metadata: DiffMetadata = {};
+  const lines = unifiedDiff.split("\n");
+
+  // Parse the header lines (first two lines)
+  if (lines.length >= 2) {
+    // Parse original file info (--- line)
+    const oldFileMatch = lines[0].match(
+      /^--- (a\/)?([^\t\s]+)(?:[\t\s]+(.+))?$/,
+    );
+    if (oldFileMatch) {
+      metadata.oldFilename = oldFileMatch[2];
+      metadata.oldTimestamp = oldFileMatch[3];
+
+      // Check if this is a new file
+      if (metadata.oldFilename === "/dev/null") {
+        metadata.isNew = true;
+      }
+    }
+
+    // Parse modified file info (+++ line)
+    const newFileMatch = lines[1].match(
+      /^\+\+\+ (b\/)?([^\t\s]+)(?:[\t\s]+(.+))?$/,
+    );
+    if (newFileMatch) {
+      metadata.newFilename = newFileMatch[2];
+      metadata.newTimestamp = newFileMatch[3];
+
+      // Check if this file was deleted
+      if (metadata.newFilename === "/dev/null") {
+        metadata.isDeleted = true;
+      }
+    }
+
+    // Check if this is a rename (different old and new names)
+    if (
+      metadata.oldFilename &&
+      metadata.newFilename &&
+      metadata.oldFilename !== "/dev/null" &&
+      metadata.newFilename !== "/dev/null" &&
+      metadata.oldFilename !== metadata.newFilename
+    ) {
+      metadata.isRename = true;
+    }
+  }
+
+  // Parse hunk headers
+  metadata.hunks = [];
+  const hunkHeaderRegex =
+    /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(?:\s(.*))?$/;
+
+  for (let i = 2; i < lines.length; i++) {
+    const line = lines[i];
+    const hunkMatch = line.match(hunkHeaderRegex);
+
+    if (hunkMatch) {
+      metadata.hunks.push({
+        oldStart: parseInt(hunkMatch[1], 10),
+        oldCount: hunkMatch[2] ? parseInt(hunkMatch[2], 10) : 1,
+        newStart: parseInt(hunkMatch[3], 10),
+        newCount: hunkMatch[4] ? parseInt(hunkMatch[4], 10) : 1,
+        header: hunkMatch[5],
+      });
+    }
+
+    // Check for binary file marker
+    if (line.includes("Binary files") || line.includes("GIT binary patch")) {
+      metadata.isBinary = true;
+    }
+  }
+
+  return metadata;
+}

--- a/core/nextEdit/context/diffFormatting.ts
+++ b/core/nextEdit/context/diffFormatting.ts
@@ -124,9 +124,7 @@ export function extractMetadataFromUnifiedDiff(
   // Parse the header lines (first two lines)
   if (lines.length >= 2) {
     // Parse original file info (--- line)
-    const oldFileMatch = lines[0].match(
-      /^--- (a\/)?([^\t\s]+)(?:[\t\s]+(.+))?$/,
-    );
+    const oldFileMatch = lines[0].match(/^--- (a\/)?(.+?)(?:\t(.+))?$/);
     if (oldFileMatch) {
       metadata.oldFilename = oldFileMatch[2];
       metadata.oldTimestamp = oldFileMatch[3];
@@ -138,9 +136,7 @@ export function extractMetadataFromUnifiedDiff(
     }
 
     // Parse modified file info (+++ line)
-    const newFileMatch = lines[1].match(
-      /^\+\+\+ (b\/)?([^\t\s]+)(?:[\t\s]+(.+))?$/,
-    );
+    const newFileMatch = lines[1].match(/^\+\+\+ (b\/)?(.+?)(?:\t(.+))?$/);
     if (newFileMatch) {
       metadata.newFilename = newFileMatch[2];
       metadata.newTimestamp = newFileMatch[3];

--- a/core/nextEdit/context/diffFormatting.vitest.ts
+++ b/core/nextEdit/context/diffFormatting.vitest.ts
@@ -1,0 +1,397 @@
+import { describe, expect, it } from "vitest";
+import {
+  BeforeAfterDiff,
+  createBeforeAfterDiff,
+  createDiff,
+  CreateDiffArgs,
+  DiffFormatType,
+  DiffMetadata,
+  extractMetadataFromUnifiedDiff,
+} from "./diffFormatting";
+
+describe("diffFormatting", () => {
+  const sampleFilePath = "test/sample.js";
+  const beforeContent = "const a = 1;\nconst b = 2;";
+  const afterContent = "const a = 1;\nconst b = 3;\nconst c = 4;";
+
+  describe("createDiff", () => {
+    it("should create unified diff when specified", () => {
+      const args: CreateDiffArgs = {
+        beforeContent,
+        afterContent,
+        filePath: sampleFilePath,
+        diffType: DiffFormatType.Unified,
+        contextLines: 3,
+      };
+
+      const result = createDiff(args);
+
+      expect(result).toContain("---");
+      expect(result).toContain("+++");
+      expect(result).toContain("@@");
+      expect(result).toContain("-const b = 2;");
+      expect(result).toContain("+const b = 3;");
+      expect(result).toContain("+const c = 4;");
+    });
+
+    it("should create token line diff when specified", () => {
+      const args: CreateDiffArgs = {
+        beforeContent,
+        afterContent,
+        filePath: sampleFilePath,
+        diffType: DiffFormatType.TokenLineDiff,
+        contextLines: 3,
+      };
+
+      const result = createDiff(args);
+
+      // Currently returns empty string as TODO
+      expect(result).toBe("");
+    });
+
+    it("should return empty string for unsupported diff types", () => {
+      const args: CreateDiffArgs = {
+        beforeContent,
+        afterContent,
+        filePath: sampleFilePath,
+        diffType: DiffFormatType.RawBeforeAfter,
+        contextLines: 3,
+      };
+
+      const result = createDiff(args);
+
+      expect(result).toBe("");
+    });
+
+    it("should handle empty content", () => {
+      const args: CreateDiffArgs = {
+        beforeContent: "",
+        afterContent: "new content",
+        filePath: sampleFilePath,
+        diffType: DiffFormatType.Unified,
+        contextLines: 3,
+      };
+
+      const result = createDiff(args);
+
+      expect(result).toContain("+++");
+      expect(result).toContain("+new content");
+    });
+
+    it("should handle deletion", () => {
+      const args: CreateDiffArgs = {
+        beforeContent: "old content",
+        afterContent: "",
+        filePath: sampleFilePath,
+        diffType: DiffFormatType.Unified,
+        contextLines: 3,
+      };
+
+      const result = createDiff(args);
+
+      expect(result).toContain("---");
+      expect(result).toContain("-old content");
+    });
+
+    it("should handle content without newlines", () => {
+      const args: CreateDiffArgs = {
+        beforeContent: "line1",
+        afterContent: "line2",
+        filePath: sampleFilePath,
+        diffType: DiffFormatType.Unified,
+        contextLines: 3,
+      };
+
+      const result = createDiff(args);
+
+      expect(result).toContain("-line1");
+      expect(result).toContain("+line2");
+    });
+
+    it("should respect contextLines parameter", () => {
+      const multiLineContent = Array(10)
+        .fill("line")
+        .map((l, i) => `${l}${i}`)
+        .join("\n");
+      const modifiedContent = multiLineContent.replace("line5", "modified5");
+
+      const args: CreateDiffArgs = {
+        beforeContent: multiLineContent,
+        afterContent: modifiedContent,
+        filePath: sampleFilePath,
+        diffType: DiffFormatType.Unified,
+        contextLines: 2,
+      };
+
+      const result = createDiff(args);
+
+      expect(result).toContain("@@ -4,5 +4,5 @@");
+    });
+  });
+
+  describe("createBeforeAfterDiff", () => {
+    it("should return BeforeAfterDiff with normalized content", () => {
+      const result: BeforeAfterDiff = createBeforeAfterDiff(
+        beforeContent,
+        afterContent,
+        sampleFilePath,
+      );
+
+      expect(result).toEqual({
+        filePath: sampleFilePath,
+        beforeContent: beforeContent + "\n",
+        afterContent: afterContent + "\n",
+      });
+    });
+
+    it("should not add extra newline if content already ends with one", () => {
+      const contentWithNewline = "const a = 1;\n";
+      const result: BeforeAfterDiff = createBeforeAfterDiff(
+        contentWithNewline,
+        contentWithNewline,
+        sampleFilePath,
+      );
+
+      expect(result.beforeContent).toBe(contentWithNewline);
+      expect(result.afterContent).toBe(contentWithNewline);
+    });
+
+    it("should handle empty content", () => {
+      const result: BeforeAfterDiff = createBeforeAfterDiff(
+        "",
+        "",
+        sampleFilePath,
+      );
+
+      expect(result).toEqual({
+        filePath: sampleFilePath,
+        beforeContent: "\n",
+        afterContent: "\n",
+      });
+    });
+
+    it("should handle mixed newline scenarios", () => {
+      const beforeWithNewline = "line1\n";
+      const afterWithoutNewline = "line2";
+      const result: BeforeAfterDiff = createBeforeAfterDiff(
+        beforeWithNewline,
+        afterWithoutNewline,
+        sampleFilePath,
+      );
+
+      expect(result.beforeContent).toBe("line1\n");
+      expect(result.afterContent).toBe("line2\n");
+    });
+  });
+
+  describe("extractMetadataFromUnifiedDiff", () => {
+    it("should extract basic file information", () => {
+      const unifiedDiff = `--- a/old.js\ttimestamp1
++++ b/new.js\ttimestamp2
+@@ -1,3 +1,3 @@
+ line1
+-line2
++modified2
+ line3`;
+
+      const metadata: DiffMetadata =
+        extractMetadataFromUnifiedDiff(unifiedDiff);
+
+      expect(metadata.oldFilename).toBe("old.js");
+      expect(metadata.newFilename).toBe("new.js");
+      expect(metadata.oldTimestamp).toBe("timestamp1");
+      expect(metadata.newTimestamp).toBe("timestamp2");
+      expect(metadata.isNew).toBeFalsy();
+      expect(metadata.isDeleted).toBeFalsy();
+      expect(metadata.isRename).toBeTruthy();
+    });
+
+    it("should detect new files", () => {
+      const unifiedDiff = `--- /dev/null
++++ b/new.js
+@@ -0,0 +1,2 @@
++line1
++line2`;
+
+      const metadata: DiffMetadata =
+        extractMetadataFromUnifiedDiff(unifiedDiff);
+
+      expect(metadata.oldFilename).toBe("/dev/null");
+      expect(metadata.newFilename).toBe("new.js");
+      expect(metadata.isNew).toBeTruthy();
+      expect(metadata.isDeleted).toBeFalsy();
+      expect(metadata.isRename).toBeFalsy();
+    });
+
+    it("should detect deleted files", () => {
+      const unifiedDiff = `--- a/old.js
++++ /dev/null
+@@ -1,2 +0,0 @@
+-line1
+-line2`;
+
+      const metadata: DiffMetadata =
+        extractMetadataFromUnifiedDiff(unifiedDiff);
+
+      expect(metadata.oldFilename).toBe("old.js");
+      expect(metadata.newFilename).toBe("/dev/null");
+      expect(metadata.isNew).toBeFalsy();
+      expect(metadata.isDeleted).toBeTruthy();
+      expect(metadata.isRename).toBeFalsy();
+    });
+
+    it("should parse hunk information", () => {
+      const unifiedDiff = `--- a/file.js
++++ b/file.js
+@@ -1,5 +1,6 @@ function header
+ line1
+-line2
++modified2
++newline
+ line3
+@@ -10,3 +11,3 @@
+ line10
+-line11
++modified11
+ line12`;
+
+      const metadata: DiffMetadata =
+        extractMetadataFromUnifiedDiff(unifiedDiff);
+
+      expect(metadata.hunks).toHaveLength(2);
+      expect(metadata.hunks![0]).toEqual({
+        oldStart: 1,
+        oldCount: 5,
+        newStart: 1,
+        newCount: 6,
+        header: "function header",
+      });
+      expect(metadata.hunks![1]).toEqual({
+        oldStart: 10,
+        oldCount: 3,
+        newStart: 11,
+        newCount: 3,
+        header: undefined,
+      });
+    });
+
+    it("should handle single line hunks", () => {
+      const unifiedDiff = `--- a/file.js
++++ b/file.js
+@@ -1 +1 @@
+-old
++new`;
+
+      const metadata: DiffMetadata =
+        extractMetadataFromUnifiedDiff(unifiedDiff);
+
+      expect(metadata.hunks).toHaveLength(1);
+      expect(metadata.hunks![0]).toEqual({
+        oldStart: 1,
+        oldCount: 1,
+        newStart: 1,
+        newCount: 1,
+        header: undefined,
+      });
+    });
+
+    it("should detect binary files", () => {
+      const unifiedDiff = `--- a/image.png
++++ b/image.png
+Binary files a/image.png and b/image.png differ`;
+
+      const metadata: DiffMetadata =
+        extractMetadataFromUnifiedDiff(unifiedDiff);
+
+      expect(metadata.isBinary).toBeTruthy();
+    });
+
+    it("should detect git binary patches", () => {
+      const unifiedDiff = `--- a/file.bin
++++ b/file.bin
+GIT binary patch
+delta 123
+...`;
+
+      const metadata: DiffMetadata =
+        extractMetadataFromUnifiedDiff(unifiedDiff);
+
+      expect(metadata.isBinary).toBeTruthy();
+    });
+
+    it("should handle files without a/ b/ prefixes", () => {
+      const unifiedDiff = `--- old.js
++++ new.js
+@@ -1,2 +1,2 @@
+-line1
++modified1
+ line2`;
+
+      const metadata: DiffMetadata =
+        extractMetadataFromUnifiedDiff(unifiedDiff);
+
+      expect(metadata.oldFilename).toBe("old.js");
+      expect(metadata.newFilename).toBe("new.js");
+    });
+
+    it("should handle empty diff", () => {
+      const metadata: DiffMetadata = extractMetadataFromUnifiedDiff("");
+
+      expect(metadata.oldFilename).toBeUndefined();
+      expect(metadata.newFilename).toBeUndefined();
+      expect(metadata.hunks).toEqual([]);
+      expect(metadata.isBinary).toBeFalsy();
+    });
+
+    it("should handle malformed diff gracefully", () => {
+      const malformedDiff = `not a diff
+random text`;
+
+      const metadata: DiffMetadata =
+        extractMetadataFromUnifiedDiff(malformedDiff);
+
+      expect(metadata.oldFilename).toBeUndefined();
+      expect(metadata.newFilename).toBeUndefined();
+      expect(metadata.hunks).toEqual([]);
+    });
+
+    it("should not consider same filenames as rename", () => {
+      const unifiedDiff = `--- a/file.js
++++ b/file.js
+@@ -1,2 +1,2 @@
+-line1
++modified1
+ line2`;
+
+      const metadata: DiffMetadata =
+        extractMetadataFromUnifiedDiff(unifiedDiff);
+
+      expect(metadata.isRename).toBeFalsy();
+    });
+
+    it("should handle files with spaces in names", () => {
+      const unifiedDiff = `--- a/my file.js\t2023-01-01 00:00:00
++++ b/my new file.js\t2023-01-01 00:01:00
+@@ -1,1 +1,1 @@
+-content
++new content`;
+
+      const metadata: DiffMetadata =
+        extractMetadataFromUnifiedDiff(unifiedDiff);
+
+      expect(metadata.oldFilename).toBe("my file.js");
+      expect(metadata.newFilename).toBe("my new file.js");
+      expect(metadata.oldTimestamp).toBe("2023-01-01 00:00:00");
+      expect(metadata.newTimestamp).toBe("2023-01-01 00:01:00");
+      expect(metadata.isRename).toBeTruthy();
+    });
+  });
+
+  describe("DiffFormatType enum", () => {
+    it("should have correct enum values", () => {
+      expect(DiffFormatType.Unified).toBe("unified");
+      expect(DiffFormatType.RawBeforeAfter).toBe("beforeAfter");
+      expect(DiffFormatType.TokenLineDiff).toBe("linediff");
+    });
+  });
+});

--- a/core/nextEdit/context/diffFormatting.vitest.ts
+++ b/core/nextEdit/context/diffFormatting.vitest.ts
@@ -265,6 +265,35 @@ describe("diffFormatting", () => {
         newStart: 1,
         newCount: 6,
         header: "function header",
+        lines: [
+          {
+            content: "line1",
+            newLineNumber: 1,
+            oldLineNumber: 1,
+            type: "context",
+          },
+          {
+            content: "line2",
+            oldLineNumber: 2,
+            type: "deletion",
+          },
+          {
+            content: "modified2",
+            newLineNumber: 2,
+            type: "addition",
+          },
+          {
+            content: "newline",
+            newLineNumber: 3,
+            type: "addition",
+          },
+          {
+            content: "line3",
+            newLineNumber: 4,
+            oldLineNumber: 3,
+            type: "context",
+          },
+        ],
       });
       expect(metadata.hunks![1]).toEqual({
         oldStart: 10,
@@ -272,6 +301,30 @@ describe("diffFormatting", () => {
         newStart: 11,
         newCount: 3,
         header: undefined,
+        lines: [
+          {
+            content: "line10",
+            newLineNumber: 11,
+            oldLineNumber: 10,
+            type: "context",
+          },
+          {
+            content: "line11",
+            oldLineNumber: 11,
+            type: "deletion",
+          },
+          {
+            content: "modified11",
+            newLineNumber: 12,
+            type: "addition",
+          },
+          {
+            content: "line12",
+            newLineNumber: 13,
+            oldLineNumber: 12,
+            type: "context",
+          },
+        ],
       });
     });
 
@@ -292,6 +345,18 @@ describe("diffFormatting", () => {
         newStart: 1,
         newCount: 1,
         header: undefined,
+        lines: [
+          {
+            content: "old",
+            oldLineNumber: 1,
+            type: "deletion",
+          },
+          {
+            content: "new",
+            newLineNumber: 1,
+            type: "addition",
+          },
+        ],
       });
     });
 

--- a/core/nextEdit/context/processNextEditData.ts
+++ b/core/nextEdit/context/processNextEditData.ts
@@ -3,6 +3,7 @@ import { AutocompleteCodeSnippet } from "../../autocomplete/snippets/types";
 import { GetLspDefinitionsFunction } from "../../autocomplete/types";
 import { ConfigHandler } from "../../config/ConfigHandler";
 import { DataLogger } from "../../data/log";
+import { NextEditProvider } from "../NextEditProvider";
 import { RecentlyEditedRange } from "../types";
 import { getAutocompleteContext } from "./autocompleteContextFetching";
 import { createDiff, DiffFormatType } from "./diffFormatting";
@@ -74,6 +75,8 @@ export const processNextEditData = async ({
     beforeContent,
     modelName,
   );
+
+  NextEditProvider.getInstance().addAutocompleteContext(autocompleteContext);
 
   // console.log(
   //   createDiff(beforeContent, afterContent, filePath, DiffFormatType.Unified),

--- a/core/nextEdit/context/processSmallEdit.ts
+++ b/core/nextEdit/context/processSmallEdit.ts
@@ -20,7 +20,7 @@ export const processSmallEdit = async (
       afterContent: beforeAfterdiff.afterContent,
       filePath: beforeAfterdiff.filePath,
       diffType: DiffFormatType.Unified,
-      contextLines: 3, // NOTE: This can change depending on experiments!
+      contextLines: 5, // NOTE: This can change depending on experiments!
     }),
   );
 

--- a/core/nextEdit/templating/NextEditPromptEngine.ts
+++ b/core/nextEdit/templating/NextEditPromptEngine.ts
@@ -12,6 +12,7 @@ import {
   MERCURY_RECENTLY_VIEWED_CODE_SNIPPETS_CLOSE,
   MERCURY_RECENTLY_VIEWED_CODE_SNIPPETS_OPEN,
   MODEL_1_USER_CURSOR_IS_HERE_TOKEN,
+  MODEL_1_USER_PROMPT_PREFIX,
 } from "../constants";
 import {
   MercuryTemplateVars,
@@ -40,8 +41,7 @@ const NEXT_EDIT_MODEL_TEMPLATES: Record<NEXT_EDIT_MODELS, NextEditTemplate> = {
     template: `${MERCURY_RECENTLY_VIEWED_CODE_SNIPPETS_OPEN}\n{{{recentlyViewedCodeSnippets}}}\n${MERCURY_RECENTLY_VIEWED_CODE_SNIPPETS_CLOSE}\n\n${MERCURY_CURRENT_FILE_CONTENT_OPEN}\n{{{currentFileContent}}}\n${MERCURY_CURRENT_FILE_CONTENT_CLOSE}\n\n${MERCURY_EDIT_DIFF_HISTORY_OPEN}\n{{{editDiffHistory}}}\n${MERCURY_EDIT_DIFF_HISTORY_CLOSE}\n\nThe developer was working on a section of code within the tags \`<|code_to_edit|>\` in the file located at {{{currentFilePath}}}.\nUsing the given \`recently_viewed_code_snippets\`, \`current_file_content\`, \`edit_diff_history\`, and the cursor position marked as \`<|cursor|>\`, please continue the developer's work. Update the \`code_to_edit\` section by predicting and completing the changes they would have made next. Provide the revised code that was between the \`<|code_to_edit|>\` and \`<|/code_to_edit|>\` tags, including the tags themselves.`,
   },
   "model-1": {
-    template:
-      "### User Edits:\n\n{{{editDiffHistory}}}\n### Context:\n{{{recentlyViewedCodeSnippets}}}\n### User Excerpts:\n\n```{{{languageShorthand}}}\n{{{currentFileContent}}}```\n### Response:",
+    template: `${MODEL_1_USER_PROMPT_PREFIX}\n\n### User Edits:\n\n{{{editDiffHistory}}}\n### Context:\n{{{recentlyViewedCodeSnippets}}}\n### User Excerpts:\n\n\`\`\`{{{languageShorthand}}}\n{{{currentFileContent}}}\`\`\`\n### Response:`,
   },
 };
 

--- a/core/nextEdit/templating/NextEditPromptEngine.ts
+++ b/core/nextEdit/templating/NextEditPromptEngine.ts
@@ -30,6 +30,7 @@ import {
   insertCursorToken,
   insertEditableRegionTokensWithStaticRange,
 } from "./utils";
+import { contextSnippetsBlock } from "./model1";
 
 type TemplateRenderer = (vars: TemplateVars) => string;
 
@@ -142,9 +143,7 @@ export async function renderPrompt(
       );
 
       const model1Ctx: Model1TemplateVars = {
-        recentlyViewedCodeSnippets: recentlyViewedCodeSnippetsBlock(
-          ctx.recentlyViewedCodeSnippets,
-        ),
+        contextSnippets: contextSnippetsBlock(ctx.contextSnippets),
         currentFileContent: currentFileContentBlock(
           ctx.currentFileContent,
           ctx.editableRegionStartLine,

--- a/core/nextEdit/templating/NextEditPromptEngine.ts
+++ b/core/nextEdit/templating/NextEditPromptEngine.ts
@@ -44,7 +44,7 @@ const NEXT_EDIT_MODEL_TEMPLATES: Record<NextEditModelName, NextEditTemplate> = {
   },
   "model-1": {
     template:
-      "### User Edits:\n\n{{{userEdits}}}\n\n### User Excerpts:\n\n```{{{languageShorthand}}}\n{{{userExcerpts}}}```",
+      "### User Edits:\n\n{{{editDiffHistory}}}\n### Context:\n{{{recentlyViewedCodeSnippets}}}\n### User Excerpts:\n\n```{{{languageShorthand}}}\n{{{currentFileContent}}}```\n### Response:",
   },
   "this field is not used": {
     template: "NEXT_EDIT",
@@ -142,9 +142,18 @@ export async function renderPrompt(
       );
 
       const model1Ctx: Model1TemplateVars = {
-        userEdits: ctx.userEdits,
+        recentlyViewedCodeSnippets: recentlyViewedCodeSnippetsBlock(
+          ctx.recentlyViewedCodeSnippets,
+        ),
+        currentFileContent: currentFileContentBlock(
+          ctx.currentFileContent,
+          ctx.editableRegionStartLine,
+          ctx.editableRegionEndLine,
+          helper.pos,
+        ),
+        editDiffHistory: editHistoryBlock(ctx.editDiffHistory),
+        currentFilePath: ctx.currentFilePath,
         languageShorthand: ctx.languageShorthand,
-        userExcerpts: ctx.userExcerpts,
       };
 
       tv = model1Ctx;

--- a/core/nextEdit/templating/NextEditPromptEngine.ts
+++ b/core/nextEdit/templating/NextEditPromptEngine.ts
@@ -41,7 +41,7 @@ const NEXT_EDIT_MODEL_TEMPLATES: Record<NEXT_EDIT_MODELS, NextEditTemplate> = {
   },
   "model-1": {
     template:
-      "### User Edits:\n\n{{{userEdits}}}\n\n### User Excerpts:\n\n```{{{languageShorthand}}}\n{{{userExcerpts}}}```",
+      "### User Edits:\n\n{{{editDiffHistory}}}\n### Context:\n{{{recentlyViewedCodeSnippets}}}\n### User Excerpts:\n\n```{{{languageShorthand}}}\n{{{currentFileContent}}}```\n### Response:",
   },
 };
 

--- a/core/nextEdit/templating/NextEditPromptEngine.ts
+++ b/core/nextEdit/templating/NextEditPromptEngine.ts
@@ -132,6 +132,8 @@ export async function renderPrompt(
         contextSnippets: contextSnippetsBlock(ctx.contextSnippets),
         currentFileContent: model1CurrentFileContentBlock(
           ctx.currentFileContent,
+          ctx.windowStart,
+          ctx.windowEnd,
           ctx.editableRegionStartLine,
           ctx.editableRegionEndLine,
           helper.pos,

--- a/core/nextEdit/templating/NextEditPromptEngine.ts
+++ b/core/nextEdit/templating/NextEditPromptEngine.ts
@@ -28,7 +28,11 @@ import {
   editHistoryBlock,
   recentlyViewedCodeSnippetsBlock,
 } from "./mercuryCoderNextEdit";
-import { contextSnippetsBlock } from "./model1";
+import {
+  contextSnippetsBlock,
+  currentFileContentBlock as model1CurrentFileContentBlock,
+  editHistoryBlock as model1EditHistoryBlock,
+} from "./model1";
 import {
   insertCursorToken,
   insertEditableRegionTokensWithStaticRange,
@@ -41,7 +45,7 @@ const NEXT_EDIT_MODEL_TEMPLATES: Record<NEXT_EDIT_MODELS, NextEditTemplate> = {
     template: `${MERCURY_RECENTLY_VIEWED_CODE_SNIPPETS_OPEN}\n{{{recentlyViewedCodeSnippets}}}\n${MERCURY_RECENTLY_VIEWED_CODE_SNIPPETS_CLOSE}\n\n${MERCURY_CURRENT_FILE_CONTENT_OPEN}\n{{{currentFileContent}}}\n${MERCURY_CURRENT_FILE_CONTENT_CLOSE}\n\n${MERCURY_EDIT_DIFF_HISTORY_OPEN}\n{{{editDiffHistory}}}\n${MERCURY_EDIT_DIFF_HISTORY_CLOSE}\n\nThe developer was working on a section of code within the tags \`<|code_to_edit|>\` in the file located at {{{currentFilePath}}}.\nUsing the given \`recently_viewed_code_snippets\`, \`current_file_content\`, \`edit_diff_history\`, and the cursor position marked as \`<|cursor|>\`, please continue the developer's work. Update the \`code_to_edit\` section by predicting and completing the changes they would have made next. Provide the revised code that was between the \`<|code_to_edit|>\` and \`<|/code_to_edit|>\` tags, including the tags themselves.`,
   },
   "model-1": {
-    template: `${MODEL_1_USER_PROMPT_PREFIX}\n\n### User Edits:\n\n{{{editDiffHistory}}}\n### Context:\n{{{recentlyViewedCodeSnippets}}}\n### User Excerpts:\n\n\`\`\`{{{languageShorthand}}}\n{{{currentFileContent}}}\`\`\`\n### Response:`,
+    template: `${MODEL_1_USER_PROMPT_PREFIX}\n\n### Context:\n{{{recentlyViewedCodeSnippets}}}\n\n### User Edits:\n\n{{{editDiffHistory}}}\n\n### User Excerpts:\n\n\`\`\`{{{languageShorthand}}}\n{{{currentFileContent}}}\`\`\`\n### Response:`,
   },
 };
 
@@ -126,13 +130,13 @@ export async function renderPrompt(
 
       const model1Ctx: Model1TemplateVars = {
         contextSnippets: contextSnippetsBlock(ctx.contextSnippets),
-        currentFileContent: currentFileContentBlock(
+        currentFileContent: model1CurrentFileContentBlock(
           ctx.currentFileContent,
           ctx.editableRegionStartLine,
           ctx.editableRegionEndLine,
           helper.pos,
         ),
-        editDiffHistory: editHistoryBlock(ctx.editDiffHistory),
+        editDiffHistory: model1EditHistoryBlock(ctx.editDiffHistory),
         currentFilePath: ctx.currentFilePath,
         languageShorthand: ctx.languageShorthand,
       };

--- a/core/nextEdit/templating/NextEditPromptEngine.ts
+++ b/core/nextEdit/templating/NextEditPromptEngine.ts
@@ -45,7 +45,7 @@ const NEXT_EDIT_MODEL_TEMPLATES: Record<NEXT_EDIT_MODELS, NextEditTemplate> = {
     template: `${MERCURY_RECENTLY_VIEWED_CODE_SNIPPETS_OPEN}\n{{{recentlyViewedCodeSnippets}}}\n${MERCURY_RECENTLY_VIEWED_CODE_SNIPPETS_CLOSE}\n\n${MERCURY_CURRENT_FILE_CONTENT_OPEN}\n{{{currentFileContent}}}\n${MERCURY_CURRENT_FILE_CONTENT_CLOSE}\n\n${MERCURY_EDIT_DIFF_HISTORY_OPEN}\n{{{editDiffHistory}}}\n${MERCURY_EDIT_DIFF_HISTORY_CLOSE}\n\nThe developer was working on a section of code within the tags \`<|code_to_edit|>\` in the file located at {{{currentFilePath}}}.\nUsing the given \`recently_viewed_code_snippets\`, \`current_file_content\`, \`edit_diff_history\`, and the cursor position marked as \`<|cursor|>\`, please continue the developer's work. Update the \`code_to_edit\` section by predicting and completing the changes they would have made next. Provide the revised code that was between the \`<|code_to_edit|>\` and \`<|/code_to_edit|>\` tags, including the tags themselves.`,
   },
   "model-1": {
-    template: `${MODEL_1_USER_PROMPT_PREFIX}\n\n### Context:\n{{{recentlyViewedCodeSnippets}}}\n\n### User Edits:\n\n{{{editDiffHistory}}}\n\n### User Excerpts:\n\n\`\`\`{{{languageShorthand}}}\n{{{currentFileContent}}}\`\`\`\n### Response:`,
+    template: `${MODEL_1_USER_PROMPT_PREFIX}\n\n### Context:\n{{{contextSnippets}}}\n\n### User Edits:\n\n{{{editDiffHistory}}}\n\n### User Excerpts:\n\n\`\`\`{{{languageShorthand}}}\n{{{currentFileContent}}}\`\`\`\n### Response:`,
   },
 };
 
@@ -120,7 +120,7 @@ export async function renderPrompt(
       break;
     }
     case "model-1": {
-      userEdits = ctx.userEdits;
+      userEdits = ctx.editDiffHistory;
 
       editedCodeWithTokens = insertTokens(
         helper.fileContents.split("\n"),

--- a/core/nextEdit/templating/model1.ts
+++ b/core/nextEdit/templating/model1.ts
@@ -1,0 +1,88 @@
+import { Position, Range } from "../..";
+import {
+  MODEL_1_CONTEXT_FILE_TOKEN,
+  MODEL_1_EDITABLE_REGION_END_TOKEN,
+  MODEL_1_EDITABLE_REGION_START_TOKEN,
+  MODEL_1_SNIPPET_TOKEN,
+  MODEL_1_USER_CURSOR_IS_HERE_TOKEN,
+} from "../constants";
+import { extractMetadataFromUnifiedDiff } from "../context/diffFormatting";
+import { insertCursorToken } from "./utils";
+
+export function recentlyViewedCodeSnippetsBlock(
+  recentlyViewedCodeSnippets: { filepath: string; content: string }[],
+) {
+  return recentlyViewedCodeSnippets.reduce((acc, snippet, i) => {
+    const block = [
+      `${MODEL_1_CONTEXT_FILE_TOKEN}: ${snippet.filepath}`,
+      `${MODEL_1_SNIPPET_TOKEN}\n${snippet.content}`,
+    ].join("\n");
+
+    return (
+      acc + block + (i === recentlyViewedCodeSnippets.length - 1 ? "" : "\n")
+    );
+  }, "");
+}
+
+export function currentFileContentBlock(
+  currentFileContent: string,
+  editableRegionStartLine: number,
+  editableRegionEndLine: number,
+  cursorPosition: Position,
+) {
+  const currentFileContentLines = currentFileContent.split("\n");
+
+  const insertedCursorLines = insertCursorToken(
+    currentFileContentLines,
+    cursorPosition,
+    MODEL_1_USER_CURSOR_IS_HERE_TOKEN,
+  );
+
+  const instrumentedLines = [
+    ...insertedCursorLines.slice(0, editableRegionStartLine),
+    MODEL_1_EDITABLE_REGION_START_TOKEN,
+    ...insertedCursorLines.slice(
+      editableRegionStartLine,
+      editableRegionEndLine + 1,
+    ),
+    MODEL_1_EDITABLE_REGION_END_TOKEN,
+    ...insertedCursorLines.slice(editableRegionEndLine + 1),
+  ];
+
+  return instrumentedLines.join("\n");
+}
+
+export function editHistoryBlock(
+  editDiffHistories: string[], // list of unified diffs
+) {
+  // diffHistory is made from createDiff.
+  // This uses createPatch from npm diff library, which includes an index line and a separator.
+  // We get rid of these first two lines.
+  const block: string[] = [];
+
+  editDiffHistories.forEach((diff) => {
+    const metadata = extractMetadataFromUnifiedDiff(diff);
+    block.push(
+      [
+        `User edited file \"${metadata.oldFilename}\"`,
+        "",
+        "```diff",
+        `${diff.split("\n").slice(2).join("\n")}`,
+        "```",
+      ].join("\n"),
+    );
+  });
+
+  return block.join("\n");
+}
+
+function mercuryNextEditTemplateBuilder(
+  recentlyViewedCodeSnippets: { filepath: string; code: string }[],
+  currentFileContent: string,
+  codeToEdit: string,
+  codeToEditRange: Range,
+  cursorPosition: Position,
+  editDiffHistory: string, // could be a singe large unified diff
+): string {
+  return "";
+}

--- a/core/nextEdit/templating/model1.ts
+++ b/core/nextEdit/templating/model1.ts
@@ -39,6 +39,8 @@ export function contextSnippetsBlock(contextSnippets: string) {
 
 export function currentFileContentBlock(
   currentFileContent: string,
+  windowStart: number,
+  windowEnd: number,
   editableRegionStartLine: number,
   editableRegionEndLine: number,
   cursorPosition: Position,
@@ -52,14 +54,14 @@ export function currentFileContentBlock(
   );
 
   const instrumentedLines = [
-    ...insertedCursorLines.slice(0, editableRegionStartLine),
+    ...insertedCursorLines.slice(windowStart, editableRegionStartLine),
     MODEL_1_EDITABLE_REGION_START_TOKEN,
     ...insertedCursorLines.slice(
       editableRegionStartLine,
       editableRegionEndLine + 1,
     ),
     MODEL_1_EDITABLE_REGION_END_TOKEN,
-    ...insertedCursorLines.slice(editableRegionEndLine + 1),
+    ...insertedCursorLines.slice(editableRegionEndLine + 1, windowEnd + 1),
   ];
 
   return instrumentedLines.join("\n");

--- a/core/nextEdit/templating/model1.vitest.ts
+++ b/core/nextEdit/templating/model1.vitest.ts
@@ -1,0 +1,402 @@
+import { describe, expect, test } from "vitest";
+import { Position } from "../..";
+import {
+  contextSnippetsBlock,
+  currentFileContentBlock,
+  editHistoryBlock,
+} from "./model1";
+
+describe("contextSnippetsBlock", () => {
+  test("should format empty context snippets", () => {
+    const result = contextSnippetsBlock("");
+    expect(result).toBe("");
+  });
+
+  test("should format single context snippet with codestral style header", () => {
+    const input = `+++++ src/utils.ts
+function helper() {
+  return "test";
+}`;
+
+    const expected = `<|context_file|>: src/utils.ts
+<|snippet|>
+function helper() {
+  return "test";
+}`;
+
+    const result = contextSnippetsBlock(input);
+    expect(result).toBe(expected);
+  });
+
+  test("should format multiple context snippets", () => {
+    const input = `+++++ src/file1.ts
+const var1 = "value1";
+
++++++ src/file2.ts
+const var2 = "value2";
+function test() {}`;
+
+    const expected = `<|context_file|>: src/file1.ts
+<|snippet|>
+const var1 = "value1";
+
+<|context_file|>: src/file2.ts
+<|snippet|>
+const var2 = "value2";
+function test() {}`;
+
+    const result = contextSnippetsBlock(input);
+    expect(result).toBe(expected);
+  });
+
+  test("should handle context snippet without content", () => {
+    const input = "+++++ src/empty.ts";
+
+    const expected = `<|context_file|>: src/empty.ts`;
+
+    const result = contextSnippetsBlock(input);
+    expect(result).toBe(expected);
+  });
+
+  test("should handle malformed headers gracefully", () => {
+    const input = `not a header
++++++ src/valid.ts
+valid content`;
+
+    const expected = `not a header
+<|context_file|>: src/valid.ts
+<|snippet|>
+valid content`;
+
+    const result = contextSnippetsBlock(input);
+    expect(result).toBe(expected);
+  });
+
+  test("should handle multiple consecutive headers", () => {
+    const input = `+++++ src/file1.ts
++++++ src/file2.ts
+content after headers`;
+
+    const expected = `<|context_file|>: src/file1.ts
+<|context_file|>: src/file2.ts
+<|snippet|>
+content after headers`;
+
+    const result = contextSnippetsBlock(input);
+    expect(result).toBe(expected);
+  });
+});
+
+describe("currentFileContentBlock", () => {
+  test("should insert cursor and editable region tokens correctly", () => {
+    const content = `line 0
+line 1
+line 2
+line 3
+line 4`;
+    const cursorPosition: Position = { line: 2, character: 4 };
+    const editableRegionStartLine = 1;
+    const editableRegionEndLine = 3;
+
+    const result = currentFileContentBlock(
+      content,
+      editableRegionStartLine,
+      editableRegionEndLine,
+      cursorPosition,
+    );
+
+    const expected = `line 0
+<|editable_region_start|>
+line 1
+line<|user_cursor_is_here|> 2
+line 3
+<|editable_region_end|>
+line 4`;
+
+    expect(result).toBe(expected);
+  });
+
+  test("should handle cursor at beginning of line", () => {
+    const content = `line 0
+line 1
+line 2`;
+    const cursorPosition: Position = { line: 1, character: 0 };
+    const editableRegionStartLine = 0;
+    const editableRegionEndLine = 2;
+
+    const result = currentFileContentBlock(
+      content,
+      editableRegionStartLine,
+      editableRegionEndLine,
+      cursorPosition,
+    );
+
+    const expected = `<|editable_region_start|>
+line 0
+<|user_cursor_is_here|>line 1
+line 2
+<|editable_region_end|>`;
+
+    expect(result).toBe(expected);
+  });
+
+  test("should handle cursor at end of line", () => {
+    const content = `line 0
+line 1
+line 2`;
+    const cursorPosition: Position = { line: 1, character: 6 }; // end of "line 1"
+    const editableRegionStartLine = 0;
+    const editableRegionEndLine = 2;
+
+    const result = currentFileContentBlock(
+      content,
+      editableRegionStartLine,
+      editableRegionEndLine,
+      cursorPosition,
+    );
+
+    const expected = `<|editable_region_start|>
+line 0
+line 1<|user_cursor_is_here|>
+line 2
+<|editable_region_end|>`;
+
+    expect(result).toBe(expected);
+  });
+
+  test("should handle single line editable region", () => {
+    const content = `line 0
+line 1
+line 2`;
+    const cursorPosition: Position = { line: 1, character: 2 };
+    const editableRegionStartLine = 1;
+    const editableRegionEndLine = 1;
+
+    const result = currentFileContentBlock(
+      content,
+      editableRegionStartLine,
+      editableRegionEndLine,
+      cursorPosition,
+    );
+
+    const expected = `line 0
+<|editable_region_start|>
+li<|user_cursor_is_here|>ne 1
+<|editable_region_end|>
+line 2`;
+
+    expect(result).toBe(expected);
+  });
+
+  test("should handle cursor outside bounds gracefully", () => {
+    const content = `line 0
+line 1`;
+    const cursorPosition: Position = { line: 10, character: 0 }; // out of bounds
+    const editableRegionStartLine = 0;
+    const editableRegionEndLine = 1;
+
+    const result = currentFileContentBlock(
+      content,
+      editableRegionStartLine,
+      editableRegionEndLine,
+      cursorPosition,
+    );
+
+    const expected = `<|editable_region_start|>
+line 0
+line 1
+<|editable_region_end|>`;
+
+    expect(result).toBe(expected);
+  });
+
+  test("should handle editable region covering entire file", () => {
+    const content = `line 0
+line 1
+line 2`;
+    const cursorPosition: Position = { line: 1, character: 0 };
+    const editableRegionStartLine = 0;
+    const editableRegionEndLine = 2;
+
+    const result = currentFileContentBlock(
+      content,
+      editableRegionStartLine,
+      editableRegionEndLine,
+      cursorPosition,
+    );
+
+    const expected = `<|editable_region_start|>
+line 0
+<|user_cursor_is_here|>line 1
+line 2
+<|editable_region_end|>`;
+
+    expect(result).toBe(expected);
+  });
+});
+
+describe("editHistoryBlock", () => {
+  test("should format empty edit history", () => {
+    const result = editHistoryBlock([]);
+    expect(result).toBe("");
+  });
+
+  test("should format single diff history entry", () => {
+    const diff = `Index: test.js
+===================================================================
+--- a/test.js	2023-01-01 10:00:00.000000000 +0000
++++ b/test.js	2023-01-01 10:01:00.000000000 +0000
+@@ -1,3 +1,3 @@
+ function test() {
+-  console.log("old");
++  console.log("new");
+ }`;
+
+    const result = editHistoryBlock([diff]);
+    const expected = `User edited file "test.js"
+
+\`\`\`diff
+--- a/test.js	2023-01-01 10:00:00.000000000 +0000
++++ b/test.js	2023-01-01 10:01:00.000000000 +0000
+@@ -1,3 +1,3 @@
+ function test() {
+-  console.log("old");
++  console.log("new");
+ }
+\`\`\``;
+
+    expect(result).toBe(expected);
+  });
+
+  test("should format multiple diff history entries", () => {
+    const diff1 = `Index: file1.js
+===================================================================
+--- a/file1.js	2023-01-01 10:00:00.000000000 +0000
++++ b/file1.js	2023-01-01 10:01:00.000000000 +0000
+@@ -1 +1 @@
+-const old = 1;
++const new = 1;`;
+
+    const diff2 = `Index: file2.js
+===================================================================
+--- a/file2.js	2023-01-01 10:02:00.000000000 +0000
++++ b/file2.js	2023-01-01 10:03:00.000000000 +0000
+@@ -1 +1 @@
+-let x = "old";
++let x = "new";`;
+
+    const result = editHistoryBlock([diff1, diff2]);
+    const expected = `User edited file "file1.js"
+
+\`\`\`diff
+--- a/file1.js	2023-01-01 10:00:00.000000000 +0000
++++ b/file1.js	2023-01-01 10:01:00.000000000 +0000
+@@ -1 +1 @@
+-const old = 1;
++const new = 1;
+\`\`\`
+User edited file "file2.js"
+
+\`\`\`diff
+--- a/file2.js	2023-01-01 10:02:00.000000000 +0000
++++ b/file2.js	2023-01-01 10:03:00.000000000 +0000
+@@ -1 +1 @@
+-let x = "old";
++let x = "new";
+\`\`\``;
+
+    expect(result).toBe(expected);
+  });
+
+  test("should handle diff with complex filename paths", () => {
+    const diff = `Index: src/components/Button/Button.tsx
+===================================================================
+--- a/src/components/Button/Button.tsx	2023-01-01 10:00:00.000000000 +0000
++++ b/src/components/Button/Button.tsx	2023-01-01 10:01:00.000000000 +0000
+@@ -1,2 +1,2 @@
+-export const Button = () => <button>Old</button>;
++export const Button = () => <button>New</button>;`;
+
+    const result = editHistoryBlock([diff]);
+    const expected = `User edited file "src/components/Button/Button.tsx"
+
+\`\`\`diff
+--- a/src/components/Button/Button.tsx	2023-01-01 10:00:00.000000000 +0000
++++ b/src/components/Button/Button.tsx	2023-01-01 10:01:00.000000000 +0000
+@@ -1,2 +1,2 @@
+-export const Button = () => <button>Old</button>;
++export const Button = () => <button>New</button>;
+\`\`\``;
+
+    expect(result).toBe(expected);
+  });
+
+  test("should handle diff with new file creation", () => {
+    const diff = `Index: newfile.js
+===================================================================
+--- /dev/null	2023-01-01 10:00:00.000000000 +0000
++++ b/newfile.js	2023-01-01 10:01:00.000000000 +0000
+@@ -0,0 +1,3 @@
++function newFunction() {
++  return "hello world";
++}`;
+
+    const result = editHistoryBlock([diff]);
+    const expected = `User edited file "/dev/null"
+
+\`\`\`diff
+--- /dev/null	2023-01-01 10:00:00.000000000 +0000
++++ b/newfile.js	2023-01-01 10:01:00.000000000 +0000
+@@ -0,0 +1,3 @@
++function newFunction() {
++  return "hello world";
++}
+\`\`\``;
+
+    expect(result).toBe(expected);
+  });
+
+  test("should handle diff with file deletion", () => {
+    const diff = `Index: deletedfile.js
+===================================================================
+--- a/deletedfile.js	2023-01-01 10:00:00.000000000 +0000
++++ /dev/null	2023-01-01 10:01:00.000000000 +0000
+@@ -1,3 +0,0 @@
+-function deletedFunction() {
+-  return "goodbye";
+-}`;
+
+    const result = editHistoryBlock([diff]);
+    const expected = `User edited file "deletedfile.js"
+
+\`\`\`diff
+--- a/deletedfile.js	2023-01-01 10:00:00.000000000 +0000
++++ /dev/null	2023-01-01 10:01:00.000000000 +0000
+@@ -1,3 +0,0 @@
+-function deletedFunction() {
+-  return "goodbye";
+-}
+\`\`\``;
+
+    expect(result).toBe(expected);
+  });
+
+  test("should handle minimal diff format", () => {
+    const diff = `Index: simple.txt
+===================================================================
+@@ -1 +1 @@
+-old text
++new text`;
+
+    const result = editHistoryBlock([diff]);
+    const expected = `User edited file "undefined"
+
+\`\`\`diff
+@@ -1 +1 @@
+-old text
++new text
+\`\`\``;
+
+    expect(result).toBe(expected);
+  });
+});

--- a/core/nextEdit/templating/model1.vitest.ts
+++ b/core/nextEdit/templating/model1.vitest.ts
@@ -94,12 +94,16 @@ line 1
 line 2
 line 3
 line 4`;
+    const windowStart = 0;
+    const windowEnd = 4;
     const cursorPosition: Position = { line: 2, character: 4 };
     const editableRegionStartLine = 1;
     const editableRegionEndLine = 3;
 
     const result = currentFileContentBlock(
       content,
+      windowStart,
+      windowEnd,
       editableRegionStartLine,
       editableRegionEndLine,
       cursorPosition,
@@ -120,12 +124,16 @@ line 4`;
     const content = `line 0
 line 1
 line 2`;
+    const windowStart = 0;
+    const windowEnd = 2;
     const cursorPosition: Position = { line: 1, character: 0 };
     const editableRegionStartLine = 0;
     const editableRegionEndLine = 2;
 
     const result = currentFileContentBlock(
       content,
+      windowStart,
+      windowEnd,
       editableRegionStartLine,
       editableRegionEndLine,
       cursorPosition,
@@ -144,12 +152,16 @@ line 2
     const content = `line 0
 line 1
 line 2`;
+    const windowStart = 0;
+    const windowEnd = 2;
     const cursorPosition: Position = { line: 1, character: 6 }; // end of "line 1"
     const editableRegionStartLine = 0;
     const editableRegionEndLine = 2;
 
     const result = currentFileContentBlock(
       content,
+      windowStart,
+      windowEnd,
       editableRegionStartLine,
       editableRegionEndLine,
       cursorPosition,
@@ -168,12 +180,16 @@ line 2
     const content = `line 0
 line 1
 line 2`;
+    const windowStart = 0;
+    const windowEnd = 2;
     const cursorPosition: Position = { line: 1, character: 2 };
     const editableRegionStartLine = 1;
     const editableRegionEndLine = 1;
 
     const result = currentFileContentBlock(
       content,
+      windowStart,
+      windowEnd,
       editableRegionStartLine,
       editableRegionEndLine,
       cursorPosition,
@@ -188,15 +204,19 @@ line 2`;
     expect(result).toBe(expected);
   });
 
-  test("should handle cursor outside bounds gracefully", () => {
+  test("should handle cursor outside bounds gracefully (this shouldn't happen)", () => {
     const content = `line 0
 line 1`;
+    const windowStart = 0;
+    const windowEnd = 1;
     const cursorPosition: Position = { line: 10, character: 0 }; // out of bounds
     const editableRegionStartLine = 0;
     const editableRegionEndLine = 1;
 
     const result = currentFileContentBlock(
       content,
+      windowStart,
+      windowEnd,
       editableRegionStartLine,
       editableRegionEndLine,
       cursorPosition,
@@ -214,12 +234,16 @@ line 1
     const content = `line 0
 line 1
 line 2`;
+    const windowStart = 0;
+    const windowEnd = 2;
     const cursorPosition: Position = { line: 1, character: 0 };
     const editableRegionStartLine = 0;
     const editableRegionEndLine = 2;
 
     const result = currentFileContentBlock(
       content,
+      windowStart,
+      windowEnd,
       editableRegionStartLine,
       editableRegionEndLine,
       cursorPosition,
@@ -230,6 +254,36 @@ line 0
 <|user_cursor_is_here|>line 1
 line 2
 <|editable_region_end|>`;
+
+    expect(result).toBe(expected);
+  });
+
+  test("should handle windowing - content outside window not included", () => {
+    const content = `line 0
+line 1
+line 2
+line 3
+line 4`;
+    const windowStart = 1;
+    const windowEnd = 3;
+    const cursorPosition: Position = { line: 2, character: 2 };
+    const editableRegionStartLine = 2;
+    const editableRegionEndLine = 2;
+
+    const result = currentFileContentBlock(
+      content,
+      windowStart,
+      windowEnd,
+      editableRegionStartLine,
+      editableRegionEndLine,
+      cursorPosition,
+    );
+
+    const expected = `line 1
+<|editable_region_start|>
+li<|user_cursor_is_here|>ne 2
+<|editable_region_end|>
+line 3`;
 
     expect(result).toBe(expected);
   });

--- a/core/nextEdit/templating/model1.vitest.ts
+++ b/core/nextEdit/templating/model1.vitest.ts
@@ -291,7 +291,7 @@ line 3`;
 
 describe("editHistoryBlock", () => {
   test("should format empty edit history", () => {
-    const result = editHistoryBlock([]);
+    const result = editHistoryBlock("");
     expect(result).toBe("");
   });
 
@@ -306,12 +306,10 @@ describe("editHistoryBlock", () => {
 +  console.log("new");
  }`;
 
-    const result = editHistoryBlock([diff]);
+    const result = editHistoryBlock(diff);
     const expected = `User edited file "test.js"
 
 \`\`\`diff
---- a/test.js	2023-01-01 10:00:00.000000000 +0000
-+++ b/test.js	2023-01-01 10:01:00.000000000 +0000
 @@ -1,3 +1,3 @@
  function test() {
 -  console.log("old");
@@ -322,16 +320,16 @@ describe("editHistoryBlock", () => {
     expect(result).toBe(expected);
   });
 
-  test("should format multiple diff history entries", () => {
-    const diff1 = `Index: file1.js
+  test("should format multiple diff history entries in unified format", () => {
+    // Multiple diffs should be concatenated into a single string
+    const unifiedDiff = `Index: file1.js
 ===================================================================
 --- a/file1.js	2023-01-01 10:00:00.000000000 +0000
 +++ b/file1.js	2023-01-01 10:01:00.000000000 +0000
 @@ -1 +1 @@
 -const old = 1;
-+const new = 1;`;
-
-    const diff2 = `Index: file2.js
++const new = 1;
+Index: file2.js
 ===================================================================
 --- a/file2.js	2023-01-01 10:02:00.000000000 +0000
 +++ b/file2.js	2023-01-01 10:03:00.000000000 +0000
@@ -339,12 +337,10 @@ describe("editHistoryBlock", () => {
 -let x = "old";
 +let x = "new";`;
 
-    const result = editHistoryBlock([diff1, diff2]);
+    const result = editHistoryBlock(unifiedDiff);
     const expected = `User edited file "file1.js"
 
 \`\`\`diff
---- a/file1.js	2023-01-01 10:00:00.000000000 +0000
-+++ b/file1.js	2023-01-01 10:01:00.000000000 +0000
 @@ -1 +1 @@
 -const old = 1;
 +const new = 1;
@@ -352,8 +348,6 @@ describe("editHistoryBlock", () => {
 User edited file "file2.js"
 
 \`\`\`diff
---- a/file2.js	2023-01-01 10:02:00.000000000 +0000
-+++ b/file2.js	2023-01-01 10:03:00.000000000 +0000
 @@ -1 +1 @@
 -let x = "old";
 +let x = "new";
@@ -362,6 +356,7 @@ User edited file "file2.js"
     expect(result).toBe(expected);
   });
 
+  // Fix remaining tests to pass strings instead of arrays
   test("should handle diff with complex filename paths", () => {
     const diff = `Index: src/components/Button/Button.tsx
 ===================================================================
@@ -371,12 +366,10 @@ User edited file "file2.js"
 -export const Button = () => <button>Old</button>;
 +export const Button = () => <button>New</button>;`;
 
-    const result = editHistoryBlock([diff]);
+    const result = editHistoryBlock(diff);
     const expected = `User edited file "src/components/Button/Button.tsx"
 
 \`\`\`diff
---- a/src/components/Button/Button.tsx	2023-01-01 10:00:00.000000000 +0000
-+++ b/src/components/Button/Button.tsx	2023-01-01 10:01:00.000000000 +0000
 @@ -1,2 +1,2 @@
 -export const Button = () => <button>Old</button>;
 +export const Button = () => <button>New</button>;
@@ -395,12 +388,10 @@ User edited file "file2.js"
 +  return "hello world";
 +}`;
 
-    const result = editHistoryBlock([diff]);
-    const expected = `User edited file "/dev/null"
+    const result = editHistoryBlock(diff);
+    const expected = `User edited file "newfile.js"
 
 \`\`\`diff
---- /dev/null	2023-01-01 10:00:00.000000000 +0000
-+++ b/newfile.js	2023-01-01 10:01:00.000000000 +0000
 @@ -0,0 +1,3 @@
 +function newFunction() {
 +  return "hello world";
@@ -420,12 +411,10 @@ User edited file "file2.js"
 -  return "goodbye";
 -}`;
 
-    const result = editHistoryBlock([diff]);
+    const result = editHistoryBlock(diff);
     const expected = `User edited file "deletedfile.js"
 
 \`\`\`diff
---- a/deletedfile.js	2023-01-01 10:00:00.000000000 +0000
-+++ /dev/null	2023-01-01 10:01:00.000000000 +0000
 @@ -1,3 +0,0 @@
 -function deletedFunction() {
 -  return "goodbye";
@@ -442,8 +431,8 @@ User edited file "file2.js"
 -old text
 +new text`;
 
-    const result = editHistoryBlock([diff]);
-    const expected = `User edited file "undefined"
+    const result = editHistoryBlock(diff);
+    const expected = `User edited file "simple.txt"
 
 \`\`\`diff
 @@ -1 +1 @@

--- a/core/nextEdit/types.ts
+++ b/core/nextEdit/types.ts
@@ -91,9 +91,11 @@ export interface NextEditTemplate {
 export interface TemplateVars {}
 
 export interface Model1TemplateVars extends TemplateVars {
-  userEdits: string;
+  recentlyViewedCodeSnippets: string;
+  currentFileContent: string;
+  editDiffHistory: string; // could be a singe large unified diff
+  currentFilePath: string;
   languageShorthand: string;
-  userExcerpts: string;
 }
 
 export interface MercuryTemplateVars extends TemplateVars {

--- a/core/nextEdit/types.ts
+++ b/core/nextEdit/types.ts
@@ -91,7 +91,7 @@ export interface NextEditTemplate {
 export interface TemplateVars {}
 
 export interface Model1TemplateVars extends TemplateVars {
-  recentlyViewedCodeSnippets: string;
+  contextSnippets: string;
   currentFileContent: string;
   editDiffHistory: string; // could be a singe large unified diff
   currentFilePath: string;


### PR DESCRIPTION
## Description

Closes CON-3231.
Add support for more models by adding templates.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

`core/nextEdit/context/diffFormatting.vitest.ts`
`core/nextEdit/templating/model1.vitest.ts`
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for more models by introducing model-specific templates and context formatting, meeting the requirements of CON-3231.

- **New Features**
 - Added template and formatting logic for "model-1" including context snippet parsing and edit history blocks.
 - Updated NextEditProvider and related functions to handle model-specific context and prompt variables.
 - Added new tokens for context and snippet identification.

- **Tests**
 - Added unit tests for new context formatting and templating helpers.

<!-- End of auto-generated description by cubic. -->

