### PR TITLE
chore: remove ids from tooltips

### DIFF
--- a/gui/src/components/AcceptRejectDiffButtons.tsx
+++ b/gui/src/components/AcceptRejectDiffButtons.tsx
@@ -58,33 +58,31 @@ export default function AcceptRejectAllButtons({
       className="flex flex-row items-center justify-evenly gap-3 px-3"
       data-testid="accept-reject-all-buttons"
     >
-      <button
-        className="text-foreground flex cursor-pointer flex-row flex-wrap justify-center gap-1 border-none bg-transparent p-0 text-xs opacity-80 hover:opacity-100 hover:brightness-125"
-        onClick={() => handleAcceptOrReject("rejectDiff")}
-        data-testid="edit-reject-button"
-        data-tooltip-id="reject-shortcut"
-        data-tooltip-content={`Reject All (${rejectShortcut})`}
-      >
-        <div className="flex flex-row items-center gap-1">
-          <XMarkIcon className="text-error h-4 w-4" />
-          <span className="hidden sm:inline">Reject</span>
-        </div>
-      </button>
-      <ToolTip id="reject-shortcut" />
+      <ToolTip content={`Reject All (${rejectShortcut})`}>
+        <button
+          className="text-foreground flex cursor-pointer flex-row flex-wrap justify-center gap-1 border-none bg-transparent p-0 text-xs opacity-80 hover:opacity-100 hover:brightness-125"
+          onClick={() => handleAcceptOrReject("rejectDiff")}
+          data-testid="edit-reject-button"
+        >
+          <div className="flex flex-row items-center gap-1">
+            <XMarkIcon className="text-error h-4 w-4" />
+            <span className="hidden sm:inline">Reject</span>
+          </div>
+        </button>
+      </ToolTip>
 
-      <button
-        className="text-foreground flex cursor-pointer flex-row flex-wrap justify-center gap-1 border-none bg-transparent p-0 text-xs opacity-80 hover:opacity-100 hover:brightness-125"
-        onClick={() => handleAcceptOrReject("acceptDiff")}
-        data-testid="edit-accept-button"
-        data-tooltip-id="accept-shortcut"
-        data-tooltip-content={`Accept All (${acceptShortcut})`}
-      >
-        <div className="flex flex-row items-center gap-1">
-          <CheckIcon className="text-success h-4 w-4" />
-          <span className="hidden sm:inline">Accept</span>
-        </div>
-      </button>
-      <ToolTip id="accept-shortcut" />
+      <ToolTip content={`Accept All (${acceptShortcut})`}>
+        <button
+          className="text-foreground flex cursor-pointer flex-row flex-wrap justify-center gap-1 border-none bg-transparent p-0 text-xs opacity-80 hover:opacity-100 hover:brightness-125"
+          onClick={() => handleAcceptOrReject("acceptDiff")}
+          data-testid="edit-accept-button"
+        >
+          <div className="flex flex-row items-center gap-1">
+            <CheckIcon className="text-success h-4 w-4" />
+            <span className="hidden sm:inline">Accept</span>
+          </div>
+        </button>
+      </ToolTip>
     </div>
   );
 }

--- a/gui/src/components/AssistantAndOrgListbox/index.tsx
+++ b/gui/src/components/AssistantAndOrgListbox/index.tsx
@@ -125,12 +125,12 @@ export function AssistantAndOrgListbox() {
                   <span className="text-description-muted flex items-center justify-between gap-x-1">
                     {session?.AUTH_TYPE !== AuthType.OnPrem &&
                       session?.account.id}
-                    <ArrowRightStartOnRectangleIcon
-                      className="h-3 w-3 cursor-pointer hover:brightness-125"
-                      onClick={onLogout}
-                      data-tooltip-id="logout-tooltip"
-                    />
-                    <ToolTip id="logout-tooltip">Logout</ToolTip>
+                    <ToolTip content="Logout">
+                      <ArrowRightStartOnRectangleIcon
+                        className="h-3 w-3 cursor-pointer hover:brightness-125"
+                        onClick={onLogout}
+                      />
+                    </ToolTip>
                   </span>
                 ) : (
                   <span

--- a/gui/src/components/AssistantAndOrgListbox/shared.tsx
+++ b/gui/src/components/AssistantAndOrgListbox/shared.tsx
@@ -187,18 +187,20 @@ export function Option({
                 />
               )
             ) : (
-              <>
+              <ToolTip
+                content={
+                  <>
+                    <div className="font-semibold">Errors</div>
+                    {JSON.stringify(errors, null, 2)}
+                  </>
+                }
+              >
                 <StyledExclamationTriangleIcon
-                  data-tooltip-id={`${idx}-errors-tooltip`}
                   $hovered={hovered}
                   className="cursor-pointer text-red-500"
                   onClick={onClickError}
                 />
-                <ToolTip id={`${idx}-errors-tooltip`}>
-                  <div className="font-semibold">Errors</div>
-                  {JSON.stringify(errors, null, 2)}
-                </ToolTip>
-              </>
+              </ToolTip>
             )}
           </div>
         </div>

