### PR TITLE
fix: max abort listeners warning

### DIFF
--- a/extensions/cli/src/streamChatResponse.ts
+++ b/extensions/cli/src/streamChatResponse.ts
@@ -300,7 +300,7 @@ export async function processStreamingResponse(
   } = options;
   const requestStartTime = Date.now();
 
-  const streamFactory = async () => {
+  const streamFactory = async (retryAbortSignal: AbortSignal) => {
     logger.debug("Creating chat completion stream", {
       model,
       messageCount: chatHistory.length,
@@ -315,7 +315,7 @@ export async function processStreamingResponse(
         tools,
         ...getDefaultCompletionOptions(model.defaultCompletionOptions),
       },
-      abortController.signal,
+      retryAbortSignal,
     );
   };
 

--- a/extensions/cli/src/util/withExponentialBackoff.test.ts
+++ b/extensions/cli/src/util/withExponentialBackoff.test.ts
@@ -20,7 +20,7 @@ describe("withExponentialBackoff", () => {
 
   it("should successfully yield all values from generator", async () => {
     const mockData = ["chunk1", "chunk2", "chunk3"];
-    const generatorFactory = vi.fn(async () => {
+    const generatorFactory = vi.fn(async (retryAbortSignal: AbortSignal) => {
       return (async function* () {
         for (const chunk of mockData) {
           yield chunk;
@@ -44,7 +44,7 @@ describe("withExponentialBackoff", () => {
 
   it("should retry on retryable errors during generator creation", async () => {
     let callCount = 0;
-    const generatorFactory = vi.fn(async () => {
+    const generatorFactory = vi.fn(async (retryAbortSignal: AbortSignal) => {
       callCount++;
       if (callCount === 1) {
         const error = new Error("Connection reset");
@@ -75,7 +75,7 @@ describe("withExponentialBackoff", () => {
   });
 
   it("should not retry on non-retryable errors", async () => {
-    const generatorFactory = vi.fn(async () => {
+    const generatorFactory = vi.fn(async (retryAbortSignal: AbortSignal) => {
       const error = new Error("Bad request");
       (error as any).status = 400;
       throw error;
@@ -96,7 +96,7 @@ describe("withExponentialBackoff", () => {
   });
 
   it("should handle abort signal", async () => {
-    const generatorFactory = vi.fn(async () => {
+    const generatorFactory = vi.fn(async (retryAbortSignal: AbortSignal) => {
       return (async function* () {
         yield "should-not-yield";
       })();


### PR DESCRIPTION
## Description

Solves the below warning that would pop up in CLI after a short time:

(node:1407) MaxListenersExceededWarning: Possible EventTarget memory leak detected. 11 abort listeners added to [AbortSignal]. Use events.setMaxListeners() to increase limit
    at [kNewListener] (node:internal/event_target:572:17)
    at [kNewListener] (node:internal/abort_controller:241:24)
    at EventTarget.addEventListener (node:internal/event_target:685:23)
    at OpenAI.fetchWithTimeout (file:///Users/nate/gh/continuedev/continue/extensions/cli/node_modules/openai/core.mjs:378:20)
    at OpenAI.makeRequest (file:///Users/nate/gh/continuedev/continue/extensions/cli/node_modules/openai/core.mjs:314:37)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async OpenAIApi.chatCompletionStream (file:///Users/nate/gh/continuedev/continue/extensions/cli/node_modules/@continuedev/openai-adapters/dist/apis/OpenAI.js:67:26)
    at async withExponentialBackoff (file:///Users/nate/gh/continuedev/continue/extensions/cli/dist/util/exponentialBackoff.js:144:30)
    at async processStreamingResponse (file:///Users/nate/gh/continuedev/continue/extensions/cli/dist/streamChatResponse.js:182:26)
    at async streamChatResponse (file:///Users/nate/gh/continuedev/continue/extensions/cli/dist/streamChatResponse.js:292:56)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the MaxListenersExceededWarning in the CLI by scoping abort signals per retry and cleaning up abort controllers. Prevents listener leaks during streaming and improves stability.

- **Bug Fixes**
  - Create a per-retry AbortController in withExponentialBackoff; forward aborts from the original signal and remove listeners after each attempt.
  - Pass retryAbortSignal through stream factory to OpenAI requests to avoid accumulating listeners.
  - Abort any in-flight request before starting a new one and clean up the controller on unmount in useChat.
  - Update tests to use the new retryAbortSignal parameter.

- **Refactors**
  - Extract executeStreamingResponse in useChat to simplify streaming flow and state handling.

<!-- End of auto-generated description by cubic. -->

