### PR TITLE
feat: line-based chat history rendering with ANSI styling preservation

### DIFF
--- a/extensions/cli/docs/line-based-rendering.md
+++ b/extensions/cli/docs/line-based-rendering.md
@@ -1,0 +1,116 @@
+# Line-Based Chat History Rendering
+
+## Overview
+
+The CLI TUI uses a line-based rendering system where each line of chat content becomes a separate chat history item. This enables granular control over chat display and eliminates flickering during updates.
+
+## Architecture
+
+### Core Components
+
+1. **AnsiParsingStream** (`src/ui/utils/AnsiParsingStream.ts`)
+   - Custom writable stream that captures and parses ANSI escape sequences
+   - Extracts styling information (colors, bold, italic, etc.) from rendered output
+   - Handles RGB colors (`48;2;r;g;b`), bright colors (`90-97`), and basic colors (`30-37`)
+   - Creates styled segments with position and style metadata
+
+2. **chatHistoryLineSplitter** (`src/ui/utils/chatHistoryLineSplitter.ts`)
+   - Converts `ChatHistoryItem[]` into `ChatHistoryLine[]` (line-based items)
+   - Renders each message invisibly to `AnsiParsingStream` to capture styling
+   - Splits multi-line content into separate line items while preserving styling
+   - Handles all message types: user, assistant, system, tool calls
+
+3. **LineBasedMessage** (`src/ui/components/LineBasedMessage.tsx`)
+   - Renders individual line-based chat items
+   - Converts styled segments back to React `<Text>` components
+   - Handles spacing between messages automatically
+
+4. **StaticChatContent** (`src/ui/components/StaticChatContent.tsx`)
+   - Modified to use line-based rendering pipeline
+   - Processes chat history through line splitter before rendering
+
+## How It Works
+
+### 1. Invisible Rendering
+```
+ChatHistoryItem → MemoizedMessage → AnsiParsingStream → ANSI codes
+```
+
+Each chat history item is rendered invisibly using the original `MemoizedMessage` component to an `AnsiParsingStream`. This captures:
+- Tool calls with green dots: `● Read(file.txt)`
+- Tool outputs with colored diffs: red/green backgrounds
+- Markdown styling: bold, italic, code blocks
+- User message gray coloring
+- All spacing and indentation
+
+### 2. ANSI Parsing
+```
+ANSI codes → Styled segments with position/style metadata
+```
+
+The stream parses escape sequences like:
+- `\x1b[90m` → `color: 'gray'` (user messages)
+- `\x1b[48;2;113;47;55m` → `backgroundColor: 'rgb(113,47,55)'` (diff red background)
+- `\x1b[1m` → `bold: true`
+- `\x1b[9m` → `strikethrough: true`
+
+### 3. Line Splitting
+```
+Styled segments → ChatHistoryLine[] (one per line)
+```
+
+Multi-line content gets split into separate `ChatHistoryLine` items:
+- Each line becomes independent chat history item
+- Styling information preserved per line
+- Blank lines preserved as empty segments
+- Original message metadata maintained (`originalIndex`, `lineIndex`)
+
+### 4. Re-rendering
+```
+ChatHistoryLine[] → React components with preserved styling
+```
+
+Line-based items are rendered with styling reconstructed:
+- RGB colors converted to hex: `rgb(113,47,55)` → `#712f37`
+- ANSI segments become `<Text>` components with proper props
+- Spacing handled automatically from captured content
+
+## Key Features
+
+### Complete Styling Preservation
+- **RGB colors**: Full 24-bit color support for colored diffs
+- **Bright colors**: Support for gray text and other bright variants  
+- **All text styles**: Bold, italic, underline, strikethrough, dim, inverse
+- **Complex layouts**: Tool calls, diffs, code blocks, headers
+
+### Universal Processing
+- **All message types**: User, assistant, system messages processed identically
+- **Tool calls**: Complete tool call structure (dots, names, outputs) captured
+- **No special cases**: Single pipeline handles all content types
+- **Blank line preservation**: Empty lines maintained for proper spacing
+
+### Performance Optimized
+- **Invisible rendering**: No visual artifacts during processing
+- **Terminal width aware**: Rendering respects actual terminal dimensions
+- **Static/pending split**: Line-based items work with existing Static component logic
+- **Memoized components**: Efficient re-rendering with proper React keys
+
+## Data Flow
+
+```
+ChatHistoryItem[] 
+  ↓ (splitChatHistoryIntoLines)
+ChatHistoryLine[] 
+  ↓ (renderLineBasedMessage)  
+React components with styling
+  ↓ (Static/Pending rendering)
+Terminal output
+```
+
+## Benefits
+
+1. **No flickering**: Each line is a stable item in chat history
+2. **Granular control**: Individual lines can be managed independently  
+3. **Style fidelity**: Complete visual reproduction of original rendering
+4. **Extensible**: Works with any future message types without modification
+5. **Transparent**: Existing components work unchanged, styling captured automatically

