### PR TITLE
feat: add tooltips to user settings page

### DIFF
--- a/gui/src/components/gui/Switch.tsx
+++ b/gui/src/components/gui/Switch.tsx
@@ -1,5 +1,7 @@
+import { InformationCircleIcon } from "@heroicons/react/24/outline";
 import React, { ReactNode } from "react";
 import { vscButtonBackground } from "..";
+import { ToolTip } from "./Tooltip";
 
 type ToggleSwitchProps = {
   isToggled: boolean;
@@ -8,6 +10,7 @@ type ToggleSwitchProps = {
   size?: number;
   showIfToggled?: ReactNode;
   disabled?: boolean;
+  tooltip?: string;
 };
 
 const ToggleSwitch: React.FC<ToggleSwitchProps> = ({
@@ -17,12 +20,20 @@ const ToggleSwitch: React.FC<ToggleSwitchProps> = ({
   size = 16,
   showIfToggled,
   disabled = false,
+  tooltip,
 }) => {
   return (
     <div
       className={`flex select-none items-center justify-between gap-3 ${disabled ? "cursor-not-allowed" : "cursor-pointer"}`}
     >
-      <span className="truncate-right">{text}</span>
+      <span className="truncate-right flex items-center gap-x-1">
+        {text}{" "}
+        {tooltip && (
+          <ToolTip content={tooltip}>
+            <InformationCircleIcon className="h-3 w-3" />
+          </ToolTip>
+        )}
+      </span>
       <div className="flex flex-row items-center gap-1">
         {isToggled && !!showIfToggled && showIfToggled}
         <div

--- a/gui/src/pages/config/UserSettingsForm.tsx
+++ b/gui/src/pages/config/UserSettingsForm.tsx
@@ -2,6 +2,7 @@ import {
   CheckIcon,
   ChevronRightIcon,
   ExclamationTriangleIcon,
+  InformationCircleIcon,
   XMarkIcon,
 } from "@heroicons/react/24/outline";
 import {
@@ -177,6 +178,7 @@ export function UserSettingsForm() {
                 })
               }
               text="Show Session Tabs"
+              tooltip="If on, displays tabs above the chat as an alternative way to organize and access your sessions."
             />
             <ToggleSwitch
               isToggled={codeWrap}
@@ -186,6 +188,7 @@ export function UserSettingsForm() {
                 })
               }
               text="Wrap Codeblocks"
+              tooltip="If on, displays tabs above the chat as an alternative way to organize and access your sessions."
             />
 
             <ToggleSwitch
@@ -196,6 +199,7 @@ export function UserSettingsForm() {
                 })
               }
               text="Show Chat Scrollbar"
+              tooltip="If on, enables a scrollbar in the chat window."
             />
             <ToggleSwitch
               isToggled={readResponseTTS}
@@ -205,6 +209,7 @@ export function UserSettingsForm() {
                 })
               }
               text="Text-to-Speech Output"
+              tooltip="If on, reads LLM responses aloud with TTS."
             />
             {/* <ToggleSwitch
                     isToggled={useChromiumForDocsCrawling}
@@ -223,6 +228,7 @@ export function UserSettingsForm() {
                 })
               }
               text="Enable Session Titles"
+              tooltip="If on, generates summary titles for each chat session after the first message, using the current Chat model."
             />
             <ToggleSwitch
               isToggled={!displayRawMarkdown}
@@ -232,6 +238,7 @@ export function UserSettingsForm() {
                 })
               }
               text="Format Markdown"
+              tooltip="If off, shows responses as raw text."
             />
 
             <ToggleSwitch
@@ -243,6 +250,7 @@ export function UserSettingsForm() {
                 })
               }
               text="Allow Anonymous Telemetry"
+              tooltip="If on, allows Continue to send anonymous telemetry."
             />
 
             <ToggleSwitch
@@ -267,7 +275,12 @@ export function UserSettingsForm() {
                   /> */}
 
             <label className="flex items-center justify-between gap-3">
