### PR TITLE
fix: broken release process of openai adapters

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -51,6 +51,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup packages
+        uses: ./.github/actions/setup-packages
+
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add a Setup packages step to the reusable release workflow to prepare packages before publishing. This prevents release failures from missing dependencies and ensures a consistent build.

<!-- End of auto-generated description by cubic. -->

