### PR TITLE
fix: HOTFIX response actions disappearing and causing jumping while streaming

### DIFF
--- a/gui/src/components/StepContainer/StepContainer.tsx
+++ b/gui/src/components/StepContainer/StepContainer.tsx
@@ -22,9 +22,6 @@ export default function StepContainer(props: StepContainerProps) {
   const dispatch = useDispatch();
   const [isTruncated, setIsTruncated] = useState(false);
   const isStreaming = useAppSelector((state) => state.session.isStreaming);
-  const historyItemAfterThis = useAppSelector(
-    (state) => state.session.history[props.index + 1],
-  );
   const uiConfig = useAppSelector(selectUIConfig);
 
   // Calculate dimming and indicator state based on latest summary index
@@ -34,22 +31,12 @@ export default function StepContainer(props: StepContainerProps) {
   const isLatestSummary =
     latestSummaryIndex !== -1 && props.index === latestSummaryIndex;
 
-  const isNextMsgAssistantOrThinking =
-    historyItemAfterThis?.message.role === "assistant" ||
-    historyItemAfterThis?.message.role === "thinking" ||
-    historyItemAfterThis?.message.role === "tool";
-
-  const shouldRenderResponseAction = () => {
-    if (isNextMsgAssistantOrThinking) {
-      return false;
-    }
-
-    if (!historyItemAfterThis) {
-      return !props.item.toolCallStates;
-    }
-
-    return true;
-  };
+  const historyItemAfterThis = useAppSelector(
+    (state) => state.session.history[props.index + 1],
+  );
+  const showResponseActions =
+    (props.isLast || historyItemAfterThis?.message.role === "user") &&
+    !(props.isLast && (isStreaming || props.item.toolCallStates));
 
   useEffect(() => {
     if (!isStreaming) {
@@ -110,9 +97,9 @@ export default function StepContainer(props: StepContainerProps) {
         {props.isLast && <ThinkingIndicator historyItem={props.item} />}
       </div>
 
-      {shouldRenderResponseAction() && !isStreaming && (
+      {showResponseActions && (
         <div
-          className={`mt-2 h-7 transition-opacity duration-300 ease-in-out ${isBeforeLatestSummary ? "opacity-35" : ""}`}
+          className={`mt-2 h-7 transition-opacity duration-300 ease-in-out ${isBeforeLatestSummary || isStreaming ? "opacity-35" : ""} ${isStreaming && "pointer-events-none cursor-not-allowed"}`}
         >
           <ResponseActions
             isTruncated={isTruncated}


### PR DESCRIPTION
## Description

Logic that preserved the space for response actions when streaming was removed, so now collapses while streaming and the pops back, causing jumping.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the response actions bar disappearing during streaming by keeping it mounted (dimmed and disabled), preventing layout jumps. Addresses Linear CON-3851.

- **Bug Fixes**
  - Replaced conditional logic with showResponseActions to always reserve space when appropriate.
  - Keep the actions container rendered during streaming with reduced opacity and no pointer events.

<!-- End of auto-generated description by cubic. -->

