### PR TITLE
chore: Add stdout console log when package fails to build (build-packages.js)

### DIFF
--- a/scripts/build-packages.js
+++ b/scripts/build-packages.js
@@ -34,6 +34,7 @@ function runCommand(command, cwd, packageName) {
       } else {
         console.error(`❌ ${packageName}: ${command} failed with code ${code}`);
         console.error(`stderr: ${stderr}`);
+        console.error(`stdout: ${stdout}`);
         reject(
           new Error(`${packageName} failed: ${command} (exit code ${code})`),
         );


### PR DESCRIPTION
## Description

Adds a new console log when build-packages.json fails. I was getting an error that had empty stderr but stdout was non-empty but not being shown. Example:

```
❌ config-types (build): npm run build failed with code 2
stderr: 
stdout: 
> @continuedev/config-types@1.0.14 build
> tsc
error TS2688: Cannot find type definition file for 'node'.
  The file is in the program because:
    Entry point of type library 'node' specified in compilerOptions
```

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
