### PR TITLE
fix: properly build packages for cli releases

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -30,7 +30,16 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           always-auth: true
 
-      - name: Install dependencies
+      - name: Setup packages
+        uses: ./.github/actions/setup-packages
+
+      - name: Setup core component
+        uses: ./.github/actions/setup-component
+        with:
+          component: core
+          include-root: true
+
+      - name: Install CLI dependencies
         working-directory: extensions/cli
         run: npm ci
         env:

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -141,6 +141,17 @@ jobs:
           # Update version to stable (remove beta suffix)
           npm version ${{ steps.find_beta.outputs.stable_version }} --no-git-tag-version
 
+      - name: Setup packages (for direct stable release)
+        if: ${{ inputs.release_type == 'direct-stable' }}
+        uses: ./.github/actions/setup-packages
+
+      - name: Setup core component (for direct stable release)
+        if: ${{ inputs.release_type == 'direct-stable' }}
+        uses: ./.github/actions/setup-component
+        with:
+          component: core
+          include-root: true
+
       - name: Prepare package for direct stable release
         if: ${{ inputs.release_type == 'direct-stable' }}
         working-directory: extensions/cli


### PR DESCRIPTION
## Description

properly build packages for cli releases
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the CLI release workflows so the CLI is built with the monorepo packages and core component before publishing. Prevents missing core artifacts in beta and direct stable releases.

- **Bug Fixes**
  - Beta workflow: add setup-packages and setup-component (core, include-root) before installing CLI deps.
  - Stable workflow: add the same setup steps when release_type == "direct-stable".
  - Result: CLI builds correctly and includes core before publishing to npm.

<!-- End of auto-generated description by cubic. -->

