### PR TITLE
docs: Update CONTRIBUTING.md to remove the "or later" reference to no…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,12 +115,12 @@ process as welcoming and straightforward as possible.
 
 #### Pre-requisites
 
-You should have Node.js version 20.19.0 (LTS) or higher installed. You can get it
+You should have Node.js version 20.19.0 (LTS) installed. You can get it
 on [nodejs.org](https://nodejs.org/en/download) or, if you are using NVM (Node Version Manager), you can set the correct
 version of Node.js for this project by running the following command in the root of the project:
 
 ```bash
-nvm use
+nvm use 20.19.0
 ```
 
 Then, install Vite globally


### PR DESCRIPTION
…de version

## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Clarified Node.js setup by pinning to version 20.19.0 and removing "or later" in CONTRIBUTING.md. Updated the nvm command to nvm use 20.19.0 to avoid version mismatches.

<!-- End of auto-generated description by cubic. -->

