### PR TITLE
feat: proper json schema for multi edit params

### DIFF
--- a/extensions/cli/src/stream/handleToolCalls.ts
+++ b/extensions/cli/src/stream/handleToolCalls.ts
@@ -15,6 +15,7 @@ import type { ToolPermissionServiceState } from "../services/ToolPermissionServi
 import { getAllBuiltinTools, ToolCall } from "../tools/index.js";
 import { logger } from "../util/logger.js";
 
+import { convertToolParametersToJsonSchema } from "src/tools/parameterConverter.js";
 import {
   executeStreamedToolCalls,
   preprocessStreamedToolCalls,
@@ -231,22 +232,7 @@ export async function getAllTools() {
     function: {
       name: tool.name,
       description: tool.description,
-      parameters: {
-        type: "object",
-        properties: Object.fromEntries(
-          Object.entries(tool.parameters).map(([key, param]) => [
-            key,
-            {
-              type: param.type,
-              description: param.description,
-              items: param.items,
-            },
-          ]),
-        ),
-        required: Object.entries(tool.parameters)
-          .filter(([_, param]) => param.required)
-          .map(([key, _]) => key),
-      },
+      parameters: convertToolParametersToJsonSchema(tool.parameters),
     },
   }));
 

--- a/extensions/cli/src/tools/multiEdit.ts
+++ b/extensions/cli/src/tools/multiEdit.ts
@@ -182,6 +182,25 @@ WARNINGS:
       required: true,
       items: {
         type: "object",
+        properties: {
+          old_string: {
+            type: "string",
+            description:
+              "The text to replace (must match the file contents exactly, including all whitespace/indentation)",
+            required: true,
+          },
+          new_string: {
+            type: "string",
+            description: "The edited text to replace the old_string",
+            required: true,
+          },
+          replace_all: {
+            type: "boolean",
+            description:
+              "Replace all occurrences of old_string. Defaults to false",
+            required: false,
+          },
+        },
       },
     },
   },

