### PR TITLE
Nate/gate-remote

### DIFF
--- a/extensions/cli/src/commands/canAccessAgents.test.ts
+++ b/extensions/cli/src/commands/canAccessAgents.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the auth module
+vi.mock("../auth/workos.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../auth/workos.js")>();
+  return {
+    ...actual,
+    loadAuthConfig: vi.fn(),
+    isAuthenticatedConfig: vi.fn(),
+  };
+});
+
+import { loadAuthConfig, isAuthenticatedConfig } from "../auth/workos.js";
+
+import { canAccessAgents } from "./remote.js";
+
+describe("canAccessAgents", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("should return false when no auth config exists", async () => {
+    (loadAuthConfig as any).mockReturnValue(null);
+
+    const result = await canAccessAgents();
+
+    expect(result).toBe(false);
+  });
+
+  it("should return false for environment auth (CONTINUE_API_KEY)", async () => {
+    const envAuthConfig = {
+      accessToken: "test-token",
+      organizationId: null,
+    };
+
+    (loadAuthConfig as any).mockReturnValue(envAuthConfig);
+    (isAuthenticatedConfig as any).mockReturnValue(false);
+
+    const result = await canAccessAgents();
+
+    expect(result).toBe(false);
+  });
+
+  it("should return true for @continue.dev email addresses", async () => {
+    const authConfig = {
+      userId: "test-user",
+      userEmail: "test@continue.dev",
+      accessToken: "test-token",
+      refreshToken: "test-refresh",
+      expiresAt: Date.now() + 3600000,
+      organizationId: null,
+    };
+
+    (loadAuthConfig as any).mockReturnValue(authConfig);
+    (isAuthenticatedConfig as any).mockReturnValue(true);
+
+    const result = await canAccessAgents();
+
+    expect(result).toBe(true);
+  });
+
+  it("should return false for non-@continue.dev email addresses", async () => {
+    const authConfig = {
+      userId: "test-user",
+      userEmail: "test@example.com",
+      accessToken: "test-token",
+      refreshToken: "test-refresh",
+      expiresAt: Date.now() + 3600000,
+      organizationId: null,
+    };
+
+    (loadAuthConfig as any).mockReturnValue(authConfig);
+    (isAuthenticatedConfig as any).mockReturnValue(true);
+
+    const result = await canAccessAgents();
+
+    expect(result).toBe(false);
+  });
+
+  it("should return false when userEmail is undefined", async () => {
+    const authConfig = {
+      userId: "test-user",
+      userEmail: undefined,
+      accessToken: "test-token",
+      refreshToken: "test-refresh",
+      expiresAt: Date.now() + 3600000,
+      organizationId: null,
+    };
+
+    (loadAuthConfig as any).mockReturnValue(authConfig);
+    (isAuthenticatedConfig as any).mockReturnValue(true);
+
+    const result = await canAccessAgents();
+
+    expect(result).toBe(false);
+  });
+
+  it("should return false when userEmail is null", async () => {
+    const authConfig = {
+      userId: "test-user",
+      userEmail: null,
+      accessToken: "test-token",
+      refreshToken: "test-refresh",
+      expiresAt: Date.now() + 3600000,
+      organizationId: null,
+    };
+
+    (loadAuthConfig as any).mockReturnValue(authConfig);
+    (isAuthenticatedConfig as any).mockReturnValue(true);
+
+    const result = await canAccessAgents();
+
+    expect(result).toBe(false);
+  });
+
+  it("should handle edge case: empty string email", async () => {
+    const authConfig = {
+      userId: "test-user",
+      userEmail: "",
+      accessToken: "test-token",
+      refreshToken: "test-refresh",
+      expiresAt: Date.now() + 3600000,
+      organizationId: null,
+    };
+
+    (loadAuthConfig as any).mockReturnValue(authConfig);
+    (isAuthenticatedConfig as any).mockReturnValue(true);
+
+    const result = await canAccessAgents();
+
+    expect(result).toBe(false);
+  });
+
+  it("should handle case sensitivity correctly", async () => {
+    const authConfig = {
+      userId: "test-user",
+      userEmail: "test@CONTINUE.DEV",
+      accessToken: "test-token",
+      refreshToken: "test-refresh",
+      expiresAt: Date.now() + 3600000,
+      organizationId: null,
+    };
+
+    (loadAuthConfig as any).mockReturnValue(authConfig);
+    (isAuthenticatedConfig as any).mockReturnValue(true);
+
+    const result = await canAccessAgents();
+
+    // Should return false because domain case doesn't match exactly
+    expect(result).toBe(false);
+  });
+});

