### PR TITLE
feat: adapt duplicate toolCallId

### DIFF
--- a/gui/src/redux/selectors/selectToolCalls.ts
+++ b/gui/src/redux/selectors/selectToolCalls.ts
@@ -50,7 +50,9 @@ export const selectApplyStateByToolCallId = createSelector(
     (_store: RootState, toolCallId: string) => toolCallId,
   ],
   (applyStates, toolCallId) => {
-    return applyStates.states.find((state) => state.toolCallId === toolCallId);
+    return applyStates.states.findLast(
+      (state) => state.toolCallId === toolCallId,
+    );
   },
 );
 

--- a/gui/src/redux/thunks/streamResponseAfterToolCall.ts
+++ b/gui/src/redux/thunks/streamResponseAfterToolCall.ts
@@ -69,7 +69,7 @@ export const streamResponseAfterToolCall = createAsyncThunk<
 
         // Check if we should continue streaming based on tool call completion
         const history = getState().session.history;
-        const assistantMessage = history.find(
+        const assistantMessage = history.findLast(
           (item) =>
             item.message.role === "assistant" &&
             item.toolCallStates?.some((tc) => tc.toolCallId === toolCallId),

--- a/gui/src/redux/util/index.ts
+++ b/gui/src/redux/util/index.ts
@@ -66,7 +66,8 @@ export function findToolCallById(
   chatHistory: RootState["session"]["history"],
   toolCallId: string,
 ): ToolCallState | undefined {
-  for (const item of chatHistory) {
+  for (let i = chatHistory.length - 1; i >= 0; i--) {
+    const item = chatHistory[i];
     if (item.toolCallStates) {
       const toolCallState = item.toolCallStates.find(
         (state) => state.toolCallId === toolCallId,
@@ -84,7 +85,7 @@ export function findChatHistoryItemByToolCallId(
   chatHistory: RootState["session"]["history"],
   toolCallId: string,
 ): ChatHistoryItemWithMessageId | undefined {
-  return chatHistory.find(
+  return chatHistory.findLast(
     (item) =>
       item.message.role === "tool" && item.message.toolCallId === toolCallId,
   );


### PR DESCRIPTION
## Description

When a large language model makes tool calls in a conversation, if the same toolCallId appears, the existing code will update the first toolCallState, resulting in an abnormal tool call status displayed on the chat page, or other unknown exceptions
Duplicate toolCallId occurs when provider is openrouter and for some models or providers

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
