### PR TITLE
chore: show windows unsupported warning only once

### DIFF
--- a/core/util/GlobalContext.ts
+++ b/core/util/GlobalContext.ts
@@ -39,6 +39,7 @@ export type GlobalContextType = {
    */
   hasDismissedConfigTsNoticeJetBrains: boolean;
   hasAlreadyCreatedAPromptFile: boolean;
+  hasShownUnsupportedPlatformWarning: boolean;
   showConfigUpdateToast: boolean;
   isSupportedLanceDbCpuTargetForLinux: boolean;
   sharedConfig: SharedConfigSchema;

--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -6,15 +6,21 @@ import { VsCodeExtension } from "../extension/VsCodeExtension";
 import registerQuickFixProvider from "../lang-server/codeActions";
 import { getExtensionVersion, isUnsupportedPlatform } from "../util/util";
 
+import { GlobalContext } from "core/util/GlobalContext";
 import { VsCodeContinueApi } from "./api";
 import setupInlineTips from "./InlineTipManager";
 
 export async function activateExtension(context: vscode.ExtensionContext) {
   const platformCheck = isUnsupportedPlatform();
-  if (platformCheck.isUnsupported) {
-    // const platformTarget = `${getPlatform()}-${getArchitecture()}`;
+  const globalContext = new GlobalContext();
+  const hasShownUnsupportedPlatformWarning = globalContext.get(
+    "hasShownUnsupportedPlatformWarning",
+  );
+
+  if (platformCheck.isUnsupported && !hasShownUnsupportedPlatformWarning) {
     const platformTarget = "windows-arm64";
 
+    globalContext.update("hasShownUnsupportedPlatformWarning", true);
     void vscode.window.showInformationMessage(
       `Continue detected that you are using ${platformTarget}. Due to native dependencies, Continue may not be able to start`,
     );


### PR DESCRIPTION
## Description

Show the windows-arm64 platform not supported notification only once.

resolves https://github.com/continuedev/continue/commit/79c9b0d0f4e3cfcacc79af804b5049b09f40d52b#commitcomment-164042843

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Show the Windows ARM64 unsupported platform warning only once during VS Code extension activation to reduce noise.

- **Bug Fixes**
  - Added hasShownUnsupportedPlatformWarning to GlobalContext.
  - Show the warning only if the platform is unsupported and the flag is false, then set the flag.

<!-- End of auto-generated description by cubic. -->

