### PR TITLE
fix HOTFIX remove cumulative args case

### DIFF
--- a/gui/src/util/toolCallState.ts
+++ b/gui/src/util/toolCallState.ts
@@ -44,13 +44,11 @@ export function addToolCallDeltaToState(
     // If args is JSON parseable, it is complete, don't add to it
     JSON.parse(currentArgs);
   } catch (e) {
-    if (argsDelta.startsWith(currentArgs)) {
-      // Case where model progresssively streams args but full args each time e.g. "{"file": "file1"}" -> "{"file": "file1", "line": 1}"
-      mergedArgs = argsDelta;
-    } else if (!currentArgs.startsWith(argsDelta)) {
-      // Case where model streams in args in parts e.g. "{"file": "file1"" -> ", "line": 1}"
-      mergedArgs = currentArgs + argsDelta;
-    }
+    // Model streams in args in parts e.g. "{"file": "file1"" -> ", "line": 1}"
+    mergedArgs = currentArgs + argsDelta;
+
+    // Note, removed case where model progresssively streams args but full args each time e.g. "{"file": "file1"}" -> "{"file": "file1", "line": 1}"
+    // Because no apis do this and difficult to detect reliably
   }
 
   const [_, parsedArgs] = incrementalParseJson(mergedArgs || "{}");


### PR DESCRIPTION
## Description
Removes extraneous args streaming handling that was causing search and replace failures.

@chezsmithy you might enjoy this postmortem since you were involved in cleaning up after the bugs I introduced at several steps:

Background:
1. I broke bedrock by making tool call args stream cumulatively in [#6499](https://github.com/continuedev/continue/pull/6499)
2. @chezsmithy and I both immediately introduced the same hotfix with [#6540](https://github.com/continuedev/continue/pull/6542) and [#6540](https://github.com/continuedev/continue/pull/6540), which handled cumulative args streaming
3. @chezsmithy then quickly found the real issue (see #1) and fixed in [#6544](https://github.com/continuedev/continue/pull/6544) which I merged in [#6559](https://github.com/continuedev/continue/pull/6559)
4. Fastforward a few weeks, @chezsmithy improved search and replace args format to encourage multiple blocks with an array of diffs in [#6586](https://github.com/continuedev/continue/pull/6586). It was now the first built in tool with complex/nested tool args.
5. Search and replace was still experimental. When it was made to be general availability it was limited to claude, and nothing broke because claude does not stream individual args in chunks
6. When gpt-5 was added to search and replace, it illuminated this issue because it streams the specific chunk that makes the hotfix in #2 unsafe (`{"`), see image below

<img width="1264" height="946" alt="image" src="https://github.com/user-attachments/assets/d5759c12-9904-4447-9577-e9dad93fdcdd" />

So this PR removes the hotfix from #2
