### PR TITLE
chore: add `uinstinct` to auto-assign-issue.yaml

### DIFF
--- a/.github/workflows/auto-assign-issue.yaml
+++ b/.github/workflows/auto-assign-issue.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: pozil/auto-assign-issue@v2
         with:
           repo-token: ${{ secrets.CI_GITHUB_TOKEN }}
-          assignees: Patrick-Erichsen,tomasz-stefaniak,RomneyDa,tingwai
+          assignees: Patrick-Erichsen,tomasz-stefaniak,RomneyDa,tingwai,uinstinct
           numOfAssignee: 1
       # - name: "Add default labels"
       #   uses: actions-ecosystem/action-add-labels@v1


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added `uinstinct` to the list of users who can be auto-assigned to new issues in the workflow configuration.

<!-- End of auto-generated description by cubic. -->

