### PR TITLE
fix(docs): broken settings page links

### DIFF
--- a/docs/features/autocomplete/how-to-customize.mdx
+++ b/docs/features/autocomplete/how-to-customize.mdx
@@ -3,6 +3,6 @@ title: “Customize Autocomplete Settings in Continue”
 description: “Learn how to customize autocomplete behavior in Continue, including user settings, configuration options, and adjustments to improve AI code suggestions in your IDE.”
 ---
 
-Continue offers a handful of settings to customize autocomplete behavior. Visit the [User Settings Page](/customize/settings) to manage these settings.
+Continue offers a handful of settings to customize autocomplete behavior. Visit the User Settings Page (Gear Icon) to manage these settings.
 
 For a comprehensive guide on all configuration options and their impacts, see the [Autocomplete deep dive](/customize/deep-dives/autocomplete).

--- a/docs/reference/deprecated-docs.mdx
+++ b/docs/reference/deprecated-docs.mdx
@@ -6,7 +6,11 @@ noindex: true
 ---
 
 <Warning>
-  **This feature is deprecated.** The `@Docs` context provider has been deprecated in favor of a more integrated approach to documentation awareness. Please refer to our [Guide on Making Agents Aware of Codebases and Documentation](/guides/codebase-documentation-awareness) for the recommended approach.
+  **This feature is deprecated.** The `@Docs` context provider has been
+  deprecated in favor of a more integrated approach to documentation awareness.
+  Please refer to our [Guide on Making Agents Aware of Codebases and
+  Documentation](/guides/codebase-documentation-awareness) for the recommended
+  approach.
 </Warning>
 
 ## Migration Guide
@@ -219,8 +223,8 @@ If your documentation is private, you can skip the default crawler and use a loc
   The default local crawler is a lightweight tool that cannot render sites that
   are dynamically generated using JavaScript. If your sites need to be rendered,
   you can enable the experimental `Use Chromium for Docs Crawling` feature from
-  your User Settings Page. This will download and install Chromium
-  to `~/.continue/.utils`, and use it as the local crawler. **Note:** Chromium
+  your User Settings Page. This will download and install Chromium to
+  `~/.continue/.utils`, and use it as the local crawler. **Note:** Chromium
   crawling support is being deprecated and may be removed in future versions.
 </Info>
 
@@ -408,4 +412,4 @@ The following configuration example includes:
   </Tab>
 </Tabs>
 
-This setup could also involve enabling Chromium as a backup for local documentation through the [User Settings Page](../customize/settings).
+This setup could also involve enabling Chromium as a backup for local documentation through the User Settings Page (Gear Icon).

--- a/docs/reference/deprecated-docs.mdx
+++ b/docs/reference/deprecated-docs.mdx
@@ -6,11 +6,7 @@ noindex: true
 ---
 
 <Warning>
-  **This feature is deprecated.** The `@Docs` context provider has been
-  deprecated in favor of a more integrated approach to documentation awareness.
-  Please refer to our [Guide on Making Agents Aware of Codebases and
-  Documentation](/guides/codebase-documentation-awareness) for the recommended
-  approach.
+  **This feature is deprecated.** The `@Docs` context provider has been deprecated in favor of a more integrated approach to documentation awareness. Please refer to our [Guide on Making Agents Aware of Codebases and Documentation](/guides/codebase-documentation-awareness) for the recommended approach.
 </Warning>
 
 ## Migration Guide
@@ -223,8 +219,8 @@ If your documentation is private, you can skip the default crawler and use a loc
   The default local crawler is a lightweight tool that cannot render sites that
   are dynamically generated using JavaScript. If your sites need to be rendered,
   you can enable the experimental `Use Chromium for Docs Crawling` feature from
-  your User Settings Page. This will download and install Chromium to
-  `~/.continue/.utils`, and use it as the local crawler. **Note:** Chromium
+  your User Settings Page. This will download and install Chromium
+  to `~/.continue/.utils`, and use it as the local crawler. **Note:** Chromium
   crawling support is being deprecated and may be removed in future versions.
 </Info>
 


### PR DESCRIPTION
## Description

Fix broken /customize/settings page links from docs

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix broken links to the User Settings page by replacing the outdated /customize/settings URL with a clear reference to “User Settings (Gear Icon)”. Prevents 404s and clarifies how to find settings in the UI.

<!-- End of auto-generated description by cubic. -->

