### PR TITLE
fix: context items dialog not visible on conversation compaction

### DIFF
--- a/gui/src/pages/gui/Chat.tsx
+++ b/gui/src/pages/gui/Chat.tsx
@@ -288,19 +288,17 @@ export function Chat() {
 
       if (message.role === "user") {
         return (
-          <div className={isBeforeLatestSummary ? "opacity-50" : ""}>
-            <ContinueInputBox
-              onEnter={(editorState, modifiers) =>
-                sendInput(editorState, modifiers, index)
-              }
-              isLastUserInput={isLastUserInput(index)}
-              isMainInput={false}
-              editorState={editorState}
-              contextItems={contextItems}
-              appliedRules={appliedRules}
-              inputId={message.id}
-            />
-          </div>
+          <ContinueInputBox
+            onEnter={(editorState, modifiers) =>
+              sendInput(editorState, modifiers, index)
+            }
+            isLastUserInput={isLastUserInput(index)}
+            isMainInput={false}
+            editorState={editorState}
+            contextItems={contextItems}
+            appliedRules={appliedRules}
+            inputId={message.id}
+          />
         );
       }
 


### PR DESCRIPTION
## Description

When conversation is compacted, the context menu items are not visible and not selectable. This PR fixes that

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot




https://github.com/user-attachments/assets/68fa736a-22b2-49a4-9dac-1969f0dbc48c

https://github.com/user-attachments/assets/60c2220f-a49d-4630-b2d3-30b2beb6c4bb


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
