### PR TITLE
docs: Update reranking.mdx

### DIFF
--- a/docs/customize/model-roles/reranking.mdx
+++ b/docs/customize/model-roles/reranking.mdx
@@ -131,6 +131,7 @@ The `"modelTitle"` field must match one of the models in your "models" array in 
     models:
       - name: Huggingface-tei Reranker
         provider: huggingface-tei
+        model: tei
         apiBase: http://localhost:8080
         apiKey: <YOUR_TEI_API_KEY>
         roles:


### PR DESCRIPTION
the yaml doesn't validate without model specified. based on the source code for this provider the default is supposed to be tei anyway, so calling it out here just so the yaml has valid syntax

https://github.com/continuedev/continue/blob/c7fdfe497995cda7c43631a369d3d9eb62575c6c/core/llm/llms/HuggingFaceTEI.ts#L9

## Description

Yaml documentation change / update for using Huggingface-tei reranker

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Tests

no tests were added or updated but this was tested locally as valid using the latest pre-release as of today

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added the model field to the Huggingface-tei reranker YAML example to ensure valid syntax and match provider defaults.

<!-- End of auto-generated description by cubic. -->

