### PR TITLE
fix: use default shell for run

### DIFF
--- a/extensions/cli/src/tools/runTerminalCommand.ts
+++ b/extensions/cli/src/tools/runTerminalCommand.ts
@@ -1,4 +1,5 @@
 import { spawn } from "child_process";
+import os from "os";
 
 import { telemetryService } from "../telemetry/telemetryService.js";
 import {
@@ -71,6 +72,7 @@ export const runTerminalCommandTool: Tool = {
       });
       let stdout = "";
       let stderr = "";
+      let output = stdout + (stderr ? `\nStderr: ${stderr}` : "");
       let timeoutId: NodeJS.Timeout;
       let isResolved = false;
 
@@ -87,7 +89,6 @@ export const runTerminalCommandTool: Tool = {
           if (isResolved) return;
           isResolved = true;
           child.kill();
-          let output = stdout + (stderr ? `\nStderr: ${stderr}` : "");
           output += `\n\n[Command timed out after ${TIMEOUT_MS / 1000} seconds of no output]`;
 
           // Truncate output if it has too many lines


### PR DESCRIPTION
## Description
Fixed bug in runTerminalCommand only using /bin/sh shell
- Changed hardcoded /bin/sh to process.env.SHELL or POWERSHELL.EXE for cli extension

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

OLD:
<img width="484" height="589" alt="Screenshot 2025-08-27 at 11 31 27 AM" src="https://github.com/user-attachments/assets/e70ae751-3be1-4b09-8742-312cd10e2a56" />

FIX:
<img width="484" height="846" alt="Screenshot 2025-08-27 at 11 28 51 AM" src="https://github.com/user-attachments/assets/0147876d-4bd9-466a-a25c-8409b876ae00" />

## Tests

- added test for checking shell

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes runTerminalCommand to use the user’s default shell instead of hardcoded /bin/sh, so commands run in the expected environment on macOS/Linux and Windows. Also adds safer cwd handling and better color support.

- **Bug Fixes**
  - Use process.env.SHELL on Unix/macOS; use PowerShell on Windows.
  - Run Unix shells as a login shell (-l) so rc files are sourced.
  - Fallback cwd to HOME/USERPROFILE or os.tmpdir() if process.cwd() fails.
  - Enable color output by setting common color env vars.
  - Add test to verify the system default shell is used.

<!-- End of auto-generated description by cubic. -->
