### PR TITLE
lol: press enter to continue

### DIFF
--- a/extensions/cli/src/ui/__tests__/TUIChat.interruption.minimal.test.tsx
+++ b/extensions/cli/src/ui/__tests__/TUIChat.interruption.minimal.test.tsx
@@ -117,7 +117,7 @@ describe("TUIChat - Interruption UI (Minimal Test)", () => {
       stdin.write("\r");
 
       // Should call onSubmit with empty string (for resume)
-      expect(mockOnSubmit).toHaveBeenCalledWith("", expect.any(Map));
+      expect(mockOnSubmit).toHaveBeenCalledWith("continue", expect.any(Map));
     } finally {
       unmount();
     }


### PR DESCRIPTION
## Description

At the suggestion of bdougie
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Changed the CLI tip and interruption message from "Press enter to resume" to "Press enter to continue" for consistency and clearer guidance. Updated related tests to match the new copy.

<!-- End of auto-generated description by cubic. -->

