### PR TITLE
fix: HOTFIX rename isSearchReplace to isSearchAndReplace for consistency

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/ApplyToFileHandler.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/ApplyToFileHandler.kt
@@ -46,7 +46,7 @@ class ApplyToFileHandler(
         }
 
         // Handle search/replace mode
-        if (params.isSearchReplace == true) {
+        if (params.isSearchAndReplace == true) {
             handleSearchReplace(editorUtils)
             return
         }

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/protocol/ideWebview.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/protocol/ideWebview.kt
@@ -9,7 +9,7 @@ data class ApplyToFileParams(
     val streamId: String,
     val filepath: String?,
     val toolCallId: String?,
-    val isSearchReplace: Boolean? = null
+    val isSearchAndReplace: Boolean? = null
 )
 
 data class InsertAtCursorParams(


### PR DESCRIPTION
## Description

There's an inconsistency in variable naming between the GUI and JetBrains extension. The GUI uses isSearchAndReplace while the JetBrains extension uses isSearchReplace.
Due to this naming mismatch, the following code block in handleApplyToFile() is never executed, which affects the new tool applying functionality introduced in https://github.com/continuedev/continue/pull/7267
``` kotlin
    suspend fun handleApplyToFile() {
        ...
        // Handle search/replace mode
        if (params.isSearchReplace == true) {
            handleSearchReplace(editorUtils)
            return
        }
        ...
    }
```

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [✅] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [✅] The relevant docs, if any, have been updated or created
- [✅] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Renamed isSearchReplace to isSearchAndReplace in the IntelliJ extension to match the GUI. This fixes search-and-replace mode not being triggered in handleApplyToFile, restoring the Apply to File tool behavior.

<!-- End of auto-generated description by cubic. -->

