### PR TITLE
feat: ✨ AWS Bedrock Provider tool streaming

### DIFF
--- a/core/llm/llms/Bedrock.ts
+++ b/core/llm/llms/Bedrock.ts
@@ -335,7 +335,9 @@ class Bedrock extends BaseLLM {
               budget_tokens: options.reasoningBudgetTokens,
             }
           : undefined,
-        anthropic_beta: ["fine-grained-tool-streaming-2025-05-14"],
+        anthropic_beta: options.model.includes("claude")
+          ? ["fine-grained-tool-streaming-2025-05-14"]
+          : undefined,
       },
     };
   }


### PR DESCRIPTION
## Description

Enable tool streaming for the AWS Bedrock provider (note we had some confusion with the openai-adapter code previously which has already been updated). 

Some time back the tool code was revised to support streaming tool call output and this takes advantage of this change.

When the model is claude, we are also enabling the fine grained tool call beta header to speed up tool output to not wait for matching JSON end tags for streaming. Beta headers are ignored when no longer applicable and are only enabled for claude models.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

Manual testing performed to validate changes. Visually noting that on file creation and edit activities for example the user receives feedback/output much faster. Before this change the provider is building the entire tool call payload before sending any data.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enable streaming tool calls for the AWS Bedrock provider so tool output arrives incrementally instead of after full JSON completion. For Claude models, enable fine-grained tool streaming to reduce latency.

- **New Features**
  - Stream tool calls via ConverseStream: emit toolCalls on start and as input deltas arrive.
  - Enable Claude’s fine-grained tool streaming (anthropic_beta: fine-grained-tool-streaming-2025-05-14); ignored for non-Claude models.
  - Stream reasoning content, including text, signatures, and redacted thinking.

- **Refactors**
  - Remove internal tool input accumulation; rely on Bedrock content block start/delta events.
  - Consolidate event parsing for ContentBlockStart/Delta and ToolUseBlock/Delta to simplify streaming.

<!-- End of auto-generated description by cubic. -->

