### PR TITLE
fix(doc): update Ollama installation guide

### DIFF
--- a/docs/guides/ollama-guide.mdx
+++ b/docs/guides/ollama-guide.mdx
@@ -34,15 +34,15 @@ curl -fsSL https://ollama.ai/install.sh | sh
 After installation, start the Ollama service:
 
 ```bash
+# Check Ollama version - verify it's installed
+ollama --version
+
 # Start Ollama (runs in background)
 ollama serve
 
 # Verify it's running
 curl http://localhost:11434
 # Should return "Ollama is running"
-
-# Check Ollama version
-ollama --version
 ```
 
 ### Step 3: Download Models


### PR DESCRIPTION
## Description

This pull request makes a minor update to the installation verification steps in the Ollama guide. The change improves the order of commands to check that Ollama is installed before starting the service.

* Installation verification: Moved the `ollama --version` command to immediately follow the installation step, ensuring users verify the installation before proceeding to start the Ollama service. (`docs/guides/ollama-guide.mdx`)

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
