### PR TITLE
Update pending items count from 2 to 1

### DIFF
--- a/extensions/cli/src/ui/components/StaticChatContent.tsx
+++ b/extensions/cli/src/ui/components/StaticChatContent.tsx
@@ -92,7 +92,7 @@ export const StaticChatContent: React.FC<StaticChatContentProps> = ({
       );
     }
 
-    const PENDING_ITEMS_COUNT = 2;
+    const PENDING_ITEMS_COUNT = 1;
     const stableCount = Math.max(
       0,
       filteredChatHistory.length - PENDING_ITEMS_COUNT,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Show only one pending chat item instead of two, so only the latest message is treated as pending and earlier messages remain stable.

<!-- End of auto-generated description by cubic. -->