--- a/extensions/cli/src/stream/streamChatResponse.getAllTools.test.ts
+++ b/extensions/cli/src/stream/streamChatResponse.getAllTools.test.ts
@@ -89,7 +89,7 @@ describe("getAllTools - Tool Filtering", () => {
     expect(toolNames).toContain("Bash");
     expect(toolNames).toContain("Read");
     expect(toolNames).toContain("Write");
-    expect(toolNames).toContain("Edit");
+    expect(toolNames).toContain("MultiEdit");
   });
 
   test("should include all tools in auto mode", async () => {
@@ -116,7 +116,7 @@ describe("getAllTools - Tool Filtering", () => {
     expect(toolNames).toContain("Bash");
     expect(toolNames).toContain("Read");
     expect(toolNames).toContain("Write");
-    expect(toolNames).toContain("Edit");
+    expect(toolNames).toContain("MultiEdit");
   });
 
   test("should respect explicit exclude in normal mode", async () => {

--- a/extensions/cli/src/stream/streamChatResponse.modeSwitch.test.ts
+++ b/extensions/cli/src/stream/streamChatResponse.modeSwitch.test.ts
@@ -43,7 +43,7 @@ describe("streamChatResponse - Mode Switch During Streaming", () => {
 
     // Should include write tools in normal mode
     expect(toolNames).toContain("Write");
-    expect(toolNames).toContain("Edit");
+    expect(toolNames).toContain("MultiEdit");
 
     // Switch to plan mode (simulating Shift+Tab during streaming)
     modeService.switchMode("plan");
@@ -91,7 +91,7 @@ describe("streamChatResponse - Mode Switch During Streaming", () => {
     // getAllTools should immediately reflect auto mode (all tools allowed)
     tools = await getAllTools();
     expect(tools.map((t) => t.function.name)).toContain("Write");
-    expect(tools.map((t) => t.function.name)).toContain("Edit");
+    expect(tools.map((t) => t.function.name)).toContain("MultiEdit");
     expect(tools.map((t) => t.function.name)).toContain("Read");
   });
 

--- a/extensions/cli/src/ui/CustomStdoutStream.test.tsx
+++ b/extensions/cli/src/ui/CustomStdoutStream.test.tsx
@@ -1,0 +1,519 @@
+import { Box, render, Text } from "ink";
+import React from "react";
+import { Writable } from "stream";
+
+class AnsiParsingStream extends Writable {
+  segments: Array<{
+    text: string;
+    position: { row: number; col: number };
+    endPosition: { row: number; col: number };
+    style: {
+      color: string | null;
+      backgroundColor: string | null;
+      bold: boolean;
+      italic: boolean;
+      underline: boolean;
+      strikethrough: boolean;
+      dim: boolean;
+      inverse: boolean;
+    };
+  }> = [];
+
+  currentPosition = { row: 0, col: 0 };
+  currentStyle = this.getDefaultStyle();
+  rawOutput = "";
+
+  constructor(options = {}) {
+    super(options);
+  }
+
+  getDefaultStyle() {
+    return {
+      color: null as string | null,
+      backgroundColor: null as string | null,
+      bold: false,
+      italic: false,
+      underline: false,
+      strikethrough: false,
+      dim: false,
+      inverse: false,
+    };
+  }
+
+  _write(
+    chunk: Buffer,
+    _encoding: string,
+    callback: (error?: Error | null) => void,
+  ) {
+    const data = chunk.toString();
+    this.rawOutput += data;
+    this.parseAnsiSequences(data);
+    callback();
+  }
+
+  parseAnsiSequences(data: string) {
+    const ansiRegex = /\x1b\[[0-9;]*[a-zA-Z]/g;
+    let lastIndex = 0;
+    let match;
+
+    while ((match = ansiRegex.exec(data)) !== null) {
+      if (match.index > lastIndex) {
+        const text = data.slice(lastIndex, match.index);
+        this.addTextSegment(text);
+      }
+
+      this.processEscapeSequence(match[0]);
+      lastIndex = match.index + match[0].length;
+    }
+
+    if (lastIndex < data.length) {
+      const text = data.slice(lastIndex);
+      this.addTextSegment(text);
+    }
+  }
+
+  addTextSegment(text: string) {
+    if (!text) return;
+
+    let currentText = "";
+    let currentCol = this.currentPosition.col;
+    let currentRow = this.currentPosition.row;
+
+    for (let i = 0; i < text.length; i++) {
+      const char = text[i];
+
+      if (char === "\n") {
+        if (currentText.length > 0) {
+          this.segments.push({
+            text: currentText,
+            position: { row: currentRow, col: currentCol },
+            endPosition: {
+              row: currentRow,
+              col: currentCol + currentText.length - 1,
+            },
+            style: { ...this.currentStyle },
+          });
+          currentText = "";
+        } else {
+          // Create empty segment for blank lines
+          this.segments.push({
+            text: "",
+            position: { row: currentRow, col: 0 },
+            endPosition: { row: currentRow, col: 0 },
+            style: { ...this.currentStyle },
+          });
+        }
+
+        currentRow++;
+        currentCol = 0;
+      } else if (char === "\r") {
+        if (currentText.length > 0) {
+          this.segments.push({
+            text: currentText,
+            position: { row: currentRow, col: currentCol },
+            endPosition: {
+              row: currentRow,
+              col: currentCol + currentText.length - 1,
+            },
+            style: { ...this.currentStyle },
+          });
+          currentText = "";
+        }
+
+        currentCol = 0;
+      } else {
+        currentText += char;
+      }
+    }
+
+    if (currentText.length > 0) {
+      this.segments.push({
+        text: currentText,
+        position: { row: currentRow, col: currentCol },
+        endPosition: {
+          row: currentRow,
+          col: currentCol + currentText.length - 1,
+        },
+        style: { ...this.currentStyle },
+      });
+      currentCol += currentText.length;
+    }
+
+    this.currentPosition.row = currentRow;
+    this.currentPosition.col = currentCol;
+  }
+
+  processEscapeSequence(sequence: string) {
+    const code = sequence.slice(2, -1);
+    const command = sequence.slice(-1);
+
+    if (command === "m") {
+      this.processSGR(code);
+    }
+  }
+
+  processSGR(code: string) {
+    const codes = code ? code.split(";").map(Number) : [0];
+
+    for (let i = 0; i < codes.length; i++) {
+      const num = codes[i];
+
+      switch (num) {
+        case 0:
+          this.currentStyle = this.getDefaultStyle();
+          break;
+        case 1:
+          this.currentStyle.bold = true;
+          break;
+        case 3:
+          this.currentStyle.italic = true;
+          break;
+        case 4:
+          this.currentStyle.underline = true;
+          break;
+        case 9:
+          this.currentStyle.strikethrough = true;
+          break;
+        case 22:
+          this.currentStyle.bold = false;
+          this.currentStyle.dim = false;
+          break;
+        case 23:
+          this.currentStyle.italic = false;
+          break;
+        case 24:
+          this.currentStyle.underline = false;
+          break;
+        case 29:
+          this.currentStyle.strikethrough = false;
+          break;
+        default:
+          if (num >= 30 && num <= 37) {
+            this.currentStyle.color = this.getColorName(num - 30);
+          } else if (num >= 90 && num <= 97) {
+            // Bright colors (90-97)
+            this.currentStyle.color = this.getBrightColorName(num - 90);
+          } else if (num >= 40 && num <= 47) {
+            this.currentStyle.backgroundColor = this.getColorName(num - 40);
+          } else if (num >= 100 && num <= 107) {
+            // Bright background colors (100-107)
+            this.currentStyle.backgroundColor = this.getBrightColorName(num - 100);
+          } else if (num === 38) {
+            // Extended foreground color
+            const colorInfo = this.parseExtendedColor(codes, i);
+            if (colorInfo) {
+              this.currentStyle.color = colorInfo.color;
+              i = colorInfo.nextIndex;
+            }
+          } else if (num === 48) {
+            // Extended background color
+            const colorInfo = this.parseExtendedColor(codes, i);
+            if (colorInfo) {
+              this.currentStyle.backgroundColor = colorInfo.color;
+              i = colorInfo.nextIndex;
+            }
+          } else if (num === 39) {
+            this.currentStyle.color = null;
+          } else if (num === 49) {
+            this.currentStyle.backgroundColor = null;
+          }
+          break;
+      }
+    }
+  }
+
+  parseExtendedColor(codes: number[], currentIndex: number) {
+    if (currentIndex + 1 >= codes.length) return null;
+    
+    const colorType = codes[currentIndex + 1];
+    
+    if (colorType === 5) {
+      // 256-color mode
+      if (currentIndex + 2 >= codes.length) return null;
+      const colorIndex = codes[currentIndex + 2];
+      return {
+        color: `ansi256-${colorIndex}`,
+        nextIndex: currentIndex + 2
+      };
+    } else if (colorType === 2) {
+      // RGB mode
+      if (currentIndex + 4 >= codes.length) return null;
+      const r = codes[currentIndex + 2];
+      const g = codes[currentIndex + 3];
+      const b = codes[currentIndex + 4];
+      return {
+        color: `rgb(${r},${g},${b})`,
+        nextIndex: currentIndex + 4
+      };
+    }
+    
+    return null;
+  }
+
+  getBrightColorName(colorIndex: number): string {
+    const brightColors = [
+      'blackBright', 'redBright', 'greenBright', 'yellowBright',
+      'blueBright', 'magentaBright', 'cyanBright', 'whiteBright'
+    ];
+    // For gray (bright black), use 'gray' which Ink recognizes
+    if (colorIndex === 0) return 'gray';
+    return brightColors[colorIndex] || `brightColor-${colorIndex}`;
+  }
+
+  getColorName(colorIndex: number): string {
+    const colors = [
+      "black",
+      "red",
+      "green",
+      "yellow",
+      "blue",
+      "magenta",
+      "cyan",
+      "white",
+    ];
+    return colors[colorIndex] || `color-${colorIndex}`;
+  }
+
+  getFormattedLines() {
+    const lines = new Map<number, typeof this.segments>();
+
+    this.segments.forEach((segment) => {
+      const row = segment.position.row;
+      if (!lines.has(row)) {
+        lines.set(row, []);
+      }
+      lines.get(row)!.push(segment);
+    });
+
+    lines.forEach((segments) => {
+      segments.sort((a, b) => a.position.col - b.position.col);
+    });
+
+    const result: Array<{
+      line: number;
+      segments: Array<{
+        text: string;
+        startCol: number;
+        endCol: number;
+        style: typeof this.currentStyle;
+      }>;
+    }> = [];
+
+    const sortedLines = Array.from(lines.entries()).sort(([a], [b]) => a - b);
+
+    sortedLines.forEach(([lineNum, segments]) => {
+      result.push({
+        line: lineNum,
+        segments: segments.map((segment) => ({
+          text: segment.text,
+          startCol: segment.position.col,
+          endCol: segment.endPosition.col,
+          style: segment.style,
+        })),
+      });
+    });
+
+    return result;
+  }
+}
+
+// Test component with individual styled text components
+const TestComponent: React.FC = () => (
+  <Box flexDirection="column">
+    <Box>
+      <Text bold>Bold </Text>
+      <Text strikethrough>strikethrough </Text>
+      <Text backgroundColor="red">red background</Text>
+    </Box>
+    <Box>
+      <Text>Normal </Text>
+      <Text color="blue" underline>
+        blue underlined
+      </Text>
+      <Text> text</Text>
+    </Box>
+  </Box>
+);
+
+describe("AnsiParsingStream", () => {
+  test("should render React component without ANSI codes in test environment", async () => {
+    const ansiStream = new AnsiParsingStream();
+
+    // Force color support
+    process.env.FORCE_COLOR = "1";
+
+    // Render the component to our custom stream
+    const { unmount } = render(<TestComponent />, {
+      stdout: ansiStream as any,
+    });
+
+    // Wait for rendering to complete
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    unmount();
+
+    const lines = ansiStream.getFormattedLines();
+
+    // In test environment, Ink renders plain text without ANSI codes
+    expect(lines.length).toBe(2);
+
+    // First line should have text content (but no styling in test mode)
+    const firstLine = lines[0];
+    expect(firstLine.segments.length).toBe(1);
+    expect(firstLine.segments[0].text).toBe(
+      "Bold strikethrough red background",
+    );
+
+    // Second line
+    const secondLine = lines[1];
+    expect(secondLine.segments.length).toBe(1);
+    expect(secondLine.segments[0].text).toBe("Normal blue underlined text");
+  });
+
+  test("should maintain proper column positions for multiple segments", async () => {
+    const ansiStream = new AnsiParsingStream();
+
+    const { unmount } = render(<TestComponent />, {
+      stdout: ansiStream as any,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    unmount();
+
+    const lines = ansiStream.getFormattedLines();
+    const firstLine = lines[0];
+
+    // Verify segments don't overlap and are in correct order
+    for (let i = 1; i < firstLine.segments.length; i++) {
+      const prevSegment = firstLine.segments[i - 1];
+      const currentSegment = firstLine.segments[i];
+
+      expect(currentSegment.startCol).toBeGreaterThanOrEqual(
+        prevSegment.endCol + 1,
+      );
+    }
+  });
+
+  test("should parse ANSI codes correctly when written directly", () => {
+    const ansiStream = new AnsiParsingStream();
+
+    // Write ANSI codes directly
+    const testData =
+      "\x1b[1mBold\x1b[22m \x1b[9mStrikethrough\x1b[29m \x1b[41mRed BG\x1b[49m";
+    ansiStream.write(testData);
+
+    const lines = ansiStream.getFormattedLines();
+
+    expect(lines.length).toBe(1);
+    const segments = lines[0].segments;
+
+    // Should have multiple segments with different styles
+    expect(segments.length).toBeGreaterThan(1);
+
+    // Check for bold segment
+    const boldSegment = segments.find((s) => s.style.bold);
+    expect(boldSegment).toBeDefined();
+    expect(boldSegment?.text).toBe("Bold");
+
+    // Check for strikethrough segment
+    const strikethroughSegment = segments.find((s) => s.style.strikethrough);
+    expect(strikethroughSegment).toBeDefined();
+    expect(strikethroughSegment?.text).toBe("Strikethrough");
+
+    // Check for red background segment
+    const redBgSegment = segments.find(
+      (s) => s.style.backgroundColor === "red",
+    );
+    expect(redBgSegment).toBeDefined();
+    expect(redBgSegment?.text).toBe("Red BG");
+  });
+
+  test('should preserve blank lines and newlines correctly', () => {
+    const ansiStream = new AnsiParsingStream();
+    
+    // Write text with blank lines
+    const testData = 'First line\n\nSecond line after blank\n\n\nThird line after two blanks';
+    ansiStream.write(testData);
+    
+    const lines = ansiStream.getFormattedLines();
+    
+    console.log('Blank line test - formatted lines:', lines);
+    console.log('Raw test data:', JSON.stringify(testData));
+    
+    // Should capture all lines including blank ones
+    expect(lines.length).toBe(6); // 3 content lines + 3 blank lines
+    
+    // Check line contents
+    expect(lines[0].segments[0].text).toBe('First line');
+    expect(lines[1].segments.length).toBe(1); // Blank line has empty segment
+    expect(lines[1].segments[0].text).toBe(''); // Empty segment
+    expect(lines[2].segments[0].text).toBe('Second line after blank');
+    expect(lines[3].segments.length).toBe(1); // Blank line has empty segment
+    expect(lines[3].segments[0].text).toBe(''); // Empty segment
+    expect(lines[4].segments.length).toBe(1); // Blank line has empty segment  
+    expect(lines[4].segments[0].text).toBe(''); // Empty segment
+    expect(lines[5].segments[0].text).toBe('Third line after two blanks');
+  });
+
+  test('should parse RGB colors correctly', () => {
+    const ansiStream = new AnsiParsingStream();
+    
+    // Write RGB ANSI codes like we see in the diff output
+    const testData = '\x1b[48;2;113;47;55m\x1b[38;2;167;94;109mRed BG Text\x1b[49m\x1b[39m \x1b[48;2;50;91;48m\x1b[38;2;89;164;103mGreen BG Text\x1b[49m\x1b[39m';
+    ansiStream.write(testData);
+    
+    const lines = ansiStream.getFormattedLines();
+    
+    console.log('RGB test segments:', lines[0].segments.map(s => ({
+      text: s.text,
+      color: s.style.color,
+      backgroundColor: s.style.backgroundColor
+    })));
+    
+    expect(lines.length).toBe(1);
+    const segments = lines[0].segments;
+    
+    // Should have segments with RGB colors
+    expect(segments.length).toBeGreaterThan(1);
+    
+    // Check for RGB background colors
+    const redBgSegment = segments.find(s => s.style.backgroundColor?.includes('113,47,55'));
+    const greenBgSegment = segments.find(s => s.style.backgroundColor?.includes('50,91,48'));
+    
+    expect(redBgSegment).toBeDefined();
+    expect(greenBgSegment).toBeDefined();
+  });
+
+  test('should parse bright colors like gray correctly', () => {
+    const ansiStream = new AnsiParsingStream();
+    
+    // Test bright colors including gray (90)
+    const testData = '\x1b[34m●\x1b[39m \x1b[90mGray text\x1b[39m \x1b[91mBright red\x1b[39m';
+    ansiStream.write(testData);
+    
+    const lines = ansiStream.getFormattedLines();
+    
+    console.log('Bright color test segments:', lines[0].segments.map(s => ({
+      text: s.text,
+      color: s.style.color
+    })));
+    
+    expect(lines.length).toBe(1);
+    const segments = lines[0].segments;
+    
+    // Check for blue bullet
+    const blueSegment = segments.find(s => s.style.color === 'blue');
+    expect(blueSegment).toBeDefined();
+    expect(blueSegment?.text).toBe('●');
+    
+    // Check for gray text
+    const graySegment = segments.find(s => s.style.color === 'gray');
+    expect(graySegment).toBeDefined();
+    expect(graySegment?.text).toBe('Gray text');
+    
+    // Check for bright red
+    const brightRedSegment = segments.find(s => s.style.color === 'redBright');
+    expect(brightRedSegment).toBeDefined();
+    expect(brightRedSegment?.text).toBe('Bright red');
+  });
+});

--- a/extensions/cli/src/ui/components/LineBasedMessage.tsx
+++ b/extensions/cli/src/ui/components/LineBasedMessage.tsx
@@ -1,0 +1,73 @@
+import { Box, Text } from "ink";
+import React, { memo } from "react";
+
+import type { ChatHistoryLine } from "../utils/chatHistoryLineSplitter.js";
+import { createStyledTextFromSegments } from "../utils/chatHistoryLineSplitter.js";
+
+interface LineBasedMessageProps {
+  item: ChatHistoryLine;
+  index: number;
+}
+
+export const LineBasedMessage = memo<LineBasedMessageProps>(
+  ({ item, index }) => {
+    const { message, styledSegments } = item;
+    const isUser = message.role === "user";
+    const isSystem = message.role === "system";
+
+    // console.log(`[DEBUG] LineBasedMessage ${index}: originalIndex=${item.originalIndex}, lineIndex=${item.lineIndex}, content="${message.content.slice(0, 50)}...", segments=${styledSegments?.length || 0}`);
+
+    // Handle system messages
+    if (isSystem) {
+      // Skip displaying the first system message (typically LLM system prompt)
+      if (item.originalIndex === 0) {
+        return null;
+      }
+
+      return (
+        <Box key={index} marginBottom={1}>
+          <Text color="gray" italic>
+            {message.content}
+          </Text>
+        </Box>
+      );
+    }
+
+    // Handle regular messages - let ANSI stream provide all formatting including spacing
+    return (
+      <Box key={index}>
+        {/* DEBUG: Add X prefix to every other line */}
+        {/* {index % 2 === 1 && <Text color="red">X </Text>} */}
+
+        {/* Render content with styling if available - all formatting comes from ANSI stream */}
+        {message.content === '' ? (
+          // Render blank lines as empty space (blank lines now have empty segments)
+          <Text> </Text>
+        ) : styledSegments && styledSegments.length > 0 ? (
+          // Use ANSI-parsed styling information
+          <Box>
+            {createStyledTextFromSegments(styledSegments)}
+          </Box>
+        ) : (
+          // Fallback to simple text rendering
+          <Text color={isUser ? "gray" : "white"}>
+            {message.content}
+          </Text>
+        )}
+      </Box>
+    );
+  },
+  (prevProps, nextProps) => {
+    // Custom comparison for performance
+    const prevMessage = prevProps.item.message;
+    const nextMessage = nextProps.item.message;
+
+    return (
+      prevMessage.content === nextMessage.content &&
+      prevMessage.role === nextMessage.role &&
+      prevProps.item.originalIndex === nextProps.item.originalIndex &&
+      prevProps.item.lineIndex === nextProps.item.lineIndex &&
+      prevProps.index === nextProps.index
+    );
+  }
+);

--- a/extensions/cli/src/ui/components/LineBasedMessage.tsx
+++ b/extensions/cli/src/ui/components/LineBasedMessage.tsx
@@ -40,19 +40,15 @@ export const LineBasedMessage = memo<LineBasedMessageProps>(
         {/* {index % 2 === 1 && <Text color="red">X </Text>} */}
 
         {/* Render content with styling if available - all formatting comes from ANSI stream */}
-        {message.content === '' ? (
+        {message.content === "" ? (
           // Render blank lines as empty space (blank lines now have empty segments)
           <Text> </Text>
         ) : styledSegments && styledSegments.length > 0 ? (
           // Use ANSI-parsed styling information
-          <Box>
-            {createStyledTextFromSegments(styledSegments)}
-          </Box>
+          <Box>{createStyledTextFromSegments(styledSegments)}</Box>
         ) : (
           // Fallback to simple text rendering
-          <Text color={isUser ? "gray" : "white"}>
-            {message.content}
-          </Text>
+          <Text color={isUser ? "gray" : "white"}>{message.content}</Text>
         )}
       </Box>
     );
@@ -69,5 +65,5 @@ export const LineBasedMessage = memo<LineBasedMessageProps>(
       prevProps.item.lineIndex === nextProps.item.lineIndex &&
       prevProps.index === nextProps.index
     );
-  }
+  },
 );

--- a/extensions/cli/src/ui/components/StaticChatContent.tsx
+++ b/extensions/cli/src/ui/components/StaticChatContent.tsx
@@ -11,13 +11,16 @@ import React, {
 import type { ChatHistoryItem } from "../../../../../core/index.js";
 import type { MCPService } from "../../services/MCPService.js";
 import type { QueuedMessage } from "../../stream/messageQueue.js";
-import { useTerminalSize } from "../hooks/useTerminalSize.js";
 import { useLineBasedMessageRenderer } from "../hooks/useLineBasedMessageRenderer.js";
+import { useTerminalSize } from "../hooks/useTerminalSize.js";
 import { IntroMessage } from "../IntroMessage.js";
 import {
-  splitChatHistoryIntoLines,
   ChatHistoryLine,
+  splitChatHistoryIntoLines,
 } from "../utils/chatHistoryLineSplitter.js";
+
+// Toggle line-based rendering (comment out to disable)
+const USE_LINE_BASED_RENDERING = true;
 
 interface StaticChatContentProps {
   showIntroMessage: boolean;
@@ -26,7 +29,7 @@ interface StaticChatContentProps {
   mcpService?: MCPService;
   chatHistory: ChatHistoryItem[];
   queuedMessages?: QueuedMessage[];
-  renderMessage: (item: ChatHistoryItem, index: number) => React.ReactElement; // Keep for compatibility but won't use
+  renderMessage: (item: ChatHistoryItem, index: number) => React.ReactElement;
   refreshTrigger?: number;
 }
 
@@ -37,7 +40,7 @@ export const StaticChatContent: React.FC<StaticChatContentProps> = ({
   mcpService,
   chatHistory,
   queuedMessages = [],
-  renderMessage, // Keep for compatibility but won't use
+  renderMessage,
   refreshTrigger,
 }) => {
   const { columns, rows } = useTerminalSize();
@@ -56,8 +59,13 @@ export const StaticChatContent: React.FC<StaticChatContentProps> = ({
     stdout.write("\x1b[3J");
   }, [stdout]);
 
-  // Convert chat history to line-based format
+  // Convert chat history to line-based format (if enabled)
   useEffect(() => {
+    if (!USE_LINE_BASED_RENDERING) {
+      setLineChatHistory([]);
+      return;
+    }
+
     let isCancelled = false;
 
     const convertToLines = async () => {
@@ -121,6 +129,13 @@ export const StaticChatContent: React.FC<StaticChatContentProps> = ({
     }
   }, [refreshTrigger, refreshStatic]);
 
+  // Filter out system messages without content (for original rendering)
+  const filteredChatHistory = useMemo(() => {
+    return chatHistory.filter(
+      (item) => item.message.role !== "system" || item.message.content,
+    );
+  }, [chatHistory]);
+
   // Split into stable and pending items
   const { staticItems, pendingItems } = useMemo(() => {
     const staticItems: React.ReactElement[] = [];
@@ -137,41 +152,57 @@ export const StaticChatContent: React.FC<StaticChatContentProps> = ({
       );
     }
 
-    // Remove processing indicator to prevent screen clearing
-    // if (isProcessingLines) {
-    //   staticItems.push(
-    //     <Box key="processing" paddingLeft={2}>
-    //       <Text color="gray" italic>Processing chat history...</Text>
-    //     </Box>
-    //   );
-    //   return { staticItems, pendingItems: [] };
-    // }
+    if (USE_LINE_BASED_RENDERING) {
+      // Use line-based rendering
+      const PENDING_ITEMS_COUNT = 1;
+      const stableCount = Math.max(
+        0,
+        lineChatHistory.length - PENDING_ITEMS_COUNT,
+      );
 
-    const PENDING_ITEMS_COUNT = 1;
-    const stableCount = Math.max(
-      0,
-      lineChatHistory.length - PENDING_ITEMS_COUNT,
-    );
+      // Add stable messages to static items
+      const stableHistory = lineChatHistory.slice(0, stableCount);
+      stableHistory.forEach((item, index) => {
+        staticItems.push(renderLineBasedMessage(item, index));
+      });
 
-    // Add stable messages to static items
-    const stableHistory = lineChatHistory.slice(0, stableCount);
-    stableHistory.forEach((item, index) => {
-      staticItems.push(renderLineBasedMessage(item, index));
-    });
+      const pendingHistory = lineChatHistory.slice(stableCount);
+      const pendingItems = pendingHistory.map((item, index) =>
+        renderLineBasedMessage(item, stableCount + index),
+      );
 
-    const pendingHistory = lineChatHistory.slice(stableCount);
-    const pendingItems = pendingHistory.map((item, index) =>
-      renderLineBasedMessage(item, stableCount + index),
-    );
+      return { staticItems, pendingItems };
+    } else {
+      // Use original rendering
+      const PENDING_ITEMS_COUNT = 1;
+      const stableCount = Math.max(
+        0,
+        filteredChatHistory.length - PENDING_ITEMS_COUNT,
+      );
+      const stableHistory = filteredChatHistory.slice(0, stableCount);
+      const pendingHistory = filteredChatHistory.slice(stableCount);
 
-    return { staticItems, pendingItems };
+      // Add stable messages to static items
+      stableHistory.forEach((item, index) => {
+        staticItems.push(renderMessage(item, index));
+      });
+
+      // Pending items will be rendered dynamically outside Static
+      const pendingItems = pendingHistory.map((item, index) =>
+        renderMessage(item, stableCount + index),
+      );
+
+      return { staticItems, pendingItems };
+    }
   }, [
     showIntroMessage,
     config,
     model,
     mcpService,
     lineChatHistory,
+    filteredChatHistory,
     renderLineBasedMessage,
+    renderMessage,
   ]);
 
   return (

--- a/extensions/cli/src/ui/components/StaticChatContent.tsx
+++ b/extensions/cli/src/ui/components/StaticChatContent.tsx
@@ -1,12 +1,14 @@
 import type { AssistantUnrolled, ModelConfig } from "@continuedev/config-yaml";
 import { Box, Static, Text, useStdout } from "ink";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { ChatHistoryItem } from "../../../../../core/index.js";
 import type { MCPService } from "../../services/MCPService.js";
 import type { QueuedMessage } from "../../stream/messageQueue.js";
 import { useTerminalSize } from "../hooks/useTerminalSize.js";
+import { useLineBasedMessageRenderer } from "../hooks/useLineBasedMessageRenderer.js";
 import { IntroMessage } from "../IntroMessage.js";
+import { splitChatHistoryIntoLines, ChatHistoryLine } from "../utils/chatHistoryLineSplitter.js";
 
 interface StaticChatContentProps {
   showIntroMessage: boolean;
@@ -15,8 +17,8 @@ interface StaticChatContentProps {
   mcpService?: MCPService;
   chatHistory: ChatHistoryItem[];
   queuedMessages?: QueuedMessage[];
-  renderMessage: (item: ChatHistoryItem, index: number) => React.ReactElement;
-  refreshTrigger?: number; // Add a prop to trigger refresh from parent
+  renderMessage: (item: ChatHistoryItem, index: number) => React.ReactElement; // Keep for compatibility but won't use
+  refreshTrigger?: number;
 }
 
 export const StaticChatContent: React.FC<StaticChatContentProps> = ({
@@ -26,25 +28,63 @@ export const StaticChatContent: React.FC<StaticChatContentProps> = ({
   mcpService,
   chatHistory,
   queuedMessages = [],
-  renderMessage,
+  renderMessage, // Keep for compatibility but won't use
   refreshTrigger,
 }) => {
   const { columns, rows } = useTerminalSize();
   const { stdout } = useStdout();
+  const { renderLineBasedMessage } = useLineBasedMessageRenderer();
 
-  // State for managing static refresh with key-based remounting (gemini-cli approach)
+  // State for managing static refresh with key-based remounting
   const [staticKey, setStaticKey] = useState(0);
+  const [lineChatHistory, setLineChatHistory] = useState<ChatHistoryLine[]>([]);
   const isInitialMount = useRef(true);
 
   // Refresh function that clears terminal and remounts Static component
   const refreshStatic = useCallback(() => {
-    // Clear terminal completely including scrollback buffer (3J)
     stdout.write("\x1b[2J\x1b[H");
     setStaticKey((prev) => prev + 1);
     stdout.write("\x1b[3J");
   }, [stdout]);
 
-  // Debounced terminal resize handler (300ms like gemini-cli)
+  // Convert chat history to line-based format
+  useEffect(() => {
+    let isCancelled = false;
+    
+    const convertToLines = async () => {
+      try {
+        // Filter out system messages without content
+        const filteredChatHistory = chatHistory.filter(
+          (item) => item.message.role !== "system" || item.message.content,
+        );
+
+        // Only process if we have new content
+        if (filteredChatHistory.length === 0) {
+          setLineChatHistory([]);
+          return;
+        }
+
+        const lines = await splitChatHistoryIntoLines(filteredChatHistory, columns);
+        
+        if (!isCancelled) {
+          setLineChatHistory(lines);
+        }
+      } catch (error) {
+        console.error('Failed to convert chat history to lines:', error);
+        if (!isCancelled) {
+          setLineChatHistory([]);
+        }
+      }
+    };
+
+    convertToLines();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [chatHistory, columns]);
+
+  // Debounced terminal resize handler
   useEffect(() => {
     // Skip refreshing Static during first mount
     if (isInitialMount.current) {
@@ -69,18 +109,11 @@ export const StaticChatContent: React.FC<StaticChatContentProps> = ({
     }
   }, [refreshTrigger, refreshStatic]);
 
-  // Filter out system messages without content
-  const filteredChatHistory = React.useMemo(() => {
-    return chatHistory.filter(
-      (item) => item.message.role !== "system" || item.message.content,
-    );
-  }, [chatHistory]);
-
-  // Split chat history into stable and pending items
-  // The last two items may have pending tool calls
-  const { staticItems, pendingItems } = React.useMemo(() => {
-    // Add intro message as first item if it should be shown
+  // Split into stable and pending items
+  const { staticItems, pendingItems } = useMemo(() => {
     const staticItems: React.ReactElement[] = [];
+    
+    // Add intro message if it should be shown
     if (showIntroMessage) {
       staticItems.push(
         <IntroMessage
@@ -92,35 +125,38 @@ export const StaticChatContent: React.FC<StaticChatContentProps> = ({
       );
     }
 
-    const PENDING_ITEMS_COUNT = 1;
-    const stableCount = Math.max(
-      0,
-      filteredChatHistory.length - PENDING_ITEMS_COUNT,
-    );
-    const stableHistory = filteredChatHistory.slice(0, stableCount);
-    const pendingHistory = filteredChatHistory.slice(stableCount);
+    // Remove processing indicator to prevent screen clearing
+    // if (isProcessingLines) {
+    //   staticItems.push(
+    //     <Box key="processing" paddingLeft={2}>
+    //       <Text color="gray" italic>Processing chat history...</Text>
+    //     </Box>
+    //   );
+    //   return { staticItems, pendingItems: [] };
+    // }
 
+    const PENDING_ITEMS_COUNT = 1;
+    const stableCount = Math.max(0, lineChatHistory.length - PENDING_ITEMS_COUNT);
+    
     // Add stable messages to static items
+    const stableHistory = lineChatHistory.slice(0, stableCount);
     stableHistory.forEach((item, index) => {
-      staticItems.push(renderMessage(item, index));
+      staticItems.push(renderLineBasedMessage(item, index));
     });
 
-    // Pending items will be rendered dynamically outside Static
+    const pendingHistory = lineChatHistory.slice(stableCount);
     const pendingItems = pendingHistory.map((item, index) =>
-      renderMessage(item, stableCount + index),
+      renderLineBasedMessage(item, stableCount + index),
     );
 
-    return {
-      staticItems,
-      pendingItems,
-    };
+    return { staticItems, pendingItems };
   }, [
     showIntroMessage,
     config,
     model,
     mcpService,
-    filteredChatHistory,
-    renderMessage,
+    lineChatHistory,
+    renderLineBasedMessage,
   ]);
 
   return (

--- a/extensions/cli/src/ui/components/StaticChatContent.tsx
+++ b/extensions/cli/src/ui/components/StaticChatContent.tsx
@@ -1,6 +1,12 @@
 import type { AssistantUnrolled, ModelConfig } from "@continuedev/config-yaml";
 import { Box, Static, Text, useStdout } from "ink";
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import type { ChatHistoryItem } from "../../../../../core/index.js";
 import type { MCPService } from "../../services/MCPService.js";
@@ -8,7 +14,10 @@ import type { QueuedMessage } from "../../stream/messageQueue.js";
 import { useTerminalSize } from "../hooks/useTerminalSize.js";
 import { useLineBasedMessageRenderer } from "../hooks/useLineBasedMessageRenderer.js";
 import { IntroMessage } from "../IntroMessage.js";
-import { splitChatHistoryIntoLines, ChatHistoryLine } from "../utils/chatHistoryLineSplitter.js";
+import {
+  splitChatHistoryIntoLines,
+  ChatHistoryLine,
+} from "../utils/chatHistoryLineSplitter.js";
 
 interface StaticChatContentProps {
   showIntroMessage: boolean;
@@ -50,7 +59,7 @@ export const StaticChatContent: React.FC<StaticChatContentProps> = ({
   // Convert chat history to line-based format
   useEffect(() => {
     let isCancelled = false;
-    
+
     const convertToLines = async () => {
       try {
         // Filter out system messages without content
@@ -64,13 +73,16 @@ export const StaticChatContent: React.FC<StaticChatContentProps> = ({
           return;
         }
 
-        const lines = await splitChatHistoryIntoLines(filteredChatHistory, columns);
-        
+        const lines = await splitChatHistoryIntoLines(
+          filteredChatHistory,
+          columns,
+        );
+
         if (!isCancelled) {
           setLineChatHistory(lines);
         }
       } catch (error) {
-        console.error('Failed to convert chat history to lines:', error);
+        console.error("Failed to convert chat history to lines:", error);
         if (!isCancelled) {
           setLineChatHistory([]);
         }
@@ -112,7 +124,7 @@ export const StaticChatContent: React.FC<StaticChatContentProps> = ({
   // Split into stable and pending items
   const { staticItems, pendingItems } = useMemo(() => {
     const staticItems: React.ReactElement[] = [];
-    
+
     // Add intro message if it should be shown
     if (showIntroMessage) {
       staticItems.push(
@@ -136,8 +148,11 @@ export const StaticChatContent: React.FC<StaticChatContentProps> = ({
     // }
 
     const PENDING_ITEMS_COUNT = 1;
-    const stableCount = Math.max(0, lineChatHistory.length - PENDING_ITEMS_COUNT);
-    
+    const stableCount = Math.max(
+      0,
+      lineChatHistory.length - PENDING_ITEMS_COUNT,
+    );
+
     // Add stable messages to static items
     const stableHistory = lineChatHistory.slice(0, stableCount);
     stableHistory.forEach((item, index) => {

--- a/extensions/cli/src/ui/hooks/useLineBasedMessageRenderer.tsx
+++ b/extensions/cli/src/ui/hooks/useLineBasedMessageRenderer.tsx
@@ -1,0 +1,17 @@
+import React, { useCallback } from "react";
+
+import { LineBasedMessage } from "../components/LineBasedMessage.js";
+import type { ChatHistoryLine } from "../utils/chatHistoryLineSplitter.js";
+
+export function useLineBasedMessageRenderer() {
+  const renderLineBasedMessage = useCallback((item: ChatHistoryLine, index: number) => {
+    // Generate a unique key using original index, line index, and content hash
+    const messageContent = item.message.content;
+    const contentHash = messageContent.slice(0, 50);
+    const uniqueKey = `line-${item.originalIndex}-${item.lineIndex}-${contentHash}-${index}`;
+
+    return <LineBasedMessage key={uniqueKey} item={item} index={index} />;
+  }, []);
+
+  return { renderLineBasedMessage };
+}

--- a/extensions/cli/src/ui/hooks/useLineBasedMessageRenderer.tsx
+++ b/extensions/cli/src/ui/hooks/useLineBasedMessageRenderer.tsx
@@ -4,14 +4,17 @@ import { LineBasedMessage } from "../components/LineBasedMessage.js";
 import type { ChatHistoryLine } from "../utils/chatHistoryLineSplitter.js";
 
 export function useLineBasedMessageRenderer() {
-  const renderLineBasedMessage = useCallback((item: ChatHistoryLine, index: number) => {
-    // Generate a unique key using original index, line index, and content hash
-    const messageContent = item.message.content;
-    const contentHash = messageContent.slice(0, 50);
-    const uniqueKey = `line-${item.originalIndex}-${item.lineIndex}-${contentHash}-${index}`;
+  const renderLineBasedMessage = useCallback(
+    (item: ChatHistoryLine, index: number) => {
+      // Generate a unique key using original index, line index, and content hash
+      const messageContent = item.message.content;
+      const contentHash = messageContent.slice(0, 50);
+      const uniqueKey = `line-${item.originalIndex}-${item.lineIndex}-${contentHash}-${index}`;
 
-    return <LineBasedMessage key={uniqueKey} item={item} index={index} />;
-  }, []);
+      return <LineBasedMessage key={uniqueKey} item={item} index={index} />;
+    },
+    [],
+  );
 
   return { renderLineBasedMessage };
 }

--- a/extensions/cli/src/ui/utils/AnsiParsingStream.ts
+++ b/extensions/cli/src/ui/utils/AnsiParsingStream.ts
@@ -1,4 +1,4 @@
-import { Writable } from 'stream';
+import { Writable } from "stream";
 
 export interface StyleInfo {
   color: string | null;
@@ -33,7 +33,7 @@ export class AnsiParsingStream extends Writable {
 
   currentPosition = { row: 0, col: 0 };
   currentStyle = this.getDefaultStyle();
-  rawOutput = '';
+  rawOutput = "";
 
   // TTY-like properties to make Ink think this is a terminal
   isTTY = false;
@@ -53,11 +53,15 @@ export class AnsiParsingStream extends Writable {
       underline: false,
       strikethrough: false,
       dim: false,
-      inverse: false
+      inverse: false,
     };
   }
 
-  _write(chunk: Buffer, _encoding: string, callback: (error?: Error | null) => void) {
+  _write(
+    chunk: Buffer,
+    _encoding: string,
+    callback: (error?: Error | null) => void,
+  ) {
     const data = chunk.toString();
     this.rawOutput += data;
     this.parseAnsiSequences(data);
@@ -87,62 +91,71 @@ export class AnsiParsingStream extends Writable {
 
   addTextSegment(text: string) {
     if (!text) return;
-    
-    let currentText = '';
+
+    let currentText = "";
     let currentCol = this.currentPosition.col;
     let currentRow = this.currentPosition.row;
-    
+
     for (let i = 0; i < text.length; i++) {
       const char = text[i];
-      
-      if (char === '\n') {
+
+      if (char === "\n") {
         if (currentText.length > 0) {
           this.segments.push({
             text: currentText,
             position: { row: currentRow, col: currentCol },
-            endPosition: { row: currentRow, col: currentCol + currentText.length - 1 },
-            style: { ...this.currentStyle }
+            endPosition: {
+              row: currentRow,
+              col: currentCol + currentText.length - 1,
+            },
+            style: { ...this.currentStyle },
           });
-          currentText = '';
+          currentText = "";
         } else {
           // Create empty segment for blank lines
           this.segments.push({
-            text: '',
+            text: "",
             position: { row: currentRow, col: 0 },
             endPosition: { row: currentRow, col: 0 },
-            style: { ...this.currentStyle }
+            style: { ...this.currentStyle },
           });
         }
-        
+
         currentRow++;
         currentCol = 0;
-      } else if (char === '\r') {
+      } else if (char === "\r") {
         if (currentText.length > 0) {
           this.segments.push({
             text: currentText,
             position: { row: currentRow, col: currentCol },
-            endPosition: { row: currentRow, col: currentCol + currentText.length - 1 },
-            style: { ...this.currentStyle }
+            endPosition: {
+              row: currentRow,
+              col: currentCol + currentText.length - 1,
+            },
+            style: { ...this.currentStyle },
           });
-          currentText = '';
+          currentText = "";
         }
-        
+
         currentCol = 0;
       } else {
         currentText += char;
       }
     }
-    
+
     if (currentText.length > 0) {
       this.segments.push({
         text: currentText,
         position: { row: currentRow, col: currentCol },
-        endPosition: { row: currentRow, col: currentCol + currentText.length - 1 },
-        style: { ...this.currentStyle }
+        endPosition: {
+          row: currentRow,
+          col: currentCol + currentText.length - 1,
+        },
+        style: { ...this.currentStyle },
       });
       currentCol += currentText.length;
     }
-    
+
     this.currentPosition.row = currentRow;
     this.currentPosition.col = currentCol;
   }
@@ -151,17 +164,17 @@ export class AnsiParsingStream extends Writable {
     const code = sequence.slice(2, -1);
     const command = sequence.slice(-1);
 
-    if (command === 'm') {
+    if (command === "m") {
       this.processSGR(code);
     }
   }
 
   processSGR(code: string) {
-    const codes = code ? code.split(';').map(Number) : [0];
-    
+    const codes = code ? code.split(";").map(Number) : [0];
+
     for (let i = 0; i < codes.length; i++) {
       const num = codes[i];
-      
+
       switch (num) {
         case 0:
           this.currentStyle = this.getDefaultStyle();
@@ -201,7 +214,9 @@ export class AnsiParsingStream extends Writable {
             this.currentStyle.backgroundColor = this.getColorName(num - 40);
           } else if (num >= 100 && num <= 107) {
             // Bright background colors (100-107)
-            this.currentStyle.backgroundColor = this.getBrightColorName(num - 100);
+            this.currentStyle.backgroundColor = this.getBrightColorName(
+              num - 100,
+            );
           } else if (num === 38) {
             // Extended foreground color
             const colorInfo = this.parseExtendedColor(codes, i);
@@ -228,16 +243,16 @@ export class AnsiParsingStream extends Writable {
 
   parseExtendedColor(codes: number[], currentIndex: number) {
     if (currentIndex + 1 >= codes.length) return null;
-    
+
     const colorType = codes[currentIndex + 1];
-    
+
     if (colorType === 5) {
       // 256-color mode
       if (currentIndex + 2 >= codes.length) return null;
       const colorIndex = codes[currentIndex + 2];
       return {
         color: `ansi256-${colorIndex}`,
-        nextIndex: currentIndex + 2
+        nextIndex: currentIndex + 2,
       };
     } else if (colorType === 2) {
       // RGB mode
@@ -247,61 +262,73 @@ export class AnsiParsingStream extends Writable {
       const b = codes[currentIndex + 4];
       return {
         color: `rgb(${r},${g},${b})`,
-        nextIndex: currentIndex + 4
+        nextIndex: currentIndex + 4,
       };
     }
-    
+
     return null;
   }
 
   getColorName(colorIndex: number): string {
     const colors = [
-      'black', 'red', 'green', 'yellow',
-      'blue', 'magenta', 'cyan', 'white'
+      "black",
+      "red",
+      "green",
+      "yellow",
+      "blue",
+      "magenta",
+      "cyan",
+      "white",
     ];
     return colors[colorIndex] || `color-${colorIndex}`;
   }
 
   getBrightColorName(colorIndex: number): string {
     const brightColors = [
-      'blackBright', 'redBright', 'greenBright', 'yellowBright',
-      'blueBright', 'magentaBright', 'cyanBright', 'whiteBright'
+      "blackBright",
+      "redBright",
+      "greenBright",
+      "yellowBright",
+      "blueBright",
+      "magentaBright",
+      "cyanBright",
+      "whiteBright",
     ];
     // For gray (bright black), use 'gray' which Ink recognizes
-    if (colorIndex === 0) return 'gray';
+    if (colorIndex === 0) return "gray";
     return brightColors[colorIndex] || `brightColor-${colorIndex}`;
   }
 
   getFormattedLines(): StyledLine[] {
     const lines = new Map<number, typeof this.segments>();
-    
-    this.segments.forEach(segment => {
+
+    this.segments.forEach((segment) => {
       const row = segment.position.row;
       if (!lines.has(row)) {
         lines.set(row, []);
       }
       lines.get(row)!.push(segment);
     });
-    
+
     lines.forEach((segments) => {
       segments.sort((a, b) => a.position.col - b.position.col);
     });
-    
+
     const result: StyledLine[] = [];
     const sortedLines = Array.from(lines.entries()).sort(([a], [b]) => a - b);
-    
+
     sortedLines.forEach(([lineNum, segments]) => {
       result.push({
         line: lineNum,
-        segments: segments.map(segment => ({
+        segments: segments.map((segment) => ({
           text: segment.text,
           startCol: segment.position.col,
           endCol: segment.endPosition.col,
-          style: segment.style
-        }))
+          style: segment.style,
+        })),
       });
     });
-    
+
     return result;
   }
 
@@ -309,6 +336,6 @@ export class AnsiParsingStream extends Writable {
     this.segments = [];
     this.currentPosition = { row: 0, col: 0 };
     this.currentStyle = this.getDefaultStyle();
-    this.rawOutput = '';
+    this.rawOutput = "";
   }
 }

--- a/extensions/cli/src/ui/utils/AnsiParsingStream.ts
+++ b/extensions/cli/src/ui/utils/AnsiParsingStream.ts
@@ -1,0 +1,314 @@
+import { Writable } from 'stream';
+
+export interface StyleInfo {
+  color: string | null;
+  backgroundColor: string | null;
+  bold: boolean;
+  italic: boolean;
+  underline: boolean;
+  strikethrough: boolean;
+  dim: boolean;
+  inverse: boolean;
+}
+
+export interface StyledSegment {
+  text: string;
+  startCol: number;
+  endCol: number;
+  style: StyleInfo;
+}
+
+export interface StyledLine {
+  line: number;
+  segments: StyledSegment[];
+}
+
+export class AnsiParsingStream extends Writable {
+  segments: Array<{
+    text: string;
+    position: { row: number; col: number };
+    endPosition: { row: number; col: number };
+    style: StyleInfo;
+  }> = [];
+
+  currentPosition = { row: 0, col: 0 };
+  currentStyle = this.getDefaultStyle();
+  rawOutput = '';
+
+  // TTY-like properties to make Ink think this is a terminal
+  isTTY = false;
+  columns = 80;
+  rows = 24;
+
+  constructor(options = {}) {
+    super(options);
+  }
+
+  getDefaultStyle(): StyleInfo {
+    return {
+      color: null as string | null,
+      backgroundColor: null as string | null,
+      bold: false,
+      italic: false,
+      underline: false,
+      strikethrough: false,
+      dim: false,
+      inverse: false
+    };
+  }
+
+  _write(chunk: Buffer, _encoding: string, callback: (error?: Error | null) => void) {
+    const data = chunk.toString();
+    this.rawOutput += data;
+    this.parseAnsiSequences(data);
+    callback();
+  }
+
+  parseAnsiSequences(data: string) {
+    const ansiRegex = /\x1b\[[0-9;]*[a-zA-Z]/g;
+    let lastIndex = 0;
+    let match;
+
+    while ((match = ansiRegex.exec(data)) !== null) {
+      if (match.index > lastIndex) {
+        const text = data.slice(lastIndex, match.index);
+        this.addTextSegment(text);
+      }
+
+      this.processEscapeSequence(match[0]);
+      lastIndex = match.index + match[0].length;
+    }
+
+    if (lastIndex < data.length) {
+      const text = data.slice(lastIndex);
+      this.addTextSegment(text);
+    }
+  }
+
+  addTextSegment(text: string) {
+    if (!text) return;
+    
+    let currentText = '';
+    let currentCol = this.currentPosition.col;
+    let currentRow = this.currentPosition.row;
+    
+    for (let i = 0; i < text.length; i++) {
+      const char = text[i];
+      
+      if (char === '\n') {
+        if (currentText.length > 0) {
+          this.segments.push({
+            text: currentText,
+            position: { row: currentRow, col: currentCol },
+            endPosition: { row: currentRow, col: currentCol + currentText.length - 1 },
+            style: { ...this.currentStyle }
+          });
+          currentText = '';
+        } else {
+          // Create empty segment for blank lines
+          this.segments.push({
+            text: '',
+            position: { row: currentRow, col: 0 },
+            endPosition: { row: currentRow, col: 0 },
+            style: { ...this.currentStyle }
+          });
+        }
+        
+        currentRow++;
+        currentCol = 0;
+      } else if (char === '\r') {
+        if (currentText.length > 0) {
+          this.segments.push({
+            text: currentText,
+            position: { row: currentRow, col: currentCol },
+            endPosition: { row: currentRow, col: currentCol + currentText.length - 1 },
+            style: { ...this.currentStyle }
+          });
+          currentText = '';
+        }
+        
+        currentCol = 0;
+      } else {
+        currentText += char;
+      }
+    }
+    
+    if (currentText.length > 0) {
+      this.segments.push({
+        text: currentText,
+        position: { row: currentRow, col: currentCol },
+        endPosition: { row: currentRow, col: currentCol + currentText.length - 1 },
+        style: { ...this.currentStyle }
+      });
+      currentCol += currentText.length;
+    }
+    
+    this.currentPosition.row = currentRow;
+    this.currentPosition.col = currentCol;
+  }
+
+  processEscapeSequence(sequence: string) {
+    const code = sequence.slice(2, -1);
+    const command = sequence.slice(-1);
+
+    if (command === 'm') {
+      this.processSGR(code);
+    }
+  }
+
+  processSGR(code: string) {
+    const codes = code ? code.split(';').map(Number) : [0];
+    
+    for (let i = 0; i < codes.length; i++) {
+      const num = codes[i];
+      
+      switch (num) {
+        case 0:
+          this.currentStyle = this.getDefaultStyle();
+          break;
+        case 1:
+          this.currentStyle.bold = true;
+          break;
+        case 3:
+          this.currentStyle.italic = true;
+          break;
+        case 4:
+          this.currentStyle.underline = true;
+          break;
+        case 9:
+          this.currentStyle.strikethrough = true;
+          break;
+        case 22:
+          this.currentStyle.bold = false;
+          this.currentStyle.dim = false;
+          break;
+        case 23:
+          this.currentStyle.italic = false;
+          break;
+        case 24:
+          this.currentStyle.underline = false;
+          break;
+        case 29:
+          this.currentStyle.strikethrough = false;
+          break;
+        default:
+          if (num >= 30 && num <= 37) {
+            this.currentStyle.color = this.getColorName(num - 30);
+          } else if (num >= 90 && num <= 97) {
+            // Bright colors (90-97)
+            this.currentStyle.color = this.getBrightColorName(num - 90);
+          } else if (num >= 40 && num <= 47) {
+            this.currentStyle.backgroundColor = this.getColorName(num - 40);
+          } else if (num >= 100 && num <= 107) {
+            // Bright background colors (100-107)
+            this.currentStyle.backgroundColor = this.getBrightColorName(num - 100);
+          } else if (num === 38) {
+            // Extended foreground color
+            const colorInfo = this.parseExtendedColor(codes, i);
+            if (colorInfo) {
+              this.currentStyle.color = colorInfo.color;
+              i = colorInfo.nextIndex;
+            }
+          } else if (num === 48) {
+            // Extended background color
+            const colorInfo = this.parseExtendedColor(codes, i);
+            if (colorInfo) {
+              this.currentStyle.backgroundColor = colorInfo.color;
+              i = colorInfo.nextIndex;
+            }
+          } else if (num === 39) {
+            this.currentStyle.color = null;
+          } else if (num === 49) {
+            this.currentStyle.backgroundColor = null;
+          }
+          break;
+      }
+    }
+  }
+
+  parseExtendedColor(codes: number[], currentIndex: number) {
+    if (currentIndex + 1 >= codes.length) return null;
+    
+    const colorType = codes[currentIndex + 1];
+    
+    if (colorType === 5) {
+      // 256-color mode
+      if (currentIndex + 2 >= codes.length) return null;
+      const colorIndex = codes[currentIndex + 2];
+      return {
+        color: `ansi256-${colorIndex}`,
+        nextIndex: currentIndex + 2
+      };
+    } else if (colorType === 2) {
+      // RGB mode
+      if (currentIndex + 4 >= codes.length) return null;
+      const r = codes[currentIndex + 2];
+      const g = codes[currentIndex + 3];
+      const b = codes[currentIndex + 4];
+      return {
+        color: `rgb(${r},${g},${b})`,
+        nextIndex: currentIndex + 4
+      };
+    }
+    
+    return null;
+  }
+
+  getColorName(colorIndex: number): string {
+    const colors = [
+      'black', 'red', 'green', 'yellow',
+      'blue', 'magenta', 'cyan', 'white'
+    ];
+    return colors[colorIndex] || `color-${colorIndex}`;
+  }
+
+  getBrightColorName(colorIndex: number): string {
+    const brightColors = [
+      'blackBright', 'redBright', 'greenBright', 'yellowBright',
+      'blueBright', 'magentaBright', 'cyanBright', 'whiteBright'
+    ];
+    // For gray (bright black), use 'gray' which Ink recognizes
+    if (colorIndex === 0) return 'gray';
+    return brightColors[colorIndex] || `brightColor-${colorIndex}`;
+  }
+
+  getFormattedLines(): StyledLine[] {
+    const lines = new Map<number, typeof this.segments>();
+    
+    this.segments.forEach(segment => {
+      const row = segment.position.row;
+      if (!lines.has(row)) {
+        lines.set(row, []);
+      }
+      lines.get(row)!.push(segment);
+    });
+    
+    lines.forEach((segments) => {
+      segments.sort((a, b) => a.position.col - b.position.col);
+    });
+    
+    const result: StyledLine[] = [];
+    const sortedLines = Array.from(lines.entries()).sort(([a], [b]) => a - b);
+    
+    sortedLines.forEach(([lineNum, segments]) => {
+      result.push({
+        line: lineNum,
+        segments: segments.map(segment => ({
+          text: segment.text,
+          startCol: segment.position.col,
+          endCol: segment.endPosition.col,
+          style: segment.style
+        }))
+      });
+    });
+    
+    return result;
+  }
+
+  reset() {
+    this.segments = [];
+    this.currentPosition = { row: 0, col: 0 };
+    this.currentStyle = this.getDefaultStyle();
+    this.rawOutput = '';
+  }
+}

--- a/extensions/cli/src/ui/utils/chatHistoryLineSplitter.ts
+++ b/extensions/cli/src/ui/utils/chatHistoryLineSplitter.ts
@@ -1,0 +1,236 @@
+import { render, Text, Box } from 'ink';
+import React from 'react';
+import type { ChatHistoryItem } from '../../../../../core/index.js';
+import { MemoizedMessage } from '../components/MemoizedMessage.js';
+import { AnsiParsingStream, StyledLine, StyledSegment } from './AnsiParsingStream.js';
+
+/**
+ * Represents a single line from a chat history item with styling information
+ */
+export interface ChatHistoryLine extends Omit<ChatHistoryItem, 'message'> {
+  message: {
+    role: ChatHistoryItem['message']['role'];
+    content: string; // Always a string for line content
+  };
+  originalIndex: number; // Index of the original chat history item
+  lineIndex: number; // Index of this line within the original message
+  styledSegments?: StyledSegment[]; // ANSI styling information for this line
+}
+
+/**
+ * Creates a React component that renders the content invisibly to capture ANSI output
+ */
+function createInvisibleRenderer(item: ChatHistoryItem, index: number, terminalWidth: number) {
+  // Debug tool output content to see if we have diff data
+  // if (item.toolCallStates?.length) {
+  //   item.toolCallStates.forEach((toolState, i) => {
+  //     const output = toolState.output?.map(o => o.content).join('\n') || '';
+  //     console.log(`[DEBUG] Tool ${i} (${toolState.toolCall.function.name}) output length:`, output.length);
+  //     console.log(`[DEBUG] Tool ${i} contains "Diff:":`, output.includes('Diff:\n'));
+  //     if (output.includes('Diff:\n')) {
+  //       const diffSection = output.split('Diff:\n')[1];
+  //       console.log(`[DEBUG] Diff section preview:`, diffSection?.slice(0, 200));
+  //     }
+  //   });
+  // }
+  
+  return React.createElement(Box, { width: terminalWidth, flexDirection: 'column' },
+    React.createElement(MemoizedMessage, { item, index })
+  );
+}
+
+/**
+ * Renders content to an invisible ANSI stream to extract styling information
+ */
+async function renderToAnsiStream(item: ChatHistoryItem, index: number, terminalWidth: number): Promise<StyledLine[]> {
+  const ansiStream = new AnsiParsingStream();
+  
+  // Create the component to render
+  const component = createInvisibleRenderer(item, index, terminalWidth);
+  
+  return new Promise((resolve, reject) => {
+    try {
+      // console.log(`[DEBUG] renderToAnsiStream: Rendering content with width ${terminalWidth}`);
+      
+      // Force color support for invisible rendering
+      const originalForceColor = process.env.FORCE_COLOR;
+      process.env.FORCE_COLOR = '1';
+      
+      // Make the stream appear as TTY to enable colors
+      (ansiStream as any).isTTY = true;
+      (ansiStream as any).columns = terminalWidth;
+      (ansiStream as any).rows = 50;
+      
+      // Render to our ANSI parsing stream
+      const { unmount } = render(component, { 
+        stdout: ansiStream as any 
+      });
+      
+      // Wait longer for complex rendering to complete (tool outputs can be large)
+      setTimeout(() => {
+        try {
+          unmount();
+          
+          // Restore original FORCE_COLOR setting
+          if (originalForceColor !== undefined) {
+            process.env.FORCE_COLOR = originalForceColor;
+          } else {
+            delete process.env.FORCE_COLOR;
+          }
+          
+          // Check what raw data was captured
+          // const rawOutput = (ansiStream as any).rawOutput || '';
+          
+          // Only log if we see RGB color codes (indicating diff content)
+          // if (rawOutput.includes('48;2;')) {
+          //   console.log('[DEBUG] Diff detected - Raw ANSI length:', rawOutput.length);
+          //   console.log('[DEBUG] Lines with RGB colors:', rawOutput.split('\n').filter((line: string) => line.includes('48;2;')).length);
+          // }
+          
+          const lines = ansiStream.getFormattedLines();
+          
+          // Only log if we have RGB styled lines
+          // const rgbLines = lines.filter(l => l.segments.some(s => s.style.backgroundColor?.startsWith('rgb(')));
+          // if (rgbLines.length > 0) {
+          //   console.log(`[DEBUG] Found ${rgbLines.length} lines with RGB backgrounds`);
+          //   console.log('[DEBUG] First RGB line:', rgbLines[0].segments.map(s => ({
+          //     text: s.text,
+          //     bg: s.style.backgroundColor
+          //   })));
+          // }
+          
+          ansiStream.reset(); // Clean up for next use
+          resolve(lines);
+        } catch (error) {
+          reject(error);
+        }
+      }, 200); // Longer delay for complex tool outputs with diffs
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+/**
+ * Splits a single ChatHistoryItem into multiple line-based items with styling preserved
+ */
+export async function splitChatHistoryItemIntoLines(
+  item: ChatHistoryItem, 
+  originalIndex: number,
+  terminalWidth: number
+): Promise<ChatHistoryLine[]> {
+  // Handle messages without content
+  if (!item.message.content) {
+    return [];
+  }
+
+
+  try {
+    // Render complete item (including tool calls) to invisible ANSI stream to get styling information
+    const styledLines = await renderToAnsiStream(item, originalIndex, terminalWidth - 4); // Account for padding/border
+    
+    // Convert styled lines to ChatHistoryLine items
+    const result: ChatHistoryLine[] = [];
+    
+    for (let lineIndex = 0; lineIndex < styledLines.length; lineIndex++) {
+      const styledLine = styledLines[lineIndex];
+      
+      // Reconstruct the text content from segments
+      const lineContent = styledLine.segments.map(seg => seg.text).join('');
+      
+      // Only skip lines with cursor control codes, preserve blank lines for spacing
+      if (/^\x1B\[\?25[lh]/.test(lineContent)) {
+        continue;
+      }
+      
+      result.push({
+        ...item,
+        message: {
+          role: item.message.role,
+          content: lineContent
+        },
+        originalIndex,
+        lineIndex,
+        styledSegments: styledLine.segments
+      });
+    }
+    
+    // If no lines were produced, return empty array - no fallback
+    if (result.length === 0) {
+      return [];
+    }
+    return result;
+  } catch (error) {
+    console.error('Failed to split chat history item into lines:', error);
+    // No fallback - return empty array to force proper line-based rendering
+    return [];
+  }
+}
+
+/**
+ * Splits an array of ChatHistoryItems into line-based items
+ */
+export async function splitChatHistoryIntoLines(
+  chatHistory: ChatHistoryItem[],
+  terminalWidth: number
+): Promise<ChatHistoryLine[]> {
+  const result: ChatHistoryLine[] = [];
+  
+  for (let i = 0; i < chatHistory.length; i++) {
+    const item = chatHistory[i];
+    const lines = await splitChatHistoryItemIntoLines(item, i, terminalWidth);
+    result.push(...lines);
+  }
+  
+  return result;
+}
+
+/**
+ * Creates a React Text component from styled segments
+ */
+export function createStyledTextFromSegments(segments: StyledSegment[]): React.ReactElement[] {
+  return segments.map((segment, index) => {
+    const props: any = { key: `segment-${index}` };
+    
+    // Apply styling based on segment style
+    if (segment.style.bold) props.bold = true;
+    if (segment.style.italic) props.italic = true;
+    if (segment.style.underline) props.underline = true;
+    if (segment.style.strikethrough) props.strikethrough = true;
+    if (segment.style.dim) props.dimColor = true;
+    if (segment.style.inverse) props.inverse = true;
+    
+    // Handle colors - convert RGB back to Ink-compatible format
+    if (segment.style.color) {
+      if (segment.style.color.startsWith('rgb(')) {
+        // RGB colors - Ink can handle hex colors, so convert rgb(r,g,b) to #hex
+        const match = segment.style.color.match(/rgb\((\d+),(\d+),(\d+)\)/);
+        if (match) {
+          const r = parseInt(match[1]).toString(16).padStart(2, '0');
+          const g = parseInt(match[2]).toString(16).padStart(2, '0');
+          const b = parseInt(match[3]).toString(16).padStart(2, '0');
+          props.color = `#${r}${g}${b}`;
+        }
+      } else {
+        props.color = segment.style.color;
+      }
+    }
+    
+    if (segment.style.backgroundColor) {
+      if (segment.style.backgroundColor.startsWith('rgb(')) {
+        // RGB background colors
+        const match = segment.style.backgroundColor.match(/rgb\((\d+),(\d+),(\d+)\)/);
+        if (match) {
+          const r = parseInt(match[1]).toString(16).padStart(2, '0');
+          const g = parseInt(match[2]).toString(16).padStart(2, '0');
+          const b = parseInt(match[3]).toString(16).padStart(2, '0');
+          props.backgroundColor = `#${r}${g}${b}`;
+        }
+      } else {
+        props.backgroundColor = segment.style.backgroundColor;
+      }
+    }
+    
+    return React.createElement(Text, props, segment.text);
+  });
+}

--- a/extensions/cli/src/ui/utils/chatHistoryLineSplitter.ts
+++ b/extensions/cli/src/ui/utils/chatHistoryLineSplitter.ts
@@ -1,15 +1,19 @@
-import { render, Text, Box } from 'ink';
-import React from 'react';
-import type { ChatHistoryItem } from '../../../../../core/index.js';
-import { MemoizedMessage } from '../components/MemoizedMessage.js';
-import { AnsiParsingStream, StyledLine, StyledSegment } from './AnsiParsingStream.js';
+import { render, Text, Box } from "ink";
+import React from "react";
+import type { ChatHistoryItem } from "../../../../../core/index.js";
+import { MemoizedMessage } from "../components/MemoizedMessage.js";
+import {
+  AnsiParsingStream,
+  StyledLine,
+  StyledSegment,
+} from "./AnsiParsingStream.js";
 
 /**
  * Represents a single line from a chat history item with styling information
  */
-export interface ChatHistoryLine extends Omit<ChatHistoryItem, 'message'> {
+export interface ChatHistoryLine extends Omit<ChatHistoryItem, "message"> {
   message: {
-    role: ChatHistoryItem['message']['role'];
+    role: ChatHistoryItem["message"]["role"];
     content: string; // Always a string for line content
   };
   originalIndex: number; // Index of the original chat history item
@@ -20,7 +24,11 @@ export interface ChatHistoryLine extends Omit<ChatHistoryItem, 'message'> {
 /**
  * Creates a React component that renders the content invisibly to capture ANSI output
  */
-function createInvisibleRenderer(item: ChatHistoryItem, index: number, terminalWidth: number) {
+function createInvisibleRenderer(
+  item: ChatHistoryItem,
+  index: number,
+  terminalWidth: number,
+) {
   // Debug tool output content to see if we have diff data
   // if (item.toolCallStates?.length) {
   //   item.toolCallStates.forEach((toolState, i) => {
@@ -33,62 +41,68 @@ function createInvisibleRenderer(item: ChatHistoryItem, index: number, terminalW
   //     }
   //   });
   // }
-  
-  return React.createElement(Box, { width: terminalWidth, flexDirection: 'column' },
-    React.createElement(MemoizedMessage, { item, index })
+
+  return React.createElement(
+    Box,
+    { width: terminalWidth, flexDirection: "column" },
+    React.createElement(MemoizedMessage, { item, index }),
   );
 }
 
 /**
  * Renders content to an invisible ANSI stream to extract styling information
  */
-async function renderToAnsiStream(item: ChatHistoryItem, index: number, terminalWidth: number): Promise<StyledLine[]> {
+async function renderToAnsiStream(
+  item: ChatHistoryItem,
+  index: number,
+  terminalWidth: number,
+): Promise<StyledLine[]> {
   const ansiStream = new AnsiParsingStream();
-  
+
   // Create the component to render
   const component = createInvisibleRenderer(item, index, terminalWidth);
-  
+
   return new Promise((resolve, reject) => {
     try {
       // console.log(`[DEBUG] renderToAnsiStream: Rendering content with width ${terminalWidth}`);
-      
+
       // Force color support for invisible rendering
       const originalForceColor = process.env.FORCE_COLOR;
-      process.env.FORCE_COLOR = '1';
-      
+      process.env.FORCE_COLOR = "1";
+
       // Make the stream appear as TTY to enable colors
       (ansiStream as any).isTTY = true;
       (ansiStream as any).columns = terminalWidth;
       (ansiStream as any).rows = 50;
-      
+
       // Render to our ANSI parsing stream
-      const { unmount } = render(component, { 
-        stdout: ansiStream as any 
+      const { unmount } = render(component, {
+        stdout: ansiStream as any,
       });
-      
+
       // Wait longer for complex rendering to complete (tool outputs can be large)
       setTimeout(() => {
         try {
           unmount();
-          
+
           // Restore original FORCE_COLOR setting
           if (originalForceColor !== undefined) {
             process.env.FORCE_COLOR = originalForceColor;
           } else {
             delete process.env.FORCE_COLOR;
           }
-          
+
           // Check what raw data was captured
           // const rawOutput = (ansiStream as any).rawOutput || '';
-          
+
           // Only log if we see RGB color codes (indicating diff content)
           // if (rawOutput.includes('48;2;')) {
           //   console.log('[DEBUG] Diff detected - Raw ANSI length:', rawOutput.length);
           //   console.log('[DEBUG] Lines with RGB colors:', rawOutput.split('\n').filter((line: string) => line.includes('48;2;')).length);
           // }
-          
+
           const lines = ansiStream.getFormattedLines();
-          
+
           // Only log if we have RGB styled lines
           // const rgbLines = lines.filter(l => l.segments.some(s => s.style.backgroundColor?.startsWith('rgb(')));
           // if (rgbLines.length > 0) {
@@ -98,7 +112,7 @@ async function renderToAnsiStream(item: ChatHistoryItem, index: number, terminal
           //     bg: s.style.backgroundColor
           //   })));
           // }
-          
+
           ansiStream.reset(); // Clean up for next use
           resolve(lines);
         } catch (error) {
@@ -115,53 +129,56 @@ async function renderToAnsiStream(item: ChatHistoryItem, index: number, terminal
  * Splits a single ChatHistoryItem into multiple line-based items with styling preserved
  */
 export async function splitChatHistoryItemIntoLines(
-  item: ChatHistoryItem, 
+  item: ChatHistoryItem,
   originalIndex: number,
-  terminalWidth: number
+  terminalWidth: number,
 ): Promise<ChatHistoryLine[]> {
   // Handle messages without content
   if (!item.message.content) {
     return [];
   }
 
-
   try {
     // Render complete item (including tool calls) to invisible ANSI stream to get styling information
-    const styledLines = await renderToAnsiStream(item, originalIndex, terminalWidth - 4); // Account for padding/border
-    
+    const styledLines = await renderToAnsiStream(
+      item,
+      originalIndex,
+      terminalWidth - 4,
+    ); // Account for padding/border
+
     // Convert styled lines to ChatHistoryLine items
     const result: ChatHistoryLine[] = [];
-    
+
     for (let lineIndex = 0; lineIndex < styledLines.length; lineIndex++) {
       const styledLine = styledLines[lineIndex];
-      
+
       // Reconstruct the text content from segments
-      const lineContent = styledLine.segments.map(seg => seg.text).join('');
-      
+      const lineContent = styledLine.segments.map((seg) => seg.text).join("");
+
       // Only skip lines with cursor control codes, preserve blank lines for spacing
       if (/^\x1B\[\?25[lh]/.test(lineContent)) {
         continue;
       }
-      
+
       result.push({
         ...item,
         message: {
           role: item.message.role,
-          content: lineContent
+          content: lineContent,
         },
         originalIndex,
         lineIndex,
-        styledSegments: styledLine.segments
+        styledSegments: styledLine.segments,
       });
     }
-    
+
     // If no lines were produced, return empty array - no fallback
     if (result.length === 0) {
       return [];
     }
     return result;
   } catch (error) {
-    console.error('Failed to split chat history item into lines:', error);
+    console.error("Failed to split chat history item into lines:", error);
     // No fallback - return empty array to force proper line-based rendering
     return [];
   }
@@ -172,26 +189,28 @@ export async function splitChatHistoryItemIntoLines(
  */
 export async function splitChatHistoryIntoLines(
   chatHistory: ChatHistoryItem[],
-  terminalWidth: number
+  terminalWidth: number,
 ): Promise<ChatHistoryLine[]> {
   const result: ChatHistoryLine[] = [];
-  
+
   for (let i = 0; i < chatHistory.length; i++) {
     const item = chatHistory[i];
     const lines = await splitChatHistoryItemIntoLines(item, i, terminalWidth);
     result.push(...lines);
   }
-  
+
   return result;
 }
 
 /**
  * Creates a React Text component from styled segments
  */
-export function createStyledTextFromSegments(segments: StyledSegment[]): React.ReactElement[] {
+export function createStyledTextFromSegments(
+  segments: StyledSegment[],
+): React.ReactElement[] {
   return segments.map((segment, index) => {
     const props: any = { key: `segment-${index}` };
-    
+
     // Apply styling based on segment style
     if (segment.style.bold) props.bold = true;
     if (segment.style.italic) props.italic = true;
@@ -199,38 +218,40 @@ export function createStyledTextFromSegments(segments: StyledSegment[]): React.R
     if (segment.style.strikethrough) props.strikethrough = true;
     if (segment.style.dim) props.dimColor = true;
     if (segment.style.inverse) props.inverse = true;
-    
+
     // Handle colors - convert RGB back to Ink-compatible format
     if (segment.style.color) {
-      if (segment.style.color.startsWith('rgb(')) {
+      if (segment.style.color.startsWith("rgb(")) {
         // RGB colors - Ink can handle hex colors, so convert rgb(r,g,b) to #hex
         const match = segment.style.color.match(/rgb\((\d+),(\d+),(\d+)\)/);
         if (match) {
-          const r = parseInt(match[1]).toString(16).padStart(2, '0');
-          const g = parseInt(match[2]).toString(16).padStart(2, '0');
-          const b = parseInt(match[3]).toString(16).padStart(2, '0');
+          const r = parseInt(match[1]).toString(16).padStart(2, "0");
+          const g = parseInt(match[2]).toString(16).padStart(2, "0");
+          const b = parseInt(match[3]).toString(16).padStart(2, "0");
           props.color = `#${r}${g}${b}`;
         }
       } else {
         props.color = segment.style.color;
       }
     }
-    
+
     if (segment.style.backgroundColor) {
-      if (segment.style.backgroundColor.startsWith('rgb(')) {
+      if (segment.style.backgroundColor.startsWith("rgb(")) {
         // RGB background colors
-        const match = segment.style.backgroundColor.match(/rgb\((\d+),(\d+),(\d+)\)/);
+        const match = segment.style.backgroundColor.match(
+          /rgb\((\d+),(\d+),(\d+)\)/,
+        );
         if (match) {
-          const r = parseInt(match[1]).toString(16).padStart(2, '0');
-          const g = parseInt(match[2]).toString(16).padStart(2, '0');
-          const b = parseInt(match[3]).toString(16).padStart(2, '0');
+          const r = parseInt(match[1]).toString(16).padStart(2, "0");
+          const g = parseInt(match[2]).toString(16).padStart(2, "0");
+          const b = parseInt(match[3]).toString(16).padStart(2, "0");
           props.backgroundColor = `#${r}${g}${b}`;
         }
       } else {
         props.backgroundColor = segment.style.backgroundColor;
       }
     }
-    
+
     return React.createElement(Text, props, segment.text);
   });
 }


### PR DESCRIPTION
## Description

See `extensions/cli/docs/line-based-rendering.md` for detailed explanation. Second attempt at fixing flickering, I'm not sure if this is over-engineering but the flickering is gone, putting up this as draft PR to get feedback and thoughts.

---

feat: line-based chat history rendering with ANSI styling preservation

Replace single-message chat items with line-by-line rendering to eliminate
flickering and enable stable display. Each line becomes a separate chat
history item while preserving all styling information through invisible
ANSI capture and parsing.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Render chat history line-by-line with preserved ANSI styling to eliminate flicker while keeping tool outputs, diffs, and markdown looking the same. Addresses Linear CON-3862 by making each line a stable item during streaming.

- **New Features**
  - Added AnsiParsingStream to capture/parse ANSI (RGB, bright colors, bold, italic, underline, strikethrough, etc.).
  - Split ChatHistoryItem into ChatHistoryLine via invisible rendering; preserves tool calls, colored diffs, markdown, spacing.
  - Updated StaticChatContent to use the line-based pipeline; added LineBasedMessage and useLineBasedMessageRenderer.
  - Docs: extensions/cli/docs/line-based-rendering.md.
  - Tests: added coverage for ANSI parsing; updated tool tests (Edit → MultiEdit).
  - Toggle: USE_LINE_BASED_RENDERING in StaticChatContent (enabled by default).

- **Bug Fixes**
  - Removed flickering during streaming by rendering each line as a stable item.
  - Respects terminal width and preserves blank lines and indentation.

<!-- End of auto-generated description by cubic. -->

