### PR TITLE
fix: remove duplicate toggleToolGroupSetting call in ToolPoliciesGroup.tsx

### DIFF
--- a/gui/src/pages/config/components/ToolPoliciesGroup.tsx
+++ b/gui/src/pages/config/components/ToolPoliciesGroup.tsx
@@ -57,12 +57,7 @@ export function ToolPoliciesGroup({
                   : `Enable all tools in ${groupName} group`
             }
           >
-            <div
-              onClick={(e) => {
-                e.stopPropagation();
-                dispatch(toggleToolGroupSetting(groupName));
-              }}
-            >
+            <div>
               <ToggleSwitch
                 isToggled={isGroupEnabled}
                 onToggle={() => dispatch(toggleToolGroupSetting(groupName))}


### PR DESCRIPTION
The tools toggle switches did not work, making it impossible to disable tools. 

This was caused by both the ToggleSwitch component and its parent div defining the same click handler. It caused the action to be dispatched twice, effectively cancelling out the toggle.

The fix removes the outer click handler.

cc @Patrick-Erichsen 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes broken tool group toggles so you can reliably enable or disable an entire group with one click. The toggle no longer flips back due to duplicate handlers.

- **Bug Fixes**
  - Removed the outer div click handler in ToolPoliciesGroup to prevent double-dispatching toggleToolGroupSetting.
  - ToggleSwitch is now the only trigger, so each click results in a single state change.

<!-- End of auto-generated description by cubic. -->

