### PR TITLE
fix: do not show indexing options unless config loads

### DIFF
--- a/gui/src/pages/config/sections/IndexingSettingsSection.tsx
+++ b/gui/src/pages/config/sections/IndexingSettingsSection.tsx
@@ -7,7 +7,7 @@ import Alert from "../../../components/gui/Alert";
 import { Card, Divider } from "../../../components/ui";
 import { IdeMessengerContext } from "../../../context/IdeMessenger";
 import { useAppDispatch, useAppSelector } from "../../../redux/hooks";
-import { updateConfig } from "../../../redux/slices/configSlice";
+import { EMPTY_CONFIG, updateConfig } from "../../../redux/slices/configSlice";
 import { selectCurrentOrg } from "../../../redux/slices/profilesSlice";
 import { ConfigHeader } from "../components/ConfigHeader";
 import { UserSetting } from "../components/UserSetting";
@@ -79,6 +79,7 @@ function EnableIndexingSetting() {
 
 export function IndexingSettingsSection() {
   const config = useAppSelector((state) => state.config.config);
+  const configLoading = JSON.stringify(config) === JSON.stringify(EMPTY_CONFIG);
   const disableIndexing = config.disableIndexing ?? false;
 
   return (
@@ -103,12 +104,16 @@ export function IndexingSettingsSection() {
               </a>
             </div>
           </div>
-          <Divider className="border-inherit" />
-          <EnableIndexingSetting />
+          {!configLoading && (
+            <>
+              <Divider className="border-inherit" />
+              <EnableIndexingSetting />
+            </>
+          )}
         </div>
       </Alert>
 
-      {!disableIndexing && (
+      {!configLoading && !disableIndexing && (
         <div className="space-y-8">
           <CodebaseSubSection />
           <DocsSection />


### PR DESCRIPTION
## Description

When config is loading, in the ui we were showing that indexing is being initialized (which was perceived as indexing was starting by users). This PR fixes that by showing it only when the config has finished loading.

resolves CON-3946

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot


https://github.com/user-attachments/assets/64a0ffb1-097c-44d5-a545-be97bdaa9f01



https://github.com/user-attachments/assets/fc02ac92-c74c-448a-8d07-1a492bbeaa7c


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
