### PR TITLE
fix: fix edit file tool render abnormal

### DIFF
--- a/gui/src/pages/gui/ToolCallDiv/EditFile.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/EditFile.tsx
@@ -17,7 +17,7 @@ export function EditFile(props: EditToolCallProps) {
     return null;
   }
 
-  const src = `\`\`\`${getMarkdownLanguageTagForFile(props.relativeFilePath)} ${props.relativeFilePath}${props.changes ? "\n" + props.changes + "\n" : ""}\`\`\``;
+  const src = `\`\`\`${getMarkdownLanguageTagForFile(props.relativeFilePath)} ${props.relativeFilePath}${props.changes ? "\n" + props.changes + "\n" : "\n"}\`\`\``;
 
   return (
     <StyledMarkdownPreview


### PR DESCRIPTION
## Description

fix edit file tool render abnormal
change src construction in gui/src/pages/gui/ToolCallDiv/EditFile.tsx

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

before:

https://github.com/user-attachments/assets/284a9801-c235-47e4-b7e4-5ded762744b5

after:

https://github.com/user-attachments/assets/b82730a1-4a88-4cc9-9795-555d1105c013

Key screenshots:
<img width="665" height="907" alt="problem" src="https://github.com/user-attachments/assets/6ddd9efa-57b7-43cc-baeb-b7010069a5ec" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
