### PR TITLE
style: remove space between terminal command and output

### DIFF
--- a/gui/src/pages/gui/ToolCallDiv/RunTerminalCommand.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/RunTerminalCommand.tsx
@@ -117,17 +117,11 @@ export function RunTerminalCommand(props: RunTerminalCommandToolCallProps) {
         <TerminalCollapsibleContainer
           collapsible={processedTerminalContent.isLimited}
           hiddenLinesCount={processedTerminalContent.hiddenLinesCount}
-          className="mt-2"
+          className="-mt-4"
           collapsedContent={
-            <div className="mt-2">
-              <Ansi>{processedTerminalContent.limitedContent}</Ansi>
-            </div>
+            <Ansi>{processedTerminalContent.limitedContent}</Ansi>
           }
-          expandedContent={
-            <div className="mt-2">
-              <Ansi>{processedTerminalContent.fullContent}</Ansi>
-            </div>
-          }
+          expandedContent={<Ansi>{processedTerminalContent.fullContent}</Ansi>}
         />
       )}
 
@@ -142,7 +136,7 @@ export function RunTerminalCommand(props: RunTerminalCommandToolCallProps) {
               onClick={(e) => {
                 e.preventDefault();
                 // Dispatch the action to move the command to the background
-                dispatch(
+                void dispatch(
                   moveTerminalProcessToBackground({
                     toolCallId: props.toolCallId as string,
                   }),

--- a/gui/src/pages/gui/ToolCallDiv/RunTerminalCommand.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/RunTerminalCommand.tsx
@@ -117,7 +117,9 @@ export function RunTerminalCommand(props: RunTerminalCommandToolCallProps) {
         <TerminalCollapsibleContainer
           collapsible={processedTerminalContent.isLimited}
           hiddenLinesCount={processedTerminalContent.hiddenLinesCount}
-          className="-mt-4"
+          className={
+            processedTerminalContent.hiddenLinesCount === 0 ? "-mt-3" : "-mt-5"
+          }
           collapsedContent={
             <Ansi>{processedTerminalContent.limitedContent}</Ansi>
           }


### PR DESCRIPTION
## Description

Remove the space between the terminal command and output in the chat area.

resolves CON-3073

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

**previous**

<img width="482" height="372" alt="image" src="https://github.com/user-attachments/assets/e486fa79-5dde-4d6d-a3ea-a05853b94c62" />

---

<img width="481" height="344" alt="image" src="https://github.com/user-attachments/assets/76b752f1-9766-497a-997b-bb064c1cfa28" />


**now**

<img width="477" height="400" alt="image" src="https://github.com/user-attachments/assets/c313c681-af2e-44ff-9916-1ff670467004" />

---

<img width="496" height="319" alt="image" src="https://github.com/user-attachments/assets/7b68b1fe-a39a-4ec2-8725-5b8035484fac" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed extra space between terminal command and output in the chat area for a cleaner display. This matches the layout requested in CON-3073.

<!-- End of auto-generated description by cubic. -->

