### PR TITLE
feat: wrap each recently viewed code snippet inside a token block

### DIFF
--- a/core/nextEdit/templating/NextEditPromptEngine.vitest.ts
+++ b/core/nextEdit/templating/NextEditPromptEngine.vitest.ts
@@ -14,6 +14,8 @@ import {
   MERCURY_EDIT_DIFF_HISTORY_OPEN,
   MERCURY_RECENTLY_VIEWED_CODE_SNIPPETS_CLOSE,
   MERCURY_RECENTLY_VIEWED_CODE_SNIPPETS_OPEN,
+  MERCURY_RECENTLY_VIEWED_CODE_SNIPPET_CLOSE,
+  MERCURY_RECENTLY_VIEWED_CODE_SNIPPET_OPEN,
 } from "../constants";
 import {
   renderDefaultSystemPrompt,
@@ -31,7 +33,7 @@ describe("NextEditPromptEngine", () => {
 
     beforeEach(() => {
       mercuryHelper = {
-        modelName: "inception/mercury-coder-nextedit" as NEXT_EDIT_MODELS,
+        modelName: "inception/mercury-coder" as NEXT_EDIT_MODELS,
         fileContents: "function test() {\n  const a = 1;\n  return a;\n}",
         pos: { line: 1, character: 12 } as Position,
         lang: { name: "typescript" },
@@ -63,7 +65,7 @@ describe("NextEditPromptEngine", () => {
       };
     });
 
-    it("should render mercury-coder-nextedit prompt correctly", async () => {
+    it("should render mercury-coder prompt correctly", async () => {
       const result = await renderPrompt(mercuryHelper, ctx);
 
       expect(result).toHaveProperty("prompt");
@@ -72,6 +74,8 @@ describe("NextEditPromptEngine", () => {
       const content = result.prompt.content;
       expect(content).toContain(MERCURY_RECENTLY_VIEWED_CODE_SNIPPETS_OPEN);
       expect(content).toContain(MERCURY_RECENTLY_VIEWED_CODE_SNIPPETS_CLOSE);
+      expect(content).toContain(MERCURY_RECENTLY_VIEWED_CODE_SNIPPET_OPEN);
+      expect(content).toContain(MERCURY_RECENTLY_VIEWED_CODE_SNIPPET_CLOSE);
       expect(content).toContain(MERCURY_CURRENT_FILE_CONTENT_OPEN);
       expect(content).toContain(MERCURY_CURRENT_FILE_CONTENT_CLOSE);
       expect(content).toContain(MERCURY_EDIT_DIFF_HISTORY_OPEN);

--- a/core/nextEdit/templating/mercuryCoderNextEdit.ts
+++ b/core/nextEdit/templating/mercuryCoderNextEdit.ts
@@ -3,6 +3,8 @@ import {
   MERCURY_CODE_TO_EDIT_CLOSE,
   MERCURY_CODE_TO_EDIT_OPEN,
   MERCURY_CURSOR,
+  MERCURY_RECENTLY_VIEWED_CODE_SNIPPET_CLOSE,
+  MERCURY_RECENTLY_VIEWED_CODE_SNIPPET_OPEN,
 } from "../constants";
 import { insertCursorToken } from "./utils";
 
@@ -11,8 +13,10 @@ export function recentlyViewedCodeSnippetsBlock(
 ) {
   return recentlyViewedCodeSnippets.reduce((acc, snippet, i) => {
     const block = [
+      MERCURY_RECENTLY_VIEWED_CODE_SNIPPET_OPEN,
       `code_snippet_file_path: ${snippet.filepath}`,
       snippet.content,
+      MERCURY_RECENTLY_VIEWED_CODE_SNIPPET_CLOSE,
     ].join("\n");
 
     return (

--- a/core/nextEdit/templating/mercuryCoderNextEdit.vitest.ts
+++ b/core/nextEdit/templating/mercuryCoderNextEdit.vitest.ts
@@ -4,6 +4,8 @@ import {
   MERCURY_CODE_TO_EDIT_CLOSE,
   MERCURY_CODE_TO_EDIT_OPEN,
   MERCURY_CURSOR,
+  MERCURY_RECENTLY_VIEWED_CODE_SNIPPET_CLOSE,
+  MERCURY_RECENTLY_VIEWED_CODE_SNIPPET_OPEN,
 } from "../constants";
 import {
   currentFileContentBlock,
@@ -25,10 +27,14 @@ describe("mercuryCoderNextEdit", () => {
       const result = recentlyViewedCodeSnippetsBlock(snippets);
 
       const expected =
+        `${MERCURY_RECENTLY_VIEWED_CODE_SNIPPET_OPEN}\n` +
         "code_snippet_file_path: /path/to/file1.ts\n" +
         "const a = 1;\n" +
+        `${MERCURY_RECENTLY_VIEWED_CODE_SNIPPET_CLOSE}\n` +
+        `${MERCURY_RECENTLY_VIEWED_CODE_SNIPPET_OPEN}\n` +
         "code_snippet_file_path: /path/to/file2.ts\n" +
-        "function test() { return true; }";
+        "function test() { return true; }\n" +
+        MERCURY_RECENTLY_VIEWED_CODE_SNIPPET_CLOSE;
 
       expect(result).toBe(expected);
     });


### PR DESCRIPTION
## Description

Closes CON-3601.

Each recently viewed code snippet is its own block, inside a bigger block.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

`core/nextEdit/templating/NextEditPromptEngine.vitest.ts`
`core/nextEdit/templating/mercuryCoderNextEdit.vitest.ts`

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Wraps each recently viewed code snippet in its own token block to improve prompt structure and parsing. Aligns with CON-3601.

- **New Features**
  - Added MERCURY_RECENTLY_VIEWED_CODE_SNIPPET_OPEN/CLOSE tokens.
  - Updated prompt builder to wrap each recent snippet with these tokens.
  - Updated tests to expect the new tokens and use the mercury-coder model name.

<!-- End of auto-generated description by cubic. -->

