### PR TITLE
fix: cli /exit and ctrl-d actually exits

### DIFF
--- a/extensions/cli/src/ui/hooks/useChat.clear.test.ts
+++ b/extensions/cli/src/ui/hooks/useChat.clear.test.ts
@@ -15,7 +15,6 @@ vi.mock("../../session.js", () => ({
 
 describe("useChat clear command", () => {
   let mockSetChatHistory: ReturnType<typeof vi.fn>;
-  let mockExit: ReturnType<typeof vi.fn>;
   let mockOnClear: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
@@ -23,7 +22,6 @@ describe("useChat clear command", () => {
     vi.clearAllMocks();
 
     mockSetChatHistory = vi.fn();
-    mockExit = vi.fn();
     mockOnClear = vi.fn();
   });
 
@@ -44,7 +42,6 @@ describe("useChat clear command", () => {
       result,
       chatHistory,
       setChatHistory: mockSetChatHistory,
-      exit: mockExit,
       onShowConfigSelector: vi.fn(),
       onClear: mockOnClear,
     });
@@ -91,7 +88,6 @@ describe("useChat clear command", () => {
         result,
         chatHistory,
         setChatHistory: mockSetChatHistory,
-        exit: mockExit,
         onShowConfigSelector: vi.fn(),
         // onClear is not provided
       });
@@ -127,7 +123,6 @@ describe("useChat clear command", () => {
       result,
       chatHistory,
       setChatHistory: mockSetChatHistory,
-      exit: mockExit,
       onShowConfigSelector: vi.fn(),
       onClear: mockOnClear,
     });
@@ -149,7 +144,6 @@ describe("useChat clear command", () => {
       result,
       chatHistory,
       setChatHistory: mockSetChatHistory,
-      exit: mockExit,
       onShowConfigSelector: vi.fn(),
       onClear: mockOnClear,
     });

--- a/extensions/cli/src/ui/hooks/useChat.helpers.ts
+++ b/extensions/cli/src/ui/hooks/useChat.helpers.ts
@@ -46,7 +46,6 @@ interface ProcessSlashCommandResultOptions {
   result: SlashCommandResult;
   chatHistory: ChatHistoryItem[];
   setChatHistory: React.Dispatch<React.SetStateAction<ChatHistoryItem[]>>;
-  exit: () => void;
   onShowConfigSelector: () => void;
   onShowModelSelector?: () => void;
   onShowMCPSelector?: () => void;
@@ -61,7 +60,6 @@ export function processSlashCommandResult({
   result,
   chatHistory,
   setChatHistory,
-  exit,
   onShowConfigSelector,
   onShowModelSelector,
   onShowMCPSelector,
@@ -69,8 +67,7 @@ export function processSlashCommandResult({
   onClear,
 }: ProcessSlashCommandResultOptions): string | null {
   if (result.exit) {
-    exit();
-    return null;
+    process.exit(0);
   }
 
   if (result.openMcpSelector) {

--- a/extensions/cli/src/ui/hooks/useChat.ts
+++ b/extensions/cli/src/ui/hooks/useChat.ts
@@ -370,7 +370,6 @@ export function useChat({
       result: commandResult,
       chatHistory,
       setChatHistory,
-      exit,
       onShowConfigSelector,
       onShowModelSelector,
       onShowMCPSelector,

--- a/extensions/cli/src/ui/hooks/useUserInput.ts
+++ b/extensions/cli/src/ui/hooks/useUserInput.ts
@@ -76,7 +76,7 @@ export function handleControlKeys(options: ControlKeysOptions): boolean {
   // Handle Ctrl+D to exit
   if (key.ctrl && input === "d") {
     exit();
-    return true;
+    process.exit(0);
   }
 
   // Handle Ctrl+L to refresh screen (clear terminal artifacts)


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Make the CLI actually exit when users type /exit or press Ctrl+D. Replaces the internal exit handler with process.exit(0) for a clean, immediate exit.

- **Bug Fixes**
  - Use process.exit(0) for /exit and Ctrl+D in useChat.helpers.ts and useUserInput.ts.
  - Aligns with Linear CON-3774: CLI should exit predictably.

<!-- End of auto-generated description by cubic. -->

