### PR TITLE
fix: :lock: Simpler fix to exclude search_web tool to signed in users

### DIFF
--- a/core/config/profile/doLoadConfig.ts
+++ b/core/config/profile/doLoadConfig.ts
@@ -93,6 +93,7 @@ export default async function doLoadConfig(options: {
   const uniqueId = await ide.getUniqueId();
   const ideSettings = await ideSettingsPromise;
   const workOsAccessToken = await controlPlaneClient.getAccessToken();
+  const isSignedIn = await controlPlaneClient.isSignedIn();
 
   // Migrations for old config files
   // Removes
@@ -285,6 +286,7 @@ export default async function doLoadConfig(options: {
       rules: newConfig.rules,
       enableExperimentalTools:
         newConfig.experimental?.enableExperimentalTools ?? false,
+      isSignedIn,
     }),
   );
 

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1111,6 +1111,7 @@ interface ToolChoice {
 export interface ConfigDependentToolParams {
   rules: RuleWithSource[];
   enableExperimentalTools: boolean;
+  isSignedIn: boolean;
 }
 
 export type GetTool = (params: ConfigDependentToolParams) => Tool;

--- a/core/tools/definitions/toolDefinitions.test.ts
+++ b/core/tools/definitions/toolDefinitions.test.ts
@@ -7,6 +7,7 @@ describe("Tool Definitions", () => {
   const mockParams: ConfigDependentToolParams = {
     rules: [],
     enableExperimentalTools: false,
+    isSignedIn: false,
   };
 
   // Helper function to get the actual tool object

--- a/core/tools/index.ts
+++ b/core/tools/index.ts
@@ -11,7 +11,6 @@ const getBaseToolDefinitions = () => [
   toolDefinitions.createNewFileTool,
   toolDefinitions.runTerminalCommandTool,
   toolDefinitions.globSearchTool,
-  toolDefinitions.searchWebTool,
   toolDefinitions.viewDiffTool,
   toolDefinitions.readCurrentlyOpenFileTool,
   toolDefinitions.lsTool,
@@ -27,6 +26,8 @@ export const getConfigDependentToolDefinitions = (
   toolDefinitions.searchAndReplaceInFileTool,
   // Keep edit file tool available for models that need it
   toolDefinitions.editFileTool,
+  // Web search is only available for signed-in users (free trial and paid subscribers)
+  ...(params.isSignedIn ? [toolDefinitions.searchWebTool] : []),
   ...(params.enableExperimentalTools
     ? [
         toolDefinitions.viewRepoMapTool,

--- a/core/tools/searchWebGating.vitest.ts
+++ b/core/tools/searchWebGating.vitest.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "vitest";
+import { getConfigDependentToolDefinitions } from "./index";
+import { BuiltInToolNames } from "./builtIn";
+
+test("searchWeb tool is only available when user is signed in", () => {
+  // Test with signed-in user
+  const signedInTools = getConfigDependentToolDefinitions({
+    rules: [],
+    enableExperimentalTools: false,
+    isSignedIn: true,
+  });
+
+  const searchWebToolSignedIn = signedInTools.find(
+    (tool) => tool.function.name === BuiltInToolNames.SearchWeb,
+  );
+  expect(searchWebToolSignedIn).toBeDefined();
+  expect(searchWebToolSignedIn?.displayTitle).toBe("Search Web");
+
+  // Test with non-signed-in user
+  const notSignedInTools = getConfigDependentToolDefinitions({
+    rules: [],
+    enableExperimentalTools: false,
+    isSignedIn: false,
+  });
+
+  const searchWebToolNotSignedIn = notSignedInTools.find(
+    (tool) => tool.function.name === BuiltInToolNames.SearchWeb,
+  );
+  expect(searchWebToolNotSignedIn).toBeUndefined();
+});


### PR DESCRIPTION
## Description

Excludes the search_web tool so it's only avaiable to signed in Hub Users. Excludes it availability to users who might be using local only features. This is due to a potential security issue with the search web tool and how it posts content to an external proxy. For highly regulated users of the extension we would not want any kind of information posted to a third party proxy.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

Tests added to validate the tool is excluded properly based on the configuration and signed in state.
