### PR TITLE
Fix dev data: standardize model fields and add missing model info

### DIFF
--- a/gui/src/util/editOutcomeLogger.ts
+++ b/gui/src/util/editOutcomeLogger.ts
@@ -7,7 +7,7 @@ import { store } from "../redux/store";
  */
 function extractModelInfo(toolCallState: ToolCallState): {
   modelProvider: string;
-  modelTitle: string;
+  modelName: string;
 } {
   // Get the conversation history to find the model info
   const history = store.getState().session.history;
@@ -28,7 +28,7 @@ function extractModelInfo(toolCallState: ToolCallState): {
     const modelParts = String(assistantMessage.message.model).split("::");
     return {
       modelProvider: modelParts[0] || "unknown",
-      modelTitle: modelParts[1] || String(assistantMessage.message.model),
+      modelName: modelParts[1] || String(assistantMessage.message.model),
     };
   }
 
@@ -38,7 +38,7 @@ function extractModelInfo(toolCallState: ToolCallState): {
 
   return {
     modelProvider: chatModel?.provider || "unknown",
-    modelTitle: chatModel?.model || "unknown",
+    modelName: chatModel?.model || "unknown",
   };
 }
 
@@ -153,7 +153,7 @@ export function assembleEditOutcomeData(
     streamId: applyState.streamId,
     timestamp: new Date().toISOString(),
     modelProvider: modelInfo.modelProvider,
-    modelTitle: modelInfo.modelTitle,
+    modelName: modelInfo.modelName,
     prompt: promptAndCompletion.prompt,
     completion: promptAndCompletion.completion,
     previousCode: codeChanges.previousCode,
@@ -187,4 +187,90 @@ export async function logAgentModeEditOutcome(
     name: "editOutcome",
     data: editOutcomeData,
   });
+}
+
+/**
+ * Log Chat Mode edit outcome to editOutcome.jsonl
+ */
+export async function logChatModeEditOutcome(
+  applyState: ApplyState,
+  accepted: boolean,
+  ideMessenger: IIdeMessenger,
+): Promise<void> {
+  // For chat mode, we need to find the tool call state from the apply state
+  const history = store.getState().session.history;
+  
+  // Find the tool call associated with this apply state if it exists
+  let toolCallState: ToolCallState | null = null;
+  
+  if (applyState.toolCallId) {
+    // Find the assistant message that contains this tool call
+    const assistantMessage = history.find(
+      (item) =>
+        item.message.role === "assistant" &&
+        item.message.toolCalls?.some((tc) => tc.id === applyState.toolCallId),
+    );
+    
+    if (assistantMessage?.message.role === "assistant" && assistantMessage.message.toolCalls) {
+      const toolCallDelta = assistantMessage.message.toolCalls.find((tc) => tc.id === applyState.toolCallId);
+      if (toolCallDelta && toolCallDelta.id && toolCallDelta.function?.name && toolCallDelta.function?.arguments) {
+        // Convert ToolCallDelta to ToolCall
+        const toolCall = {
+          id: toolCallDelta.id,
+          type: "function" as const,
+          function: {
+            name: toolCallDelta.function.name,
+            arguments: toolCallDelta.function.arguments,
+          },
+        };
+        
+        toolCallState = {
+          toolCallId: applyState.toolCallId,
+          toolCall,
+          status: accepted ? "done" : "canceled",
+          parsedArgs: {},
+        };
+      }
+    }
+  }
+
+  if (toolCallState) {
+    // If we have a tool call, use the same logic as agent mode
+    const editOutcomeData = assembleEditOutcomeData(
+      toolCallState,
+      applyState,
+      accepted,
+    );
+
+    ideMessenger.post("devdata/log", {
+      name: "editOutcome",
+      data: editOutcomeData,
+    });
+  } else {
+    // For manual chat mode interactions without tool calls, create minimal data
+    const codeChanges = extractCodeChanges(applyState);
+    const config = store.getState().config.config;
+    const chatModel = config?.selectedModelByRole?.chat;
+
+    const editOutcomeData = {
+      streamId: applyState.streamId,
+      timestamp: new Date().toISOString(),
+      modelProvider: chatModel?.provider || "unknown",
+      modelName: chatModel?.model || "unknown",
+      prompt: "Chat mode manual apply", // Placeholder for manual applies
+      completion: "Code applied via chat", // Placeholder for manual applies
+      previousCode: codeChanges.previousCode,
+      newCode: codeChanges.newCode,
+      filepath: applyState.filepath || "",
+      previousCodeLines: codeChanges.previousCodeLines,
+      newCodeLines: codeChanges.newCodeLines,
+      lineChange: codeChanges.lineChange,
+      accepted,
+    };
+
+    ideMessenger.post("devdata/log", {
+      name: "editOutcome",
+      data: editOutcomeData,
+    });
+  }
 }

