### PR TITLE
Reduce test flake

### DIFF
--- a/.github/actions/check-llm-changes/action.yml
+++ b/.github/actions/check-llm-changes/action.yml
@@ -1,0 +1,55 @@
+name: "Check LLM Changes"
+description: "Check if LLM-related files have changed and set environment variable to control API tests"
+outputs:
+  llm_changed:
+    description: "Whether LLM-related files have changed"
+    value: ${{ steps.check-changes.outputs.llm_changed }}
+  ignore_api_tests:
+    description: "Whether to ignore API tests based on file changes and other conditions"
+    value: ${{ steps.check-changes.outputs.ignore_api_tests }}
+inputs:
+  is_fork:
+    description: "Whether this is a fork PR"
+    required: false
+    default: "false"
+  is_dependabot:
+    description: "Whether this is a dependabot PR"
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check if LLM-related files changed
+      id: check-changes
+      shell: bash
+      run: |
+        if [ "${{ github.event_name }}" = "push" ]; then
+          # For push events, compare against the previous commit
+          CHANGED_FILES=$(git diff --name-only HEAD~1...HEAD)
+        else
+          # For PR events, compare against the base branch
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD)
+        fi
+
+        echo "Changed files:"
+        echo "$CHANGED_FILES"
+
+        # Check if any LLM-related files were changed
+        LLM_CHANGED=false
+        if echo "$CHANGED_FILES" | grep -E "(^core/llm/|^core/index\.ts|^core/package\.json|^core/jest\.config\.js|^packages/.*/(.*llm.*|.*openai.*|.*anthropic.*)|\.github/workflows/pr-checks\.yaml|\.github/actions/check-llm-changes/)" > /dev/null; then
+          LLM_CHANGED=true
+        fi
+
+        echo "LLM files changed: $LLM_CHANGED"
+        echo "llm_changed=$LLM_CHANGED" >> $GITHUB_OUTPUT
+
+        # Determine whether to ignore API tests
+        IGNORE_API_TESTS=false
+        if [ "${{ inputs.is_fork }}" = "true" ] || [ "${{ inputs.is_dependabot }}" = "true" ] || [ "$LLM_CHANGED" = "false" ]; then
+          IGNORE_API_TESTS=true
+        fi
+
+        echo "Ignore API tests: $IGNORE_API_TESTS"
+        echo "ignore_api_tests=$IGNORE_API_TESTS" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -44,6 +44,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # Needed for git diff to work
       - name: Setup packages
         uses: ./.github/actions/setup-packages
       - name: Setup core component
@@ -51,6 +53,13 @@ jobs:
         with:
           component: core
           include-root: true
+
+      - name: Check if LLM-related files changed
+        id: llm-changes
+        uses: ./.github/actions/check-llm-changes
+        with:
+          is_fork: ${{ github.event.pull_request.head.repo.fork == true }}
+          is_dependabot: ${{ github.actor == 'dependabot[bot]' }}
 
       - name: Type check and lint
         run: |
@@ -66,7 +75,7 @@ jobs:
           npm test
           npm run vitest
         env:
-          IGNORE_API_KEY_TESTS: ${{ github.event.pull_request.head.repo.fork == true || github.actor == 'dependabot[bot]' }}
+          IGNORE_API_KEY_TESTS: ${{ steps.llm-changes.outputs.ignore_api_tests }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
@@ -180,8 +189,17 @@ jobs:
         package: ${{ fromJson(needs.get-packages-matrix.outputs.packages) }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # Needed for git diff to work
       - name: Setup packages
         uses: ./.github/actions/setup-packages
+
+      - name: Check if LLM-related files changed
+        id: llm-changes
+        uses: ./.github/actions/check-llm-changes
+        with:
+          is_fork: ${{ github.event.pull_request.head.repo.fork == true }}
+          is_dependabot: ${{ github.actor == 'dependabot[bot]' }}
 
       - name: Test and check ${{ matrix.package }}
         run: |
@@ -189,7 +207,7 @@ jobs:
           npm ci
           npm test
         env:
-          IGNORE_API_KEY_TESTS: ${{ github.event.pull_request.head.repo.fork == true || github.actor == 'dependabot[bot]' }}
+          IGNORE_API_KEY_TESTS: ${{ steps.llm-changes.outputs.ignore_api_tests }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/core/indexing/docs/crawlers/DocsCrawler.test.ts
+++ b/core/indexing/docs/crawlers/DocsCrawler.test.ts
@@ -155,9 +155,27 @@ describe("DocsCrawler", () => {
       test(
         `Default crawler common site: ${url}`,
         async () => {
-          const { pages, crawler } = await runCrawl(url);
-          expect(pages.length).toBeGreaterThanOrEqual(1);
-          expect(crawler).toEqual("default");
+          // Retry logic to handle flaky network requests to TRIAL_PROXY_URL
+          let lastError;
+          const maxRetries = 3;
+
+          for (let attempt = 1; attempt <= maxRetries; attempt++) {
+            try {
+              const { pages, crawler } = await runCrawl(url);
+              expect(pages.length).toBeGreaterThanOrEqual(1);
+              expect(crawler).toEqual("default");
+              return; // Test passed, exit retry loop
+            } catch (error) {
+              lastError = error;
+              if (attempt === maxRetries) {
+                throw error; // Final attempt failed, throw the error
+              }
+              // Wait before retrying (exponential backoff)
+              await new Promise((resolve) =>
+                setTimeout(resolve, 1000 * attempt),
+              );
+            }
+          }
         },
         TIMEOUT_MS,
       );


### PR DESCRIPTION
Various updates to reduce test flake, including for DocsCrawler tests, llm.test.ts, etc.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add retry with exponential backoff to DocsCrawler default-crawler tests to reduce flakiness from TRIAL_PROXY_URL network hiccups. Tests retry runCrawl up to three times and return early on success; assertions and timeouts are unchanged.

<!-- End of auto-generated description by cubic. -->

