### PR TITLE
feat: :sparkles: Provide feedback from edit tools

### DIFF
--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -1058,9 +1058,12 @@ declare global {
     streamId: string;
     status?: ApplyStateStatus;
     numDiffs?: number;
+    numAccepted?: number;
+    numRejected?: number;
     filepath?: string;
     fileContent?: string;
     originalFileContent?: string;
+    toolCallId?: string;
   }
   
   export interface RangeInFileWithContents {

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1375,6 +1375,8 @@ export interface ApplyState {
   streamId: string;
   status?: ApplyStateStatus;
   numDiffs?: number;
+  numAccepted?: number;
+  numRejected?: number;
   filepath?: string;
   fileContent?: string;
   originalFileContent?: string;

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/types.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/types.kt
@@ -286,6 +286,8 @@ data class ApplyState(
     val streamId: String,
     val status: String,
     val numDiffs: Int? = null,
+    val numAccepted: Int? = null,
+    val numRejected: Int? = null,
     val filepath: String? = null,
     val fileContent: String? = null,
     val originalFileContent: String? = null,

--- a/extensions/intellij/src/test/kotlin/com/github/continuedev/continueintellijextension/unit/ApplyToFileHandlerTest.kt
+++ b/extensions/intellij/src/test/kotlin/com/github/continuedev/continueintellijextension/unit/ApplyToFileHandlerTest.kt
@@ -74,6 +74,9 @@ class ApplyToFileHandlerTest : TestCase() {
                 withArg { payload ->
                     assert(payload is ApplyState)
                     assert((payload as ApplyState).status == ApplyStateStatus.STREAMING.status)
+                    // New fields should be included
+                    assert((payload as ApplyState).numAccepted == 0)
+                    assert((payload as ApplyState).numRejected == 0)
                 },
                 any()
             )
@@ -85,6 +88,9 @@ class ApplyToFileHandlerTest : TestCase() {
                 withArg { payload ->
                     assert(payload is ApplyState)
                     assert((payload as ApplyState).status == ApplyStateStatus.CLOSED.status)
+                    // New fields should be included
+                    assert((payload as ApplyState).numAccepted == 0)
+                    assert((payload as ApplyState).numRejected == 0)
                 },
                 any()
             )

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "1.1.79",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "1.1.79",
+      "version": "1.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "file:../../packages/config-types",
@@ -116,7 +116,6 @@
         "@sentry/esbuild-plugin": "^4.0.2",
         "@sentry/node": "^9.43.0",
         "@sentry/vite-plugin": "^4.0.2",
-        "@typescript-eslint/eslint-plugin": "^7.8.0",
         "@xenova/transformers": "2.14.0",
         "adf-to-md": "^1.1.0",
         "async-mutex": "^0.5.0",
@@ -135,7 +134,7 @@
         "http-proxy-agent": "^7.0.1",
         "https-proxy-agent": "^7.0.3",
         "iconv-lite": "^0.6.3",
-        "ignore": "^5.3.1",
+        "ignore": "^7.0.5",
         "is-localhost-ip": "^2.0.0",
         "jinja-js": "0.1.8",
         "js-tiktoken": "^1.0.8",
@@ -196,6 +195,8 @@
         "@types/tar": "^6.1.13",
         "@types/uuid": "^9.0.7",
         "@types/win-ca": "^3.5.4",
+        "@typescript-eslint/eslint-plugin": "^8.40.0",
+        "@typescript-eslint/parser": "^8.40.0",
         "cross-env": "^7.0.3",
         "esbuild": "0.17.19",
         "eslint": "^8",

--- a/extensions/vscode/src/diff/processDiff.ts
+++ b/extensions/vscode/src/diff/processDiff.ts
@@ -42,8 +42,6 @@ export async function processDiff(
   }
 
   if (streamId) {
-    const fileContent = await ide.readFile(newOrCurrentUri);
-
     // Record the edit outcome before updating the apply state
     await editOutcomeTracker.recordEditOutcome(
       streamId,
@@ -51,14 +49,10 @@ export async function processDiff(
       DataLogger.getInstance(),
     );
 
-    await sidebar.webviewProtocol.request("updateApplyState", {
-      fileContent,
-      filepath: newOrCurrentUri,
-      streamId,
-      status: "closed",
-      numDiffs: 0,
-      toolCallId,
-    });
+    // Note: We don't need to send updateApplyState here because the VerticalDiffHandler
+    // already sends it with the correct acceptance counts in its clear() method.
+    // Sending it again would overwrite the correct counts with zeros since the handler
+    // gets disposed after calling clear().
   }
 
   // Save the file

--- a/gui/src/components/AcceptRejectDiffButtons.tsx
+++ b/gui/src/components/AcceptRejectDiffButtons.tsx
@@ -3,7 +3,6 @@ import { ApplyState } from "core";
 import { useContext } from "react";
 import { IdeMessengerContext } from "../context/IdeMessenger";
 import { useAppDispatch } from "../redux/hooks";
-import { cancelToolCall } from "../redux/slices/sessionSlice";
 import { getMetaKeyLabel } from "../util";
 import { ToolTip } from "./gui/Tooltip";
 
@@ -24,19 +23,6 @@ export default function AcceptRejectAllButtons({
   const ideMessenger = useContext(IdeMessengerContext);
   const dispatch = useAppDispatch();
   async function handleAcceptOrReject(status: AcceptOrRejectOutcome) {
-    // For reject operations, cancel all tool calls associated with pending apply states
-    if (status === "rejectDiff") {
-      for (const applyState of pendingApplyStates) {
-        if (applyState.toolCallId && applyState.status === "done") {
-          dispatch(
-            cancelToolCall({
-              toolCallId: applyState.toolCallId,
-            }),
-          );
-        }
-      }
-    }
-
     // Process all pending apply states
     for (const { filepath = "", streamId } of pendingApplyStates) {
       ideMessenger.post(status, {

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/ApplyActions.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/ApplyActions.tsx
@@ -33,7 +33,10 @@ export function ApplyActions(props: ApplyActionsProps) {
       return (
         <div className="bg-badge flex select-none items-center rounded sm:gap-1 md:px-1.5">
           <span className="text-lightgray flex items-center text-center text-xs max-md:hidden">
-            {`${props.applyState?.numDiffs === 1 ? "1 diff" : `${props.applyState?.numDiffs} diffs`}`}
+            {props.applyState?.numAccepted !== undefined ||
+            props.applyState?.numRejected !== undefined
+              ? `${props.applyState?.numAccepted || 0} accepted, ${props.applyState?.numRejected || 0} rejected`
+              : `${props.applyState?.numDiffs === 1 ? "1 diff" : `${props.applyState?.numDiffs} diffs`}`}
           </span>
 
           <div className="flex items-center">

--- a/gui/src/components/mainInput/Lump/LumpToolbar/EditOutcomeToolbar.tsx
+++ b/gui/src/components/mainInput/Lump/LumpToolbar/EditOutcomeToolbar.tsx
@@ -16,7 +16,12 @@ export function EditOutcomeToolbar() {
   return (
     <div className="text-description-muted flex items-center justify-between py-0.5 text-xs">
       <div className="bg-badge rounded px-1.5">
-        <span>{`${editApplyState.numDiffs} diff${editApplyState.numDiffs !== 1 ? "s" : ""}`}</span>
+        <span>
+          {editApplyState.numAccepted !== undefined ||
+          editApplyState.numRejected !== undefined
+            ? `${editApplyState.numAccepted || 0} accepted, ${editApplyState.numRejected || 0} rejected`
+            : `${editApplyState.numDiffs} diff${editApplyState.numDiffs !== 1 ? "s" : ""}`}
+        </span>
       </div>
       <AcceptRejectDiffButtons
         applyStates={[editApplyState]}

--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -783,6 +783,8 @@ export const sessionSlice = createSlice({
       } else {
         applyState.status = payload.status ?? applyState.status;
         applyState.numDiffs = payload.numDiffs ?? applyState.numDiffs;
+        applyState.numAccepted = payload.numAccepted ?? applyState.numAccepted;
+        applyState.numRejected = payload.numRejected ?? applyState.numRejected;
         applyState.filepath = payload.filepath ?? applyState.filepath;
         applyState.fileContent = payload.fileContent ?? applyState.fileContent;
         applyState.originalFileContent =

--- a/gui/src/redux/thunks/handleApplyStateUpdate.ts
+++ b/gui/src/redux/thunks/handleApplyStateUpdate.ts
@@ -1,5 +1,5 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
-import { ApplyState } from "core";
+import { ApplyState, ContextItem } from "core";
 import { EDIT_MODE_STREAM_ID } from "core/edit/constants";
 import { logAgentModeEditOutcome } from "../../util/editOutcomeLogger";
 import {
@@ -61,7 +61,10 @@ export const handleApplyStateUpdate = createAsyncThunk<
           );
 
           if (toolCallState) {
-            const accepted = toolCallState.status !== "canceled";
+            // If we reach here with status "closed", the apply process completed
+            // Don't consider it "canceled" just because diffs were rejected
+            const wasCanceled = toolCallState.status === "canceled";
+            const accepted = !wasCanceled;
 
             logToolUsage(toolCallState, accepted, true, extra.ideMessenger);
 
@@ -82,15 +85,40 @@ export const handleApplyStateUpdate = createAsyncThunk<
               );
             }
 
-            if (accepted) {
-              if (toolCallState.status !== "errored") {
+            // Generate feedback based on diff acceptance status (only for final "closed" status)
+            let shouldStreamResponse = false;
+            if (
+              toolCallState.status !== "errored" &&
+              applyState.status === "closed"
+            ) {
+              const feedbackContextItem =
+                generateDiffAcceptanceFeedback(applyState);
+              if (feedbackContextItem) {
                 dispatch(
-                  acceptToolCall({
+                  updateToolCallOutput({
                     toolCallId: applyState.toolCallId,
+                    contextItems: [feedbackContextItem],
                   }),
                 );
+                shouldStreamResponse = true; // We have feedback to respond to
               }
+            }
 
+            // If the apply process completed (status is "closed"), mark tool as accepted
+            // The feedback will communicate the actual diff acceptance outcome
+            if (accepted && toolCallState.status !== "errored") {
+              dispatch(
+                acceptToolCall({
+                  toolCallId: applyState.toolCallId,
+                }),
+              );
+            }
+
+            // Stream response if we have feedback or if tool was accepted
+            if (
+              shouldStreamResponse ||
+              (accepted && toolCallState.status !== "errored")
+            ) {
               void dispatch(
                 streamResponseAfterToolCall({
                   toolCallId: applyState.toolCallId,
@@ -104,6 +132,52 @@ export const handleApplyStateUpdate = createAsyncThunk<
     }
   },
 );
+
+function generateDiffAcceptanceFeedback(
+  applyState: ApplyState,
+): ContextItem | null {
+  const acceptedDiffs = applyState.numAccepted || 0;
+  const rejectedDiffs = applyState.numRejected || 0;
+  const totalProcessedDiffs = acceptedDiffs + rejectedDiffs;
+
+  if (totalProcessedDiffs === 0) {
+    return null;
+  }
+
+  let contextItem: ContextItem;
+
+  if (acceptedDiffs === totalProcessedDiffs) {
+    // All diffs accepted
+    contextItem = {
+      name: "Edit Result - Accepted All",
+      description: `All proposed changes were accepted by the user`,
+      content: "User accepted all proposed changes",
+      status: "user_accepted_all",
+    };
+  } else if (acceptedDiffs === 0) {
+    // No diffs accepted
+    contextItem = {
+      name: "Edit Result - Rejected All",
+      description:
+        "Tool succeeded but user rejected all changes - LLM must stop and consult user",
+      content:
+        "The search and replace tool executed successfully, but the user rejected ALL proposed changes. This means:\n\n1. DO NOT attempt any more file modifications\n2. DO NOT try different changes\n3. STOP and ask the user for clarification\n\nYou must now ask the user: 'I see you rejected all my proposed changes. Could you help me understand what you're looking for instead? What specific changes would you like me to make to the file?'",
+      status: "user_rejected_all",
+    };
+  } else {
+    // Partial acceptance
+    contextItem = {
+      name: "Edit Result - Partial Acceptance",
+      description:
+        "Partial acceptance of changes - LLM should ask user for next steps",
+      content:
+        "User partially accepted changes. Some of your proposed changes were accepted while others were rejected.\n\nPlease ask the user what they would like to do next. For example:\n- Do they want you to try different approaches for the rejected changes?\n- Are they satisfied with the current state?\n- Do they have specific feedback about what they want instead?",
+      status: "user_accepted_partial",
+    };
+  }
+
+  return contextItem;
+}
 
 export const handleEditToolApplyError = createAsyncThunk<
   void,


### PR DESCRIPTION
## Description

Edit tools now provide tri-state feedback to the LLM after an edit completes from the search and replace or apply tool.

The LLM is presented with one of three statuses:

1) All diffs were accepted, proceed.
2) All diffs were rejected by the user, ask for further instructions.
3) Partial acceptance of diffs, ask for futher instructions.

This helps guide the LLM for next steps, and removes the abrupt cancellation of tool calls in the partial and full rejection cases.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

Tests updated as needed.
Performed extensive manual testing of vscode through all the various use cases.
[ ] TODO: Perform manual testing of IntelliJ extension.
