### PR TITLE
Feat: Untangle NES and autocomplete logic

### DIFF
--- a/core/autocomplete/util/processSingleLineCompletion.vitest.ts
+++ b/core/autocomplete/util/processSingleLineCompletion.vitest.ts
@@ -13,6 +13,7 @@ describe("processSingleLineCompletion", () => {
       testCase.input.lastLineOfCompletionText,
       testCase.input.currentText,
       testCase.input.cursorPosition,
+      true,
     );
 
     expect(result).toEqual(testCase.expectedResult);
@@ -20,14 +21,16 @@ describe("processSingleLineCompletion", () => {
 
   it("should handle midline insert repeating the end of line", () => {
     const testCase = processTestCase({
-      original: "console.log(|cur|);|till|",
+      original: "console.log(|cur|);",
       completion: '"Hello, world!");',
+      appliedCompletion: '"Hello, world!"',
     });
 
     const result = processSingleLineCompletion(
       testCase.input.lastLineOfCompletionText,
       testCase.input.currentText,
       testCase.input.cursorPosition,
+      true,
     );
 
     expect(result).toEqual(testCase.expectedResult);
@@ -43,6 +46,24 @@ describe("processSingleLineCompletion", () => {
       testCase.input.lastLineOfCompletionText,
       testCase.input.currentText,
       testCase.input.cursorPosition,
+      true,
+    );
+
+    expect(result).toEqual(testCase.expectedResult);
+  });
+
+  it("should handle midline insert plus extra when range can't be changed", () => {
+    const testCase = processTestCase({
+      original: "console.log(|cur|)",
+      completion: '"Hello, world!");',
+      appliedCompletion: '"Hello, world!"',
+    });
+
+    const result = processSingleLineCompletion(
+      testCase.input.lastLineOfCompletionText,
+      testCase.input.currentText,
+      testCase.input.cursorPosition,
+      false,
     );
 
     expect(result).toEqual(testCase.expectedResult);
@@ -58,6 +79,7 @@ describe("processSingleLineCompletion", () => {
       testCase.input.lastLineOfCompletionText,
       testCase.input.currentText,
       testCase.input.cursorPosition,
+      true,
     );
 
     expect(result).toEqual(testCase.expectedResult);
@@ -74,6 +96,7 @@ describe("processSingleLineCompletion", () => {
       testCase.input.lastLineOfCompletionText,
       testCase.input.currentText,
       testCase.input.cursorPosition,
+      true,
     );
 
     expect(result).toEqual(testCase.expectedResult);
@@ -89,6 +112,7 @@ describe("processSingleLineCompletion", () => {
       testCase.input.lastLineOfCompletionText,
       testCase.input.currentText,
       testCase.input.cursorPosition,
+      true,
     );
 
     expect(result).toEqual(testCase.expectedResult);


### PR DESCRIPTION
## Description

This commit refactors the ContinueCompletionProvider to separate the logic for Next Edit Suggestions (NES) from the standard inline autocomplete functionality.

Previously, the two features were intertwined, leading to complex conditional logic. This was particularly problematic when interacting with VS Code's native completion widget (selectedCompletionInfo), where changing the completion range is restricted.

Key changes include:
  - The main provideInlineCompletionItems method is now split into two distinct paths for NES and standard autocomplete.

  - A mayChangeRange parameter was added to processSingleLineCompletion to prevent replacing the rest of a line when the VS Code completion widget is visible.

  - The willDisplay function was split into willDisplayForNES and willDisplayForAutocomplete to handle the distinct validation requirements of each path.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Separated Next Edit Suggestions (NES) from standard inline autocomplete in the VS Code provider to reduce complexity and fix conflicts with the native completion widget. This makes suggestions more reliable and predictable.

- **Refactors**
  - Split provideInlineCompletionItems into distinct NES and autocomplete paths.
  - Added mayChangeRange to processSingleLineCompletion to respect widget constraints.
  - Replaced willDisplay with willDisplayForNES and willDisplayForAutocomplete.

- **Bug Fixes**
  - Prevents unintended range replacement when the VS Code completion widget is visible.
  - Ensures inline completions extend selectedCompletionInfo and use its range when required.

<!-- End of auto-generated description by cubic. -->