--- a/packages/config-yaml/src/schemas/data/chatFeedback/index.ts
+++ b/packages/config-yaml/src/schemas/data/chatFeedback/index.ts
@@ -2,7 +2,8 @@ import { z } from "zod";
 import { baseDevDataAllSchema } from "../base.js";
 
 export const chatFeedbackEventAllSchema = baseDevDataAllSchema.extend({
-  modelTitle: z.string(),
+  modelProvider: z.string(),
+  modelName: z.string(),
   completionOptions: z.object({}),
   prompt: z.string(),
   completion: z.string(),

--- a/packages/config-yaml/src/schemas/data/chatFeedback/v0.1.0.ts
+++ b/packages/config-yaml/src/schemas/data/chatFeedback/v0.1.0.ts
@@ -1,7 +1,8 @@
 import { chatFeedbackEventAllSchema } from "./index.js";
 
 export const chatFeedbackEventSchema_0_1_0 = chatFeedbackEventAllSchema.pick({
-  modelTitle: true,
+  modelProvider: true,
+  modelName: true,
   completionOptions: true,
   prompt: true,
   completion: true,

--- a/packages/config-yaml/src/schemas/data/chatFeedback/v0.2.0.ts
+++ b/packages/config-yaml/src/schemas/data/chatFeedback/v0.2.0.ts
@@ -12,7 +12,8 @@ export const chatFeedbackEventSchema_0_2_0 = chatFeedbackEventAllSchema.pick({
   // other
   prompt: true,
   completion: true,
-  modelTitle: true,
+  modelProvider: true,
+  modelName: true,
   feedback: true,
   sessionId: true,
 });

--- a/packages/config-yaml/src/schemas/data/chatInteraction/index.ts
+++ b/packages/config-yaml/src/schemas/data/chatInteraction/index.ts
@@ -3,7 +3,7 @@ import { baseDevDataAllSchema } from "../base.js";
 
 export const chatInteractionEventAllSchema = baseDevDataAllSchema.extend({
   modelProvider: z.string(),
-  modelTitle: z.string(),
+  modelName: z.string(),
   prompt: z.string(),
   completion: z.string(),
   sessionId: z.string(),

--- a/packages/config-yaml/src/schemas/data/chatInteraction/v0.2.0.ts
+++ b/packages/config-yaml/src/schemas/data/chatInteraction/v0.2.0.ts
@@ -13,7 +13,7 @@ export const chatInteractionEventSchema_0_2_0 =
     // other
     prompt: true,
     completion: true,
-    modelTitle: true,
+    modelName: true,
     modelProvider: true,
     sessionId: true,
     tools: true,

--- a/packages/config-yaml/src/schemas/data/editInteraction/index.ts
+++ b/packages/config-yaml/src/schemas/data/editInteraction/index.ts
@@ -6,7 +6,7 @@ import { baseDevDataAllSchema } from "../base.js";
  */
 export const editInteractionEventAllSchema = baseDevDataAllSchema.extend({
   modelProvider: z.string(),
-  modelTitle: z.string(),
+  modelName: z.string(),
   prompt: z.string(),
   completion: z.string(),
   filepath: z.string(),

--- a/packages/config-yaml/src/schemas/data/editInteraction/v0.2.0.ts
+++ b/packages/config-yaml/src/schemas/data/editInteraction/v0.2.0.ts
@@ -13,7 +13,7 @@ export const editInteractionEventSchema_0_2_0 =
     // other
     prompt: true,
     completion: true,
-    modelTitle: true,
+    modelName: true,
     modelProvider: true,
     filepath: true,
   });

--- a/packages/config-yaml/src/schemas/data/editOutcome/index.ts
+++ b/packages/config-yaml/src/schemas/data/editOutcome/index.ts
@@ -3,7 +3,7 @@ import { baseDevDataAllSchema } from "../base.js";
 
 export const editOutcomeEventAllSchema = baseDevDataAllSchema.extend({
   modelProvider: z.string(),
-  modelTitle: z.string(),
+  modelName: z.string(),
   prompt: z.string(),
   completion: z.string(),
   previousCode: z.string(),

--- a/packages/config-yaml/src/schemas/data/editOutcome/v0.2.0.ts
+++ b/packages/config-yaml/src/schemas/data/editOutcome/v0.2.0.ts
@@ -12,7 +12,7 @@ export const editOutcomeEventSchema_0_2_0 = editOutcomeEventAllSchema.pick({
   // other
   prompt: true,
   completion: true,
-  modelTitle: true,
+  modelName: true,
   modelProvider: true,
   accepted: true,
   previousCode: true,

--- a/packages/config-yaml/src/schemas/data/nextEditWithHistory/index.ts
+++ b/packages/config-yaml/src/schemas/data/nextEditWithHistory/index.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 import { baseDevDataAllSchema } from "../base.js";
 
 export const nextEditEventAllSchema = baseDevDataAllSchema.extend({
+  modelProvider: z.string(),
+  modelName: z.string(),
   previousEdits: z.array(
     z.object({
       filename: z.string(),

--- a/packages/config-yaml/src/schemas/data/nextEditWithHistory/v0.2.0.ts
+++ b/packages/config-yaml/src/schemas/data/nextEditWithHistory/v0.2.0.ts
@@ -10,6 +10,8 @@ export const nextEditEventSchema_0_2_0 = nextEditEventAllSchema.pick({
   schema: true,
 
   // nextedit-specific
+  modelProvider: true,
+  modelName: true,
   previousEdits: true,
   fileURI: true,
   workspaceDirURI: true,


### PR DESCRIPTION
## Summary
- Standardize `modelTitle` → `modelName` across all dev data schemas for consistency
- Add missing `modelProvider` and `modelName` fields to `chatFeedback` events
- Add missing `modelProvider` and `modelName` fields to `nextEditWithHistory` events  
- Enhance chat mode `editOutcome` logging with proper model information

**Resolves:** CON-3424 and sub-issues CON-3400, CON-3401, CON-3402, CON-3080

## Test plan
- [x] Schemas build successfully 
- [x] All dev data events now use consistent `modelName` field
- [x] Chat mode edit outcomes are properly logged with model info