### PR TITLE
Fix: runTerminalCommand respect command aliases

### DIFF
--- a/extensions/cli/src/tools/runTerminalCommand.ts
+++ b/extensions/cli/src/tools/runTerminalCommand.ts
@@ -40,7 +40,7 @@ export const runTerminalCommandTool: Tool = {
   },
   run: async ({ command }: { command: string }): Promise<string> => {
     return new Promise((resolve, reject) => {
-      const child = spawn("sh", ["-c", command]);
+      const child = spawn("bash", ["-i", "-c", command]);
       let stdout = "";
       let stderr = "";
       let timeoutId: NodeJS.Timeout;


### PR DESCRIPTION
## Description

Coming from Claude code the terminal tool feels a bit flake. The environment is too different from what I would expect in a lot of cases.

I think the biggest offender is not respecting aliases which a user may rely on. See minimal example of the change:
<img width="302" height="139" alt="image" src="https://github.com/user-attachments/assets/5d0b09a7-19fd-4815-bb64-d83943d3ce82" />

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created


## Tests

Tested manually, the change is minimal. Everyone should have bash installed on their machine.
