### PR TITLE
feat: add salvage functionality for security-sensitive values in Glob…

### DIFF
--- a/core/util/GlobalContext.ts
+++ b/core/util/GlobalContext.ts
@@ -1,6 +1,10 @@
 import fs from "node:fs";
 
 import { ModelRole } from "@continuedev/config-yaml";
+import {
+  OAuthClientInformationFull,
+  OAuthTokens,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
 
 import { SiteIndexingConfig } from "..";
 import {
@@ -41,6 +45,13 @@ export type GlobalContextType = {
   failedDocs: SiteIndexingConfig[];
   shownDeprecatedProviderWarnings: {
     [providerTitle: string]: boolean;
+  };
+  mcpOauthStorage: {
+    [serverUrl: string]: {
+      clientInformation?: OAuthClientInformationFull;
+      tokens?: OAuthTokens;
+      codeVerifier?: string;
+    };
   };
 };
 


### PR DESCRIPTION
Closes CON-2978
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added salvage functionality to recover security-sensitive values like allowAnonymousTelemetry from corrupted GlobalContext files instead of deleting all data.

- **New Features**
 - Extracts valid sharedConfig values from partially corrupted files during updates.
 - Preserves important settings if file corruption occurs.

<!-- End of auto-generated description by cubic. -->

