### PR TITLE
fix: disable tool support for moonshotai/kimi-k2:free model

### DIFF
--- a/core/llm/toolSupport.test.ts
+++ b/core/llm/toolSupport.test.ts
@@ -280,6 +280,15 @@ describe("PROVIDER_TOOL_SUPPORT", () => {
     });
   });
 
+  describe("openrouter", () => {
+    const supportsFn = PROVIDER_TOOL_SUPPORT["openrouter"];
+
+    it("should return false for moonshotai/kimi-k2:free model", () => {
+      // This fixes issue #6619
+      expect(supportsFn("moonshotai/kimi-k2:free")).toBe(false);
+    });
+  });
+
   describe("edge cases", () => {
     it("should handle empty model names", () => {
       expect(PROVIDER_TOOL_SUPPORT["continue-proxy"]("")).toBe(false);

--- a/core/llm/toolSupport.ts
+++ b/core/llm/toolSupport.ts
@@ -239,13 +239,13 @@ export const PROVIDER_TOOL_SUPPORT: Record<string, (model: string) => boolean> =
     },
     openrouter: (model) => {
       // https://openrouter.ai/models?fmt=cards&supported_parameters=tools
-      
+
       // Specific free models that don't support tools
       // Fixes issue #6619 - moonshotai/kimi-k2:free causing 400 errors
       if (model.toLowerCase() === "moonshotai/kimi-k2:free") {
         return false;
       }
-      
+
       if (
         ["vision", "math", "guard", "mistrallite", "mistral-openorca"].some(
           (part) => model.toLowerCase().includes(part),

--- a/core/llm/toolSupport.ts
+++ b/core/llm/toolSupport.ts
@@ -239,6 +239,13 @@ export const PROVIDER_TOOL_SUPPORT: Record<string, (model: string) => boolean> =
     },
     openrouter: (model) => {
       // https://openrouter.ai/models?fmt=cards&supported_parameters=tools
+      
+      // Specific free models that don't support tools
+      // Fixes issue #6619 - moonshotai/kimi-k2:free causing 400 errors
+      if (model.toLowerCase() === "moonshotai/kimi-k2:free") {
+        return false;
+      }
+      
       if (
         ["vision", "math", "guard", "mistrallite", "mistral-openorca"].some(
           (part) => model.toLowerCase().includes(part),


### PR DESCRIPTION
## Description

Minimal fix for issue #6619 where `moonshotai/kimi-k2:free` was causing 400 errors in agent mode.

## Problem
The OpenRouter free tier model `moonshotai/kimi-k2:free` doesn't support tool calls, causing 400 errors when used in agent mode.

## Solution
Added a simple check in `toolSupport.ts` to return `false` for this specific model.

## Changes
- **core/llm/toolSupport.ts**: Added 5-line check for the specific model
- **core/llm/toolSupport.test.ts**: Added test to verify the fix

## Testing
✅ All existing tests pass
✅ New test specifically verifies the fix

Fixes #6619
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Disabled tool support for the moonshotai/kimi-k2:free model to prevent 400 errors in agent mode, addressing issue #6619.

- **Bug Fixes**
 - Updated toolSupport.ts to return false for moonshotai/kimi-k2:free.
 - Added a test to confirm the fix.

<!-- End of auto-generated description by cubic. -->

