### PR TITLE
feat: CLI: add diagnostics to /info screen

### DIFF
--- a/extensions/cli/src/infoScreen.ts
+++ b/extensions/cli/src/infoScreen.ts
@@ -1,5 +1,6 @@
-import chalk from "chalk";
 import { execSync } from "child_process";
+
+import chalk from "chalk";
 
 import {
   isAuthenticated,

--- a/extensions/cli/src/infoScreen.ts
+++ b/extensions/cli/src/infoScreen.ts
@@ -1,0 +1,134 @@
+import chalk from "chalk";
+import { execSync } from "child_process";
+
+import {
+  isAuthenticated,
+  isAuthenticatedConfig,
+  loadAuthConfig,
+} from "./auth/workos.js";
+import { services } from "./services/index.js";
+import { getCurrentSession, getSessionFilePath } from "./session.js";
+import { posthogService } from "./telemetry/posthogService.js";
+import { getVersion } from "./version.js";
+
+export async function handleInfoSlashCommand() {
+  posthogService.capture("useSlashCommand", { name: "info" });
+
+  const infoLines = [];
+
+  // Version and working directory info
+  const version = getVersion();
+  const cwd = process.cwd();
+
+  infoLines.push(
+    chalk.white("CLI Information:"),
+    `  Version: ${chalk.green(version)}`,
+    `  Working Directory: ${chalk.blue(cwd)}`,
+  );
+
+  // Auth info
+  if (isAuthenticated()) {
+    const config = loadAuthConfig();
+    if (config && isAuthenticatedConfig(config)) {
+      const email = config.userEmail || config.userId;
+      const org = "(no org)"; // Organization info not available in AuthenticatedConfig
+      infoLines.push(
+        "",
+        chalk.white("Authentication:"),
+        `  Email: ${chalk.green(email)}`,
+        `  Organization: ${chalk.cyan(org)}`,
+      );
+    } else {
+      infoLines.push(
+        "",
+        chalk.white("Authentication:"),
+        `  ${chalk.yellow("Authenticated via environment variable")}`,
+      );
+    }
+  } else {
+    infoLines.push(
+      "",
+      chalk.white("Authentication:"),
+      `  ${chalk.red("Not logged in")}`,
+    );
+  }
+
+  // Config info
+  try {
+    const configState = services.config.getState();
+    infoLines.push("", chalk.white("Configuration:"));
+    if (configState.config) {
+      infoLines.push(`  ${chalk.gray(`Using ${configState.config?.name}`)}`);
+    } else {
+      infoLines.push(`  ${chalk.red(`Config not found`)}`);
+    }
+    if (configState.configPath) {
+      infoLines.push(`  Path: ${chalk.blue(configState.configPath)}`);
+    }
+
+    // Add current model info
+    try {
+      const modelInfo = services.model?.getModelInfo();
+      if (modelInfo) {
+        infoLines.push(`  Model: ${chalk.cyan(modelInfo.name)}`);
+      } else {
+        infoLines.push(`  Model: ${chalk.red("Not available")}`);
+      }
+    } catch {
+      infoLines.push(`  Model: ${chalk.red("Error retrieving model info")}`);
+    }
+  } catch {
+    infoLines.push(
+      "",
+      chalk.white("Configuration:"),
+      `  ${chalk.red("Configuration service not available")}`,
+    );
+  }
+
+  // Session info
+  infoLines.push("", chalk.white("Session:"));
+  try {
+    const currentSession = getCurrentSession();
+    const sessionFilePath = getSessionFilePath();
+    infoLines.push(
+      `  Title: ${chalk.green(currentSession.title)}`,
+      `  ID: ${chalk.gray(currentSession.sessionId)}`,
+      `  File: ${chalk.blue(sessionFilePath)}`,
+    );
+  } catch {
+    infoLines.push(`  ${chalk.red("Session not available")}`);
+  }
+
+  // Runtime diagnostic info
+  const nodePath = process.execPath;
+  const invokedPath = process.argv[1];
+
+  // Get npm version
+  let npmVersion = "unknown";
+  try {
+    npmVersion = execSync("npm --version", {
+      encoding: "utf8",
+      timeout: 5000,
+      stdio: ["pipe", "pipe", "ignore"],
+    }).trim();
+  } catch (error) {
+    // If npm command fails, fallback to "unknown"
+    console.warn("Failed to get npm version:", error);
+  }
+
+  // Diagnostic info
+  infoLines.push(
+    "",
+    chalk.white("Diagnostic Info"),
+    `  Currently running: npm-global (${chalk.green(npmVersion)})`,
+    `  Path: ${chalk.blue(nodePath)}`,
+    `  Invoked: ${chalk.blue(invokedPath)}`,
+  );
+
+  // TODO add global settings like auto update etc.
+
+  return {
+    exit: false,
+    output: infoLines.join("\n"),
+  };
+}

--- a/extensions/cli/src/infoScreen.ts
+++ b/extensions/cli/src/infoScreen.ts
@@ -33,12 +33,12 @@ export async function handleInfoSlashCommand() {
     const config = loadAuthConfig();
     if (config && isAuthenticatedConfig(config)) {
       const email = config.userEmail || config.userId;
-      const org = "(no org)"; // Organization info not available in AuthenticatedConfig
+      const orgId = config.organizationId;
       infoLines.push(
         "",
         chalk.white("Authentication:"),
         `  Email: ${chalk.green(email)}`,
-        `  Organization: ${chalk.cyan(org)}`,
+        `  Org ID: ${chalk.cyan(orgId)}`,
       );
     } else {
       infoLines.push(

--- a/extensions/cli/src/infoScreen.ts
+++ b/extensions/cli/src/infoScreen.ts
@@ -10,6 +10,7 @@ import {
 import { services } from "./services/index.js";
 import { getCurrentSession, getSessionFilePath } from "./session.js";
 import { posthogService } from "./telemetry/posthogService.js";
+import { logger } from "./util/logger.js";
 import { getVersion } from "./version.js";
 
 export async function handleInfoSlashCommand() {
@@ -114,7 +115,7 @@ export async function handleInfoSlashCommand() {
     }).trim();
   } catch (error) {
     // If npm command fails, fallback to "unknown"
-    console.warn("Failed to get npm version:", error);
+    logger.warn("Failed to get npm version:", error);
   }
 
   // Diagnostic info

--- a/extensions/cli/src/slashCommands.test.ts
+++ b/extensions/cli/src/slashCommands.test.ts
@@ -217,7 +217,7 @@ describe("slashCommands", () => {
       expect(result).toBeDefined();
       expect(result?.output).toContain("Authentication:");
       expect(result?.output).toContain("test@example.com");
-      expect(result?.output).toContain("(no org)");
+      expect(result?.output).toContain("test-org-id");
       expect(result?.output).toContain("Configuration:");
       expect(result?.output).toContain("/custom/config.yaml");
       expect(result?.exit).toBe(false);

--- a/extensions/cli/src/slashCommands.ts
+++ b/extensions/cli/src/slashCommands.ts
@@ -7,11 +7,11 @@ import {
   loadAuthConfig,
 } from "./auth/workos.js";
 import { getAllSlashCommands } from "./commands/commands.js";
+import { handleInfoSlashCommand } from "./infoScreen.js";
 import { reloadService, SERVICE_NAMES, services } from "./services/index.js";
-import { getCurrentSession, getSessionFilePath } from "./session.js";
+import { getCurrentSession } from "./session.js";
 import { posthogService } from "./telemetry/posthogService.js";
 import { SlashCommandResult } from "./ui/hooks/useChat.types.js";
-import { getVersion } from "./version.js";
 
 type CommandHandler = (
   args: string[],
@@ -115,93 +115,6 @@ function handleWhoami() {
   }
 }
 
-async function handleInfo() {
-  posthogService.capture("useSlashCommand", { name: "info" });
-
-  const infoLines = [];
-
-  // Version and working directory info
-  const version = getVersion();
-  const cwd = process.cwd();
-
-  infoLines.push(chalk.white("CLI Information:"));
-  infoLines.push(`  Version: ${chalk.green(version)}`);
-  infoLines.push(`  Working Directory: ${chalk.blue(cwd)}`);
-
-  // Auth info
-  if (isAuthenticated()) {
-    const config = loadAuthConfig();
-    if (config && isAuthenticatedConfig(config)) {
-      const email = config.userEmail || config.userId;
-      const org = "(no org)"; // Organization info not available in AuthenticatedConfig
-      infoLines.push("");
-      infoLines.push(chalk.white("Authentication:"));
-      infoLines.push(`  Email: ${chalk.green(email)}`);
-      infoLines.push(`  Organization: ${chalk.cyan(org)}`);
-    } else {
-      infoLines.push("");
-      infoLines.push(chalk.white("Authentication:"));
-      infoLines.push(
-        `  ${chalk.yellow("Authenticated via environment variable")}`,
-      );
-    }
-  } else {
-    infoLines.push("");
-    infoLines.push(chalk.white("Authentication:"));
-    infoLines.push(`  ${chalk.red("Not logged in")}`);
-  }
-
-  // Config info
-  try {
-    const configState = services.config.getState();
-    infoLines.push("");
-    infoLines.push(chalk.white("Configuration:"));
-    if (configState.config) {
-      infoLines.push(`  ${chalk.gray(`Using ${configState.config?.name}`)}`);
-    } else {
-      infoLines.push(`  ${chalk.red(`Config not found`)}`);
-    }
-    if (configState.configPath) {
-      infoLines.push(`  Path: ${chalk.blue(configState.configPath)}`);
-    }
-
-    // Add current model info
-    try {
-      const modelInfo = services.model?.getModelInfo();
-      if (modelInfo) {
-        infoLines.push(`  Model: ${chalk.cyan(modelInfo.name)}`);
-      } else {
-        infoLines.push(`  Model: ${chalk.red("Not available")}`);
-      }
-    } catch {
-      infoLines.push(`  Model: ${chalk.red("Error retrieving model info")}`);
-    }
-  } catch {
-    infoLines.push("");
-    infoLines.push(chalk.white("Configuration:"));
-    infoLines.push(`  ${chalk.red("Configuration service not available")}`);
-  }
-
-  // Session info
-  infoLines.push("");
-  infoLines.push(chalk.white("Session:"));
-  try {
-    const currentSession = getCurrentSession();
-    infoLines.push(`  Title: ${chalk.green(currentSession.title)}`);
-    infoLines.push(`  ID: ${chalk.gray(currentSession.sessionId)}`);
-
-    const sessionFilePath = getSessionFilePath();
-    infoLines.push(`  File: ${chalk.blue(sessionFilePath)}`);
-  } catch {
-    infoLines.push(`  ${chalk.red("Session not available")}`);
-  }
-
-  return {
-    exit: false,
-    output: infoLines.join("\n"),
-  };
-}
-
 async function handleFork() {
   posthogService.capture("useSlashCommand", { name: "fork" });
 
@@ -247,7 +160,7 @@ const commandHandlers: Record<string, CommandHandler> = {
   login: handleLogin,
   logout: handleLogout,
   whoami: handleWhoami,
-  info: handleInfo,
+  info: handleInfoSlashCommand,
   model: () => ({ openModelSelector: true }),
   compact: () => {
     posthogService.capture("useSlashCommand", { name: "compact" });


### PR DESCRIPTION
## Description
<img width="686" height="227" alt="image" src="https://github.com/user-attachments/assets/67a95307-d473-4c02-a73e-a3d207ea74ae" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add diagnostics to the /info CLI screen to aid troubleshooting and support (CON-3089). Shows npm version and Node runtime paths alongside existing info.

- **New Features**
  - Adds a “Diagnostic Info” block: npm version, Node path, and invoked script path.

- **Refactors**
  - Moves /info handling into infoScreen.ts and wires slashCommands to the new handler.

<!-- End of auto-generated description by cubic. -->

