### PR TITLE
fix(cli): add keyboard interruption handler until tui starts

### DIFF
--- a/extensions/cli/src/index.ts
+++ b/extensions/cli/src/index.ts
@@ -107,6 +107,11 @@ process.on("uncaughtException", (error) => {
   // Don't exit the process, just log the error
 });
 
+// keyboard interruption handler for non-TUI flows
+process.on("SIGINT", async () => {
+  await gracefulExit(130);
+});
+
 const program = new Command();
 
 program


### PR DESCRIPTION
## Description

Previously login (and also logout when there was slow network) did not let the cli exit on ctrl+c keyboard events.
This adds the ability to listen for those events until tui starts.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

**before**

<img width="1220" height="252" alt="image" src="https://github.com/user-attachments/assets/2fff3205-9281-4ec2-9e41-da0447398cd6" />

**after**

<img width="1225" height="373" alt="image" src="https://github.com/user-attachments/assets/52fa9ef9-4dbc-445c-959d-a2648d6991ce" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
