### PR TITLE
feat: Add OpenRouter model provider and its API integration

### DIFF
--- a/core/llm/llms/OpenRouter.ts
+++ b/core/llm/llms/OpenRouter.ts
@@ -29,11 +29,42 @@ class OpenRouter extends OpenAI {
     useLegacyCompletionsEndpoint: false,
   };
 
+  constructor(options: LLMOptions) {
+    super(options);
+
+    // Set context length based on the model
+    if (!options.contextLength) {
+      this._contextLength = this.getContextLengthForModel(options.model);
+    }
+  }
+
+  private getContextLengthForModel(model: string): number {
+    const modelContextLengths: Record<string, number> = {
+      "openai/gpt-4o": 128000,
+      "openai/gpt-4o-mini": 128000,
+      "anthropic/claude-3.5-sonnet": 200000,
+      "anthropic/claude-3-haiku": 200000,
+      "meta-llama/llama-3.1-405b-instruct": 131072,
+      "meta-llama/llama-3.1-70b-instruct": 131072,
+      "meta-llama/llama-3.1-8b-instruct": 131072,
+      "google/gemini-pro-1.5": 2097152,
+      "mistralai/mistral-large": 128000,
+      "cohere/command-r-plus": 128000,
+      "deepseek/deepseek-chat": 128000,
+      "qwen/qwen-2.5-72b-instruct": 131072,
+      "nvidia/llama-3.1-nemotron-70b-instruct": 131072,
+      "x-ai/grok-beta": 131072,
+      "perplexity/llama-3.1-sonar-large-128k-online": 131072,
+    };
+
+    return modelContextLengths[model] || 32768; // fallback to default
+  }
+
   async listModels(): Promise<string[]> {
     try {
       const response = await fetch("https://openrouter.ai/api/v1/models", {
         headers: {
-          "Authorization": this.apiKey ? `Bearer ${this.apiKey}` : "",
+          Authorization: this.apiKey ? `Bearer ${this.apiKey}` : "",
           "Content-Type": "application/json",
         },
       });
@@ -69,7 +100,7 @@ class OpenRouter extends OpenAI {
   static async exchangeCodeForApiKey(
     code: string,
     codeVerifier?: string,
-    codeChallengeMethod?: string
+    codeChallengeMethod?: string,
   ): Promise<{ key: string; userId?: string }> {
     const response = await fetch("https://openrouter.ai/api/v1/auth/keys", {
       method: "POST",
@@ -84,7 +115,9 @@ class OpenRouter extends OpenAI {
     });
 
     if (!response.ok) {
-      throw new Error(`Failed to exchange code for API key: ${response.statusText}`);
+      throw new Error(
+        `Failed to exchange code for API key: ${response.statusText}`,
+      );
     }
 
     return await response.json();
@@ -97,7 +130,7 @@ class OpenRouter extends OpenAI {
     clientId: string,
     redirectUri: string,
     codeChallenge?: string,
-    codeChallengeMethod: string = "S256"
+    codeChallengeMethod: string = "S256",
   ): string {
     const params = new URLSearchParams({
       response_type: "code",

--- a/core/llm/llms/OpenRouter.ts
+++ b/core/llm/llms/OpenRouter.ts
@@ -3,6 +3,21 @@ import { osModelsEditPrompt } from "../templates/edit.js";
 
 import OpenAI from "./OpenAI.js";
 
+interface OpenRouterModel {
+  id: string;
+  name: string;
+  description?: string;
+  context_length?: number;
+  pricing?: {
+    prompt: string;
+    completion: string;
+  };
+}
+
+interface OpenRouterModelsResponse {
+  data: OpenRouterModel[];
+}
+
 class OpenRouter extends OpenAI {
   static providerName = "openrouter";
   static defaultOptions: Partial<LLMOptions> = {
@@ -13,6 +28,90 @@ class OpenRouter extends OpenAI {
     },
     useLegacyCompletionsEndpoint: false,
   };
+
+  async listModels(): Promise<string[]> {
+    try {
+      const response = await fetch("https://openrouter.ai/api/v1/models", {
+        headers: {
+          "Authorization": this.apiKey ? `Bearer ${this.apiKey}` : "",
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch models: ${response.statusText}`);
+      }
+
+      const data: OpenRouterModelsResponse = await response.json();
+      return data.data.map((model) => model.id);
+    } catch (error) {
+      console.error("Error fetching OpenRouter models:", error);
+      // Return a fallback list of popular models if the API call fails
+      return [
+        "openai/gpt-4o",
+        "openai/gpt-4o-mini",
+        "anthropic/claude-3.5-sonnet",
+        "anthropic/claude-3-haiku",
+        "meta-llama/llama-3.1-405b-instruct",
+        "meta-llama/llama-3.1-70b-instruct",
+        "meta-llama/llama-3.1-8b-instruct",
+        "google/gemini-pro-1.5",
+        "mistralai/mistral-large",
+        "cohere/command-r-plus",
+      ];
+    }
+  }
+
+  /**
+   * Exchange OAuth authorization code for API key
+   * This method supports the OAuth PKCE flow for OpenRouter
+   */
+  static async exchangeCodeForApiKey(
+    code: string,
+    codeVerifier?: string,
+    codeChallengeMethod?: string
+  ): Promise<{ key: string; userId?: string }> {
+    const response = await fetch("https://openrouter.ai/api/v1/auth/keys", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        code,
+        code_verifier: codeVerifier,
+        code_challenge_method: codeChallengeMethod,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to exchange code for API key: ${response.statusText}`);
+    }
+
+    return await response.json();
+  }
+
+  /**
+   * Generate OAuth authorization URL for PKCE flow
+   */
+  static generateOAuthUrl(
+    clientId: string,
+    redirectUri: string,
+    codeChallenge?: string,
+    codeChallengeMethod: string = "S256"
+  ): string {
+    const params = new URLSearchParams({
+      response_type: "code",
+      client_id: clientId,
+      redirect_uri: redirectUri,
+    });
+
+    if (codeChallenge) {
+      params.append("code_challenge", codeChallenge);
+      params.append("code_challenge_method", codeChallengeMethod);
+    }
+
+    return `https://openrouter.ai/auth?${params.toString()}`;
+  }
 }
 
 export default OpenRouter;

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "file:../../packages/config-types",

--- a/gui/src/components/mainInput/Lump/sections/docs/DocsIndexingStatus.tsx
+++ b/gui/src/components/mainInput/Lump/sections/docs/DocsIndexingStatus.tsx
@@ -215,7 +215,6 @@ function DocsIndexingStatus({
 
       {indexedPages && (
         <ToolTip
-          id={`docs-tooltip-${startUrlSlug}`}
           isOpen={showTooltip}
           setIsOpen={setShowTooltip}
           clickable

--- a/gui/src/pages/AddNewModel/configs/providers.ts
+++ b/gui/src/pages/AddNewModel/configs/providers.ts
@@ -998,6 +998,34 @@ To get started, [register](https://dataplatform.cloud.ibm.com/registration/stepo
     packages: [{ ...models.AUTODETECT }],
     apiKeyUrl: "https://venice.ai/chat",
   },
+  openrouter: {
+    title: "OpenRouter",
+    provider: "openrouter",
+    description: "Access 200+ AI models through a unified API with competitive pricing",
+    longDescription:
+      "OpenRouter provides access to a wide variety of AI models from different providers through a single API. Get started by obtaining an API key from [OpenRouter](https://openrouter.ai/settings/keys).",
+    tags: [ModelProviderTags.RequiresApiKey],
+    collectInputFor: [
+      {
+        inputType: "text",
+        key: "apiKey",
+        label: "API Key",
+        placeholder: "Enter your OpenRouter API key",
+        required: true,
+      },
+      ...completionParamsInputsConfigs,
+    ],
+    packages: [
+      {
+        ...models.AUTODETECT,
+        params: {
+          ...models.AUTODETECT.params,
+          title: "OpenRouter",
+        },
+      },
+    ],
+    apiKeyUrl: "https://openrouter.ai/settings/keys",
+  },
   tars: {
     title: "Tetrate Agent Router Service",
     provider: "tars",

--- a/packages/llm-info/src/index.ts
+++ b/packages/llm-info/src/index.ts
@@ -6,6 +6,7 @@ import { Gemini } from "./providers/gemini.js";
 import { Mistral } from "./providers/mistral.js";
 import { Ollama } from "./providers/ollama.js";
 import { OpenAi } from "./providers/openai.js";
+import { OpenRouter } from "./providers/openrouter.js";
 import { Vllm } from "./providers/vllm.js";
 import { Voyage } from "./providers/voyage.js";
 import { xAI } from "./providers/xAI.js";
@@ -19,6 +20,7 @@ export const allModelProviders: ModelProvider[] = [
   Voyage,
   Azure,
   Ollama,
+  OpenRouter,
   Vllm,
   Bedrock,
   Cohere,

--- a/packages/llm-info/src/providers/openrouter.ts
+++ b/packages/llm-info/src/providers/openrouter.ts
@@ -1,0 +1,98 @@
+import { ModelProvider } from "../types.js";
+
+export const OpenRouter: ModelProvider = {
+  models: [
+    {
+      model: "openai/gpt-4o",
+      displayName: "GPT-4o",
+      contextLength: 128000,
+      maxCompletionTokens: 16384,
+    },
+    {
+      model: "openai/gpt-4o-mini",
+      displayName: "GPT-4o Mini",
+      contextLength: 128000,
+      maxCompletionTokens: 16384,
+    },
+    {
+      model: "anthropic/claude-3.5-sonnet",
+      displayName: "Claude 3.5 Sonnet",
+      contextLength: 200000,
+      maxCompletionTokens: 8192,
+    },
+    {
+      model: "anthropic/claude-3-haiku",
+      displayName: "Claude 3 Haiku",
+      contextLength: 200000,
+      maxCompletionTokens: 4096,
+    },
+    {
+      model: "meta-llama/llama-3.1-405b-instruct",
+      displayName: "Llama 3.1 405B Instruct",
+      contextLength: 131072,
+      maxCompletionTokens: 4096,
+    },
+    {
+      model: "meta-llama/llama-3.1-70b-instruct",
+      displayName: "Llama 3.1 70B Instruct",
+      contextLength: 131072,
+      maxCompletionTokens: 4096,
+    },
+    {
+      model: "meta-llama/llama-3.1-8b-instruct",
+      displayName: "Llama 3.1 8B Instruct",
+      contextLength: 131072,
+      maxCompletionTokens: 4096,
+    },
+    {
+      model: "google/gemini-pro-1.5",
+      displayName: "Gemini Pro 1.5",
+      contextLength: 2097152,
+      maxCompletionTokens: 8192,
+    },
+    {
+      model: "mistralai/mistral-large",
+      displayName: "Mistral Large",
+      contextLength: 128000,
+      maxCompletionTokens: 4096,
+    },
+    {
+      model: "cohere/command-r-plus",
+      displayName: "Command R+",
+      contextLength: 128000,
+      maxCompletionTokens: 4096,
+    },
+    {
+      model: "deepseek/deepseek-chat",
+      displayName: "DeepSeek Chat",
+      contextLength: 128000,
+      maxCompletionTokens: 4096,
+    },
+    {
+      model: "qwen/qwen-2.5-72b-instruct",
+      displayName: "Qwen 2.5 72B Instruct",
+      contextLength: 131072,
+      maxCompletionTokens: 8192,
+    },
+    {
+      model: "nvidia/llama-3.1-nemotron-70b-instruct",
+      displayName: "Llama 3.1 Nemotron 70B",
+      contextLength: 131072,
+      maxCompletionTokens: 4096,
+    },
+    {
+      model: "x-ai/grok-beta",
+      displayName: "Grok Beta",
+      contextLength: 131072,
+      maxCompletionTokens: 4096,
+    },
+    {
+      model: "perplexity/llama-3.1-sonar-large-128k-online",
+      displayName: "Llama 3.1 Sonar Large (Online)",
+      contextLength: 131072,
+      maxCompletionTokens: 4096,
+    },
+  ],
+  id: "openrouter",
+  displayName: "OpenRouter",
+};


### PR DESCRIPTION
This pull request adds support for the OpenRouter provider, enabling access to a wide variety of AI models through a unified API. The changes include integration of OpenRouter into the model provider registry, implementation of model listing and OAuth authentication flows, and configuration updates to allow users to select and configure OpenRouter in the UI.

**OpenRouter provider integration:**

* Added the `OpenRouter` provider to the model registry, including a list of supported models with their display names and token limits in `packages/llm-info/src/providers/openrouter.ts`.
* Registered `OpenRouter` in the global model provider list in `packages/llm-info/src/index.ts`, making it available for selection and use. [[1]](diffhunk://#diff-6c0b0038a8e1986780d6603ab185a4af81973a05c2d4d267adff63a5b2a1de9bR9) [[2]](diffhunk://#diff-6c0b0038a8e1986780d6603ab185a4af81973a05c2d4d267adff63a5b2a1de9bR23)

**Core API and authentication enhancements:**

* Defined TypeScript interfaces for OpenRouter models and model list responses, and implemented the `listModels` method in `core/llm/llms/OpenRouter.ts` to fetch available models from the OpenRouter API, with a fallback to popular models if the API call fails. [[1]](diffhunk://#diff-8164d821dcd922ca9d70d1eed544ceba228445ea2c52a99df6ed078711388e6bR6-R20) [[2]](diffhunk://#diff-8164d821dcd922ca9d70d1eed544ceba228445ea2c52a99df6ed078711388e6bR31-R114)
* Added static methods to `OpenRouter` for OAuth PKCE flow: `exchangeCodeForApiKey` to exchange an authorization code for an API key, and `generateOAuthUrl` to generate the OAuth authorization URL.

**UI configuration:**

* Updated the provider configuration in `gui/src/pages/AddNewModel/configs/providers.ts` to include OpenRouter, with descriptions, API key collection, and relevant UI tags for easy setup.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds OpenRouter as a model provider with API integration and OAuth. Users can now select OpenRouter in the UI and access 200+ models through one provider.

- **New Features**
  - Registered OpenRouter in the provider list and model registry.
  - Implemented model fetching from the OpenRouter API with a safe fallback list.
  - Added OAuth PKCE helpers to generate the auth URL and exchange codes for an API key.
  - Updated Add New Model UI to include OpenRouter with API key input and autodetect config, plus popular model metadata (names, context, token limits).

<!-- End of auto-generated description by cubic. -->

