### PR TITLE
feat: check for model before using full file diffs

### DIFF
--- a/core/nextEdit/templating/NextEditPromptEngine.ts
+++ b/core/nextEdit/templating/NextEditPromptEngine.ts
@@ -43,7 +43,7 @@ const NEXT_EDIT_MODEL_TEMPLATES: Record<NEXT_EDIT_MODELS, NextEditTemplate> = {
     template: `${MERCURY_RECENTLY_VIEWED_CODE_SNIPPETS_OPEN}\n{{{recentlyViewedCodeSnippets}}}\n${MERCURY_RECENTLY_VIEWED_CODE_SNIPPETS_CLOSE}\n\n${MERCURY_CURRENT_FILE_CONTENT_OPEN}\n{{{currentFileContent}}}\n${MERCURY_CURRENT_FILE_CONTENT_CLOSE}\n\n${MERCURY_EDIT_DIFF_HISTORY_OPEN}\n{{{editDiffHistory}}}\n${MERCURY_EDIT_DIFF_HISTORY_CLOSE}\n\nThe developer was working on a section of code within the tags \`<|code_to_edit|>\` in the file located at {{{currentFilePath}}}.\nUsing the given \`recently_viewed_code_snippets\`, \`current_file_content\`, \`edit_diff_history\`, and the cursor position marked as \`<|cursor|>\`, please continue the developer's work. Update the \`code_to_edit\` section by predicting and completing the changes they would have made next. Provide the revised code that was between the \`<|code_to_edit|>\` and \`<|/code_to_edit|>\` tags, including the tags themselves.`,
   },
   instinct: {
-    template: `${INSTINCT_USER_PROMPT_PREFIX}\n\n### Context:\n{{{contextSnippets}}}\n\n### User Edits:\n\n{{{editDiffHistory}}}\n\n### User Excerpts:\n{{{currentFilePath}}}\n\n{{{currentFileContent}}}\`\`\`\n### Response:`,
+    template: `${INSTINCT_USER_PROMPT_PREFIX}\n\n### Context:\n{{{contextSnippets}}}\n\n### User Edits:\n\n{{{editDiffHistory}}}\n\n### User Excerpt:\n{{{currentFilePath}}}\n\n{{{currentFileContent}}}\`\`\`\n### Response:`,
   },
 };
 
@@ -144,6 +144,7 @@ export async function renderPrompt(
       };
 
       tv = instinctCtx;
+      console.log(tv);
 
       editedCodeWithTokens = instinctCtx.currentFileContent;
 

--- a/core/nextEdit/templating/NextEditPromptEngine.ts
+++ b/core/nextEdit/templating/NextEditPromptEngine.ts
@@ -144,7 +144,6 @@ export async function renderPrompt(
       };
 
       tv = instinctCtx;
-      console.log(tv);
 
       editedCodeWithTokens = instinctCtx.currentFileContent;
 

--- a/core/nextEdit/templating/NextEditPromptEngine.vitest.ts
+++ b/core/nextEdit/templating/NextEditPromptEngine.vitest.ts
@@ -106,7 +106,7 @@ describe("NextEditPromptEngine", () => {
       expect(result.prompt.content).toContain(INSTINCT_USER_PROMPT_PREFIX);
       expect(result.prompt.content).toContain("### Context:");
       expect(result.prompt.content).toContain("### User Edits:");
-      expect(result.prompt.content).toContain("### User Excerpts:");
+      expect(result.prompt.content).toContain("### User Excerpt:");
 
       expect(result.userEdits).toBe(instinctCtx.editDiffHistory);
       expect(result.userExcerpts).toContain(INSTINCT_USER_CURSOR_IS_HERE_TOKEN);

--- a/extensions/vscode/src/activation/SelectionChangeManager.ts
+++ b/extensions/vscode/src/activation/SelectionChangeManager.ts
@@ -150,6 +150,10 @@ export class SelectionChangeManager {
     );
   }
 
+  /**
+   * Updates this class's usingFullFileDiff flag.
+   * @param usingFullFileDiff New value to set.
+   */
   public updateUsingFullFileDiff(usingFullFileDiff: boolean) {
     this.usingFullFileDiff = usingFullFileDiff;
   }

--- a/extensions/vscode/src/activation/SelectionChangeManager.ts
+++ b/extensions/vscode/src/activation/SelectionChangeManager.ts
@@ -150,6 +150,10 @@ export class SelectionChangeManager {
     );
   }
 
