### PR TITLE
fix: :bug: Fix lsTool Exclusions

### DIFF
--- a/core/tools/implementations/lsTool.ts
+++ b/core/tools/implementations/lsTool.ts
@@ -1,3 +1,5 @@
+import ignore from "ignore";
+
 import { ToolImpl } from ".";
 import { walkDir } from "../../indexing/walkDir";
 import { resolveRelativePathInDir } from "../../util/ideUtils";
@@ -27,6 +29,7 @@ export const lsToolImpl: ToolImpl = async (args, extras) => {
     returnRelativeUrisPaths: true,
     include: "both",
     recursive: args?.recursive ?? false,
+    overrideDefaultIgnores: ignore(), // Show all directories including dist/, build/, etc.
   });
 
   const lines = entries.slice(0, MAX_LS_TOOL_LINES);


### PR DESCRIPTION
## Description

Noting that there are excessive fallbacks to the terminal tool to try and discover certain files and folders in the repo. In looking at the code the lsTool is using the walkDir function which is shared with the codebase indexer. There are extensive exlusions in place for the codebase indexer which makes sense, however for the lsTool these exclusions are confusing for the LLM when files that should exist are just not found. 

This change allows the lsTool to find all files but still considers the default ignore mechanisms.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

No tests were added. Manual testing was performed in the testing sandbox. For example before the change the dist directory is not returned. After the change the dist directory is included.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes lsTool to stop inheriting codebase indexer exclusions, so it returns full directory listings and avoids terminal fallbacks. It now includes directories like dist/ and build/ while still honoring default ignore rules (e.g., .gitignore).

<!-- End of auto-generated description by cubic. -->

