### PR TITLE
build: hide new version of JetBrains plugin by default

### DIFF
--- a/extensions/intellij/build.gradle.kts
+++ b/extensions/intellij/build.gradle.kts
@@ -59,13 +59,24 @@ intellijPlatform {
             sinceBuild = "241"
         }
     }
+    publishing {
+        token = environment("PUBLISH_TOKEN")
+        hidden = true
+        val channel = if (isEap) "eap" else "default"
+        channels = listOf(channel)
+    }
+    signing {
+        certificateChain = environment("CERTIFICATE_CHAIN")
+        privateKey = environment("PRIVATE_KEY")
+        password = environment("PRIVATE_KEY_PASSWORD")
+    }
     pluginVerification {
         ides {
-            ide("IC", "2025.2")
-            ide("IC", "2025.1")
-            ide("IC", "2024.3")
-            ide("IC", "2024.2")
-            ide("IC", "2024.1")
+            create("IC", "2025.2")
+            create("IC", "2025.1")
+            create("IC", "2024.3")
+            create("IC", "2024.2")
+            create("IC", "2024.1")
         }
     }
 }
@@ -120,19 +131,6 @@ tasks {
             .substringBefore("<!-- Plugin description end -->")
             .let(::markdownToHTML)
         check(pluginDescription.get().isNotEmpty()) { "Plugin description section not found in README.md" }
-    }
-
-    signPlugin {
-        certificateChain = environment("CERTIFICATE_CHAIN")
-        privateKey = environment("PRIVATE_KEY")
-        password = environment("PRIVATE_KEY_PASSWORD")
-    }
-
-    publishPlugin {
-        token = environment("PUBLISH_TOKEN")
-
-        val channel = if (isEap) "eap" else "default"
-        channels = listOf(channel)
     }
 
     runIde {


### PR DESCRIPTION
Extra:
* migrate publish/sign-in config to v2 (based on: https://github.com/JetBrains/intellij-platform-gradle-plugin)
* replace deprecated `ide(*, *)` with `create(*, *)` 
