### PR TITLE
feat: plan mode sys prompt

### DIFF
--- a/extensions/cli/src/systemMessage.test.ts
+++ b/extensions/cli/src/systemMessage.test.ts
@@ -151,28 +151,46 @@ Rule 3: Third rule`;
     const result = await constructSystemMessage(undefined, "json");
 
     expect(result).toContain("You are an agent in the Continue CLI");
-    expect(result).toContain("IMPORTANT: You are operating in JSON output mode");
+    expect(result).toContain(
+      "IMPORTANT: You are operating in JSON output mode",
+    );
     expect(result).toContain("Your final response MUST be valid JSON");
     expect(result).toContain("JSON.parse()");
   });
 
   it("should add plan mode instructions when mode is plan", async () => {
-    const result = await constructSystemMessage(undefined, undefined, false, "plan");
+    const result = await constructSystemMessage(
+      undefined,
+      undefined,
+      false,
+      "plan",
+    );
 
     expect(result).toContain("You are an agent in the Continue CLI");
     expect(result).toContain("PLAN MODE: You are operating in plan mode");
-    expect(result).toContain("which means that your goal is to help the user investigate their ideas");
+    expect(result).toContain(
+      "which means that your goal is to help the user investigate their ideas",
+    );
     expect(result).toContain("develop a plan before taking action");
     expect(result).toContain("read-only tools");
-    expect(result).toContain("should not attempt to circumvent them to write / delete / create files");
+    expect(result).toContain(
+      "should not attempt to circumvent them to write / delete / create files",
+    );
   });
 
   it("should not add plan mode instructions when mode is not plan", async () => {
-    const result = await constructSystemMessage(undefined, undefined, false, "normal");
+    const result = await constructSystemMessage(
+      undefined,
+      undefined,
+      false,
+      "normal",
+    );
 
     expect(result).toContain("You are an agent in the Continue CLI");
     expect(result).not.toContain("PLAN MODE: You are operating in plan mode");
-    expect(result).not.toContain("which means that your goal is to help the user investigate their ideas");
+    expect(result).not.toContain(
+      "which means that your goal is to help the user investigate their ideas",
+    );
   });
 
   it("should not add plan mode instructions when mode is undefined", async () => {
@@ -180,11 +198,18 @@ Rule 3: Third rule`;
 
     expect(result).toContain("You are an agent in the Continue CLI");
     expect(result).not.toContain("PLAN MODE: You are operating in plan mode");
-    expect(result).not.toContain("which means that your goal is to help the user investigate their ideas");
+    expect(result).not.toContain(
+      "which means that your goal is to help the user investigate their ideas",
+    );
   });
 
   it("should include basic plan mode description", async () => {
-    const result = await constructSystemMessage(undefined, undefined, false, "plan");
+    const result = await constructSystemMessage(
+      undefined,
+      undefined,
+      false,
+      "plan",
+    );
 
     expect(result).toContain("PLAN MODE: You are operating in plan mode");
     expect(result).toContain("read-only tools");
@@ -192,18 +217,34 @@ Rule 3: Third rule`;
   });
 
   it("should combine plan mode with headless mode instructions", async () => {
-    const result = await constructSystemMessage(undefined, undefined, true, "plan");
+    const result = await constructSystemMessage(
+      undefined,
+      undefined,
+      true,
+      "plan",
+    );
 
     expect(result).toContain("IMPORTANT: You are running in headless mode");
     expect(result).toContain("PLAN MODE: You are operating in plan mode");
-    expect(result).toContain("which means that your goal is to help the user investigate their ideas");
+    expect(result).toContain(
+      "which means that your goal is to help the user investigate their ideas",
+    );
   });
 
   it("should combine plan mode with JSON format instructions", async () => {
-    const result = await constructSystemMessage(undefined, "json", false, "plan");
+    const result = await constructSystemMessage(
+      undefined,
+      "json",
+      false,
+      "plan",
+    );
 
-    expect(result).toContain("IMPORTANT: You are operating in JSON output mode");
+    expect(result).toContain(
+      "IMPORTANT: You are operating in JSON output mode",
+    );
     expect(result).toContain("PLAN MODE: You are operating in plan mode");
-    expect(result).toContain("which means that your goal is to help the user investigate their ideas");
+    expect(result).toContain(
+      "which means that your goal is to help the user investigate their ideas",
+    );
   });
 });

--- a/extensions/cli/src/systemMessage.ts
+++ b/extensions/cli/src/systemMessage.ts
@@ -196,7 +196,7 @@ Example response format:
     systemMessage += `
 
 PLAN MODE: You are operating in plan mode, which means that your goal is to help the user investigate their ideas and develop a plan before taking action. You only have access to read-only tools and should not attempt to circumvent them to write / delete / create files.`;
-}
+  }
 
   // Add rules section if we have any rules or agent content
   if (agentContent || processedRules.length > 0) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "wt-nate-4",
+  "name": "wt-plan-mode-sys-prompt",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## Description

System prompt for plan mode so it doesn't try to edit
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add plan mode guidance to the CLI system prompt so the agent plans and investigates without modifying files. Also adds tests and updates the local build script.

- **New Features**
  - System prompt includes plan mode instructions: read-only tools; do not write/delete/create files.
  - constructSystemMessage accepts an optional mode and falls back to modeService.getCurrentMode().
  - Tests cover plan mode presence/absence and interactions with headless and JSON output modes.

- **Dependencies**
  - build:local-deps now runs npm install and build for config-types, config-yaml, fetch, and openai-adapters.

<!-- End of auto-generated description by cubic. -->

