### PR TITLE
fix: open file on EDT

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IntelliJIde.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IntelliJIde.kt
@@ -199,7 +199,9 @@ class IntelliJIDE(
     }
 
     override suspend fun openFile(path: String) =
-        fileUtils.openFile(path)
+        withContext(Dispatchers.EDT) {
+            fileUtils.openFile(path)
+        }
 
     override suspend fun openUrl(url: String) {
         withContext(Dispatchers.IO) {


### PR DESCRIPTION
Solves CON-3809

### Testing

I manually re-tested this feature ("edit rule" from the toolbar) and there is no longer any exceptions.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Open files on the IntelliJ EDT to prevent UI thread exceptions when using “Edit rule” from the toolbar. Addresses CON-3809.

- **Bug Fixes**
  - Wrap openFile(...) with withContext(Dispatchers.EDT) so it runs on the UI thread.

<!-- End of auto-generated description by cubic. -->

