### PR TITLE
feat: improve next edit UI

### DIFF
--- a/core/codeRenderer/CodeRenderer.ts
+++ b/core/codeRenderer/CodeRenderer.ts
@@ -320,29 +320,46 @@ export class CodeRenderer {
         const y = index * options.lineHeight;
         const isFirst = index === 0;
         const isLast = index === lines.length - 1;
+        const isSingleLine = isFirst && isLast;
         const radius = 10;
+
+        // Handle single line case (both first and last)
+        if (isSingleLine) {
+          return `<path d="M ${radius} ${y}
+         L ${options.dimensions.width - radius} ${y}
+         Q ${options.dimensions.width} ${y} ${options.dimensions.width} ${y + radius}
+         L ${options.dimensions.width} ${y + options.lineHeight - radius}
+         Q ${options.dimensions.width} ${y + options.lineHeight} ${options.dimensions.width - radius} ${y + options.lineHeight}
+         L ${radius} ${y + options.lineHeight}
+         Q ${0} ${y + options.lineHeight} ${0} ${y + options.lineHeight - radius}
+         L ${0} ${y + radius}
+         Q ${0} ${y} ${radius} ${y}
+         Z"
+      fill="${bgColor}" />`;
+        }
+
         // SVG notes:
         // By default SVGs have anti-aliasing on.
         // This is undesirable in our case because pixel-perfect alignment of these rectangles will introduce thin gaps.
         // Turning it off with 'shape-rendering="crispEdges"' solves the issue.
         return isFirst
           ? `<path d="M ${0} ${y + options.lineHeight}
-             L ${0} ${y + radius}
-             Q ${0} ${y} ${radius} ${y}
-             L ${options.dimensions.width - radius} ${y}
-             Q ${options.dimensions.width} ${y} ${options.dimensions.width} ${y + radius}
-             L ${options.dimensions.width} ${y + options.lineHeight}
-             Z"
-          fill="${bgColor}" />`
+         L ${0} ${y + radius}
+         Q ${0} ${y} ${radius} ${y}
+         L ${options.dimensions.width - radius} ${y}
+         Q ${options.dimensions.width} ${y} ${options.dimensions.width} ${y + radius}
+         L ${options.dimensions.width} ${y + options.lineHeight}
+         Z"
+      fill="${bgColor}" />`
           : isLast
             ? `<path d="M ${0} ${y}
-             L ${0} ${y + options.lineHeight - radius}
-             Q ${0} ${y + options.lineHeight} ${radius} ${y + options.lineHeight}
-             L ${options.dimensions.width - radius} ${y + options.lineHeight}
-             Q ${options.dimensions.width} ${y + options.lineHeight} ${options.dimensions.width} ${y + options.lineHeight - 10}
-             L ${options.dimensions.width} ${y}
-             Z"
-          fill="${bgColor}" />`
+         L ${0} ${y + options.lineHeight - radius}
+         Q ${0} ${y + options.lineHeight} ${radius} ${y + options.lineHeight}
+         L ${options.dimensions.width - radius} ${y + options.lineHeight}
+         Q ${options.dimensions.width} ${y + options.lineHeight} ${options.dimensions.width} ${y + options.lineHeight - 10}
+         L ${options.dimensions.width} ${y}
+         Z"
+      fill="${bgColor}" />`
             : `<rect x="0" y="${y}" width="100%" height="${options.lineHeight}" fill="${bgColor}" shape-rendering="crispEdges" />`;
       })
       .join("\n");

--- a/core/codeRenderer/CodeRenderer.ts
+++ b/core/codeRenderer/CodeRenderer.ts
@@ -243,7 +243,10 @@ export class CodeRenderer {
     );
     const backgroundColor = this.getBackgroundColor(highlightedCodeHtml);
 
-    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${options.dimensions.width}" height="${options.dimensions.height}" shape-rendering="crispEdges">
+    const lines = code.split("\n");
+    const actualHeight = lines.length * options.lineHeight;
+
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${options.dimensions.width}" height="${actualHeight}" shape-rendering="crispEdges">
     <style>
       :root {
         --purple: rgb(112, 114, 209);
@@ -252,7 +255,7 @@ export class CodeRenderer {
       }
     </style>
     <g>
-    <rect x="0" y="0" rx="10" ry="10" width="${options.dimensions.width}" height="${options.dimensions.height}" fill="${this.editorBackground}" shape-rendering="crispEdges" />
+    <rect x="0" y="0" rx="10" ry="10" width="${options.dimensions.width}" height="${actualHeight}" fill="${this.editorBackground}" shape-rendering="crispEdges" />
       ${lineBackgrounds}
       ${guts}
     </g>

--- a/extensions/vscode/src/activation/NextEditWindowManager.ts
+++ b/extensions/vscode/src/activation/NextEditWindowManager.ts
@@ -669,10 +669,8 @@ export class NextEditWindowManager {
     const offsetFromTop =
       (position.line - editableRegionStartLine) * SVG_CONFIG.lineHeight;
 
-    // Set the margin-left so that it's never covering code inside the editable region.
-    const marginLeft =
-      SVG_CONFIG.getTipWidth(originalCode) -
-      SVG_CONFIG.getTipWidth(originalCode.split("\n")[currLineOffsetFromTop]);
+    // Position the decoration with minimal left margin since it's already at line end
+    const marginLeft = SVG_CONFIG.paddingX; // Use consistent padding instead of complex calculation
 
     return vscode.window.createTextEditorDecorationType({
       before: {
@@ -764,12 +762,16 @@ export class NextEditWindowManager {
   ): vscode.Position {
     // Create a position that's offset spaces to the right of the cursor.
 
+    // const line = editor.document.lineAt(position.line);
+    // const offsetChar = Math.min(
+    //   position.character + SVG_CONFIG.cursorOffset,
+    //   line.text.length,
+    // );
+    // return new vscode.Position(position.line, offsetChar);
+
+    // Place decoration at the end of the current line
     const line = editor.document.lineAt(position.line);
-    const offsetChar = Math.min(
-      position.character + SVG_CONFIG.cursorOffset,
-      line.text.length,
-    );
-    return new vscode.Position(position.line, offsetChar);
+    return new vscode.Position(position.line, line.text.length);
   }
 
   /**


### PR DESCRIPTION
## Description

Closes CON-3514.

Builds on CON-3498:
- SVG is now placed at the end of the line instead of after the cursor.
- SVG no longer has empty blank spaces at the bottom.
- Highlights for new lines are rendered properly for single line completions.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
