### PR TITLE
Update tutorial instructions to use /init slash command instead of unit test examples

### DIFF
--- a/extensions/intellij/src/main/resources/continue_tutorial.java
+++ b/extensions/intellij/src/main/resources/continue_tutorial.java
@@ -58,6 +58,6 @@ public static int[] sortingAlgorithm2(int[] x) {
 //            the model to make decisions and save you the work of manually finding context and performing actions.
 
 // 1. Switch from "Chat" to "Agent" mode using the dropdown in the bottom left of the input box
-// 2. Try asking Continue "Write unit tests for this code in a new file and run the test"
+// 2. Use the "/init" slash command to generate a CONTINUE.md file
 
 // ——————————————————      Learn more at https://docs.continue.dev/getting-started/overview      ——————————————————— //

--- a/extensions/intellij/src/main/resources/continue_tutorial.py
+++ b/extensions/intellij/src/main/resources/continue_tutorial.py
@@ -47,6 +47,6 @@ def sorting_algorithm2(x):
 #             the model to make decisions and save you the work of manually finding context and performing actions.
 
 # 1. Switch from "Chat" to "Agent" mode using the dropdown in the bottom left of the input box
-# 2. Try asking Continue "Write unit tests for this code in a new file and run the test"
+# 2. Use the "/init" slash command to generate a CONTINUE.md file
 
 # ——————————————————      Learn more at https://docs.continue.dev/getting-started/overview      ——————————————————— #

--- a/extensions/intellij/src/main/resources/continue_tutorial.ts
+++ b/extensions/intellij/src/main/resources/continue_tutorial.ts
@@ -58,6 +58,6 @@ function sortingAlgorithm2(x: number[]): number[] {
 //              the model to make decisions and save you the work of manually finding context and performing actions.
 
 // 1. Switch from "Chat" to "Agent" mode using the dropdown in the bottom left of the input box
-// 2. Try asking Continue "Write unit tests for this code in a new file"
+// 2. Use the "/init" slash command to generate a CONTINUE.md file
 
 // ——————————————————      Learn more at https://docs.continue.dev/getting-started/overview      ——————————————————— //

--- a/extensions/vscode/continue_tutorial.py
+++ b/extensions/vscode/continue_tutorial.py
@@ -47,7 +47,6 @@ def sorting_algorithm2(x):
 #           the model to make decisions and save you the work of manually finding context and performing actions.
 
 # 1. Switch from "Chat" to "Agent" mode using the dropdown in the bottom left of the input box
-# 2. Try asking Continue "Write unit tests for this code in a new file",
-#    or if you have Python installed, "Write unit tests for this code in a new file and run the test"
+# 2. Use the "/init" slash command to generate a CONTINUE.md file
 
 # ——————————————————      Learn more at https://docs.continue.dev/getting-started/overview      ——————————————————— #


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated tutorial instructions in IntelliJ and VS Code examples to use the /init slash command to generate CONTINUE.md instead of unit test prompts, aligning onboarding with the new init flow.

<!-- End of auto-generated description by cubic. -->

