### PR TITLE
fix: update broken links to Next Edit documentation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1099,6 +1099,10 @@
     {
       "source": "/customize/model-providers",
       "destination": "/customize/model-providers/overview"
+    },
+    {
+      "source": "/features/edit/next-edit",
+      "destination": "/features/autocomplete/next-edit"
     }
   ]
 }

--- a/docs/features/autocomplete/model-setup.mdx
+++ b/docs/features/autocomplete/model-setup.mdx
@@ -52,7 +52,7 @@ This model provides good suggestions while keeping your code completely private.
 
 ## Next Edit Model
 
-For proactive code prediction that anticipates your next edit, Continue supports specialized [Next Edit](/features/edit/next-edit) models:
+For proactive code prediction that anticipates your next edit, Continue supports specialized [Next Edit](/features/autocomplete/next-edit) models:
 
 **Supported Next Edit model:**
 

--- a/docs/features/edit/how-it-works.mdx
+++ b/docs/features/edit/how-it-works.mdx
@@ -14,7 +14,7 @@ When you start an edit session, Continue:
 If you accept the diff, we remove the previously highlighted lines, and if you reject the diff, we remove the proposed changes.
 
 <Info>
-**Looking for AI that predicts your next edit?** Check out [Next Edit](/features/edit/next-edit), an experimental feature that proactively suggests code changes before you even start typing, going beyond traditional autocomplete to anticipate entire code modifications.
+**Looking for AI that predicts your next edit?** Check out [Next Edit](/features/autocomplete/next-edit), an experimental feature that proactively suggests code changes before you even start typing, going beyond traditional autocomplete to anticipate entire code modifications.
 </Info>
 
 If you would like to view the exact prompt that is sent to the model during an edit, you can [find it in the prompt logs](/troubleshooting#check-the-logs).


### PR DESCRIPTION
## Summary

This PR fixes broken links reported by Mintlify that were pointing to incorrect paths for the Next Edit documentation.

## Changes

- Fixed broken: 
  - From: /features/edit/next-edit
  - To: /features/autocomplete/next-edit

## Context

The Next Edit documentation is located in the autocomplete section (), not the edit section. This was causing Mintlify to report these as broken links.

## Testing

- [ ] Verified that the links now point to the correct location
- [ ] Confirmed that  exists and contains the Next Edit documentation
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix broken links to the Next Edit docs by updating references from /features/edit/next-edit to /features/autocomplete/next-edit in two pages. This resolves Mintlify reports and points users to the correct docs.

<!-- End of auto-generated description by cubic. -->

