### PR TITLE
chore: vscode 1.1.82

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "1.1.81",
+  "version": "1.1.82",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION
## Description
Vs code version bump
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Bumped the VS Code extension version from 1.1.80 to 1.1.82 to prep a patch release. No functional changes; metadata-only update for Marketplace publishing.

<!-- End of auto-generated description by cubic. -->

