### PR TITLE
Virtual tools move 2

### DIFF
--- a/gui/src/pages/config/UserSettingsForm.tsx
+++ b/gui/src/pages/config/UserSettingsForm.tsx
@@ -93,7 +93,7 @@ export function UserSettingsForm() {
   const enableExperimentalTools =
     config.experimental?.enableExperimentalTools ?? false;
   const onlyUseSystemMessageTools =
-    config.experimental?.onlyUseSystemMessageTools ?? false;
+    config.experimental?.onlyUseSystemMessageTools ?? true;
   const codebaseToolCallingOnly =
     config.experimental?.codebaseToolCallingOnly ?? false;
   const enableStaticContextualization =

--- a/gui/src/redux/selectors/selectUseSystemMessageTools.test.ts
+++ b/gui/src/redux/selectors/selectUseSystemMessageTools.test.ts
@@ -59,17 +59,23 @@ describe("selectUseSystemMessageTools", () => {
     expect(selectUseSystemMessageTools(state)).toBe(false);
   });
 
-  test("falls back to manual setting when no auto-preference: manual true", () => {
-    mockSelectSelectedChatModel.mockReturnValue(createModel("openai", "gpt-4"));
+  test.only("falls back to manual setting when no auto-preference: manual true", () => {
+    mockSelectSelectedChatModel.mockReturnValue(createModel("ollama", "phi3"));
     const state = createMockState(true);
     expect(selectUseSystemMessageTools(state)).toBe(true);
   });
 
   test("falls back to manual setting when no auto-preference: manual false", () => {
     mockSelectSelectedChatModel.mockReturnValue(
-      createModel("anthropic", "claude-3.5-sonnet"),
+      createModel("lmstudio", "gemma3"),
     );
     const state = createMockState(false);
+    expect(selectUseSystemMessageTools(state)).toBe(false);
+  });
+
+  test("should be false when model natively supports native tools", () => {
+    mockSelectSelectedChatModel.mockReturnValue(createModel("openai", "gpt-5"));
+    const state = createMockState(true);
     expect(selectUseSystemMessageTools(state)).toBe(false);
   });
 

--- a/gui/src/redux/selectors/selectUseSystemMessageTools.ts
+++ b/gui/src/redux/selectors/selectUseSystemMessageTools.ts
@@ -1,4 +1,5 @@
 import { shouldAutoEnableSystemMessageTools } from "core/config/shouldAutoEnableSystemMessageTools";
+import { modelSupportsNativeTools } from "core/llm/toolSupport";
 import { selectSelectedChatModel } from "../slices/configSlice";
 import { RootState } from "../store";
 
@@ -30,6 +31,11 @@ export function selectUseSystemMessageTools(state: RootState): boolean {
   // If auto-detection has a preference, use it (takes priority)
   if (autoSetting !== undefined) {
     return autoSetting;
+  }
+
+  // For native supported models, use native tools
+  if (modelSupportsNativeTools(selectedModel)) {
+    return false;
   }
 
   // If no auto-preference, use manual setting or default to false


### PR DESCRIPTION
## Description

Make system message tools on by default and use whenever native tools are absent.

closes https://github.com/continuedev/continue/pull/7096

resolves CON-3262

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
