### PR TITLE
fix: bump semver check for extension release

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,7 +20,7 @@ jobs:
       - id: check
         working-directory: .
         run: |
-          if [[ "${{ github.event.release.tag_name }}" == v1.0.*-vscode ]]; then
+          if [[ "${{ github.event.release.tag_name }}" == v1.2.*-vscode ]]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
           else
             echo "should_run=false" >> $GITHUB_OUTPUT

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,9 +176,9 @@ See [`intellij/CONTRIBUTING.md`](./extensions/intellij/CONTRIBUTING.md) for the 
 ### Our Git Workflow
 
 We keep a single permanent branch: `main`. When we are ready to create a "pre-release" version, we create a tag on the
-`main` branch titled `v1.1.x-vscode`, which automatically triggers the workflow
+`main` branch titled `v1.3.x-vscode`, which automatically triggers the workflow
 in [preview.yaml](./.github/workflows/preview.yaml), which builds and releases a version of the VS Code extension. When
-a release has been sufficiently tested, we will create a new release titled `v1.0x-vscode`, triggering a similar
+a release has been sufficiently tested, we will create a new release titled `v1.2.x-vscode`, triggering a similar
 workflow in [main.yaml](./.github/workflows/main.yaml), which will build and release a main release of the VS Code
 extension. Any hotfixes can be made by creating a feature branch from the tag for the release in question. This workflow
 is well explained by <http://releaseflow.org>.


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the GitHub Actions release check to match v1.2.*-vscode tags instead of v1.0.*-vscode. Ensures the VS Code extension release workflow runs only for the 1.2.x series and does not trigger on older tags.

<!-- End of auto-generated description by cubic. -->

