### PR TITLE
chore: :white_check_mark: Add ui tests for the new Unified Terminal

### DIFF
--- a/gui/src/components/UnifiedTerminal/UnifiedTerminal.test.tsx
+++ b/gui/src/components/UnifiedTerminal/UnifiedTerminal.test.tsx
@@ -1,0 +1,330 @@
+import { screen, waitFor } from "@testing-library/react";
+import { ToolCallState } from "core";
+import { renderWithProviders } from "../../util/test/render";
+import { UnifiedTerminalCommand } from "./UnifiedTerminal";
+
+const MOCK_COMMAND = "npm test";
+const MOCK_OUTPUT = `Running tests...
+✓ Test 1 passed
+✓ Test 2 passed
+✗ Test 3 failed
+  Error: Expected true but got false
+
+Test Results:
+  2 passed, 1 failed
+  Total: 3 tests`;
+
+const LONG_OUTPUT = Array.from({ length: 25 }, (_, i) => `Line ${i + 1}`).join("\n");
+const MOCK_TOOL_CALL_ID = "terminal-call-123";
+
+const MOCK_ANSI_OUTPUT = `\u001b[32m✓\u001b[0m Test passed
+\u001b[31m✗\u001b[0m Test failed
+\u001b[1mBold text\u001b[0m
+\u001b[4mUnderlined text\u001b[0m`;
+
+const MOCK_OUTPUT_WITH_LINKS = `Build successful!
+Visit https://example.com for more info
+Check www.github.com/user/repo
+Error logs at file:///tmp/error.log`;
+
+// Mock the redux hooks
+const mockDispatch = vi.fn();
+const mockSelector = vi.fn();
+vi.mock("../../redux/hooks", () => ({
+  useAppDispatch: () => mockDispatch,
+  useAppSelector: () => mockSelector,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("UnifiedTerminalCommand", () => {
+  test("renders basic terminal command without output", async () => {
+    const { user } = await renderWithProviders(
+      <UnifiedTerminalCommand 
+        command={MOCK_COMMAND}
+        status="completed"
+      />
+    );
+
+    // Should show the command
+    expect(screen.getByText(`$ ${MOCK_COMMAND}`)).toBeInTheDocument();
+    
+    // Should show terminal header
+    expect(screen.getByText("Terminal")).toBeInTheDocument();
+    
+    // Should show completed status icon (green dot)
+    const terminalContainer = screen.getByTestId("terminal-container");
+    expect(terminalContainer).toBeInTheDocument();
+  });
+
+  test("renders terminal command with output", async () => {
+    const { container } = await renderWithProviders(
+      <UnifiedTerminalCommand 
+        command={MOCK_COMMAND}
+        output={MOCK_OUTPUT}
+        status="completed"
+      />
+    );
+
+    // Should show the command and output
+    expect(screen.getByText(`$ ${MOCK_COMMAND}`)).toBeInTheDocument();
+    
+    // Check that the output content exists in the container
+    expect(container.textContent).toMatch(/Test 1 passed/);
+    expect(container.textContent).toMatch(/Test 3 failed/);
+  });
+
+  test("shows running state with blinking cursor", async () => {
+    const mockToolCallState: ToolCallState = {
+      status: "calling",
+    };
+
+    const { user } = await renderWithProviders(
+      <UnifiedTerminalCommand 
+        command={MOCK_COMMAND}
+        status="running"
+        toolCallState={mockToolCallState}
+        toolCallId={MOCK_TOOL_CALL_ID}
+      />
+    );
+
+    // Should show running status
+    expect(screen.getByText("Running")).toBeInTheDocument();
+    
+    // Should show move to background link
+    expect(screen.getByText("Move to background")).toBeInTheDocument();
+  });
+
+  test("can expand and collapse terminal", async () => {
+    const { user, container } = await renderWithProviders(
+      <UnifiedTerminalCommand 
+        command={MOCK_COMMAND}
+        output={MOCK_OUTPUT}
+        status="completed"
+      />
+    );
+
+    // Should initially be expanded and show output
+    expect(container.textContent).toMatch(/Test 1 passed/);
+
+    // Find and click the collapse chevron (SVG icon)
+    const chevron = container.querySelector('svg[class*="cursor-pointer"], .cursor-pointer svg');
+    expect(chevron).toBeInTheDocument();
+    
+    if (chevron) {
+      await user.click(chevron);
+      
+      // After collapsing, output should not be visible
+      await waitFor(() => {
+        expect(container.textContent).not.toMatch(/Test 1 passed/);
+      });
+    }
+  });
+
+  test("shows collapsible output for long content", async () => {
+    const { user, container } = await renderWithProviders(
+      <UnifiedTerminalCommand 
+        command={MOCK_COMMAND}
+        output={LONG_OUTPUT}
+        status="completed"
+        displayLines={15}
+      />
+    );
+
+    // Should show the "+X more lines" indicator
+    expect(screen.getByText(/\+\d+ more lines/)).toBeInTheDocument();
+    
+    // Should initially show only some of the last lines
+    expect(container.textContent).toMatch(/Line 25/);
+    
+    // Click to expand using the "+X more lines" button
+    const expandButton = screen.getByText(/\+\d+ more lines/);
+    await user.click(expandButton);
+    
+    // Should now show all lines
+    await waitFor(() => {
+      expect(container.textContent).toMatch(/Line 1/);
+    });
+    
+    // Should show collapse option
+    expect(screen.getByText(/Collapse/)).toBeInTheDocument();
+  });
+
+  test("renders ANSI colors and formatting", async () => {
+    const { container } = await renderWithProviders(
+      <UnifiedTerminalCommand 
+        command={MOCK_COMMAND}
+        output={MOCK_ANSI_OUTPUT}
+        status="completed"
+      />
+    );
+
+    // Should render ANSI content (check the container text since ANSI splits across elements)
+    expect(container.textContent).toMatch(/Test passed/);
+    expect(container.textContent).toMatch(/Test failed/);
+    expect(container.textContent).toMatch(/Bold text/);
+    expect(container.textContent).toMatch(/Underlined text/);
+    
+    // Verify ANSI processing created styled spans
+    const styledSpans = container.querySelectorAll('span[class*="sc-esYiGF"]');
+    expect(styledSpans.length).toBeGreaterThan(0);
+  });
+
+  test("handles links in output", async () => {
+    const { container } = await renderWithProviders(
+      <UnifiedTerminalCommand 
+        command={MOCK_COMMAND}
+        output={MOCK_OUTPUT_WITH_LINKS}
+        status="completed"
+      />
+    );
+
+    // Should contain the link text in the output
+    expect(container.textContent).toMatch(/https:\/\/example\.com/);
+    expect(container.textContent).toMatch(/www\.github\.com/);
+    
+    // Note: Link detection might create actual <a> tags or just display the URLs
+    // The important thing is the URLs are visible in the output
+  });
+
+  test("shows copy and run in terminal buttons when not running", async () => {
+    const { container } = await renderWithProviders(
+      <UnifiedTerminalCommand 
+        command={MOCK_COMMAND}
+        output={MOCK_OUTPUT}
+        status="completed"
+      />
+    );
+
+    // Look for toolbar elements - they may be hidden by responsive classes but exist in DOM
+    const toolbarArea = container.querySelector('[class*="gap-2.5"]');
+    expect(toolbarArea).toBeInTheDocument();
+    
+    // Should contain SVG icons for copy/run operations
+    const svgIcons = container.querySelectorAll('svg');
+    expect(svgIcons.length).toBeGreaterThan(0);
+    
+    // Should show "Run" text (may be hidden on small screens)
+    expect(container.textContent).toMatch(/Run/);
+  });
+
+  test("handles move to background action", async () => {
+    const mockToolCallState: ToolCallState = {
+      status: "calling",
+    };
+
+    const { user } = await renderWithProviders(
+      <UnifiedTerminalCommand 
+        command={MOCK_COMMAND}
+        status="running"
+        toolCallState={mockToolCallState}
+        toolCallId={MOCK_TOOL_CALL_ID}
+      />
+    );
+
+    // Find and click move to background link
+    const moveToBackgroundLink = screen.getByText("Move to background");
+    await user.click(moveToBackgroundLink);
+
+    // Should dispatch the move to background action
+    expect(mockDispatch).toHaveBeenCalled();
+  });
+
+  test("shows different status types correctly", async () => {
+    // Test completed status
+    const { rerender, container } = await renderWithProviders(
+      <UnifiedTerminalCommand 
+        command={MOCK_COMMAND}
+        status="completed"
+        statusMessage="Command completed successfully"
+      />
+    );
+
+    expect(container.textContent).toMatch(/Command completed successfully/);
+
+    // Test failed status
+    rerender(
+      <UnifiedTerminalCommand 
+        command={MOCK_COMMAND}
+        status="failed"
+        statusMessage="Command failed with exit code 1"
+      />
+    );
+
+    expect(container.textContent).toMatch(/Command failed with exit code 1/);
+
+    // Test background status
+    rerender(
+      <UnifiedTerminalCommand 
+        command={MOCK_COMMAND}
+        status="background"
+        statusMessage="Command moved to background"
+      />
+    );
+
+    expect(container.textContent).toMatch(/Command moved to background/);
+  });
+
+  test("handles empty output gracefully", async () => {
+    const { container } = await renderWithProviders(
+      <UnifiedTerminalCommand 
+        command={MOCK_COMMAND}
+        output=""
+        status="completed"
+      />
+    );
+
+    // Should show command but no output section
+    expect(screen.getByText(`$ ${MOCK_COMMAND}`)).toBeInTheDocument();
+    
+    // Should not show any output content
+    const outputElements = container.querySelectorAll('pre code > div:not(:first-child)');
+    expect(outputElements.length).toBe(0);
+  });
+
+  test("processes terminal content correctly for line limiting", async () => {
+    const { container } = await renderWithProviders(
+      <UnifiedTerminalCommand 
+        command={MOCK_COMMAND}
+        output={LONG_OUTPUT}
+        status="completed"
+        displayLines={10}
+      />
+    );
+
+    // Should show correct number of hidden lines
+    expect(screen.getByText(/\+15 more lines/)).toBeInTheDocument();
+    
+    // Should show the last lines
+    expect(container.textContent).toMatch(/Line 25/);
+    
+    // Should not initially show the first lines (Line 1-15 should be hidden)
+    // The component shows last 10 lines (16-25) with a +15 more lines indicator
+    expect(container.textContent).toMatch(/Line 16/);
+  });
+
+  test("clicking on collapsible output toggles expansion", async () => {
+    const { user, container } = await renderWithProviders(
+      <UnifiedTerminalCommand 
+        command={MOCK_COMMAND}
+        output={LONG_OUTPUT}
+        status="completed"
+        displayLines={10}
+      />
+    );
+
+    // Click on the "+15 more lines" button to expand
+    const expandButton = screen.getByText(/\+15 more lines/);
+    await user.click(expandButton);
+    
+    // Should expand and show all content
+    await waitFor(() => {
+      expect(container.textContent).toMatch(/Line 1/);
+    });
+    
+    // Should show collapse option after expansion
+    expect(screen.getByText(/Collapse/)).toBeInTheDocument();
+  });
+});

--- a/gui/src/components/UnifiedTerminal/UnifiedTerminal.test.tsx
+++ b/gui/src/components/UnifiedTerminal/UnifiedTerminal.test.tsx
@@ -14,7 +14,9 @@ Test Results:
   2 passed, 1 failed
   Total: 3 tests`;
 
-const LONG_OUTPUT = Array.from({ length: 25 }, (_, i) => `Line ${i + 1}`).join("\n");
+const LONG_OUTPUT = Array.from({ length: 25 }, (_, i) => `Line ${i + 1}`).join(
+  "\n",
+);
 const MOCK_TOOL_CALL_ID = "terminal-call-123";
 
 const MOCK_ANSI_OUTPUT = `\u001b[32m✓\u001b[0m Test passed
@@ -42,18 +44,15 @@ beforeEach(() => {
 describe("UnifiedTerminalCommand", () => {
   test("renders basic terminal command without output", async () => {
     const { user } = await renderWithProviders(
-      <UnifiedTerminalCommand 
-        command={MOCK_COMMAND}
-        status="completed"
-      />
+      <UnifiedTerminalCommand command={MOCK_COMMAND} status="completed" />,
     );
 
     // Should show the command
     expect(screen.getByText(`$ ${MOCK_COMMAND}`)).toBeInTheDocument();
-    
+
     // Should show terminal header
     expect(screen.getByText("Terminal")).toBeInTheDocument();
-    
+
     // Should show completed status icon (green dot)
     const terminalContainer = screen.getByTestId("terminal-container");
     expect(terminalContainer).toBeInTheDocument();
@@ -61,16 +60,16 @@ describe("UnifiedTerminalCommand", () => {
 
   test("renders terminal command with output", async () => {
     const { container } = await renderWithProviders(
-      <UnifiedTerminalCommand 
+      <UnifiedTerminalCommand
         command={MOCK_COMMAND}
         output={MOCK_OUTPUT}
         status="completed"
-      />
+      />,
     );
 
     // Should show the command and output
     expect(screen.getByText(`$ ${MOCK_COMMAND}`)).toBeInTheDocument();
-    
+
     // Check that the output content exists in the container
     expect(container.textContent).toMatch(/Test 1 passed/);
     expect(container.textContent).toMatch(/Test 3 failed/);
@@ -79,43 +78,55 @@ describe("UnifiedTerminalCommand", () => {
   test("shows running state with blinking cursor", async () => {
     const mockToolCallState: ToolCallState = {
       status: "calling",
+      toolCallId: MOCK_TOOL_CALL_ID,
+      toolCall: {
+        id: MOCK_TOOL_CALL_ID,
+        type: "function",
+        function: {
+          name: "terminal",
+          arguments: "{}",
+        },
+      },
+      parsedArgs: {},
     };
 
     const { user } = await renderWithProviders(
-      <UnifiedTerminalCommand 
+      <UnifiedTerminalCommand
         command={MOCK_COMMAND}
         status="running"
         toolCallState={mockToolCallState}
         toolCallId={MOCK_TOOL_CALL_ID}
-      />
+      />,
     );
 
     // Should show running status
     expect(screen.getByText("Running")).toBeInTheDocument();
-    
+
     // Should show move to background link
     expect(screen.getByText("Move to background")).toBeInTheDocument();
   });
 
   test("can expand and collapse terminal", async () => {
     const { user, container } = await renderWithProviders(
-      <UnifiedTerminalCommand 
+      <UnifiedTerminalCommand
         command={MOCK_COMMAND}
         output={MOCK_OUTPUT}
         status="completed"
-      />
+      />,
     );
 
     // Should initially be expanded and show output
     expect(container.textContent).toMatch(/Test 1 passed/);
 
     // Find and click the collapse chevron (SVG icon)
-    const chevron = container.querySelector('svg[class*="cursor-pointer"], .cursor-pointer svg');
+    const chevron = container.querySelector(
+      'svg[class*="cursor-pointer"], .cursor-pointer svg',
+    );
     expect(chevron).toBeInTheDocument();
-    
+
     if (chevron) {
       await user.click(chevron);
-      
+
       // After collapsing, output should not be visible
       await waitFor(() => {
         expect(container.textContent).not.toMatch(/Test 1 passed/);
@@ -125,40 +136,40 @@ describe("UnifiedTerminalCommand", () => {
 
   test("shows collapsible output for long content", async () => {
     const { user, container } = await renderWithProviders(
-      <UnifiedTerminalCommand 
+      <UnifiedTerminalCommand
         command={MOCK_COMMAND}
         output={LONG_OUTPUT}
         status="completed"
         displayLines={15}
-      />
+      />,
     );
 
     // Should show the "+X more lines" indicator
     expect(screen.getByText(/\+\d+ more lines/)).toBeInTheDocument();
-    
+
     // Should initially show only some of the last lines
     expect(container.textContent).toMatch(/Line 25/);
-    
+
     // Click to expand using the "+X more lines" button
     const expandButton = screen.getByText(/\+\d+ more lines/);
     await user.click(expandButton);
-    
+
     // Should now show all lines
     await waitFor(() => {
       expect(container.textContent).toMatch(/Line 1/);
     });
-    
+
     // Should show collapse option
     expect(screen.getByText(/Collapse/)).toBeInTheDocument();
   });
 
   test("renders ANSI colors and formatting", async () => {
     const { container } = await renderWithProviders(
-      <UnifiedTerminalCommand 
+      <UnifiedTerminalCommand
         command={MOCK_COMMAND}
         output={MOCK_ANSI_OUTPUT}
         status="completed"
-      />
+      />,
     );
 
     // Should render ANSI content (check the container text since ANSI splits across elements)
@@ -166,7 +177,7 @@ describe("UnifiedTerminalCommand", () => {
     expect(container.textContent).toMatch(/Test failed/);
     expect(container.textContent).toMatch(/Bold text/);
     expect(container.textContent).toMatch(/Underlined text/);
-    
+
     // Verify ANSI processing created styled spans
     const styledSpans = container.querySelectorAll('span[class*="sc-esYiGF"]');
     expect(styledSpans.length).toBeGreaterThan(0);
@@ -174,38 +185,38 @@ describe("UnifiedTerminalCommand", () => {
 
   test("handles links in output", async () => {
     const { container } = await renderWithProviders(
-      <UnifiedTerminalCommand 
+      <UnifiedTerminalCommand
         command={MOCK_COMMAND}
         output={MOCK_OUTPUT_WITH_LINKS}
         status="completed"
-      />
+      />,
     );
 
     // Should contain the link text in the output
     expect(container.textContent).toMatch(/https:\/\/example\.com/);
     expect(container.textContent).toMatch(/www\.github\.com/);
-    
+
     // Note: Link detection might create actual <a> tags or just display the URLs
     // The important thing is the URLs are visible in the output
   });
 
   test("shows copy and run in terminal buttons when not running", async () => {
     const { container } = await renderWithProviders(
-      <UnifiedTerminalCommand 
+      <UnifiedTerminalCommand
         command={MOCK_COMMAND}
         output={MOCK_OUTPUT}
         status="completed"
-      />
+      />,
     );
 
     // Look for toolbar elements - they may be hidden by responsive classes but exist in DOM
     const toolbarArea = container.querySelector('[class*="gap-2.5"]');
     expect(toolbarArea).toBeInTheDocument();
-    
+
     // Should contain SVG icons for copy/run operations
-    const svgIcons = container.querySelectorAll('svg');
+    const svgIcons = container.querySelectorAll("svg");
     expect(svgIcons.length).toBeGreaterThan(0);
-    
+
     // Should show "Run" text (may be hidden on small screens)
     expect(container.textContent).toMatch(/Run/);
   });
@@ -213,15 +224,25 @@ describe("UnifiedTerminalCommand", () => {
   test("handles move to background action", async () => {
     const mockToolCallState: ToolCallState = {
       status: "calling",
+      toolCallId: MOCK_TOOL_CALL_ID,
+      toolCall: {
+        id: MOCK_TOOL_CALL_ID,
+        type: "function",
+        function: {
+          name: "terminal",
+          arguments: "{}",
+        },
+      },
+      parsedArgs: {},
     };
 
     const { user } = await renderWithProviders(
-      <UnifiedTerminalCommand 
+      <UnifiedTerminalCommand
         command={MOCK_COMMAND}
         status="running"
         toolCallState={mockToolCallState}
         toolCallId={MOCK_TOOL_CALL_ID}
-      />
+      />,
     );
 
     // Find and click move to background link
@@ -235,33 +256,33 @@ describe("UnifiedTerminalCommand", () => {
   test("shows different status types correctly", async () => {
     // Test completed status
     const { rerender, container } = await renderWithProviders(
-      <UnifiedTerminalCommand 
+      <UnifiedTerminalCommand
         command={MOCK_COMMAND}
         status="completed"
         statusMessage="Command completed successfully"
-      />
+      />,
     );
 
     expect(container.textContent).toMatch(/Command completed successfully/);
 
     // Test failed status
     rerender(
-      <UnifiedTerminalCommand 
+      <UnifiedTerminalCommand
         command={MOCK_COMMAND}
         status="failed"
         statusMessage="Command failed with exit code 1"
-      />
+      />,
     );
 
     expect(container.textContent).toMatch(/Command failed with exit code 1/);
 
     // Test background status
     rerender(
-      <UnifiedTerminalCommand 
+      <UnifiedTerminalCommand
         command={MOCK_COMMAND}
         status="background"
         statusMessage="Command moved to background"
-      />
+      />,
     );
 
     expect(container.textContent).toMatch(/Command moved to background/);
@@ -269,37 +290,39 @@ describe("UnifiedTerminalCommand", () => {
 
   test("handles empty output gracefully", async () => {
     const { container } = await renderWithProviders(
-      <UnifiedTerminalCommand 
+      <UnifiedTerminalCommand
         command={MOCK_COMMAND}
         output=""
         status="completed"
-      />
+      />,
     );
 
     // Should show command but no output section
     expect(screen.getByText(`$ ${MOCK_COMMAND}`)).toBeInTheDocument();
-    
+
     // Should not show any output content
-    const outputElements = container.querySelectorAll('pre code > div:not(:first-child)');
+    const outputElements = container.querySelectorAll(
+      "pre code > div:not(:first-child)",
+    );
     expect(outputElements.length).toBe(0);
   });
 
   test("processes terminal content correctly for line limiting", async () => {
     const { container } = await renderWithProviders(
-      <UnifiedTerminalCommand 
+      <UnifiedTerminalCommand
         command={MOCK_COMMAND}
         output={LONG_OUTPUT}
         status="completed"
         displayLines={10}
-      />
+      />,
     );
 
     // Should show correct number of hidden lines
     expect(screen.getByText(/\+15 more lines/)).toBeInTheDocument();
-    
+
     // Should show the last lines
     expect(container.textContent).toMatch(/Line 25/);
-    
+
     // Should not initially show the first lines (Line 1-15 should be hidden)
     // The component shows last 10 lines (16-25) with a +15 more lines indicator
     expect(container.textContent).toMatch(/Line 16/);
@@ -307,23 +330,23 @@ describe("UnifiedTerminalCommand", () => {
 
   test("clicking on collapsible output toggles expansion", async () => {
     const { user, container } = await renderWithProviders(
-      <UnifiedTerminalCommand 
+      <UnifiedTerminalCommand
         command={MOCK_COMMAND}
         output={LONG_OUTPUT}
         status="completed"
         displayLines={10}
-      />
+      />,
     );
 
     // Click on the "+15 more lines" button to expand
     const expandButton = screen.getByText(/\+15 more lines/);
     await user.click(expandButton);
-    
+
     // Should expand and show all content
     await waitFor(() => {
       expect(container.textContent).toMatch(/Line 1/);
     });
-    
+
     // Should show collapse option after expansion
     expect(screen.getByText(/Collapse/)).toBeInTheDocument();
   });

--- a/gui/src/components/UnifiedTerminal/UnifiedTerminal.tsx
+++ b/gui/src/components/UnifiedTerminal/UnifiedTerminal.tsx
@@ -418,7 +418,11 @@ export function UnifiedTerminalCommand({
   }, [command, output, hasOutput]);
 
   return (
-    <StyledTerminalContainer fontSize={getFontSize()} className="mb-4" data-testid="terminal-container">
+    <StyledTerminalContainer
+      fontSize={getFontSize()}
+      className="mb-4"
+      data-testid="terminal-container"
+    >
       <div className="outline-command-border -outline-offset-0.5 rounded-default bg-editor !my-2 flex min-w-0 flex-col outline outline-1">
         {/* Toolbar */}
         <div

--- a/gui/src/components/UnifiedTerminal/UnifiedTerminal.tsx
+++ b/gui/src/components/UnifiedTerminal/UnifiedTerminal.tsx
@@ -418,7 +418,7 @@ export function UnifiedTerminalCommand({
   }, [command, output, hasOutput]);
 
   return (
-    <StyledTerminalContainer fontSize={getFontSize()} className="mb-4">
+    <StyledTerminalContainer fontSize={getFontSize()} className="mb-4" data-testid="terminal-container">
       <div className="outline-command-border -outline-offset-0.5 rounded-default bg-editor !my-2 flex min-w-0 flex-col outline outline-1">
         {/* Toolbar */}
         <div


### PR DESCRIPTION
## Description

Adding UI tests for the Unified Terminal

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

Adding tests for the new Unified Terminal

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a UI test suite for the new Unified Terminal to verify rendering, states, and interactions. Also adds a data-testid to the terminal container for stable test selection.

- **New Features**
  - Tests command rendering, toolbar actions, and collapse/expand.
  - Verifies running/completed/failed/background statuses and messages.
  - Checks long output truncation with "+X more lines" and collapse.
  - Validates ANSI color/formatting handling and URL visibility.
  - Ensures "Move to background" dispatch and presence of Run/Copy controls.
  - Adds data-testid="terminal-container" for reliable selectors.

<!-- End of auto-generated description by cubic. -->

