### PR TITLE
fix: pass no proxy hosts in IntelliJ Plugin

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/process/ContinueBinaryProcess.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/process/ContinueBinaryProcess.kt
@@ -1,8 +1,8 @@
 package com.github.continuedev.continueintellijextension.`continue`.process
 
-import com.github.continuedev.continueintellijextension.proxy.ProxySettings
-import com.github.continuedev.continueintellijextension.error.ContinueSentryService
 import com.github.continuedev.continueintellijextension.error.ContinuePostHogService
+import com.github.continuedev.continueintellijextension.error.ContinueSentryService
+import com.github.continuedev.continueintellijextension.proxy.ProxySettings
 import com.github.continuedev.continueintellijextension.utils.OS
 import com.github.continuedev.continueintellijextension.utils.getContinueBinaryPath
 import com.github.continuedev.continueintellijextension.utils.getOS
@@ -37,6 +37,7 @@ class ContinueBinaryProcess(
         val proxySettings = ProxySettings.getSettings()
         if (proxySettings.enabled)
             builder.environment() += "HTTP_PROXY" to proxySettings.proxy
+            builder.environment() += "NO_PROXY" to proxySettings.noProxy
         return builder
             .directory(File(path).parentFile)
             .start()

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/proxy/ProxySettings.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/proxy/ProxySettings.kt
@@ -5,6 +5,7 @@ import com.intellij.util.net.HttpConfigurable
 data class ProxySettings(
     val enabled: Boolean,
     val proxy: String,
+    val noProxy: String,
 ) {
 
     companion object {
@@ -12,7 +13,8 @@ data class ProxySettings(
             val settings = HttpConfigurable.getInstance()
             return ProxySettings(
                 enabled = settings.USE_HTTP_PROXY,
-                proxy = "${settings.PROXY_HOST}:${settings.PROXY_PORT}"
+                proxy = "${settings.PROXY_HOST}:${settings.PROXY_PORT}",
+                noProxy = settings.PROXY_EXCEPTIONS,
             )
         }
     }


### PR DESCRIPTION
## Description

After https://github.com/continuedev/continue/pull/6752, some users met issues with connection (probably, https://github.com/continuedev/continue/issues/7092 and https://github.com/continuedev/continue/issues/7081). This fix passes proxy exceptions from IntelliJ Idea settings to the binaries.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Test

You need to disable TCP transport if you would like to run the plugin from sources. See https://github.com/continuedev/continue/pull/6752