### PR TITLE
fix: remove empty lines from start/end in find and replace

### DIFF
--- a/gui/src/pages/gui/ToolCallDiv/FindAndReplace.test.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/FindAndReplace.test.tsx
@@ -19,9 +19,16 @@ vi.mock("../../../components/ui", () => ({
   useFontSize: () => 14,
 }));
 
-vi.mock("../../../util/clientTools/findAndReplaceUtils", () => ({
-  performFindAndReplace: vi.fn(),
-}));
+vi.mock("../../../util/clientTools/findAndReplaceUtils", async () => {
+  const actual = await vi.importActual(
+    "../../../util/clientTools/findAndReplaceUtils",
+  );
+
+  return {
+    performFindAndReplace: vi.fn(),
+    removeEmptyLines: actual.removeEmptyLines,
+  };
+});
 
 vi.mock("./utils", () => ({
   getStatusIcon: vi.fn(() => <div data-testid="status-icon">✓</div>),

--- a/gui/src/pages/gui/ToolCallDiv/FindAndReplace.test.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/FindAndReplace.test.tsx
@@ -26,7 +26,7 @@ vi.mock("../../../util/clientTools/findAndReplaceUtils", async () => {
 
   return {
     performFindAndReplace: vi.fn(),
-    removeEmptyLines: actual.removeEmptyLines,
+    trimEmptyLines: actual.trimEmptyLines,
   };
 });
 

--- a/gui/src/pages/gui/ToolCallDiv/FindAndReplace.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/FindAndReplace.tsx
@@ -15,7 +15,7 @@ import {
 } from "../../../redux/selectors/selectToolCalls";
 import {
   performFindAndReplace,
-  removeEmptyLines,
+  trimEmptyLines,
 } from "../../../util/clientTools/findAndReplaceUtils";
 import { cn } from "../../../util/cn";
 import { getStatusIcon } from "./utils";
@@ -321,11 +321,11 @@ export function FindAndReplaceDisplay({
               : showMiddleEllipses || showEndEllipsis
                 ? lines.slice(0, MAX_SAME_LINES)
                 : lines;
-            startLines = removeEmptyLines.fromStart(startLines);
+            startLines = trimEmptyLines({ lines: startLines, fromEnd: false });
             let endLines = showMiddleEllipses
               ? lines.slice(-MAX_SAME_LINES)
               : [];
-            endLines = removeEmptyLines.fromEnd(endLines);
+            endLines = trimEmptyLines({ lines: endLines, fromEnd: true });
 
             return (
               <div key={index}>

--- a/gui/src/pages/gui/ToolCallDiv/FindAndReplace.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/FindAndReplace.tsx
@@ -13,7 +13,10 @@ import {
   selectApplyStateByToolCallId,
   selectToolCallById,
 } from "../../../redux/selectors/selectToolCalls";
-import { performFindAndReplace } from "../../../util/clientTools/findAndReplaceUtils";
+import {
+  performFindAndReplace,
+  removeEmptyLines,
+} from "../../../util/clientTools/findAndReplaceUtils";
 import { cn } from "../../../util/cn";
 import { getStatusIcon } from "./utils";
 
@@ -313,14 +316,16 @@ export function FindAndReplaceDisplay({
             const showMiddleEllipses =
               !isFirst && !isLast && lines.length > MAX_SAME_LINES * 2 + 1;
 
-            const startLines = showStartEllipsis
+            let startLines = showStartEllipsis
               ? lines.slice(-MAX_SAME_LINES)
               : showMiddleEllipses || showEndEllipsis
                 ? lines.slice(0, MAX_SAME_LINES)
                 : lines;
-            const endLines = showMiddleEllipses
+            startLines = removeEmptyLines.fromStart(startLines);
+            let endLines = showMiddleEllipses
               ? lines.slice(-MAX_SAME_LINES)
               : [];
+            endLines = removeEmptyLines.fromEnd(endLines);
 
             return (
               <div key={index}>

--- a/gui/src/util/clientTools/findAndReplaceUtils.test.ts
+++ b/gui/src/util/clientTools/findAndReplaceUtils.test.ts
@@ -4,6 +4,7 @@ import {
   EMPTY_NON_FIRST_EDIT_MESSAGE,
   FOUND_MULTIPLE_FIND_STRINGS_ERROR,
   performFindAndReplace,
+  trimEmptyLines,
   validateCreatingForMultiEdit,
   validateSingleEdit,
 } from "./findAndReplaceUtils";
@@ -452,5 +453,25 @@ describe("validateCreatingForMultiEdit", () => {
       expect(() => validateCreatingForMultiEdit(edits)).not.toThrow();
       expect(validateCreatingForMultiEdit(edits)).toBe(false);
     });
+  });
+});
+
+describe("trimEmptyLines", () => {
+  it("trims leading empty lines from start", () => {
+    const input = ["", "", "a", "", "b"];
+    const result = trimEmptyLines({ lines: input, fromEnd: false });
+    expect(result).toEqual(["a", "", "b"]);
+  });
+
+  it("trims trailing empty lines from end", () => {
+    const input = ["a", "", "b", "", ""];
+    const result = trimEmptyLines({ lines: input, fromEnd: true });
+    expect(result).toEqual(["a", "", "b"]);
+  });
+
+  it("returns empty array when all lines are empty", () => {
+    const input = ["", "", ""];
+    const result = trimEmptyLines({ lines: input, fromEnd: false });
+    expect(result).toEqual([]);
   });
 });

--- a/gui/src/util/clientTools/findAndReplaceUtils.ts
+++ b/gui/src/util/clientTools/findAndReplaceUtils.ts
@@ -96,24 +96,21 @@ export function validateCreatingForMultiEdit(edits: EditOperation[]) {
   return isCreating;
 }
 
-/**remove all empty lines from the start/end in an array of lines */
-export const removeEmptyLines = {
-  _remove: (lines: string[]) => {
-    const newLines = [];
-    let index = 0,
-      shouldContinueRemoving = true;
-    while (index < lines.length) {
-      if (shouldContinueRemoving && lines[index].trim() === "") {
-        index++;
-        continue;
-      }
-      shouldContinueRemoving = false;
-      newLines.push(lines[index]);
-      index++;
-    }
-    return newLines;
-  },
-  fromStart: (lines: string[]) => removeEmptyLines._remove(lines),
-  fromEnd: (lines: string[]) =>
-    removeEmptyLines._remove(lines.toReversed()).toReversed(),
-};
+export function trimEmptyLines({
+  lines,
+  fromEnd,
+}: {
+  lines: string[];
+  fromEnd: boolean;
+}): string[] {
+  lines = fromEnd ? lines.toReversed() : lines.slice();
+  const newLines: string[] = [];
+  let shouldContinueRemoving = true;
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index];
+    if (shouldContinueRemoving && line.trim() === "") continue;
+    shouldContinueRemoving = false;
+    newLines.push(line);
+  }
+  return fromEnd ? newLines.reverse() : newLines;
+}

--- a/gui/src/util/clientTools/findAndReplaceUtils.ts
+++ b/gui/src/util/clientTools/findAndReplaceUtils.ts
@@ -95,3 +95,25 @@ export function validateCreatingForMultiEdit(edits: EditOperation[]) {
 
   return isCreating;
 }
+
+/**remove all empty lines from the start/end in an array of lines */
+export const removeEmptyLines = {
+  _remove: (lines: string[]) => {
+    const newLines = [];
+    let index = 0,
+      shouldContinueRemoving = true;
+    while (index < lines.length) {
+      if (shouldContinueRemoving && lines[index].trim() === "") {
+        index++;
+        continue;
+      }
+      shouldContinueRemoving = false;
+      newLines.push(lines[index]);
+      index++;
+    }
+    return newLines;
+  },
+  fromStart: (lines: string[]) => removeEmptyLines._remove(lines),
+  fromEnd: (lines: string[]) =>
+    removeEmptyLines._remove(lines.toReversed()).toReversed(),
+};


### PR DESCRIPTION
## Description

Remove empty lines in FindAndReplace lines content which would otherwise be perceived as padding.

resolves CON-3916

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

**before**
<img width="479" height="791" alt="image" src="https://github.com/user-attachments/assets/7bf44556-0ca1-4ace-a76b-314151a530a1" />

**after**
<img width="508" height="680" alt="image" src="https://github.com/user-attachments/assets/536255e1-d949-4e2e-bff3-0b72f1b9f90a" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removes leading and trailing empty lines from Find & Replace previews to avoid visual padding and misleading context. Addresses CON-3916.

- **Bug Fixes**
  - Added removeEmptyLines util (fromStart/fromEnd) to strip blank lines.
  - Applied trimming to startLines and endLines in FindAndReplaceDisplay without changing diff logic.

<!-- End of auto-generated description by cubic. -->

