### PR TITLE
improv: add invokable parsing

### DIFF
--- a/packages/config-yaml/src/markdown/markdownToRule.test.ts
+++ b/packages/config-yaml/src/markdown/markdownToRule.test.ts
@@ -261,6 +261,66 @@ This is a rule with alwaysApply explicitly set to false.`;
     const result = markdownToRule(content, mockId);
     expect(result.alwaysApply).toBe(false);
   });
+
+  it("should include invokable from frontmatter when true", () => {
+    const content = `---
+globs: "**/test/**/*.kt"
+name: Test Rule
+invokable: true
+---
+
+# Test Rule
+
+This is an invokable rule.`;
+
+    const result = markdownToRule(content, mockId);
+    expect(result.invokable).toBe(true);
+  });
+
+  it("should include invokable from frontmatter when false", () => {
+    const content = `---
+globs: "**/test/**/*.kt"
+name: Test Rule
+invokable: false
+---
+
+# Test Rule
+
+This is a non-invokable rule.`;
+
+    const result = markdownToRule(content, mockId);
+    expect(result.invokable).toBe(false);
+  });
+
+  it("should handle invokable with alwaysApply together", () => {
+    const content = `---
+alwaysApply: true
+invokable: true
+name: Test Rule
+---
+
+# Test Rule
+
+This is a rule with both alwaysApply and invokable.`;
+
+    const result = markdownToRule(content, mockId);
+    expect(result.alwaysApply).toBe(true);
+    expect(result.invokable).toBe(true);
+  });
+
+  it("should not include invokable when not in frontmatter", () => {
+    const content = `---
+globs: "**/test/**/*.kt"
+name: Test Rule
+---
+
+# Test Rule
+
+This is a rule without invokable property.`;
+
+    const result = markdownToRule(content, mockId);
+    expect(result.invokable).toBeUndefined();
+  });
 });
 
 describe("getRuleName", () => {

--- a/packages/config-yaml/src/markdown/markdownToRule.ts
+++ b/packages/config-yaml/src/markdown/markdownToRule.ts
@@ -12,6 +12,7 @@ export interface RuleFrontmatter {
   name?: RuleObject["name"];
   description?: RuleObject["description"];
   alwaysApply?: RuleObject["alwaysApply"];
+  invokable?: RuleObject["invokable"];
 }
 
 /**
@@ -115,6 +116,7 @@ export function markdownToRule(
     regex: frontmatter.regex,
     description: frontmatter.description,
     alwaysApply: frontmatter.alwaysApply,
+    invokable: frontmatter.invokable,
     sourceFile: id.uriType === "file" ? id.fileUri : undefined,
   };
 }


### PR DESCRIPTION
## Description

add invokable parsing

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add support for parsing the invokable flag from rule frontmatter. Rules now include invokable in markdownToRule output.

- **New Features**
  - Parse frontmatter.invokable and pass it through to the returned rule.
  - Added tests for true/false values, coexistence with alwaysApply, and when absent.

<!-- End of auto-generated description by cubic. -->

