### PR TITLE
Fix reranking on vllm provider

### DIFF
--- a/core/llm/llms/Vllm.ts
+++ b/core/llm/llms/Vllm.ts
@@ -45,7 +45,7 @@ class Vllm extends OpenAI {
       // vLLM uses 'results' array instead of 'data'
       if (results.results && Array.isArray(results.results)) {
         const sortedResults = results.results.sort((a, b) => a.index - b.index);
-        return sortedResults.map((result) => result.index);
+        return sortedResults.map((result) => result.relevance_score);
       }
 
       throw new Error(


### PR DESCRIPTION
Use scores instead of indices for vllm provider

## Description

Fixed the reranking pipeline to actually return a list of scores instead of list of indices.
## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

Maybe y