### PR TITLE
feat: allow/blocklisted blocks in unrollAssistant

### DIFF
--- a/packages/config-yaml/src/__tests__/index.test.ts
+++ b/packages/config-yaml/src/__tests__/index.test.ts
@@ -368,7 +368,7 @@ describe("E2E Scenarios", () => {
     ).toBe(true);
   });
 
-  it("should throw when a block is not on the allowlist", async () => {
+  it("should return an error when a block is not on the allowlist", async () => {
     const result = await unrollAssistant(
       {
         uriType: "slug",

--- a/packages/config-yaml/src/__tests__/index.test.ts
+++ b/packages/config-yaml/src/__tests__/index.test.ts
@@ -330,5 +330,163 @@ describe("E2E Scenarios", () => {
     ).toBe(true);
   });
 
+  it("should throw when a block is blocklisted", async () => {
+    const result = await unrollAssistant(
+      {
+        uriType: "slug",
+        fullSlug: {
+          ownerSlug: "test-org",
+          packageSlug: "agent",
+          versionSlug: "latest",
+        },
+      },
+      registry,
+      {
+        renderSecrets: true,
+        platformClient,
+        orgScopeId: "test-org",
+        currentUserSlug: "test-user",
+        onPremProxyUrl: null,
+        blocklistedBlocks: [
+          {
+            ownerSlug: "test-org",
+            packageSlug: "gemini",
+          },
+        ],
+      },
+    );
+
+    // Should contain an error about the blocklisted block
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.length).toBeGreaterThan(0);
+    expect(
+      result.errors?.some(error => 
+        error.message.includes("test-org/gemini is block listed and can not be used.")
+      )
+    ).toBe(true);
+  });
+
+  it("should throw when a block is not on the allowlist", async () => {
+    const result = await unrollAssistant(
+      {
+        uriType: "slug",
+        fullSlug: {
+          ownerSlug: "test-org",
+          packageSlug: "agent",
+          versionSlug: "latest",
+        },
+      },
+      registry,
+      {
+        renderSecrets: true,
+        platformClient,
+        orgScopeId: "test-org",
+        currentUserSlug: "test-user",
+        onPremProxyUrl: null,
+        allowlistedBlocks: [
+          {
+            ownerSlug: "test-org",
+            packageSlug: "docs",
+          },
+          {
+            ownerSlug: "test-org",
+            packageSlug: "rules",
+          },
+          {
+            ownerSlug: "test-org",
+            packageSlug: "claude35sonnet",
+          },
+        ],
+      },
+    );
+
+    // Should contain an error about the non-allowlisted block (gemini)
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.length).toBeGreaterThan(0);
+    expect(
+      result.errors?.some(error => 
+        error.message.includes("test-org/gemini is block listed and can not be used.")
+      )
+    ).toBe(true);
+  });
+
+  it("should allow blocks when they are on the allowlist", async () => {
+    const result = await unrollAssistant(
+      {
+        uriType: "slug",
+        fullSlug: {
+          ownerSlug: "test-org",
+          packageSlug: "agent",
+          versionSlug: "latest",
+        },
+      },
+      registry,
+      {
+        renderSecrets: true,
+        platformClient,
+        orgScopeId: "test-org",
+        currentUserSlug: "test-user",
+        onPremProxyUrl: null,
+        allowlistedBlocks: [
+          {
+            ownerSlug: "test-org",
+            packageSlug: "docs",
+          },
+          {
+            ownerSlug: "test-org",
+            packageSlug: "rules",
+          },
+          {
+            ownerSlug: "test-org",
+            packageSlug: "gemini",
+          },
+          {
+            ownerSlug: "test-org",
+            packageSlug: "claude35sonnet",
+          },
+        ],
+      },
+    );
+
+    // Should successfully unroll without errors for allowed blocks
+    expect(result.config?.models?.length).toBe(4);
+    expect(result.config?.rules?.length).toBe(2);
+    expect(result.config?.docs?.length).toBe(1);
+  });
+
+  it("should not affect file-based blocks with allow/blocklists", async () => {
+    const result = await unrollAssistant(
+      {
+        uriType: "file",
+        fileUri: "./src/__tests__/local-files/duplicate-test-agent.yaml",
+      },
+      registry,
+      {
+        renderSecrets: true,
+        platformClient,
+        orgScopeId: "test-org",
+        currentUserSlug: "test-user",
+        onPremProxyUrl: null,
+        blocklistedBlocks: [
+          {
+            ownerSlug: "test-org",
+            packageSlug: "docs",
+          },
+        ],
+        injectBlocks: [
+          {
+            uriType: "file",
+            fileUri: "./src/__tests__/local-files/rules.yaml",
+          },
+        ],
+      },
+    );
+
+    // File-based blocks should not be affected by blocklists
+    expect(result.config?.models?.length).toBe(1);
+    expect(result.config?.context?.length).toBe(1);
+    expect(result.config?.rules?.length).toBeGreaterThan(0);
+  });
+
   it.skip("should prioritize org over user / package secrets", () => {});
 });

--- a/packages/config-yaml/src/__tests__/index.test.ts
+++ b/packages/config-yaml/src/__tests__/index.test.ts
@@ -360,9 +360,11 @@ describe("E2E Scenarios", () => {
     expect(result.errors).toBeDefined();
     expect(result.errors?.length).toBeGreaterThan(0);
     expect(
-      result.errors?.some(error => 
-        error.message.includes("test-org/gemini is block listed and can not be used.")
-      )
+      result.errors?.some((error) =>
+        error.message.includes(
+          "test-org/gemini is block listed and can not be used.",
+        ),
+      ),
     ).toBe(true);
   });
 
@@ -404,9 +406,11 @@ describe("E2E Scenarios", () => {
     expect(result.errors).toBeDefined();
     expect(result.errors?.length).toBeGreaterThan(0);
     expect(
-      result.errors?.some(error => 
-        error.message.includes("test-org/gemini is block listed and can not be used.")
-      )
+      result.errors?.some((error) =>
+        error.message.includes(
+          "test-org/gemini is block listed and can not be used.",
+        ),
+      ),
     ).toBe(true);
   });
 

--- a/packages/config-yaml/src/load/unroll.ts
+++ b/packages/config-yaml/src/load/unroll.ts
@@ -6,8 +6,12 @@ import {
   decodeFQSN,
   decodePackageIdentifier,
   encodeFQSN,
+  encodePackageIdentifier,
+  encodePackageSlug,
   FQSN,
   PackageIdentifier,
+  PackageSlug,
+  packageSlugsEqual,
 } from "../interfaces/slugs.js";
 import { markdownToRule } from "../markdown/index.js";
 import {
@@ -197,6 +201,8 @@ async function extractRenderedSecretsMap(
 export interface BaseUnrollAssistantOptions {
   renderSecrets: boolean;
   injectBlocks?: PackageIdentifier[];
+  allowlistedBlocks?: PackageSlug[];
+  blocklistedBlocks?: PackageSlug[];
 }
 
 export interface DoNotRenderSecretsUnrollAssistantOptions
@@ -262,7 +268,13 @@ export async function unrollAssistantFromContent(
     config: unrolledAssistant,
     configLoadInterrupted,
     errors,
-  } = await unrollBlocks(parsedYaml, registry, options.injectBlocks);
+  } = await unrollBlocks(
+    parsedYaml,
+    registry,
+    options.injectBlocks,
+    options.allowlistedBlocks,
+    options.blocklistedBlocks,
+  );
 
   // Back to a string so we can fill in template variables
   const rawUnrolledYaml = YAML.stringify(unrolledAssistant);
@@ -300,10 +312,44 @@ export async function unrollAssistantFromContent(
   return { config: finalConfig, errors, configLoadInterrupted };
 }
 
+function isPackageAllowed(
+  pkgId: PackageIdentifier,
+  allowlistedBlocks?: PackageSlug[],
+  blocklistedBlocks?: PackageSlug[],
+): boolean {
+  // Only "slug" type blocks can be allow/block listed
+  if (pkgId.uriType !== "slug") {
+    return true;
+  }
+
+  const packageSlug = {
+    ownerSlug: pkgId.fullSlug.ownerSlug,
+    packageSlug: pkgId.fullSlug.packageSlug,
+  };
+
+  if (
+    allowlistedBlocks &&
+    !allowlistedBlocks.some((block) => packageSlugsEqual(block, packageSlug))
+  ) {
+    return false;
+  }
+
+  if (
+    blocklistedBlocks &&
+    blocklistedBlocks.some((block) => packageSlugsEqual(block, packageSlug))
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
 export async function unrollBlocks(
   assistant: ConfigYaml,
   registry: Registry,
   injectBlocks: PackageIdentifier[] | undefined,
+  allowlistedBlocks?: PackageSlug[],
+  blocklistedBlocks?: PackageSlug[],
 ): Promise<ConfigResult<AssistantUnrolled>> {
   const errors: ConfigValidationError[] = [];
 
@@ -336,8 +382,28 @@ export async function unrollBlocks(
         // "uses/with" block
         if ("uses" in unrolledBlock) {
           try {
+            const blockIdentifier = decodePackageIdentifier(unrolledBlock.uses);
+
+            if (
+              !isPackageAllowed(
+                blockIdentifier,
+                allowlistedBlocks,
+                blocklistedBlocks,
+              )
+            ) {
+              throw new Error(
+                `${blockIdentifier.uriType === 'slug' 
+                  ? encodePackageSlug({
+                      ownerSlug: blockIdentifier.fullSlug.ownerSlug,
+                      packageSlug: blockIdentifier.fullSlug.packageSlug,
+                    })
+                  : encodePackageIdentifier(blockIdentifier)
+                } is block listed and can not be used.`,
+              );
+            }
+
             const blockConfigYaml = await resolveBlock(
-              decodePackageIdentifier(unrolledBlock.uses),
+              blockIdentifier,
               unrolledBlock.with,
               registry,
             );

--- a/packages/config-yaml/src/load/unroll.ts
+++ b/packages/config-yaml/src/load/unroll.ts
@@ -392,12 +392,13 @@ export async function unrollBlocks(
               )
             ) {
               throw new Error(
-                `${blockIdentifier.uriType === 'slug' 
-                  ? encodePackageSlug({
-                      ownerSlug: blockIdentifier.fullSlug.ownerSlug,
-                      packageSlug: blockIdentifier.fullSlug.packageSlug,
-                    })
-                  : encodePackageIdentifier(blockIdentifier)
+                `${
+                  blockIdentifier.uriType === "slug"
+                    ? encodePackageSlug({
+                        ownerSlug: blockIdentifier.fullSlug.ownerSlug,
+                        packageSlug: blockIdentifier.fullSlug.packageSlug,
+                      })
+                    : encodePackageIdentifier(blockIdentifier)
                 } is block listed and can not be used.`,
               );
             }


### PR DESCRIPTION
## Description

feat: allow/blocklisted blocks in unrollAssistant
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add allowlist and blocklist support to unrollAssistant to restrict which registry blocks can be used. Checks apply to slug-based "uses" blocks; file-based blocks are not affected and continue to work.

- **New Features**
  - Added allowlistedBlocks and blocklistedBlocks options to unrollAssistant/unrollBlocks.
  - If an allowlist is provided, only those slugs are permitted; any block on the blocklist is rejected.
  - Disallowed blocks return clear errors including the owner/package slug via result.errors.
  - Defaults remain unchanged when no lists are provided.
  - Tests cover blocklisted, not-allowlisted, allowed, and file-based scenarios.

<!-- End of auto-generated description by cubic. -->

