### PR TITLE
fix: SIGINT handler logic to run in TUI only

### DIFF
--- a/extensions/cli/src/ui/index.ts
+++ b/extensions/cli/src/ui/index.ts
@@ -1,7 +1,7 @@
 import { render, RenderOptions } from "ink";
 import React from "react";
 
-import { setTUIUnmount } from "../index.js";
+import { enableSigintHandler, setTUIUnmount } from "../index.js";
 import { PermissionMode } from "../permissions/types.js";
 import { initializeServices } from "../services/index.js";
 import { ServiceContainerProvider } from "../services/ServiceContainerContext.js";
@@ -78,6 +78,9 @@ export async function startTUIChat(
 
   // Register unmount function with main process for two-stage Ctrl+C exit
   setTUIUnmount(unmount);
+
+  // Enable the two-stage SIGINT handler for TUI mode
+  enableSigintHandler();
 
   return { unmount };
 }


### PR DESCRIPTION
## Description

Fixes issue of user not being able to ctrl-c while onboarding

## Summary by cubic
Scopes the two-press Ctrl+C (SIGINT) handler to the TUI only, so single Ctrl+C cancels onboarding and other non-TUI flows again. Keeps the double-press-to-exit behavior in the TUI. Addresses CON-3836.

- **Bug Fixes**
  - Removed global SIGINT listener; added enableSigintHandler and call it only in startTUIChat.
  - TUI still shows the exit hint on first Ctrl+C, then unmounts and exits on a second press within 1s (with Sentry flush).

<!-- End of auto-generated description by cubic. -->

