### PR TITLE
feat: add mcp request timeout when calling tool

### DIFF
--- a/core/tools/callTool.ts
+++ b/core/tools/callTool.ts
@@ -1,3 +1,4 @@
+import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
 import { ContextItem, Tool, ToolCall, ToolExtras } from "..";
 import { MCPManagerSingleton } from "../context/mcp/MCPManagerSingleton";
 import { canParseUrl } from "../util/url";
@@ -87,10 +88,14 @@ async function callToolFromUri(
       if (!client) {
         throw new Error("MCP connection not found");
       }
-      const response = await client.client.callTool({
-        name: toolName,
-        arguments: args,
-      });
+      const response = await client.client.callTool(
+        {
+          name: toolName,
+          arguments: args,
+        },
+        CallToolResultSchema,
+        { timeout: client.options.timeout },
+      );
 
       if (response.isError === true) {
         throw new Error(JSON.stringify(response.content));


### PR DESCRIPTION
## Description

Use the `mcpServers.connectionTimeout` (initially used for mcp connection timeout) to specify request timeout when calling mcp tool.

closes https://github.com/continuedev/continue/issues/7509

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
