### PR TITLE
chore: fix oneper build workflow

### DIFF
--- a/.github/workflows/main-build.yaml
+++ b/.github/workflows/main-build.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - test-workflow-fix
   workflow_dispatch:
     inputs:
       test_pr_number:
@@ -24,17 +25,19 @@ jobs:
 
       - name: Get merged PR number
         id: get-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Get the commit message of the merge commit
-          COMMIT_MSG=$(git log --format=%B -n 1 HEAD)
-          echo "Commit message: $COMMIT_MSG"
-
-          # Extract PR number from merge commit message (format: "Merge pull request #123 from...")
-          PR_NUMBER=$(echo "$COMMIT_MSG" | grep -o "Merge pull request #[0-9]*" | grep -o "[0-9]*" || echo "6723")
+          # Get PR number for the current commit using GitHub API
+          COMMIT_SHA=$(git rev-parse HEAD)
+          echo "Getting PR for commit: $COMMIT_SHA"
+          
+          PR_NUMBER=$(curl -s -H "Authorization: token $GH_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/commits/$COMMIT_SHA/pulls" \
+            | jq -r '.[0].number // empty')
 
           if [ -z "$PR_NUMBER" ]; then
-            echo "❌ Could not extract PR number from commit message. This might not be a PR merge."
-            echo "Commit message was: $COMMIT_MSG"
+            echo "❌ Could not find PR for commit $COMMIT_SHA"
             exit 1
           fi
 

--- a/.github/workflows/main-build.yaml
+++ b/.github/workflows/main-build.yaml
@@ -4,7 +4,7 @@ name: Main Branch Build
 on:
   push:
     branches:
-      - pe/fix-oneper
+      - main
   workflow_dispatch:
     inputs:
       test_pr_number:

--- a/.github/workflows/main-build.yaml
+++ b/.github/workflows/main-build.yaml
@@ -4,7 +4,7 @@ name: Main Branch Build
 on:
   push:
     branches:
-      - main
+      - pe/fix-oneper
   workflow_dispatch:
     inputs:
       test_pr_number:
@@ -30,7 +30,7 @@ jobs:
           # Get PR number for the current commit using GitHub API
           COMMIT_SHA=$(git rev-parse HEAD)
           echo "Getting PR for commit: $COMMIT_SHA"
-          
+
           PR_NUMBER=$(curl -s -H "Authorization: token $GH_TOKEN" \
             "https://api.github.com/repos/${{ github.repository }}/commits/$COMMIT_SHA/pulls" \
             | jq -r '.[0].number // empty')

--- a/.github/workflows/main-build.yaml
+++ b/.github/workflows/main-build.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - test-workflow-fix
   workflow_dispatch:
     inputs:
       test_pr_number:


### PR DESCRIPTION
The issue here was that we were trying to regex match against commit titles to get the PR from a given merge commit, to then get the build artifact from that PR. When it failed we fell back to an old PR that happened to be on version `1.1.69` that everyone kept installing.

Instead we now curl the GH API to more reliably grab it.

See [this workflow](https://github.com/continuedev/continue/actions/runs/16999882126/job/48199322171) for an example where it correctly grabs the PR number for this PR.
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switch the main build workflow to fetch the PR number via the GitHub API using the commit SHA. This replaces fragile commit message parsing and removes the hardcoded fallback, making the job more reliable.

- **Bug Fixes**
  - Call commits/{sha}/pulls with curl + jq and GH_TOKEN to get the PR number.
  - Remove fallback to PR 6723; add clearer failure message when no PR is found.
  - Works across different merge strategies; no reliance on commit message format.

<!-- End of auto-generated description by cubic. -->

