### PR TITLE
feat(cli): allow some space after the dot in chat input

### DIFF
--- a/extensions/cli/src/ui/UserInput.tsx
+++ b/extensions/cli/src/ui/UserInput.tsx
@@ -801,7 +801,7 @@ const UserInput: React.FC<UserInputProps> = ({
           color={showBashMode ? "yellow" : isRemoteMode ? "cyan" : "blue"}
           bold
         >
-          {showBashMode ? "$" : isRemoteMode ? "◉" : "●"}
+          {showBashMode ? "$ " : isRemoteMode ? "◉ " : "● "}
         </Text>
         {renderInputText()}
       </Box>


### PR DESCRIPTION
## Description

Show a space after the dot in the chat input area  for improved readability.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot


https://github.com/user-attachments/assets/045ab0f4-749b-494e-9eea-272a623e1347

https://github.com/user-attachments/assets/b6220b30-a701-4c17-b8c4-921d951ae2c2



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