--- a/extensions/cli/src/commands/commands.ts
+++ b/extensions/cli/src/commands/commands.ts
@@ -6,6 +6,7 @@ export { login } from "./login.js";
 export { logout } from "./logout.js";
 export { listSessionsCommand } from "./ls.js";
 export { remote } from "./remote.js";
+export { listAgentsCommand } from "./remote-ls.js";
 export { serve } from "./serve.js";
 
 export interface SlashCommand {

--- a/extensions/cli/src/commands/remote-ls.ts
+++ b/extensions/cli/src/commands/remote-ls.ts
@@ -1,0 +1,122 @@
+import { render } from "ink";
+import React from "react";
+
+import { getAccessToken, loadAuthConfig } from "../auth/workos.js";
+import { env } from "../env.js";
+import { Agent, AgentSelector } from "../ui/AgentSelector.js";
+import { logger } from "../util/logger.js";
+
+import { canAccessAgents, remote } from "./remote.js";
+
+interface ListAgentsOptions {
+  format?: "json";
+}
+
+/**
+ * List available agents and allow selection
+ */
+export async function listAgentsCommand(
+  options: ListAgentsOptions = {},
+): Promise<void> {
+  // Check if user has access to agents feature
+  if (!(await canAccessAgents())) {
+    console.error("You don't have access to the agents feature.");
+    process.exit(1);
+  }
+
+  try {
+    const authConfig = loadAuthConfig();
+    const accessToken = getAccessToken(authConfig);
+
+    if (!accessToken) {
+      console.error("Not authenticated. Please run 'cn login' first.");
+      process.exit(1);
+    }
+
+    // Fetch agents from the API
+    const response = await fetch(new URL("agents/devboxes", env.apiBase), {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `Failed to fetch agents: ${response.status} ${errorText}`,
+      );
+    }
+
+    const agents: Agent[] = await response.json();
+
+    // Handle JSON format output
+    if (options.format === "json") {
+      console.log(
+        JSON.stringify(
+          {
+            agents: agents.map((agent) => ({
+              id: agent.id,
+              name: agent.name,
+              description: agent.description,
+              slug: agent.slug,
+              createdAt: agent.createdAt,
+            })),
+          },
+          null,
+          2,
+        ),
+      );
+      return;
+    }
+
+    // Handle empty agents case
+    if (agents.length === 0) {
+      console.log("No agents found.");
+      return;
+    }
+
+    // Start TUI selector
+    return new Promise<void>((resolve, reject) => {
+      const handleSelect = async (agentSlug: string) => {
+        try {
+          app.unmount();
+
+          logger.info(`Starting remote session with agent: ${agentSlug}`);
+
+          // Create a remote environment with the selected agent
+          // We pass the agent slug as part of the prompt for now
+          // This will need to be modified once the API supports agent selection
+          const agentPrompt = `Agent: ${agentSlug}`;
+
+          await remote(agentPrompt, {
+            // Add any specific options for agent-based remote sessions
+          });
+
+          resolve();
+        } catch (error) {
+          logger.error("Error starting remote session with agent:", error);
+          reject(error);
+        }
+      };
+
+      const handleExit = () => {
+        app.unmount();
+        resolve();
+      };
+
+      const app = render(
+        React.createElement(AgentSelector, {
+          agents,
+          onSelect: handleSelect,
+          onExit: handleExit,
+        }),
+      );
+    });
+  } catch (error: any) {
+    logger.error(`Failed to fetch agents: ${error.message}`);
+    console.error(`Failed to fetch agents: ${error.message}`);
+    process.exit(1);
+  }
+}

--- a/extensions/cli/src/commands/remote.access.test.ts
+++ b/extensions/cli/src/commands/remote.access.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock console.log to prevent output during tests
+const mockConsoleLog = vi.fn();
+const mockProcessExit = vi.fn();
+
+// Mock the process.exit function
+vi.stubGlobal('console', {
+  ...console,
+  log: mockConsoleLog,
+});
+
+// Mock process.exit
+Object.defineProperty(process, 'exit', {
+  value: mockProcessExit,
+  writable: true,
+});
+
+// Mock the auth module
+vi.mock("../auth/workos.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../auth/workos.js")>();
+  return {
+    ...actual,
+    loadAuthConfig: vi.fn(),
+    isAuthenticatedConfig: vi.fn(),
+  };
+});
+
+import { loadAuthConfig, isAuthenticatedConfig } from "../auth/workos.js";
+
+import { canAccessAgents } from "./remote.js";
+
+describe("canAccessAgents access control", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("should return false when no auth config exists", async () => {
+    (loadAuthConfig as any).mockReturnValue(null);
+
+    const result = await canAccessAgents();
+
+    expect(result).toBe(false);
+  });
+
+  it("should return false for environment auth (CONTINUE_API_KEY)", async () => {
+    const envAuthConfig = {
+      accessToken: "test-token",
+      organizationId: null,
+    };
+
+    (loadAuthConfig as any).mockReturnValue(envAuthConfig);
+    (isAuthenticatedConfig as any).mockReturnValue(false);
+
+    const result = await canAccessAgents();
+
+    expect(result).toBe(false);
+  });
+
+  it("should return true for @continue.dev email addresses", async () => {
+    const authConfig = {
+      userId: "test-user",
+      userEmail: "test@continue.dev",
+      accessToken: "test-token",
+      refreshToken: "test-refresh",
+      expiresAt: Date.now() + 3600000,
+      organizationId: null,
+    };
+
+    (loadAuthConfig as any).mockReturnValue(authConfig);
+    (isAuthenticatedConfig as any).mockReturnValue(true);
+
+    const result = await canAccessAgents();
+
+    expect(result).toBe(true);
+  });
+
+  it("should return false for non-@continue.dev email addresses", async () => {
+    const authConfig = {
+      userId: "test-user",
+      userEmail: "test@example.com",
+      accessToken: "test-token",
+      refreshToken: "test-refresh",
+      expiresAt: Date.now() + 3600000,
+      organizationId: null,
+    };
+
+    (loadAuthConfig as any).mockReturnValue(authConfig);
+    (isAuthenticatedConfig as any).mockReturnValue(true);
+
+    const result = await canAccessAgents();
+
+    expect(result).toBe(false);
+  });
+
+  it("should return false when userEmail is undefined", async () => {
+    const authConfig = {
+      userId: "test-user",
+      userEmail: undefined,
+      accessToken: "test-token",
+      refreshToken: "test-refresh",
+      expiresAt: Date.now() + 3600000,
+      organizationId: null,
+    };
+
+    (loadAuthConfig as any).mockReturnValue(authConfig);
+    (isAuthenticatedConfig as any).mockReturnValue(true);
+
+    const result = await canAccessAgents();
+
+    expect(result).toBe(false);
+  });
+
+  it("should return false when userEmail is null", async () => {
+    const authConfig = {
+      userId: "test-user",
+      userEmail: null,
+      accessToken: "test-token",
+      refreshToken: "test-refresh",
+      expiresAt: Date.now() + 3600000,
+      organizationId: null,
+    };
+
+    (loadAuthConfig as any).mockReturnValue(authConfig);
+    (isAuthenticatedConfig as any).mockReturnValue(true);
+
+    const result = await canAccessAgents();
+
+    expect(result).toBe(false);
+  });
+
+  it("should handle edge case: empty string email", async () => {
+    const authConfig = {
+      userId: "test-user",
+      userEmail: "",
+      accessToken: "test-token",
+      refreshToken: "test-refresh",
+      expiresAt: Date.now() + 3600000,
+      organizationId: null,
+    };
+
+    (loadAuthConfig as any).mockReturnValue(authConfig);
+    (isAuthenticatedConfig as any).mockReturnValue(true);
+
+    const result = await canAccessAgents();
+
+    expect(result).toBe(false);
+  });
+
+  it("should handle case sensitivity correctly", async () => {
+    const authConfig = {
+      userId: "test-user",
+      userEmail: "test@CONTINUE.DEV",
+      accessToken: "test-token",
+      refreshToken: "test-refresh",
+      expiresAt: Date.now() + 3600000,
+      organizationId: null,
+    };
+
+    (loadAuthConfig as any).mockReturnValue(authConfig);
+    (isAuthenticatedConfig as any).mockReturnValue(true);
+
+    const result = await canAccessAgents();
+
+    // Should return false because domain case doesn't match exactly
+    expect(result).toBe(false);
+  });
+});

