### PR TITLE
feat: change blue UI elements to yellow in assistant sidebar

### DIFF
--- a/gui/src/styles/theme.ts
+++ b/gui/src/styles/theme.ts
@@ -29,7 +29,7 @@ export const THEME_COLORS = {
   },
   "primary-background": {
     vars: ["--vscode-button-background"],
-    default: "#2c5aa0", // medium blue
+    default: "#ffc107", // yellow
   },
   "primary-foreground": {
     vars: ["--vscode-button-foreground"],
@@ -37,7 +37,7 @@ export const THEME_COLORS = {
   },
   "primary-hover": {
     vars: ["--vscode-button-hoverBackground"],
-    default: "#3a6db3", // lighter blue
+    default: "#ffb300", // darker yellow
   },
   "secondary-background": {
     vars: ["--vscode-button-secondaryBackground"],
@@ -57,7 +57,7 @@ export const THEME_COLORS = {
   },
   "border-focus": {
     vars: ["--vscode-focusBorder"],
-    default: "#3a6db3", // lighter blue
+    default: "#ffc107", // yellow
   },
   // Command styles are used for tip-tap editor
   "command-background": {
@@ -74,7 +74,7 @@ export const THEME_COLORS = {
   },
   "command-border-focus": {
     vars: ["--vscode-commandCenter-activeBorder"],
-    default: "#4d8bf0", // bright blue
+    default: "#ffc107", // yellow
   },
   description: {
     vars: ["--vscode-descriptionForeground"],
@@ -138,7 +138,7 @@ export const THEME_COLORS = {
   },
   link: {
     vars: ["--vscode-textLink-foreground"],
-    default: "#5c9ce6", // medium blue
+    default: "#ffc107", // yellow
   },
   textCodeBlockBackground: {
     vars: ["--vscode-textCodeBlock-background"],
@@ -146,11 +146,11 @@ export const THEME_COLORS = {
   },
   accent: {
     vars: ["--vscode-tab-activeBorderTop", "--vscode-focusBorder"],
-    default: "#4d8bf0", // bright blue
+    default: "#ffc107", // yellow
   },
   "find-match": {
     vars: ["--vscode-editor-findMatchBackground"], // Can't get "var(--vscode-editor-findMatchBackground, rgba(237, 18, 146, 0.5))" to work
-    default: "#264f7840", // translucent blue
+    default: "#ffc10740", // translucent yellow
   },
   "find-match-selected": {
     vars: ["--vscode-editor-findMatchHighlightBackground"],
@@ -163,7 +163,7 @@ export const THEME_COLORS = {
   },
   "list-active": {
     vars: ["--vscode-list-activeSelectionBackground"],
-    default: "#2c5aa050", // translucent medium blue
+    default: "#ffeb3b50", // translucent yellow
   },
   "list-active-foreground": {
     vars: ["--vscode-list-activeSelectionForeground"],

--- a/scratchpad.txt
+++ b/scratchpad.txt
@@ -1,0 +1,6 @@
+- [x] Analyze codebase structure to understand UI components
+- [x] Find blue color references in the assistant/sidebar UI
+- [x] Change blue to yellow in the relevant files
+- [x] Verify changes are correct
+- [ ] Create branch and commit changes
+- [ ] Send summary via Slack


### PR DESCRIPTION
Changed blue accent colors to yellow throughout the assistant sidebar and UI components. Updated theme colors in gui/src/styles/theme.ts to use yellow (#ffc107) instead of blue variants.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switched the assistant sidebar’s accent color from blue to yellow to match the new design palette. Updated theme variables in gui/src/styles/theme.ts (primary background/hover, focus borders, command active border, links, accent, find-match, and list selection) to use yellow (#ffc107 and variants).

<!-- End of auto-generated description by cubic. -->

