### PR TITLE
chore: package lock updates

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -152,10 +152,10 @@
     },
     "../packages/config-yaml": {
       "name": "@continuedev/config-yaml",
-      "version": "1.0.96",
+      "version": "1.14.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@continuedev/config-types": "file:../config-types",
+        "@continuedev/config-types": "^1.0.14",
         "yaml": "^2.6.1",
         "zod": "^3.24.2"
       },
@@ -179,17 +179,22 @@
     },
     "../packages/fetch": {
       "name": "@continuedev/fetch",
-      "version": "1.0.16",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@continuedev/config-types": "file:../config-types",
+        "@continuedev/config-types": "^1.0.14",
         "follow-redirects": "^1.15.6",
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.5",
         "node-fetch": "^3.3.2"
       },
       "devDependencies": {
+        "@semantic-release/changelog": "^6.0.3",
+        "@semantic-release/git": "^10.0.1",
+        "@semantic-release/github": "^9.2.6",
+        "@semantic-release/npm": "^10.0.6",
         "@types/follow-redirects": "^1.14.4",
+        "semantic-release": "^21.1.2",
         "typescript": "^5.0.0",
         "vitest": "^3.2.0"
       }
@@ -199,20 +204,25 @@
       "version": "1.0.9",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@semantic-release/changelog": "^6.0.3",
+        "@semantic-release/git": "^10.0.1",
+        "@semantic-release/github": "^9.2.6",
+        "@semantic-release/npm": "^10.0.6",
         "@types/node": "^22.15.29",
+        "semantic-release": "^21.1.2",
         "typescript": "^5.5.2"
       }
     },
     "../packages/openai-adapters": {
       "name": "@continuedev/openai-adapters",
-      "version": "1.5.1",
+      "version": "1.14.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.842.0",
         "@aws-sdk/credential-providers": "^3.840.0",
         "@continuedev/config-types": "^1.0.14",
-        "@continuedev/config-yaml": "^1.8.0",
-        "@continuedev/fetch": "^1.0.16",
+        "@continuedev/config-yaml": "^1.14.0",
+        "@continuedev/fetch": "^1.1.0",
         "dotenv": "^16.5.0",
         "google-auth-library": "^10.1.0",
         "json-schema": "^0.4.0",

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "1.3.3",
+  "version": "1.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "1.3.3",
+      "version": "1.3.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "file:../../packages/config-types",
@@ -231,17 +231,22 @@
     },
     "../../packages/fetch": {
       "name": "@continuedev/fetch",
-      "version": "1.0.16",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@continuedev/config-types": "file:../config-types",
+        "@continuedev/config-types": "^1.0.14",
         "follow-redirects": "^1.15.6",
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.5",
         "node-fetch": "^3.3.2"
       },
       "devDependencies": {
+        "@semantic-release/changelog": "^6.0.3",
+        "@semantic-release/git": "^10.0.1",
+        "@semantic-release/github": "^9.2.6",
+        "@semantic-release/npm": "^10.0.6",
         "@types/follow-redirects": "^1.14.4",
+        "semantic-release": "^21.1.2",
         "typescript": "^5.0.0",
         "vitest": "^3.2.0"
       }

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -234,10 +234,11 @@
       }
     },
     "../packages/config-yaml": {
-      "version": "1.0.96",
+      "name": "@continuedev/config-yaml",
+      "version": "1.14.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@continuedev/config-types": "file:../config-types",
+        "@continuedev/config-types": "^1.0.14",
         "yaml": "^2.6.1",
         "zod": "^3.24.2"
       },
@@ -260,6 +261,7 @@
       }
     },
     "../packages/terminal-security": {
+      "name": "@continuedev/terminal-security",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -269,7 +271,7 @@
         "@types/node": "^20.11.19",
         "@types/shell-quote": "^1.7.5",
         "typescript": "^5.5.2",
-        "vitest": "^1.6.0"
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@adobe/css-tools": {


### PR DESCRIPTION
## Description
When bumping fetch/openai-adapters I didn't update some package locks
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Update package-lock.json files in core, VS Code extension, and GUI to match recent dependency upgrades. Locks @continuedev/fetch 1.1.0, @continuedev/openai-adapters 1.14.0, @continuedev/config-yaml 1.14.0, switches to @continuedev/config-types ^1.0.14, and syncs related devDependencies for consistent installs.

<!-- End of auto-generated description by cubic. -->

