### PR TITLE
fix: Prevent tool content with <think> tags from triggering incorrect tool calls

### DIFF
--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -545,7 +545,7 @@ export const sessionSlice = createSlice({
 
           // OpenAI-compatible models in agent mode sometimes send
           // all of their data in one message, so we handle that case early.
-          if (messageContent) {
+          if (messageContent && message.role !== "tool") {
             const thinkMatches = messageContent.match(
               /<think>([\s\S]*)<\/think>([\s\S]*)/,
             );
@@ -605,7 +605,7 @@ export const sessionSlice = createSlice({
 
           // Add to the existing message
           if (messageContent) {
-            if (messageContent.includes("<think>")) {
+            if (messageContent.includes("<think>") && message.role !== "tool") {
               lastItem.reasoning = {
                 startAt: Date.now(),
                 active: true,


### PR DESCRIPTION
## Description

This PR addresses a bug where tool content containing the `<think>` tag was not being processed correctly, leading to unexpected behavior.

It can be triggered by "please help me to review gui/src/redux/slices/sessionSlice.ts" when using readFile tool, because the file contains the `<think>` tag 😅

## Screen recording or screenshot



https://github.com/user-attachments/assets/8b5afc43-3673-4ce8-8181-39dc89d4e551


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevented tool messages that contain <think> tags from being parsed as reasoning, which was causing incorrect tool calls and noisy “thinking” states.

- **Bug Fixes**
  - Parse <think> tags only for non-tool messages (both the one-message and incremental paths).
  - Stops readFile from misfiring when file contents include <think>.

<!-- End of auto-generated description by cubic. -->

