### PR TITLE
Prevent zero click image rendering

### DIFF
--- a/gui/src/components/StyledMarkdownPreview/SecureImageComponent.test.tsx
+++ b/gui/src/components/StyledMarkdownPreview/SecureImageComponent.test.tsx
@@ -12,7 +12,9 @@ describe("SecureImageComponent", () => {
       render(<SecureImageComponent src="https://example.com/image.jpg" />);
 
       expect(
-        screen.getByText(/Image blocked for security.*External images can leak data/),
+        screen.getByText(
+          /Image blocked for security.*External images can leak data/,
+        ),
       ).toBeInTheDocument();
       expect(screen.getByText("Load Image")).toBeInTheDocument();
       expect(screen.queryByRole("img")).not.toBeInTheDocument();
@@ -97,7 +99,9 @@ describe("SecureImageComponent", () => {
 
       // Warning message should be gone
       expect(
-        screen.queryByText(/Image blocked for security.*External images can leak data/),
+        screen.queryByText(
+          /Image blocked for security.*External images can leak data/,
+        ),
       ).not.toBeInTheDocument();
     });
 

--- a/gui/src/components/StyledMarkdownPreview/SecureImageComponent.test.tsx
+++ b/gui/src/components/StyledMarkdownPreview/SecureImageComponent.test.tsx
@@ -1,0 +1,198 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SecureImageComponent } from "./SecureImageComponent";
+
+describe("SecureImageComponent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("Default blocking behavior", () => {
+    it("should block images by default and show warning message", () => {
+      render(<SecureImageComponent src="https://example.com/image.jpg" />);
+      
+      expect(screen.getByText(/Image blocked for security/)).toBeInTheDocument();
+      expect(screen.getByText("Load Image")).toBeInTheDocument();
+      expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    });
+
+    it("should display the image URL", () => {
+      const testUrl = "https://example.com/test-image.png";
+      render(<SecureImageComponent src={testUrl} />);
+      
+      expect(screen.getByText(testUrl)).toBeInTheDocument();
+    });
+
+    it("should handle invalid src prop", () => {
+      render(<SecureImageComponent src={undefined} />);
+      
+      expect(screen.getByText("[Invalid image: no source]")).toBeInTheDocument();
+      expect(screen.queryByText("Load Image")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Query parameter detection", () => {
+    it("should detect and display query parameters", () => {
+      render(<SecureImageComponent src="https://example.com/image.jpg?user=123&token=abc" />);
+      
+      expect(screen.getByText(/Warning: URL contains query parameters/)).toBeInTheDocument();
+      expect(screen.getByText(/"user": "123"/)).toBeInTheDocument();
+      expect(screen.getByText(/"token": "abc"/)).toBeInTheDocument();
+    });
+
+    it("should not show query parameter warning for URLs without parameters", () => {
+      render(<SecureImageComponent src="https://example.com/image.jpg" />);
+      
+      expect(screen.queryByText(/Warning: URL contains query parameters/)).not.toBeInTheDocument();
+    });
+
+    it("should handle relative URLs with query parameters", () => {
+      render(<SecureImageComponent src="/images/test.jpg?id=456&session=xyz" />);
+      
+      expect(screen.getByText(/Warning: URL contains query parameters/)).toBeInTheDocument();
+      expect(screen.getByText(/"id": "456"/)).toBeInTheDocument();
+      expect(screen.getByText(/"session": "xyz"/)).toBeInTheDocument();
+    });
+
+    it("should handle malformed URLs gracefully", () => {
+      render(<SecureImageComponent src="not-a-valid-url://image" />);
+      
+      // Should still display the URL even if it can't be parsed
+      expect(screen.getByText("not-a-valid-url://image")).toBeInTheDocument();
+      expect(screen.getByText("Load Image")).toBeInTheDocument();
+    });
+  });
+
+  describe("User interaction", () => {
+    it("should show image when Load Image button is clicked", () => {
+      const testUrl = "https://example.com/image.jpg";
+      render(<SecureImageComponent src={testUrl} alt="Test image" />);
+      
+      // Initially no image
+      expect(screen.queryByRole("img")).not.toBeInTheDocument();
+      
+      // Click load button
+      const loadButton = screen.getByText("Load Image");
+      fireEvent.click(loadButton);
+      
+      // Image should now be displayed (query by tag since it might be role="presentation")
+      const image = screen.getByAltText("Test image");
+      expect(image).toBeInTheDocument();
+      expect(image).toHaveAttribute("src", testUrl);
+      expect(image).toHaveAttribute("alt", "Test image");
+      
+      // Warning message should be gone
+      expect(screen.queryByText(/Image blocked for security/)).not.toBeInTheDocument();
+    });
+
+    it("should handle image load errors", async () => {
+      const testUrl = "https://example.com/broken-image.jpg";
+      render(<SecureImageComponent src={testUrl} alt="broken image" />);
+      
+      // Click load button
+      const loadButton = screen.getByText("Load Image");
+      fireEvent.click(loadButton);
+      
+      // Simulate image error (query by alt text since role might be presentation)
+      const image = screen.getByAltText("broken image");
+      fireEvent.error(image);
+      
+      // Should show error message and hide image
+      await waitFor(() => {
+        expect(screen.getByText(/Failed to load image/)).toBeInTheDocument();
+        expect(screen.queryByAltText("broken image")).not.toBeInTheDocument();
+      });
+      
+      // Load button should be available again
+      expect(screen.getByText("Load Image")).toBeInTheDocument();
+    });
+
+    it("should pass through title and className props", () => {
+      render(
+        <SecureImageComponent 
+          src="https://example.com/image.jpg" 
+          alt="test image"
+          title="Image title"
+          className="custom-class"
+        />
+      );
+      
+      // Click load button
+      fireEvent.click(screen.getByText("Load Image"));
+      
+      // Check image has title (query by alt text)
+      const image = screen.getByAltText("test image");
+      expect(image).toHaveAttribute("title", "Image title");
+      
+      // Check container has className
+      const container = image.parentElement;
+      expect(container).toHaveClass("custom-class");
+    });
+  });
+
+  describe("Security features", () => {
+    it("should display query parameters as JSON for transparency", () => {
+      render(
+        <SecureImageComponent 
+          src="https://malicious.com/track.gif?email=user@example.com&id=12345&action=view" 
+        />
+      );
+      
+      // Should show all parameters clearly
+      expect(screen.getByText(/Warning: URL contains query parameters/)).toBeInTheDocument();
+      
+      // Check JSON is properly formatted
+      const preElement = screen.getByText(/"email": "user@example.com"/);
+      expect(preElement).toBeInTheDocument();
+      expect(screen.getByText(/"id": "12345"/)).toBeInTheDocument();
+      expect(screen.getByText(/"action": "view"/)).toBeInTheDocument();
+    });
+
+    it("should handle encoded query parameters", () => {
+      render(
+        <SecureImageComponent 
+          src="https://example.com/img.png?data=%7B%22user%22%3A%22test%22%7D" 
+        />
+      );
+      
+      // Should decode and display the parameter
+      expect(screen.getByText(/Warning: URL contains query parameters/)).toBeInTheDocument();
+      // The decoded value should be shown in the pre element
+      const preElement = document.querySelector('pre');
+      expect(preElement).toBeTruthy();
+      // Check that the JSON contains the decoded data
+      expect(preElement?.textContent).toContain('"data"');
+      // The value is decoded as a string containing JSON
+      expect(preElement?.textContent).toContain('"{');
+      expect(preElement?.textContent).toContain('user');
+      expect(preElement?.textContent).toContain('test');
+    });
+  });
+
+  describe("Alt text handling", () => {
+    it("should use empty string for alt when not provided", () => {
+      render(<SecureImageComponent src="https://example.com/image.jpg" />);
+      
+      fireEvent.click(screen.getByText("Load Image"));
+      
+      // Query by tag name since empty alt makes it role="presentation"
+      const images = document.querySelectorAll('img');
+      expect(images.length).toBe(1);
+      expect(images[0]).toHaveAttribute("alt", "");
+    });
+
+    it("should use provided alt text", () => {
+      render(
+        <SecureImageComponent 
+          src="https://example.com/image.jpg" 
+          alt="Description of image"
+        />
+      );
+      
+      fireEvent.click(screen.getByText("Load Image"));
+      
+      const image = screen.getByAltText("Description of image");
+      expect(image).toHaveAttribute("alt", "Description of image");
+    });
+  });
+});

--- a/gui/src/components/StyledMarkdownPreview/SecureImageComponent.test.tsx
+++ b/gui/src/components/StyledMarkdownPreview/SecureImageComponent.test.tsx
@@ -12,7 +12,7 @@ describe("SecureImageComponent", () => {
       render(<SecureImageComponent src="https://example.com/image.jpg" />);
 
       expect(
-        screen.getByText(/Image blocked for security/),
+        screen.getByText(/Image blocked for security.*External images can leak data/),
       ).toBeInTheDocument();
       expect(screen.getByText("Load Image")).toBeInTheDocument();
       expect(screen.queryByRole("img")).not.toBeInTheDocument();
@@ -97,7 +97,7 @@ describe("SecureImageComponent", () => {
 
       // Warning message should be gone
       expect(
-        screen.queryByText(/Image blocked for security/),
+        screen.queryByText(/Image blocked for security.*External images can leak data/),
       ).not.toBeInTheDocument();
     });
 

--- a/gui/src/components/StyledMarkdownPreview/SecureImageComponent.test.tsx
+++ b/gui/src/components/StyledMarkdownPreview/SecureImageComponent.test.tsx
@@ -10,8 +10,10 @@ describe("SecureImageComponent", () => {
   describe("Default blocking behavior", () => {
     it("should block images by default and show warning message", () => {
       render(<SecureImageComponent src="https://example.com/image.jpg" />);
-      
-      expect(screen.getByText(/Image blocked for security/)).toBeInTheDocument();
+
+      expect(
+        screen.getByText(/Image blocked for security/),
+      ).toBeInTheDocument();
       expect(screen.getByText("Load Image")).toBeInTheDocument();
       expect(screen.queryByRole("img")).not.toBeInTheDocument();
     });
@@ -19,44 +21,56 @@ describe("SecureImageComponent", () => {
     it("should display the image URL", () => {
       const testUrl = "https://example.com/test-image.png";
       render(<SecureImageComponent src={testUrl} />);
-      
+
       expect(screen.getByText(testUrl)).toBeInTheDocument();
     });
 
     it("should handle invalid src prop", () => {
       render(<SecureImageComponent src={undefined} />);
-      
-      expect(screen.getByText("[Invalid image: no source]")).toBeInTheDocument();
+
+      expect(
+        screen.getByText("[Invalid image: no source]"),
+      ).toBeInTheDocument();
       expect(screen.queryByText("Load Image")).not.toBeInTheDocument();
     });
   });
 
   describe("Query parameter detection", () => {
     it("should detect and display query parameters", () => {
-      render(<SecureImageComponent src="https://example.com/image.jpg?user=123&token=abc" />);
-      
-      expect(screen.getByText(/Warning: URL contains query parameters/)).toBeInTheDocument();
+      render(
+        <SecureImageComponent src="https://example.com/image.jpg?user=123&token=abc" />,
+      );
+
+      expect(
+        screen.getByText(/Warning: URL contains query parameters/),
+      ).toBeInTheDocument();
       expect(screen.getByText(/"user": "123"/)).toBeInTheDocument();
       expect(screen.getByText(/"token": "abc"/)).toBeInTheDocument();
     });
 
     it("should not show query parameter warning for URLs without parameters", () => {
       render(<SecureImageComponent src="https://example.com/image.jpg" />);
-      
-      expect(screen.queryByText(/Warning: URL contains query parameters/)).not.toBeInTheDocument();
+
+      expect(
+        screen.queryByText(/Warning: URL contains query parameters/),
+      ).not.toBeInTheDocument();
     });
 
     it("should handle relative URLs with query parameters", () => {
-      render(<SecureImageComponent src="/images/test.jpg?id=456&session=xyz" />);
-      
-      expect(screen.getByText(/Warning: URL contains query parameters/)).toBeInTheDocument();
+      render(
+        <SecureImageComponent src="/images/test.jpg?id=456&session=xyz" />,
+      );
+
+      expect(
+        screen.getByText(/Warning: URL contains query parameters/),
+      ).toBeInTheDocument();
       expect(screen.getByText(/"id": "456"/)).toBeInTheDocument();
       expect(screen.getByText(/"session": "xyz"/)).toBeInTheDocument();
     });
 
     it("should handle malformed URLs gracefully", () => {
       render(<SecureImageComponent src="not-a-valid-url://image" />);
-      
+
       // Should still display the URL even if it can't be parsed
       expect(screen.getByText("not-a-valid-url://image")).toBeInTheDocument();
       expect(screen.getByText("Load Image")).toBeInTheDocument();
@@ -67,63 +81,65 @@ describe("SecureImageComponent", () => {
     it("should show image when Load Image button is clicked", () => {
       const testUrl = "https://example.com/image.jpg";
       render(<SecureImageComponent src={testUrl} alt="Test image" />);
-      
+
       // Initially no image
       expect(screen.queryByRole("img")).not.toBeInTheDocument();
-      
+
       // Click load button
       const loadButton = screen.getByText("Load Image");
       fireEvent.click(loadButton);
-      
+
       // Image should now be displayed (query by tag since it might be role="presentation")
       const image = screen.getByAltText("Test image");
       expect(image).toBeInTheDocument();
       expect(image).toHaveAttribute("src", testUrl);
       expect(image).toHaveAttribute("alt", "Test image");
-      
+
       // Warning message should be gone
-      expect(screen.queryByText(/Image blocked for security/)).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/Image blocked for security/),
+      ).not.toBeInTheDocument();
     });
 
     it("should handle image load errors", async () => {
       const testUrl = "https://example.com/broken-image.jpg";
       render(<SecureImageComponent src={testUrl} alt="broken image" />);
-      
+
       // Click load button
       const loadButton = screen.getByText("Load Image");
       fireEvent.click(loadButton);
-      
+
       // Simulate image error (query by alt text since role might be presentation)
       const image = screen.getByAltText("broken image");
       fireEvent.error(image);
-      
+
       // Should show error message and hide image
       await waitFor(() => {
         expect(screen.getByText(/Failed to load image/)).toBeInTheDocument();
         expect(screen.queryByAltText("broken image")).not.toBeInTheDocument();
       });
-      
+
       // Load button should be available again
       expect(screen.getByText("Load Image")).toBeInTheDocument();
     });
 
     it("should pass through title and className props", () => {
       render(
-        <SecureImageComponent 
-          src="https://example.com/image.jpg" 
+        <SecureImageComponent
+          src="https://example.com/image.jpg"
           alt="test image"
           title="Image title"
           className="custom-class"
-        />
+        />,
       );
-      
+
       // Click load button
       fireEvent.click(screen.getByText("Load Image"));
-      
+
       // Check image has title (query by alt text)
       const image = screen.getByAltText("test image");
       expect(image).toHaveAttribute("title", "Image title");
-      
+
       // Check container has className
       const container = image.parentElement;
       expect(container).toHaveClass("custom-class");
@@ -133,14 +149,14 @@ describe("SecureImageComponent", () => {
   describe("Security features", () => {
     it("should display query parameters as JSON for transparency", () => {
       render(
-        <SecureImageComponent 
-          src="https://malicious.com/track.gif?email=user@example.com&id=12345&action=view" 
-        />
+        <SecureImageComponent src="https://malicious.com/track.gif?email=user@example.com&id=12345&action=view" />,
       );
-      
+
       // Should show all parameters clearly
-      expect(screen.getByText(/Warning: URL contains query parameters/)).toBeInTheDocument();
-      
+      expect(
+        screen.getByText(/Warning: URL contains query parameters/),
+      ).toBeInTheDocument();
+
       // Check JSON is properly formatted
       const preElement = screen.getByText(/"email": "user@example.com"/);
       expect(preElement).toBeInTheDocument();
@@ -150,47 +166,47 @@ describe("SecureImageComponent", () => {
 
     it("should handle encoded query parameters", () => {
       render(
-        <SecureImageComponent 
-          src="https://example.com/img.png?data=%7B%22user%22%3A%22test%22%7D" 
-        />
+        <SecureImageComponent src="https://example.com/img.png?data=%7B%22user%22%3A%22test%22%7D" />,
       );
-      
+
       // Should decode and display the parameter
-      expect(screen.getByText(/Warning: URL contains query parameters/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Warning: URL contains query parameters/),
+      ).toBeInTheDocument();
       // The decoded value should be shown in the pre element
-      const preElement = document.querySelector('pre');
+      const preElement = document.querySelector("pre");
       expect(preElement).toBeTruthy();
       // Check that the JSON contains the decoded data
       expect(preElement?.textContent).toContain('"data"');
       // The value is decoded as a string containing JSON
       expect(preElement?.textContent).toContain('"{');
-      expect(preElement?.textContent).toContain('user');
-      expect(preElement?.textContent).toContain('test');
+      expect(preElement?.textContent).toContain("user");
+      expect(preElement?.textContent).toContain("test");
     });
   });
 
   describe("Alt text handling", () => {
     it("should use empty string for alt when not provided", () => {
       render(<SecureImageComponent src="https://example.com/image.jpg" />);
-      
+
       fireEvent.click(screen.getByText("Load Image"));
-      
+
       // Query by tag name since empty alt makes it role="presentation"
-      const images = document.querySelectorAll('img');
+      const images = document.querySelectorAll("img");
       expect(images.length).toBe(1);
       expect(images[0]).toHaveAttribute("alt", "");
     });
 
     it("should use provided alt text", () => {
       render(
-        <SecureImageComponent 
-          src="https://example.com/image.jpg" 
+        <SecureImageComponent
+          src="https://example.com/image.jpg"
           alt="Description of image"
-        />
+        />,
       );
-      
+
       fireEvent.click(screen.getByText("Load Image"));
-      
+
       const image = screen.getByAltText("Description of image");
       expect(image).toHaveAttribute("alt", "Description of image");
     });

--- a/gui/src/components/StyledMarkdownPreview/SecureImageComponent.tsx
+++ b/gui/src/components/StyledMarkdownPreview/SecureImageComponent.tsx
@@ -1,0 +1,169 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import {
+  lightGray,
+  vscBackground,
+  vscButtonBackground,
+  vscButtonForeground,
+  vscForeground,
+  vscInputBorder,
+} from "../";
+
+const ImagePlaceholder = styled.div`
+  border: 1px solid ${vscInputBorder};
+  border-radius: 4px;
+  padding: 12px;
+  margin: 8px 0;
+  background-color: ${vscBackground};
+  display: inline-block;
+  max-width: 100%;
+`;
+
+const WarningText = styled.div`
+  color: ${lightGray};
+  font-size: 12px;
+  margin-bottom: 8px;
+`;
+
+const UrlDisplay = styled.div`
+  font-family: var(--vscode-editor-font-family);
+  font-size: 12px;
+  color: ${vscForeground};
+  word-break: break-all;
+  margin: 8px 0;
+  padding: 8px;
+  background-color: rgba(0, 0, 0, 0.1);
+  border-radius: 3px;
+`;
+
+const QueryParamsDisplay = styled.div`
+  font-family: var(--vscode-editor-font-family);
+  font-size: 11px;
+  color: ${vscForeground};
+  margin: 8px 0;
+  padding: 8px;
+  background-color: rgba(128, 128, 128, 0.1);
+  border-radius: 3px;
+  border: 1px solid ${lightGray};
+`;
+
+const LoadButton = styled.button`
+  background-color: ${vscButtonBackground};
+  color: ${vscButtonForeground};
+  border: 1px solid ${vscInputBorder};
+  padding: 6px 12px;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 12px;
+  margin-top: 8px;
+
+  &:hover {
+    opacity: 0.9;
+  }
+
+  &:active {
+    transform: translateY(1px);
+  }
+`;
+
+const ImageContainer = styled.div`
+  max-width: 100%;
+  display: inline-block;
+  
+  img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+  }
+`;
+
+interface SecureImageComponentProps {
+  src?: string;
+  alt?: string;
+  title?: string;
+  className?: string;
+}
+
+export const SecureImageComponent: React.FC<SecureImageComponentProps> = ({
+  src,
+  alt,
+  title,
+  className,
+}) => {
+  const [showImage, setShowImage] = useState(false);
+  const [imageError, setImageError] = useState(false);
+
+  if (!src) {
+    return <span>[Invalid image: no source]</span>;
+  }
+
+  // Parse URL to check for query parameters
+  let queryParams: Record<string, string> = {};
+  let hasQueryParams = false;
+  
+  try {
+    const url = new URL(src, window.location.href);
+    const params = new URLSearchParams(url.search);
+    params.forEach((value, key) => {
+      queryParams[key] = value;
+      hasQueryParams = true;
+    });
+  } catch (e) {
+    // If URL parsing fails, treat src as a relative path
+    const queryIndex = src.indexOf('?');
+    if (queryIndex > -1) {
+      hasQueryParams = true;
+      const params = new URLSearchParams(src.substring(queryIndex));
+      params.forEach((value, key) => {
+        queryParams[key] = value;
+      });
+    }
+  }
+
+  if (showImage && !imageError) {
+    return (
+      <ImageContainer className={className}>
+        <img
+          src={src}
+          alt={alt || ""}
+          title={title}
+          onError={() => {
+            setImageError(true);
+            setShowImage(false);
+          }}
+        />
+      </ImageContainer>
+    );
+  }
+
+  return (
+    <ImagePlaceholder>
+      <WarningText>
+        Image blocked for security. Click to load if you trust the source.
+      </WarningText>
+      
+      <UrlDisplay>
+        <strong>URL:</strong> {src}
+      </UrlDisplay>
+      
+      {hasQueryParams && (
+        <QueryParamsDisplay>
+          <strong>Warning: URL contains query parameters:</strong>
+          <pre style={{ margin: "4px 0", fontSize: "11px" }}>
+            {JSON.stringify(queryParams, null, 2)}
+          </pre>
+        </QueryParamsDisplay>
+      )}
+      
+      {imageError && (
+        <div style={{ color: lightGray, fontSize: "12px", marginTop: "8px" }}>
+          Failed to load image. The URL may be invalid or inaccessible.
+        </div>
+      )}
+      
+      <LoadButton onClick={() => setShowImage(true)}>
+        Load Image {hasQueryParams && "(Contains Parameters)"}
+      </LoadButton>
+    </ImagePlaceholder>
+  );
+};

--- a/gui/src/components/StyledMarkdownPreview/SecureImageComponent.tsx
+++ b/gui/src/components/StyledMarkdownPreview/SecureImageComponent.tsx
@@ -139,7 +139,8 @@ export const SecureImageComponent: React.FC<SecureImageComponentProps> = ({
   return (
     <ImagePlaceholder>
       <WarningText>
-        Image blocked for security. External images can leak data through URL parameters. Click to load if you trust the source.
+        Image blocked for security. External images can leak data through URL
+        parameters. Click to load if you trust the source.
       </WarningText>
 
       <UrlDisplay>

--- a/gui/src/components/StyledMarkdownPreview/SecureImageComponent.tsx
+++ b/gui/src/components/StyledMarkdownPreview/SecureImageComponent.tsx
@@ -162,7 +162,7 @@ export const SecureImageComponent: React.FC<SecureImageComponentProps> = ({
       )}
       
       <LoadButton onClick={() => setShowImage(true)}>
-        Load Image {hasQueryParams && "(Contains Parameters)"}
+        Load Image
       </LoadButton>
     </ImagePlaceholder>
   );

--- a/gui/src/components/StyledMarkdownPreview/SecureImageComponent.tsx
+++ b/gui/src/components/StyledMarkdownPreview/SecureImageComponent.tsx
@@ -69,7 +69,7 @@ const LoadButton = styled.button`
 const ImageContainer = styled.div`
   max-width: 100%;
   display: inline-block;
-  
+
   img {
     max-width: 100%;
     height: auto;
@@ -100,7 +100,7 @@ export const SecureImageComponent: React.FC<SecureImageComponentProps> = ({
   // Parse URL to check for query parameters
   let queryParams: Record<string, string> = {};
   let hasQueryParams = false;
-  
+
   try {
     const url = new URL(src, window.location.href);
     const params = new URLSearchParams(url.search);
@@ -110,7 +110,7 @@ export const SecureImageComponent: React.FC<SecureImageComponentProps> = ({
     });
   } catch (e) {
     // If URL parsing fails, treat src as a relative path
-    const queryIndex = src.indexOf('?');
+    const queryIndex = src.indexOf("?");
     if (queryIndex > -1) {
       hasQueryParams = true;
       const params = new URLSearchParams(src.substring(queryIndex));
@@ -141,11 +141,11 @@ export const SecureImageComponent: React.FC<SecureImageComponentProps> = ({
       <WarningText>
         Image blocked for security. Click to load if you trust the source.
       </WarningText>
-      
+
       <UrlDisplay>
         <strong>URL:</strong> {src}
       </UrlDisplay>
-      
+
       {hasQueryParams && (
         <QueryParamsDisplay>
           <strong>Warning: URL contains query parameters:</strong>
@@ -154,16 +154,14 @@ export const SecureImageComponent: React.FC<SecureImageComponentProps> = ({
           </pre>
         </QueryParamsDisplay>
       )}
-      
+
       {imageError && (
         <div style={{ color: lightGray, fontSize: "12px", marginTop: "8px" }}>
           Failed to load image. The URL may be invalid or inaccessible.
         </div>
       )}
-      
-      <LoadButton onClick={() => setShowImage(true)}>
-        Load Image
-      </LoadButton>
+
+      <LoadButton onClick={() => setShowImage(true)}>Load Image</LoadButton>
     </ImagePlaceholder>
   );
 };

--- a/gui/src/components/StyledMarkdownPreview/SecureImageComponent.tsx
+++ b/gui/src/components/StyledMarkdownPreview/SecureImageComponent.tsx
@@ -139,7 +139,7 @@ export const SecureImageComponent: React.FC<SecureImageComponentProps> = ({
   return (
     <ImagePlaceholder>
       <WarningText>
-        Image blocked for security. Click to load if you trust the source.
+        Image blocked for security. External images can leak data through URL parameters. Click to load if you trust the source.
       </WarningText>
 
       <UrlDisplay>

--- a/gui/src/components/StyledMarkdownPreview/index.tsx
+++ b/gui/src/components/StyledMarkdownPreview/index.tsx
@@ -23,6 +23,7 @@ import "./katex.css";
 import "./markdown.css";
 import MermaidBlock from "./MermaidBlock";
 import { rehypeHighlightPlugin } from "./rehypeHighlightPlugin";
+import { SecureImageComponent } from "./SecureImageComponent";
 import { StepContainerPreToolbar } from "./StepContainerPreToolbar";
 import SymbolLink from "./SymbolLink";
 import { SyntaxHighlightedPre } from "./SyntaxHighlightedPre";
@@ -345,6 +346,16 @@ const StyledMarkdownPreview = memo(function StyledMarkdownPreview(
             return <MermaidBlock code={codeText} />;
           }
           return <code {...codeProps}>{codeProps.children}</code>;
+        },
+        img: ({ ...imgProps }) => {
+          return (
+            <SecureImageComponent
+              src={imgProps.src}
+              alt={imgProps.alt}
+              title={imgProps.title}
+              className={imgProps.className}
+            />
+          );
         },
       },
     },


### PR DESCRIPTION
## Description

Prevent zero click image rendering

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Block zero‑click image rendering in the Markdown preview to prevent automatic external requests and tracking. Images now show a safe placeholder with the URL and a clear option to load.

- **New Features**
  - Added SecureImageComponent that blocks images by default and requires an explicit click to load.
  - Shows the full URL and warns when query parameters are present (rendered as JSON for visibility).
  - Handles invalid/malformed URLs and image load errors, reverting to the placeholder with a clear message.
  - Preserves alt/title/className when the image is displayed.
  - Integrated into StyledMarkdownPreview by overriding img rendering, with tests covering default blocking, query params, interactions, and errors.

<!-- End of auto-generated description by cubic. -->

