### PR TITLE
chore: bold Rules to match other headers IntroMessage

### DIFF
--- a/binary/package-lock.json
+++ b/binary/package-lock.json
@@ -40,7 +40,7 @@
         "pkg": "^5.8.1",
         "rimraf": "^5.0.7",
         "ts-jest": "^29.1.4",
-        "typescript": "^5.3.3"
+        "typescript": "^5.6.3"
       }
     },
     "../core": {
@@ -59,6 +59,11 @@
         "@modelcontextprotocol/sdk": "^1.12.0",
         "@mozilla/readability": "^0.5.0",
         "@octokit/rest": "^20.1.1",
+        "@sentry/cli": "^2.50.2",
+        "@sentry/core": "^9.43.0",
+        "@sentry/esbuild-plugin": "^4.0.2",
+        "@sentry/node": "^9.43.0",
+        "@sentry/vite-plugin": "^4.0.2",
         "@typescript-eslint/eslint-plugin": "^7.8.0",
         "@xenova/transformers": "2.14.0",
         "adf-to-md": "^1.1.0",
@@ -91,7 +96,7 @@
         "node-html-markdown": "^1.3.0",
         "ollama": "^0.4.6",
         "onnxruntime-node": "1.14.0",
-        "openai": "^4.104.0",
+        "openai": "^5.13.1",
         "p-limit": "^6.1.0",
         "partial-json": "^0.1.7",
         "pg": "^8.11.3",
@@ -6758,10 +6763,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/extensions/cli/src/ui/IntroMessage.tsx
+++ b/extensions/cli/src/ui/IntroMessage.tsx
@@ -85,7 +85,9 @@ const IntroMessage: React.FC<IntroMessageProps> = ({
       {/* Rules */}
       {allRules.length > 0 && (
         <>
-          <Text color="blue">Rules:</Text>
+          <Text bold color="blue">
+            Rules:
+          </Text>
           {allRules.map((rule, index) => (
             <Text key={index}>
               - <Text color="white">{rule}</Text>


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Bolded the "Rules:" header in the CLI IntroMessage to match other headers and improve visual consistency.

<!-- End of auto-generated description by cubic. -->

