### PR TITLE
fix: migrate proxy pooling activity to project activity

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/proxy/ProxyPoolingActivity.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/proxy/ProxyPoolingActivity.kt
@@ -4,31 +4,31 @@ import com.github.continuedev.continueintellijextension.services.ContinuePluginS
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.startup.StartupActivity
-import kotlinx.coroutines.*
+import com.intellij.openapi.startup.ProjectActivity
+import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.seconds
 
-class ProxyPoolingActivity : StartupActivity {
-    private val scope = CoroutineScope(Dispatchers.Default)
+class ProxyPoolingActivity : ProjectActivity {
     private var lastSettings = ProxySettings.getSettings()
-    private val log = Logger.getInstance(ProxyPoolingActivity::class.java)
 
-    override fun runActivity(project: Project) {
-        scope.launch {
-            while (isActive) {
-                val newSettings = ProxySettings.getSettings()
-                if (newSettings != lastSettings) {
-                    onSettingsChanged(project)
-                    lastSettings = newSettings
-                }
-                delay(2.seconds)
+    override suspend fun execute(project: Project) {
+        while (true) {
+            val newSettings = ProxySettings.getSettings()
+            if (newSettings != lastSettings) {
+                onSettingsChanged(project)
+                lastSettings = newSettings
             }
+            delay(2.seconds)
         }
     }
 
     private fun onSettingsChanged(project: Project) {
-        log.warn("Proxy settings changed, restarting")
+        LOG.warn("Proxy settings changed, restarting")
         project.service<ContinuePluginService>().coreMessengerManager?.coreMessenger?.restart()
+    }
+
+    private companion object {
+        private val LOG = Logger.getInstance(ProxyPoolingActivity::class.java.simpleName)
     }
 }
 


### PR DESCRIPTION
Solves:
```
com.intellij.diagnostic.PluginException: Migrate com.github.continuedev.continueintellijextension.proxy.ProxyPoolingActivity to ProjectActivity [Plugin: com.github.continuedev.continueintellijextension]
	at com.intellij.ide.startup.impl.StartupManagerImpl.runPostStartupActivities(StartupManagerImpl.kt:275)
	at com.intellij.ide.startup.impl.StartupManagerImpl.access$runPostStartupActivities(StartupManagerImpl.kt:68)
	at com.intellij.ide.startup.impl.StartupManagerImpl$runPostStartupActivities$3$2.invokeSuspend(StartupManagerImpl.kt:191)
```

I fixed this because since bumping the platform version we were getting an exception on startup about a required migration.

Note: the new activity is asynchronous, so we don't need to create our own coroutine scope for polling the settings.

I tested this feature manually (change in settings is properly recognized & binary restarts on apply).

