### PR TITLE
fix: don't show unchanged diff sections in extension UI

### DIFF
--- a/gui/src/pages/gui/ToolCallDiv/FindAndReplace.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/FindAndReplace.tsx
@@ -251,6 +251,7 @@ export function FindAndReplaceDisplay({
                 lines={part.value.split("\n")}
                 className="border-l-4 border-red-900 bg-red-900/30"
                 diffCharClass="text-red-600"
+                diffChar="-"
               />
             );
           } else if (part.added) {
@@ -260,6 +261,7 @@ export function FindAndReplaceDisplay({
                 lines={part.value.split("\n")}
                 diffCharClass="text-green-600"
                 className="border-l-4 border-green-600 bg-green-600/20"
+                diffChar="+"
               />
             );
           } else {

--- a/gui/src/pages/gui/ToolCallDiv/FindAndReplace.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/FindAndReplace.tsx
@@ -3,7 +3,7 @@ import { ApplyState } from "core";
 import { EditOperation } from "core/tools/definitions/multiEdit";
 import { renderContextItems } from "core/util/messageContent";
 import { getLastNPathParts, getUriPathBasename } from "core/util/uri";
-import { ChangeObject, diffLines } from "diff";
+import { diffLines } from "diff";
 import { useContext, useMemo, useState } from "react";
 import { ApplyActions } from "../../../components/StyledMarkdownPreview/StepContainerPreToolbar/ApplyActions";
 import { FileInfo } from "../../../components/StyledMarkdownPreview/StepContainerPreToolbar/FileInfo";
@@ -14,6 +14,7 @@ import {
   selectToolCallById,
 } from "../../../redux/selectors/selectToolCalls";
 import { performFindAndReplace } from "../../../util/clientTools/findAndReplaceUtils";
+import { cn } from "../../../util/cn";
 import { getStatusIcon } from "./utils";
 
 interface FindAndReplaceDisplayProps {
@@ -23,6 +24,48 @@ interface FindAndReplaceDisplayProps {
   edits: EditOperation[];
   toolCallId: string;
   historyIndex: number;
+}
+
+const MAX_SAME_LINES = 2;
+
+function EllipsisLine() {
+  return (
+    <div className="text-description-muted px-3 py-1 text-center font-mono">
+      ⋯
+    </div>
+  );
+}
+
+function DiffLines({
+  lines,
+  className = "",
+  diffChar = " ",
+  diffCharClass = "text-description-muted",
+}: {
+  lines: string[];
+  diffChar?: string;
+  diffCharClass?: string;
+  className?: string;
+}) {
+  return (
+    <>
+      {lines.map((line, lineIndex) => {
+        const isLastPartLine = lineIndex === lines.length - 1;
+        if (line === "" && isLastPartLine) return null;
+        return (
+          <div
+            key={lineIndex}
+            className={cn("text-foreground px-3 py-px font-mono", className)}
+          >
+            <span className={cn("mr-2 select-none", diffCharClass)}>
+              {diffChar}
+            </span>
+            {line}
+          </div>
+        );
+      })}
+    </>
+  );
 }
 
 export function FindAndReplaceDisplay({
@@ -122,107 +165,6 @@ export function FindAndReplaceDisplay({
     }
   }, [toolCallState?.status, toolCallState?.output]);
 
-  const processedDiff: (ChangeObject<string> | { ellipsis: true })[] =
-    useMemo(() => {
-      if (!diffResult?.diff) return [];
-
-      const MAX_CONTEXT_LINES = 2;
-      const processed: (ChangeObject<string> | { ellipsis: true })[] = [];
-
-      for (let i = 0; i < diffResult.diff.length; i++) {
-        const part = diffResult.diff[i];
-
-        if (part.added || part.removed) {
-          processed.push(part);
-        } else {
-          // This is an unchanged part
-          const lines = part.value.split("\n");
-          // Remove empty line at the end if it exists
-          if (lines[lines.length - 1] === "") {
-            lines.pop();
-          }
-
-          const isFirstPart = i === 0;
-          const isLastPart = i === diffResult.diff.length - 1;
-          const hasChangesAfter =
-            i < diffResult.diff.length - 1 &&
-            diffResult.diff.slice(i + 1).some((p) => p.added || p.removed);
-          const hasChangesBefore =
-            i > 0 &&
-            diffResult.diff.slice(0, i).some((p) => p.added || p.removed);
-
-          let startIndex = 0;
-          let endIndex = lines.length;
-          let addEllipsisAtStart = false;
-          let addEllipsisAtEnd = false;
-
-          if (isFirstPart && hasChangesAfter) {
-            // Show only last MAX_CONTEXT_LINES lines
-            const newStartIndex = Math.max(0, lines.length - MAX_CONTEXT_LINES);
-            if (newStartIndex > 0) {
-              addEllipsisAtStart = true;
-            }
-            startIndex = newStartIndex;
-          } else if (isLastPart && hasChangesBefore) {
-            // Show only first MAX_CONTEXT_LINES lines
-            const newEndIndex = Math.min(lines.length, MAX_CONTEXT_LINES);
-            if (newEndIndex < lines.length) {
-              addEllipsisAtEnd = true;
-            }
-            endIndex = newEndIndex;
-          } else if (
-            !isFirstPart &&
-            !isLastPart &&
-            (hasChangesBefore || hasChangesAfter)
-          ) {
-            // Show MAX_CONTEXT_LINES at start and end
-            if (lines.length > MAX_CONTEXT_LINES * 2) {
-              const contextLines = [
-                ...lines.slice(0, MAX_CONTEXT_LINES),
-                ...lines.slice(-MAX_CONTEXT_LINES),
-              ];
-              processed.push({
-                ...part,
-                value:
-                  contextLines.slice(0, MAX_CONTEXT_LINES).join("\n") + "\n",
-              });
-
-              // Add ellipsis indicator
-              processed.push({
-                ellipsis: true,
-              });
-
-              processed.push({
-                ...part,
-                value: contextLines.slice(MAX_CONTEXT_LINES).join("\n") + "\n",
-              });
-              continue;
-            }
-          }
-
-          if (startIndex < endIndex) {
-            const visibleLines = lines.slice(startIndex, endIndex);
-            if (visibleLines.length > 0) {
-              if (addEllipsisAtStart) {
-                processed.unshift({ ellipsis: true });
-              }
-
-              processed.push({
-                ...part,
-                value: visibleLines.join("\n") + "\n",
-              });
-
-              if (addEllipsisAtEnd) {
-                processed.push({ ellipsis: true });
-              }
-            }
-          }
-        }
-      }
-
-      return processed;
-    }, [diffResult?.diff]);
-
   // Unified container component that always renders the same structure
   const renderContainer = (content: React.ReactNode) => (
     <div className="outline-command-border -outline-offset-0.5 rounded-default bg-editor mx-2 my-1 flex min-w-0 flex-col outline outline-1">
@@ -301,81 +243,50 @@ export function FindAndReplaceDisplay({
       <pre
         className={`bg-editor m-0 w-full text-xs leading-tight ${config?.ui?.codeWrap ? "whitespace-pre-wrap" : "whitespace-pre"}`}
       >
-        {processedDiff.map((part, index) => {
-          if ("ellipsis" in part) {
-            return (
-              <div
-                key={index}
-                className="text-description-muted px-3 py-1 text-center font-mono"
-              >
-                ⋯
-              </div>
-            );
-          }
-
+        {diffResult.diff?.map((part, index) => {
           if (part.removed) {
             return (
-              <div
+              <DiffLines
                 key={index}
-                className="text-foreground border-l-4 border-red-900 bg-red-900/30"
-              >
-                {part.value.split("\n").map((line, lineIndex) => {
-                  if (
-                    line === "" &&
-                    lineIndex === part.value.split("\n").length - 1
-                  )
-                    return null;
-                  return (
-                    <div key={lineIndex} className="px-3 py-px font-mono">
-                      <span className="mr-2 select-none text-red-600">-</span>
-                      {line}
-                    </div>
-                  );
-                })}
-              </div>
+                lines={part.value.split("\n")}
+                className="border-l-4 border-red-900 bg-red-900/30"
+                diffCharClass="text-red-600"
+              />
             );
           } else if (part.added) {
             return (
-              <div
+              <DiffLines
                 key={index}
-                className="text-foreground border-l-4 border-green-600 bg-green-600/20"
-              >
-                {part.value.split("\n").map((line, lineIndex) => {
-                  if (
-                    line === "" &&
-                    lineIndex === part.value.split("\n").length - 1
-                  )
-                    return null;
-                  return (
-                    <div key={lineIndex} className="px-3 py-px font-mono">
-                      <span className="mr-2 select-none text-green-600">+</span>
-                      {line}
-                    </div>
-                  );
-                })}
-              </div>
+                lines={part.value.split("\n")}
+                diffCharClass="text-green-600"
+                className="border-l-4 border-green-600 bg-green-600/20"
+              />
             );
           } else {
+            const isFirst = index === 0;
+            const isLast = index === diffResult.diff.length - 1;
+            const lines = part.value.split("\n");
+            const showStartEllipsis = isFirst && lines.length > MAX_SAME_LINES;
+            const showEndEllipsis = isLast && lines.length > MAX_SAME_LINES;
+            const showMiddleEllipses =
+              !isFirst && !isLast && lines.length > MAX_SAME_LINES * 2 + 1;
+
+            const startLines = showStartEllipsis
+              ? lines.slice(-MAX_SAME_LINES)
+              : showMiddleEllipses || showEndEllipsis
+                ? lines.slice(0, MAX_SAME_LINES)
+                : lines;
+            const endLines = showMiddleEllipses
+              ? lines.slice(-MAX_SAME_LINES)
+              : [];
+
             return (
               <div key={index}>
-                {part.value.split("\n").map((line, lineIndex) => {
-                  if (
-                    line === "" &&
-                    lineIndex === part.value.split("\n").length - 1
-                  )
-                    return null;
-                  return (
-                    <div
-                      key={lineIndex}
-                      className="text-foreground px-3 py-px font-mono"
-                    >
-                      <span className="text-description-muted mr-2 select-none">
-                        {" "}
-                      </span>
-                      {line}
-                    </div>
-                  );
-                })}
+                {showStartEllipsis && <EllipsisLine />}
+                <DiffLines lines={startLines} />
+                {showMiddleEllipses && <EllipsisLine />}
+                <DiffLines lines={endLines} />
+                {showEndEllipsis && <EllipsisLine />}
               </div>
             );
           }


### PR DESCRIPTION
## Description
Adds ellipses for unchanged sections at the beginning/end of diff > 2 lines and between diffs > 5 lines
Also cleans up components and unifies diff view component

<img width="437" height="393" alt="image" src="https://github.com/user-attachments/assets/7672dc6d-8bc5-4b0b-ab5e-7a8013e285ff" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Hides unchanged sections in the extension diff view by collapsing them and showing a centered ellipsis. Keeps up to 2 lines of context to make diffs easier to scan.

- **Bug Fixes**
  - Collapse unchanged blocks: start/end show up to 2 context lines; middle blocks >4 lines show 2 leading and 2 trailing lines with an ellipsis.
  - Render a muted “⋯” row for skipped content and skip trailing empty lines.
  - Use a memoized processedDiff list (no changes to added/removed rendering).

<!-- End of auto-generated description by cubic. -->

