### PR TITLE
fix: update claude models in getting started

### DIFF
--- a/gui/src/pages/AddNewModel/configs/models.ts
+++ b/gui/src/pages/AddNewModel/configs/models.ts
@@ -1184,42 +1184,27 @@ export const models: { [key: string]: ModelPackage } = {
     icon: "openai.png",
     isOpenSource: false,
   },
-  claude35Sonnet: {
-    title: "Claude 3.5 Sonnet",
+  claude4Sonnet: {
+    title: "Claude 4 Sonnet",
     description:
-      "Anthropic's most intelligent model, but much less expensive than Claude 3 Opus",
+      "The most intelligent model in the Claude 4 series. Costing lesser than Claude 4 Opus.",
     params: {
-      model: "claude-3-5-sonnet-latest",
+      model: "claude-4-sonnet-latest",
       contextLength: 200_000,
-      title: "Claude 3.5 Sonnet",
+      title: "Claude 4 Sonnet",
       apiKey: "",
     },
     providerOptions: ["anthropic", "askSage"],
     icon: "anthropic.png",
     isOpenSource: false,
   },
-  claude3Opus: {
-    title: "Claude 3 Opus",
-    description:
-      "The most capable model in the Claude 3 series, beating GPT-4 on many benchmarks",
+  claude41Opus: {
+    title: "Claude 4.1 Opus",
+    description: "The most capable model in the Claude 4 series",
     params: {
-      model: "claude-3-opus-20240229",
+      model: "claude-opus-4-1-20250805",
       contextLength: 200_000,
-      title: "Claude 3 Opus",
-      apiKey: "",
-    },
-    providerOptions: ["anthropic", "askSage"],
-    icon: "anthropic.png",
-    isOpenSource: false,
-  },
-  claude3Sonnet: {
-    title: "Claude 3 Sonnet",
-    description:
-      "The second most capable model in the Claude 3 series: ideal balance of intelligence and speed",
-    params: {
-      model: "claude-3-sonnet-20240229",
-      contextLength: 200_000,
-      title: "Claude 3 Sonnet",
+      title: "Claude 4.1 Opus",
       apiKey: "",
     },
     providerOptions: ["anthropic", "askSage"],

--- a/gui/src/pages/AddNewModel/configs/providers.ts
+++ b/gui/src/pages/AddNewModel/configs/providers.ts
@@ -107,12 +107,7 @@ export const providers: Partial<Record<string, ProviderInfo>> = {
         defaultValue: 100000,
       },
     ],
-    packages: [
-      models.claude35Sonnet,
-      models.claude3Opus,
-      models.claude3Sonnet,
-      models.claude35Haiku,
-    ],
+    packages: [models.claude4Sonnet, models.claude41Opus, models.claude35Haiku],
     apiKeyUrl: "https://console.anthropic.com/account/keys",
   },
   moonshot: {


### PR DESCRIPTION
## Description

The Claude 4 models were missing in the getting started dialog for anthropic. This PR adds them.

closes https://github.com/continuedev/continue/discussions/7376

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the Anthropic models in the Getting Started dialog to include Claude 4 Sonnet and Claude 4.1 Opus, replacing outdated Claude 3/3.5 entries. This fixes missing options and aligns defaults with Anthropic’s current lineup.

- **Bug Fixes**
  - Added presets: claude-4-sonnet-latest and claude-opus-4-1-20250805.
  - Removed Claude 3 Opus and Claude 3 Sonnet; replaced 3.5 Sonnet. Kept 3.5 Haiku.
  - Updated the Anthropic provider’s package list so the new models show in Add New Model.

<!-- End of auto-generated description by cubic. -->

