### PR TITLE
fix: show local assistant in hub organization

### DIFF
--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -262,7 +262,7 @@ export class ConfigHandler {
     org: OrganizationDescription,
   ): Promise<OrgWithProfiles> {
     const localProfiles = await this.getLocalProfiles({
-      includeGlobal: false,
+      includeGlobal: true,
       includeWorkspace: true,
     });
     const profiles = [...(await this.getHubProfiles(org.id)), ...localProfiles];


### PR DESCRIPTION
## Description

When an organization is selected from the profile dropdown, the "Local Assistant" is absent. This PR fixes it.

resolves CON-3519

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

**before**

<img width="336" height="434" alt="image" src="https://github.com/user-attachments/assets/70b83212-fbbb-42f1-923b-b54c0de53881" />


**after**

<img width="337" height="488" alt="image" src="https://github.com/user-attachments/assets/89ea8d92-2806-4c32-b4a6-a39567e6803e" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the missing Local Assistant when a hub organization is selected by including global local profiles in the org profile list. Users now see Local Assistant alongside org and workspace profiles. Resolves CON-3519.

- **Bug Fixes**
  - Set includeGlobal: true when loading local profiles for orgs to include the Local Assistant.

<!-- End of auto-generated description by cubic. -->

