### PR TITLE
feat(cli): skip telemetry if there is no internet connection

### DIFF
--- a/extensions/cli/src/telemetry/posthogService.ts
+++ b/extensions/cli/src/telemetry/posthogService.ts
@@ -1,3 +1,4 @@
+import dns from "dns/promises";
 import os from "node:os";
 
 import node_machine_id from "node-machine-id";
@@ -15,13 +16,36 @@ export class PosthogService {
     this.uniqueId = this.getEventUserId();
   }
 
+  private _hasInternetConnection: boolean | undefined = undefined;
+  private async hasInternetConnection() {
+    const refetchConnection = async () => {
+      try {
+        await dns.lookup("app.posthog.com");
+        this._hasInternetConnection = true;
+      } catch {
+        this._hasInternetConnection = false;
+      }
+    };
+
+    if (typeof this._hasInternetConnection !== "undefined") {
+      void refetchConnection(); // check in background if connection became available
+      return this._hasInternetConnection;
+    }
+
+    await refetchConnection();
+    return this._hasInternetConnection;
+  }
+
   get isEnabled() {
     return process.env.CONTINUE_CLI_ENABLE_TELEMETRY !== "0";
   }
 
   private _client: PostHogType | undefined;
   private async getClient() {
-    if (this.isEnabled) {
+    if (!(await this.hasInternetConnection())) {
+      this._client = undefined;
+      logger.warn("No internet connection, skipping telemetry");
+    } else if (this.isEnabled) {
       if (!this._client) {
         const { PostHog } = await import("posthog-node");
         this._client = new PostHog(
@@ -30,6 +54,7 @@ export class PosthogService {
             host: "https://app.posthog.com",
           },
         );
+        logger.debug("Initialized telemetry");
       }
     } else {
       this._client = undefined;
@@ -83,7 +108,13 @@ export class PosthogService {
     try {
       const client = await this.getClient();
       if (client) {
-        await client.shutdown();
+        // Set a timeout for shutdown to prevent hanging
+        const shutdownPromise = client.shutdown();
+        const timeoutPromise = new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("Shutdown timeout")), 5000),
+        );
+
+        await Promise.race([shutdownPromise, timeoutPromise]);
       }
     } catch (e) {
       logger.debug(`Failed to shutdown PostHog client: ${e}`);


### PR DESCRIPTION
## Description

A posthog error appears where there is no internet connection prevent further chat. This PR fixes it.

<details><summary>posthog connection error</summary>
```
Error while flushing PostHog PostHogFetchNetworkError: Network error while fetching PostHog
    at file:///Users/instinct/Desktop/continue/extensions/cli/node_modules/@posthog/core/dist/index.mjs:569:23
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async retriable (file:///Users/instinct/Desktop/continue/extensions/cli/node_modules/@posthog/core/dist/utils.mjs:17:25)
    at async PostHog.fetchWithRetry (file:///Users/instinct/Desktop/continue/extensions/cli/node_modules/@posthog/core/dist/index.mjs:561:16)
    at async PostHog._flush (file:///Users/instinct/Desktop/continue/extensions/cli/node_modules/@posthog/core/dist/index.mjs:527:17) {
  error: TypeError: fetch failed
      at node:internal/deps/undici/undici:13502:13
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async file:///Users/instinct/Desktop/continue/extensions/cli/node_modules/@posthog/core/dist/index.mjs:564:23
      at async retriable (file:///Users/instinct/Desktop/continue/extensions/cli/node_modules/@posthog/core/dist/utils.mjs:17:25)
      at async PostHog.fetchWithRetry (file:///Users/instinct/Desktop/continue/extensions/cli/node_modules/@posthog/core/dist/index.mjs:561:16)
      at async PostHog._flush (file:///Users/instinct/Desktop/continue/extensions/cli/node_modules/@posthog/core/dist/index.mjs:527:17) {
    [cause]: Error: getaddrinfo ENOTFOUND app.posthog.com
        at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:120:26) {
      errno: -3008,
      code: 'ENOTFOUND',
      syscall: 'getaddrinfo',
      hostname: 'app.posthog.com'
    }
  },
  [cause]: TypeError: fetch failed
      at node:internal/deps/undici/undici:13502:13
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async file:///Users/instinct/Desktop/continue/extensions/cli/node_modules/@posthog/core/dist/index.mjs:564:23
      at async retriable (file:///Users/instinct/Desktop/continue/extensions/cli/node_modules/@posthog/core/dist/utils.mjs:17:25)
      at async PostHog.fetchWithRetry (file:///Users/instinct/Desktop/continue/extensions/cli/node_modules/@posthog/core/dist/index.mjs:561:16)
      at async PostHog._flush (file:///Users/instinct/Desktop/continue/extensions/cli/node_modules/@posthog/core/dist/index.mjs:527:17) {
    [cause]: Error: getaddrinfo ENOTFOUND app.posthog.com
        at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:120:26) {
      errno: -3008,
      code: 'ENOTFOUND',
      syscall: 'getaddrinfo',
      hostname: 'app.posthog.com'
    }
  }
}
```
</details>

resolves CON-3551

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
