### PR TITLE
fix: Don't fail on non-fatal errors in CLI

### DIFF
--- a/extensions/cli/src/configLoader.ts
+++ b/extensions/cli/src/configLoader.ts
@@ -232,10 +232,13 @@ async function loadUserAssistantWithFallback(
     if (!result.config) {
       throw new Error(result.errors?.join("\n") ?? "Failed to load assistant.");
     }
-    
+
     const errors = result.errors;
     if (errors?.some((e: any) => e.fatal)) {
-      throw new Error(errors.map((e: any) => e.message).join("\n") ?? "Failed to load assistant.");
+      throw new Error(
+        errors.map((e: any) => e.message).join("\n") ??
+          "Failed to load assistant.",
+      );
     }
 
     return result.config as AssistantUnrolled;
@@ -381,7 +384,10 @@ async function loadAssistantSlug(
   const result = resp.configResult;
   const errors = result.errors;
   if (errors?.some((e: any) => e.fatal)) {
-    throw new Error(errors.map((e: any) => e.message).join("\n") ?? "Failed to load assistant.");
+    throw new Error(
+      errors.map((e: any) => e.message).join("\n") ??
+        "Failed to load assistant.",
+    );
   }
 
   return result.config as AssistantUnrolled;

--- a/extensions/cli/src/configLoader.ts
+++ b/extensions/cli/src/configLoader.ts
@@ -373,8 +373,9 @@ async function loadAssistantSlug(
   });
 
   const result = resp.configResult;
-  if (result.errors?.length || !result.config) {
-    throw new Error(result.errors?.join("\n") ?? "Failed to load assistant.");
+  const errors = result.errors;
+  if (errors?.some((e: any) => e.fatal)) {
+    throw new Error(errors.map((e: any) => e.message).join("\n") ?? "Failed to load assistant.");
   }
 
   return result.config as AssistantUnrolled;

--- a/extensions/cli/src/configLoader.ts
+++ b/extensions/cli/src/configLoader.ts
@@ -229,9 +229,15 @@ async function loadUserAssistantWithFallback(
 
   if (assistants.length > 0) {
     const result = assistants[0].configResult;
-    if (result.errors?.length || !result.config) {
+    if (!result.config) {
       throw new Error(result.errors?.join("\n") ?? "Failed to load assistant.");
     }
+    
+    const errors = result.errors;
+    if (errors?.some((e: any) => e.fatal)) {
+      throw new Error(errors.map((e: any) => e.message).join("\n") ?? "Failed to load assistant.");
+    }
+
     return result.config as AssistantUnrolled;
   }
 


### PR DESCRIPTION
## Description

don't fail to load assistant on non-fatal errors
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Stop failing the CLI on non‑fatal config errors so assistants still load. We now only throw when errors are marked fatal.

- **Bug Fixes**
  - Ignore non‑fatal errors in configLoader when loading by fallback and by slug.
  - Aggregate fatal error messages into a single thrown error.
  - Prevent premature CLI exit on warnings or non‑blocking issues.

<!-- End of auto-generated description by cubic. -->

