### PR TITLE
fix: update MermaidBlock styles for improved rendering and add foreignObject width

### DIFF
--- a/gui/src/components/StyledMarkdownPreview/MermaidBlock.tsx
+++ b/gui/src/components/StyledMarkdownPreview/MermaidBlock.tsx
@@ -141,7 +141,7 @@ export default function MermaidDiagram({ code }: { code: string }) {
       {!!error ? (
         <div className="text-error whitespace-pre text-sm">{error}</div>
       ) : (
-        <div className="relative">
+        <div className="mermaid relative">
           <div className="absolute right-0 z-10 m-2 flex items-center gap-x-1">
             <ToolTip content={"Zoom In"}>
               <MagnifyingGlassPlusIcon

--- a/gui/src/components/StyledMarkdownPreview/markdown.css
+++ b/gui/src/components/StyledMarkdownPreview/markdown.css
@@ -1038,3 +1038,6 @@ body[data-color-mode*="light"] {
 .token.entity {
   cursor: help;
 }
+.mermaid foreignObject {
+  width: 100%;
+}


### PR DESCRIPTION
## Description

In idea, the mermaid diagram doesn't display text completely. The width of foreignObject calculated wrong. So make it width 100%

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot
![20250904-152906](https://github.com/user-attachments/assets/af02b974-4a97-4301-a08c-f20d102f5512)


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes clipped text in Mermaid diagrams by correcting the foreignObject width. Adds a .mermaid wrapper and sets foreignObject width: 100% so text renders fully in IDEA and other environments.

<!-- End of auto-generated description by cubic. -->

