### PR TITLE
docs: add required properties to assistant YAML examples

### DIFF
--- a/docs/reference.mdx
+++ b/docs/reference.mdx
@@ -40,6 +40,10 @@ For example, the following assistant imports an Anthropic model and defines an O
 Assistant models section
 
 ```yaml
+name: Team Agent
+version: 1.0.0
+schema: v1
+
 models:
   - uses: anthropic/claude-3.5-sonnet # an imported model block
   - model: deepseek-reasoner # an explicit model block
@@ -82,6 +86,9 @@ Blocks can be passed user inputs, including hub secrets and raw text values. To 
 
 ```yaml title="config.yaml"
 name: myprofile/custom-model
+version: 1.0.0
+schema: v1
+
 models:
   - name: My Favorite Model
     provider: anthropic
@@ -94,6 +101,9 @@ Which can then be imported like this:
 
 ```yaml title="config.yaml"
 name: myprofile/custom-assistant
+version: 1.0.0
+schema: v1
+
 models:
   - uses: myprofile/custom-model
     with:
@@ -109,6 +119,9 @@ Block properties can be also be directly overriden using `override`. For example
 
 ```yaml title="config.yaml"
 name: myprofile/custom-assistant
+version: 1.0.0
+schema: v1
+
 models:
   - uses: myprofile/custom-model
     with:


### PR DESCRIPTION
## Summary

Updates the reference documentation to include the required properties (`name`, `version`, `schema`) in all YAML assistant and block examples, ensuring consistency and clarity for users.

## Changes

- Added `name`, `version`, and `schema` properties to all assistant/block examples in `docs/reference.mdx`
- Used "Team Agent" as the example assistant name
- Standardized on version `1.0.0` and schema `v1` for all examples
- Fixed incomplete YAML examples that were missing these required properties

## Why

Per feedback, the required properties were lost from some assistant examples at some point. This ensures all examples properly show the required properties, making it clearer for users how to properly format their YAML configurations.

## Type of Change

- 📚 Documentation update
- 🐛 Bug fix (documentation examples were incomplete)