### PR TITLE
feat: pass --config to cn remote

### DIFF
--- a/.github/workflows/respond-to-cubic.yaml
+++ b/.github/workflows/respond-to-cubic.yaml
@@ -91,7 +91,7 @@ jobs:
           Please analyze the current PR, understand the request, implement the necessary changes, and commit them to this branch."
 
           # Start remote session and capture JSON output
-          SESSION_OUTPUT=$(echo "$PROMPT" | cn remote -s --branch ${{ steps.pr-info.outputs.head_ref }})
+          SESSION_OUTPUT=$(echo "$PROMPT" | cn remote -s --config continuedev/address-code-review --branch ${{ steps.pr-info.outputs.head_ref }})
           echo "Raw session output: $SESSION_OUTPUT"
 
           # Extract URL from JSON output
@@ -195,7 +195,7 @@ jobs:
 
           # Start remote session and capture JSON output
           echo "Starting cn with prompt..."
-          SESSION_OUTPUT=$(cat /tmp/prompt.txt | cn remote -s --branch ${{ github.event.pull_request.head.ref }})
+          SESSION_OUTPUT=$(cat /tmp/prompt.txt | cn remote -s --config continuedev/address-code-review --branch ${{ github.event.pull_request.head.ref }})
           echo "Raw session output: $SESSION_OUTPUT"
 
           # Extract URL from JSON output

--- a/extensions/cli/src/commands/remote.test.ts
+++ b/extensions/cli/src/commands/remote.test.ts
@@ -236,6 +236,71 @@ describe("remote command", () => {
       prompt: "test prompt",
       idempotencyKey: testIdempotencyKey,
       branchName: testBranch,
+      agent: undefined,
+      config: undefined,
+    });
+  });
+
+  it("should include config in request body when config option is provided", async () => {
+    const testConfig = "test-config-path";
+
+    await remote("test prompt", { config: testConfig });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      new URL("agents/devboxes", mockEnv.env.apiBase),
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer test-token",
+        },
+        body: expect.stringContaining(`"config":"${testConfig}"`),
+      }),
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      new URL("agents/devboxes", mockEnv.env.apiBase),
+      expect.objectContaining({
+        body: expect.stringContaining(`"agent":"${testConfig}"`),
+      }),
+    );
+  });
+
+  it("should handle proper request body structure with config field", async () => {
+    const testConfig = "my-agent-config";
+    const testIdempotencyKey = "test-with-config";
+
+    await remote("test prompt", {
+      config: testConfig,
+      idempotencyKey: testIdempotencyKey,
+    });
+
+    const fetchCall = mockFetch.mock.calls[0];
+    const requestBody = JSON.parse(fetchCall[1].body);
+
+    expect(requestBody).toEqual({
+      repoUrl: "https://github.com/user/test-repo.git",
+      name: expect.stringMatching(/^devbox-\d+$/),
+      prompt: "test prompt",
+      idempotencyKey: testIdempotencyKey,
+      agent: testConfig,
+      config: testConfig,
+    });
+  });
+
+  it("should not include config in request body when config option is not provided", async () => {
+    await remote("test prompt", {});
+
+    const fetchCall = mockFetch.mock.calls[0];
+    const requestBody = JSON.parse(fetchCall[1].body);
+
+    expect(requestBody).toEqual({
+      repoUrl: "https://github.com/user/test-repo.git",
+      name: expect.stringMatching(/^devbox-\d+$/),
+      prompt: "test prompt",
+      idempotencyKey: undefined,
+      agent: undefined,
+      config: undefined,
     });
   });
 

--- a/extensions/cli/src/commands/remote.ts
+++ b/extensions/cli/src/commands/remote.ts
@@ -16,6 +16,7 @@ export async function remote(
     start?: boolean;
     branch?: string;
     repo?: string;
+    config?: string;
   } = {},
 ) {
   // Check if prompt should come from stdin instead of parameter
@@ -84,6 +85,8 @@ export async function remote(
       name: `devbox-${Date.now()}`,
       prompt: actualPrompt,
       idempotencyKey: options.idempotencyKey,
+      agent: options.config,
+      config: options.config,
     };
 
     // Add branchName to request body if branch option is provided

--- a/extensions/cli/src/index.ts
+++ b/extensions/cli/src/index.ts
@@ -218,9 +218,11 @@ program
   });
 
 // Remote subcommand
-program
-  .command("remote [prompt]", { hidden: true })
-  .description("Launch a remote instance of the cn agent")
+addCommonOptions(
+  program
+    .command("remote [prompt]", { hidden: true })
+    .description("Launch a remote instance of the cn agent"),
+)
   .option(
     "--url <url>",
     "Connect directly to the specified URL instead of creating a new remote environment",


### PR DESCRIPTION
## Description

so we can use custom agents when starting them remotely
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a --config flag to cn remote to launch remote sessions with a custom agent/config. The request now includes agent and config fields, and the PR review workflow uses this flag.

- New Features
  - Accepts --config on cn remote; forwards value to API as agent and config.
  - Applies common CLI options to remote via addCommonOptions.
  - Adds tests for config handling and updates the GitHub workflow to pass a default config.

<!-- End of auto-generated description by cubic. -->

