### PR TITLE
feat: Respect Org Policies

### DIFF
--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -45,7 +45,7 @@ export class ConfigHandler {
 
   private organizations: OrgWithProfiles[] = [];
   currentProfile: ProfileLifecycleManager | null;
-  currentOrg: OrgWithProfiles;
+  currentOrg: OrgWithProfiles | null;
   totalConfigReloads: number = 0;
 
   public isInitialized: Promise<void>;
@@ -83,16 +83,9 @@ export class ConfigHandler {
       this.ide,
     );
 
-    // Just to be safe, always force a default personal org with local profile manager
-    this.currentProfile = this.globalLocalProfileManager;
-    const personalOrg: OrgWithProfiles = {
-      currentProfile: this.globalLocalProfileManager,
-      profiles: [this.globalLocalProfileManager],
-      ...this.PERSONAL_ORG_DESC,
-    };
-
-    this.currentOrg = personalOrg;
-    this.organizations = [personalOrg];
+    this.currentOrg = null;
+    this.currentProfile = null;
+    this.organizations = [];
 
     this.initter = new EventEmitter();
     this.isInitialized = new Promise((resolve) => {
@@ -132,10 +125,10 @@ export class ConfigHandler {
       const firstNonPersonal = orgs.find(
         (org) => org.id !== this.PERSONAL_ORG_DESC.id,
       );
-      const fallback = firstNonPersonal ?? orgs[0];
-      // note, ignoring case of zero orgs since should never happen
+      const fallback: OrgWithProfiles | null =
+        firstNonPersonal ?? orgs[0] ?? null;
 
-      let selectedOrg: OrgWithProfiles;
+      let selectedOrg: OrgWithProfiles | null;
       if (currentSelection) {
         const match = orgs.find((org) => org.id === currentSelection);
         if (match) {
@@ -153,12 +146,12 @@ export class ConfigHandler {
 
       this.globalContext.update("lastSelectedOrgIdForWorkspace", {
         ...selectedOrgs,
-        [workspaceId]: selectedOrg.id,
+        [workspaceId]: selectedOrg?.id,
       });
 
       this.organizations = orgs;
       this.currentOrg = selectedOrg;
-      this.currentProfile = selectedOrg.currentProfile;
+      this.currentProfile = selectedOrg?.currentProfile;
 
       await this.reloadConfig(reason, errors);
     } catch (e) {
@@ -179,7 +172,17 @@ export class ConfigHandler {
     const isSignedIn = await this.controlPlaneClient.isSignedIn();
     if (isSignedIn) {
       try {
+        // TODO use policy returned with org?
+        const policy = await this.controlPlaneClient.getPolicy();
         const orgDescs = await this.controlPlaneClient.listOrganizations();
+        if (policy?.policy?.allowOtherOrganizations === false) {
+          if (orgDescs.length === 0) {
+            return { orgs: [] };
+          } else {
+            const firstOrg = await this.getNonPersonalHubOrg(orgDescs[0]);
+            return { orgs: [firstOrg] };
+          }
+        }
         const orgs = await Promise.all([
           this.getPersonalHubOrg(),
           ...orgDescs.map((org) => this.getNonPersonalHubOrg(org)),
@@ -426,7 +429,7 @@ export class ConfigHandler {
 
   // Org id: check id validity, save selection, switch and reload
   async setSelectedOrgId(orgId: string, profileId?: string) {
-    if (orgId === this.currentOrg.id) {
+    if (orgId === this.currentOrg?.id) {
       return;
     }
     const org = this.organizations.find((org) => org.id === orgId);
@@ -454,6 +457,9 @@ export class ConfigHandler {
 
   // Profile id: check id validity, save selection, switch and reload
   async setSelectedProfileId(profileId: string) {
+    if (!this.currentOrg) {
+      throw new Error(`No org selected`);
+    }
     if (
       this.currentProfile &&
       profileId === this.currentProfile.profileDescription.id
@@ -598,11 +604,15 @@ export class ConfigHandler {
     if (!openProfileId) {
       return;
     }
-    const profile = this.currentOrg.profiles.find(
+    const profile = this.currentOrg?.profiles.find(
       (p) => p.profileDescription.id === openProfileId,
     );
+    if (!profile) {
+      console.error(`Profile ${profileId} not found`);
+      return;
+    }
 
-    if (profile?.profileDescription.profileType === "local") {
+    if (profile.profileDescription.profileType === "local") {
       const configFile = element?.sourceFile ?? profile.profileDescription.uri;
       await this.ide.openFile(configFile);
     } else {

--- a/core/config/ConfigHandler.vitest.ts
+++ b/core/config/ConfigHandler.vitest.ts
@@ -10,7 +10,7 @@ import { defaultConfig } from "./default";
 
 describe.skip("Test the ConfigHandler and E2E config loading", () => {
   test("should show only local profile", () => {
-    const profiles = testConfigHandler.currentOrg.profiles;
+    const profiles = testConfigHandler.currentOrg?.profiles;
     expect(profiles?.length).toBe(1);
     expect(profiles?.[0].profileDescription.id).toBe("local");
 

--- a/core/config/ProfileLifecycleManager.ts
+++ b/core/config/ProfileLifecycleManager.ts
@@ -2,6 +2,7 @@ import {
   ConfigResult,
   ConfigValidationError,
   FullSlug,
+  Policy,
 } from "@continuedev/config-yaml";
 
 import {
@@ -30,6 +31,7 @@ export interface OrganizationDescription {
   iconUrl: string;
   name: string;
   slug: string | undefined; // TODO: This doesn't need to be undefined, just doing while transitioning the backend
+  policy?: Policy;
 }
 
 export type OrgWithProfiles = OrganizationDescription & {

--- a/core/config/profile/doLoadConfig.ts
+++ b/core/config/profile/doLoadConfig.ts
@@ -26,6 +26,7 @@ import RulesContextProvider from "../../context/providers/RulesContextProvider";
 import { ControlPlaneProxyInfo } from "../../control-plane/analytics/IAnalyticsProvider.js";
 import { ControlPlaneClient } from "../../control-plane/client.js";
 import { getControlPlaneEnv } from "../../control-plane/env.js";
+import { PolicySingleton } from "../../control-plane/PolicySingleton";
 import { TeamAnalytics } from "../../control-plane/TeamAnalytics.js";
 import ContinueProxy from "../../llm/llms/stubs/ContinueProxy";
 import { getConfigDependentToolDefinitions } from "../../tools";
@@ -325,8 +326,18 @@ export default async function doLoadConfig(options: {
     }
   });
 
-  newConfig.allowAnonymousTelemetry =
-    newConfig.allowAnonymousTelemetry && (await ide.isTelemetryEnabled());
+  if (newConfig.allowAnonymousTelemetry !== false) {
+    if ((await ide.isTelemetryEnabled()) === false) {
+      newConfig.allowAnonymousTelemetry = false;
+    }
+  }
+
+  if (
+    PolicySingleton.getInstance().policy?.policy?.allowAnonymousTelemetry ===
+    false
+  ) {
+    newConfig.allowAnonymousTelemetry = false;
+  }
 
   // Setup telemetry only after (and if) we know it is enabled
   await Telemetry.setup(

--- a/core/context/providers/_context-providers.vitest.ts
+++ b/core/context/providers/_context-providers.vitest.ts
@@ -36,6 +36,7 @@ async function getContextProviderExtras(
     llmLogger,
     Promise.resolve(undefined),
   );
+  await configHandler.isInitialized;
   const { config } = await configHandler.loadConfig();
   if (!config) {
     throw new Error("Config not found");
@@ -54,7 +55,7 @@ async function getContextProviderExtras(
   };
 }
 
-describe.skip("Should successfully run all context providers", () => {
+describe("Should successfully run all context providers", () => {
   afterAll(() => {
     tearDownTestDir();
   });

--- a/core/control-plane/PolicySingleton.ts
+++ b/core/control-plane/PolicySingleton.ts
@@ -1,0 +1,15 @@
+import { PolicyResponse } from "./client.js";
+
+export class PolicySingleton {
+  private static instance: PolicySingleton;
+  public policy: PolicyResponse | null = null;
+
+  private constructor() {}
+
+  public static getInstance(): PolicySingleton {
+    if (!PolicySingleton.instance) {
+      PolicySingleton.instance = new PolicySingleton();
+    }
+    return PolicySingleton.instance;
+  }
+}

--- a/core/control-plane/client.ts
+++ b/core/control-plane/client.ts
@@ -4,6 +4,7 @@ import {
   ConfigResult,
   FQSN,
   FullSlug,
+  Policy,
   SecretResult,
   SecretType,
 } from "@continuedev/config-yaml";
@@ -14,6 +15,11 @@ import { IdeInfo, IdeSettings, ModelDescription } from "../index.js";
 
 import { ControlPlaneSessionInfo, isOnPremSession } from "./AuthTypes.js";
 import { getControlPlaneEnv } from "./env.js";
+
+export interface PolicyResponse {
+  orgSlug?: string;
+  policy?: Policy;
+}
 
 export interface ControlPlaneWorkspace {
   id: string;
@@ -210,6 +216,21 @@ export class ControlPlaneClient {
       });
       const { fullSlugs } = (await resp.json()) as any;
       return fullSlugs;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  public async getPolicy(): Promise<PolicyResponse | null> {
+    if (!(await this.isSignedIn())) {
+      return null;
+    }
+
+    try {
+      const resp = await this.request(`ide/policy`, {
+        method: "GET",
+      });
+      return (await resp.json()) as PolicyResponse;
     } catch (e) {
       return null;
     }

--- a/core/core.ts
+++ b/core/core.ts
@@ -184,7 +184,7 @@ export class Core {
           profileId:
             this.configHandler.currentProfile?.profileDescription.id || null,
           organizations: this.configHandler.getSerializedOrgs(),
-          selectedOrgId: this.configHandler.currentOrg.id,
+          selectedOrgId: this.configHandler.currentOrg?.id ?? null,
         });
 
         // update additional submenu context providers registered via VSCode API
@@ -465,7 +465,7 @@ export class Core {
         profileId:
           this.configHandler.currentProfile?.profileDescription.id ?? null,
         organizations: this.configHandler.getSerializedOrgs(),
-        selectedOrgId: this.configHandler.currentOrg.id,
+        selectedOrgId: this.configHandler.currentOrg?.id ?? null,
       };
     });
 

--- a/core/protocol/core.ts
+++ b/core/protocol/core.ts
@@ -90,7 +90,7 @@ export type ToCoreFromIdeOrWebviewProtocol = {
       result: ConfigResult<BrowserSerializedContinueConfig>;
       profileId: string | null;
       organizations: SerializedOrgWithProfiles[];
-      selectedOrgId: string;
+      selectedOrgId: string | null;
     },
   ];
   "config/deleteModel": [{ title: string }, void];

--- a/gui/src/components/config/FatalErrorNotice.tsx
+++ b/gui/src/components/config/FatalErrorNotice.tsx
@@ -32,9 +32,10 @@ export const FatalErrorIndicator = () => {
     return null;
   }
 
-  const displayName =
-    selectedProfile?.title ??
-    `${selectedProfile?.fullSlug?.ownerSlug}/${selectedProfile?.fullSlug?.packageSlug}`;
+  const displayName = selectedProfile
+    ? (selectedProfile.title ??
+      `${selectedProfile.fullSlug?.ownerSlug}/${selectedProfile.fullSlug?.packageSlug}`)
+    : "agent";
 
   return (
     <Alert type="error" className="mx-2 my-1 px-2">

--- a/gui/src/components/config/FatalErrorNotice.tsx
+++ b/gui/src/components/config/FatalErrorNotice.tsx
@@ -34,8 +34,7 @@ export const FatalErrorIndicator = () => {
 
   const displayName =
     selectedProfile?.title ??
-    `${selectedProfile?.fullSlug?.ownerSlug}/${selectedProfile?.fullSlug?.packageSlug}` ??
-    "assistant";
+    `${selectedProfile?.fullSlug?.ownerSlug}/${selectedProfile?.fullSlug?.packageSlug}`;
 
   return (
     <Alert type="error" className="mx-2 my-1 px-2">

--- a/gui/src/pages/config/UserSettingsForm.tsx
+++ b/gui/src/pages/config/UserSettingsForm.tsx
@@ -20,6 +20,7 @@ import { useAuth } from "../../context/Auth";
 import { IdeMessengerContext } from "../../context/IdeMessenger";
 import { useAppDispatch, useAppSelector } from "../../redux/hooks";
 import { updateConfig } from "../../redux/slices/configSlice";
+import { selectCurrentOrg } from "../../redux/slices/profilesSlice";
 import { setLocalStorage } from "../../util/localStorage";
 import { ContinueFeaturesMenu } from "./ContinueFeaturesMenu";
 
@@ -28,6 +29,8 @@ export function UserSettingsForm() {
   const dispatch = useAppDispatch();
   const ideMessenger = useContext(IdeMessengerContext);
   const config = useAppSelector((state) => state.config.config);
+  const currentOrg = useAppSelector(selectCurrentOrg);
+
   const [showExperimental, setShowExperimental] = useState(false);
   const { session } = useAuth();
 
@@ -133,6 +136,9 @@ export function UserSettingsForm() {
     "@continue.dev",
   );
 
+  const disableTelemetryToggle =
+    currentOrg?.policy?.allowAnonymousTelemetry === false;
+
   return (
     <div className="flex flex-col">
       {/* {selectedProfile && isLocalProfile(selectedProfile) ? (
@@ -225,6 +231,7 @@ export function UserSettingsForm() {
 
             <ToggleSwitch
               isToggled={allowAnonymousTelemetry}
+              disabled={disableTelemetryToggle}
               onToggle={() =>
                 handleUpdate({
                   allowAnonymousTelemetry: !allowAnonymousTelemetry,

--- a/packages/config-yaml/src/browser.ts
+++ b/packages/config-yaml/src/browser.ts
@@ -15,4 +15,5 @@ export * from "./modelName.js";
 export * from "./schemas/data/index.js";
 export * from "./schemas/index.js";
 export * from "./schemas/models.js";
+export * from "./schemas/policy.js";
 export * from "./validation.js";

--- a/packages/config-yaml/src/schemas/policy.ts
+++ b/packages/config-yaml/src/schemas/policy.ts
@@ -1,0 +1,9 @@
+import * as z from "zod";
+
+export const policySchema = z.object({
+  allowAnonymousTelemetry: z.boolean().optional(),
+  allowLocalConfigFile: z.boolean().optional(),
+  allowOtherOrganizations: z.boolean().optional(),
+});
+
+export type Policy = z.infer<typeof policySchema>;

--- a/packages/config-yaml/src/schemas/policy.ts
+++ b/packages/config-yaml/src/schemas/policy.ts
@@ -2,8 +2,8 @@ import * as z from "zod";
 
 export const policySchema = z.object({
   allowAnonymousTelemetry: z.boolean().optional(),
-  allowLocalConfigFile: z.boolean().optional(),
-  allowOtherOrganizations: z.boolean().optional(),
+  allowOtherOrgs: z.boolean().optional(),
+  // allowLocalConfigFile: z.boolean().optional(),
 });
 
 export type Policy = z.infer<typeof policySchema>;


### PR DESCRIPTION
## Description
Adds extension support for org-level allow anonymous telemetry and allow other orgs settings

Uses `/policy` endpoint for now, I think eventually should just use policy returned from `list-organizations` but endpoint doesn't currently return that.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for organization-level policies to control anonymous telemetry and organization access in the extension. The extension now uses the `/policy` endpoint to enforce these settings.

- **New Features**
 - Disabled anonymous telemetry toggle if the org policy disallows it.
 - Restricted organization selection if the org policy does not allow access to other orgs.

<!-- End of auto-generated description by cubic. -->

