### PR TITLE
feat: use on prem proxy in CLI

### DIFF
--- a/extensions/cli/src/configLoader.ts
+++ b/extensions/cli/src/configLoader.ts
@@ -353,7 +353,7 @@ async function loadAssistantSlug(
   }
 
   // Unroll locally if not logged in
-  if (!(apiClient as any).configuration.apiKey) {
+  if (!(apiClient as any).configuration.accessToken) {
     return await unrollAssistantWithConfig(
       {
         uriType: "slug",

--- a/extensions/cli/src/services/ModelService.ts
+++ b/extensions/cli/src/services/ModelService.ts
@@ -102,7 +102,7 @@ export class ModelService
                 env: {
                   apiKeyLocation: (selectedModel as any).apiKeyLocation,
                   orgScopeId: organizationId,
-                  proxyUrl: undefined,
+                  proxyUrl: (selectedModel as any).onPremProxyUrl ?? undefined,
                 },
               }
             : {
@@ -301,7 +301,7 @@ export class ModelService
               env: {
                 apiKeyLocation: (selectedModel as any).apiKeyLocation,
                 orgScopeId: organizationId,
-                proxyUrl: undefined,
+                proxyUrl: (selectedModel as any).onPremProxyUrl ?? undefined,
               },
             }
           : {

--- a/extensions/cli/src/ui/ToolResultSummary.tsx
+++ b/extensions/cli/src/ui/ToolResultSummary.tsx
@@ -8,6 +8,8 @@ import { getToolDisplayName } from "src/tools/index.js";
 import { ColoredDiff } from "./ColoredDiff.js";
 import { ChecklistDisplay } from "./components/ChecklistDisplay.js";
 
+const MAX_BASH_OUTPUT_LINES = 4;
+
 interface ToolResultSummaryProps {
   toolName?: string;
   content: string;
@@ -74,8 +76,8 @@ const ToolResultSummary: React.FC<ToolResultSummaryProps> = ({
     const actualOutput = isStderr ? content.slice(7).trim() : content;
     const outputLines = actualOutput.split("\n");
 
-    if (outputLines.length <= 16) {
-      // Show actual output for 16 lines or fewer
+    if (outputLines.length <= MAX_BASH_OUTPUT_LINES) {
+      // Show actual output for MAX_BASH_OUTPUT_LINES lines or fewer
       return (
         <Box flexDirection="column">
           <Box>
@@ -88,8 +90,8 @@ const ToolResultSummary: React.FC<ToolResultSummaryProps> = ({
         </Box>
       );
     } else {
-      // Show first 16 lines with ellipsis for more than 16 lines
-      const first16Lines = outputLines.slice(0, 16).join("\n");
+      // Show first MAX_BASH_OUTPUT_LINES lines with ellipsis for more lines
+      const firstLines = outputLines.slice(0, MAX_BASH_OUTPUT_LINES).join("\n");
       return (
         <Box flexDirection="column">
           <Box>
@@ -97,10 +99,12 @@ const ToolResultSummary: React.FC<ToolResultSummaryProps> = ({
             <Text color="gray"> Terminal output:</Text>
           </Box>
           <Box paddingLeft={2}>
-            <Text color={isStderr ? "red" : "white"}>{first16Lines}</Text>
+            <Text color={isStderr ? "red" : "white"}>{firstLines}</Text>
           </Box>
           <Box paddingLeft={2}>
-            <Text color="gray">...</Text>
+            <Text color="gray">
+              ... +{outputLines.length - MAX_BASH_OUTPUT_LINES} lines
+            </Text>
           </Box>
         </Box>
       );


### PR DESCRIPTION
## Description

Correctly use on prem proxy settings in CLI
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Routes CLI model requests through the configured on‑prem proxy. Also fixes login detection and trims noisy terminal output in tool results.

- **Bug Fixes**
  - Use selectedModel.onPremProxyUrl for proxyUrl so requests go through the on‑prem proxy.
  - Check configuration.accessToken to detect not-logged-in state and unroll locally.
  - Truncate bash output to the first 4 lines and show a “+N lines” indicator.

<!-- End of auto-generated description by cubic. -->

