### PR TITLE
fix(doc): formatting issue in codebase awareness for agents documentation

### DIFF
--- a/docs/guides/codebase-documentation-awareness.mdx
+++ b/docs/guides/codebase-documentation-awareness.mdx
@@ -84,7 +84,6 @@ You can use the `gh` CLI to:
 #### DeepWiki MCP
 
 [DeepWiki MCP](https://hub.continue.dev/deepwiki/deepwiki-mcp) lets your agent explore any public GitHub repository.
-```
 
 Once configured, your agent can explore repositories like:
 - "Explore the React repository structure"


### PR DESCRIPTION
## Description

This pull request makes a documentation update to the `codebase-documentation-awareness.mdx` guide. The change removes wrongly placed backticks which led to formatting the entire "DeepWiki MCP" section as a code block, hence crippling readability to some sort.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

https://github.com/user-attachments/assets/f6a2c4d7-4970-4c19-9f27-7cfedc97b012

## Tests

None

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed a stray code fence in codebase-documentation-awareness.mdx that caused the entire “DeepWiki MCP” section to render as a code block. Restores proper formatting and readability for that section.

<!-- End of auto-generated description by cubic. -->

