### PR TITLE
style: move file gen spinner to right

### DIFF
--- a/gui/src/pages/gui/ToolCallDiv/FindAndReplace.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/FindAndReplace.tsx
@@ -184,7 +184,7 @@ export function FindAndReplaceDisplay({
       if (status === "canceled" || status === "errored" || status === "done") {
         return (
           <div
-            className={`mr-1 h-4 w-4 flex-shrink-0 ${toolCallState.output ? "cursor-pointer" : ""}`}
+            className={`mr-1 grid h-4 w-4 flex-shrink-0 place-items-center ${toolCallState.output ? "cursor-pointer" : ""}`}
             onClick={(e) => {
               if (toolCallState.output) {
                 e.stopPropagation();

--- a/gui/src/pages/gui/ToolCallDiv/FindAndReplace.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/FindAndReplace.tsx
@@ -213,7 +213,6 @@ export function FindAndReplaceDisplay({
       >
         <div className="flex min-w-0 flex-1 flex-row items-center gap-2 text-xs">
           <div className="flex min-w-0 flex-row items-center">
-            {statusIcon}
             <ChevronDownIcon
               data-testid="toggle-find-and-replace-diff"
               className={`text-lightgray h-3.5 w-3.5 flex-shrink-0 cursor-pointer select-none transition-all hover:brightness-125 ${
@@ -234,6 +233,7 @@ export function FindAndReplaceDisplay({
           <DiffStats added={diffStats.added} removed={diffStats.removed} />
         </div>
 
+        {statusIcon}
         {applyState && (
           <ApplyActions
             onClickAccept={() => {


### PR DESCRIPTION
## Description

Moves the spinner to the right in the find and replace blocks

resolves CON-3814

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

<img width="653" height="237" alt="image" src="https://github.com/user-attachments/assets/187ae2ef-54ee-4c85-b08e-4697a604d4c4" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Moved the status spinner to the right side of the Find and Replace header to match the CON-3814 design and improve alignment. No functional changes; UI-only update.

<!-- End of auto-generated description by cubic. -->

