### PR TITLE
docs: add Release Notes link to documentation navigation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -290,6 +290,11 @@
           "anchor": "Blog",
           "href": "https://continue.dev/blog",
           "icon": "newspaper"
+        },
+        {
+          "anchor": "Release Notes",
+          "href": "https://changelog.continue.dev/",
+          "icon": "bullhorn"
         }
       ]
     }


### PR DESCRIPTION
## Summary

Adds a "Release Notes" link to the global navigation in the documentation site, providing users with easy access to the Continue changelog.

## Changes

- Added new global navigation anchor "Release Notes" in `docs/docs.json`
- Link points to https://changelog.continue.dev/
- Uses bullhorn icon for visual consistency
- Positioned after the Blog link in navigation order

## Why

Users should have easy access to release notes and changelog information directly from the documentation navigation, making it easier to stay updated with Continue's latest features and changes.

## Type of Change

- 📚 Documentation update
- ✨ Enhancement (non-breaking change which adds functionality)