--- a/extensions/cli/src/tools/parameterConverter.test.ts
+++ b/extensions/cli/src/tools/parameterConverter.test.ts
@@ -1,0 +1,393 @@
+import { describe, it, expect } from "vitest";
+import { convertToolParametersToJsonSchema } from "./parameterConverter.js";
+
+describe("convertToolParametersToJsonSchema", () => {
+  it("should convert simple parameters to JSON schema", () => {
+    const parameters = {
+      name: {
+        type: "string",
+        description: "The name",
+        required: true,
+      },
+      age: {
+        type: "number",
+        description: "The age",
+        required: false,
+      },
+    };
+
+    const result = convertToolParametersToJsonSchema(parameters);
+
+    expect(result).toEqual({
+      type: "object",
+      properties: {
+        name: {
+          type: "string",
+          description: "The name",
+        },
+        age: {
+          type: "number",
+          description: "The age",
+        },
+      },
+      required: ["name"],
+    });
+  });
+
+  it("should handle parameters with no required fields", () => {
+    const parameters = {
+      optional1: {
+        type: "string",
+        description: "Optional field 1",
+        required: false,
+      },
+      optional2: {
+        type: "boolean",
+        description: "Optional field 2",
+        required: false,
+      },
+    };
+
+    const result = convertToolParametersToJsonSchema(parameters);
+
+    expect(result).toEqual({
+      type: "object",
+      properties: {
+        optional1: {
+          type: "string",
+          description: "Optional field 1",
+        },
+        optional2: {
+          type: "boolean",
+          description: "Optional field 2",
+        },
+      },
+    });
+  });
+
+  it("should handle array parameters with items", () => {
+    const parameters = {
+      tags: {
+        type: "array",
+        description: "List of tags",
+        required: true,
+        items: {
+          type: "string",
+        },
+      },
+    };
+
+    const result = convertToolParametersToJsonSchema(parameters);
+
+    expect(result).toEqual({
+      type: "object",
+      properties: {
+        tags: {
+          type: "array",
+          description: "List of tags",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["tags"],
+    });
+  });
+
+  it("should handle nested object properties", () => {
+    const parameters = {
+      user: {
+        type: "object",
+        description: "User information",
+        required: true,
+        properties: {
+          firstName: {
+            type: "string",
+            description: "First name",
+            required: true,
+          },
+          lastName: {
+            type: "string",
+            description: "Last name",
+            required: true,
+          },
+          email: {
+            type: "string",
+            description: "Email address",
+            required: false,
+          },
+        },
+      },
+    };
+
+    const result = convertToolParametersToJsonSchema(parameters);
+
+    expect(result).toEqual({
+      type: "object",
+      properties: {
+        user: {
+          type: "object",
+          description: "User information",
+          properties: {
+            firstName: {
+              type: "string",
+              description: "First name",
+            },
+            lastName: {
+              type: "string",
+              description: "Last name",
+            },
+            email: {
+              type: "string",
+              description: "Email address",
+            },
+          },
+          required: ["firstName", "lastName"],
+        },
+      },
+      required: ["user"],
+    });
+  });
+
+  it("should handle arrays of objects with nested properties", () => {
+    const parameters = {
+      users: {
+        type: "array",
+        description: "List of users",
+        required: true,
+        items: {
+          type: "object",
+          properties: {
+            id: {
+              type: "number",
+              description: "User ID",
+              required: true,
+            },
+            name: {
+              type: "string",
+              description: "User name",
+              required: true,
+            },
+            active: {
+              type: "boolean",
+              description: "Is active",
+              required: false,
+            },
+          },
+        },
+      },
+    };
+
+    const result = convertToolParametersToJsonSchema(parameters);
+
+    expect(result).toEqual({
+      type: "object",
+      properties: {
+        users: {
+          type: "array",
+          description: "List of users",
+          items: {
+            type: "object",
+            properties: {
+              id: {
+                type: "number",
+                description: "User ID",
+              },
+              name: {
+                type: "string",
+                description: "User name",
+              },
+              active: {
+                type: "boolean",
+                description: "Is active",
+              },
+            },
+            required: ["id", "name"],
+          },
+        },
+      },
+      required: ["users"],
+    });
+  });
+
+  it("should handle deeply nested structures", () => {
+    const parameters = {
+      company: {
+        type: "object",
+        description: "Company info",
+        required: true,
+        properties: {
+          name: {
+            type: "string",
+            description: "Company name",
+            required: true,
+          },
+          departments: {
+            type: "array",
+            description: "Departments",
+            required: false,
+            items: {
+              type: "object",
+              properties: {
+                name: {
+                  type: "string",
+                  description: "Department name",
+                  required: true,
+                },
+                employees: {
+                  type: "array",
+                  description: "Employees",
+                  required: true,
+                  items: {
+                    type: "object",
+                    properties: {
+                      name: {
+                        type: "string",
+                        description: "Employee name",
+                        required: true,
+                      },
+                      role: {
+                        type: "string",
+                        description: "Employee role",
+                        required: false,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = convertToolParametersToJsonSchema(parameters);
+
+    expect(result).toEqual({
+      type: "object",
+      properties: {
+        company: {
+          type: "object",
+          description: "Company info",
+          properties: {
+            name: {
+              type: "string",
+              description: "Company name",
+            },
+            departments: {
+              type: "array",
+              description: "Departments",
+              items: {
+                type: "object",
+                properties: {
+                  name: {
+                    type: "string",
+                    description: "Department name",
+                  },
+                  employees: {
+                    type: "array",
+                    description: "Employees",
+                    items: {
+                      type: "object",
+                      properties: {
+                        name: {
+                          type: "string",
+                          description: "Employee name",
+                        },
+                        role: {
+                          type: "string",
+                          description: "Employee role",
+                        },
+                      },
+                      required: ["name"],
+                    },
+                  },
+                },
+                required: ["name", "employees"],
+              },
+            },
+          },
+          required: ["name"],
+        },
+      },
+      required: ["company"],
+    });
+  });
+
+  it("should handle arrays of arrays", () => {
+    const parameters = {
+      matrix: {
+        type: "array",
+        description: "2D matrix",
+        required: true,
+        items: {
+          type: "array",
+          items: {
+            type: "number",
+          },
+        },
+      },
+    };
+
+    const result = convertToolParametersToJsonSchema(parameters);
+
+    expect(result).toEqual({
+      type: "object",
+      properties: {
+        matrix: {
+          type: "array",
+          description: "2D matrix",
+          items: {
+            type: "array",
+            items: {
+              type: "number",
+            },
+          },
+        },
+      },
+      required: ["matrix"],
+    });
+  });
+
+  it("should handle empty parameters", () => {
+    const parameters = {};
+
+    const result = convertToolParametersToJsonSchema(parameters);
+
+    expect(result).toEqual({
+      type: "object",
+      properties: {},
+    });
+  });
+
+  it("should handle items with description", () => {
+    const parameters = {
+      codes: {
+        type: "array",
+        description: "List of codes",
+        required: true,
+        items: {
+          type: "string",
+          description: "A code value",
+        },
+      },
+    };
+
+    const result = convertToolParametersToJsonSchema(parameters);
+
+    expect(result).toEqual({
+      type: "object",
+      properties: {
+        codes: {
+          type: "array",
+          description: "List of codes",
+          items: {
+            type: "string",
+            description: "A code value",
+          },
+        },
+      },
+      required: ["codes"],
+    });
+  });
+});

--- a/extensions/cli/src/tools/parameterConverter.ts
+++ b/extensions/cli/src/tools/parameterConverter.ts
@@ -1,0 +1,78 @@
+/**
+ * Converts tool parameters to JSON Schema format.
+ * Handles nested properties and converts required booleans to required arrays.
+ */
+export function convertToolParametersToJsonSchema(
+  parameters: Record<string, any>,
+): any {
+  const properties: Record<string, any> = {};
+  const required: string[] = [];
+
+  for (const [key, param] of Object.entries(parameters)) {
+    const schema: any = {
+      type: param.type,
+      description: param.description,
+    };
+
+    // Add this key to required array if it's required
+    if (param.required) {
+      required.push(key);
+    }
+
+    // Handle array items
+    if (param.items) {
+      schema.items = convertItemsToJsonSchema(param.items);
+    }
+
+    // Handle object properties (nested properties)
+    if (param.properties) {
+      const nestedSchema = convertToolParametersToJsonSchema(param.properties);
+      schema.properties = nestedSchema.properties;
+      if (nestedSchema.required?.length > 0) {
+        schema.required = nestedSchema.required;
+      }
+    }
+
+    properties[key] = schema;
+  }
+
+  const result: any = {
+    type: "object",
+    properties,
+  };
+
+  if (required.length > 0) {
+    result.required = required;
+  }
+
+  return result;
+}
+
+/**
+ * Converts items schema to JSON Schema format
+ */
+function convertItemsToJsonSchema(items: any): any {
+  const itemSchema: any = {
+    type: items.type,
+  };
+
+  if (items.description) {
+    itemSchema.description = items.description;
+  }
+
+  // Handle nested properties in items
+  if (items.properties) {
+    const nestedSchema = convertToolParametersToJsonSchema(items.properties);
+    itemSchema.properties = nestedSchema.properties;
+    if (nestedSchema.required?.length > 0) {
+      itemSchema.required = nestedSchema.required;
+    }
+  }
+
+  // Handle nested items (for arrays of arrays)
+  if (items.items) {
+    itemSchema.items = convertItemsToJsonSchema(items.items);
+  }
+
+  return itemSchema;
+}

--- a/extensions/cli/src/tools/types.ts
+++ b/extensions/cli/src/tools/types.ts
@@ -8,6 +8,15 @@ export type ToolParameters = Record<
     required: boolean;
     items?: {
       type: string;
+      properties?: Record<
+        string,
+        {
+          type: string;
+          description: string;
+          required: boolean;
+        }
+      >;
+      required?: string[];
     };
   }
 >;


### PR DESCRIPTION
## Description
Adds proper json schema for the multi-edit array args and handling for converstion between continue cli tool params and json schema
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Implements a JSON Schema converter for CLI tool parameters and updates multiEdit to use a proper array-of-objects schema. This standardizes tool schemas (including nested and required fields) and fixes validation for multi-edit calls.

- New Features
  - Added convertToolParametersToJsonSchema with support for nested objects/arrays and required propagation.
  - Updated getAllTools to use the converter for consistent tool schemas.
  - Defined multiEdit changes[] items with old_string, new_string, and replace_all fields.
  - Added comprehensive unit tests and extended types to cover nested structures.

<!-- End of auto-generated description by cubic. -->

