### PR TITLE
feat: support `uses` blocks locally

### DIFF
--- a/packages/openai-adapters/package-lock.json
+++ b/packages/openai-adapters/package-lock.json
@@ -12531,7 +12531,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
## Description

Add support for having local `uses` block in config.yaml defined with `file://path/to/file`

resolves CON-3869
closes https://github.com/continuedev/continue/issues/5943
closes https://github.com/continuedev/continue/issues/6107

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot


https://github.com/user-attachments/assets/5ca5cb48-0a57-486f-802d-040e40516f49


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Support local file includes in config.yaml via file:// uses blocks, so assistants can load models, MCP servers, prompts, and rules from nearby files. Addresses CON-3869; closes #5943 and #6107.

- New Features
  - Unrolls file:// uses in models, mcpServers, prompts, and rules during config load, including overrideConfigYaml.
  - Resolves local URIs with localPathOrUriToPath and derives registry root from the config file directory.
  - Adds a test that loads a rule from a local block to verify end-to-end resolution.

<!-- End of auto-generated description by cubic. -->

