### PR TITLE
fix: :lipstick: Align component styles

### DIFF
--- a/gui/src/components/UnifiedTerminal/UnifiedTerminal.tsx
+++ b/gui/src/components/UnifiedTerminal/UnifiedTerminal.tsx
@@ -7,12 +7,6 @@ import styled, { keyframes } from "styled-components";
 import { useAppDispatch } from "../../redux/hooks";
 import { moveTerminalProcessToBackground } from "../../redux/thunks/moveTerminalProcessToBackground";
 import { getFontSize } from "../../util";
-import {
-  defaultBorderRadius,
-  vscBackground,
-  vscEditorBackground,
-  vscForeground,
-} from "../index";
 import { CopyButton } from "../StyledMarkdownPreview/StepContainerPreToolbar/CopyButton";
 import { RunInTerminalButton } from "../StyledMarkdownPreview/StepContainerPreToolbar/RunInTerminalButton";
 import { ButtonContent, SpoilerButton } from "../ui/SpoilerButton";
@@ -26,7 +20,7 @@ const BlinkingCursor = styled.span`
   &::after {
     content: "█";
     animation: ${blinkCursor} 1s infinite;
-    color: ${vscForeground};
+    color: var(--foreground);
   }
 `;
 
@@ -60,7 +54,7 @@ const AnsiSpan = styled.span<{
 `;
 
 const AnsiLink = styled.a`
-  color: var(--vscode-textLink-foreground, #3794ff);
+  color: var(--link);
   text-decoration: none;
   &:hover {
     text-decoration: underline;
@@ -69,24 +63,11 @@ const AnsiLink = styled.a`
 
 const StyledTerminalContainer = styled.div<{
   fontSize?: number;
-  bgColor: string;
 }>`
-  background-color: ${(props) => props.bgColor};
-  font-family:
-    var(--vscode-font-family),
-    system-ui,
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    Roboto,
-    Oxygen,
-    Ubuntu,
-    Cantarell,
-    "Open Sans",
-    "Helvetica Neue",
-    sans-serif;
+  background-color: var(--background);
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
   font-size: ${(props) => props.fontSize || getFontSize()}px;
-  color: ${vscForeground};
+  color: var(--foreground);
   line-height: 1.5;
 
   > *:last-child {
@@ -109,25 +90,16 @@ const TerminalContent = styled.div`
       display: none;
     }
     word-wrap: break-word;
-    border-radius: ${defaultBorderRadius};
-    background-color: ${vscEditorBackground};
+    border-radius: 0.5rem;
+    background-color: var(--editor-background);
     font-size: ${getFontSize() - 2}px;
-    font-family: var(--vscode-editor-font-family);
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
   }
 
   code:not(pre > code) {
-    font-family: var(--vscode-editor-font-family);
-    color: var(--vscode-input-placeholderForeground);
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
+    color: var(--input-placeholder);
   }
-`;
-
-const ToolbarContainer = styled.div<{ isExpanded: boolean }>`
-  font-size: ${getFontSize() - 2}px;
-`;
-
-const CommandLine = styled.div`
-  padding-bottom: 0.5rem;
-  color: var(--vscode-terminal-ansiGreen, #0dbc79);
 `;
 
 function ansiToJSON(
@@ -434,7 +406,6 @@ export function UnifiedTerminalCommand({
   return (
     <StyledTerminalContainer
       fontSize={getFontSize()}
-      bgColor={vscBackground}
       className="mb-4"
     >
       <div className="outline-command-border -outline-offset-0.5 rounded-default bg-editor !my-2 flex min-w-0 flex-col outline outline-1">
@@ -450,11 +421,11 @@ export function UnifiedTerminalCommand({
           <div className="flex max-w-[50%] flex-row items-center">
             <ChevronDownIcon
               onClick={() => setIsExpanded(!isExpanded)}
-              className={`text-lightgray h-3.5 w-3.5 flex-shrink-0 cursor-pointer hover:brightness-125 ${
+              className={`text-description h-3.5 w-3.5 flex-shrink-0 cursor-pointer hover:brightness-125 ${
                 isExpanded ? "rotate-0" : "-rotate-90"
               }`}
             />
-            <span className="text-lightgray ml-2 select-none">Terminal</span>
+            <span className="text-description ml-2 select-none">Terminal</span>
           </div>
 
           <div className="flex items-center gap-2.5">
@@ -474,8 +445,7 @@ export function UnifiedTerminalCommand({
               <code>
                 {/* Command is always visible */}
                 <div
-                  className="pb-2"
-                  style={{ color: "var(--vscode-terminal-ansiGreen, #0DBC79)" }}
+                  className="pb-2 text-terminal"
                 >
                   $ {command}
                 </div>
@@ -528,7 +498,10 @@ export function UnifiedTerminalCommand({
 
         {/* Status information */}
         {(statusMessage || isRunning) && (
-          <div className="text-description mt-2 flex items-center px-2 pb-2 text-xs">
+          <div 
+            className="text-description flex items-center px-2 pb-2 pt-2 text-xs"
+            style={{ borderTop: '1px solid var(--vscode-commandCenter-inactiveBorder, #555555)' }}
+          >
             <StatusIcon status={statusType} />
             {isRunning ? "Running" : statusMessage}
             {isRunning && toolCallId && (

--- a/gui/src/components/UnifiedTerminal/UnifiedTerminal.tsx
+++ b/gui/src/components/UnifiedTerminal/UnifiedTerminal.tsx
@@ -65,7 +65,17 @@ const StyledTerminalContainer = styled.div<{
   fontSize?: number;
 }>`
   background-color: var(--background);
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    "Helvetica Neue",
+    Arial,
+    "Noto Sans",
+    sans-serif;
   font-size: ${(props) => props.fontSize || getFontSize()}px;
   color: var(--foreground);
   line-height: 1.5;
@@ -93,11 +103,15 @@ const TerminalContent = styled.div`
     border-radius: 0.5rem;
     background-color: var(--editor-background);
     font-size: ${getFontSize() - 2}px;
-    font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
+    font-family:
+      ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono",
+      Menlo, monospace;
   }
 
   code:not(pre > code) {
-    font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
+    font-family:
+      ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono",
+      Menlo, monospace;
     color: var(--input-placeholder);
   }
 `;
@@ -404,10 +418,7 @@ export function UnifiedTerminalCommand({
   }, [command, output, hasOutput]);
 
   return (
-    <StyledTerminalContainer
-      fontSize={getFontSize()}
-      className="mb-4"
-    >
+    <StyledTerminalContainer fontSize={getFontSize()} className="mb-4">
       <div className="outline-command-border -outline-offset-0.5 rounded-default bg-editor !my-2 flex min-w-0 flex-col outline outline-1">
         {/* Toolbar */}
         <div
@@ -444,11 +455,7 @@ export function UnifiedTerminalCommand({
             <pre className="bg-editor">
               <code>
                 {/* Command is always visible */}
-                <div
-                  className="pb-2 text-terminal"
-                >
-                  $ {command}
-                </div>
+                <div className="text-terminal pb-2">$ {command}</div>
 
                 {/* Running state with cursor */}
                 {isRunning && !hasOutput && (
@@ -498,9 +505,12 @@ export function UnifiedTerminalCommand({
 
         {/* Status information */}
         {(statusMessage || isRunning) && (
-          <div 
+          <div
             className="text-description flex items-center px-2 pb-2 pt-2 text-xs"
-            style={{ borderTop: '1px solid var(--vscode-commandCenter-inactiveBorder, #555555)' }}
+            style={{
+              borderTop:
+                "1px solid var(--vscode-commandCenter-inactiveBorder, #555555)",
+            }}
           >
             <StatusIcon status={statusType} />
             {isRunning ? "Running" : statusMessage}

--- a/gui/src/components/UnifiedTerminal/UnifiedTerminal.tsx
+++ b/gui/src/components/UnifiedTerminal/UnifiedTerminal.tsx
@@ -97,10 +97,6 @@ const StyledTerminalContainer = styled.div<{
 const TerminalContent = styled.div`
   pre {
     white-space: pre-wrap;
-    background-color: ${vscEditorBackground};
-    border-radius: ${defaultBorderRadius};
-    border: 1px solid
-      var(--vscode-editorWidget-border, rgba(127, 127, 127, 0.3));
     max-width: calc(100vw - 24px);
     overflow-x: scroll;
     overflow-y: hidden;
@@ -474,7 +470,7 @@ export function UnifiedTerminalCommand({
         {/* Content */}
         {isExpanded && (
           <TerminalContent>
-            <pre>
+            <pre className="bg-editor">
               <code>
                 {/* Command is always visible */}
                 <div

--- a/gui/src/pages/gui/ToolCallDiv/FindAndReplace.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/FindAndReplace.tsx
@@ -198,7 +198,7 @@ export function FindAndReplaceDisplay({
       className={`${config?.ui?.showChatScrollbar ? "thin-scrollbar" : "no-scrollbar"} max-h-72 overflow-auto`}
     >
       <pre
-        className={`m-0 text-xs leading-tight ${config?.ui?.codeWrap ? "w-full whitespace-pre-wrap" : "w-min whitespace-pre"}`}
+        className={`bg-editor m-0 w-full text-xs leading-tight ${config?.ui?.codeWrap ? "whitespace-pre-wrap" : "whitespace-pre"}`}
       >
         {diffResult.diff.map((part, index) => {
           if (part.removed) {
@@ -245,7 +245,7 @@ export function FindAndReplaceDisplay({
             );
           } else {
             return (
-              <div key={index} className="bg-background">
+              <div key={index}>
                 {part.value.split("\n").map((line, lineIndex) => {
                   if (
                     line === "" &&

--- a/gui/src/styles/theme.ts
+++ b/gui/src/styles/theme.ts
@@ -140,6 +140,10 @@ export const THEME_COLORS = {
     vars: ["--vscode-textLink-foreground"],
     default: "#5c9ce6", // medium blue
   },
+  terminal: {
+    vars: ["--vscode-terminal-ansiGreen"],
+    default: "#0dbc79", // green
+  },
   textCodeBlockBackground: {
     vars: ["--vscode-textCodeBlock-background"],
     default: "#1e1e1e", // same as editor-background

--- a/gui/tailwind.config.cjs
+++ b/gui/tailwind.config.cjs
@@ -86,6 +86,7 @@ module.exports = {
         error: varWithFallback("error"),
         link: varWithFallback("link"),
         accent: varWithFallback("accent"),
+        terminal: varWithFallback("terminal"),
         findMatch: {
           DEFAULT: THEME_COLORS["find-match"].default,
           selected: varWithFallback("find-match-selected"),


### PR DESCRIPTION
## Description

After the introduction of the new diff component in the chat, small tweaks to the new unifed terminal to align the styling and background colors across themes. Remove inner rounded container for command and output.

The background of code, diffs and the terminal now follow the editor background theme.

Small fix to the Diff component so the background fills the component even when the source is narrow.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Examples of the new aligned compoents:

<img width="496" height="332" alt="image" src="https://github.com/user-attachments/assets/7cb7b9f9-9aff-4590-9f11-c71ea62d5a5c" />

<img width="496" height="181" alt="image" src="https://github.com/user-attachments/assets/bed41c64-02b5-4130-ba40-292729ce51a9" />

<img width="496" height="96" alt="image" src="https://github.com/user-attachments/assets/9a3eafc8-b1f7-42dd-ac0b-737d1153824e" />

## Tests

Performed manual testing across a number of VSCode themes.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Aligns Unified Terminal and Diff/Find & Replace backgrounds across themes by using the shared bg-editor style. Also ensures diff backgrounds fill the container even when content is narrow.

- **Bug Fixes**
  - Unified Terminal: apply bg-editor to pre; remove inline background/border styles.
  - Find & Replace: use bg-editor and full-width pre; drop inner background wrapper for a continuous background.

<!-- End of auto-generated description by cubic. -->

