### PR TITLE
Fix dev data: standardize model fields and add missing model info

### DIFF
--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -1056,6 +1056,15 @@ declare global {
     filepath?: string;
     fileContent?: string;
     originalFileContent?: string;
+    toolCallId?: string;
+    
+    // Precise diff information to avoid recomputing changes in GUI
+    changedLines?: {
+      previousLines: string[];  // The original lines that were changed
+      newLines: string[];       // The new lines that replaced them
+      startLine: number;        // Line number where changes start (0-based)
+      endLine: number;          // Line number where changes end (0-based)
+    };
   }
   
   export interface RangeInFileWithContents {

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1361,6 +1361,14 @@ export interface ApplyState {
   fileContent?: string;
   originalFileContent?: string;
   toolCallId?: string;
+  
+  // Precise diff information to avoid recomputing changes in GUI
+  changedLines?: {
+    previousLines: string[];  // The original lines that were changed
+    newLines: string[];       // The new lines that replaced them  
+    startLine: number;        // Line number where changes start (0-based)
+    endLine: number;          // Line number where changes end (0-based)
+  };
 }
 
 export interface StreamDiffLinesPayload {

--- a/core/nextEdit/context/processNextEditData.ts
+++ b/core/nextEdit/context/processNextEditData.ts
@@ -109,10 +109,20 @@ export const processNextEditData = async ({
   }
 
   if (filenamesAndDiffs.length > 0) {
+    // Load the autocomplete model configuration
+    const { config } = await configHandler.loadConfig();
+    const autocompleteModel = modelNameOrInstance || config?.selectedModelByRole.autocomplete;
+    
     // if there are previous edits, log
     void DataLogger.getInstance().logDevData({
       name: "nextEditWithHistory",
       data: {
+        modelProvider: typeof autocompleteModel === "string" 
+          ? "unknown" 
+          : (autocompleteModel?.underlyingProviderName ?? "unknown"),
+        modelName: typeof autocompleteModel === "string" 
+          ? autocompleteModel 
+          : (autocompleteModel?.title ?? autocompleteModel?.model ?? "unknown"),
         previousEdits: filenamesAndDiffs,
         fileURI: filePath,
         workspaceDirURI: workspaceDir,

--- a/extensions/vscode/src/apply/ApplyManager.ts
+++ b/extensions/vscode/src/apply/ApplyManager.ts
@@ -8,6 +8,7 @@ import { myersDiff } from "core/diff/myers";
 import { generateLines } from "core/diff/util";
 import { ApplyAbortManager } from "core/edit/applyAbortManager";
 import { VerticalDiffManager } from "../diff/vertical/manager";
+// import { computeChangedLines } from "../util/diffUtils"; // Removed - was comparing wrong data
 import { VsCodeIde } from "../VsCodeIde";
 import { VsCodeWebviewProtocol } from "../webviewProtocol";
 
@@ -48,6 +49,8 @@ export class ApplyManager {
       fileContent: text,
       originalFileContent,
       toolCallId,
+      // Don't compute changedLines here - text is LLM output, not actual applied diff
+      // changedLines: computeChangedLines(originalFileContent, text),
     });
 
     const hasExistingDocument = !!activeTextEditor.document.getText().trim();
@@ -109,6 +112,8 @@ export class ApplyManager {
       numDiffs: 0,
       fileContent: text,
       toolCallId,
+      // Don't compute changedLines for new files - the fallback approach handles this correctly
+      // changedLines: computeChangedLines("", text),
     });
   }
 

--- a/extensions/vscode/src/diff/processDiff.ts
+++ b/extensions/vscode/src/diff/processDiff.ts
@@ -4,6 +4,7 @@ import { ContinueGUIWebviewViewProvider } from "../ContinueGUIWebviewViewProvide
 import { editOutcomeTracker } from "../extension/EditOutcomeTracker";
 import { VsCodeIde } from "../VsCodeIde";
 import { VerticalDiffManager } from "./vertical/manager";
+import { computeChangedLines } from "../util/diffUtils";
 
 export async function processDiff(
   action: "accept" | "reject",
@@ -51,6 +52,9 @@ export async function processDiff(
       DataLogger.getInstance(),
     );
 
+    // TODO: Get original content from VerticalDiffManager or apply state
+    // For now, we can't compute changedLines here since we don't have the original content
+    // The diff was already applied to the file, so fileContent is the final state
     await sidebar.webviewProtocol.request("updateApplyState", {
       fileContent,
       filepath: newOrCurrentUri,
@@ -58,6 +62,7 @@ export async function processDiff(
       status: "closed",
       numDiffs: 0,
       toolCallId,
+      // changedLines will be computed upstream in ApplyManager where we have both contents
     });
   }
 

--- a/extensions/vscode/src/util/diffUtils.ts
+++ b/extensions/vscode/src/util/diffUtils.ts
@@ -1,0 +1,98 @@
+import { ApplyState } from "core";
+
+/**
+ * Compute precise diff information between original and new content
+ * Returns the exact lines that changed and their positions
+ */
+export function computeChangedLines(
+  originalContent: string,
+  newContent: string,
+): ApplyState["changedLines"] {
+  
+  // Handle empty content cases
+  if (!originalContent && !newContent) {
+    return undefined;
+  }
+  
+  if (!originalContent) {
+    // New file - all lines are new
+    const newLines = newContent.split('\n');
+    return {
+      previousLines: [],
+      newLines,
+      startLine: 0,
+      endLine: newLines.length - 1,
+    };
+  }
+  
+  if (!newContent) {
+    // File deleted - all lines were removed
+    const originalLines = originalContent.split('\n');
+    return {
+      previousLines: originalLines,
+      newLines: [],
+      startLine: 0,
+      endLine: originalLines.length - 1,
+    };
+  }
+
+  const originalLines = originalContent.split('\n');
+  const newLines = newContent.split('\n');
+
+  // Find the range of changed lines using a simple approach
+  let firstChangedLine = 0;
+  let lastChangedLineOriginal = originalLines.length - 1;
+  let lastChangedLineNew = newLines.length - 1;
+
+  // Find first differing line from the start
+  while (
+    firstChangedLine < originalLines.length &&
+    firstChangedLine < newLines.length &&
+    originalLines[firstChangedLine] === newLines[firstChangedLine]
+  ) {
+    firstChangedLine++;
+  }
+
+  // Find last differing line from the end
+  while (
+    lastChangedLineOriginal >= firstChangedLine &&
+    lastChangedLineNew >= firstChangedLine &&
+    originalLines[lastChangedLineOriginal] === newLines[lastChangedLineNew]
+  ) {
+    lastChangedLineOriginal--;
+    lastChangedLineNew--;
+  }
+
+  // If no differences found, content is identical
+  if (firstChangedLine > lastChangedLineOriginal && firstChangedLine > lastChangedLineNew) {
+    return undefined;
+  }
+
+  // Extract the changed sections
+  const previousLines = originalLines.slice(firstChangedLine, lastChangedLineOriginal + 1);
+  const changedNewLines = newLines.slice(firstChangedLine, lastChangedLineNew + 1);
+
+  const result = {
+    previousLines,
+    newLines: changedNewLines,
+    startLine: firstChangedLine,
+    endLine: Math.max(lastChangedLineOriginal, lastChangedLineNew),
+  };
+
+  console.log("DIFF_DEBUG:", JSON.stringify({
+    originalContentLength: originalContent.length,
+    newContentLength: newContent.length,
+    originalLinesCount: originalLines.length,
+    newLinesCount: newLines.length,
+    firstChangedLine,
+    lastChangedLineOriginal,
+    lastChangedLineNew,
+    previousLinesCount: previousLines.length,
+    changedNewLinesCount: changedNewLines.length,
+    previousLinesPreview: previousLines.slice(0, 3),
+    newLinesPreview: changedNewLines.slice(0, 3),
+    result
+  }, null, 2));
+
+  return result;
+}

--- a/gui/src/components/AcceptRejectDiffButtons.tsx
+++ b/gui/src/components/AcceptRejectDiffButtons.tsx
@@ -5,6 +5,7 @@ import { IdeMessengerContext } from "../context/IdeMessenger";
 import { useAppDispatch } from "../redux/hooks";
 import { cancelToolCall } from "../redux/slices/sessionSlice";
 import { getMetaKeyLabel } from "../util";
+import { logChatModeEditOutcome } from "../util/editOutcomeLogger";
 import { ToolTip } from "./gui/Tooltip";
 
 export interface AcceptRejectAllButtonsProps {
@@ -24,6 +25,8 @@ export default function AcceptRejectAllButtons({
   const ideMessenger = useContext(IdeMessengerContext);
   const dispatch = useAppDispatch();
   async function handleAcceptOrReject(status: AcceptOrRejectOutcome) {
+    const accepted = status === "acceptDiff";
+
     // For reject operations, cancel all tool calls associated with pending apply states
     if (status === "rejectDiff") {
       for (const applyState of pendingApplyStates) {
@@ -35,6 +38,11 @@ export default function AcceptRejectAllButtons({
           );
         }
       }
+    }
+
+    // Log editOutcome data for each apply state before processing
+    for (const applyState of pendingApplyStates) {
+      await logChatModeEditOutcome(applyState, accepted, ideMessenger);
     }
 
     // Process all pending apply states

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/ApplyActions.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/ApplyActions.tsx
@@ -23,7 +23,7 @@ export function ApplyActions(props: ApplyActionsProps) {
     case "streaming":
       return (
         <div className="bg-badge flex select-none items-center rounded pl-2 pr-1">
-          <span className="text-lightgray inline-flex w-min items-center gap-2 text-center text-xs">
+          <span className="text-lightgray inline-flex items-center gap-2 text-center text-xs whitespace-nowrap">
             Applying
             <Spinner />
           </span>

--- a/gui/src/hooks/ParallelListeners.tsx
+++ b/gui/src/hooks/ParallelListeners.tsx
@@ -58,7 +58,8 @@ function ParallelListeners() {
   // Load symbols for chat on any session change
   const sessionId = useAppSelector((state) => state.session.id);
   
-  // Track logged stream IDs to prevent duplicates
+  // Track logged stream IDs to prevent duplicates caused by multiple VS Code extension
+  // components (ApplyManager, processDiff, etc.) sending separate "closed" events
   const loggedStreamIds = useRef(new Set<string>());
 
   const handleConfigUpdate = useCallback(
@@ -276,9 +277,12 @@ function ParallelListeners() {
         }
         
         if (state.status === "closed") {
-          // Prevent duplicate logging for the same streamId
+          // Prevent duplicate logging for the same streamId - multiple VS Code extension
+          // components (extensions/vscode/src/apply/ApplyManager.ts:108 and 
+          // extensions/vscode/src/diff/processDiff.ts:58) can send separate "closed" 
+          // events for the same operation
           if (loggedStreamIds.current.has(state.streamId)) {
-            console.log("Skipping duplicate logging for streamId:", state.streamId);
+            console.log("Skipping duplicate editOutcome logging for streamId:", state.streamId);
             return;
           }
           loggedStreamIds.current.add(state.streamId);

--- a/gui/src/hooks/ParallelListeners.tsx
+++ b/gui/src/hooks/ParallelListeners.tsx
@@ -250,7 +250,6 @@ function ParallelListeners() {
   useWebviewListener(
     "updateApplyState",
     async (state) => {
-      console.log("updateApplyState received:", state);
       if (state.streamId === EDIT_MODE_STREAM_ID) {
         dispatch(updateEditStateApplyState(state));
 
@@ -282,7 +281,6 @@ function ParallelListeners() {
           // extensions/vscode/src/diff/processDiff.ts:58) can send separate "closed" 
           // events for the same operation
           if (loggedStreamIds.current.has(state.streamId)) {
-            console.log("Skipping duplicate editOutcome logging for streamId:", state.streamId);
             return;
           }
           loggedStreamIds.current.add(state.streamId);
@@ -293,12 +291,6 @@ function ParallelListeners() {
             (s) => s.streamId === state.streamId,
           );
 
-          console.log("ParallelListeners updateApplyState status=closed:", {
-            currentMode,
-            applyState,
-            hasToolCallId: !!state.toolCallId,
-            streamId: state.streamId,
-          });
 
           // Handle tool call based interactions (agent mode or chat with tool calls)
           if (state.toolCallId) {
@@ -314,7 +306,6 @@ function ParallelListeners() {
 
               if (applyState) {
                 if (currentMode === "agent") {
-                  console.log("Logging agent mode edit outcome");
                   void logAgentModeEditOutcome(
                     toolCallState,
                     applyState,
@@ -322,7 +313,6 @@ function ParallelListeners() {
                     ideMessenger,
                   );
                 } else {
-                  console.log("Logging chat mode edit outcome (with tool call)");
                   void logChatModeEditOutcome(
                     applyState,
                     accepted,
@@ -347,15 +337,12 @@ function ParallelListeners() {
           } else if (applyState && currentMode === "chat") {
             // Handle manual chat mode applies (no tool call)
             // For manual applies, we assume accepted=true since the user manually triggered the apply
-            console.log("Logging manual chat mode edit outcome");
             void logChatModeEditOutcome(
               applyState,
               true, // Manual applies are considered accepted
               ideMessenger,
             );
           }
-          
-          console.log("End of updateApplyState status=closed processing");
         }
       }
     },

--- a/gui/src/util/editOutcomeLogger.ts
+++ b/gui/src/util/editOutcomeLogger.ts
@@ -7,7 +7,7 @@ import { store } from "../redux/store";
  */
 function extractModelInfo(toolCallState: ToolCallState): {
   modelProvider: string;
-  modelTitle: string;
+  modelName: string;
 } {
   // Get the conversation history to find the model info
   const history = store.getState().session.history;
@@ -28,7 +28,7 @@ function extractModelInfo(toolCallState: ToolCallState): {
     const modelParts = String(assistantMessage.message.model).split("::");
     return {
       modelProvider: modelParts[0] || "unknown",
-      modelTitle: modelParts[1] || String(assistantMessage.message.model),
+      modelName: modelParts[1] || String(assistantMessage.message.model),
     };
   }
 
@@ -38,7 +38,7 @@ function extractModelInfo(toolCallState: ToolCallState): {
 
   return {
     modelProvider: chatModel?.provider || "unknown",
-    modelTitle: chatModel?.model || "unknown",
+    modelName: chatModel?.model || "unknown",
   };
 }
 
@@ -277,7 +277,7 @@ export function assembleEditOutcomeData(
     streamId: applyState.streamId,
     timestamp: new Date().toISOString(),
     modelProvider: modelInfo.modelProvider,
-    modelTitle: modelInfo.modelTitle,
+    modelName: modelInfo.modelName,
     prompt: promptAndCompletion.prompt,
     completion: promptAndCompletion.completion,
     previousCode: codeChanges.previousCode,
@@ -380,7 +380,7 @@ export async function logChatModeEditOutcome(
       streamId: applyState.streamId,
       timestamp: new Date().toISOString(),
       modelProvider: chatModel?.provider || "unknown",
-      modelTitle: chatModel?.model || "unknown",
+      modelName: chatModel?.model || "unknown",
       prompt: "Chat mode manual apply", // Placeholder for manual applies
       completion: "Code applied via chat", // Placeholder for manual applies
       previousCode: codeChanges.previousCode,

--- a/packages/config-yaml/src/schemas/data/chatFeedback/index.ts
+++ b/packages/config-yaml/src/schemas/data/chatFeedback/index.ts
@@ -2,7 +2,8 @@ import { z } from "zod";
 import { baseDevDataAllSchema } from "../base.js";
 
 export const chatFeedbackEventAllSchema = baseDevDataAllSchema.extend({
-  modelTitle: z.string(),
+  modelProvider: z.string(),
+  modelName: z.string(),
   completionOptions: z.object({}),
   prompt: z.string(),
   completion: z.string(),

--- a/packages/config-yaml/src/schemas/data/chatFeedback/v0.1.0.ts
+++ b/packages/config-yaml/src/schemas/data/chatFeedback/v0.1.0.ts
@@ -1,7 +1,8 @@
 import { chatFeedbackEventAllSchema } from "./index.js";
 
 export const chatFeedbackEventSchema_0_1_0 = chatFeedbackEventAllSchema.pick({
-  modelTitle: true,
+  modelProvider: true,
+  modelName: true,
   completionOptions: true,
   prompt: true,
   completion: true,

--- a/packages/config-yaml/src/schemas/data/chatFeedback/v0.2.0.ts
+++ b/packages/config-yaml/src/schemas/data/chatFeedback/v0.2.0.ts
@@ -12,7 +12,8 @@ export const chatFeedbackEventSchema_0_2_0 = chatFeedbackEventAllSchema.pick({
   // other
   prompt: true,
   completion: true,
-  modelTitle: true,
+  modelProvider: true,
+  modelName: true,
   feedback: true,
   sessionId: true,
 });

--- a/packages/config-yaml/src/schemas/data/chatInteraction/index.ts
+++ b/packages/config-yaml/src/schemas/data/chatInteraction/index.ts
@@ -3,7 +3,7 @@ import { baseDevDataAllSchema } from "../base.js";
 
 export const chatInteractionEventAllSchema = baseDevDataAllSchema.extend({
   modelProvider: z.string(),
-  modelTitle: z.string(),
+  modelName: z.string(),
   prompt: z.string(),
   completion: z.string(),
   sessionId: z.string(),

--- a/packages/config-yaml/src/schemas/data/chatInteraction/v0.2.0.ts
+++ b/packages/config-yaml/src/schemas/data/chatInteraction/v0.2.0.ts
@@ -13,7 +13,7 @@ export const chatInteractionEventSchema_0_2_0 =
     // other
     prompt: true,
     completion: true,
-    modelTitle: true,
+    modelName: true,
     modelProvider: true,
     sessionId: true,
     tools: true,

--- a/packages/config-yaml/src/schemas/data/editInteraction/index.ts
+++ b/packages/config-yaml/src/schemas/data/editInteraction/index.ts
@@ -6,7 +6,7 @@ import { baseDevDataAllSchema } from "../base.js";
  */
 export const editInteractionEventAllSchema = baseDevDataAllSchema.extend({
   modelProvider: z.string(),
-  modelTitle: z.string(),
+  modelName: z.string(),
   prompt: z.string(),
   completion: z.string(),
   filepath: z.string(),

--- a/packages/config-yaml/src/schemas/data/editInteraction/v0.2.0.ts
+++ b/packages/config-yaml/src/schemas/data/editInteraction/v0.2.0.ts
@@ -13,7 +13,7 @@ export const editInteractionEventSchema_0_2_0 =
     // other
     prompt: true,
     completion: true,
-    modelTitle: true,
+    modelName: true,
     modelProvider: true,
     filepath: true,
   });

--- a/packages/config-yaml/src/schemas/data/editOutcome/index.ts
+++ b/packages/config-yaml/src/schemas/data/editOutcome/index.ts
@@ -3,7 +3,7 @@ import { baseDevDataAllSchema } from "../base.js";
 
 export const editOutcomeEventAllSchema = baseDevDataAllSchema.extend({
   modelProvider: z.string(),
-  modelTitle: z.string(),
+  modelName: z.string(),
   prompt: z.string(),
   completion: z.string(),
   previousCode: z.string(),

--- a/packages/config-yaml/src/schemas/data/editOutcome/v0.2.0.ts
+++ b/packages/config-yaml/src/schemas/data/editOutcome/v0.2.0.ts
@@ -12,7 +12,7 @@ export const editOutcomeEventSchema_0_2_0 = editOutcomeEventAllSchema.pick({
   // other
   prompt: true,
   completion: true,
-  modelTitle: true,
+  modelName: true,
   modelProvider: true,
   accepted: true,
   previousCode: true,

--- a/packages/config-yaml/src/schemas/data/nextEditWithHistory/index.ts
+++ b/packages/config-yaml/src/schemas/data/nextEditWithHistory/index.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 import { baseDevDataAllSchema } from "../base.js";
 
 export const nextEditEventAllSchema = baseDevDataAllSchema.extend({
+  modelProvider: z.string(),
+  modelName: z.string(),
   previousEdits: z.array(
     z.object({
       filename: z.string(),

--- a/packages/config-yaml/src/schemas/data/nextEditWithHistory/v0.2.0.ts
+++ b/packages/config-yaml/src/schemas/data/nextEditWithHistory/v0.2.0.ts
@@ -10,6 +10,8 @@ export const nextEditEventSchema_0_2_0 = nextEditEventAllSchema.pick({
   schema: true,
 
   // nextedit-specific
+  modelProvider: true,
+  modelName: true,
   previousEdits: true,
   fileURI: true,
   workspaceDirURI: true,


### PR DESCRIPTION
## Summary
- Standardize `modelTitle` → `modelName` across all dev data schemas for consistency
- Add missing `modelProvider` and `modelName` fields to `chatFeedback` events
- Add missing `modelProvider` and `modelName` fields to `nextEditWithHistory` events  
- Enhance chat mode `editOutcome` logging with proper model information

**Resolves:** CON-3424 and sub-issues CON-3400, CON-3401, CON-3402, CON-3080
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Standardized all dev data schemas to use modelName instead of modelTitle, and added missing modelProvider and modelName fields to chatFeedback and nextEditWithHistory events. Improved chat mode editOutcome logging to include accurate model information.

- **Refactors**
 - Updated schemas and event logging to match Linear issue requirements for consistent model field naming and completeness.

<!-- End of auto-generated description by cubic. -->

