### PR TITLE
fix: add Enter Enterprise License Key action

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/license/AddLicenseKey.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/license/AddLicenseKey.kt
@@ -11,19 +11,20 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.service
+import com.intellij.openapi.ui.DialogWrapper
 
 class AddLicenseKey : AnAction() {
 
     override fun actionPerformed(e: AnActionEvent) {
         val dialog = AddLicenseKeyDialog(e.project)
         dialog.show()
-        if (dialog.exitCode != 0)
+        if (dialog.exitCode != DialogWrapper.OK_EXIT_CODE)
             return
         val messenger = e.project?.service<ContinuePluginService>()?.coreMessenger
             ?: return
         messenger.request("mdm/setLicenseKey", mapOf("licenseKey" to dialog.licenseKey), null) { response ->
             val isValid = response.castNestedOrNull<Boolean>("content")!!
-            val notification = if (!isValid)
+            val notification = if (isValid)
                 createSuccessAction()
             else
                 createErrorAction()

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/license/AddLicenseKey.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/license/AddLicenseKey.kt
@@ -1,0 +1,67 @@
+package com.github.continuedev.continueintellijextension.license
+
+import com.github.continuedev.continueintellijextension.services.ContinuePluginService
+import com.github.continuedev.continueintellijextension.utils.castNestedOrNull
+import com.intellij.notification.NotificationAction
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.ActionPlaces
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.service
+
+class AddLicenseKey : AnAction() {
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val dialog = AddLicenseKeyDialog(e.project)
+        dialog.show()
+        if (dialog.exitCode != 0)
+            return
+        val messenger = e.project?.service<ContinuePluginService>()?.coreMessenger
+            ?: return
+        messenger.request("mdm/setLicenseKey", mapOf("licenseKey" to dialog.licenseKey), null) { response ->
+            val isValid = response.castNestedOrNull<Boolean>("content")!!
+            val notification = if (!isValid)
+                createSuccessAction()
+            else
+                createErrorAction()
+            notification.notify(e.project)
+        }
+    }
+
+    private fun createSuccessAction() =
+        getContinueNotifications().createNotification(
+            "License key is valid. A restart is required for it to take effect.",
+            NotificationType.INFORMATION
+        ).addAction(
+            NotificationAction.create("Restart IDE") { event, notification ->
+                ApplicationManager.getApplication().restart()
+            }
+        )
+
+    private fun createErrorAction() =
+        getContinueNotifications().createNotification(
+            "License key is invalid.",
+            NotificationType.ERROR
+        ).addAction(
+            NotificationAction.create("Try again") { event, notification ->
+                notification.expire()
+                val action = this@AddLicenseKey
+                action.actionPerformed(
+                    AnActionEvent(
+                        null,
+                        event.dataContext,
+                        ActionPlaces.UNKNOWN,
+                        action.templatePresentation.clone(),
+                        ActionManager.getInstance(),
+                        0
+                    )
+                )
+            }
+        )
+
+    private fun getContinueNotifications() =
+        NotificationGroupManager.getInstance().getNotificationGroup("Continue")
+}

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/license/AddLicenseKey.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/license/AddLicenseKey.kt
@@ -23,7 +23,7 @@ class AddLicenseKey : AnAction() {
         val messenger = e.project?.service<ContinuePluginService>()?.coreMessenger
             ?: return
         messenger.request("mdm/setLicenseKey", mapOf("licenseKey" to dialog.licenseKey), null) { response ->
-            val isValid = response.castNestedOrNull<Boolean>("content")!!
+            val isValid = response.castNestedOrNull<Boolean>("content") ?: false
             val notification = if (isValid)
                 createSuccessAction()
             else

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/license/AddLicenseKeyDialog.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/license/AddLicenseKeyDialog.kt
@@ -1,0 +1,35 @@
+package com.github.continuedev.continueintellijextension.license
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.ui.ValidationInfo
+import com.intellij.ui.dsl.builder.bindText
+import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.dsl.gridLayout.HorizontalAlign
+import javax.swing.JComponent
+
+class AddLicenseKeyDialog(project: Project?) : DialogWrapper(project) {
+
+    var licenseKey: String = ""
+        private set
+
+    init {
+        title = "Enterprise License Key"
+        init()
+    }
+
+    override fun createCenterPanel(): JComponent? =
+        panel {
+            row {
+                textField().bindText(::licenseKey)
+                    .horizontalAlign(HorizontalAlign.FILL)
+                    .focused()
+                    .validation {
+                        if (it.text.isBlank())
+                            ValidationInfo("License key cannot be empty")
+                        else
+                            null
+                    }
+            }
+        }
+}


### PR DESCRIPTION
Solves CON-3473

Notes:
* I don't have a license key, so I haven't fully tested this, but looking at the TypeScript: `true` in the response means it's valid, and `false` means it's not
* Extra: I added Try Again because I noticed that searching for the action every time the key is invalid is inconvenient
* I wasn't sure if restarting the IDE is safe without more testing, so I ended with Restart IDE action (it was much faster to implement)


## GIFs

### Invalid

![Peek 2025-08-15 01-24](https://github.com/user-attachments/assets/ece8e065-e593-432d-b2c0-a126a79c60d1)

### Valid

![Peek 2025-08-15 01-25](https://github.com/user-attachments/assets/e414b381-a0af-4423-a970-4e3d1877d363)

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added an "Enter Enterprise License Key" action to IntelliJ for setting and validating license keys. Users get instant feedback, with options to retry or restart the IDE as needed.

- **New Features**
  - Dialog to enter and validate license key.
  - "Try again" option if key is invalid.
  - Prompt to restart IDE when key is valid.

<!-- End of auto-generated description by cubic. -->

