### PR TITLE
chore: prerelease versions

### DIFF
--- a/extensions/intellij/gradle.properties
+++ b/extensions/intellij/gradle.properties
@@ -1,5 +1,5 @@
 pluginGroup=com.github.continuedev.continueintellijextension
-pluginVersion=1.0.40
+pluginVersion=1.0.41
 platformVersion=2024.1
 kotlin.stdlib.default.dependency=false
 org.gradle.configuration-cache=true

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION
## Description
Bump vscode and jetrains versions
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Bumped extension versions for a prerelease build. VS Code: 1.3.4 → 1.3.5; IntelliJ: 1.0.40 → 1.0.41.

<!-- End of auto-generated description by cubic. -->

