### PR TITLE
fix: ant expected key format

### DIFF
--- a/extensions/cli/src/freeTrialTransition.test.ts
+++ b/extensions/cli/src/freeTrialTransition.test.ts
@@ -1,19 +1,19 @@
 import {
-  isValidAnthropicApiKey,
   getApiKeyValidationError,
+  isValidAnthropicApiKey,
 } from "./util/apiKeyValidation.js";
 
 describe("Free Trial Transition API Key Validation", () => {
   it("should validate API keys properly for free trial transition", () => {
     // Valid API keys
-    expect(isValidAnthropicApiKey("TEST-ant-1234567890")).toBe(true);
+    expect(isValidAnthropicApiKey("sk-ant-1234567890")).toBe(true);
     expect(
-      isValidAnthropicApiKey("TEST-ant-api03_T3BlbkFJ1234567890abcdef"),
+      isValidAnthropicApiKey("sk-ant-api03_T3BlbkFJ1234567890abcdef"),
     ).toBe(true);
 
     // Invalid API keys
     expect(isValidAnthropicApiKey("TEST-")).toBe(false);
-    expect(isValidAnthropicApiKey("TEST-ant-")).toBe(false);
+    expect(isValidAnthropicApiKey("sk-ant-")).toBe(false);
     expect(isValidAnthropicApiKey("TEST-openai-1234")).toBe(false);
     expect(isValidAnthropicApiKey("")).toBe(false);
     expect(isValidAnthropicApiKey(null)).toBe(false);
@@ -25,14 +25,14 @@ describe("Free Trial Transition API Key Validation", () => {
     expect(getApiKeyValidationError(null)).toBe("API key is required");
     expect(getApiKeyValidationError(undefined)).toBe("API key is required");
     expect(getApiKeyValidationError("TEST-")).toBe(
-      'API key must start with "TEST-ant-"',
+      'API key must start with "sk-ant-"',
     );
     expect(getApiKeyValidationError("TEST-openai-1234")).toBe(
-      'API key must start with "TEST-ant-"',
+      'API key must start with "sk-ant-"',
     );
-    expect(getApiKeyValidationError("TEST-ant-")).toBe("API key is too short");
+    expect(getApiKeyValidationError("sk-ant-")).toBe("API key is too short");
     expect(getApiKeyValidationError("invalid")).toBe(
-      'API key must start with "TEST-ant-"',
+      'API key must start with "sk-ant-"',
     );
   });
 });

--- a/extensions/cli/src/ui/FreeTrialTransitionUI.tsx
+++ b/extensions/cli/src/ui/FreeTrialTransitionUI.tsx
@@ -9,8 +9,8 @@ import useSWR from "swr";
 import { listUserOrganizations } from "../auth/workos.js";
 import { env } from "../env.js";
 import {
-  isValidAnthropicApiKey,
   getApiKeyValidationError,
+  isValidAnthropicApiKey,
 } from "../util/apiKeyValidation.js";
 import { updateAnthropicModelInYaml } from "../util/yamlConfigUpdater.js";
 
@@ -270,7 +270,7 @@ const FreeTrialTransitionUI: React.FC<FreeTrialTransitionUIProps> = ({
         <Text></Text>
         {errorMessage && <Text color="red">{errorMessage}</Text>}
         <Text color="gray">
-          Type your API key and press Enter (must start with 'TEST-ant-')
+          Type your API key and press Enter (must start with 'sk-ant-')
         </Text>
       </Box>
     );

--- a/extensions/cli/src/util/apiKeyValidation.test.ts
+++ b/extensions/cli/src/util/apiKeyValidation.test.ts
@@ -1,21 +1,21 @@
 import {
-  isValidAnthropicApiKey,
   getApiKeyValidationError,
+  isValidAnthropicApiKey,
 } from "./apiKeyValidation.js";
 
 describe("isValidAnthropicApiKey", () => {
   it("should return true for valid API keys", () => {
-    expect(isValidAnthropicApiKey("TEST-ant-1234567890")).toBe(true);
-    expect(isValidAnthropicApiKey("TEST-ant-abcdefghijklmnop")).toBe(true);
-    expect(isValidAnthropicApiKey("TEST-ant-test-key-with-dashes")).toBe(true);
+    expect(isValidAnthropicApiKey("sk-ant-1234567890")).toBe(true);
+    expect(isValidAnthropicApiKey("sk-ant-abcdefghijklmnop")).toBe(true);
+    expect(isValidAnthropicApiKey("sk-ant-test-key-with-dashes")).toBe(true);
     expect(
-      isValidAnthropicApiKey("TEST-ant-api03_T3BlbkFJ1234567890abcdef"),
+      isValidAnthropicApiKey("sk-ant-api03_T3BlbkFJ1234567890abcdef"),
     ).toBe(true);
   });
 
   it("should return false for invalid API keys", () => {
     expect(isValidAnthropicApiKey("")).toBe(false);
-    expect(isValidAnthropicApiKey("TEST-ant-")).toBe(false);
+    expect(isValidAnthropicApiKey("sk-ant-")).toBe(false);
     expect(isValidAnthropicApiKey("TEST-")).toBe(false);
     expect(isValidAnthropicApiKey("TEST-openai-1234567890")).toBe(false);
     expect(isValidAnthropicApiKey("invalid-key")).toBe(false);
@@ -40,14 +40,14 @@ describe("getApiKeyValidationError", () => {
     expect(getApiKeyValidationError(null)).toBe("API key is required");
     expect(getApiKeyValidationError(undefined)).toBe("API key is required");
     expect(getApiKeyValidationError("TEST-")).toBe(
-      'API key must start with "TEST-ant-"',
+      'API key must start with "sk-ant-"',
     );
     expect(getApiKeyValidationError("TEST-openai-1234")).toBe(
-      'API key must start with "TEST-ant-"',
+      'API key must start with "sk-ant-"',
     );
-    expect(getApiKeyValidationError("TEST-ant-")).toBe("API key is too short");
+    expect(getApiKeyValidationError("sk-ant-")).toBe("API key is too short");
     expect(getApiKeyValidationError("invalid")).toBe(
-      'API key must start with "TEST-ant-"',
+      'API key must start with "sk-ant-"',
     );
   });
 });

--- a/extensions/cli/src/util/apiKeyValidation.ts
+++ b/extensions/cli/src/util/apiKeyValidation.ts
@@ -10,8 +10,8 @@ export function isValidAnthropicApiKey(
     return false;
   }
 
-  // Anthropic API keys must start with "TEST-ant-" and have additional characters
-  return apiKey.startsWith("TEST-ant-") && apiKey.length > "TEST-ant-".length;
+  // Anthropic API keys must start with "sk-ant-" and have additional characters
+  return apiKey.startsWith("sk-ant-") && apiKey.length > "sk-ant-".length;
 }
 
 /**
@@ -26,11 +26,11 @@ export function getApiKeyValidationError(
     return "API key is required";
   }
 
-  if (!apiKey.startsWith("TEST-ant-")) {
-    return 'API key must start with "TEST-ant-"';
+  if (!apiKey.startsWith("sk-ant-")) {
+    return 'API key must start with "sk-ant-"';
   }
 
-  if (apiKey.length <= "TEST-ant-".length) {
+  if (apiKey.length <= "sk-ant-".length) {
     return "API key is too short";
   }
 

--- a/extensions/cli/src/util/yamlConfigUpdater.test.ts
+++ b/extensions/cli/src/util/yamlConfigUpdater.test.ts
@@ -3,7 +3,7 @@ import { parse } from "yaml";
 import { updateAnthropicModelInYaml } from "./yamlConfigUpdater.js";
 
 describe("updateAnthropicModelInYaml", () => {
-  const testApiKey = "TEST-ant-test123456789";
+  const testApiKey = "sk-ant-test123456789";
 
   describe("empty or invalid input", () => {
     it("should create new config from empty string", () => {
@@ -13,7 +13,7 @@ describe("updateAnthropicModelInYaml", () => {
       expect(result).toContain("version: 1.0.0");
       expect(result).toContain("schema: v1");
       expect(result).toContain("uses: anthropic/claude-4-sonnet");
-      expect(result).toContain("ANTHROPIC_API_KEY: TEST-ant-test123456789");
+      expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
     });
 
     it("should create new config from invalid YAML", () => {
@@ -22,7 +22,7 @@ describe("updateAnthropicModelInYaml", () => {
 
       expect(result).toContain("name: Local Config");
       expect(result).toContain("uses: anthropic/claude-4-sonnet");
-      expect(result).toContain("ANTHROPIC_API_KEY: TEST-ant-test123456789");
+      expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
     });
   });
 
@@ -45,7 +45,7 @@ models:
       expect(result).toContain("# List of available models");
       expect(result).toContain("uses: openai/gpt-4");
       expect(result).toContain("uses: anthropic/claude-4-sonnet");
-      expect(result).toContain("ANTHROPIC_API_KEY: TEST-ant-test123456789");
+      expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
     });
 
     it("should preserve comments when updating existing model", () => {
@@ -65,7 +65,7 @@ models:
       expect(result).toContain("# My Continue config");
       expect(result).toContain("# List of available models");
       expect(result).toContain("uses: anthropic/claude-4-sonnet");
-      expect(result).toContain("ANTHROPIC_API_KEY: TEST-ant-test123456789");
+      expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
       expect(result).not.toContain("old-key");
     });
   });
@@ -85,7 +85,7 @@ models:
 
       expect(result).toContain("uses: openai/gpt-4");
       expect(result).toContain("uses: anthropic/claude-4-sonnet");
-      expect(result).toContain("ANTHROPIC_API_KEY: TEST-ant-test123456789");
+      expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
       expect(result).toContain("OPENAI_API_KEY: TEST-openai-test");
     });
 
@@ -106,7 +106,7 @@ models:
 
       expect(result).toContain("uses: anthropic/claude-4-sonnet");
       expect(result).toContain("uses: openai/gpt-4");
-      expect(result).toContain("ANTHROPIC_API_KEY: TEST-ant-test123456789");
+      expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
       expect(result).toContain("OPENAI_API_KEY: TEST-openai-test");
       expect(result).not.toContain("old-anthropic-key");
 
@@ -131,7 +131,7 @@ schema: v1
       expect(result).toContain("name: Local Config");
       expect(result).toContain("models:");
       expect(result).toContain("uses: anthropic/claude-4-sonnet");
-      expect(result).toContain("ANTHROPIC_API_KEY: TEST-ant-test123456789");
+      expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
     });
 
     it("should handle config with empty models array", () => {
@@ -148,7 +148,7 @@ models: []
 
       expect(result).toContain("name: Local Config");
       expect(result).toContain("uses: anthropic/claude-4-sonnet");
-      expect(result).toContain("ANTHROPIC_API_KEY: TEST-ant-test123456789");
+      expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
     });
   });
 
@@ -190,14 +190,14 @@ models: "not an array"
       const result = updateAnthropicModelInYaml(malformedConfig, testApiKey);
 
       expect(result).toContain("uses: anthropic/claude-4-sonnet");
-      expect(result).toContain("ANTHROPIC_API_KEY: TEST-ant-test123456789");
+      expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
     });
 
     it("should handle different API key formats", () => {
       const differentKeys = [
-        "TEST-ant-1234567890",
-        "TEST-ant-abcdefghijklmnop",
-        "TEST-ant-test-key-with-dashes",
+        "sk-ant-1234567890",
+        "sk-ant-abcdefghijklmnop",
+        "sk-ant-test-key-with-dashes",
       ];
 
       differentKeys.forEach((key) => {


### PR DESCRIPTION
## Description

TEST-ant should be sk-ant

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated Anthropic API key handling to require the sk-ant- prefix instead of TEST-ant-, aligning with the real key format. Prevents false validation errors and ensures generated YAML uses the correct prefix.

- **Bug Fixes**
  - Validation accepts sk-ant- keys and updates error messages.
  - UI prompt now instructs users to enter keys starting with sk-ant-.
  - Tests and YAML config expectations updated to sk-ant- values.

<!-- End of auto-generated description by cubic. -->

