### PR TITLE
docs: clarify apiVersion usage in Azure YAML configuration

### DIFF
--- a/docs/customize/model-providers/top-level/azure.mdx
+++ b/docs/customize/model-providers/top-level/azure.mdx
@@ -142,11 +142,6 @@ To find this information in _Azure AI Foundry_, first select the model that you 
 
 For example, a Target URI of `https://just-an-example.openai.azure.com/openai/deployments/gpt-4o-july/chat/completions?api-version=2023-03-15-preview` would map to the following:
 
-<Info>
-  **Important:** When migrating from `config.json` to `config.yaml`, the
-  `apiVersion` parameter must be moved from the top level to the `env` section.
-</Info>
-
 <Tabs>
 	<Tab title="YAML">
     ```yaml title="config.yaml"

--- a/docs/reference.mdx
+++ b/docs/reference.mdx
@@ -17,8 +17,6 @@ Continue hub assistants are defined using the `config.yaml` specification. Assis
   Guide](/customize/yaml-migration)**.
 </Info>
 
-The complete YAML schema is available in the [Continue repository](https://github.com/continuedev/continue/blob/main/packages/config-yaml/schema/config-yaml-schema.json).
-
 An assistant is made up of:
 
 1. **Top level properties**, which specify the `name`, `version`, and `config.yaml` `schema` for the assistant
@@ -177,11 +175,11 @@ The `models` section defines the language models used in your configuration. Mod
 
 - `roles`: An array specifying the roles this model can fulfill, such as `chat`, `autocomplete`, `embed`, `rerank`, `edit`, `apply`, `summarize`. The default value is `[chat, edit, apply, summarize]`. Note that the `summarize` role is not currently used.
 
-
 - `capabilities`: Array of strings denoting model capabilities, which will overwrite Continue's autodetection based on provider and model. See the [Model Capabilities guide](/customize/deep-dives/model-capabilities) for detailed information. Supported capabilities include:
+
   - `tool_use`: Enables function/tool calling support (required for Agent mode)
   - `image_input`: Enables image upload and processing support
-  
+
   Continue automatically detects these capabilities for most models, but you can override this when using custom deployments or if autodetection isn't working correctly.
 
 - `maxStopWords`: Maximum number of stop words allowed, to avoid API errors with extensive lists.
@@ -246,22 +244,6 @@ The `models` section defines the language models used in your configuration. Mod
   - `useRecentlyEdited`: If `true`, includes recently edited files in context.
   - `useRecentlyOpened`: If `true`, includes recently opened files in context.
 
-- `env`: Provider-specific environment parameters. These are parameters that were at the model config level in `config.json` but have been moved to a nested `env` section in `config.yaml`:
-
-  - `apiVersion`: API version for Azure OpenAI Service (e.g., `2023-03-15-preview`).
-  - `apiType`: API type specification, typically `azure-openai` or `azure-foundry`.
-  - `deployment`: Deployment name for Azure models.
-  - `deploymentId`: Deployment ID for specific cloud deployments.
-  - `projectId`: Project ID for Google Cloud or other cloud providers.
-  - `region`: Region where the model is hosted (e.g., `us-east-1`, `eu-central-1`).
-  - `profile`: AWS security profile for authorization.
-  - `accessKeyId`: AWS access key ID.
-  - `secretAccessKey`: AWS secret access key.
-  - `modelArn`: AWS ARN for imported models (e.g., for Bedrock).
-  - `aiGatewaySlug`: AI Gateway slug for Cloudflare AI Gateway.
-  - `accountId`: Account ID for various cloud providers.
-  - `useLegacyCompletionsEndpoint`: Boolean to use legacy completions endpoint.
-
 **Example:**
 
 ```yaml title="config.yaml"
@@ -276,18 +258,6 @@ models:
     defaultCompletionOptions:
       temperature: 0.7
       maxTokens: 1500
-  - name: GPT-4o Azure
-    provider: azure
-    model: gpt-4o
-    apiBase: https://just-an-example.openai.azure.com
-    apiKey: <YOUR_AZURE_API_KEY>
-    env:
-      apiVersion: 2023-03-15-preview
-      deployment: gpt-4o-july
-      apiType: azure-openai
-    roles:
-      - chat
-      - edit
   - name: Codestral
     provider: mistral
     model: codestral-latest


### PR DESCRIPTION
Fixes #7098

Adds `apiVersion` info.
