### PR TITLE
feat: focus on chat input after apply

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/DiffStreamHandler.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/DiffStreamHandler.kt
@@ -335,7 +335,6 @@ class DiffStreamHandler(
 
     private fun setClosed() {
         sendUpdate(ApplyStateStatus.CLOSED)
-        project.service<ContinuePluginService>().sendToWebview("focusContinueInputWithoutClear", Nil)
         resetState()
     }
 }


### PR DESCRIPTION
## Description

Focus on the chat input area after apply is accepted/rejected.

closes CON-2693

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

https://github.com/user-attachments/assets/e452d542-c3db-4ec2-bc8a-6698ec2f42e0


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
After accepting or rejecting an Apply diff, the chat input now auto-focuses without clearing existing text, so you can continue typing immediately. Implemented for VS Code and IntelliJ; addresses CON-2693.

<!-- End of auto-generated description by cubic. -->

