### PR TITLE
Update telemetryService.ts

### DIFF
--- a/extensions/cli/spec/otlp-metrics.md
+++ b/extensions/cli/spec/otlp-metrics.md
@@ -51,7 +51,7 @@ All metrics and events share these standard attributes:
 
 ## Core Metrics
 
-### ✅ `continue.cli.session.count`
+### ✅ `continue_cli_session_count`
 
 **Type:** Counter  
 **Unit:** `count`  
@@ -65,7 +65,7 @@ All metrics and events share these standard attributes:
 
 ---
 
-### ✅ `continue.cli.lines_of_code.count`
+### ✅ `continue_cli_lines_of_code_count`
 
 **Type:** Counter  
 **Unit:** `count`  
@@ -80,7 +80,7 @@ All metrics and events share these standard attributes:
 
 ---
 
-### ✅ `continue.cli.pull_request.count`
+### ✅ `continue_cli_pull_request_count`
 
 **Type:** Counter  
 **Unit:** `count`  
@@ -94,7 +94,7 @@ All metrics and events share these standard attributes:
 
 ---
 
-### ✅ `continue.cli.commit.count`
+### ✅ `continue_cli_commit_count`
 
 **Type:** Counter  
 **Unit:** `count`  
@@ -108,7 +108,7 @@ All metrics and events share these standard attributes:
 
 ---
 
-### ✅ `continue.cli.cost.usage`
+### ✅ `continue_cli_cost_usage`
 
 **Type:** Counter  
 **Unit:** `USD`  
@@ -123,7 +123,7 @@ All metrics and events share these standard attributes:
 
 ---
 
-### ✅ `continue.cli.token.usage`
+### ✅ `continue_cli_token_usage`
 
 **Type:** Counter  
 **Unit:** `tokens`  
@@ -139,7 +139,7 @@ All metrics and events share these standard attributes:
 
 ---
 
-### ❌ `continue.cli.code_edit_tool.decision`
+### ❌ `continue_cli_code_edit_tool_decision`
 
 **Type:** Counter  
 **Unit:** `count`  
@@ -156,7 +156,7 @@ All metrics and events share these standard attributes:
 
 ---
 
-### ✅ `continue.cli.active_time.total`
+### ✅ `continue_cli_active_time_total`
 
 **Type:** Counter  
 **Unit:** `s`  
@@ -172,7 +172,7 @@ All metrics and events share these standard attributes:
 
 ### ✅ User Prompt Event
 
-**Event Name:** `continue.cli.user_prompt`
+**Event Name:** `continue_cli_user_prompt`
 
 **Attributes:**
 
@@ -188,7 +188,7 @@ All metrics and events share these standard attributes:
 
 ### ✅ Tool Result Event
 
-**Event Name:** `continue.cli.tool_result`
+**Event Name:** `continue_cli_tool_result`
 
 **Attributes:**
 
@@ -209,7 +209,7 @@ All metrics and events share these standard attributes:
 
 ### ✅ API Request Event
 
-**Event Name:** `continue.cli.api_request`
+**Event Name:** `continue_cli_api_request`
 
 **Attributes:**
 
@@ -232,7 +232,7 @@ These metrics are unique to Continue CLI and provide additional insights without
 
 ### Authentication Metrics
 
-#### ✅ `continue.cli.auth.attempts`
+#### ✅ `continue_cli_auth_attempts`
 
 **Type:** Counter  
 **Unit:** `{attempt}`  
@@ -248,7 +248,7 @@ These metrics are unique to Continue CLI and provide additional insights without
 
 ### MCP Integration Metrics
 
-#### ❌ `continue.cli.mcp.connections`
+#### ❌ `continue_cli_mcp_connections`
 
 **Type:** Gauge  
 **Unit:** `{connection}`  
@@ -264,7 +264,7 @@ These metrics are unique to Continue CLI and provide additional insights without
 
 ### Performance Metrics
 
-#### ❌ `continue.cli.startup.time`
+#### ❌ `continue_cli_startup_time`
 
 **Type:** Histogram  
 **Unit:** `ms`  
@@ -278,7 +278,7 @@ These metrics are unique to Continue CLI and provide additional insights without
 
 **Implementation:** Track in `src/index.ts` and `src/commands/chat.ts`
 
-#### ✅ `continue.cli.response_time`
+#### ✅ `continue_cli_response_time`
 
 **Type:** Histogram  
 **Unit:** `ms`  
@@ -297,7 +297,7 @@ These metrics are unique to Continue CLI and provide additional insights without
 
 ### Migration from Claude Code Dashboards
 
