### PR TITLE
fix: split thinking and chat messages when Ollama is not streaming

### DIFF
--- a/core/llm/llms/Ollama.ts
+++ b/core/llm/llms/Ollama.ts
@@ -422,31 +422,35 @@ class Ollama extends BaseLLM implements ModelInstaller {
       signal,
     });
 
-    function convertChatMessage(res: OllamaChatResponse): ChatMessage {
+    function convertChatMessage(res: OllamaChatResponse): ChatMessage[] {
       if ("error" in res) {
         throw new Error(res.error);
       }
-      if (res.message.role === "tool") {
+
+      const { role, content, thinking, tool_calls: toolCalls } = res.message;
+
+      if (role === "tool") {
         throw new Error(
-          "Unexpected message received from ollama with role = tool",
+          "Unexpected message received from Ollama with role = tool",
         );
       }
-      if (res.message.role === "assistant") {
-        if (res.message.thinking) {
-          const thinkingMessage: ThinkingChatMessage = {
-            role: "thinking",
-            content: res.message.thinking,
-          };
-          return thinkingMessage;
+
+      if (role === "assistant") {
+        const thinkingMessage: ThinkingChatMessage | null = thinking
+          ? { role: "thinking", content: thinking }
+          : null;
+
+        if (thinkingMessage && !content) {
+          // When Streaming you can't have both thinking and content
+          return [thinkingMessage];
         }
-        const chatMessage: ChatMessage = {
-          role: "assistant",
-          content: res.message.content,
-        };
-        if (res.message.tool_calls) {
+        // Either not thinking, or not streaming
+        const chatMessage: ChatMessage = { role: "assistant", content };
+
+        if (toolCalls?.length) {
           // Continue handles the response as a tool call delta but
           // But ollama returns the full object in one response with no streaming
-          chatMessage.toolCalls = res.message.tool_calls.map((tc) => ({
+          chatMessage.toolCalls = toolCalls.map((tc) => ({
             type: "function",
             id: `tc_${uuidv4()}`, // Generate a proper UUID with a prefix
             function: {
@@ -455,13 +459,13 @@ class Ollama extends BaseLLM implements ModelInstaller {
             },
           }));
         }
-        return chatMessage;
-      } else {
-        return {
-          role: res.message.role,
-          content: res.message.content,
-        };
+
+        // Return both thinking and chat messages if applicable
+        return thinkingMessage ? [thinkingMessage, chatMessage] : [chatMessage];
       }
+
+      // Fallback for all other roles
+      return [{ role, content }];
     }
 
     if (chatOptions.stream === false) {
@@ -469,7 +473,9 @@ class Ollama extends BaseLLM implements ModelInstaller {
         return; // Aborted by user
       }
       const json = (await response.json()) as OllamaChatResponse;
-      yield convertChatMessage(json);
+      for (const msg of convertChatMessage(json)) {
+        yield msg;
+      }
     } else {
       let buffer = "";
       for await (const value of streamResponse(response)) {
@@ -484,8 +490,9 @@ class Ollama extends BaseLLM implements ModelInstaller {
           if (chunk.trim() !== "") {
             try {
               const j = JSON.parse(chunk) as OllamaChatResponse;
-              const chatMessage = convertChatMessage(j);
-              yield chatMessage;
+              for (const msg of convertChatMessage(j)) {
+                yield msg;
+              }
             } catch (e) {
               throw new Error(`Error parsing Ollama response: ${e} ${chunk}`);
             }


### PR DESCRIPTION
Following up on #7389, I noticed that Ollama, when not streaming, returns both thinking and chat content in the same message, which my previous code didn't handle, basically only showing thinking and no content  with the following settings:

```yaml
name: Local Assistant
version: 1.0.0
schema: v1
models:
  - name: gpt-oss:20b
    provider: ollama
    model: gpt-oss:20b
    defaultCompletionOptions: 
      stream: false
```
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes Ollama non‑streaming responses by splitting thinking and assistant content into separate messages so chat content is no longer dropped. Also preserves tool calls and yields messages correctly in both streaming and non‑streaming modes.

- **Bug Fixes**
  - Split non‑streaming assistant responses into thinking and chat messages.
  - Preserve and emit tool_calls with generated IDs.
  - Update converters to return arrays and yield each message safely.
  - Guard against unexpected role=tool messages.

<!-- End of auto-generated description by cubic. -->

