### PR TITLE
chore: bump prerelease versions

### DIFF
--- a/extensions/intellij/gradle.properties
+++ b/extensions/intellij/gradle.properties
@@ -1,5 +1,5 @@
 pluginGroup=com.github.continuedev.continueintellijextension
-pluginVersion=1.0.41
+pluginVersion=1.0.42
 platformVersion=2024.1
 kotlin.stdlib.default.dependency=false
 org.gradle.configuration-cache=true

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION
## Description
Bump prerelease extension versions
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Bumped prerelease versions for the IDE extensions to prepare the next publish.
IntelliJ plugin: 1.0.42; VS Code extension: 1.3.6.

<!-- End of auto-generated description by cubic. -->

