### PR TITLE
feat: add filepath to apply prompt template vars

### DIFF
--- a/core/edit/streamDiffLines.ts
+++ b/core/edit/streamDiffLines.ts
@@ -108,23 +108,24 @@ export async function* streamDiffLines({
 
   // Rules can be included with edit prompt
   // If any rules are present this will result in using chat instead of legacy completion
-  const systemMessage = rulesToInclude
-    ? getSystemMessageWithRules({
-        availableRules: rulesToInclude,
-        userMessage:
-          typeof prompt === "string"
-            ? ({
-                role: "user",
-                content: prompt,
-              } as UserChatMessage)
-            : (findLast(
-                prompt,
-                (msg) => msg.role === "user" || msg.role === "tool",
-              ) as UserChatMessage | ToolResultChatMessage | undefined),
-        baseSystemMessage: undefined,
-        contextItems: [],
-      }).systemMessage
-    : undefined;
+  const systemMessage =
+    rulesToInclude || llm.baseChatSystemMessage
+      ? getSystemMessageWithRules({
+          availableRules: rulesToInclude ?? [],
+          userMessage:
+            typeof prompt === "string"
+              ? ({
+                  role: "user",
+                  content: prompt,
+                } as UserChatMessage)
+              : (findLast(
+                  prompt,
+                  (msg) => msg.role === "user" || msg.role === "tool",
+                ) as UserChatMessage | ToolResultChatMessage | undefined),
+          baseSystemMessage: llm.baseChatSystemMessage,
+          contextItems: [],
+        }).systemMessage
+      : undefined;
 
   if (systemMessage) {
     if (typeof prompt === "string") {

--- a/extensions/vscode/src/diff/vertical/manager.ts
+++ b/extensions/vscode/src/diff/vertical/manager.ts
@@ -13,6 +13,7 @@ import { VsCodeWebviewProtocol } from "../../webviewProtocol";
 import { ApplyAbortManager } from "core/edit/applyAbortManager";
 import { EDIT_MODE_STREAM_ID } from "core/edit/constants";
 import { stripImages } from "core/util/messageContent";
+import { getLastNPathParts } from "core/util/uri";
 import { editOutcomeTracker } from "../../extension/EditOutcomeTracker";
 import { VerticalDiffHandler, VerticalDiffHandlerOptions } from "./handler";
 
@@ -432,9 +433,11 @@ export class VerticalDiffManager {
 
     let overridePrompt: ChatMessage[] | undefined;
     if (llm.promptTemplates?.apply) {
+      const filepath = getLastNPathParts(fileUri, 1);
       const rendered = llm.renderPromptTemplate(llm.promptTemplates.apply, [], {
         original_code: rangeContent,
         new_code: newCode ?? "",
+        filepath,
       });
       overridePrompt =
         typeof rendered === "string"

--- a/gui/src/util/clientTools/editImpl.ts
+++ b/gui/src/util/clientTools/editImpl.ts
@@ -12,16 +12,20 @@ export const editToolImpl: ClientToolImpl = async (
       "`filepath` and `changes` arguments are required to edit an existing file.",
     );
   }
+  let filepath = args.filepath;
+  if (filepath.startsWith("./")) {
+    filepath = filepath.slice(2);
+  }
 
   const openFiles = await extras.ideMessenger.ide.getOpenFiles();
   let firstUriMatch = await resolveRelativePathInDir(
-    args.filepath,
+    filepath,
     extras.ideMessenger.ide,
   );
 
   if (!firstUriMatch) {
     for (const uri of openFiles) {
-      if (uri.endsWith(args.filepath)) {
+      if (uri.endsWith(filepath)) {
         firstUriMatch = uri;
         break;
       }
@@ -29,7 +33,7 @@ export const editToolImpl: ClientToolImpl = async (
   }
 
   if (!firstUriMatch) {
-    throw new Error(`${args.filepath} does not exist`);
+    throw new Error(`${filepath} does not exist`);
   }
   const streamId = uuid();
   void extras.dispatch(
@@ -42,7 +46,13 @@ export const editToolImpl: ClientToolImpl = async (
   );
 
   return {
-    respondImmediately: false,
-    output: undefined, // No immediate output.
+    respondImmediately: true,
+    output: [
+      {
+        name: "File edited successfully",
+        content: `Successfully initiated edit for ${firstUriMatch}`,
+        description: "File edit operation started",
+      },
+    ],
   };
 };

--- a/gui/src/util/clientTools/editImpl.ts
+++ b/gui/src/util/clientTools/editImpl.ts
@@ -12,10 +12,22 @@ export const editToolImpl: ClientToolImpl = async (
       "`filepath` and `changes` arguments are required to edit an existing file.",
     );
   }
-  const firstUriMatch = await resolveRelativePathInDir(
+
+  const openFiles = await extras.ideMessenger.ide.getOpenFiles();
+  let firstUriMatch = await resolveRelativePathInDir(
     args.filepath,
     extras.ideMessenger.ide,
   );
+
+  if (!firstUriMatch) {
+    for (const uri of openFiles) {
+      if (uri.endsWith(args.filepath)) {
+        firstUriMatch = uri;
+        break;
+      }
+    }
+  }
+
   if (!firstUriMatch) {
     throw new Error(`${args.filepath} does not exist`);
   }


### PR DESCRIPTION
## Description

can now use {{{ filepath }}} in promptTemplates for apply
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enable {{{ filepath }}} in apply prompt templates so prompts can adapt to the current file. We pass the last path segment from fileUri as "filepath" to renderPromptTemplate alongside original_code and new_code.

<!-- End of auto-generated description by cubic. -->

