### PR TITLE
docs: update offline guide with correct links and config.yaml references

### DIFF
--- a/docs/guides/running-continue-without-internet.mdx
+++ b/docs/guides/running-continue-without-internet.mdx
@@ -3,7 +3,7 @@ title: "How to Run Continue Without Internet"
 description: "Learn how to set up Continue for air-gapped or offline environments using local models, including steps to disable telemetry and configure local model providers"
 ---
 
-1. Download the latest .vsix file from the [Open VSX Registry](https://open-vsx.org/extension/Continue/continue) and [install it to VS Code](https://code.visualstudio.com/docs/editor/extension-marketplace#_install-from-a-vsix).
-2. Turn off "Allow Anonymous Telemetry" in the user settings. This will stop Continue from attempting requests to PostHog for [anonymous telemetry](/customize/telemetry).
-3. Also in `config.json`, set the default model to a local model. You can available options [here](/customization/models#openai).
-4. Restart VS Code to ensure that the changes to `config.json` or `config.yaml` take effect.
+1. Download the latest .vsix file from the [GitHub Releases page](https://github.com/continuedev/continue/releases) and [install it to VS Code](https://code.visualstudio.com/docs/editor/extension-marketplace#_install-from-a-vsix).
+2. Turn off "Allow Anonymous Telemetry" in the user settings. This will stop Continue from attempting requests to PostHog for [anonymous telemetry](https://docs.continue.dev/reference/telemetry).
+3. In your `config.yaml` file (or through the Continue UI), set the default model to a local model. You can find available local model options [here](https://docs.continue.dev/reference/model-providers/ollama).
+4. Restart VS Code to ensure that the changes to `config.yaml` take effect.


### PR DESCRIPTION
## Description
This PR updates the offline/air-gapped installation guide to fix outdated links and deprecated configuration references.

## Changes
- Replace Open VSX Registry link with GitHub Releases page for VSIX downloads
- Fix broken telemetry documentation link
- Update deprecated `config.json` references to `config.yaml`
- Update local models link to point to Ollama documentation (most common local option)

## Why
The previous links were outdated or broken, and the guide was still referencing the deprecated `config.json` format instead of the current `config.yaml` configuration approach.

Generated with [Continue](https://continue.dev)

Co-Authored-By: Continue <noreply@continue.dev>
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the offline/air-gapped setup guide with correct links and the current config.yaml format. Replaced the Open VSX link with GitHub Releases, fixed the telemetry docs URL, and pointed local model guidance to Ollama.

<!-- End of auto-generated description by cubic. -->

