### PR TITLE
fix: HOTFIX diff line color overflow

### DIFF
--- a/gui/src/pages/gui/ToolCallDiv/FindAndReplace.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/FindAndReplace.tsx
@@ -241,7 +241,7 @@ export function FindAndReplaceDisplay({
       className={`${config?.ui?.showChatScrollbar ? "thin-scrollbar" : "no-scrollbar"} max-h-72 overflow-auto`}
     >
       <pre
-        className={`bg-editor m-0 w-full text-xs leading-tight ${config?.ui?.codeWrap ? "whitespace-pre-wrap" : "whitespace-pre"}`}
+        className={`bg-editor m-0 w-fit min-w-full text-xs leading-tight ${config?.ui?.codeWrap ? "whitespace-pre-wrap" : "whitespace-pre"}`}
       >
         {diffResult.diff?.map((part, index) => {
           if (part.removed) {


### PR DESCRIPTION
## Description
Allows diff colors in find replace display to fill width

Before:

<img width="468" height="407" alt="image" src="https://github.com/user-attachments/assets/c7781591-e987-4f22-8d77-a14abd983f6a" />

After:

<img width="469" height="388" alt="image" src="https://github.com/user-attachments/assets/2391bfdf-0a5f-46c2-8a6e-460c8df2050c" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes diff highlight width in Find & Replace so added/removed colors span the full line and don’t overflow in the scroll container. Applies w-fit with min-w-full to the pre element to align backgrounds with the container.

<!-- End of auto-generated description by cubic. -->

