### PR TITLE
fix: HOTFIX opening correct apikey url

### DIFF
--- a/gui/src/pages/gui/StreamError.tsx
+++ b/gui/src/pages/gui/StreamError.tsx
@@ -59,12 +59,7 @@ const StreamErrorDialog = ({ error }: StreamErrorProps) => {
   const checkKeysButton = apiKeyUrl ? (
     <GhostButton
       className="flex items-center"
-      onClick={() => {
-        ideMessenger.post("controlPlane/openUrl", {
-          path: apiKeyUrl,
-          orgSlug: undefined,
-        });
-      }}
+      onClick={() => ideMessenger.ide.openUrl(apiKeyUrl)}
     >
       <KeyIcon className="mr-1.5 h-3.5 w-3.5" />
       <span>View key</span>


### PR DESCRIPTION
## Description

When clicking on "View Key" during a stream error, it used to prepend the hub url. Fixed to use only the api key url

resolves CON-3489

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

**before**

<img width="912" height="750" alt="image" src="https://github.com/user-attachments/assets/b81ed2bf-d731-459b-8cf2-9c4e932de9f6" />

**after**

<img width="1062" height="692" alt="image" src="https://github.com/user-attachments/assets/30a7b680-3d95-48c1-8f57-3671baccf365" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the "View key" link in the Stream Error dialog so it opens the correct API key URL without the hub prefix. Resolves CON-3489.

- **Bug Fixes**
  - Use ide.openUrl(apiKeyUrl) to open the API key page directly.

<!-- End of auto-generated description by cubic. -->