--- a/extensions/cli/src/commands/remote.test.ts
+++ b/extensions/cli/src/commands/remote.test.ts
@@ -78,7 +78,7 @@ describe("remote command", () => {
     await remote("test prompt", { idempotencyKey: testIdempotencyKey });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      new URL("agents/devboxes", mockEnv.env.apiBase),
+      new URL("agents", mockEnv.env.apiBase),
       expect.objectContaining({
         method: "POST",
         headers: {
@@ -96,7 +96,7 @@ describe("remote command", () => {
     await remote("test prompt", {});
 
     expect(mockFetch).toHaveBeenCalledWith(
-      new URL("agents/devboxes", mockEnv.env.apiBase),
+      new URL("agents", mockEnv.env.apiBase),
       expect.objectContaining({
         method: "POST",
         headers: {
@@ -190,7 +190,7 @@ describe("remote command", () => {
     await remote("test prompt", { branch: testBranch });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      new URL("agents/devboxes", mockEnv.env.apiBase),
+      new URL("agents", mockEnv.env.apiBase),
       expect.objectContaining({
         method: "POST",
         headers: {
@@ -206,7 +206,7 @@ describe("remote command", () => {
     await remote("test prompt", {});
 
     expect(mockFetch).toHaveBeenCalledWith(
-      new URL("agents/devboxes", mockEnv.env.apiBase),
+      new URL("agents", mockEnv.env.apiBase),
       expect.objectContaining({
         method: "POST",
         headers: {
@@ -267,7 +267,7 @@ describe("remote command", () => {
 
       // Should make POST request to create environment
       expect(mockFetch).toHaveBeenCalledWith(
-        new URL("agents/devboxes", mockEnv.env.apiBase),
+        new URL("agents", mockEnv.env.apiBase),
         expect.objectContaining({
           method: "POST",
           headers: {

--- a/extensions/cli/src/index.ts
+++ b/extensions/cli/src/index.ts
@@ -9,6 +9,7 @@ import { chat } from "./commands/chat.js";
 import { login } from "./commands/login.js";
 import { logout } from "./commands/logout.js";
 import { listSessionsCommand } from "./commands/ls.js";
+import { listAgentsCommand } from "./commands/remote-ls.js";
 import { remoteTest } from "./commands/remote-test.js";
 import { canAccessAgents, remote } from "./commands/remote.js";
 import { serve } from "./commands/serve.js";
@@ -218,7 +219,7 @@ program
   });
 
 // Remote subcommand - gate access based on user permissions
-program
+const remoteCommand = program
   .command("remote [prompt]", { hidden: true })
   .description("Launch a remote instance of the cn agent")
   .option(
@@ -248,6 +249,17 @@ program
       process.exit(0);
     }
     await remote(prompt, options);
+  });
+
+// Remote list subcommand for listing and selecting agents
+remoteCommand
+  .command("ls")
+  .description("List available agents and select one to connect to")
+  .option("--json", "Output in JSON format")
+  .action(async (options) => {
+    await listAgentsCommand({
+      format: options.json ? "json" : undefined,
+    });
   });
 
 // Serve subcommand

--- a/extensions/cli/src/index.ts
+++ b/extensions/cli/src/index.ts
@@ -10,7 +10,7 @@ import { login } from "./commands/login.js";
 import { logout } from "./commands/logout.js";
 import { listSessionsCommand } from "./commands/ls.js";
 import { remoteTest } from "./commands/remote-test.js";
-import { remote } from "./commands/remote.js";
+import { canAccessAgents, remote } from "./commands/remote.js";
 import { serve } from "./commands/serve.js";
 import {
   handleValidationErrors,
@@ -217,7 +217,7 @@ program
     });
   });
 
-// Remote subcommand
+// Remote subcommand - gate access based on user permissions
 program
   .command("remote [prompt]", { hidden: true })
   .description("Launch a remote instance of the cn agent")
@@ -242,6 +242,11 @@ program
     "Specify the repository URL to use in the remote environment",
   )
   .action(async (prompt: string | undefined, options) => {
+    // Check if user has access to agents feature
+    if (!(await canAccessAgents())) {
+      // Silently exit - make it appear as if command doesn't exist
+      process.exit(0);
+    }
     await remote(prompt, options);
   });
 

--- a/extensions/cli/src/ui/AgentSelector.tsx
+++ b/extensions/cli/src/ui/AgentSelector.tsx
@@ -1,0 +1,95 @@
+import { Box, Text, useInput } from "ink";
+import React, { useMemo, useState } from "react";
+
+import { useTerminalSize } from "./hooks/useTerminalSize.js";
+import { defaultBoxStyles } from "./styles.js";
+
+export interface Agent {
+  id: string;
+  name: string;
+  description?: string;
+  slug: string;
+  createdAt?: string;
+}
+
+interface AgentSelectorProps {
+  agents: Agent[];
+  onSelect: (agentSlug: string) => void;
+  onExit: () => void;
+}
+
+export function AgentSelector({ agents, onSelect, onExit }: AgentSelectorProps) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const { rows: terminalHeight } = useTerminalSize();
+
+  // Calculate how many agents we can display based on terminal height
+  const displayAgents = useMemo(() => {
+    // Reserve 5 lines for header and instructions, each agent takes 3 lines (2 content + 1 spacer)
+    const availableHeight = Math.max(1, terminalHeight - 5);
+    const maxDisplayableAgents = Math.floor(availableHeight / 3);
+
+    return agents.slice(0, maxDisplayableAgents);
+  }, [agents, terminalHeight]);
+
+  useInput((input, key) => {
+    if (key.upArrow || input === "k") {
+      setSelectedIndex((prev) =>
+        prev > 0 ? prev - 1 : displayAgents.length - 1,
+      );
+    } else if (key.downArrow || input === "j") {
+      setSelectedIndex((prev) =>
+        prev < displayAgents.length - 1 ? prev + 1 : 0,
+      );
+    } else if (key.return) {
+      if (displayAgents[selectedIndex]) {
+        onSelect(displayAgents[selectedIndex].slug);
+      }
+    } else if (key.escape || (key.ctrl && input === "d")) {
+      onExit();
+    }
+  });
+
+  if (agents.length === 0) {
+    return (
+      <Box {...defaultBoxStyles("blue")}>
+        <Text color="yellow">No agents found.</Text>
+        <Text color="gray">Press Esc to exit</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box {...defaultBoxStyles("blue")}>
+      <Text color="blue" bold>
+        Available Agents
+      </Text>
+      <Text color="gray">↑/↓ to navigate, Enter to select, Esc to exit</Text>
+      <Text> </Text>
+
+      {displayAgents.map((agent, index) => {
+        const isSelected = index === selectedIndex;
+        const indicator = isSelected ? "➤ " : "  ";
+        const color = isSelected ? "blue" : "white";
+
+        return (
+          <Box key={agent.id} flexDirection="column">
+            <Box paddingRight={3}>
+              <Text bold={isSelected} color={color} wrap="truncate-end">
+                {indicator}
+                {agent.name}
+              </Text>
+            </Box>
+            <Box marginLeft={2}>
+              <Text color="gray">
+                {agent.description || `Agent: ${agent.slug}`}
+              </Text>
+            </Box>
+            {index < displayAgents.length - 1 && (
+              <Text key={`spacer-${agent.id}`}> </Text>
+            )}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Gate the cn remote feature behind access control and add an interactive agent picker via cn remote ls. Also update the remote creation endpoint to /agents and add tests for the new rules.

- **New Features**
  - Added canAccessAgents to restrict cn remote to @continue.dev users; others exit silently.
  - Introduced cn remote ls to list agents (JSON or TUI) and start a session after selection.
  - New AgentSelector TUI component for keyboard navigation and selection.
  - Switched remote create requests from /agents/devboxes to /agents.
  - Added tests for access control and updated existing remote tests.

<!-- End of auto-generated description by cubic. -->

