### PR TITLE
fix: use validation method that also works 2024.1

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/license/AddLicenseKeyDialog.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/license/AddLicenseKeyDialog.kt
@@ -24,7 +24,7 @@ class AddLicenseKeyDialog(project: Project?) : DialogWrapper(project) {
                 textField().bindText(::licenseKey)
                     .horizontalAlign(HorizontalAlign.FILL)
                     .focused()
-                    .validation {
+                    .validationOnApply {
                         if (it.text.isBlank())
                             ValidationInfo("License key cannot be empty")
                         else


### PR DESCRIPTION
The alternative `validationOnApply` does the job + it's compatible with future platform versions like `2024.1`.