### PR TITLE
fix: focus on the selected file for edit/apply when showing diffs

### DIFF
--- a/extensions/vscode/src/diff/vertical/manager.ts
+++ b/extensions/vscode/src/diff/vertical/manager.ts
@@ -51,7 +51,7 @@ export class VerticalDiffManager {
       this.fileUriToHandler.get(fileUri)?.clear(false);
       this.fileUriToHandler.delete(fileUri);
     }
-    const editor = vscode.window.activeTextEditor; // TODO might cause issues if user switches files
+    const editor = vscode.window.activeTextEditor;
     if (editor && URI.equal(editor.document.uri.toString(), fileUri)) {
       const handler = new VerticalDiffHandler(
         startLine,


### PR DESCRIPTION
## Description

Open the selected file for edit when vscode is applying diffs.




closes https://github.com/continuedev/continue/issues/5768

resolves CON-2026

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]



https://github.com/user-attachments/assets/073b6de1-700c-4e0c-9f6b-3b1ad9b1ca51

https://github.com/user-attachments/assets/3b7aebb5-5f4a-48f4-b5d8-eba2b25ebcf0

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Ensures the selected file is opened and focused before applying vertical diff edits in VS Code, so changes always land in the correct editor. Closes #5768 and resolves CON-2026.

- **Bug Fixes**
  - Focuses the target file before any vertical diff operation (apply, insert, delete).
  - Reuses a visible editor when available or opens the document if needed.
  - Prevents edits from applying to the wrong file when users switch tabs.

<!-- End of auto-generated description by cubic. -->

