### PR TITLE
fix: edit output overridden

### DIFF
--- a/gui/src/redux/thunks/handleApplyStateUpdate.ts
+++ b/gui/src/redux/thunks/handleApplyStateUpdate.ts
@@ -83,43 +83,44 @@ export const handleApplyStateUpdate = createAsyncThunk<
             }
 
             if (accepted) {
-              // Add autoformatting diff to tool output if present
-              if (applyState.autoFormattingDiff) {
-                dispatch(
-                  updateToolCallOutput({
-                    toolCallId: applyState.toolCallId,
-                    contextItems: [
-                      {
-                        icon: "info",
-                        name: "Auto-formatting Applied",
-                        description: "Editor auto-formatting changes",
-                        content: `Along with your edits, the editor applied the following auto-formatting:\n\n${applyState.autoFormattingDiff}\n\n(Note: Pay close attention to changes such as single quotes being converted to double quotes, semicolons being removed or added, long lines being broken into multiple lines, adjusting indentation style, adding/removing trailing commas, etc. This will help you ensure future SEARCH/REPLACE operations to this file are accurate.)`,
-                        hidden: false,
-                      },
-                    ],
-                  }),
-                );
-              }
-
               if (toolCallState.status !== "errored") {
                 dispatch(
                   acceptToolCall({
                     toolCallId: applyState.toolCallId,
                   }),
                 );
-                dispatch(
-                  updateToolCallOutput({
-                    toolCallId: applyState.toolCallId,
-                    contextItems: [
-                      {
-                        name: "Edit Success",
-                        content: `Successfully edited ${applyState.filepath}`,
-                        description: "",
-                        hidden: true,
-                      },
-                    ],
-                  }),
-                );
+
+                // Add autoformatting diff to tool output if present
+                if (applyState.autoFormattingDiff) {
+                  dispatch(
+                    updateToolCallOutput({
+                      toolCallId: applyState.toolCallId,
+                      contextItems: [
+                        {
+                          icon: "info",
+                          name: "Auto-formatting Applied",
+                          description: "Editor auto-formatting changes",
+                          content: `Along with your edits, the editor applied the following auto-formatting:\n\n${applyState.autoFormattingDiff}\n\n(Note: Pay close attention to changes such as single quotes being converted to double quotes, semicolons being removed or added, long lines being broken into multiple lines, adjusting indentation style, adding/removing trailing commas, etc. This will help you ensure future SEARCH/REPLACE operations to this file are accurate.)`,
+                          hidden: false,
+                        },
+                      ],
+                    }),
+                  );
+                } else {
+                  dispatch(
+                    updateToolCallOutput({
+                      toolCallId: applyState.toolCallId,
+                      contextItems: [
+                        {
+                          name: "Edit Success",
+                          content: `Successfully edited ${applyState.filepath}`,
+                          description: "",
+                          hidden: true,
+                        },
+                      ],
+                    }),
+                  );
+                }
               } else {
                 dispatch(
                   updateToolCallOutput({


### PR DESCRIPTION
## Description
https://github.com/continuedev/continue/pull/7660
and
https://github.com/continuedev/continue/pull/7696

Had some conflicting logic. This merges correctly
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes a bug where the auto-formatting diff in tool output was being overwritten by the “Edit Success” message. Now the diff is preserved, and the success message is only added when no diff exists.

- **Bug Fixes**
  - Consolidated updateToolCallOutput calls in handleApplyStateUpdate to prevent overwriting context.
  - On successful edits without errors: show auto-formatting diff if present; otherwise add a hidden “Edit Success” note.

<!-- End of auto-generated description by cubic. -->

