### PR TITLE
fix: ignore Stream closed exceptions on flush

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/process/ContinueProcessHandler.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/process/ContinueProcessHandler.kt
@@ -43,10 +43,14 @@ class ContinueProcessHandler(
         }
         scope.launch(Dispatchers.IO) {
             for (message in pendingWrites) {
-                log.debug("Write: $message")
-                writer.write(message)
-                writer.write("\r\n")
-                writer.flush()
+                try {
+                    log.debug("Write: $message")
+                    writer.write(message)
+                    writer.write("\r\n")
+                    writer.flush()
+                } catch (e: IOException) {
+                    log.warn(e)
+                }
             }
         }
     }


### PR DESCRIPTION
Solves: CON-3587

This exception occurs if `continue-binary` is killed or throws some unexpected error, but in the previous version, the exception would bubble up and be logged as an IDE error (visible for users).

After this change, we catch this exception and only log it, because there's no point in throwing it. The handler still recognizes this invalid state and gracefully restarts the binary.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Ignore “Stream closed” IOExceptions during write/flush to continue-binary to prevent IDE error popups and allow clean restarts. Addresses CON-3587 by wrapping writes in try/catch and logging instead of propagating the error.

<!-- End of auto-generated description by cubic. -->

