### PR TITLE
feat: add Close Inline Edit action with keyboard shortcuts Esc

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/CloseInlineEditAction.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/CloseInlineEditAction.kt
@@ -1,0 +1,40 @@
+package com.github.continuedev.continueintellijextension.editor
+
+import com.intellij.openapi.actionSystem.*
+import com.intellij.openapi.components.service
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+
+fun closeInlineEdit(project: Project, editor: Editor) {
+    try {
+        val diffStreamService = project.service<DiffStreamService>()
+        diffStreamService.reject(editor)
+    } catch (e: Exception) {
+        println("Failed to close inline edit: ${e.message}")
+    }
+}
+
+class CloseInlineEditAction : AnAction(), DumbAware {
+    override fun actionPerformed(e: AnActionEvent) {
+        if (isInvokedInEditor(e)) {
+            val editor = e.getData(PlatformDataKeys.EDITOR) ?: return
+            val project = e.getData(PlatformDataKeys.PROJECT) ?: return
+            closeInlineEdit(project, editor)
+        }
+    }
+
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabledAndVisible = isInvokedInEditor(e)
+    }
+
+    private fun isInvokedInEditor(e: AnActionEvent): Boolean {
+        val project: Project? = e.project
+        val editor: Editor? = e.getData(CommonDataKeys.EDITOR)
+        return project != null && editor != null && editor.contentComponent.hasFocus()
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return ActionUpdateThread.EDT
+    }
+}

--- a/extensions/intellij/src/main/resources/META-INF/plugin.xml
+++ b/extensions/intellij/src/main/resources/META-INF/plugin.xml
@@ -56,6 +56,17 @@
             <override-text place="GoToAction" text="Continue: Edit Code"/>
         </action>
 
+        <action class="com.github.continuedev.continueintellijextension.editor.CloseInlineEditAction"
+                id="explore.closeInlineEdit"
+                description="close Inline Edit"
+                text="close Inline Edit">
+            <keyboard-shortcut keymap="$default"
+                               first-keystroke="ESCAPE"/>
+            <keyboard-shortcut keymap="Mac OS X"
+                               first-keystroke="ESCAPE"/>
+            <override-text place="GoToAction" text="Continue: Close Inline Edit"/>
+        </action>
+
         <action id="continue.acceptDiff"
                 class="com.github.continuedev.continueintellijextension.actions.AcceptDiffAction"
                 text="Accept Diff" description="Accept Diff">


### PR DESCRIPTION
## Description

allow close the inline-edit panel by pressing esc in editor

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

https://github.com/user-attachments/assets/3c1ba4c8-00cc-4b5f-8ccb-fcf256e14a51


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a Close Inline Edit action to the IntelliJ plugin, bound to Esc, that rejects the current inline edit and closes the panel when the editor has focus.

<!-- End of auto-generated description by cubic. -->

