### PR TITLE
fix: prevent AUTODETECT model from being queried on Ollama

### DIFF
--- a/core/llm/llms/Ollama.ts
+++ b/core/llm/llms/Ollama.ts
@@ -150,7 +150,7 @@ class Ollama extends BaseLLM implements ModelInstaller {
   constructor(options: LLMOptions) {
     super(options);
 
-    if (options.isFromAutoDetect) {
+    if (options.model === "AUTODETECT") {
       return;
     }
     const headers: Record<string, string> = {


### PR DESCRIPTION
bf8b4bd introduced a regression which makes Ollama.ts query /api/show for AUTODETECT models. Since it's not a real model, the log is littered with: 

> The model "AUTODETECT" was not found. To download it, run `ollama run AUTODETECT`.
> 
> Code: undefined
> Error number: undefined
> Syscall: undefined
> Type: undefined
> 
> Error: The model "AUTODETECT" was not found. To download it, run `ollama run AUTODETECT`.
>     at _Ollama.parseError (/Users/fbricon/Dev/souk/continue-for-granite/core/llm/index.ts:421:16)
>     at processTicksAndRejections (node:internal/process/task_queues:105:5)
>     at customFetch2 (/Users/fbricon/Dev/souk/continue-for-granite/core/llm/index.ts:468:25)
>     at withExponentialBackoff (/Users/fbricon/Dev/souk/continue-for-granite/core/util/withExponentialBackoff.ts:14:22)
> 

While AUTODETECT model is not a real model, models satisfying `isFromAutoDetect` are though. While looking for fimSupport is probably not relevant now for autodetected models, I'm considering applying the same sort of logic to detect if thinking is supported, so /api/show would still need to be queried for those models. But that's another story.

cc @RomneyDa 