### PR TITLE
fix: broken Tooltip usage in DocsIndexingStatus.tsx

### DIFF
--- a/gui/src/components/mainInput/Lump/sections/docs/DocsIndexingStatus.tsx
+++ b/gui/src/components/mainInput/Lump/sections/docs/DocsIndexingStatus.tsx
@@ -202,7 +202,6 @@ function DocsIndexingStatus({
                 showPagesList();
               }
             }}
-            data-tooltip-id={`docs-tooltip-${startUrlSlug}`}
           >
             {isComplete
               ? indexedPages
@@ -215,7 +214,6 @@ function DocsIndexingStatus({
 
       {indexedPages && (
         <ToolTip
-          id={`docs-tooltip-${startUrlSlug}`}
           isOpen={showTooltip}
           setIsOpen={setShowTooltip}
           clickable
@@ -229,12 +227,15 @@ function DocsIndexingStatus({
             mouseleave: false,
             click: true,
           }}
+          content={
+            <IndexedPagesTooltip
+              pages={indexedPages}
+              siteTitle={docConfig.title ?? docConfig.startUrl}
+              baseUrl={docConfig.startUrl}
+            />
+          }
         >
-          <IndexedPagesTooltip
-            pages={indexedPages}
-            siteTitle={docConfig.title ?? docConfig.startUrl}
-            baseUrl={docConfig.startUrl}
-          />
+          <span></span>
         </ToolTip>
       )}
     </div>


### PR DESCRIPTION
Merging https://github.com/continuedev/continue/pull/7254 before it was rebased against https://github.com/continuedev/continue/pull/7007 led to DocsIndexingStatus.tsx failing to compile:

> Error: src/components/mainInput/Lump/sections/docs/DocsIndexingStatus.tsx(218,11): error TS2322: Type '{ children: Element; id: string; isOpen: boolean; setIsOpen: Dispatch<SetStateAction<boolean>>; clickable: true; delayShow: number; openEvents: { mouseenter: false; click: true; }; closeEvents: { ...; }; }' is not assignable to type 'IntrinsicAttributes & Omit<ITooltipController, "content" | "id" | "children"> & { content: ChildrenType; children: ReactElement<...>; }'.
>   Property 'id' does not exist on type 'IntrinsicAttributes & Omit<ITooltipController, "content" | "id" | "children"> & { content: ChildrenType; children: ReactElement<...>; }'. 

This PR should fix the build

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes a TypeScript build error by updating DocsIndexingStatus to the new Tooltip API. Moves tooltip content to the content prop and removes id-based wiring with no UI changes.

- Bug Fixes
  - Removed id and data-tooltip-id usage not supported by ITooltipController.
  - Passed IndexedPagesTooltip via content and rendered a stub <span> child.
  - Preserved click-to-open behavior and open/close event config.

<!-- End of auto-generated description by cubic. -->