--- a/gui/src/components/GenerateRuleDialog/GenerationScreen.tsx
+++ b/gui/src/components/GenerateRuleDialog/GenerationScreen.tsx
@@ -139,7 +139,6 @@ export function GenerationScreen({
   };
 
   const showNameSpinner = isGenerating && !formData.name && !isManualMode;
-  const tooltipId = "rule-type-tooltip";
 
   return (
     <div className="px-2 pb-2 pt-4 sm:px-4">
@@ -181,14 +180,12 @@ export function GenerationScreen({
                   <label className="text-foreground text-sm font-medium">
                     Rule Type
                   </label>
-                  <InformationCircleIcon
-                    data-tooltip-id={tooltipId}
-                    data-tooltip-content={
-                      RuleTypeDescriptions[selectedRuleType]
-                    }
-                    className="h-4 w-4 text-gray-500"
-                  />
-                  <ToolTip id={tooltipId} style={{ zIndex: 100001 }} />
+                  <ToolTip
+                    style={{ zIndex: 100001 }}
+                    content={RuleTypeDescriptions[selectedRuleType]}
+                  >
+                    <InformationCircleIcon className="h-4 w-4 text-gray-500" />
+                  </ToolTip>
                 </div>
                 <div className="relative">
                   <select

--- a/gui/src/components/InfoHover.tsx
+++ b/gui/src/components/InfoHover.tsx
@@ -1,5 +1,4 @@
 import { InformationCircleIcon } from "@heroicons/react/24/outline";
-import { ReactNode } from "react";
 import { ToolTip } from "./gui/Tooltip";
 
 const DEFAULT_SIZE = "5";
@@ -10,22 +9,15 @@ const InfoHover = ({
   id,
 }: {
   id: string;
-  msg: ReactNode;
+  msg: string;
   size?: string;
 }) => {
-  const dataTooltipId = `info-hover-${encodeURIComponent(id)}`;
-
   return (
-    <>
+    <ToolTip content={msg} place="bottom">
       <InformationCircleIcon
-        data-tooltip-id={dataTooltipId}
         className={`h-${size ?? DEFAULT_SIZE} w-${size ?? DEFAULT_SIZE} cursor-help text-gray-500`}
       />
-
-      <ToolTip id={dataTooltipId} place="bottom">
-        {msg}
-      </ToolTip>
-    </>
+    </ToolTip>
   );
 };
 

--- a/gui/src/components/ModeSelect/ModeSelect.tsx
+++ b/gui/src/components/ModeSelect/ModeSelect.tsx
@@ -98,18 +98,14 @@ export function ModeSelect() {
   const notSupported = <span>(Not supported)</span>;
   const notGreatAtAgent = (
     <>
-      <ExclamationTriangleIcon
-        data-tooltip-id="bad-at-agent-mode-tooltip"
-        className="text-warning h-2.5 w-2.5"
-      />
       <ToolTip
-        id="bad-at-agent-mode-tooltip"
         style={{
           zIndex: 200001, // in front of listbox
         }}
         className="flex items-center gap-1"
+        content={`${capitalize(mode)} might not work well with this model.`}
       >
-        {`${capitalize(mode)} might not work well with this model.`}
+        <ExclamationTriangleIcon className="text-warning h-2.5 w-2.5" />
       </ToolTip>
     </>
   );
@@ -135,17 +131,16 @@ export function ModeSelect() {
             <div className="flex flex-row items-center gap-1.5">
               <ModeIcon mode="chat" />
               <span className="">Chat</span>
-              <InformationCircleIcon
-                data-tooltip-id="chat-tip"
-                className="h-2.5 w-2.5 flex-shrink-0"
-              />
               <ToolTip
-                id="chat-tip"
                 style={{
                   zIndex: 200001,
                 }}
+                content="All tools disabled"
               >
-                All tools disabled
+                <InformationCircleIcon
+                  data-tooltip-id="chat-tip"
+                  className="h-2.5 w-2.5 flex-shrink-0"
+                />
               </ToolTip>
               <span
                 className={`text-description-muted text-[${getFontSize() - 3}px] mr-auto`}
@@ -159,17 +154,13 @@ export function ModeSelect() {
             <div className="flex flex-row items-center gap-1.5">
               <ModeIcon mode="plan" />
               <span className="">Plan</span>
-              <InformationCircleIcon
-                data-tooltip-id="plan-tip"
-                className="h-2.5 w-2.5 flex-shrink-0"
-              />
               <ToolTip
-                id="plan-tip"
                 style={{
                   zIndex: 200001,
                 }}
+                content="Read-only/MCP tools available"
               >
-                Read-only/MCP tools available
+                <InformationCircleIcon className="h-2.5 w-2.5 flex-shrink-0" />
               </ToolTip>
             </div>
             {isAgentSupported ? (
@@ -188,17 +179,13 @@ export function ModeSelect() {
             <div className="flex flex-row items-center gap-1.5">
               <ModeIcon mode="agent" />
               <span className="">Agent</span>
-              <InformationCircleIcon
-                data-tooltip-id="agent-tip"
-                className="h-2.5 w-2.5 flex-shrink-0"
-              />
               <ToolTip
-                id="agent-tip"
                 style={{
                   zIndex: 200001,
                 }}
+                content="All tools available"
               >
-                All tools available
+                <InformationCircleIcon className="h-2.5 w-2.5 flex-shrink-0" />
               </ToolTip>
             </div>
             {isAgentSupported ? (

--- a/gui/src/components/OnboardingCard/components/OllamaModelDownload.tsx
+++ b/gui/src/components/OnboardingCard/components/OllamaModelDownload.tsx
@@ -18,7 +18,6 @@ function OllamaModelDownload({
 }: OllamaModelDownloadProps) {
   const ideMessenger = useContext(IdeMessengerContext);
   const command = `ollama pull ${modelName}`;
-  const id = `info-hover-${encodeURIComponent(command)}`;
 
   function onClick() {
     void ideMessenger.ide.runCommand(command);
@@ -31,20 +30,12 @@ function OllamaModelDownload({
       {hasDownloaded ? (
         <OllamaCompletedStep text={command} />
       ) : (
-        <>
-          <StyledActionButton
-            data-tooltip-id={id}
-            onClick={onClick}
-            className="gap-2"
-          >
+        <ToolTip place="top" content="Copy into terminal">
+          <StyledActionButton onClick={onClick} className="gap-2">
             <p className="lines m-0 px-0 py-2 font-mono text-xs">{command}</p>
             <CommandLineIcon width={16} height={16} />
           </StyledActionButton>
-
-          <ToolTip id={id} place="top">
-            Copy into terminal
-          </ToolTip>
-        </>
+        </ToolTip>
       )}
     </div>
   );

--- a/gui/src/components/OnboardingCard/components/OnboardingCardLanding.tsx
+++ b/gui/src/components/OnboardingCard/components/OnboardingCardLanding.tsx
@@ -72,20 +72,20 @@ export function OnboardingCardLanding({
           <p className="mb-5 mt-0 w-full text-sm">
             Log in to access a free trial of the
             <br />
-            <span
-              className="cursor-pointer underline hover:brightness-125"
-              data-tooltip-id="models-addon-tooltip"
-              onClick={() =>
-                ideMessenger.post("controlPlane/openUrl", {
-                  path: "pricing",
-                })
-              }
+            <ToolTip
+              place="bottom"
+              content="Free trial includes 50 Chat requests and 2,000 autocomplete requests"
             >
-              Models Add-On
-            </span>
-            <ToolTip id="models-addon-tooltip" place="bottom">
-              Free trial includes 50 Chat requests and 2,000 autocomplete
-              requests
+              <span
+                className="cursor-pointer underline hover:brightness-125"
+                onClick={() =>
+                  ideMessenger.post("controlPlane/openUrl", {
+                    path: "pricing",
+                  })
+                }
+              >
+                Models Add-On
+              </span>
             </ToolTip>
           </p>
 

--- a/gui/src/components/StyledMarkdownPreview/FilenameLink.tsx
+++ b/gui/src/components/StyledMarkdownPreview/FilenameLink.tsx
@@ -1,7 +1,6 @@
 import { RangeInFile } from "core";
 import { findUriInDirs, getUriPathBasename } from "core/util/uri";
 import { useContext } from "react";
-import { v4 as uuidv4 } from "uuid";
 import { IdeMessengerContext } from "../../context/IdeMessenger";
 import FileIcon from "../FileIcon";
 import { ToolTip } from "../gui/Tooltip";
@@ -21,8 +20,6 @@ function FilenameLink({ rif }: FilenameLinkProps) {
     });
   }
 
-  const id = uuidv4();
-
   let relPathOrBasename = "";
   try {
     const { relativePathOrBasename } = findUriInDirs(
@@ -35,9 +32,8 @@ function FilenameLink({ rif }: FilenameLinkProps) {
   }
 
   return (
-    <>
+    <ToolTip place="top" content={"/" + relPathOrBasename}>
       <span
-        data-tooltip-id={id}
         data-tooltip-delay-show={500}
         className="mx-[0.1em] mb-[0.15em] inline-flex cursor-pointer items-center gap-0.5 rounded-md pr-[0.2em] align-middle hover:ring-1"
         onClick={onClick}
@@ -47,10 +43,7 @@ function FilenameLink({ rif }: FilenameLinkProps) {
           {getUriPathBasename(rif.filepath)}
         </span>
       </span>
-      <ToolTip id={id} place="top">
-        {"/" + relPathOrBasename}
-      </ToolTip>
-    </>
+    </ToolTip>
   );
 }
 

--- a/gui/src/components/StyledMarkdownPreview/MermaidBlock.tsx
+++ b/gui/src/components/StyledMarkdownPreview/MermaidBlock.tsx
@@ -7,7 +7,7 @@ import {
 import Panzoom from "@panzoom/panzoom";
 // @ts-ignore
 import mermaid from "mermaid";
-import { useEffect, useId, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useDebouncedEffect } from "../find/useDebounce";
 import { ToolTip } from "../gui/Tooltip";
 
@@ -78,10 +78,6 @@ export default function MermaidDiagram({ code }: { code: string }) {
   const zoomOutButtonRef = useRef<SVGSVGElement>(null);
   const resetZoomButtonRef = useRef<SVGSVGElement>(null);
 
-  const zoomInButtonId = useId();
-  const zoomOutButtonId = useId();
-  const resetZoomButtonId = useId();
-
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
 
@@ -147,24 +143,25 @@ export default function MermaidDiagram({ code }: { code: string }) {
       ) : (
         <div className="relative">
           <div className="absolute right-0 z-10 m-2 flex items-center gap-x-1">
-            <MagnifyingGlassPlusIcon
-              data-tooltip-id={zoomInButtonId}
-              ref={zoomInButtonRef}
-              className="h-4 w-4 cursor-pointer"
-            />
-            <ToolTip id={zoomInButtonId}>Zoom In</ToolTip>
-            <MagnifyingGlassMinusIcon
-              data-tooltip-id={zoomOutButtonId}
-              ref={zoomOutButtonRef}
-              className="h-4 w-4 cursor-pointer"
-            />
-            <ToolTip id={zoomOutButtonId}>Zoom Out</ToolTip>
-            <ArrowPathRoundedSquareIcon
-              data-tooltip-id={resetZoomButtonId}
-              ref={resetZoomButtonRef}
-              className="h-4 w-4 cursor-pointer"
-            />
-            <ToolTip id={resetZoomButtonId}>Reset Zoom</ToolTip>
+            <ToolTip content={"Zoom In"}>
+              <MagnifyingGlassPlusIcon
+                ref={zoomInButtonRef}
+                className="h-4 w-4 cursor-pointer"
+              />
+            </ToolTip>
+            <ToolTip content={"Zoom Out"}>
+              <MagnifyingGlassMinusIcon
+                ref={zoomOutButtonRef}
+                className="h-4 w-4 cursor-pointer"
+              />
+            </ToolTip>
+
+            <ToolTip content="Reset Zoom">
+              <ArrowPathRoundedSquareIcon
+                ref={resetZoomButtonRef}
+                className="h-4 w-4 cursor-pointer"
+              />
+            </ToolTip>
           </div>
           <div
             className="flex min-h-5 justify-center"

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/ApplyActions.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/ApplyActions.tsx
@@ -62,24 +62,23 @@ export function ApplyActions(props: ApplyActionsProps) {
       }
 
       return (
-        <HoverItem
-          data-tooltip-id="codeblock-apply-code-button-tooltip"
-          className="!p-0"
-        >
-          <button
-            data-testid="codeblock-toolbar-apply"
-            className="text-lightgray flex cursor-pointer items-center border-none bg-transparent pl-0 text-xs outline-none hover:brightness-125"
-            onClick={props.onClickApply}
+        <ToolTip place="top" content="Apply Code">
+          <HoverItem
+            data-tooltip-id="codeblock-apply-code-button-tooltip"
+            className="!p-0"
           >
-            <div className="text-lightgray flex items-center gap-1">
-              <PlayIcon className="h-3.5 w-3.5" />
-              <span className="xs:inline hidden">Apply</span>
-            </div>
-          </button>
-          <ToolTip id="codeblock-apply-code-button-tooltip" place="top">
-            Apply Code
-          </ToolTip>
-        </HoverItem>
+            <button
+              data-testid="codeblock-toolbar-apply"
+              className="text-lightgray flex cursor-pointer items-center border-none bg-transparent pl-0 text-xs outline-none hover:brightness-125"
+              onClick={props.onClickApply}
+            >
+              <div className="text-lightgray flex items-center gap-1">
+                <PlayIcon className="h-3.5 w-3.5" />
+                <span className="xs:inline hidden">Apply</span>
+              </div>
+            </button>
+          </HoverItem>
+        </ToolTip>
       );
   }
 }

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/CopyButton.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/CopyButton.tsx
@@ -11,22 +11,21 @@ export function CopyButton({ text }: CopyButtonProps) {
   const { copyText, copied } = useCopy(text);
 
   return (
-    <HoverItem data-tooltip-id="codeblock-copy-button-tooltip" className="!p-0">
-      <div
-        className="text-lightgray flex cursor-pointer items-center border-none bg-transparent text-xs outline-none hover:brightness-125"
-        onClick={copyText}
-      >
-        <div className="flex items-center gap-1 transition-colors duration-200 hover:brightness-125">
-          {copied ? (
-            <CheckIcon className="h-3.5 w-3.5 text-green-500 hover:brightness-125" />
-          ) : (
-            <ClipboardIcon className="h-3.5 w-3.5 hover:brightness-125" />
-          )}
+    <ToolTip place="top" content="Copy Code">
+      <HoverItem className="!p-0">
+        <div
+          className="text-lightgray flex cursor-pointer items-center border-none bg-transparent text-xs outline-none hover:brightness-125"
+          onClick={copyText}
+        >
+          <div className="flex items-center gap-1 transition-colors duration-200 hover:brightness-125">
+            {copied ? (
+              <CheckIcon className="h-3.5 w-3.5 text-green-500 hover:brightness-125" />
+            ) : (
+              <ClipboardIcon className="h-3.5 w-3.5 hover:brightness-125" />
+            )}
+          </div>
         </div>
-      </div>
-      <ToolTip id="codeblock-copy-button-tooltip" place="top">
-        Copy Code
-      </ToolTip>
-    </HoverItem>
+      </HoverItem>
+    </ToolTip>
   );
 }

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/CreateFileButton.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/CreateFileButton.tsx
@@ -9,25 +9,21 @@ interface CreateFileButtonProps {
 
 export function CreateFileButton({ onClick }: CreateFileButtonProps) {
   return (
-    <HoverItem
-      data-tooltip-id="codeblock-create-file-button-tooltip"
-      className="!p-0"
-    >
-      <button
-        data-testid="codeblock-toolbar-create"
-        className={`text-lightgray flex items-center border-none bg-transparent pl-0 text-xs text-[${vscForeground}] cursor-pointer outline-none hover:brightness-125`}
-        onClick={onClick}
-      >
-        <div className="flex items-center gap-1">
-          <DocumentPlusIcon className="h-3.5 w-3.5 shrink-0" />
-          <span className="line-clamp-1 select-none break-all">
-            Create file
-          </span>
-        </div>
-      </button>
-      <ToolTip id="codeblock-create-file-button-tooltip" place="top">
-        Create File with Code
-      </ToolTip>
-    </HoverItem>
+    <ToolTip place="top" content="Create File with Code">
+      <HoverItem className="!p-0">
+        <button
+          data-testid="codeblock-toolbar-create"
+          className={`text-lightgray flex items-center border-none bg-transparent pl-0 text-xs text-[${vscForeground}] cursor-pointer outline-none hover:brightness-125`}
+          onClick={onClick}
+        >
+          <div className="flex items-center gap-1">
+            <DocumentPlusIcon className="h-3.5 w-3.5 shrink-0" />
+            <span className="line-clamp-1 select-none break-all">
+              Create file
+            </span>
+          </div>
+        </button>
+      </HoverItem>
+    </ToolTip>
   );
 }

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/FileInfo.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/FileInfo.tsx
@@ -8,17 +8,21 @@ export interface FileInfoProps {
   range?: string;
 }
 
-const TOOLTIP_ID = "file-info-tooltip";
-
 export const FileInfo = ({ filepath, range, onClick }: FileInfoProps) => {
   return (
-    <>
+    <ToolTip
+      style={{
+        maxWidth: "200px",
+        textAlign: "left",
+        whiteSpace: "normal",
+        wordBreak: "break-word",
+      }}
+      content={filepath}
+      place="top-end"
+    >
       <div
         className={`flex select-none flex-row items-center gap-0.5 ${onClick && "cursor-pointer hover:underline"}`}
         onClick={onClick}
-        data-tooltip-id={TOOLTIP_ID}
-        data-tooltip-content={filepath}
-        data-tooltip-place="top-end"
       >
         <div>
           <FileIcon height="20px" width="20px" filename={filepath} />
@@ -28,15 +32,6 @@ export const FileInfo = ({ filepath, range, onClick }: FileInfoProps) => {
           {range && ` ${range}`}
         </span>
       </div>
-      <ToolTip
-        id={TOOLTIP_ID}
-        style={{
-          maxWidth: "200px",
-          textAlign: "left",
-          whiteSpace: "normal",
-          wordBreak: "break-word",
-        }}
-      />
-    </>
+    </ToolTip>
   );
 };

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/InsertButton.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/InsertButton.tsx
@@ -15,16 +15,15 @@ export function InsertButton({ onInsert }: InsertButtonProps) {
       data-tooltip-id="codeblock-insert-button-tooltip"
       className="!p-0"
     >
-      <div
-        className="text-lightgray flex cursor-pointer items-center border-none bg-transparent text-xs outline-none hover:brightness-125"
-        onClick={onInsert}
-      >
-        <div className="max-2xs:hidden flex items-center gap-1 transition-colors duration-200">
-          <ArrowLeftEndOnRectangleIcon className="h-3.5 w-3.5" />
+      <ToolTip place="top" content="Insert Code">
+        <div
+          className="text-lightgray flex cursor-pointer items-center border-none bg-transparent text-xs outline-none hover:brightness-125"
+          onClick={onInsert}
+        >
+          <div className="max-2xs:hidden flex items-center gap-1 transition-colors duration-200">
+            <ArrowLeftEndOnRectangleIcon className="h-3.5 w-3.5" />
+          </div>
         </div>
-      </div>
-      <ToolTip id="codeblock-insert-button-tooltip" place="top">
-        Insert Code
       </ToolTip>
     </HoverItem>
   );

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/ToolbarButtonWithTooltip.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/ToolbarButtonWithTooltip.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useMemo } from "react";
+import { ReactNode } from "react";
 import { ToolTip } from "../../gui/Tooltip";
 
 interface ToolbarButtonWithTooltipProps {
@@ -14,27 +14,18 @@ export function ToolbarButtonWithTooltip({
   tooltipContent,
   "data-testid": testId,
 }: ToolbarButtonWithTooltipProps) {
-  const tooltipId = useMemo(
-    () => `tooltip-${Math.random().toString(36).slice(2, 11)}`,
-    [],
-  );
-
   return (
-    <>
+    <ToolTip place="top" content={tooltipContent}>
       <div
         onClick={(e) => {
           e.stopPropagation();
           onClick();
         }}
-        data-tooltip-id={tooltipId}
         data-testid={testId}
         className="hover:description-muted/30 flex cursor-pointer select-none items-center justify-center rounded bg-transparent px-0.5 py-0.5 hover:opacity-80"
       >
         {children}
       </div>
-      <ToolTip id={tooltipId} place="top">
-        {tooltipContent}
-      </ToolTip>
-    </>
+    </ToolTip>
   );
 }

--- a/gui/src/components/StyledMarkdownPreview/SymbolLink.tsx
+++ b/gui/src/components/StyledMarkdownPreview/SymbolLink.tsx
@@ -1,6 +1,5 @@
 import { SymbolWithRange } from "core";
 import { useContext, useMemo } from "react";
-import { v4 as uuidv4 } from "uuid";
 import { IdeMessengerContext } from "../../context/IdeMessenger";
 import { ToolTip } from "../gui/Tooltip";
 
@@ -35,21 +34,22 @@ function SymbolLink({ symbol, content }: SymbolLinkProps) {
     return content.length > 200 ? content.slice(0, 196) + "\n..." : content;
   }, [symbol]);
 
-  const id = uuidv4();
   return (
-    <>
+    <ToolTip
+      place="top"
+      className="m-0 p-0"
+      content={
+        <pre className="text-left">{processedContent ?? symbol.filepath}</pre>
+      }
+    >
       <span
         className="mx-[0.1em] mb-[0.15em] inline-flex cursor-pointer flex-row items-center gap-[0.2rem] rounded-md align-middle hover:ring-1"
         onClick={onClick}
-        data-tooltip-id={id}
         data-tooltip-delay-show={500}
       >
         <code className="text-link align-middle">{content}</code>
       </span>
-      <ToolTip id={id} place="top" className="m-0 p-0">
-        <pre className="text-left">{processedContent ?? symbol.filepath}</pre>
-      </ToolTip>
-    </>
+    </ToolTip>
   );
 }
 

--- a/gui/src/components/StyledMarkdownPreview/index.tsx
+++ b/gui/src/components/StyledMarkdownPreview/index.tsx
@@ -260,22 +260,12 @@ const StyledMarkdownPreview = memo(function StyledMarkdownPreview(
     rehypeReactOptions: {
       components: {
         a: ({ ...aProps }) => {
-          const tooltipId = uuidv4();
-
           return (
-            <>
-              <a
-                href={aProps.href}
-                target="_blank"
-                className="hover:underline"
-                data-tooltip-id={tooltipId}
-              >
+            <ToolTip place="top" className="m-0 p-0" content={aProps.href}>
+              <a href={aProps.href} target="_blank" className="hover:underline">
                 {aProps.children}
               </a>
-              <ToolTip id={tooltipId} place="top" className="m-0 p-0">
-                {aProps.href}
-              </ToolTip>
-            </>
+            </ToolTip>
           );
         },
         pre: ({ ...preProps }) => {

--- a/gui/src/components/dialogs/AddDocsDialog.tsx
+++ b/gui/src/components/dialogs/AddDocsDialog.tsx
@@ -94,13 +94,11 @@ function AddDocsDialog() {
                 <div className="flex flex-row items-center gap-1">
                   <span>Title</span>
                   <div>
-                    <InformationCircleIcon
-                      data-tooltip-id={"add-docs-form-title"}
-                      className="text-lightgray h-3.5 w-3.5 select-none"
-                    />
-                    <ToolTip id={"add-docs-form-title"} place="top">
-                      The title that will be displayed to users in the `@docs`
-                      submenu
+                    <ToolTip
+                      place="top"
+                      content="The title that will be displayed to users in the `@docs` submenu"
+                    >
+                      <InformationCircleIcon className="text-lightgray h-3.5 w-3.5 select-none" />
                     </ToolTip>
                   </div>
                 </div>
@@ -120,13 +118,11 @@ function AddDocsDialog() {
                     Start URL
                   </span>
                   <div>
-                    <InformationCircleIcon
-                      data-tooltip-id={"add-docs-form-url"}
-                      className="text-lightgray h-3.5 w-3.5 select-none"
-                    />
-                    <ToolTip id={"add-docs-form-url"} place="top">
-                      The starting location to begin crawling the documentation
-                      site
+                    <ToolTip
+                      place="top"
+                      content="The starting location to begin crawling the documentation site"
+                    >
+                      <InformationCircleIcon className="text-lightgray h-3.5 w-3.5 select-none" />
                     </ToolTip>
                   </div>
                 </div>

--- a/gui/src/components/gui/HeaderButtonWithToolTip.tsx
+++ b/gui/src/components/gui/HeaderButtonWithToolTip.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { type PlacesType } from "react-tooltip";
-import { v4 as uuidv4 } from "uuid";
 import { HeaderButton } from "..";
 import { ToolTip } from "./Tooltip";
 
@@ -25,15 +24,14 @@ const HeaderButtonWithToolTip = React.forwardRef<
   HTMLButtonElement,
   HeaderButtonWithToolTipProps
 >((props: HeaderButtonWithToolTipProps, ref) => {
-  const id = uuidv4();
-  const tooltipId = `header_button_${id}`;
-
   return (
-    <>
+    <ToolTip
+      place={props.tooltipPlacement ?? "bottom"}
+      content={<span className="text-xs">{props.text}</span>}
+    >
       <HeaderButton
         hoverBackgroundColor={props.hoverBackgroundColor}
         backgroundColor={props.backgroundColor}
-        data-tooltip-id={tooltipId}
         data-testid={props.testId}
         inverted={props.inverted}
         disabled={props.disabled}
@@ -46,11 +44,7 @@ const HeaderButtonWithToolTip = React.forwardRef<
       >
         {props.children}
       </HeaderButton>
-
-      <ToolTip id={tooltipId} place={props.tooltipPlacement ?? "bottom"}>
-        <span className="text-xs">{props.text}</span>
-      </ToolTip>
-    </>
+    </ToolTip>
   );
 });
 

--- a/gui/src/components/gui/Tooltip.tsx
+++ b/gui/src/components/gui/Tooltip.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties } from "react";
+import { cloneElement, CSSProperties, ReactElement, useId } from "react";
 import ReactDOM from "react-dom";
 import { ITooltip, Tooltip } from "react-tooltip";
 import { vscBackground, vscForeground } from "..";
@@ -17,7 +17,16 @@ const TooltipStyles: CSSProperties = {
   textAlign: "center",
 };
 
-export function ToolTip(props: ITooltip) {
+export function ToolTip({
+  children,
+  content,
+  ...props
+}: Omit<ITooltip, "id" | "children" | "content"> & {
+  content: ITooltip["children"];
+  children: ReactElement;
+}) {
+  const tooltipId = useId();
+
   const combinedStyles = {
     ...TooltipStyles,
     ...props.style,
@@ -25,17 +34,27 @@ export function ToolTip(props: ITooltip) {
 
   const tooltipPortalDiv = document.getElementById("tooltip-portal-div");
 
+  const childrenWithTooltipId = cloneElement(children, {
+    "data-tooltip-id": tooltipId,
+  });
+
   return (
-    tooltipPortalDiv &&
-    ReactDOM.createPortal(
-      <Tooltip
-        {...props}
-        noArrow
-        style={combinedStyles}
-        opacity={1}
-        delayShow={200}
-      />,
-      tooltipPortalDiv,
-    )
+    <>
+      {childrenWithTooltipId}
+      {tooltipPortalDiv &&
+        ReactDOM.createPortal(
+          <Tooltip
+            {...props}
+            id={tooltipId}
+            noArrow
+            style={combinedStyles}
+            opacity={1}
+            delayShow={200}
+          >
+            {content}
+          </Tooltip>,
+          tooltipPortalDiv,
+        )}
+    </>
   );
 }

--- a/gui/src/components/loaders/FreeTrialProgressBar.tsx
+++ b/gui/src/components/loaders/FreeTrialProgressBar.tsx
@@ -32,27 +32,25 @@ function FreeTrialProgressBar({ completed, total }: FreeTrialProgressBarProps) {
 
   if (completed > total) {
     return (
-      <>
-        <div
-          className="flex flex-1 cursor-default select-none items-center justify-center gap-1"
-          data-tooltip-id="usage_progress_bar"
-        >
+      <ToolTip
+        place="top"
+        content="Configure a model above in order to continue"
+      >
+        <div className="flex flex-1 cursor-default select-none items-center justify-center gap-1">
           <ExclamationCircleIcon width="18px" height="18px" color="red" />
           Trial limit reached
         </div>
-
-        <ToolTip id="usage_progress_bar" place="top">
-          Configure a model above in order to continue
-        </ToolTip>
-      </>
+      </ToolTip>
     );
   }
 
   return (
-    <>
+    <ToolTip
+      place="top"
+      content={`Click to use your own API key or local LLM (required after ${FREE_TRIAL_LIMIT_REQUESTS} inputs)`}
+    >
       <div
         className="flex flex-1 cursor-pointer flex-row items-center gap-2 text-[10px] text-gray-400 sm:gap-3"
-        data-tooltip-id="usage_progress_bar"
         onClick={onClick}
       >
         <span>
@@ -72,10 +70,7 @@ function FreeTrialProgressBar({ completed, total }: FreeTrialProgressBarProps) {
           {completed} / {total}
         </span>
       </div>
-      <ToolTip id="usage_progress_bar" place="top">
-        {`Click to use your own API key or local LLM (required after ${FREE_TRIAL_LIMIT_REQUESTS} inputs)`}
-      </ToolTip>
-    </>
+    </ToolTip>
   );
 }
 

--- a/gui/src/components/mainInput/ContextStatus.tsx
+++ b/gui/src/components/mainInput/ContextStatus.tsx
@@ -22,7 +22,6 @@ const ContextStatus = () => {
   return (
     <div>
       <ToolTip
-        id="context-status"
         closeEvents={{
           // blur: false,
           mouseleave: true,
@@ -30,53 +29,52 @@ const ContextStatus = () => {
           mouseup: false,
         }}
         clickable
-      >
-        <div className="flex flex-col gap-0 text-left text-xs">
-          <span className="inline-block">
-            {`${percent}% of context filled.`}
-          </span>
-          {isPruned && (
+        content={
+          <div className="flex flex-col gap-0 text-left text-xs">
             <span className="inline-block">
-              {`Oldest messages are being removed.`}
+              {`${percent}% of context filled.`}
             </span>
-          )}
-          {history.length > 0 && (
-            <div className="flex flex-col gap-1 whitespace-pre">
-              <div>
-                <span
-                  className="hover:text-link inline-block cursor-pointer underline"
-                  onClick={() => compactConversation(history.length - 1)}
-                >
-                  Compact conversation
-                </span>
-                {"\n"}
-                <span
-                  className="hover:text-link inline-block cursor-pointer underline"
-                  onClick={() => {
-                    dispatch(
-                      saveCurrentSession({
-                        openNewSession: true,
-                        generateTitle: false,
-                      }),
-                    );
-                  }}
-                >
-                  Start a new session
-                </span>
+            {isPruned && (
+              <span className="inline-block">
+                {`Oldest messages are being removed.`}
+              </span>
+            )}
+            {history.length > 0 && (
+              <div className="flex flex-col gap-1 whitespace-pre">
+                <div>
+                  <span
+                    className="hover:text-link inline-block cursor-pointer underline"
+                    onClick={() => compactConversation(history.length - 1)}
+                  >
+                    Compact conversation
+                  </span>
+                  {"\n"}
+                  <span
+                    className="hover:text-link inline-block cursor-pointer underline"
+                    onClick={() => {
+                      void dispatch(
+                        saveCurrentSession({
+                          openNewSession: true,
+                          generateTitle: false,
+                        }),
+                      );
+                    }}
+                  >
+                    Start a new session
+                  </span>
+                </div>
               </div>
-            </div>
-          )}
+            )}
+          </div>
+        }
+      >
+        <div className="border-description-muted relative h-[14px] w-[7px] rounded-[1px] border-[0.5px] border-solid md:h-[10px] md:w-[5px]">
+          <div
+            className={`transition-height absolute bottom-0 left-0 w-full duration-300 ease-in-out ${barColorClass}`}
+            style={{ height: `${percent}%` }}
+          />
         </div>
       </ToolTip>
-      <div
-        data-tooltip-id="context-status"
-        className="border-description-muted relative h-[14px] w-[7px] rounded-[1px] border-[0.5px] border-solid md:h-[10px] md:w-[5px]"
-      >
-        <div
-          className={`transition-height absolute bottom-0 left-0 w-full duration-300 ease-in-out ${barColorClass}`}
-          style={{ height: `${percent}%` }}
-        ></div>
-      </div>
     </div>
   );
 };

--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -80,19 +80,17 @@ function InputToolbar(props: InputToolbarProps) {
       >
         <div className="xs:gap-1.5 flex flex-row items-center gap-1">
           {!isInEdit && (
-            <HoverItem data-tooltip-id="mode-select-tooltip" className="!p-0">
-              <ModeSelect />
-              <ToolTip id="mode-select-tooltip" place="top">
-                Select Mode
-              </ToolTip>
-            </HoverItem>
-          )}
-          <HoverItem data-tooltip-id="model-select-tooltip" className="!p-0">
-            <ModelSelect />
-            <ToolTip id="model-select-tooltip" place="top">
-              Select Model
+            <ToolTip place="top" content="Select Mode">
+              <HoverItem className="!p-0">
+                <ModeSelect />
+              </HoverItem>
             </ToolTip>
-          </HoverItem>
+          )}
+          <ToolTip place="top" content="Select Model">
+            <HoverItem className="!p-0">
+              <ModelSelect />
+            </HoverItem>
+          </ToolTip>
           <div className="xs:flex text-description -mb-1 hidden items-center transition-colors duration-200">
             {props.toolbarOptions?.hideImageUpload ||
               (supportsImages && (
@@ -112,32 +110,25 @@ function InputToolbar(props: InputToolbarProps) {
                       }
                     }}
                   />
-                  <HoverItem className="">
-                    <PhotoIcon
-                      className="h-3 w-3 hover:brightness-125"
-                      data-tooltip-id="image-tooltip"
-                      onClick={(e) => {
-                        fileInputRef.current?.click();
-                      }}
-                    />
 
-                    <ToolTip id="image-tooltip" place="top">
-                      Attach Image
-                    </ToolTip>
-                  </HoverItem>
+                  <ToolTip place="top" content="Attach Image">
+                    <HoverItem className="">
+                      <PhotoIcon
+                        className="h-3 w-3 hover:brightness-125"
+                        onClick={(e) => {
+                          fileInputRef.current?.click();
+                        }}
+                      />
+                    </HoverItem>
+                  </ToolTip>
                 </>
               ))}
             {props.toolbarOptions?.hideAddContext || (
-              <HoverItem onClick={props.onAddContextItem}>
-                <AtSymbolIcon
-                  data-tooltip-id="add-context-item-tooltip"
-                  className="h-3 w-3 hover:brightness-125"
-                />
-
-                <ToolTip id="add-context-item-tooltip" place="top">
-                  Attach Context
-                </ToolTip>
-              </HoverItem>
+              <ToolTip place="top" content="Attach Context">
+                <HoverItem onClick={props.onAddContextItem}>
+                  <AtSymbolIcon className="h-3 w-3 hover:brightness-125" />
+                </HoverItem>
+              </ToolTip>
             )}
             {defaultModel?.underlyingProviderName === "anthropic" && (
               <HoverItem
@@ -145,22 +136,19 @@ function InputToolbar(props: InputToolbarProps) {
                   dispatch(setHasReasoningEnabled(!hasReasoningEnabled))
                 }
               >
-                {hasReasoningEnabled ? (
-                  <LightBulbIconSolid
-                    data-tooltip-id="model-reasoning-tooltip"
-                    className="h-3 w-3 brightness-200 hover:brightness-150"
-                  />
-                ) : (
-                  <LightBulbIconOutline
-                    data-tooltip-id="model-reasoning-tooltip"
-                    className="h-3 w-3 hover:brightness-150"
-                  />
-                )}
-
-                <ToolTip id="model-reasoning-tooltip" place="top">
-                  {hasReasoningEnabled
-                    ? "Disable model reasoning"
-                    : "Enable model reasoning"}
+                <ToolTip
+                  place="top"
+                  content={
+                    hasReasoningEnabled
+                      ? "Disable model reasoning"
+                      : "Enable model reasoning"
+                  }
+                >
+                  {hasReasoningEnabled ? (
+                    <LightBulbIconSolid className="h-3 w-3 brightness-200 hover:brightness-150" />
+                  ) : (
+                    <LightBulbIconOutline className="h-3 w-3 hover:brightness-150" />
+                  )}
                 </ToolTip>
               </HoverItem>
             )}
@@ -187,15 +175,19 @@ function InputToolbar(props: InputToolbarProps) {
                   })
                 }
               >
-                <span data-tooltip-id="add-active-file-context-tooltip">
-                  {getAltKeyLabel()}⏎{" "}
-                  {useActiveFile ? "No active file" : "Active file"}
-                </span>
-                <ToolTip id="add-active-file-context-tooltip" place="top-end">
-                  {useActiveFile
-                    ? "Send Without Active File"
-                    : "Send With Active File"}{" "}
-                  ({getAltKeyLabel()}⏎)
+                <ToolTip
+                  place="top-end"
+                  content={`
+                    ${
+                      useActiveFile
+                        ? "Send Without Active File"
+                        : "Send With Active File"
+                    } (${getAltKeyLabel()}⏎)`}
+                >
+                  <span>
+                    {getAltKeyLabel()}⏎{" "}
+                    {useActiveFile ? "No active file" : "Active file"}
+                  </span>
                 </ToolTip>
               </HoverItem>
             </div>
@@ -213,29 +205,27 @@ function InputToolbar(props: InputToolbarProps) {
               </span>
             </HoverItem>
           )}
-          <Button
-            data-tooltip-id="enter-tooltip"
-            variant={props.isMainInput ? "primary" : "secondary"}
-            size="sm"
-            data-testid="submit-input-button"
-            onClick={async (e) => {
-              if (props.onEnter) {
-                props.onEnter({
-                  useCodebase: isMetaEquivalentKeyPressed(e as any),
-                  noContext: useActiveFile ? e.altKey : !e.altKey,
-                });
-              }
-            }}
-            disabled={isEnterDisabled}
-          >
-            <span className="hidden md:inline">
-              ⏎ {props.toolbarOptions?.enterText ?? "Enter"}
-            </span>
-            <span className="md:hidden">⏎</span>
-            <ToolTip id="enter-tooltip" place="top">
-              Send (⏎)
-            </ToolTip>
-          </Button>
+          <ToolTip place="top" content="Send (⏎)">
+            <Button
+              variant={props.isMainInput ? "primary" : "secondary"}
+              size="sm"
+              data-testid="submit-input-button"
+              onClick={async (e) => {
+                if (props.onEnter) {
+                  props.onEnter({
+                    useCodebase: isMetaEquivalentKeyPressed(e as any),
+                    noContext: useActiveFile ? e.altKey : !e.altKey,
+                  });
+                }
+              }}
+              disabled={isEnterDisabled}
+            >
+              <span className="hidden md:inline">
+                ⏎ {props.toolbarOptions?.enterText ?? "Enter"}
+              </span>
+              <span className="md:hidden">⏎</span>
+            </Button>
+          </ToolTip>
         </div>
       </div>
     </>

--- a/gui/src/components/mainInput/Lump/LumpToolbar/BlockSettingsTopToolbar.tsx
+++ b/gui/src/components/mainInput/Lump/LumpToolbar/BlockSettingsTopToolbar.tsx
@@ -81,13 +81,8 @@ function BlockSettingsToolbarIcon(
 
   const fontSize = useFontSize(-3);
   return (
-    <>
-      <HoverItem
-        px={0}
-        onClick={props.onClick}
-        data-testid={id}
-        data-tooltip-id={id}
-      >
+    <ToolTip delayShow={700} content={props.tooltip}>
+      <HoverItem px={0} onClick={props.onClick} data-testid={id}>
         <div
           role="button"
           tabIndex={0}
@@ -129,10 +124,7 @@ function BlockSettingsToolbarIcon(
           </div>
         </div>
       </HoverItem>
-      <ToolTip delayShow={700} id={id}>
-        {props.tooltip}
-      </ToolTip>
-    </>
+    </ToolTip>
   );
 }
 
@@ -229,19 +221,21 @@ export function BlockSettingsTopToolbar() {
         </div>
       </div>
       <div className="flex gap-0.5">
-        <HoverItem
-          data-tooltip-id="assistant-select-tooltip"
-          className="!m-0 !p-0"
+        <ToolTip
+          place="top"
+          content={isUsingFreeTrial ? "View free trial usage" : "Select Agent"}
         >
-          {isUsingFreeTrial ? (
-            <FreeTrialButton freeTrialStatus={freeTrialStatus} />
-          ) : (
-            <AssistantAndOrgListbox />
-          )}
-          <ToolTip id="assistant-select-tooltip" place="top">
-            {isUsingFreeTrial ? "View free trial usage" : "Select Agent"}
-          </ToolTip>
-        </HoverItem>
+          <HoverItem
+            data-tooltip-id="assistant-select-tooltip"
+            className="!m-0 !p-0"
+          >
+            {isUsingFreeTrial ? (
+              <FreeTrialButton freeTrialStatus={freeTrialStatus} />
+            ) : (
+              <AssistantAndOrgListbox />
+            )}
+          </HoverItem>
+        </ToolTip>
       </div>
     </div>
   );

--- a/gui/src/components/mainInput/Lump/sections/docs/StatusIndicator.tsx
+++ b/gui/src/components/mainInput/Lump/sections/docs/StatusIndicator.tsx
@@ -25,20 +25,13 @@ export function StatusIndicator({
 }: StatusIndicatorProps) {
   if (!status) return null;
 
-  const indicator = (
-    <div
-      data-tooltip-id={hoverMessage ? "status-tooltip" : undefined}
-      data-tooltip-content={hoverMessage}
-      className={`h-${size} w-${size} rounded-full ${STATUS_TO_COLOR[status]} ${
-        status === "indexing" ? "animate-pulse" : ""
-      } ${className}`}
-    />
-  );
-
   return (
-    <>
-      {indicator}
-      {hoverMessage && <ToolTip id="status-tooltip" />}
-    </>
+    <ToolTip hidden={!hoverMessage} content={hoverMessage}>
+      <div
+        className={`h-${size} w-${size} rounded-full ${STATUS_TO_COLOR[status]} ${
+          status === "indexing" ? "animate-pulse" : ""
+        } ${className}`}
+      />
+    </ToolTip>
   );
 }

--- a/gui/src/components/mainInput/Lump/sections/mcp/MCPSection.tsx
+++ b/gui/src/components/mainInput/Lump/sections/mcp/MCPSection.tsx
@@ -29,11 +29,6 @@ function MCPServerPreview({ server, serverFromYaml }: MCPServerStatusProps) {
   const ideMessenger = useContext(IdeMessengerContext);
   const config = useAppSelector((store) => store.config.config);
   const dispatch = useAppDispatch();
-  const toolsTooltipId = `${server.id}-tools`;
-  const promptsTooltipId = `${server.id}-prompts`;
-  const resourcesTooltipId = `${server.id}-resources`;
-  const errorsTooltipId = `${server.id}-errors`;
-  const mcpAuthTooltipId = `${server.id}-auth`;
 
   const updateMCPServerStatus = (status: MCPServerStatus["status"]) => {
     // optimistic config update
@@ -82,110 +77,111 @@ function MCPServerPreview({ server, serverFromYaml }: MCPServerStatusProps) {
 
         {/* Error indicator if any */}
         {server.errors.length ? (
-          <>
+          <ToolTip
+            clickable
+            delayHide={
+              server.errors.some((error) => error.length > 150) ? 1500 : 0
+            }
+            className="flex flex-col gap-0.5"
+            content={server.errors.map((error, idx) => (
+              <Fragment key={idx}>
+                <div>
+                  {error.length > 150 ? error.substring(0, 150) + "..." : error}
+                </div>
+                {error.length > 150 && (
+                  <Button
+                    className="my-0"
+                    size="sm"
+                    variant="ghost"
+                    onClick={() =>
+                      void ideMessenger.ide.showVirtualFile(server.name, error)
+                    }
+                  >
+                    View full error
+                  </Button>
+                )}
+              </Fragment>
+            ))}
+          >
             <InformationCircleIcon
               className={`h-3 w-3 ${server.status === "error" ? "text-red-500" : "text-yellow-500"}`}
-              data-tooltip-id={errorsTooltipId}
             />
-            <ToolTip
-              clickable
-              id={errorsTooltipId}
-              delayHide={
-                server.errors.some((error) => error.length > 150) ? 1500 : 0
-              }
-              className="flex flex-col gap-0.5"
-            >
-              {server.errors.map((error, idx) => (
-                <Fragment key={idx}>
-                  <div>
-                    {error.length > 150
-                      ? error.substring(0, 150) + "..."
-                      : error}
-                  </div>
-                  {error.length > 150 && (
-                    <Button
-                      className="my-0"
-                      size="sm"
-                      variant="ghost"
-                      onClick={() =>
-                        void ideMessenger.ide.showVirtualFile(
-                          server.name,
-                          error,
-                        )
-                      }
-                    >
-                      View full error
-                    </Button>
-                  )}
-                </Fragment>
-              ))}
-            </ToolTip>
-          </>
+          </ToolTip>
         ) : null}
 
         {/* Tools, Prompts, Resources with counts */}
         <div className="flex flex-row items-center gap-3">
-          <div
-            className="flex cursor-zoom-in items-center gap-1 hover:opacity-80"
-            data-tooltip-id={toolsTooltipId}
+          <ToolTip
+            className="flex flex-col gap-0.5"
+            content={
+              <>
+                {server.tools.map((tool, idx) => (
+                  <code key={idx}>{tool.name}</code>
+                ))}
+                {server.tools.length === 0 && (
+                  <span className="text-lightgray">No tools</span>
+                )}
+              </>
+            }
           >
-            <WrenchScrewdriverIcon className="h-3 w-3" />
-            <span className="text-xs">{server.tools.length}</span>
-            <ToolTip id={toolsTooltipId} className="flex flex-col gap-0.5">
-              {server.tools.map((tool, idx) => (
-                <code key={idx}>{tool.name}</code>
-              ))}
-              {server.tools.length === 0 && (
-                <span className="text-lightgray">No tools</span>
-              )}
-            </ToolTip>
-          </div>
-          <div
-            className="flex cursor-zoom-in items-center gap-1 hover:opacity-80"
-            data-tooltip-id={promptsTooltipId}
+            <div className="flex cursor-zoom-in items-center gap-1 hover:opacity-80">
+              <WrenchScrewdriverIcon className="h-3 w-3" />
+              <span className="text-xs">{server.tools.length}</span>
+            </div>
+          </ToolTip>
+
+          <ToolTip
+            className="flex flex-col gap-0.5"
+            content={
+              <>
+                {server.prompts.map((prompt, idx) => (
+                  <code key={idx}>{prompt.name}</code>
+                ))}
+                {server.prompts.length === 0 && (
+                  <span className="text-lightgray">No prompts</span>
+                )}
+              </>
+            }
           >
-            <CommandLineIcon className="h-3 w-3" />
-            <span className="text-xs">{server.prompts.length}</span>
-            <ToolTip id={promptsTooltipId} className="flex flex-col gap-0.5">
-              {server.prompts.map((prompt, idx) => (
-                <code key={idx}>{prompt.name}</code>
-              ))}
-              {server.prompts.length === 0 && (
-                <span className="text-lightgray">No prompts</span>
-              )}
-            </ToolTip>
-          </div>
-          <div
-            className="flex cursor-zoom-in items-center gap-1 hover:opacity-80"
-            data-tooltip-id={resourcesTooltipId}
+            <div className="flex cursor-zoom-in items-center gap-1 hover:opacity-80">
+              <CommandLineIcon className="h-3 w-3" />
+              <span className="text-xs">{server.prompts.length}</span>
+            </div>
+          </ToolTip>
+
+          <ToolTip
+            className="flex flex-col gap-0.5"
+            content={
+              <>
+                {[...server.resources, ...server.resourceTemplates].map(
+                  (resource, idx) => (
+                    <code key={idx}>{resource.name}</code>
+                  ),
+                )}
+                {server.resources.length === 0 && (
+                  <span className="text-lightgray">No resources</span>
+                )}
+              </>
+            }
           >
-            <CircleStackIcon className="h-3 w-3" />
-            <span className="text-xs">
-              {server.resources.length + server.resourceTemplates.length}
-            </span>
-            <ToolTip id={resourcesTooltipId} className="flex flex-col gap-0.5">
-              {[...server.resources, ...server.resourceTemplates].map(
-                (resource, idx) => (
-                  <code key={idx}>{resource.name}</code>
-                ),
-              )}
-              {server.resources.length === 0 && (
-                <span className="text-lightgray">No resources</span>
-              )}
-            </ToolTip>
-          </div>
+            <div className="flex cursor-zoom-in items-center gap-1 hover:opacity-80">
+              <CircleStackIcon className="h-3 w-3" />
+              <span className="text-xs">
+                {server.resources.length + server.resourceTemplates.length}
+              </span>
+            </div>
+          </ToolTip>
         </div>
       </div>
 
       <div className="flex items-center gap-2">
         {server.isProtectedResource && (
-          <>
-            <div
-              className="text-lightgray flex cursor-pointer items-center hover:text-white hover:opacity-80"
-              data-tooltip-id={
-                server.status !== "authenticating" ? mcpAuthTooltipId : ""
-              }
-            >
+          <ToolTip
+            place="left"
+            hidden={server.status === "authenticating"}
+            content={server.status === "error" ? "Authenticate" : "Logout"}
+          >
+            <div className="text-lightgray flex cursor-pointer items-center hover:text-white hover:opacity-80">
               {server.status === "error" ? (
                 <ShieldExclamationIcon
                   className="h-3 w-3"
@@ -197,12 +193,7 @@ function MCPServerPreview({ server, serverFromYaml }: MCPServerStatusProps) {
                 <ShieldCheckIcon className="h-3 w-3" onClick={onRemoveAuth} />
               )}
             </div>
-            {server.status !== "authenticating" && (
-              <ToolTip place="left" id={mcpAuthTooltipId}>
-                {server.status === "error" ? "Authenticate" : "Logout"}
-              </ToolTip>
-            )}
-          </>
+          </ToolTip>
         )}
         <EditBlockButton
           blockType={"mcpServers"}

--- a/gui/src/components/mainInput/Lump/sections/tool-policies/ToolPolicyItem.tsx
+++ b/gui/src/components/mainInput/Lump/sections/tool-policies/ToolPolicyItem.tsx
@@ -81,18 +81,10 @@ function ToolPolicyItem(props: ToolDropdownItemProps) {
             }}
           >
             {props.duplicatesDetected ? (
-              <>
-                <InformationCircleIcon
-                  data-tooltip-id={
-                    props.tool.displayTitle + "-duplicate-warning"
-                  }
-                  className="h-3 w-3 flex-shrink-0 cursor-help text-yellow-500"
-                />
-                <ToolTip
-                  id={props.tool.displayTitle + "-duplicate-warning"}
-                  place="bottom"
-                  className="flex flex-wrap items-center"
-                >
+              <ToolTip
+                place="bottom"
+                className="flex flex-wrap items-center"
+                content={
                   <p className="m-0 p-0">
                     <span>Duplicate tool name</span>{" "}
                     <code>{props.tool.function.name}</code>{" "}
@@ -101,8 +93,10 @@ function ToolPolicyItem(props: ToolDropdownItemProps) {
                       unpredictable
                     </span>
                   </p>
-                </ToolTip>
-              </>
+                }
+              >
+                <InformationCircleIcon className="h-3 w-3 flex-shrink-0 cursor-help text-yellow-500" />
+              </ToolTip>
             ) : null}
             {props.tool.faviconUrl && (
               <img

--- a/gui/src/pages/config/ModelRoleSelector.tsx
+++ b/gui/src/pages/config/ModelRoleSelector.tsx
@@ -8,7 +8,6 @@ import { ModelDescription } from "core";
 import { LLMConfigurationStatuses } from "core/llm/constants";
 import { MouseEvent, useContext, useState } from "react";
 import { defaultBorderRadius } from "../../components";
-import { ToolTip } from "../../components/gui/Tooltip";
 import InfoHover from "../../components/InfoHover";
 import {
   Listbox,
@@ -72,9 +71,6 @@ const ModelRoleSelector = ({
       <div className="mt-2 flex flex-row items-center gap-1 sm:mt-0">
         <span style={{ fontSize: fontSize(-3) }}>{displayName}</span>
         <InfoHover size="3" id={displayName} msg={description} />
-        <ToolTip id={`${displayName}-description`} place={"bottom"}>
-          {description}
-        </ToolTip>
       </div>
 
       <Listbox value={selectedModel?.title ?? null} onChange={handleSelect}>

--- a/gui/src/pages/config/UserSettingsForm.tsx
+++ b/gui/src/pages/config/UserSettingsForm.tsx
@@ -398,12 +398,10 @@ export function UserSettingsForm() {
                   text="Auto-Accept Agent Edits"
                   showIfToggled={
                     <>
-                      <ExclamationTriangleIcon
-                        data-tooltip-id={`auto-accept-diffs-warning-tooltip`}
-                        className="h-3 w-3 text-yellow-500"
-                      />
-                      <ToolTip id={`auto-accept-diffs-warning-tooltip`}>
-                        {`Be very careful with this setting. When turned on, Agent mode's edit tool can make changes to files with no manual review or guaranteed stopping point`}
+                      <ToolTip
+                        content={`Be very careful with this setting. When turned on, Agent mode's edit tool can make changes to files with no manual review or guaranteed stopping point`}
+                      >
+                        <ExclamationTriangleIcon className="h-3 w-3 text-yellow-500" />
                       </ToolTip>
                     </>
                   }


### PR DESCRIPTION
## Description

Initially TooTips required to have an id associated with 2 elements to display it. This required 2 independent elements one with `id` and another with `data-tooltip-id`.
This PR introduces a single Tooltip which removes the usage of `id` and the displaying element can be passed as children to the tooltip

- refactors ToolTips to match new props
- keeps all of the UI and other content the same

resolves CON-3586

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced id-based tooltip wiring with a simpler, id-less API. Tooltips now wrap the trigger element and accept content directly, keeping UI and behavior the same.

- **Refactors**
  - New API: <ToolTip content="...">{trigger}</ToolTip> with auto-generated ids.
  - Removed data-tooltip-id and id usage across components.
  - Preserves existing options (place, className, style, clickable, delays).
  - Simplified helpers (e.g., InfoHover now accepts msg as a string).

- **Migration**
  - Wrap the target element with <ToolTip content="..."> instead of pairing an element with data-tooltip-id and a separate <ToolTip id>.
  - Move any previous tooltip children into the content prop.
  - Update InfoHover to pass msg as a string.

<!-- End of auto-generated description by cubic. -->

