### PR TITLE
chore: move system message tools out of experimental

### DIFF
--- a/core/config/migrateSharedConfig.ts
+++ b/core/config/migrateSharedConfig.ts
@@ -130,6 +130,15 @@ export function migrateJsonSharedConfig(filepath: string, ide: IDE): void {
         effected = true;
       }
 
+      const { onlyUseSystemMessageTools, ...withoutOnlyUseSystemMessageTools } =
+        migratedExperimental as any;
+      if (onlyUseSystemMessageTools !== undefined) {
+        shareConfigUpdates.onlyUseSystemMessageTools =
+          onlyUseSystemMessageTools;
+        migratedExperimental = withoutOnlyUseSystemMessageTools;
+        effected = true;
+      }
+
       if (Object.keys(migratedExperimental).length > 0) {
         config = {
           ...withoutExperimental,

--- a/core/config/sharedConfig.ts
+++ b/core/config/sharedConfig.ts
@@ -13,6 +13,7 @@ export const sharedConfigSchema = z
     allowAnonymousTelemetry: z.boolean(),
     disableIndexing: z.boolean(),
     disableSessionTitles: z.boolean(),
+    onlyUseSystemMessageTools: z.boolean(),
 
     // `experimental` in `ContinueConfig`
     useChromiumForDocsCrawling: z.boolean(),
@@ -20,7 +21,6 @@ export const sharedConfigSchema = z
     promptPath: z.string(),
     useCurrentFileAsContext: z.boolean(),
     enableExperimentalTools: z.boolean(),
-    onlyUseSystemMessageTools: z.boolean(),
     codebaseToolCallingOnly: z.boolean(),
     enableStaticContextualization: z.boolean(),
 
@@ -153,6 +153,10 @@ export function modifyAnyConfigWithSharedConfig<
   if (sharedConfig.disableSessionTitles !== undefined) {
     configCopy.disableSessionTitles = sharedConfig.disableSessionTitles;
   }
+  if (sharedConfig.onlyUseSystemMessageTools !== undefined) {
+    (configCopy as any).onlyUseSystemMessageTools =
+      sharedConfig.onlyUseSystemMessageTools;
+  }
 
   if (sharedConfig.showSessionTabs !== undefined) {
     configCopy.ui.showSessionTabs = sharedConfig.showSessionTabs;
@@ -180,11 +184,6 @@ export function modifyAnyConfigWithSharedConfig<
   if (sharedConfig.useCurrentFileAsContext !== undefined) {
     configCopy.experimental.useCurrentFileAsContext =
       sharedConfig.useCurrentFileAsContext;
-  }
-
-  if (sharedConfig.onlyUseSystemMessageTools !== undefined) {
-    configCopy.experimental.onlyUseSystemMessageTools =
-      sharedConfig.onlyUseSystemMessageTools;
   }
 
   if (sharedConfig.codebaseToolCallingOnly !== undefined) {

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1529,7 +1529,6 @@ export interface ExperimentalConfig {
   defaultContext?: DefaultContextProvider[];
   promptPath?: string;
   enableExperimentalTools?: boolean;
-  onlyUseSystemMessageTools?: boolean;
 
   /**
    * Quick actions are a way to add custom commands to the Code Lens of
@@ -1607,6 +1606,7 @@ export interface JSONModelDescription {
 export interface SerializedContinueConfig {
   env?: string[];
   allowAnonymousTelemetry?: boolean;
+  onlyUseSystemMessageTools?: boolean;
   models: JSONModelDescription[];
   systemMessage?: string;
   completionOptions?: BaseCompletionOptions;
@@ -1638,6 +1638,8 @@ export type ContinueRcJson = Partial<SerializedContinueConfig> & {
 export interface Config {
   /** If set to true, Continue will collect anonymous usage data to improve the product. If set to false, we will collect nothing. Read here to learn more: https://docs.continue.dev/telemetry */
   allowAnonymousTelemetry?: boolean;
+  /** If set to true, use system message tools instead of native tool calling */
+  onlyUseSystemMessageTools?: boolean;
   /** Each entry in this array will originally be a JSONModelDescription, the same object from your config.json, but you may add CustomLLMs.
    * A CustomLLM requires you only to define an AsyncGenerator that calls the LLM and yields string updates. You can choose to define either `streamCompletion` or `streamChat` (or both).
    * Continue will do the rest of the work to construct prompt templates, handle context items, prune context, etc.
@@ -1684,6 +1686,7 @@ export interface Config {
 // in the actual Continue source code
 export interface ContinueConfig {
   allowAnonymousTelemetry?: boolean;
+  onlyUseSystemMessageTools?: boolean;
   // systemMessage?: string;
   completionOptions?: BaseCompletionOptions;
   requestOptions?: RequestOptions;
@@ -1707,6 +1710,7 @@ export interface ContinueConfig {
 
 export interface BrowserSerializedContinueConfig {
   allowAnonymousTelemetry?: boolean;
+  onlyUseSystemMessageTools?: boolean;
   // systemMessage?: string;
   completionOptions?: BaseCompletionOptions;
   requestOptions?: RequestOptions;

--- a/gui/src/pages/config/UserSettingsForm.tsx
+++ b/gui/src/pages/config/UserSettingsForm.tsx
@@ -91,8 +91,7 @@ export function UserSettingsForm() {
     config.experimental?.useCurrentFileAsContext ?? false;
   const enableExperimentalTools =
     config.experimental?.enableExperimentalTools ?? false;
-  const onlyUseSystemMessageTools =
-    config.experimental?.onlyUseSystemMessageTools ?? false;
+  const onlyUseSystemMessageTools = config.onlyUseSystemMessageTools ?? false;
   const codebaseToolCallingOnly =
     config.experimental?.codebaseToolCallingOnly ?? false;
   const enableStaticContextualization =
@@ -248,6 +247,16 @@ export function UserSettingsForm() {
                 })
               }
               text="Enable Indexing"
+            />
+
+            <ToggleSwitch
+              isToggled={onlyUseSystemMessageTools}
+              onToggle={() =>
+                handleUpdate({
+                  onlyUseSystemMessageTools: !onlyUseSystemMessageTools,
+                })
+              }
+              text="Only use system message tools"
             />
 
             {/* <ToggleSwitch
@@ -426,16 +435,6 @@ export function UserSettingsForm() {
                     })
                   }
                   text="Enable experimental tools"
-                />
-
-                <ToggleSwitch
-                  isToggled={onlyUseSystemMessageTools}
-                  onToggle={() =>
-                    handleUpdate({
-                      onlyUseSystemMessageTools: !onlyUseSystemMessageTools,
-                    })
-                  }
-                  text="Only use system message tools"
                 />
 
                 <ToggleSwitch

--- a/gui/src/redux/selectors/selectUseSystemMessageTools.test.ts
+++ b/gui/src/redux/selectors/selectUseSystemMessageTools.test.ts
@@ -28,9 +28,7 @@ describe("selectUseSystemMessageTools", () => {
     return {
       config: {
         config: {
-          experimental: {
-            onlyUseSystemMessageTools: manualSetting,
-          },
+          onlyUseSystemMessageTools: manualSetting,
         },
       },
     } as any;

--- a/gui/src/redux/selectors/selectUseSystemMessageTools.ts
+++ b/gui/src/redux/selectors/selectUseSystemMessageTools.ts
@@ -16,8 +16,7 @@ import { RootState } from "../store";
  */
 export function selectUseSystemMessageTools(state: RootState): boolean {
   const selectedModel = selectSelectedChatModel(state);
-  const manualSetting =
-    state.config.config.experimental?.onlyUseSystemMessageTools;
+  const manualSetting = state.config.config.onlyUseSystemMessageTools;
 
   // If no model is selected, fall back to manual setting or default
   if (!selectedModel) {

--- a/gui/src/redux/thunks/streamResponse_toolCalls.test.ts
+++ b/gui/src/redux/thunks/streamResponse_toolCalls.test.ts
@@ -788,9 +788,8 @@ describe("streamResponseThunk - tool calls", () => {
             rerank: null,
             embed: null,
           },
-          experimental: {
-            onlyUseSystemMessageTools: false,
-          },
+          onlyUseSystemMessageTools: false,
+          experimental: {},
         } as any,
         lastSelectedModelByRole: {
           chat: mockClaudeModel.title,


### PR DESCRIPTION
## Description

Move system message tools or virtual tool calls from experimental to the core feature section.

resolves CON-3262

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
