### PR TITLE
fix: disable clipboard content by default in autocomplete

### DIFF
--- a/core/util/parameters.ts
+++ b/core/util/parameters.ts
@@ -21,7 +21,7 @@ export const DEFAULT_AUTOCOMPLETE_OPTS: TabAutocompleteOptions = {
   transform: true,
   showWhateverWeHaveAtXMs: 300,
   // Experimental options: true = enabled, false = disabled, number = enabled w priority
-  experimental_includeClipboard: true,
+  experimental_includeClipboard: false,
   experimental_includeRecentlyVisitedRanges: true,
   experimental_includeRecentlyEditedRanges: true,
   experimental_includeDiff: true,


### PR DESCRIPTION
## Description

Disables clipboard content by default in autocomplete addressing potential security concerns. Further work / documentation needed before deciding whether to re-enable
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Disable clipboard-based suggestions in autocomplete by default to reduce privacy/security risk. The feature remains opt-in via experimental_includeClipboard if needed.

<!-- End of auto-generated description by cubic. -->

