### PR TITLE
fix: keep assistant menu open when clicking 'Reload agents'

### DIFF
--- a/gui/src/components/AssistantAndOrgListbox/index.tsx
+++ b/gui/src/components/AssistantAndOrgListbox/index.tsx
@@ -176,9 +176,10 @@ export function AssistantAndOrgListbox() {
                 value="reload-assistant"
                 fontSizeModifier={-2}
                 className="border-border border-b px-2 py-1.5"
-                onClick={() =>
-                  refreshProfiles("Manual refresh from assistant list")
-                }
+                onClick={(e) => {
+                  e.stopPropagation();
+                  refreshProfiles("Manual refresh from assistant list");
+                }}
               >
                 <span
                   className="text-description flex flex-row items-center"

--- a/scratchpad.txt
+++ b/scratchpad.txt
@@ -1,0 +1,5 @@
+- [x] Find the Reload assistants functionality in the codebase
+- [x] Identify where the menu close behavior is implemented
+- [x] Modify the code to keep menu open for Reload assistants option
+- [x] Test the changes to ensure they work correctly
+- [ ] Create PR with the changes


### PR DESCRIPTION
Prevents the assistants dropdown menu from closing when the user clicks the 'Reload agents' option by using stopPropagation() to prevent event bubbling to the parent component that handles menu closure.

Previously, clicking 'Reload agents' would immediately close the menu, making it impossible to see the loading state or perform subsequent actions without reopening the menu. Now the menu stays open as expected for this action.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Keeps the Assistants dropdown open when "Reload assistants" is clicked, so the loading state stays visible and you can take follow-up actions without reopening the menu. Prevents click event bubbling to the parent close handler.

<!-- End of auto-generated description by cubic. -->

