### PR TITLE
Codex/refactor-grep-implementation-in-extensions

### DIFF
--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -718,7 +718,7 @@ declare global {
   
     getPinnedFiles(): Promise<string[]>;
   
-    getSearchResults(query: string, maxResults?: number): Promise<string>;
+    getSearchResults(rgArgs: string[], maxResults?: number): Promise<string>;
   
     subprocess(command: string, cwd?: string): Promise<[string, string]>;
   

--- a/core/context/providers/SearchContextProvider.ts
+++ b/core/context/providers/SearchContextProvider.ts
@@ -3,7 +3,10 @@ import {
   ContextProviderDescription,
   ContextProviderExtras,
 } from "../../index.js";
-import { formatGrepSearchResults } from "../../util/grepSearch.js";
+import {
+  buildRipgrepArgs,
+  formatGrepSearchResults,
+} from "../../util/grepSearch.js";
 import { BaseContextProvider } from "../index.js";
 
 const DEFAULT_MAX_SEARCH_CONTEXT_RESULTS = 200;
@@ -20,10 +23,10 @@ class SearchContextProvider extends BaseContextProvider {
     query: string,
     extras: ContextProviderExtras,
   ): Promise<ContextItem[]> {
-    const results = await extras.ide.getSearchResults(
-      query,
-      this.options?.maxResults ?? DEFAULT_MAX_SEARCH_CONTEXT_RESULTS,
-    );
+    const maxResults =
+      this.options?.maxResults ?? DEFAULT_MAX_SEARCH_CONTEXT_RESULTS;
+    const ripgrepArgs = buildRipgrepArgs(query, { maxResults });
+    const results = await extras.ide.getSearchResults(ripgrepArgs, maxResults);
     // Note, search context provider will not truncate result chars, but will limit number of results
     const { formatted } = formatGrepSearchResults(results);
     return [

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -842,7 +842,7 @@ export interface IDE {
 
   getPinnedFiles(): Promise<string[]>;
 
-  getSearchResults(query: string, maxResults?: number): Promise<string>;
+  getSearchResults(rgArgs: string[], maxResults?: number): Promise<string>;
 
   getFileResults(pattern: string, maxResults?: number): Promise<string[]>;
 

--- a/core/protocol/ide.ts
+++ b/core/protocol/ide.ts
@@ -29,7 +29,7 @@ export type ToIdeFromWebviewOrCoreProtocol = {
   openFile: [{ path: string }, void];
   openUrl: [string, void];
   runCommand: [{ command: string; options?: TerminalOptions }, void];
-  getSearchResults: [{ query: string; maxResults?: number }, string];
+  getSearchResults: [{ rgArgs: string[]; maxResults?: number }, string];
   getFileResults: [{ pattern: string; maxResults?: number }, string[]];
   subprocess: [{ command: string; cwd?: string }, [string, string]];
   saveFile: [{ filepath: string }, void];

--- a/core/protocol/messenger/messageIde.ts
+++ b/core/protocol/messenger/messageIde.ts
@@ -204,8 +204,8 @@ export class MessageIde implements IDE {
     return this.request("getPinnedFiles", undefined);
   }
 
-  getSearchResults(query: string, maxResults?: number): Promise<string> {
-    return this.request("getSearchResults", { query, maxResults });
+  getSearchResults(rgArgs: string[], maxResults?: number): Promise<string> {
+    return this.request("getSearchResults", { rgArgs, maxResults });
   }
 
   getFileResults(pattern: string): Promise<string[]> {

--- a/core/protocol/messenger/reverseMessageIde.ts
+++ b/core/protocol/messenger/reverseMessageIde.ts
@@ -155,7 +155,7 @@ export class ReverseMessageIde {
     });
 
     this.on("getSearchResults", (data) => {
-      return this.ide.getSearchResults(data.query, data.maxResults);
+      return this.ide.getSearchResults(data.rgArgs, data.maxResults);
     });
 
     this.on("getFileResults", (data) => {

--- a/core/tools/definitions/grepSearch.ts
+++ b/core/tools/definitions/grepSearch.ts
@@ -21,7 +21,7 @@ export const grepSearchTool: Tool = {
         query: {
           type: "string",
           description:
-            "The search query to use. Must be a valid ripgrep regex expression, escaped where needed",
+            "The search query to use. Must be a valid ripgrep regex expression. For word boundaries use \\b, for literal parentheses use \\(, for alternations use (pattern1|pattern2). Examples: 'function.*add', '\\bclass\\b', 'add.*\\(', '\\b(def|function)\\b'",
         },
         args: {
           type: "array",
@@ -29,12 +29,20 @@ export const grepSearchTool: Tool = {
           description:
             "Optional additional ripgrep arguments, for example ['-n', '-w']",
         },
+        path: {
+          type: "string",
+          description:
+            "Optional path to search in - can be a specific file (e.g., 'src/main.ts') or directory (e.g., 'src/'). If not provided, searches entire project.",
+        },
       },
     },
   },
   defaultToolPolicy: "allowedWithoutPermission",
   systemMessageDescription: {
     prefix: `To perform a grep search within the project, call the ${BuiltInToolNames.GrepSearch} tool with the query pattern to match. For example:`,
-    exampleArgs: [["query", ".*main_services.*"]],
+    exampleArgs: [
+      ["query", ".*main_services.*"],
+      ["query", "throw new Error"],
+    ],
   },
 };

--- a/core/tools/definitions/grepSearch.ts
+++ b/core/tools/definitions/grepSearch.ts
@@ -23,6 +23,12 @@ export const grepSearchTool: Tool = {
           description:
             "The search query to use. Must be a valid ripgrep regex expression, escaped where needed",
         },
+        args: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Optional additional ripgrep arguments, for example ['-n', '-w']",
+        },
       },
     },
   },

--- a/core/tools/implementations/grepSearch.ts
+++ b/core/tools/implementations/grepSearch.ts
@@ -1,7 +1,10 @@
 import { ToolImpl } from ".";
 import { ContextItem } from "../..";
-import { formatGrepSearchResults } from "../../util/grepSearch";
-import { getStringArg } from "../parseArgs";
+import {
+  buildRipgrepArgs,
+  formatGrepSearchResults,
+} from "../../util/grepSearch";
+import { getOptionalStringArrayArg, getStringArg } from "../parseArgs";
 
 const DEFAULT_GREP_SEARCH_RESULTS_LIMIT = 100;
 const DEFAULT_GREP_SEARCH_CHAR_LIMIT = 5000; // ~1000 tokens, will keep truncation simply for now
@@ -43,9 +46,14 @@ function splitGrepResultsByFile(content: string): ContextItem[] {
 
 export const grepSearchImpl: ToolImpl = async (args, extras) => {
   const query = getStringArg(args, "query");
+  const extraArgs = getOptionalStringArrayArg(args, "args");
+  const ripgrepArgs = buildRipgrepArgs(query, {
+    extraArgs,
+    maxResults: DEFAULT_GREP_SEARCH_RESULTS_LIMIT,
+  });
 
   const results = await extras.ide.getSearchResults(
-    query,
+    ripgrepArgs,
     DEFAULT_GREP_SEARCH_RESULTS_LIMIT,
   );
   const { formatted, numResults, truncated } = formatGrepSearchResults(

--- a/core/tools/implementations/grepSearch.ts
+++ b/core/tools/implementations/grepSearch.ts
@@ -47,9 +47,11 @@ function splitGrepResultsByFile(content: string): ContextItem[] {
 export const grepSearchImpl: ToolImpl = async (args, extras) => {
   const query = getStringArg(args, "query");
   const extraArgs = getOptionalStringArrayArg(args, "args");
+  const path = args.path as string | undefined;
   const ripgrepArgs = buildRipgrepArgs(query, {
     extraArgs,
     maxResults: DEFAULT_GREP_SEARCH_RESULTS_LIMIT,
+    path,
   });
 
   const results = await extras.ide.getSearchResults(

--- a/core/tools/parseArgs.ts
+++ b/core/tools/parseArgs.ts
@@ -61,3 +61,22 @@ export function getBooleanArg(args: any, argName: string, required = false) {
   }
   return args[argName];
 }
+
+export function getOptionalStringArrayArg(
+  args: any,
+  argName: string,
+): string[] | undefined {
+  if (typeof args?.[argName] === "undefined") {
+    return undefined;
+  }
+  const val = args[argName];
+  if (Array.isArray(val)) {
+    return val.filter((v) => typeof v === "string");
+  }
+  if (typeof val === "string") {
+    return val.split(" ").filter((v) => v.length > 0);
+  }
+  throw new Error(
+    `Argument \`${argName}\` must be a string or array of strings`,
+  );
+}

--- a/core/util/filesystem.ts
+++ b/core/util/filesystem.ts
@@ -252,7 +252,10 @@ class FileSystemIde implements IDE {
     return Promise.resolve([]);
   }
 
-  async getSearchResults(query: string, maxResults?: number): Promise<string> {
+  async getSearchResults(
+    rgArgs: string[],
+    maxResults?: number,
+  ): Promise<string> {
     return "";
   }
 

--- a/core/util/grepSearch.ts
+++ b/core/util/grepSearch.ts
@@ -1,8 +1,78 @@
+export const DEFAULT_RIPGREP_ARGS = [
+  "-i", // Case-insensitive search
+  "--ignore-file",
+  ".continueignore",
+  "--ignore-file",
+  ".gitignore",
+];
+
+const DEFAULT_CONTEXT_BEFORE = 2;
+const DEFAULT_CONTEXT_AFTER = 2;
+const HEADING_FLAG = "--heading";
+
+function sanitizeRipgrepArgs(args?: string[]): string[] {
+  if (!args) {
+    return [];
+  }
+  const unsafe = /[|;&`]/;
+  return args.filter(
+    (arg): arg is string => typeof arg === "string" && !unsafe.test(arg),
+  );
+}
+
+export function buildRipgrepArgs(
+  query: string,
+  { extraArgs, maxResults }: { extraArgs?: string[]; maxResults?: number } = {},
+): string[] {
+  const args = [...DEFAULT_RIPGREP_ARGS];
+  const sanitized = sanitizeRipgrepArgs(extraArgs);
+
+  let before = DEFAULT_CONTEXT_BEFORE;
+  let after = DEFAULT_CONTEXT_AFTER;
+  const remaining: string[] = [];
+
+  for (let i = 0; i < sanitized.length; i++) {
+    const arg = sanitized[i];
+    if ((arg === "-A" || arg === "-B" || arg === "-C") && i + 1 < sanitized.length) {
+      const val = parseInt(sanitized[i + 1]!, 10);
+      if (!isNaN(val)) {
+        if (arg === "-A") {
+          after = val;
+        } else if (arg === "-B") {
+          before = val;
+        } else if (arg === "-C") {
+          before = val;
+          after = val;
+        }
+        i++; // skip number
+        continue;
+      }
+    }
+    remaining.push(arg);
+  }
+
+  if (before === after) {
+    args.push("-C", before.toString());
+  } else {
+    args.push("-A", after.toString(), "-B", before.toString());
+  }
+
+  args.push(HEADING_FLAG);
+
+  if (typeof maxResults === "number") {
+    args.push("-m", maxResults.toString());
+  }
+
+  args.push(...remaining);
+  args.push("-e", query, ".");
+  return args;
+}
+
 /*
   Formats the output of a grep search to reduce unnecessary indentation, lines, etc
   Assumes a command with these params
     ripgrep -i --ignore-file .continueignore --ignore-file .gitignore -C 2 --heading -m 100 -e <query> .
-  
+
   Also can truncate the output to a specified number of characters
 */
 export function formatGrepSearchResults(

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
@@ -359,7 +359,7 @@ class IdeProtocolClient(
                             dataElement.toString(),
                             GetSearchResultsParams::class.java
                         )
-                        val results = ide.getSearchResults(params.query, params.maxResults)
+                        val results = ide.getSearchResults(params.rgArgs, params.maxResults)
                         respond(results)
                     }
 

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IntelliJIde.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IntelliJIde.kt
@@ -364,35 +364,13 @@ class IntelliJIDE(
         }
     }
 
-    override suspend fun getSearchResults(query: String, maxResults: Int?): String {
+    override suspend fun getSearchResults(ripgrepArgs: List<String>, maxResults: Int?): String {
         val ideInfo = this.getIdeInfo()
         if (ideInfo.remoteName == "local") {
             try {
-                val commandArgs = mutableListOf(
-                    ripgrep,
-                    "-i",
-                    "--ignore-file",
-                    ".continueignore",
-                    "--ignore-file",
-                    ".gitignore",
-                    "-C",
-                    "2",
-                    "--heading"
-                )
-
-                // Conditionally add maxResults flag
-                if (maxResults != null) {
-                    commandArgs.add("-m")
-                    commandArgs.add(maxResults.toString())
-                }
-
-                // Add the search query and path
-                commandArgs.add("-e")
-                commandArgs.add(query)
-                commandArgs.add(".")
-
+                val commandArgs = mutableListOf(ripgrep)
+                commandArgs.addAll(ripgrepArgs)
                 val command = GeneralCommandLine(commandArgs)
-
                 command.setWorkDirectory(project.basePath)
                 return ExecUtil.execAndGetOutput(command).stdout
             } catch (exception: Exception) {

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/protocol/ide.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/protocol/ide.kt
@@ -22,7 +22,7 @@ typealias OpenUrlParam = String
 
 typealias getTagsParams = String
 
-data class GetSearchResultsParams(val query: String, val maxResults: Int?)
+data class GetSearchResultsParams(val rgArgs: List<String>, val maxResults: Int?)
 
 data class GetFileResultsParams(val pattern: String, val maxResults: Int?)
 

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/types.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/types.kt
@@ -223,7 +223,7 @@ interface IDE {
 
     suspend fun getPinnedFiles(): List<String>
 
-    suspend fun getSearchResults(query: String, maxResults: Int?): String
+    suspend fun getSearchResults(rgArgs: List<String>, maxResults: Int?): String
 
     suspend fun getFileResults(pattern: String, maxResults: Int?): List<String>
 

--- a/extensions/vscode/src/extension/VsCodeMessenger.ts
+++ b/extensions/vscode/src/extension/VsCodeMessenger.ts
@@ -326,7 +326,7 @@ export class VsCodeMessenger {
       await ide.runCommand(msg.data.command);
     });
     this.onWebviewOrCore("getSearchResults", async (msg) => {
-      return ide.getSearchResults(msg.data.query, msg.data.maxResults);
+      return ide.getSearchResults(msg.data.rgArgs, msg.data.maxResults);
     });
     this.onWebviewOrCore("getFileResults", async (msg) => {
       return ide.getFileResults(msg.data.pattern, msg.data.maxResults);


### PR DESCRIPTION
## Description

Performed extensive analysis of common grep scenarios being attempted by the LLM and researched common features enabled in grep tools in other code assistants. 

Implementing recommended changes to allow the LLM to request specific arguments like -A and -B or -l for example to research code just before or just after.

Implementating scoping by add an optional path parameter so the LLM doesn't need to always search the whole repo which might result in truncation. Also allow scoping searches to specific files to avoid the need to always read the whole file.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

Added exstensive tests.
Perfomed extensive manual testing by asking the LLM to generate common lsTool type queries against the test repo and observed the outcomes expecting full passes.
