### PR TITLE
cai: mention continue workflow

### DIFF
--- a/.github/workflows/respond-to-cubic.yaml
+++ b/.github/workflows/respond-to-cubic.yaml
@@ -1,0 +1,215 @@
+name: Respond to @continuedev Comments
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  respond-to-comment:
+    # Only run on pull request comments
+    if: github.event_name == 'issue_comment' && github.event.issue.pull_request
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check if comment contains @continuedev
+        id: check-mention
+        run: |
+          if echo "${{ github.event.comment.body }}" | grep -q "@continuedev"; then
+            echo "contains_mention=true" >> $GITHUB_OUTPUT
+          else
+            echo "contains_mention=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout PR branch
+        if: steps.check-mention.outputs.contains_mention == 'true'
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Get PR information
+        if: steps.check-mention.outputs.contains_mention == 'true'
+        id: pr-info
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+
+            core.setOutput('head_ref', pr.head.ref);
+            core.setOutput('head_sha', pr.head.sha);
+            return pr;
+
+      - name: Checkout PR branch
+        if: steps.check-mention.outputs.contains_mention == 'true'
+        run: |
+          git checkout ${{ steps.pr-info.outputs.head_ref }}
+
+      - name: Setup Node.js
+        if: steps.check-mention.outputs.contains_mention == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Continue CLI globally
+        if: steps.check-mention.outputs.contains_mention == 'true'
+        run: npm i -g @continuedev/cli
+
+      - name: Start remote session
+        if: steps.check-mention.outputs.contains_mention == 'true'
+        id: remote-session
+        env:
+          CONTINUE_API_KEY: ${{ secrets.CONTINUE_API_KEY }}
+        run: |
+          # Create the prompt for remote session
+          PROMPT="Please help with the following request from @${{ github.event.comment.user.login }} on PR #${{ github.event.issue.number }}:
+
+          ${{ github.event.comment.body }}
+
+          Please analyze the current PR, understand the request, implement the necessary changes, and commit them to this branch."
+
+          # Start remote session and capture JSON output
+          SESSION_OUTPUT=$(echo "$PROMPT" | cn remote -s --branch ${{ steps.pr-info.outputs.head_ref }})
+          echo "Raw session output: $SESSION_OUTPUT"
+
+          # Extract URL from JSON output
+          SESSION_URL=$(echo "$SESSION_OUTPUT" | jq -r '.url // empty')
+
+          if [ -z "$SESSION_URL" ] || [ "$SESSION_URL" = "null" ]; then
+            echo "Failed to extract session URL from output: $SESSION_OUTPUT"
+            exit 1
+          fi
+
+          echo "session_url=$SESSION_URL" >> $GITHUB_OUTPUT
+          echo "✅ Started remote session: $SESSION_URL"
+
+      - name: Comment with session URL
+        if: steps.check-mention.outputs.contains_mention == 'true' && steps.remote-session.outputs.session_url
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commentBody = `I've started [a remote session](${{ steps.remote-session.outputs.session_url }}) to help with your request:
+            > ${{ github.event.comment.body }}`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: commentBody
+            });
+
+      - name: Log session details
+        if: steps.check-mention.outputs.contains_mention == 'true'
+        run: |
+          echo "✅ Successfully started remote session for comment from ${{ github.event.comment.user.login }} on PR #${{ github.event.issue.number }}"
+          echo "Session URL: ${{ steps.remote-session.outputs.session_url }}"
+          echo "Original comment: ${{ github.event.comment.body }}"
+
+  respond-to-review-comment:
+    # Only run on pull request review comments
+    if: github.event_name == 'pull_request_review_comment'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check if comment contains @continuedev
+        id: check-mention
+        run: |
+          if echo "${{ github.event.comment.body }}" | grep -q "@continuedev"; then
+            echo "contains_mention=true" >> $GITHUB_OUTPUT
+          else
+            echo "contains_mention=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout PR branch
+        if: steps.check-mention.outputs.contains_mention == 'true'
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Setup Node.js
+        if: steps.check-mention.outputs.contains_mention == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Continue CLI globally
+        if: steps.check-mention.outputs.contains_mention == 'true'
+        run: npm i -g @continuedev/cli
+
+      - name: Start remote session
+        if: steps.check-mention.outputs.contains_mention == 'true'
+        id: remote-session
+        env:
+          CONTINUE_API_KEY: ${{ secrets.CONTINUE_API_KEY }}
+        run: |
+          # Create a temporary file for the prompt to handle special characters and newlines properly
+          cat > /tmp/prompt.txt << 'PROMPT_EOF'
+          Please help with the following code review comment from @${{ github.event.comment.user.login }} on PR #${{ github.event.pull_request.number }}:
+
+          **File:** ${{ github.event.comment.path }}
+          **Line:** ${{ github.event.comment.line || github.event.comment.original_line || 'N/A' }}
+          **Comment:** ${{ github.event.comment.body }}
+
+          Please analyze the specific file and line mentioned, understand the review feedback, implement the necessary changes, and commit them to this branch.
+          PROMPT_EOF
+
+          # Debug output
+          echo "PROMPT content:"
+          cat /tmp/prompt.txt
+
+          # Start remote session and capture JSON output
+          echo "Starting cn with prompt..."
+          SESSION_OUTPUT=$(cat /tmp/prompt.txt | cn remote -s --branch ${{ github.event.pull_request.head.ref }})
+          echo "Raw session output: $SESSION_OUTPUT"
+
+          # Extract URL from JSON output
+          SESSION_URL=$(echo "$SESSION_OUTPUT" | jq -r '.url // empty')
+
+          if [ -z "$SESSION_URL" ] || [ "$SESSION_URL" = "null" ]; then
+            echo "Failed to extract session URL from output: $SESSION_OUTPUT"
+            exit 1
+          fi
+
+          echo "session_url=$SESSION_URL" >> $GITHUB_OUTPUT
+          echo "✅ Started remote session: $SESSION_URL"
+
+      - name: Comment with session URL
+        if: steps.check-mention.outputs.contains_mention == 'true' && steps.remote-session.outputs.session_url
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commentBody = `I've started [a remote session](${{ steps.remote-session.outputs.session_url }}) to help with your request:
+            > ${{ github.event.comment.body }}`;
+
+            const commentParams = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: ${{ github.event.pull_request.number }},
+              body: commentBody,
+              commit_id: '${{ github.event.pull_request.head.sha }}',
+              path: '${{ github.event.comment.path }}',
+              in_reply_to: ${{ github.event.comment.id }}
+            };
+
+            await github.rest.pulls.createReviewComment(commentParams);
+
+      - name: Log session details
+        if: steps.check-mention.outputs.contains_mention == 'true'
+        run: |
+          echo "✅ Successfully started remote session for review comment from ${{ github.event.comment.user.login }} on PR #${{ github.event.pull_request.number }}"
+          echo "Session URL: ${{ steps.remote-session.outputs.session_url }}"
+          echo "File: ${{ github.event.comment.path }}"
+          echo "Line: ${{ github.event.comment.line }}"
+          echo "Original comment: ${{ github.event.comment.body }}"


### PR DESCRIPTION
## Description

Bring the respond to cubic workflow to continue repo from cli
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add a GitHub Action that listens for @continuedev mentions on PR comments and review comments, starts a Continue remote session on the PR branch, and replies with the session link. This lets reviewers trigger automated help directly from the thread.

- New Features
  - Triggers on PR and review comments that include @continuedev.
  - Checks out the PR head, installs Node 20 and @continuedev/cli, then runs cn remote -s with CONTINUE_API_KEY.
  - Extracts the session URL and posts it as a reply in the same thread.
  - Uses repository write permissions for contents, pull requests, and issues.

- Migration
  - Add CONTINUE_API_KEY to repository secrets.

<!-- End of auto-generated description by cubic. -->

