### PR TITLE
docs: update CLI status from alpha to beta

### DIFF
--- a/docs/guides/cli.mdx
+++ b/docs/guides/cli.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Continue CLI (cn)"
 description: "Learn how to use Continue's command-line interface for context engineering, automated coding tasks, and headless development workflows with customizable models, rules, and tools"
 ---
 
-<Warning>Continue CLI (cn) is currently in Alpha</Warning>
+<Warning>Continue CLI (cn) is currently in Beta</Warning>
 
 `cn` is an open-source, modular coding agent for the command line.
 
@@ -91,4 +91,4 @@ cn --exclude Fetch
 
 Run `cn` with the `--verbose` flag to see more detailed logs. These will be output to `~/.continue/logs/cn.log`.
 
-If you have feedback on the alpha, please [share in our Discord](https://discord.com/invite/EfJEfdFnDQ).
+If you have feedback on the beta, please [share in our Discord](https://discord.com/invite/EfJEfdFnDQ) or [leave feedback in the GitHub discussion](https://github.com/continuedev/continue/discussions/7307).


### PR DESCRIPTION
## Summary

Updates the Continue CLI documentation to reflect the current Beta status (previously Alpha).

## Changes

- Changed warning message from "Alpha" to "Beta"
- Added GitHub discussion link for beta feedback alongside the existing Discord link
- Updated feedback section text to mention beta instead of alpha

## Related

- GitHub Discussion for CLI feedback: https://github.com/continuedev/continue/discussions/7307

## Type of Change

- 📚 Documentation update
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Update the Continue CLI docs to mark the CLI as Beta instead of Alpha and clarify feedback channels. Adds a GitHub Discussion link alongside Discord.

<!-- End of auto-generated description by cubic. -->

