### PR TITLE
fix: model specification for next edit

### DIFF
--- a/docs/features/autocomplete/next-edit.mdx
+++ b/docs/features/autocomplete/next-edit.mdx
@@ -4,9 +4,10 @@ description: "Learn how Continue's Next Edit feature predicts and suggests your 
 ---
 
 <Warning>
-  Next Edit is currently an experimental feature. It requires Mercury Coder
-  model configured in your Continue autocomplete settings and is not yet
-  available for JetBrains use.
+  Next Edit is currently an experimental feature. It requires [Mercury Coder
+  model](https://hub.continue.dev/inceptionlabs/mercury-coder) configured in
+  your Continue autocomplete settings and is not yet available for JetBrains
+  use.
 </Warning>
 
 ## What is Next Edit?

--- a/docs/features/autocomplete/next-edit.mdx
+++ b/docs/features/autocomplete/next-edit.mdx
@@ -4,8 +4,8 @@ description: "Learn how Continue's Next Edit feature predicts and suggests your 
 ---
 
 <Warning>
-  Next Edit is currently an experimental feature. It requires Mercury Coder Next
-  Edit model configured in your Continue autocomplete settings and is not yet
+  Next Edit is currently an experimental feature. It requires Mercury Coder
+  model configured in your Continue autocomplete settings and is not yet
   available for JetBrains use.
 </Warning>
 
@@ -70,16 +70,16 @@ Next Edit activates automatically when:
 
 Next Edit requires:
 
-- Compatible AI models (Mercury Coder Next Edit)
+- Compatible AI models (Mercury Coder)
 - Continue development team access
 - VS Code (JetBrains support coming soon)
 - **API Keys**: Organizations can add API keys to [org secrets](/hub/secrets/secret-types) for team-wide access. Individual users need to provide their own API keys in their [model configuration](/customize/model-providers/overview)
 
 <Note>
-  To use Next Edit, you must have the Mercury Coder Next Edit model configured
-  in your Continue autocomplete model settings. This model is specifically
-  designed for next edit predictions. Once it's been loaded, you must reload VS
-  Code to activate it.
+  To use Next Edit, you must have the Mercury Coder model configured in your
+  Continue autocomplete model settings. This model is specifically designed for
+  next edit predictions. Once it's been loaded, you must reload VS Code to
+  activate it.
   <img
     src="/images/features/autocomplete/images/mercury-coder-next-edit.png"
     alt="Next Edit Model Setup"
@@ -115,7 +115,7 @@ Next Edit requires:
 
 Next Edit requires AI models specifically trained for code prediction:
 
-- **Mercury Coder Next Edit**: Primary model optimized for next edit prediction
+- **Mercury Coder**: Primary model optimized for next edit prediction
 
 ### Automatic Detection
 


### PR DESCRIPTION
## Description

I had mercury coder next edit model listed for autocomplete. I updated it to Mercury Coder.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Corrected the model name in the Next Edit docs from “Mercury Coder Next Edit” to “Mercury Coder” and added a link to the model on the Hub. This clarifies setup requirements and avoids confusion in autocomplete settings.

<!-- End of auto-generated description by cubic. -->

