### PR TITLE
fix: :ambulance: Fix bedrock conversation prompt caching

### DIFF
--- a/core/llm/llms/Bedrock.ts
+++ b/core/llm/llms/Bedrock.ts
@@ -513,7 +513,10 @@ class Bedrock extends BaseLLM {
     // The second-to-last because it retrieves potentially already cached contents,
     // The last one because we want it cached for later retrieval.
     // See: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
-    if (this.cacheBehavior?.cacheConversation || this.completionOptions.promptCaching) {
+    if (
+      this.cacheBehavior?.cacheConversation ||
+      this.completionOptions.promptCaching
+    ) {
       this._addCachingToLastTwoUserMessages(converted);
     }
 

--- a/core/llm/llms/Bedrock.ts
+++ b/core/llm/llms/Bedrock.ts
@@ -513,7 +513,7 @@ class Bedrock extends BaseLLM {
     // The second-to-last because it retrieves potentially already cached contents,
     // The last one because we want it cached for later retrieval.
     // See: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
-    if (this.cacheBehavior?.cacheConversation) {
+    if (this.cacheBehavior?.cacheConversation || this.completionOptions.promptCaching) {
       this._addCachingToLastTwoUserMessages(converted);
     }
 


### PR DESCRIPTION
## Description

Some time back a change was made to the bedrock provider copying code over from the openai-adapter code. As the prompt caching logic hasn't been properly unified the bedrock provider lost recognition of it's global "promptCaching" setting to enable all forms of caching. As such the user conversation isn't currently being cached causing excessive spend on bedrock.

A work around is to enable the cacheBehavior.cacheConversation setting until this critical fix is released to GA, but his workaround requires us to touch every users' configuration which is an extensive effort.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

Updated tests to include validation promptCaching is included as a way to enable conversation caching.


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Restores Bedrock conversation prompt caching by honoring the global promptCaching option. This re-enables caching of user messages and helps reduce Bedrock spend.

- **Bug Fixes**
  - Honor completionOptions.promptCaching to add cache points to the last two user messages.
  - Preserve cacheBehavior.cacheConversation; either setting now enables conversation caching.
  - Added tests for promptCaching enabled/disabled and clarified the existing caching test name.

<!-- End of auto-generated description by cubic. -->

