### PR TITLE
feat: do not show context fill display when model changes

### DIFF
--- a/gui/src/components/mainInput/ContextStatus.tsx
+++ b/gui/src/components/mainInput/ContextStatus.tsx
@@ -1,3 +1,4 @@
+import { useMemo, useRef } from "react";
 import { useAppDispatch, useAppSelector } from "../../redux/hooks";
 import { saveCurrentSession } from "../../redux/thunks/session";
 import { useCompactConversation } from "../../util/compactConversation";
@@ -8,12 +9,33 @@ const ContextStatus = () => {
   const contextPercentage = useAppSelector(
     (state) => state.session.contextPercentage,
   );
+  const selectedChatModel = useAppSelector(
+    (state) => state.config.config.selectedModelByRole.chat?.model,
+  );
+  const previousHistoryLength = useRef<number | null>(null);
+  const previousSelectedChatModel = useRef<string | null>(null);
   const history = useAppSelector((state) => state.session.history);
   const percent = Math.round((contextPercentage ?? 0) * 100);
   const isPruned = useAppSelector((state) => state.session.isPruned);
 
+  const isDifferentModelAndSameHistory = useMemo(() => {
+    if (!selectedChatModel) return false;
+    // only reset if history changes
+    if (previousHistoryLength.current !== history.length) {
+      previousHistoryLength.current = history.length;
+      previousSelectedChatModel.current = selectedChatModel;
+      return false;
+    }
+    return previousSelectedChatModel.current !== selectedChatModel;
+  }, [history.length, selectedChatModel]);
+
   const compactConversation = useCompactConversation();
   if (!isPruned && percent < 60) {
+    return null;
+  }
+
+  // if user changed to a different model, we shouldn't show the context status until the user sends a new message
+  if (isDifferentModelAndSameHistory) {
     return null;
   }
 


### PR DESCRIPTION
## Description

When the user changes the model, we do not want to show the context length display fill. This is because it was calculated for the model the user had the previous conversation with.

closes CON-2965

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot


https://github.com/user-attachments/assets/c7574415-7f5a-45db-8949-dfef8fb87824



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Hide the context length fill when the user switches chat models, since the previous value was computed for the old model. Implements CON-2965 by showing the bar again only after the next message updates the conversation history.

<!-- End of auto-generated description by cubic. -->

