### PR TITLE
feat: parse for thinking tags and dim them 

### DIFF
--- a/extensions/cli/src/ui/MarkdownRenderer.thinking.test.tsx
+++ b/extensions/cli/src/ui/MarkdownRenderer.thinking.test.tsx
@@ -1,0 +1,36 @@
+import { render } from "ink-testing-library";
+import React from "react";
+
+import { MarkdownRenderer } from "./MarkdownRenderer.js";
+
+describe("MarkdownRenderer - thinking tags", () => {
+  it("handles multiple thinking tags", () => {
+    const content =
+      "Text <think>First thought</think> middle <think>Second thought</think> end";
+    const { lastFrame } = render(<MarkdownRenderer content={content} />);
+
+    expect(lastFrame()).toContain("First thought");
+    expect(lastFrame()).toContain("Second thought");
+  });
+
+  it("handles thinking tags with multiline content", () => {
+    const content = `<think>
+    This is a multiline
+    thinking block
+    </think>`;
+    const { lastFrame } = render(<MarkdownRenderer content={content} />);
+
+    expect(lastFrame()).toContain("This is a multiline");
+    expect(lastFrame()).toContain("thinking block");
+  });
+
+  it("ignores thinking tags inside code blocks", () => {
+    const content = "```\n<think>This should not be processed</think>\n```";
+    const { lastFrame } = render(<MarkdownRenderer content={content} />);
+
+    // The thinking tag should appear as literal text within the code block
+    expect(lastFrame()).toContain(
+      "<think>This should not be processed</think>",
+    );
+  });
+});

--- a/extensions/cli/src/ui/MarkdownRenderer.tsx
+++ b/extensions/cli/src/ui/MarkdownRenderer.tsx
@@ -2,10 +2,10 @@ import { Text } from "ink";
 import React from "react";
 
 import {
-  highlightCode,
-  detectLanguage,
-  SyntaxHighlighterTheme,
   defaultTheme,
+  detectLanguage,
+  highlightCode,
+  SyntaxHighlighterTheme,
 } from "./SyntaxHighlighter.js";
 
 interface MarkdownRendererProps {
@@ -27,6 +27,14 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = React.memo(
           // content here is the captured group, but we need to parse the full match
           return null; // This will be handled separately
         },
+      },
+      {
+        regex: /<think>([\s\S]*?)<\/think>/g,
+        render: (content, key) => (
+          <Text key={key} color="gray">
+            {content.trim()}
+          </Text>
+        ),
       },
       {
         regex: /^(#{1,6})\s+(.+)$/gm,
@@ -225,6 +233,5 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = React.memo(
 
 MarkdownRenderer.displayName = "MarkdownRenderer";
 
-export { MarkdownRenderer };
+export { defaultTheme, MarkdownRenderer };
 export type { SyntaxHighlighterTheme };
-export { defaultTheme };


### PR DESCRIPTION
## Description

<img width="960" height="419" alt="Screenshot 2025-09-09 at 1 49 02 PM" src="https://github.com/user-attachments/assets/1e7cfcc4-0b69-4cf0-8191-2939839af772" />

Originally had it italicize the text too but I couldn't figure out how to do multi-line italics, ink would only just render the first line :/ There's also a visual bug unrelated to this PR with some models response's where the dot and vertical alignment don't line up (as seen in this screenshot) 

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Render <think>...</think> blocks in the CLI as italic gray text to clearly distinguish thinking content, and ignore these tags inside code blocks. Implements CON-3771.

- **New Features**
  - Render <think> blocks as italic gray text
  - Do not process <think> tags inside code blocks
  - Tests for multiple tags, multiline content, and code-block cases

<!-- End of auto-generated description by cubic. -->

