### PR TITLE
fix: stable reelase paths

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -67,6 +67,7 @@ jobs:
       - name: Find beta version to promote
         if: ${{ (inputs.release_type || 'promote-beta') == 'promote-beta' }}
         id: find_beta
+        working-directory: extensions/cli
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
@@ -116,6 +117,7 @@ jobs:
 
       - name: Download and verify beta package
         if: ${{ (inputs.release_type || 'promote-beta') == 'promote-beta' }}
+        working-directory: extensions/cli
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
@@ -131,6 +133,7 @@ jobs:
 
       - name: Prepare package for beta promotion
         if: ${{ (inputs.release_type || 'promote-beta') == 'promote-beta' }}
+        working-directory: extensions/cli
         run: |
           # Copy the beta package contents
           cp -r package/* .
@@ -140,6 +143,7 @@ jobs:
 
       - name: Prepare package for direct stable release
         if: ${{ inputs.release_type == 'direct-stable' }}
+        working-directory: extensions/cli
         run: |
           # Install dependencies for direct build
           npm ci
@@ -148,9 +152,11 @@ jobs:
           npm version ${{ inputs.stable_version }} --no-git-tag-version
 
       - name: Build (verification step)
+        working-directory: extensions/cli
         run: npm run build
 
       - name: Run tests (verification step)
+        working-directory: extensions/cli
         run: npm test
 
       - name: Set final version
@@ -167,6 +173,7 @@ jobs:
           echo "release_notes=$RELEASE_NOTES" >> $GITHUB_OUTPUT
 
       - name: Publish stable to npm
+        working-directory: extensions/cli
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the stable release workflow by running all CLI release steps from extensions/cli. This prevents path errors and ensures beta promotion and direct stable releases publish the correct package.

- **Bug Fixes**
  - Set working-directory: extensions/cli for find beta, download/verify, prepare, build, test, and publish steps.
  - Aligns both promote-beta and direct-stable paths to the correct package directory.

<!-- End of auto-generated description by cubic. -->

