### PR TITLE
fix: missing secret declarations in reusable workflow

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -32,6 +32,10 @@ on:
         required: false
       VOYAGE_API_KEY:
         required: false
+      RELACE_API_KEY:
+        required: false
+      INCEPTION_API_KEY:
+        required: false
 
 permissions:
   contents: write


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds missing secret declarations to the reusable-release workflow so callers can pass and use them without errors. Prevents failures when these secrets are referenced in jobs.

- **Bug Fixes**
  - Declared RELACE_API_KEY and INCEPTION_API_KEY under on.workflow_call.secrets (required: false) to align with referenced secrets and avoid “unrecognized secret” errors.

<!-- End of auto-generated description by cubic. -->

