### PR TITLE
fix: fix disposing of plugin service

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/services/ContinuePluginService.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/services/ContinuePluginService.kt
@@ -8,6 +8,7 @@ import com.github.continuedev.continueintellijextension.listeners.ActiveHandlerM
 import com.github.continuedev.continueintellijextension.listeners.DocumentChangeTracker
 import com.github.continuedev.continueintellijextension.toolWindow.ContinuePluginToolWindowFactory
 import com.github.continuedev.continueintellijextension.utils.uuid
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.editor.EditorFactory
@@ -20,7 +21,7 @@ import kotlinx.coroutines.cancel
 import kotlin.properties.Delegates
 
 @Service(Service.Level.PROJECT)
-class ContinuePluginService(private val project: Project) : DumbAware {
+class ContinuePluginService(private val project: Project) : Disposable, DumbAware {
     private val coroutineScope = CoroutineScope(Dispatchers.Main)
     var listener: (() -> Unit)? = null
     var ideProtocolClient: IdeProtocolClient? by Delegates.observable(null) { _, _, _ ->
@@ -57,7 +58,7 @@ class ContinuePluginService(private val project: Project) : DumbAware {
         }
     }
 
-    fun dispose() {
+    override fun dispose() {
         coroutineScope.cancel()
         coreMessenger?.coroutineScope?.let {
             it.cancel()


### PR DESCRIPTION
Fixes regression introduced in:

https://github.com/continuedev/continue/pull/7131/files#diff-d3886b7ebfd66e6390e222840e9a67487179837d15c0729fa4d7832bf1e39405L17
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Restore proper disposal of ContinuePluginService in the IntelliJ plugin by implementing Disposable and overriding dispose(). This prevents coroutine leaks and ensures the service cleans up correctly when a project closes.

<!-- End of auto-generated description by cubic. -->

