### PR TITLE
Respect "useReranking" field from configuration

### DIFF
--- a/core/context/retrieval/retrieval.ts
+++ b/core/context/retrieval/retrieval.ts
@@ -37,7 +37,7 @@ export async function retrieveContextItemsFromEmbeddings(
   const nFinal =
     options?.nFinal ??
     Math.min(DEFAULT_N_FINAL, contextLength / tokensPerSnippet / 2);
-  const useReranking = !!extras.reranker;
+  const useReranking = options?.useReranking ?? !!extras.reranker;
   const nRetrieve = useReranking ? options?.nRetrieve || 2 * nFinal : nFinal;
 
   const branches = (await Promise.race([


### PR DESCRIPTION
## Description

Make the retrieval pipeline respect the "useReranking" value from context provider configuration.

For example, having this configuration for codebase provider:
`
{ name: "codebase", params: { "nFinal": 15, "useReranking: "false" } }
`
reranking was still being done given you had a reranker model configured.
You had to delete the model from config entirely to disable the reranking. Field from config was ignored.

This one-liner adresses that.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
The retrieval pipeline now respects the useReranking flag from provider configuration. If useReranking is set, it overrides the presence of a reranker model; previously reranking always ran when a reranker was configured.

<!-- End of auto-generated description by cubic. -->

