### PR TITLE
fix: additional filter for apply / edit

### DIFF
--- a/core/autocomplete/filtering/streamTransforms/lineStream.ts
+++ b/core/autocomplete/filtering/streamTransforms/lineStream.ts
@@ -166,8 +166,13 @@ export const CODE_KEYWORDS_ENDING_IN_SEMICOLON = ["def"];
 export const CODE_STOP_BLOCK = "[/CODE]";
 export const BRACKET_ENDING_CHARS = [")", "]", "}", ";"];
 export const PREFIXES_TO_SKIP = ["<COMPLETION>"];
-export const LINES_TO_STOP_AT = ["# End of file.", "<STOP EDITING HERE"];
-export const LINES_TO_SKIP = ["</START EDITING HERE>"];
+export const LINES_TO_STOP_AT = [
+  "# End of file.",
+  "<STOP EDITING HERE",
+  "<|/updated_code|>",
+  "```",
+];
+export const LINES_TO_SKIP = ["</START EDITING HERE>", "<|updated_code|>"];
 export const LINES_TO_REMOVE_BEFORE_START = [
   "<COMPLETION>",
   "[CODE]",


### PR DESCRIPTION
## Description

adds filters for models that output different tokens during apply / edit
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add extra stop/skip markers to the apply/edit line stream filter to prevent control tokens from appearing in edits. Now stops at <|/updated_code|> and ``` and skips <|updated_code|>, alongside existing START/STOP markers.

<!-- End of auto-generated description by cubic. -->