-The core metrics (`session.count`, `lines_of_code.count`, `token.usage`, `cost.usage`, etc.) use identical naming and attribute structures to Claude Code, allowing for easy dashboard migration by simply changing the metric prefix from `claude_code.*` to `continue.cli.*`.
+The core metrics (`session_count`, `lines_of_code_count`, `token_usage`, `cost_usage`, etc.) use identical naming and attribute structures to Claude Code, allowing for easy dashboard migration by simply changing the metric prefix from `claude_code_*` to `continue_cli_*`.
 
 ### Privacy Considerations
 
@@ -337,6 +337,6 @@ All metrics should include these resource attributes:
 
 **Missing implementations:**
 
-- `continue.cli.code_edit_tool.decision` - requires user confirmation UI
-- `continue.cli.mcp.connections` - needs MCP service monitoring
-- `continue.cli.startup.time` - needs startup time tracking
+- `continue_cli_code_edit_tool_decision` - requires user confirmation UI
+- `continue_cli_mcp_connections` - needs MCP service monitoring
+- `continue_cli_startup_time` - needs startup time tracking

--- a/extensions/cli/src/telemetry/telemetryService.ts
+++ b/extensions/cli/src/telemetry/telemetryService.ts
@@ -195,7 +195,7 @@ class TelemetryService {
 
     // Core metrics (Claude Code compatible)
     this.sessionCounter = this.meter.createCounter(
-      "continue.cli.session.count",
+      "continue_cli_session_count",
       {
         description: "Count of CLI sessions started",
         unit: "count",
@@ -203,7 +203,7 @@ class TelemetryService {
     );
 
     this.linesOfCodeCounter = this.meter.createCounter(
-      "continue.cli.lines_of_code.count",
+      "continue_cli_lines_of_code_count",
       {
         description: "Count of lines of code modified",
         unit: "count",
@@ -211,30 +211,30 @@ class TelemetryService {
     );
 
     this.pullRequestCounter = this.meter.createCounter(
-      "continue.cli.pull_request.count",
+      "continue_cli_pull_request_count",
       {
         description: "Number of pull requests created",
         unit: "count",
       },
     );
 
-    this.commitCounter = this.meter.createCounter("continue.cli.commit.count", {
+    this.commitCounter = this.meter.createCounter("continue_cli_commit_count", {
       description: "Number of git commits created",
       unit: "count",
     });
 
-    this.costCounter = this.meter.createCounter("continue.cli.cost.usage", {
+    this.costCounter = this.meter.createCounter("continue_cli_cost_usage", {
       description: "Cost of the Continue CLI session",
       unit: "USD",
     });
 
-    this.tokenCounter = this.meter.createCounter("continue.cli.token.usage", {
+    this.tokenCounter = this.meter.createCounter("continue_cli_token_usage", {
       description: "Number of tokens used",
       unit: "tokens",
     });
 
     this.codeEditDecisionCounter = this.meter.createCounter(
-      "continue.cli.code_edit_tool.decision",
+      "continue_cli_code_edit_tool_decision",
       {
         description: "Count of code editing tool permission decisions",
         unit: "count",
@@ -242,7 +242,7 @@ class TelemetryService {
     );
 
     this.activeTimeCounter = this.meter.createCounter(
-      "continue.cli.active_time.total",
+      "continue_cli_active_time_total",
       {
         description: "Total active time in seconds",
         unit: "s",
@@ -251,7 +251,7 @@ class TelemetryService {
 
     // Additional Continue CLI specific metrics
     this.authAttemptsCounter = this.meter.createCounter(
-      "continue.cli.auth.attempts",
+      "continue_cli_auth_attempts",
       {
         description: "Authentication attempts",
         unit: "{attempt}",
@@ -259,7 +259,7 @@ class TelemetryService {
     );
 
     this.mcpConnectionsGauge = this.meter.createObservableGauge(
-      "continue.cli.mcp.connections",
+      "continue_cli_mcp_connections",
       {
         description: "Active MCP connections",
         unit: "{connection}",
@@ -267,7 +267,7 @@ class TelemetryService {
     );
 
     this.startupTimeHistogram = this.meter.createHistogram(
-      "continue.cli.startup.time",
+      "continue_cli_startup_time",
       {
         description: "Time from CLI start to ready state",
         unit: "ms",
@@ -275,7 +275,7 @@ class TelemetryService {
     );
 
     this.responseTimeHistogram = this.meter.createHistogram(
-      "continue.cli.response_time",
+      "continue_cli_response_time",
       {
         description: "LLM response time metrics",
         unit: "ms",


### PR DESCRIPTION
- Converts dot notation to snake_case for metric names (dot notation is incompatible with prometheus)
- Adds flush logic to still emit OTel metrics on exit
- Decreases OTel metric logging from 1m -> 20s