### PR TITLE
feat: /init slash command for CLI

### DIFF
--- a/extensions/cli/src/commands/commands.ts
+++ b/extensions/cli/src/commands/commands.ts
@@ -65,7 +65,11 @@ export const SYSTEM_SLASH_COMMANDS: SystemCommand[] = [
     description: "Manage MCP server connections",
     category: "system",
   },
-
+  {
+    name: "init",
+    description: "Create an AGENTS.md file",
+    category: "system",
+  },
   {
     name: "compact",
     description: "Summarize chat history into a compact form",

--- a/extensions/cli/src/commands/init.ts
+++ b/extensions/cli/src/commands/init.ts
@@ -1,0 +1,45 @@
+import { type AssistantConfig } from "@continuedev/sdk";
+
+import { SlashCommandResult } from "../ui/hooks/useChat.types.js";
+
+function createInitPrompt(): string {
+  return `Please analyze this repository and create a comprehensive AGENTS.md file. Use your available tools to understand the project structure, read important files like README.md, package.json, requirements.txt, and other configuration files to understand the technology stack and setup.
+
+Create an AGENTS.md file with the following structure:
+
+# Repository Overview
+
+## Project Description
+- What this project does
+- Main purpose and goals  
+- Key technologies used
+
+## Architecture Overview
+- High-level architecture
+- Main components and their relationships
+- Data flow and system interactions
+
+## Directory Structure
+- Important directories and their purposes
+- Key files and configuration
+- Entry points and main modules
+
+## Development Workflow
+- How to build/run the project
+- Testing approach
+- Development environment setup
+- Lint and format commands
+
+Please create the AGENTS.md file using the Write tool after analyzing the repository. Focus on providing actionable information that would help both AI agents and human developers understand and work effectively with this codebase. Keep the file concise but informational.`;
+}
+
+export async function handleInit(
+  _args: string[],
+  _assistant: AssistantConfig,
+): Promise<SlashCommandResult> {
+  const prompt = createInitPrompt();
+
+  return {
+    newInput: prompt,
+  };
+}

--- a/extensions/cli/src/slashCommands.ts
+++ b/extensions/cli/src/slashCommands.ts
@@ -7,6 +7,7 @@ import {
   loadAuthConfig,
 } from "./auth/workos.js";
 import { getAllSlashCommands } from "./commands/commands.js";
+import { handleInit } from "./commands/init.js";
 import { handleInfoSlashCommand } from "./infoScreen.js";
 import { reloadService, SERVICE_NAMES, services } from "./services/index.js";
 import { getCurrentSession } from "./session.js";
@@ -176,6 +177,10 @@ const commandHandlers: Record<string, CommandHandler> = {
     return { openSessionSelector: true };
   },
   fork: handleFork,
+  init: (args, assistant) => {
+    posthogService.capture("useSlashCommand", { name: "init" });
+    return handleInit(args, assistant);
+  },
 };
 
 export async function handleSlashCommands(

--- a/extensions/cli/src/ui/TipsDisplay.tsx
+++ b/extensions/cli/src/ui/TipsDisplay.tsx
@@ -9,6 +9,7 @@ const CONTINUE_CLI_TIPS = [
   'Multi-line input is supported by typing "\\" and pressing enter',
   "Use `cn ls` or `/resume` to resume a previous conversation",
   'Run `cn` with the `-p` flag for headless mode. For example: `cn -p "Generate a commit message for the current changes. Output _only_ the commit message and nothing else."`',
+  "Use the /init slash command to generate an AGENTS.md file. This will help `cn` understand your codebase and generate better responses.",
 ];
 
 interface TipsDisplayProps {


### PR DESCRIPTION
## Description

type /init to generate an AGENTS.md file (already supported by cn)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a /init slash command to generate an AGENTS.md by prompting the assistant to analyze the repo and write the file. This helps cn understand the codebase and produce better answers.

- **New Features**
  - New system command: /init creates a structured prompt to analyze the project and author AGENTS.md.
  - Wired up command handler and usage tracking.
  - Added a CLI tip promoting /init.

<!-- End of auto-generated description by cubic. -->

