### PR TITLE
fix: remove extraneous quotation mark in className for useCodebase div

### DIFF
--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -163,9 +163,7 @@ function InputToolbar(props: InputToolbarProps) {
         >
           {!isInEdit && <ContextStatus />}
           {!props.toolbarOptions?.hideUseCodebase && !isInEdit && (
-            <div
-              className={`hover:underline" hidden transition-colors duration-200 md:flex`}
-            >
+            <div className="hidden transition-colors duration-200 hover:underline md:flex">
               <HoverItem
                 className={props.activeKey === "Alt" ? "underline" : ""}
                 onClick={(e) =>


### PR DESCRIPTION
## Description

remove extraneous quotation mark in className for useCodebase div

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed a stray quote in the InputToolbar "Use Codebase" div className to fix a malformed class list. Restores the hover underline style and prevents Tailwind parsing issues.

<!-- End of auto-generated description by cubic. -->

