### PR TITLE
fix: stop reading on EOF

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/process/ContinueProcessHandler.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/process/ContinueProcessHandler.kt
@@ -50,8 +50,8 @@ class ContinueProcessHandler(
 
         processScope!!.launch(Dispatchers.IO) {
             while (isActive) {
-                val line = reader.readLine()
-                if (line != null && line.isNotEmpty())
+                val line = reader.readLine() ?: break
+                if (line.isNotEmpty())
                     readMessage(line)
             }
         }


### PR DESCRIPTION
Before this change, if the process returned EOF (if the line was `null` - that's how `BufferedReader` works), the loop kept trying to read forever.
