### PR TITLE
fix: dispose JCEF JSQuery handler correctly

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/browser/ContinueBrowserService.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/browser/ContinueBrowserService.kt
@@ -1,22 +1,32 @@
 package com.github.continuedev.continueintellijextension.browser
 
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
 import com.intellij.ui.jcef.JBCefApp
 
 @Service(Service.Level.PROJECT)
-class ContinueBrowserService(project: Project) {
+class ContinueBrowserService(project: Project): Disposable {
 
     private val browser: ContinueBrowser? =
         if (JBCefApp.isSupported())
             ContinueBrowser(project)
         else null
 
+    override fun dispose() {
+        if (browser != null)
+            Disposer.dispose(browser)
+    }
+
     companion object {
 
-        fun Project.getBrowser() =
-            service<ContinueBrowserService>().browser
+        fun Project.getBrowser(): ContinueBrowser? {
+            if (isDisposed)
+                return null
+            return service<ContinueBrowserService>().browser
+        }
 
     }
 }


### PR DESCRIPTION
The JCEF browser wasn’t registered as a Disposable when held by the service. Service was disposed, but async JSQuery handler tried to run some code on a disposed browser (browsers are disposed automatically by default according to docs), throwing exceptions when opening another project.

This fix registers both the browser and the handler as disposable. I tested this change manually, and opening project after project (with the same IDE) is no longer causing exceptions.

Side note: I think it would be useful to have an e2e test at some point that _"opens a project, closes it, and then opens another one"_ to trigger that mechanism. Such a test should catch this issue early.