+  public updateUsingFullFileDiff(usingFullFileDiff: boolean) {
+    this.usingFullFileDiff = usingFullFileDiff;
+  }
+
   public documentChanged(): void {
     this.isTypingSession = true;
     this.lastDocumentChangeTime = Date.now();

--- a/extensions/vscode/src/autocomplete/completionProvider.ts
+++ b/extensions/vscode/src/autocomplete/completionProvider.ts
@@ -132,6 +132,11 @@ export class ContinueCompletionProvider
     return config.selectedModelByRole.rerank ?? undefined;
   }
 
+  public updateUsingFullFileDiff(usingFullFileDiff: boolean) {
+    this.usingFullFileDiff = usingFullFileDiff;
+    this.prefetchQueue.initialize(this.usingFullFileDiff);
+  }
+
   public async provideInlineCompletionItems(
     document: vscode.TextDocument,
     position: vscode.Position,

--- a/extensions/vscode/src/autocomplete/completionProvider.ts
+++ b/extensions/vscode/src/autocomplete/completionProvider.ts
@@ -132,6 +132,10 @@ export class ContinueCompletionProvider
     return config.selectedModelByRole.rerank ?? undefined;
   }
 
+  /**
+   * Updates this class and the prefetch queue's usingFullFileDiff flag.
+   * @param usingFullFileDiff New value to set.
+   */
   public updateUsingFullFileDiff(usingFullFileDiff: boolean) {
     this.usingFullFileDiff = usingFullFileDiff;
     this.prefetchQueue.initialize(this.usingFullFileDiff);

--- a/extensions/vscode/src/extension/VsCodeExtension.ts
+++ b/extensions/vscode/src/extension/VsCodeExtension.ts
@@ -44,6 +44,7 @@ import { VsCodeMessenger } from "./VsCodeMessenger";
 
 import { getAst } from "core/autocomplete/util/ast";
 import { modelSupportsNextEdit } from "core/llm/autodetect";
+import { NEXT_EDIT_MODELS } from "core/llm/constants";
 import { DocumentHistoryTracker } from "core/nextEdit/DocumentHistoryTracker";
 import { NextEditProvider } from "core/nextEdit/NextEditProvider";
 import { isNextEditTest } from "core/nextEdit/utils";
@@ -122,14 +123,14 @@ export class VsCodeExtension {
         return false;
       }
 
-      if (autocompleteModel.model.includes("instinct")) {
+      if (autocompleteModel.model.includes(NEXT_EDIT_MODELS.INSTINCT)) {
         return false;
       }
 
       return true;
     };
 
-    let usingFullFileDiff = true;
+    const usingFullFileDiff = true;
     const selectionManager = SelectionChangeManager.getInstance();
     selectionManager.initialize(this.ide, usingFullFileDiff);
 


### PR DESCRIPTION
## Description

Closes CON-3559.

Checks for model before using full file diffs.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

`core/nextEdit/templating/NextEditPromptEngine.vitest.ts`

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Use full file diffs only when the selected autocomplete model supports Next Edit (currently Mercury). Addresses CON-3559 to avoid sending unsupported diffs to Instinct.

- **New Features**
  - Detect model support (via capabilities and model name) and enable full file diffs only for compatible models; disable for Instinct.
  - Apply this on startup and on config changes; propagate to SelectionChangeManager and completionProvider, reinitializing the prefetch queue.

- **Bug Fixes**
  - Rename "User Excerpts" to "User Excerpt" in the Instinct prompt template and update the test.

<!-- End of auto-generated description by cubic. -->

