### PR TITLE
fix: reinstate gui telemetry for non-continue users by separating sentry and posthog logic

### DIFF
--- a/gui/src/hooks/TelemetryProviders.tsx
+++ b/gui/src/hooks/TelemetryProviders.tsx
@@ -29,7 +29,8 @@ const TelemetryProviders = ({ children }: PropsWithChildren) => {
   );
 
   useEffect(() => {
-    if (allowAnonymousTelemetry && hasContinueEmail) {
+    // PostHog depends only on allowAnonymousTelemetry
+    if (allowAnonymousTelemetry) {
       // Initialize PostHog (existing logic)
       posthog.init("phc_JS6XFROuNbhJtVCEdTSYk6gl5ArRrTNMpCcguAXlSPs", {
         api_host: "https://app.posthog.com",
@@ -41,7 +42,13 @@ const TelemetryProviders = ({ children }: PropsWithChildren) => {
       });
       posthog.identify(window.vscMachineId);
       posthog.opt_in_capturing();
+    } else {
+      // Disable PostHog
+      posthog.opt_out_capturing();
+    }
 
+    // Sentry depends on both allowAnonymousTelemetry and hasContinueEmail
+    if (allowAnonymousTelemetry && hasContinueEmail) {
       // Initialize Sentry (new for GUI - enhanced React setup)
       Sentry.init({
         dsn: SENTRY_DSN,
@@ -95,9 +102,6 @@ const TelemetryProviders = ({ children }: PropsWithChildren) => {
       });
       Sentry.setUser(anonymizedUser);
     } else {
-      // Disable PostHog
-      posthog.opt_out_capturing();
-
       // Disable Sentry properly - close the client to stop all network requests
       try {
         const client = Sentry.getClient();


### PR DESCRIPTION
## Description

It looks like https://github.com/continuedev/continue/pull/6881 introduced a check for hasContinueEmail around _both_ Sentry and PostHog, when it was only intended for PostHog. This should fix the decrease in events we were seeing