-              <span className="text-left">Font Size</span>
+              <span className="flex items-center gap-x-1 text-left">
+                Font Size{" "}
+                <ToolTip content="Specifies base font size for UI elements">
+                  <InformationCircleIcon className="h-3 w-3" />
+                </ToolTip>
+              </span>
               <NumberInput
                 value={fontSize}
                 onChange={(val) => {
@@ -281,8 +294,11 @@ export function UserSettingsForm() {
               />
             </label>
             <label className="flex items-center justify-between gap-3">
-              <span className="lines lines-1 text-left">
+              <span className="lines lines-1 flex items-center gap-x-1 text-left">
                 Multiline Autocompletions
+                <ToolTip content="Controls multiline completions for autocomplete.">
+                  <InformationCircleIcon className="h-3 w-3" />
+                </ToolTip>
               </span>
               <Select
                 value={useAutocompleteMultilineCompletions}
@@ -301,7 +317,12 @@ export function UserSettingsForm() {
               </Select>
             </label>
             <label className="flex items-center justify-between gap-3">
-              <span className="text-left">Autocomplete Timeout (ms)</span>
+              <span className="flex items-center gap-x-1 text-left">
+                Autocomplete Timeout (ms)
+                <ToolTip content="Maximum time in milliseconds for autocomplete request/retrieval.">
+                  <InformationCircleIcon className="h-3 w-3" />
+                </ToolTip>
+              </span>
               <NumberInput
                 value={modelTimeout}
                 onChange={(val) =>
@@ -314,7 +335,12 @@ export function UserSettingsForm() {
               />
             </label>
             <label className="flex items-center justify-between gap-3">
-              <span className="text-left">Autocomplete Debounce (ms)</span>
+              <span className="flex items-center gap-x-1 text-left">
+                Autocomplete Debounce (ms)
+                <ToolTip content="Minimum time in milliseconds to trigger an autocomplete request after a change.">
+                  <InformationCircleIcon className="h-3 w-3" />
+                </ToolTip>
+              </span>
               <NumberInput
                 value={debounceDelay}
                 onChange={(val) =>
@@ -334,7 +360,12 @@ export function UserSettingsForm() {
               }}
             >
               <div className="flex items-center justify-between">
-                <span>Disable autocomplete in files</span>
+                <span className="flex items-center gap-x-1">
+                  Disable autocomplete in files
+                  <ToolTip content="List of comma-separated glob pattern to disable autocomplete in matching files. E.g., **/*.{txt,md}">
+                    <InformationCircleIcon className="h-3 w-3" />
+                  </ToolTip>
+                </span>
                 <div className="flex items-center gap-2">
                   <Input
                     value={formDisableAutocomplete}
@@ -401,6 +432,8 @@ export function UserSettingsForm() {
                     })
                   }
                   text="Auto-Accept Agent Edits"
+                  tooltip="If on, diffs generated by the edit tool are
+  automatically accepted and Agent proceeds with the next conversational turn."
                   showIfToggled={
                     <>
                       <ToolTip
@@ -420,6 +453,7 @@ export function UserSettingsForm() {
                     })
                   }
                   text="Add Current File by Default"
+                  tooltip="If on, the currently open file is added as context in every new conversation."
                 />
 
                 <ToggleSwitch
@@ -439,6 +473,7 @@ export function UserSettingsForm() {
                       onlyUseSystemMessageTools: !onlyUseSystemMessageTools,
                     })
                   }
+                  tooltip="If on, Continue will not attempt to use native tool calling and will only use system message tools."
                   text="Only use system message tools"
                 />
 
@@ -460,6 +495,7 @@ export function UserSettingsForm() {
                     })
                   }
                   text="Stream after tool rejection"
+                  tooltip="If on, streaming will continue after the tool call is rejected."
                 />
 
                 {hasContinueEmail && (


### PR DESCRIPTION
## Description

From the old [settings page](https://github.com/continuedev/continue/blob/4b51607595ba01e94b7bb85428a9cff9b5ac1859/docs/customize/settings.mdx), add tooltips with content describing each setting.

resolves CON-3484

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

<img width="1024" height="1686" alt="image" src="https://github.com/user-attachments/assets/551c713a-80a6-4fc1-b034-c5d6ef42fb29" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds hover tooltips to the User Settings page to explain each option, improving clarity and onboarding. Completes CON-3484 by porting concise descriptions from the legacy settings docs and adding tooltip support to the ToggleSwitch component.

- **New Features**
  - ToggleSwitch: new tooltip prop with info icon (InformationCircleIcon + ToolTip).
  - Display/general: tooltips for Session Tabs, Wrap Codeblocks, Chat Scrollbar, Text-to-Speech, Session Titles, Format Markdown, Anonymous Telemetry, Font Size.
  - Autocomplete/Agent: tooltips for Multiline Autocompletions, Autocomplete Timeout/Debounce, Disable-in-files globs, Auto-Accept Agent Edits, Add Current File by Default, Only use system message tools, Stream after tool rejection.

<!-- End of auto-generated description by cubic. -->

