### PR TITLE
chore: remove katex font links to avoid warnings

### DIFF
--- a/gui/src/components/StyledMarkdownPreview/katex.css
+++ b/gui/src/components/StyledMarkdownPreview/katex.css
@@ -1,183 +1,3 @@
-@font-face {
-  font-family: KaTeX_AMS;
-  font-style: normal;
-  font-weight: 400;
-  src:
-    url(fonts/KaTeX_AMS-Regular.woff2) format("woff2"),
-    url(fonts/KaTeX_AMS-Regular.woff) format("woff"),
-    url(fonts/KaTeX_AMS-Regular.ttf) format("truetype");
-}
-@font-face {
-  font-family: KaTeX_Caligraphic;
-  font-style: normal;
-  font-weight: 700;
-  src:
-    url(fonts/KaTeX_Caligraphic-Bold.woff2) format("woff2"),
-    url(fonts/KaTeX_Caligraphic-Bold.woff) format("woff"),
-    url(fonts/KaTeX_Caligraphic-Bold.ttf) format("truetype");
-}
-@font-face {
-  font-family: KaTeX_Caligraphic;
-  font-style: normal;
-  font-weight: 400;
-  src:
-    url(fonts/KaTeX_Caligraphic-Regular.woff2) format("woff2"),
-    url(fonts/KaTeX_Caligraphic-Regular.woff) format("woff"),
-    url(fonts/KaTeX_Caligraphic-Regular.ttf) format("truetype");
-}
-@font-face {
-  font-family: KaTeX_Fraktur;
-  font-style: normal;
-  font-weight: 700;
-  src:
-    url(fonts/KaTeX_Fraktur-Bold.woff2) format("woff2"),
-    url(fonts/KaTeX_Fraktur-Bold.woff) format("woff"),
-    url(fonts/KaTeX_Fraktur-Bold.ttf) format("truetype");
-}
-@font-face {
-  font-family: KaTeX_Fraktur;
-  font-style: normal;
-  font-weight: 400;
-  src:
-    url(fonts/KaTeX_Fraktur-Regular.woff2) format("woff2"),
-    url(fonts/KaTeX_Fraktur-Regular.woff) format("woff"),
-    url(fonts/KaTeX_Fraktur-Regular.ttf) format("truetype");
-}
-@font-face {
-  font-family: KaTeX_Main;
-  font-style: normal;
-  font-weight: 700;
-  src:
-    url(fonts/KaTeX_Main-Bold.woff2) format("woff2"),
-    url(fonts/KaTeX_Main-Bold.woff) format("woff"),
-    url(fonts/KaTeX_Main-Bold.ttf) format("truetype");
-}
-@font-face {
-  font-family: KaTeX_Main;
-  font-style: italic;
-  font-weight: 700;
-  src:
-    url(fonts/KaTeX_Main-BoldItalic.woff2) format("woff2"),
-    url(fonts/KaTeX_Main-BoldItalic.woff) format("woff"),
-    url(fonts/KaTeX_Main-BoldItalic.ttf) format("truetype");
-}
-@font-face {
-  font-family: KaTeX_Main;
-  font-style: italic;
-  font-weight: 400;
-  src:
-    url(fonts/KaTeX_Main-Italic.woff2) format("woff2"),
-    url(fonts/KaTeX_Main-Italic.woff) format("woff"),
-    url(fonts/KaTeX_Main-Italic.ttf) format("truetype");
-}
-@font-face {
-  font-family: KaTeX_Main;
-  font-style: normal;
-  font-weight: 400;
-  src:
-    url(fonts/KaTeX_Main-Regular.woff2) format("woff2"),
-    url(fonts/KaTeX_Main-Regular.woff) format("woff"),
-    url(fonts/KaTeX_Main-Regular.ttf) format("truetype");
-}
-@font-face {
-  font-family: KaTeX_Math;
-  font-style: italic;
-  font-weight: 700;
-  src:
-    url(fonts/KaTeX_Math-BoldItalic.woff2) format("woff2"),
-    url(fonts/KaTeX_Math-BoldItalic.woff) format("woff"),
-    url(fonts/KaTeX_Math-BoldItalic.ttf) format("truetype");
-}
-@font-face {
-  font-family: KaTeX_Math;
-  font-style: italic;
-  font-weight: 400;
-  src:
-    url(fonts/KaTeX_Math-Italic.woff2) format("woff2"),
-    url(fonts/KaTeX_Math-Italic.woff) format("woff"),
-    url(fonts/KaTeX_Math-Italic.ttf) format("truetype");
-}
-@font-face {
-  font-family: "KaTeX_SansSerif";
-  font-style: normal;
-  font-weight: 700;
-  src:
-    url(fonts/KaTeX_SansSerif-Bold.woff2) format("woff2"),
-    url(fonts/KaTeX_SansSerif-Bold.woff) format("woff"),
-    url(fonts/KaTeX_SansSerif-Bold.ttf) format("truetype");
-}
-@font-face {
-  font-family: "KaTeX_SansSerif";
-  font-style: italic;
-  font-weight: 400;
-  src:
-    url(fonts/KaTeX_SansSerif-Italic.woff2) format("woff2"),
-    url(fonts/KaTeX_SansSerif-Italic.woff) format("woff"),
-    url(fonts/KaTeX_SansSerif-Italic.ttf) format("truetype");
-}
-@font-face {
-  font-family: "KaTeX_SansSerif";
-  font-style: normal;
-  font-weight: 400;
-  src:
-    url(fonts/KaTeX_SansSerif-Regular.woff2) format("woff2"),
-    url(fonts/KaTeX_SansSerif-Regular.woff) format("woff"),
-    url(fonts/KaTeX_SansSerif-Regular.ttf) format("truetype");
-}
-@font-face {
-  font-family: KaTeX_Script;
-  font-style: normal;
-  font-weight: 400;
-  src:
-    url(fonts/KaTeX_Script-Regular.woff2) format("woff2"),
-    url(fonts/KaTeX_Script-Regular.woff) format("woff"),
-    url(fonts/KaTeX_Script-Regular.ttf) format("truetype");
-}
-@font-face {
-  font-family: KaTeX_Size1;
-  font-style: normal;
-  font-weight: 400;
-  src:
-    url(fonts/KaTeX_Size1-Regular.woff2) format("woff2"),
-    url(fonts/KaTeX_Size1-Regular.woff) format("woff"),
-    url(fonts/KaTeX_Size1-Regular.ttf) format("truetype");
-}
-@font-face {
-  font-family: KaTeX_Size2;
-  font-style: normal;
-  font-weight: 400;
-  src:
-    url(fonts/KaTeX_Size2-Regular.woff2) format("woff2"),
-    url(fonts/KaTeX_Size2-Regular.woff) format("woff"),
-    url(fonts/KaTeX_Size2-Regular.ttf) format("truetype");
-}
-@font-face {
-  font-family: KaTeX_Size3;
-  font-style: normal;
-  font-weight: 400;
-  src:
-    url(fonts/KaTeX_Size3-Regular.woff2) format("woff2"),
-    url(fonts/KaTeX_Size3-Regular.woff) format("woff"),
-    url(fonts/KaTeX_Size3-Regular.ttf) format("truetype");
-}
-@font-face {
-  font-family: KaTeX_Size4;
-  font-style: normal;
-  font-weight: 400;
-  src:
-    url(fonts/KaTeX_Size4-Regular.woff2) format("woff2"),
-    url(fonts/KaTeX_Size4-Regular.woff) format("woff"),
-    url(fonts/KaTeX_Size4-Regular.ttf) format("truetype");
-}
-@font-face {
-  font-family: KaTeX_Typewriter;
-  font-style: normal;
-  font-weight: 400;
-  src:
-    url(fonts/KaTeX_Typewriter-Regular.woff2) format("woff2"),
-    url(fonts/KaTeX_Typewriter-Regular.woff) format("woff"),
-    url(fonts/KaTeX_Typewriter-Regular.ttf) format("truetype");
-}
 .katex {
   text-rendering: auto;
   font:
@@ -220,73 +40,24 @@
 .katex .textbf {
   font-weight: 700;
 }
-.katex .textit {
-  font-style: italic;
-}
-.katex .textrm {
-  font-family: KaTeX_Main;
-}
-.katex .textsf {
-  font-family: KaTeX_SansSerif;
-}
-.katex .texttt {
-  font-family: KaTeX_Typewriter;
-}
-.katex .mathnormal {
-  font-family: KaTeX_Math;
-  font-style: italic;
-}
-.katex .mathit {
-  font-family: KaTeX_Main;
+.katex .textit,
+.katex .mathnormal,
+.katex .mathit,
+.katex .mathitsf,
+.katex .textitsf {
   font-style: italic;
 }
 .katex .mathrm {
   font-style: normal;
 }
 .katex .mathbf {
-  font-family: KaTeX_Main;
   font-weight: 700;
 }
 .katex .boldsymbol {
-  font-family: KaTeX_Math;
   font-style: italic;
   font-weight: 700;
-}
-.katex .amsrm,
-.katex .mathbb,
-.katex .textbb {
-  font-family: KaTeX_AMS;
-}
-.katex .mathcal {
-  font-family: KaTeX_Caligraphic;
-}
-.katex .mathfrak,
-.katex .textfrak {
-  font-family: KaTeX_Fraktur;
-}
-.katex .mathtt {
-  font-family: KaTeX_Typewriter;
-}
-.katex .mathscr,
-.katex .textscr {
-  font-family: KaTeX_Script;
-}
-.katex .mathsf,
-.katex .textsf {
-  font-family: KaTeX_SansSerif;
-}
-.katex .mathboldsf,
-.katex .textboldsf {
-  font-family: KaTeX_SansSerif;
-  font-weight: 700;
-}
-.katex .mathitsf,
-.katex .textitsf {
-  font-family: KaTeX_SansSerif;
-  font-style: italic;
 }
 .katex .mainrm {
-  font-family: KaTeX_Main;
   font-style: normal;
 }
 .katex .vlist-t {
@@ -896,22 +667,16 @@
   font-size: 1em;
 }
 .katex .delimsizing.size1 {
-  font-family: KaTeX_Size1;
 }
 .katex .delimsizing.size2 {
-  font-family: KaTeX_Size2;
 }
 .katex .delimsizing.size3 {
-  font-family: KaTeX_Size3;
 }
 .katex .delimsizing.size4 {
-  font-family: KaTeX_Size4;
 }
 .katex .delimsizing.mult .delim-size1 > span {
-  font-family: KaTeX_Size1;
 }
 .katex .delimsizing.mult .delim-size4 > span {
-  font-family: KaTeX_Size4;
 }
 .katex .nulldelimiter {
   display: inline-block;
@@ -922,10 +687,8 @@
   position: relative;
 }
 .katex .op-symbol.small-op {
-  font-family: KaTeX_Size1;
 }
 .katex .op-symbol.large-op {
-  font-family: KaTeX_Size2;
 }
 .katex .accent > .vlist-t,
 .katex .op-limits > .vlist-t {


### PR DESCRIPTION
## Description

The katex font files produced warnings during gui folder's build. The fonts were never present but they referenced in katex.css. This PR removes their references.

- No changes in styling

resolves CON-3258

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot


**no build warnings in gui's `npm run build`**

<img width="1213" height="487" alt="image" src="https://github.com/user-attachments/assets/e91ab61a-31aa-43dd-8cc6-1eb0e585d60a" />

**before and after images when removing the fonts (no changes)**

<img width="546" height="504" alt="image" src="https://github.com/user-attachments/assets/c80665ab-2432-4d1e-a7bc-5a50071ade83" />



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed KaTeX font-face and font-family references from gui’s katex.css to eliminate build warnings from missing font files. No visual changes to math rendering. Resolves CON-3258.

- **Bug Fixes**
  - Removed @font-face links and related font-family usages that pointed to absent KaTeX fonts.
  - gui build no longer emits font warnings; layout and styling remain the same.

<!-- End of auto-generated description by cubic. -->

