### PR TITLE
fix: CSS files not being indexed (#7072)

### DIFF
--- a/core/indexing/chunk/chunk.ts
+++ b/core/indexing/chunk/chunk.ts
@@ -22,7 +22,22 @@ export async function* chunkDocumentWithoutId(
     return;
   }
   const extension = getUriFileExtension(fileUri);
-  if (extension in supportedLanguages) {
+  // Files that should use basicChunker despite having tree-sitter support
+  // These files don't have code structure (classes/functions) that codeChunker expects
+  const NON_CODE_EXTENSIONS = [
+    "css",
+    "html",
+    "htm",
+    "json",
+    "toml",
+    "yaml",
+    "yml",
+  ];
+
+  if (
+    extension in supportedLanguages &&
+    !NON_CODE_EXTENSIONS.includes(extension)
+  ) {
     try {
       for await (const chunk of codeChunker(fileUri, contents, maxChunkSize)) {
         yield chunk;


### PR DESCRIPTION
## Description
CSS files were not being indexed because codeChunker expects code structures (classes/functions) that don't exist in CSS. The chunker would return zero chunks, preventing CSS files from being indexed.

This fix routes CSS, HTML, JSON and similar non-code files to basicChunker instead of codeChunker, ensuring they are properly indexed while maintaining intelligent chunking for actual code files.

Root Cause's Found
- CSS files were being processed by codeChunker which expects code structures (classes/functions)
- CSS doesn't have these structures, so codeChunker returns 0 chunks
- No chunks = no indexing = no retrieval

## Screen recording or screenshot
<img width="307" height="417" alt="Screenshot 2025-08-24 at 11 53 20 PM" src="https://github.com/user-attachments/assets/e9da4d51-a0ad-416e-9346-4a086924962a" />

## Tests
•  Manually verified CSS files are now indexed and retrievable via @Codebase 
•  Confirmed all existing chunk tests pass (10/10)
•  TypeScript compilation succeeds with no errors
•  Prettier formatting applied

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes CSS files not being skipped during indexing by sending non-code files to the basic chunker so they produce chunks and can be retrieved. Code files still use the code chunker.

- **Bug Fixes**
  - Route css, html/htm, json, toml, yaml/yml to basicChunker.
  - Verified CSS indexing and retrieval; existing chunk tests pass.
  - No changes to behavior for code files.

<!-- End of auto-generated description by cubic. -->

