### PR TITLE
chore: vs code 1.3.7

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION
## Description
version bump for vscode prerelease
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Bump the VS Code extension version from 1.3.6 to 1.3.7. This prepares the next prerelease build for publishing.

<!-- End of auto-generated description by cubic. -->

