### PR TITLE
feat: cli: press enter to continue 

### DIFF
--- a/extensions/cli/package-lock.json
+++ b/extensions/cli/package-lock.json
@@ -310,7 +310,7 @@
         "@types/node": "^20.11.19",
         "@types/shell-quote": "^1.7.5",
         "typescript": "^5.5.2",
-        "vitest": "^1.6.0"
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {

--- a/extensions/cli/src/ui/TipsDisplay.tsx
+++ b/extensions/cli/src/ui/TipsDisplay.tsx
@@ -4,7 +4,7 @@ import React, { useMemo } from "react";
 // Array of helpful tips for Continue CLI users
 const CONTINUE_CLI_TIPS = [
   "Use `/help` to learn keyboard shortcuts",
-  "Press escape to pause cn, and press enter to resume",
+  "Press escape to pause cn, and press enter to continue",
   "Use arrow keys (↑/↓) to navigate through your input history",
   'Multi-line input is supported by typing "\\" and pressing enter',
   "Use `cn ls` or `/resume` to resume a previous conversation",

--- a/extensions/cli/src/ui/UserInput.tsx
+++ b/extensions/cli/src/ui/UserInput.tsx
@@ -27,9 +27,7 @@ const InterruptedBanner: React.FC<{ wasInterrupted: boolean }> = ({
   if (!wasInterrupted) return null;
   return (
     <Box paddingX={1} marginBottom={0}>
-      <Text color="yellow">
-        ⚠ Interrupted by user - Press enter to continue
-      </Text>
+      <Text color="yellow">Interrupted by user - Press enter to continue</Text>
     </Box>
   );
 };

--- a/extensions/cli/src/ui/UserInput.tsx
+++ b/extensions/cli/src/ui/UserInput.tsx
@@ -27,7 +27,9 @@ const InterruptedBanner: React.FC<{ wasInterrupted: boolean }> = ({
   if (!wasInterrupted) return null;
   return (
     <Box paddingX={1} marginBottom={0}>
-      <Text color="yellow">⚠ Interrupted by user - Press enter to resume</Text>
+      <Text color="yellow">
+        ⚠ Interrupted by user - Press enter to continue
+      </Text>
     </Box>
   );
 };

--- a/extensions/cli/src/ui/__tests__/TUIChat.interruption.minimal.test.tsx
+++ b/extensions/cli/src/ui/__tests__/TUIChat.interruption.minimal.test.tsx
@@ -1,6 +1,6 @@
 import { render } from "ink-testing-library";
 import React from "react";
-import { vi, expect, describe, it, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { UserInput } from "../UserInput.js";
 
@@ -32,7 +32,7 @@ describe("TUIChat - Interruption UI (Minimal Test)", () => {
       // Initial render - no interruption message
       let frame = lastFrame();
       expect(frame).toBeDefined();
-      expect(frame).not.toContain("⚠ Interrupted by user");
+      expect(frame).not.toContain("Interrupted by user");
       expect(frame).not.toContain("Press enter to continue");
 
       // Re-render with wasInterrupted: true
@@ -49,7 +49,7 @@ describe("TUIChat - Interruption UI (Minimal Test)", () => {
       // Should show interruption message
       frame = lastFrame();
       expect(frame).toBeDefined();
-      expect(frame).toContain("⚠ Interrupted by user");
+      expect(frame).toContain("Interrupted by user");
       expect(frame).toContain("Press enter to continue");
     } finally {
       unmount();
@@ -74,7 +74,7 @@ describe("TUIChat - Interruption UI (Minimal Test)", () => {
       // Initial render - should show interruption message
       let frame = lastFrame();
       expect(frame).toBeDefined();
-      expect(frame).toContain("⚠ Interrupted by user");
+      expect(frame).toContain("Interrupted by user");
       expect(frame).toContain("Press enter to continue");
 
       // Re-render with wasInterrupted: false
@@ -91,7 +91,7 @@ describe("TUIChat - Interruption UI (Minimal Test)", () => {
       // Should not show interruption message
       frame = lastFrame();
       expect(frame).toBeDefined();
-      expect(frame).not.toContain("⚠ Interrupted by user");
+      expect(frame).not.toContain("Interrupted by user");
       expect(frame).not.toContain("Press enter to continue");
     } finally {
       unmount();

--- a/extensions/cli/src/ui/__tests__/TUIChat.interruption.minimal.test.tsx
+++ b/extensions/cli/src/ui/__tests__/TUIChat.interruption.minimal.test.tsx
@@ -33,7 +33,7 @@ describe("TUIChat - Interruption UI (Minimal Test)", () => {
       let frame = lastFrame();
       expect(frame).toBeDefined();
       expect(frame).not.toContain("⚠ Interrupted by user");
-      expect(frame).not.toContain("Press enter to resume");
+      expect(frame).not.toContain("Press enter to continue");
 
       // Re-render with wasInterrupted: true
       rerender(
@@ -50,7 +50,7 @@ describe("TUIChat - Interruption UI (Minimal Test)", () => {
       frame = lastFrame();
       expect(frame).toBeDefined();
       expect(frame).toContain("⚠ Interrupted by user");
-      expect(frame).toContain("Press enter to resume");
+      expect(frame).toContain("Press enter to continue");
     } finally {
       unmount();
     }
@@ -75,7 +75,7 @@ describe("TUIChat - Interruption UI (Minimal Test)", () => {
       let frame = lastFrame();
       expect(frame).toBeDefined();
       expect(frame).toContain("⚠ Interrupted by user");
-      expect(frame).toContain("Press enter to resume");
+      expect(frame).toContain("Press enter to continue");
 
       // Re-render with wasInterrupted: false
       rerender(
@@ -92,7 +92,7 @@ describe("TUIChat - Interruption UI (Minimal Test)", () => {
       frame = lastFrame();
       expect(frame).toBeDefined();
       expect(frame).not.toContain("⚠ Interrupted by user");
-      expect(frame).not.toContain("Press enter to resume");
+      expect(frame).not.toContain("Press enter to continue");
     } finally {
       unmount();
     }

--- a/extensions/cli/src/ui/__tests__/TUIChat.interruption.minimal.test.tsx
+++ b/extensions/cli/src/ui/__tests__/TUIChat.interruption.minimal.test.tsx
@@ -177,10 +177,10 @@ describe("TUIChat - Interruption UI (Minimal Test)", () => {
       let foundInputBoxLine = -1;
 
       frameLines.forEach((line, index) => {
-        if (line.includes("⚠ Interrupted by user")) {
+        if (line.includes("Interrupted by user")) {
           foundInterruptionLine = index;
         }
-        if (line.includes("●") && line.includes("▋")) {
+        if (line.includes("●") || line.includes("▋")) {
           foundInputBoxLine = index;
         }
       });


### PR DESCRIPTION
## Description
Authored by @sestinj and @bdougie, just recopying here
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Update CLI copy to say "Press enter to continue" instead of "resume" in TipsDisplay and the interruption banner, and update tests to match.

<!-- End of auto-generated description by cubic. -->

