### PR TITLE
style: prevent text selection when double clicking tool policy

### DIFF
--- a/gui/src/components/mainInput/Lump/sections/tool-policies/ToolPolicyItem.tsx
+++ b/gui/src/components/mainInput/Lump/sections/tool-policies/ToolPolicyItem.tsx
@@ -118,7 +118,7 @@ function ToolPolicyItem(props: ToolDropdownItemProps) {
         </div>
 
         <div
-          className={`flex w-8 flex-row items-center justify-end gap-2 px-2 py-0.5 sm:w-16 ${disabled ? "cursor-not-allowed" : "hover:text-list-active-foreground cursor-pointer hover:brightness-125"}`}
+          className={`flex w-8 select-none flex-row items-center justify-end gap-2 px-2 py-0.5 sm:w-16 ${disabled ? "cursor-not-allowed" : "hover:text-list-active-foreground cursor-pointer hover:brightness-125"}`}
           data-testid={`tool-policy-item-${props.tool.function.name}`}
           data-tooltip-id={disabled ? disabledTooltipId : undefined}
           onClick={


### PR DESCRIPTION
## Description

prevent mouse text select in tool policy changing

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

https://github.com/user-attachments/assets/5257df62-f64b-46a0-bb98-96be7835f6df

https://github.com/user-attachments/assets/2b2350a9-f90e-42e5-8e94-abb325e456b8



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Stopped text from being selected when double clicking tool policy items to improve the user experience.

<!-- End of auto-generated description by cubic. -->

