### PR TITLE
fix: don't use override-only actionPerformed to invoke action

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/error/ContinueErrorSubmitter.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/error/ContinueErrorSubmitter.kt
@@ -21,6 +21,7 @@ class ContinueErrorSubmitter : ErrorReportSubmitter() {
         consumer: Consumer<in SubmittedReportInfo>
     ): Boolean {
         try {
+            // todo: IdeaReportingEvent is deprecated; migrate to IdeaLoggingEvent + figure out how to read attachments
             val event = events.filterIsInstance<IdeaReportingEvent>()
                 .firstOrNull() ?: return false
             service<ContinueSentryService>().report(

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/license/AddLicenseKeyDialog.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/license/AddLicenseKeyDialog.kt
@@ -3,9 +3,9 @@ package com.github.continuedev.continueintellijextension.license
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.ValidationInfo
+import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.bindText
 import com.intellij.ui.dsl.builder.panel
-import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import javax.swing.JComponent
 
 class AddLicenseKeyDialog(project: Project?) : DialogWrapper(project) {
@@ -22,7 +22,7 @@ class AddLicenseKeyDialog(project: Project?) : DialogWrapper(project) {
         panel {
             row {
                 textField().bindText(::licenseKey)
-                    .horizontalAlign(HorizontalAlign.FILL)
+                    .align(AlignX.FILL)
                     .focused()
                     .validationOnApply {
                         if (it.text.isBlank())


### PR DESCRIPTION
It's resolving one of problems during plugin verification. I manually tested this feature to make sure there are no regressions.

Solves:
`Override-only method AddLicenseKey.actionPerformed(AnActionEvent) is invoked in AddLicenseKey.createErrorAction$1.invoke(...). This method is marked with @ApiStatus.OverrideOnly annotation, which indicates that the method must be only overridden but not invoked by client code. See documentation of the @ApiStatus.OverrideOnly for more info.`

Extra: minor fixes (deprecated methods removal/attempts).
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes IntelliJ Plugin Verifier error by removing direct calls to the override-only AddLicenseKey.actionPerformed and moving logic into a reusable method. No behavior changes.

- **Bug Fixes**
  - Extracted performAddLicenseKey(project) and used it for both the action and the “Try again” notification.
  - Ensures a non-null project before showing the dialog and sending the request.

- **Refactors**
  - Replaced deprecated HorizontalAlign.FILL with AlignX.FILL in the dialog.
  - Added TODO to migrate from IdeaReportingEvent to IdeaLoggingEvent in error submitter.

<!-- End of auto-generated description by cubic. -->

