### PR TITLE
fix: add the missing EP to add license action

### DIFF
--- a/extensions/intellij/src/main/resources/META-INF/plugin.xml
+++ b/extensions/intellij/src/main/resources/META-INF/plugin.xml
@@ -106,6 +106,13 @@
             <override-text place="GoToAction" text="Continue: Reject Vertical Diff Block"/>
         </action>
 
+        <action id="continue.addLicenseKey"
+                class="com.github.continuedev.continueintellijextension.license.AddLicenseKey"
+                text="Enter Enterprise License Key"
+                description="Enter Enterprise License Key">
+            <override-text place="GoToAction" text="Continue: Enter Enterprise License Key"/>
+        </action>
+
         <action id="continue.focusContinueInputWithoutClear"
                 class="com.github.continuedev.continueintellijextension.actions.FocusContinueInputWithoutClearAction"
                 text="Add selected code to context"


### PR DESCRIPTION
Related to https://github.com/continuedev/continue/pull/7159 (CON-3473)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds the missing registration for the "Enter Enterprise License Key" action in plugin.xml so it appears in IntelliJ's Go to Action and can run. Fixes CON-3473 where users couldn't open the license entry.

<!-- End of auto-generated description by cubic. -->

