### PR TITLE
fix: diff colors should reach till end

### DIFF
--- a/gui/src/pages/gui/ToolCallDiv/FindAndReplace.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/FindAndReplace.tsx
@@ -4,7 +4,7 @@ import { EditOperation } from "core/tools/definitions/multiEdit";
 import { renderContextItems } from "core/util/messageContent";
 import { getLastNPathParts, getUriPathBasename } from "core/util/uri";
 import { diffLines } from "diff";
-import { useContext, useMemo, useState } from "react";
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { ApplyActions } from "../../../components/StyledMarkdownPreview/StepContainerPreToolbar/ApplyActions";
 import { FileInfo } from "../../../components/StyledMarkdownPreview/StepContainerPreToolbar/FileInfo";
 import { IdeMessengerContext } from "../../../context/IdeMessenger";
@@ -77,6 +77,8 @@ export function FindAndReplaceDisplay({
   historyIndex,
 }: FindAndReplaceDisplayProps) {
   const [isExpanded, setIsExpanded] = useState<boolean | undefined>(undefined);
+  const [diffWidth, setDiffWidth] = useState<number | undefined>(undefined);
+  const diffDivRef = useRef<HTMLDivElement>(null);
   const ideMessenger = useContext(IdeMessengerContext);
   const applyState: ApplyState | undefined = useAppSelector((state) =>
     selectApplyStateByToolCallId(state, toolCallId),
@@ -236,12 +238,22 @@ export function FindAndReplaceDisplay({
     );
   }
 
+  useEffect(() => {
+    if (!diffDivRef.current) return;
+    const newWidth =
+      diffDivRef.current?.scrollWidth ??
+      diffDivRef.current?.getBoundingClientRect().width;
+    setDiffWidth(newWidth ? Math.ceil(newWidth) : undefined);
+  }, [isExpanded]);
+
   return renderContainer(
     <div
       className={`${config?.ui?.showChatScrollbar ? "thin-scrollbar" : "no-scrollbar"} max-h-72 overflow-auto`}
+      ref={diffDivRef}
     >
       <pre
-        className={`bg-editor m-0 w-full text-xs leading-tight ${config?.ui?.codeWrap ? "whitespace-pre-wrap" : "whitespace-pre"}`}
+        className={`bg-editor m-0 text-xs leading-tight ${config?.ui?.codeWrap ? "whitespace-pre-wrap" : "whitespace-pre"}`}
+        style={{ width: diffWidth ? `${diffWidth}px` : "100%" }}
       >
         {diffResult.diff?.map((part, index) => {
           if (part.removed) {


### PR DESCRIPTION
## Description

Diff colors should be reach till the end of the `pre` text block.

resolves CON-3852

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot


![before](https://github.com/user-attachments/assets/ac17ac22-dbd3-4e50-aa2f-42972b99b465)

![after](https://github.com/user-attachments/assets/4c67c6b4-e80d-44e1-9389-f8e9bc38eaee)

## Tests



[ What tests were added or updated to ensure the changes work as expected? ]
