### PR TITLE
refactor: next edit model provider rename

### DIFF
--- a/core/nextEdit/NextEditPrefetchQueue.ts
+++ b/core/nextEdit/NextEditPrefetchQueue.ts
@@ -7,6 +7,9 @@ export interface ProcessedItem {
   outcome: NextEditOutcome; // Result from the model
 }
 
+/**
+ * Keeps a queue of the broken down diffs from a changed editable range, as determined in core/nextEdit/diff.ts
+ */
 export class PrefetchQueue {
   private static instance: PrefetchQueue | null = null;
 

--- a/core/nextEdit/NextEditProvider.ts
+++ b/core/nextEdit/NextEditProvider.ts
@@ -26,7 +26,7 @@ import { DocumentHistoryTracker } from "./DocumentHistoryTracker.js";
 import { NextEditLoggingService } from "./NextEditLoggingService.js";
 import { PrefetchQueue } from "./NextEditPrefetchQueue.js";
 import { NextEditProviderFactory } from "./NextEditProviderFactory.js";
-import { BaseNextEditProvider } from "./providers/BaseNextEditProvider.js";
+import { BaseNextEditModelProvider } from "./providers/BaseNextEditProvider.js";
 import {
   ModelSpecificContext,
   NextEditOutcome,
@@ -65,7 +65,7 @@ export class NextEditProvider {
   // private nextEditableRegionsInTheCurrentChain: RangeInFile[] = [];
 
   // Model-specific provider instance.
-  private modelProvider: BaseNextEditProvider | null = null;
+  private modelProvider: BaseNextEditModelProvider | null = null;
 
   private constructor(
     private readonly configHandler: ConfigHandler,

--- a/core/nextEdit/NextEditProviderFactory.ts
+++ b/core/nextEdit/NextEditProviderFactory.ts
@@ -1,10 +1,10 @@
 import { NEXT_EDIT_MODELS } from "../llm/constants.js";
-import { BaseNextEditProvider } from "./providers/BaseNextEditProvider.js";
+import { BaseNextEditModelProvider } from "./providers/BaseNextEditProvider.js";
 import { InstinctProvider } from "./providers/InstinctNextEditProvider.js";
 import { MercuryCoderProvider } from "./providers/MercuryCoderNextEditProvider.js";
 
 export class NextEditProviderFactory {
-  static createProvider(modelName: string): BaseNextEditProvider {
+  static createProvider(modelName: string): BaseNextEditModelProvider {
     if (modelName.includes(NEXT_EDIT_MODELS.MERCURY_CODER)) {
       return new MercuryCoderProvider();
     } else if (modelName.includes(NEXT_EDIT_MODELS.INSTINCT)) {

--- a/core/nextEdit/providers/BaseNextEditProvider.ts
+++ b/core/nextEdit/providers/BaseNextEditProvider.ts
@@ -19,7 +19,7 @@ import {
 } from "../types.js";
 import { isWhitespaceOnlyDeletion } from "../utils.js";
 
-export abstract class BaseNextEditProvider {
+export abstract class BaseNextEditModelProvider {
   protected readonly modelName: string;
 
   constructor(modelName: string) {

--- a/core/nextEdit/providers/InstinctNextEditProvider.ts
+++ b/core/nextEdit/providers/InstinctNextEditProvider.ts
@@ -11,9 +11,9 @@ import {
   PromptTemplateRenderer,
 } from "../templating/NextEditPromptEngine.js";
 import { ModelSpecificContext, Prompt, PromptMetadata } from "../types.js";
-import { BaseNextEditProvider } from "./BaseNextEditProvider.js";
+import { BaseNextEditModelProvider } from "./BaseNextEditProvider.js";
 
-export class InstinctProvider extends BaseNextEditProvider {
+export class InstinctProvider extends BaseNextEditModelProvider {
   private templateRenderer: PromptTemplateRenderer;
 
   constructor() {

--- a/core/nextEdit/providers/MercuryCoderNextEditProvider.ts
+++ b/core/nextEdit/providers/MercuryCoderNextEditProvider.ts
@@ -11,9 +11,9 @@ import {
   PromptTemplateRenderer,
 } from "../templating/NextEditPromptEngine.js";
 import { ModelSpecificContext, Prompt, PromptMetadata } from "../types.js";
-import { BaseNextEditProvider } from "./BaseNextEditProvider.js";
+import { BaseNextEditModelProvider } from "./BaseNextEditProvider.js";
 
-export class MercuryCoderProvider extends BaseNextEditProvider {
+export class MercuryCoderProvider extends BaseNextEditModelProvider {
   private templateRenderer: PromptTemplateRenderer;
 
   constructor() {


### PR DESCRIPTION
## Description

Quick renaming / safe refactoring of next edit code
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Renamed the NextEdit base provider class to BaseNextEditModelProvider to clarify intent and improve type clarity. Updated all imports, types, and subclass extends accordingly. No behavior changes.

- **Refactors**
  - Renamed BaseNextEditProvider → BaseNextEditModelProvider and updated factory return type.
  - Updated Instinct and MercuryCoder providers and NextEditProvider to use the new base class.

<!-- End of auto-generated description by cubic. -->

