### PR TITLE
feat: Verify SSL for MCP

### DIFF
--- a/core/context/mcp/MCPConnection.ts
+++ b/core/context/mcp/MCPConnection.ts
@@ -1,6 +1,4 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
-
 import {
   SSEClientTransport,
   SseError,
@@ -8,7 +6,8 @@ import {
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { WebSocketClientTransport } from "@modelcontextprotocol/sdk/client/websocket.js";
-
+import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { Agent as HttpsAgent } from "https";
 import {
   IDE,
   MCPConnectionStatus,
@@ -393,6 +392,11 @@ class MCPConnection {
       case "websocket":
         return new WebSocketClientTransport(new URL(options.transport.url));
       case "sse":
+        const sseAgent =
+          options.transport.requestOptions?.verifySsl === false
+            ? new HttpsAgent({ rejectUnauthorized: false })
+            : undefined;
+
         return new SSEClientTransport(new URL(options.transport.url), {
           eventSourceInit: {
             fetch: (input, init) =>
@@ -404,17 +408,27 @@ class MCPConnection {
                     | Record<string, string>
                     | undefined),
                 },
+                ...(sseAgent && { agent: sseAgent }),
               }),
           },
-          requestInit: { headers: options.transport.requestOptions?.headers },
+          requestInit: {
+            headers: options.transport.requestOptions?.headers,
+            ...(sseAgent && { agent: sseAgent }),
+          },
         });
       case "streamable-http":
-        return new StreamableHTTPClientTransport(
-          new URL(options.transport.url),
-          {
-            requestInit: { headers: options.transport.requestOptions?.headers },
+        const { url, requestOptions } = options.transport;
+        const streamableAgent =
+          requestOptions?.verifySsl === false
+            ? new HttpsAgent({ rejectUnauthorized: false })
+            : undefined;
+
+        return new StreamableHTTPClientTransport(new URL(url), {
+          requestInit: {
+            headers: requestOptions?.headers,
+            ...(streamableAgent && { agent: streamableAgent }),
           },
-        );
+        });
       default:
         throw new Error(
           `Unsupported transport type: ${(options.transport as any).type}`,

--- a/extensions/intellij/src/main/resources/continue_tutorial.java
+++ b/extensions/intellij/src/main/resources/continue_tutorial.java
@@ -58,6 +58,6 @@ public static int[] sortingAlgorithm2(int[] x) {
 //            the model to make decisions and save you the work of manually finding context and performing actions.
 
 // 1. Switch from "Chat" to "Agent" mode using the dropdown in the bottom left of the input box
-// 2. Try asking Continue "Write unit tests for this code in a new file and run the test"
+// 2. Use the "/init" slash command to generate a CONTINUE.md file
 
 // ——————————————————      Learn more at https://docs.continue.dev/getting-started/overview      ——————————————————— //

--- a/extensions/intellij/src/main/resources/continue_tutorial.py
+++ b/extensions/intellij/src/main/resources/continue_tutorial.py
@@ -47,6 +47,6 @@ def sorting_algorithm2(x):
 #             the model to make decisions and save you the work of manually finding context and performing actions.
 
 # 1. Switch from "Chat" to "Agent" mode using the dropdown in the bottom left of the input box
-# 2. Try asking Continue "Write unit tests for this code in a new file and run the test"
+# 2. Use the "/init" slash command to generate a CONTINUE.md file
 
 # ——————————————————      Learn more at https://docs.continue.dev/getting-started/overview      ——————————————————— #

--- a/extensions/intellij/src/main/resources/continue_tutorial.ts
+++ b/extensions/intellij/src/main/resources/continue_tutorial.ts
@@ -58,6 +58,6 @@ function sortingAlgorithm2(x: number[]): number[] {
 //              the model to make decisions and save you the work of manually finding context and performing actions.
 
 // 1. Switch from "Chat" to "Agent" mode using the dropdown in the bottom left of the input box
-// 2. Try asking Continue "Write unit tests for this code in a new file"
+// 2. Use the "/init" slash command to generate a CONTINUE.md file
 
 // ——————————————————      Learn more at https://docs.continue.dev/getting-started/overview      ——————————————————— //

--- a/extensions/vscode/continue_tutorial.py
+++ b/extensions/vscode/continue_tutorial.py
@@ -47,7 +47,6 @@ def sorting_algorithm2(x):
 #           the model to make decisions and save you the work of manually finding context and performing actions.
 
 # 1. Switch from "Chat" to "Agent" mode using the dropdown in the bottom left of the input box
-# 2. Try asking Continue "Write unit tests for this code in a new file",
-#    or if you have Python installed, "Write unit tests for this code in a new file and run the test"
+# 2. Use the "/init" slash command to generate a CONTINUE.md file
 
 # ——————————————————      Learn more at https://docs.continue.dev/getting-started/overview      ——————————————————— #


### PR DESCRIPTION
## Description
Coauthored by @paulnegz on https://github.com/continuedev/continue/pull/6884, transferring to this PR since stale

Adds `rejectUnauthorized: false` agent to request options in case of `requestOptions.verifySsl = false`