### PR TITLE
fix: Object object in profile URI

### DIFF
--- a/core/config/profile/PlatformProfileLoader.ts
+++ b/core/config/profile/PlatformProfileLoader.ts
@@ -109,7 +109,7 @@ export default class PlatformProfileLoader implements IProfileLoader {
       title: configResult.config?.name ?? `${ownerSlug}/${packageSlug}`,
       errors: configResult.errors,
       iconUrl: iconUrl,
-      uri: `${controlPlaneEnv}${ownerSlug}/${packageSlug}`,
+      uri: `${controlPlaneEnv.APP_URL}${ownerSlug}/${packageSlug}`,
       rawYaml,
     };
 


### PR DESCRIPTION
## Description
Was stringifying object in URI
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed profile URI construction so it no longer shows [object Object]; now uses the correct APP_URL value.

<!-- End of auto-generated description by cubic. -->

