### PR TITLE
feat: Add reasoning field support for OpenAI o-series models

### DIFF
--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -332,6 +332,7 @@ declare global {
     role: "assistant";
     content: MessageContent;
     toolCalls?: ToolCallDelta[];
+    reasoning?: string;
   }
   
   export interface SystemChatMessage {

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -397,6 +397,7 @@ export interface AssistantChatMessage {
   role: "assistant";
   content: MessageContent;
   toolCalls?: ToolCallDelta[];
+  reasoning?: string;
   usage?: Usage;
 }
 
@@ -485,6 +486,10 @@ interface Reasoning {
   text: string;
   startAt: number;
   endAt?: number;
+  // Flag to track if this reasoning originated from OpenAI's harmony reasoning field
+  // vs <think> tags. OpenAI reasoning ends when content appears without reasoning field,
+  // while <think> tag reasoning only ends with explicit </think> tags.
+  isOpenAIReasoning?: boolean;
 }
 
 export interface ChatHistoryItem {

--- a/core/llm/openaiTypeConverters.reasoning.test.ts
+++ b/core/llm/openaiTypeConverters.reasoning.test.ts
@@ -1,0 +1,311 @@
+import { ChatCompletion, ChatCompletionChunk } from "openai/resources/chat/completions";
+import { fromChatCompletionChunk, fromChatResponse } from "./openaiTypeConverters";
+
+describe("OpenAI Type Converters - Reasoning Support", () => {
+  describe("fromChatResponse", () => {
+    it("should handle response with reasoning field", () => {
+      const mockResponse: ChatCompletion = {
+        id: "test-id",
+        object: "chat.completion",
+        created: 1234567890,
+        model: "gpt-4o",
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "This is the response content",
+              refusal: null,
+              // @ts-ignore - reasoning field is not in OpenAI types yet
+              reasoning: "This is the internal reasoning",
+            },
+            finish_reason: "stop",
+            logprobs: null,
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+      };
+
+      const result = fromChatResponse(mockResponse);
+
+      expect(result).toEqual({
+        role: "assistant",
+        content: "This is the response content",
+        reasoning: "This is the internal reasoning",
+      });
+    });
+
+    it("should handle response without reasoning field", () => {
+      const mockResponse: ChatCompletion = {
+        id: "test-id",
+        object: "chat.completion",
+        created: 1234567890,
+        model: "gpt-4o",
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "This is the response content",
+              refusal: null,
+            },
+            finish_reason: "stop",
+            logprobs: null,
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+      };
+
+      const result = fromChatResponse(mockResponse);
+
+      expect(result).toEqual({
+        role: "assistant",
+        content: "This is the response content",
+        reasoning: undefined,
+      });
+    });
+
+    it("should handle response with tool calls and reasoning", () => {
+      const mockResponse: ChatCompletion = {
+        id: "test-id",
+        object: "chat.completion",
+        created: 1234567890,
+        model: "gpt-4o",
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              refusal: null,
+              tool_calls: [
+                {
+                  id: "tool-call-id",
+                  type: "function",
+                  function: {
+                    name: "test_function",
+                    arguments: '{"param": "value"}',
+                  },
+                },
+              ],
+              // @ts-ignore - reasoning field is not in OpenAI types yet
+              reasoning: "I need to call this function to help the user",
+            },
+            finish_reason: "tool_calls",
+            logprobs: null,
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+      };
+
+      const result = fromChatResponse(mockResponse);
+
+      expect(result).toEqual({
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          {
+            id: "tool-call-id",
+            type: "function",
+            function: {
+              name: "test_function",
+              arguments: '{"param": "value"}',
+            },
+          },
+        ],
+        reasoning: "I need to call this function to help the user",
+      });
+    });
+  });
+
+  describe("fromChatCompletionChunk", () => {
+    it("should handle chunk with content only", () => {
+      const mockChunk: ChatCompletionChunk = {
+        id: "test-id",
+        object: "chat.completion.chunk",
+        created: 1234567890,
+        model: "gpt-4o",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              content: "Hello world",
+            },
+            finish_reason: null,
+          },
+        ],
+      };
+
+      const result = fromChatCompletionChunk(mockChunk);
+
+      expect(result).toEqual({
+        role: "assistant",
+        content: "Hello world",
+        toolCalls: undefined,
+        reasoning: undefined,
+      });
+    });
+
+    it("should handle chunk with reasoning only", () => {
+      const mockChunk: ChatCompletionChunk = {
+        id: "test-id",
+        object: "chat.completion.chunk",
+        created: 1234567890,
+        model: "gpt-4o",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              // @ts-ignore - reasoning field is not in OpenAI types yet
+              reasoning: "I'm thinking about this...",
+            },
+            finish_reason: null,
+          },
+        ],
+      };
+
+      const result = fromChatCompletionChunk(mockChunk);
+
+      expect(result).toEqual({
+        role: "assistant",
+        content: "",
+        toolCalls: undefined,
+        reasoning: "I'm thinking about this...",
+      });
+    });
+
+    it("should handle chunk with both content and reasoning", () => {
+      const mockChunk: ChatCompletionChunk = {
+        id: "test-id",
+        object: "chat.completion.chunk",
+        created: 1234567890,
+        model: "gpt-4o",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              content: "The answer is 42",
+              // @ts-ignore - reasoning field is not in OpenAI types yet
+              reasoning: "Let me calculate this step by step",
+            },
+            finish_reason: null,
+          },
+        ],
+      };
+
+      const result = fromChatCompletionChunk(mockChunk);
+
+      expect(result).toEqual({
+        role: "assistant",
+        content: "The answer is 42",
+        toolCalls: undefined,
+        reasoning: "Let me calculate this step by step",
+      });
+    });
+
+    it("should handle chunk with tool calls and reasoning", () => {
+      const mockChunk: ChatCompletionChunk = {
+        id: "test-id",
+        object: "chat.completion.chunk",
+        created: 1234567890,
+        model: "gpt-4o",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              content: "",
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "tool-call-id",
+                  type: "function",
+                  function: {
+                    name: "search_function",
+                    arguments: '{"query": "test"}',
+                  },
+                },
+              ],
+              // @ts-ignore - reasoning field is not in OpenAI types yet
+              reasoning: "I should search for this information",
+            },
+            finish_reason: null,
+          },
+        ],
+      };
+
+      const result = fromChatCompletionChunk(mockChunk);
+
+      expect(result).toEqual({
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          {
+            id: "tool-call-id",
+            type: "function",
+            function: {
+              name: "search_function",
+              arguments: '{"query": "test"}',
+            },
+          },
+        ],
+        reasoning: "I should search for this information",
+      });
+    });
+
+    it("should return undefined for chunk with no content, tool_calls, or reasoning", () => {
+      const mockChunk: ChatCompletionChunk = {
+        id: "test-id",
+        object: "chat.completion.chunk",
+        created: 1234567890,
+        model: "gpt-4o",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              role: "assistant",
+            },
+            finish_reason: null,
+          },
+        ],
+      };
+
+      const result = fromChatCompletionChunk(mockChunk);
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should return undefined for chunk with no choices", () => {
+      const mockChunk: ChatCompletionChunk = {
+        id: "test-id",
+        object: "chat.completion.chunk",
+        created: 1234567890,
+        model: "gpt-4o",
+        choices: [],
+      };
+
+      const result = fromChatCompletionChunk(mockChunk);
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should return undefined for chunk with no delta", () => {
+      const mockChunk: ChatCompletionChunk = {
+        id: "test-id",
+        object: "chat.completion.chunk",
+        created: 1234567890,
+        model: "gpt-4o",
+        choices: [
+          {
+            index: 0,
+            delta: {},
+            finish_reason: null,
+          },
+        ],
+      };
+
+      const result = fromChatCompletionChunk(mockChunk);
+
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/gui/src/components/StepContainer/Reasoning.test.tsx
+++ b/gui/src/components/StepContainer/Reasoning.test.tsx
@@ -1,0 +1,184 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ChatHistoryItem } from "core";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Reasoning from "./Reasoning";
+
+// Mock dependencies
+vi.mock("../StyledMarkdownPreview", () => ({
+  default: ({ source }: { source: string }) => (
+    <div data-testid="markdown-preview">{source}</div>
+  ),
+}));
+
+describe("Reasoning Component", () => {
+  const mockItem: ChatHistoryItem = {
+    message: {
+      role: "assistant",
+      content: "Test response",
+    },
+    contextItems: [],
+    reasoning: {
+      text: "This is my internal reasoning process",
+      startAt: 1000,
+      endAt: 2000,
+      active: false,
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render thinking button when reasoning is active", () => {
+    const activeReasoningItem: ChatHistoryItem = {
+      ...mockItem,
+      reasoning: {
+        text: "I'm thinking about this...",
+        startAt: 1000,
+        active: true,
+      },
+    };
+
+    render(<Reasoning item={activeReasoningItem} index={0} isLast={false} />);
+
+    expect(screen.getByText("Thinking")).toBeInTheDocument();
+    expect(screen.getByText("Thinking").parentElement).toBeInTheDocument();
+  });
+
+  it("should render thought duration when reasoning is complete", () => {
+    render(<Reasoning item={mockItem} index={0} isLast={false} />);
+
+    expect(screen.getByText("Thought for 1.0s")).toBeInTheDocument();
+    expect(screen.getByText("Thought for 1.0s").parentElement).toBeInTheDocument();
+  });
+
+  it("should not render anything when no reasoning text is present", () => {
+    const itemWithoutReasoning: ChatHistoryItem = {
+      ...mockItem,
+      reasoning: undefined,
+    };
+
+    const { container } = render(
+      <Reasoning item={itemWithoutReasoning} index={0} isLast={false} />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should not render when reasoning text is empty", () => {
+    const itemWithEmptyReasoning: ChatHistoryItem = {
+      ...mockItem,
+      reasoning: {
+        text: "",
+        startAt: 1000,
+        endAt: 2000,
+        active: false,
+      },
+    };
+
+    const { container } = render(
+      <Reasoning item={itemWithEmptyReasoning} index={0} isLast={false} />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should toggle reasoning content when clicked", () => {
+    render(<Reasoning item={mockItem} index={0} isLast={false} />);
+
+    const button = screen.getByText("Thought for 1.0s").parentElement!;
+    
+    // Initially closed
+    expect(screen.queryByTestId("markdown-preview")).not.toBeInTheDocument();
+
+    // Click to open
+    fireEvent.click(button);
+    
+    expect(screen.getByTestId("markdown-preview")).toBeInTheDocument();
+    expect(screen.getByText("This is my internal reasoning process")).toBeInTheDocument();
+
+    // Click to close
+    fireEvent.click(button);
+    
+    expect(screen.queryByTestId("markdown-preview")).not.toBeInTheDocument();
+  });
+
+  it("should calculate correct duration from startAt and endAt", () => {
+    const itemWithSpecificTiming: ChatHistoryItem = {
+      ...mockItem,
+      reasoning: {
+        text: "Test reasoning",
+        startAt: 1000,
+        endAt: 3500, // 2.5 seconds later
+        active: false,
+      },
+    };
+
+    render(<Reasoning item={itemWithSpecificTiming} index={0} isLast={false} />);
+
+    expect(screen.getByText("Thought for 2.5s")).toBeInTheDocument();
+  });
+
+  it("should handle missing startAt gracefully", () => {
+    const itemWithMissingStartAt: ChatHistoryItem = {
+      ...mockItem,
+      reasoning: {
+        text: "Test reasoning",
+        startAt: Date.now() - 1000,
+        endAt: Date.now(),
+        active: false,
+      },
+    };
+
+    render(<Reasoning item={itemWithMissingStartAt} index={0} isLast={false} />);
+
+    // Should still render with calculated duration
+    const reasoningText = screen.getByText((content) => content.includes("Thought for") && content.includes("s"));
+    expect(reasoningText).toBeInTheDocument();
+  });
+
+  it("should show animated thinking indicator for active reasoning", () => {
+    const activeReasoningItem: ChatHistoryItem = {
+      ...mockItem,
+      reasoning: {
+        text: "Thinking...",
+        startAt: 1000,
+        active: true,
+      },
+    };
+
+    render(<Reasoning item={activeReasoningItem} index={0} isLast={false} />);
+
+    const thinkingElement = screen.getByText("Thinking");
+    expect(thinkingElement).toBeInTheDocument();
+    expect(thinkingElement.parentElement).toBeInTheDocument();
+  });
+
+  it("should pass correct props to StyledMarkdownPreview", () => {
+    render(<Reasoning item={mockItem} index={0} isLast={false} />);
+
+    // Open the reasoning content
+    fireEvent.click(screen.getByText("Thought for 1.0s").parentElement!);
+
+    const markdownPreview = screen.getByTestId("markdown-preview");
+    expect(markdownPreview).toBeInTheDocument();
+    expect(markdownPreview).toHaveTextContent("This is my internal reasoning process");
+  });
+
+  it("should handle reasoning with no endAt for active state", () => {
+    const activeItemWithoutEndAt: ChatHistoryItem = {
+      ...mockItem,
+      reasoning: {
+        text: "Still thinking...",
+        startAt: 1000,
+        active: true,
+      },
+    };
+
+    render(<Reasoning item={activeItemWithoutEndAt} index={0} isLast={false} />);
+
+    expect(screen.getByText("Thinking")).toBeInTheDocument();
+    // Should not show duration when still thinking
+    expect(screen.queryByText(/Thought for/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Add support for the `reasoning` field returned by OpenAI's o-series models (o1, o3, etc.) that includes their internal reasoning/thinking process.

## Changes Made

### Core Type System
- Added `reasoning?: string` field to `AssistantChatMessage` types in both `core/config/types.ts` and `core/index.d.ts`
- Maintains type safety throughout the application

### OpenAI Integration  
- Updated `openaiTypeConverters.ts` to handle reasoning field in both streaming and non-streaming responses
- Added comprehensive tests for reasoning field conversion logic

### UI Components
- Added new `Reasoning.tsx` component for displaying reasoning with:
  - Collapsible reasoning display
  - "Thinking..." animation during active reasoning  
  - "Thought for X.Xs" display with duration calculation
  - Proper styling and interaction states

### Session State Management
- Updated `sessionSlice.ts` to handle reasoning field processing:
  - Streaming reasoning updates with proper timing
  - Active/inactive reasoning state management  
  - Integration with existing `<think>` tag system
  - Support for reasoning with tool calls

### Test Coverage
- Added comprehensive test suites for all new functionality:
  - OpenAI type converter reasoning tests (10 tests)
  - Reasoning UI component tests (10 tests) 
  - Session state reasoning handling tests (6 tests)
- All tests passing with no regressions

## How It Works

When OpenAI's o-series models return responses with reasoning:
1. The reasoning field is extracted from the API response
2. Timing information is tracked (start/end timestamps)
3. The UI displays reasoning as collapsible sections
4. Users can expand/collapse to see the model's thinking process
5. Proper integration with streaming responses and tool calls

## Test Plan

- ✅ All existing tests continue to pass (no regressions)
- ✅ New reasoning field type converter tests pass
- ✅ New reasoning UI component tests pass  
- ✅ New session state reasoning tests pass
- ✅ Manual testing with reasoning field responses
- ✅ Integration testing with tool calls and reasoning

## Screenshots

The reasoning is displayed as collapsible "Thought for X.Xs" sections in the chat interface, allowing users to see the internal reasoning process of o-series models when available.

This enhancement provides users with insight into how o-series models approach problems while maintaining a clean interface that doesn't clutter the main conversation flow.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for the reasoning field from OpenAI o-series models, showing the model's internal thinking in chat as a collapsible section with timing and streaming updates.

- **New Features**
 - Added reasoning field to AssistantChatMessage types and OpenAI response converters.
 - Created Reasoning UI component with collapsible display, "Thinking..." animation, and duration tracking.
 - Updated session state to handle reasoning streaming and integration with tool calls.
 - Added tests for reasoning field handling and UI.

<!-- End of auto-generated description by cubic. -->

