### PR TITLE
fix: openai adapters

### DIFF
--- a/packages/openai-adapters/package-lock.json
+++ b/packages/openai-adapters/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@continuedev/openai-adapters",
-  "version": "1.1.1",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@continuedev/openai-adapters",
-      "version": "1.1.1",
+      "version": "1.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.842.0",
         "@aws-sdk/credential-providers": "^3.840.0",
-        "@continuedev/config-types": "file:../config-types",
-        "@continuedev/config-yaml": "file:../config-yaml",
-        "@continuedev/fetch": "file:../fetch",
+        "@continuedev/config-types": "^1.0.14",
+        "@continuedev/config-yaml": "^1.8.0",
+        "@continuedev/fetch": "^1.0.16",
         "dotenv": "^16.5.0",
         "google-auth-library": "^10.1.0",
         "json-schema": "^0.4.0",
@@ -42,6 +42,7 @@
     "../config-types": {
       "name": "@continuedev/config-types",
       "version": "1.0.14",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.24.2"
@@ -49,33 +50,6 @@
       "devDependencies": {
         "@types/node": "^20.11.19",
         "typescript": "^5.5.2"
-      }
-    },
-    "../config-yaml": {
-      "name": "@continuedev/config-yaml",
-      "version": "1.0.96",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@continuedev/config-types": "file:../config-types",
-        "yaml": "^2.6.1",
-        "zod": "^3.24.2"
-      },
-      "bin": {
-        "config-yaml": "dist/cli.js"
-      },
-      "devDependencies": {
-        "@semantic-release/changelog": "^6.0.3",
-        "@semantic-release/git": "^10.0.1",
-        "@semantic-release/github": "^9.2.6",
-        "@semantic-release/npm": "^10.0.6",
-        "@types/jest": "^29.5.14",
-        "@types/node": "^20.0.0",
-        "cross-env": "^7.0.3",
-        "jest": "^29.7.0",
-        "semantic-release": "^21.1.2",
-        "ts-jest": "^29.2.3",
-        "ts-node": "^10.9.2",
-        "zod-to-json-schema": "^3.24.5"
       }
     },
     "../fetch": {
@@ -1392,12 +1366,25 @@
       }
     },
     "node_modules/@continuedev/config-types": {
-      "resolved": "../config-types",
-      "link": true
+      "version": "1.0.14",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^3.24.2"
+      }
     },
     "node_modules/@continuedev/config-yaml": {
-      "resolved": "../config-yaml",
-      "link": true
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@continuedev/config-yaml/-/config-yaml-1.8.0.tgz",
+      "integrity": "sha512-L/6MNpCmpZu6H6x2iDYCdJuLYJqD8Pigj16IUofboSmQtrMKJS379MdI9+5fA/FS+bnqqyzyTNImYXoTBXUn3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@continuedev/config-types": "file:../config-types",
+        "yaml": "^2.6.1",
+        "zod": "^3.24.2"
+      },
+      "bin": {
+        "config-yaml": "dist/cli.js"
+      }
     },
     "node_modules/@continuedev/fetch": {
       "resolved": "../fetch",
@@ -12870,7 +12857,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13387,9 +13373,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
       "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/packages/openai-adapters/package.json
+++ b/packages/openai-adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@continuedev/openai-adapters",
-  "version": "1.1.1",
+  "version": "1.5.1",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -14,9 +14,9 @@
   "dependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.842.0",
     "@aws-sdk/credential-providers": "^3.840.0",
-    "@continuedev/config-types": "file:../config-types",
-    "@continuedev/config-yaml": "file:../config-yaml",
-    "@continuedev/fetch": "file:../fetch",
+    "@continuedev/config-types": "^1.0.14",
+    "@continuedev/config-yaml": "^1.8.0",
+    "@continuedev/fetch": "^1.0.16",
     "dotenv": "^16.5.0",
     "google-auth-library": "^10.1.0",
     "json-schema": "^0.4.0",


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes build issues in @continuedev/openai-adapters by switching local workspace links to published packages and bumping the package to 1.5.1. This makes the adapter installable outside the monorepo and stabilizes CI builds.

- **Dependencies**
  - Use @continuedev/config-types ^1.0.14 instead of file:../config-types
  - Use @continuedev/config-yaml ^1.8.0 instead of file:../config-yaml
  - Use @continuedev/fetch ^1.0.16 instead of file:../fetch
  - Regenerated lockfile to reflect published deps

<!-- End of auto-generated description by cubic. -->

