### PR TITLE
docs: update Inception Labs references to Inception

### DIFF
--- a/docs/customize/model-providers/top-level/inception.mdx
+++ b/docs/customize/model-providers/top-level/inception.mdx
@@ -1,7 +1,7 @@
 ---
 title: "How to Configure Inception with Continue"
 slug: ../inception
-description: "Configure Inception Labs models with Continue, featuring Mercury Coder Small for both chat and autocomplete functions, optimized for programming and code generation tasks"
+description: "Configure Inception models with Continue, featuring Mercury Coder Small for both chat and autocomplete functions, optimized for programming and code generation tasks"
 sidebarTitle: "Inception"
 ---
 

--- a/docs/features/autocomplete/model-setup.mdx
+++ b/docs/features/autocomplete/model-setup.mdx
@@ -27,13 +27,13 @@ This model is specifically designed for code completion and offers excellent per
 
 ### Hosted (Best Speed/Quality Tradeoff)
 
-For fast, quality autocomplete suggestions, we recommend **[Mercury Coder Small](https://hub.continue.dev/inceptionlabs/mercury-coder-small)** from Inception Labs.
+For fast, quality autocomplete suggestions, we recommend **[Mercury Coder Small](https://hub.continue.dev/inceptionlabs/mercury-coder-small)** from Inception.
 
 This model is specifically designed for code completion and is particularly fast because it is a diffusion model.
 
 **Mercury Coder Small Quick Setup:**
 
-1. Get your API key from [Inception Labs](https://platform.inceptionlabs.ai/)
+1. Get your API key from [Inception](https://platform.inceptionlabs.ai/)
 2. Add [Mercury Coder Small](https://hub.continue.dev/inceptionlabs/mercury-coder-small) to your assistant on Continue Hub
 3. Add `INCEPTION_API_KEY` as a [User Secret](https://docs.continue.dev/hub/secrets/secret-types#user-secrets) on Continue Hub [here](https://hub.continue.dev/settings/secrets)
 4. Click `Reload config` in the assistant selector in the Continue IDE extension


### PR DESCRIPTION
Updated all documentation references from 'Inception Labs' to 'Inception' for consistency with current branding.

Generated with Continue (cn)

## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
