### PR TITLE
Fix: Improve Continue review workflows error handling

### DIFF
--- a/actions/detailed-review/action.yml
+++ b/actions/detailed-review/action.yml
@@ -73,7 +73,7 @@ runs:
     - name: Install Continue CLI
       if: env.SKIP_REVIEW != 'true'
       shell: bash
-      run: npm install -g @continuedev/cli@1.4.25
+      run: npm install -g @continuedev/cli@latest
 
     - name: Build Inline Review Prompt
       if: env.SKIP_REVIEW != 'true'
@@ -194,6 +194,12 @@ runs:
           exit 1
         fi
 
+        # Validate API key
+        if [ -z "$CONTINUE_API_KEY" ]; then
+          echo "Error: CONTINUE_API_KEY environment variable is not set"
+          exit 1
+        fi
+
         # Log the prompt for debugging
         echo "===== START REVIEW PROMPT ====="
         head -n 50 inline_review_prompt.txt
@@ -201,23 +207,46 @@ runs:
         tail -n 20 inline_review_prompt.txt
         echo "===== END REVIEW PROMPT ====="
 
-        # Run the CLI and capture JSON output
-        cn --readonly --format json --org "${{ inputs.continue-org }}" --config "${{ inputs.continue-config }}" -p "$(cat inline_review_prompt.txt)" > inline_review_raw.json
+        # Test Continue CLI availability
+        echo "Testing Continue CLI..."
+        cn --version || { echo "Error: Continue CLI not found"; exit 1; }
 
-        # Log the output for debugging
-        echo "Initial Continue CLI output:"
-        cat inline_review_raw.json
+        # Run the CLI and capture JSON output with error handling
+        echo "Executing Continue CLI with org: ${{ inputs.continue-org }}, config: ${{ inputs.continue-config }}"
+        if ! cn --readonly --format json --org "${{ inputs.continue-org }}" --config "${{ inputs.continue-config }}" -p "$(cat inline_review_prompt.txt)" > inline_review_raw.json 2>cli_error.log; then
+          echo "Error: Continue CLI command failed"
+          echo "CLI error log:"
+          cat cli_error.log
+          
+          # Create fallback review
+          cat > inline_review.json << 'EOF'
+        {
+          "review_summary": "AI review failed due to service initialization issues. Please check the Continue API key and configuration.",
+          "comments": []
+        }
+        EOF
+          # Don't exit with failure to allow posting fallback comment
+        else
+          # Log the output for debugging
+          echo "Initial Continue CLI output:"
+          cat inline_review_raw.json
 
-        # Validate JSON output and use it directly
-        if ! jq empty inline_review_raw.json 2>/dev/null; then
-          echo "Error: Invalid JSON output from Continue CLI"
-          exit 1
+          # Validate JSON output and use it directly
+          if ! jq empty inline_review_raw.json 2>/dev/null; then
+            echo "Warning: Invalid JSON output from Continue CLI, using fallback"
+            cat > inline_review.json << 'EOF'
+        {
+          "review_summary": "AI review completed but failed to parse output correctly.",
+          "comments": []
+        }
+        EOF
+          else
+            # Use the JSON output directly
+            cp inline_review_raw.json inline_review.json
+            echo "Review output:"
+            cat inline_review.json
+          fi
         fi
-        
-        # Use the JSON output directly
-        cp inline_review_raw.json inline_review.json
-        echo "Review output:"
-        cat inline_review.json
 
     - name: Post Inline Review Comments
       if: env.SKIP_REVIEW != 'true'

--- a/actions/general-review/action.yml
+++ b/actions/general-review/action.yml
@@ -68,7 +68,7 @@ runs:
     - name: Install Continue CLI
       if: env.SHOULD_RUN == 'true'
       shell: bash
-      run: npm install -g @continuedev/cli@1.4.25
+      run: npm install -g @continuedev/cli@latest
 
     - name: Build PR Review Prompt
       if: env.SHOULD_RUN == 'true'
@@ -157,6 +157,12 @@ runs:
         echo "=================================="
         echo ""
 
+        # Validate API key
+        if [ -z "$CONTINUE_API_KEY" ]; then
+          echo "Error: CONTINUE_API_KEY environment variable is not set"
+          exit 1
+        fi
+
         # Validate inputs to prevent command injection
         if [[ ! "$CONTINUE_ORG" =~ ^[a-zA-Z0-9_-]+$ ]]; then
           echo "Error: Invalid organization name. Must contain only alphanumeric characters, hyphens, and underscores."
@@ -168,8 +174,31 @@ runs:
           exit 1
         fi
 
-        # Run the CLI with validated config
-        cn --readonly --org "$CONTINUE_ORG" --config "$CONTINUE_CONFIG" -p "$(cat review_prompt.txt)" > code_review.md
+        # Test Continue CLI availability
+        echo "Testing Continue CLI..."
+        cn --version || { echo "Error: Continue CLI not found"; exit 1; }
+
+        # Run the CLI with validated config and error handling
+        echo "Executing Continue CLI with org: $CONTINUE_ORG, config: $CONTINUE_CONFIG"
+        if ! cn --readonly --org "$CONTINUE_ORG" --config "$CONTINUE_CONFIG" -p "$(cat review_prompt.txt)" > code_review.md 2>cli_error.log; then
+          echo "Error: Continue CLI command failed"
+          echo "CLI error log:"
+          cat cli_error.log
+          
+          # Create fallback review
+          cat > code_review.md << 'EOF'
+## Code Review Summary
+
+⚠️ AI review failed due to service initialization issues. Please check the Continue API key and configuration.
+
+### Troubleshooting
+- Verify the CONTINUE_API_KEY secret is set correctly
+- Check that the organization and config path are valid
+- Ensure the Continue service is accessible
+EOF
+        else
+          echo "Review generated successfully"
+        fi
 
     - name: Upload Review Results
       if: env.SHOULD_RUN == 'true' && always()


### PR DESCRIPTION
## Problem

The Continue detailed and general review workflows have been failing on every PR with service initialization errors:
- `Failed to initialize ConfigService: Response returned an error code`
- `Failed to load service 'config': Fatal error: Response returned an error code`

## Root Causes

1. **Outdated CLI version**: Using pinned version `@continuedev/cli@1.4.25` which may have compatibility issues
2. **Missing API key validation**: No explicit check for CONTINUE_API_KEY before running CLI commands
3. **Poor error handling**: Workflows fail completely when CLI errors occur, preventing any feedback

## Solution

### Changes to both `actions/detailed-review/action.yml` and `actions/general-review/action.yml`:

1. **Updated CLI Installation**
   - Changed from `@continuedev/cli@1.4.25` to `@continuedev/cli@latest`
   - Ensures we get latest bug fixes and compatibility updates

2. **Added API Key Validation**
   - Explicit check for CONTINUE_API_KEY environment variable
   - Fails early with clear error message if missing

3. **Improved Error Handling**
   - Added CLI version check to verify installation
   - Capture CLI errors to separate log file for debugging
   - Create fallback reviews when CLI fails
   - Workflow continues to post informative comments even on failure

4. **Better Debugging**
   - More verbose logging showing org and config being used
   - CLI error output captured and displayed
   - Clearer error messages for troubleshooting

## Testing

After merging, verify:
1. The `CONTINUE_API_KEY` secret exists and is valid in repository settings
2. The config path `continuedev/review-bot` is correct and accessible
3. The Continue service/API is operational

## Impact

- Workflows will now fail gracefully with informative messages
- Root causes of failures will be clearly visible in logs
- Users will get feedback even when the AI review fails
- Easier to diagnose and fix configuration issues