### PR TITLE
fix: render Ollama thinking messages

### DIFF
--- a/core/llm/llms/Ollama.ts
+++ b/core/llm/llms/Ollama.ts
@@ -9,6 +9,7 @@ import {
   CompletionOptions,
   LLMOptions,
   ModelInstaller,
+  ThinkingChatMessage,
 } from "../../index.js";
 import { renderChatMessage } from "../../util/messageContent.js";
 import { getRemoteModelInfo } from "../../util/ollamaHelper.js";
@@ -18,6 +19,7 @@ type OllamaChatMessage = {
   role: ChatMessageRole;
   content: string;
   images?: string[] | null;
+  thinking?: string;
   tool_calls?: {
     function: {
       name: string;
@@ -430,6 +432,13 @@ class Ollama extends BaseLLM implements ModelInstaller {
         );
       }
       if (res.message.role === "assistant") {
+        if (res.message.thinking) {
+          const thinkingMessage: ThinkingChatMessage = {
+            role: "thinking",
+            content: res.message.thinking,
+          };
+          return thinkingMessage;
+        }
         const chatMessage: ChatMessage = {
           role: "assistant",
           content: res.message.content,


### PR DESCRIPTION
When calling gpt-oss:20b running on ollama, the thinking part is not displayed. We can see blank "assistant" messages in the Continue console. Turns out ollama puts the thinking part into a separate "thinking" field, but with the "assistant" role:

<img width="751" height="87" alt="Screenshot 2025-08-25 at 16 07 17" src="https://github.com/user-attachments/assets/473ef804-bf92-487e-b6ae-e34c73e0aad8" /> 

Small code change to read that property allows us to see the model reasoning:

https://github.com/user-attachments/assets/d3581d5e-873a-4f77-aa85-a13654e3df78



    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Show Ollama model reasoning by handling the thinking field and emitting a thinking message, fixing blank assistant messages in the console.

- **Bug Fixes**
  - Parse res.message.thinking (when role is assistant) and return a ThinkingChatMessage.
  - Prevents blank assistant outputs for gpt-oss:20b and other Ollama models.

<!-- End of auto-generated description by cubic. -->

