### PR TITLE
chore: disable fail-fast for cli workflow

### DIFF
--- a/.github/workflows/cli-pr-checks.yml
+++ b/.github/workflows/cli-pr-checks.yml
@@ -59,6 +59,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [18, 20, 22, 24]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
There's some flakey tests in cli test suite, let's not fail fast so one failed matrix won't immediately stop all other running matrixes.[

[`fail-fast` documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategyfail-fast)

[Example of flakey test](https://github.com/continuedev/continue/actions/runs/17478278546/job/49643268150?pr=7587) which causes all other running tests to stop. Causes a painful cycle of re-running tests 