### PR TITLE
fix: :pencil2: Fix typo in No Parallel Tool Calling Instruction

### DIFF
--- a/core/tools/definitions/editFile.ts
+++ b/core/tools/definitions/editFile.ts
@@ -7,7 +7,7 @@ export interface EditToolArgs {
   changes: string;
 }
 
-export const NO_PARALLEL_TOOL_CALLING_INTSRUCTION =
+export const NO_PARALLEL_TOOL_CALLING_INSTRUCTION =
   "This tool CANNOT be called in parallel with other tools.";
 
 const CHANGES_DESCRIPTION =
@@ -24,7 +24,7 @@ export const editFileTool: Tool = {
   isInstant: false,
   function: {
     name: BuiltInToolNames.EditExistingFile,
-    description: `Use this tool to edit an existing file. If you don't know the contents of the file, read it first.\n${EDIT_CODE_INSTRUCTIONS}\n${NO_PARALLEL_TOOL_CALLING_INTSRUCTION}`,
+    description: `Use this tool to edit an existing file. If you don't know the contents of the file, read it first.\n${EDIT_CODE_INSTRUCTIONS}\n${NO_PARALLEL_TOOL_CALLING_INSTRUCTION}`,
     parameters: {
       type: "object",
       required: ["filepath", "changes"],

--- a/core/tools/definitions/multiEdit.ts
+++ b/core/tools/definitions/multiEdit.ts
@@ -1,6 +1,6 @@
 import { Tool } from "../..";
 import { BUILT_IN_GROUP_NAME, BuiltInToolNames } from "../builtIn";
-import { NO_PARALLEL_TOOL_CALLING_INTSRUCTION } from "./editFile";
+import { NO_PARALLEL_TOOL_CALLING_INSTRUCTION } from "./editFile";
 import { singleFindAndReplaceTool } from "./singleFindAndReplace";
 
 export interface EditOperation {
@@ -43,7 +43,7 @@ IMPORTANT:
 
 CRITICAL REQUIREMENTS:
 1. ALWAYS use the ${BuiltInToolNames.ReadFile} tool just before making edits, to understand the file's up-to-date contents and context. The user can also edit the file while you are working with it.
-2. ${NO_PARALLEL_TOOL_CALLING_INTSRUCTION}
+2. ${NO_PARALLEL_TOOL_CALLING_INSTRUCTION}
 3. When making edits:
 - Ensure all edits result in idiomatic, correct code
 - Do not leave the code in a broken state

--- a/core/tools/definitions/singleFindAndReplace.ts
+++ b/core/tools/definitions/singleFindAndReplace.ts
@@ -1,6 +1,6 @@
 import { Tool } from "../..";
 import { BUILT_IN_GROUP_NAME, BuiltInToolNames } from "../builtIn";
-import { NO_PARALLEL_TOOL_CALLING_INTSRUCTION } from "./editFile";
+import { NO_PARALLEL_TOOL_CALLING_INSTRUCTION } from "./editFile";
 
 export interface SingleFindAndReplaceArgs {
   filepath: string;
@@ -24,7 +24,7 @@ export const singleFindAndReplaceTool: Tool = {
 
 IMPORTANT:
 - ALWAYS use the \`${BuiltInToolNames.ReadFile}\` tool just before making edits, to understand the file's up-to-date contents and context. The user can also edit the file while you are working with it.
-- ${NO_PARALLEL_TOOL_CALLING_INTSRUCTION}
+- ${NO_PARALLEL_TOOL_CALLING_INSTRUCTION}
 - When editing text from \`${BuiltInToolNames.ReadFile}\` tool output, ensure you preserve exact whitespace/indentation.
 - Only use emojis if the user explicitly requests it. Avoid adding emojis to files unless asked.
 - Use \`replace_all\` for replacing and renaming strings across the file. This parameter is useful if you want to rename a variable, for instance.


### PR DESCRIPTION
## Description

Fix minor typo discovered in No Parallel Tool Calling Instruction.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

N/A

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Renamed NO_PARALLEL_TOOL_CALLING_INTSRUCTION to NO_PARALLEL_TOOL_CALLING_INSTRUCTION and updated references in editFile, multiEdit, and singleFindAndReplace. This fixes the typo, prevents broken imports, and ensures the instruction appears correctly in tool descriptions.

<!-- End of auto-generated description by cubic. -->

