### PR TITLE
fix: sanitize proxy settings + add NO_PROXY support + add unit tests

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/process/ContinueBinaryProcess.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/process/ContinueBinaryProcess.kt
@@ -1,8 +1,8 @@
 package com.github.continuedev.continueintellijextension.`continue`.process
 
-import com.github.continuedev.continueintellijextension.proxy.ProxySettings
-import com.github.continuedev.continueintellijextension.error.ContinueSentryService
 import com.github.continuedev.continueintellijextension.error.ContinuePostHogService
+import com.github.continuedev.continueintellijextension.error.ContinueSentryService
+import com.github.continuedev.continueintellijextension.proxy.ProxySettings
 import com.github.continuedev.continueintellijextension.utils.OS
 import com.github.continuedev.continueintellijextension.utils.getContinueBinaryPath
 import com.github.continuedev.continueintellijextension.utils.getOS
@@ -34,9 +34,7 @@ class ContinueBinaryProcess(
         }
 
         val builder = ProcessBuilder(path)
-        val proxySettings = ProxySettings.getSettings()
-        if (proxySettings.enabled)
-            builder.environment() += "HTTP_PROXY" to proxySettings.proxy
+        builder.environment() += ProxySettings.getSettings().toContinueEnvVars()
         return builder
             .directory(File(path).parentFile)
             .start()

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/proxy/ProxySettings.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/proxy/ProxySettings.kt
@@ -3,18 +3,32 @@ package com.github.continuedev.continueintellijextension.proxy
 import com.intellij.util.net.HttpConfigurable
 
 data class ProxySettings(
-    val enabled: Boolean,
-    val proxy: String,
+    private val enabled: Boolean,
+    private val proxy: String?,
+    private val noProxy: String?
 ) {
+    fun toContinueEnvVars(): Map<String, String> {
+        if (!enabled)
+            return emptyMap()
+        val env = mutableMapOf<String, String>()
+        proxy?.let { env["HTTP_PROXY"] = it }
+        noProxy?.let { env["NO_PROXY"] = it }
+        return env.filterValues { it.isNotBlank() }
+    }
 
     companion object {
         fun getSettings(): ProxySettings {
             val settings = HttpConfigurable.getInstance()
+            val validProxyOrNull =
+                if (settings.PROXY_HOST != null && settings.PROXY_HOST.isNotBlank())
+                    "${settings.PROXY_HOST}:${settings.PROXY_PORT}"
+                else
+                    null
             return ProxySettings(
                 enabled = settings.USE_HTTP_PROXY,
-                proxy = "${settings.PROXY_HOST}:${settings.PROXY_PORT}"
+                proxy = validProxyOrNull,
+                noProxy = settings.PROXY_EXCEPTIONS
             )
         }
     }
-
 }

--- a/extensions/intellij/src/test/kotlin/com/github/continuedev/continueintellijextension/unit/ProxySettingsTest.kt
+++ b/extensions/intellij/src/test/kotlin/com/github/continuedev/continueintellijextension/unit/ProxySettingsTest.kt
@@ -1,0 +1,58 @@
+package com.github.continuedev.continueintellijextension.unit
+
+import com.github.continuedev.continueintellijextension.proxy.ProxySettings
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.util.net.HttpConfigurable
+
+class ProxySettingsTest : BasePlatformTestCase() {
+
+    fun `test enabled proxy config`() {
+        HttpConfigurable.getInstance().apply {
+            USE_HTTP_PROXY = true
+            PROXY_HOST = "127.0.0.1"
+            PROXY_PORT = 80
+            PROXY_EXCEPTIONS = "*.example.com, 192.168.*"
+        }
+        val settingsMap = ProxySettings.getSettings().toContinueEnvVars()
+        assertEquals(
+            mapOf(
+                "HTTP_PROXY" to "127.0.0.1:80",
+                "NO_PROXY" to "*.example.com, 192.168.*"
+            ), settingsMap
+        )
+    }
+
+    fun `test disabled proxy ignores other settings`() {
+        HttpConfigurable.getInstance().apply {
+            USE_HTTP_PROXY = false
+            PROXY_HOST = "127.0.0.1"
+            PROXY_PORT = 80
+            PROXY_EXCEPTIONS = "*.example.com, 192.168.*"
+        }
+        val settingsMap = ProxySettings.getSettings().toContinueEnvVars()
+        assertEquals(emptyMap<String, String>(), settingsMap)
+    }
+
+    fun `test enabled proxy config with null values`() {
+        HttpConfigurable.getInstance().apply {
+            USE_HTTP_PROXY = true
+            PROXY_HOST = null
+            PROXY_PORT = 80
+            PROXY_EXCEPTIONS = null
+        }
+        val settingsMap = ProxySettings.getSettings().toContinueEnvVars()
+        assertEquals(emptyMap<String, String>(), settingsMap)
+    }
+
+    fun `test enabled proxy config with blank values`() {
+        HttpConfigurable.getInstance().apply {
+            USE_HTTP_PROXY = true
+            PROXY_HOST = ""
+            PROXY_PORT = 80
+            PROXY_EXCEPTIONS = ""
+        }
+        val settingsMap = ProxySettings.getSettings().toContinueEnvVars()
+        assertEquals(emptyMap<String, String>(), settingsMap)
+    }
+
+}


### PR DESCRIPTION
Previously, proxy settings parsing was very _"garbage-in, garbage-out"_ and since the HttpConfigurable class was written in Java, some settings could be null. We didn’t guard against that and simply concatenated proxy + port, which sometimes produced invalid values like `null:8080`.

The implementation has been updated to sanitize + skip entries that cannot be used as env vars. In the worst case, the result is simply an empty map and the process env vars are unaffected.

Co-author: @vldF
Related to: https://github.com/continuedev/continue/pull/7128
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Sanitize IntelliJ proxy settings and add NO_PROXY support so the Continue binary gets valid env vars and respects proxy exceptions. Adds unit tests for enabled/disabled/null/blank cases.

- **Bug Fixes**
  - Validate PROXY_HOST and skip null/blank to avoid values like "null:8080".
  - When proxy is disabled, return an empty env map so process env stays unchanged.

- **New Features**
  - Forward IntelliJ proxy exceptions as NO_PROXY.
  - Use toContinueEnvVars() to set HTTP_PROXY and NO_PROXY together.

<!-- End of auto-generated description by cubic. -->

