### PR TITLE
fix: node types in oai adapters

### DIFF
--- a/packages/openai-adapters/package-lock.json
+++ b/packages/openai-adapters/package-lock.json
@@ -32,6 +32,7 @@
         "@types/follow-redirects": "^1.14.4",
         "@types/jest": "^29.5.14",
         "@types/json-schema": "^7.0.15",
+        "@types/node": "^24.3.0",
         "cross-env": "^7.0.3",
         "semantic-release": "^24.2.7",
         "ts-jest": "^29.2.3",
@@ -1369,7 +1370,7 @@
       "version": "1.0.14",
       "license": "Apache-2.0",
       "dependencies": {
-        "zod": "^3.24.2"
+        "zod": "^3.23.8"
       }
     },
     "node_modules/@continuedev/config-yaml": {
@@ -4021,13 +4022,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
-      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.8.0"
+        "undici-types": "~7.10.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -12549,9 +12550,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "dev": true,
       "license": "MIT"
     },

--- a/packages/openai-adapters/package.json
+++ b/packages/openai-adapters/package.json
@@ -35,6 +35,7 @@
     "@types/follow-redirects": "^1.14.4",
     "@types/jest": "^29.5.14",
     "@types/json-schema": "^7.0.15",
+    "@types/node": "^24.3.0",
     "cross-env": "^7.0.3",
     "semantic-release": "^24.2.7",
     "ts-jest": "^29.2.3",


### PR DESCRIPTION
## Description

add types/node to oai adapters to fix beta release
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added @types/node (^24.3.0) to openai-adapters to restore Node type resolution and fix the beta release build. Updated the lockfile accordingly (undici-types aligned) so TypeScript compilation succeeds.

<!-- End of auto-generated description by cubic. -->

