### PR TITLE
fix: update cli repo link

### DIFF
--- a/extensions/cli/package.json
+++ b/extensions/cli/package.json
@@ -37,7 +37,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/continuedev/cli.git"
+    "url": "https://github.com/continuedev/continue.git"
   },
   "bugs": {
     "url": "https://github.com/continuedev/continue/issues"


### PR DESCRIPTION
## Description
Update CLI repo link
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Update the CLI package.json repository URL to https://github.com/continuedev/continue so it points to the correct repo.
Fixes package metadata so npm/GitHub links go to the right project.

<!-- End of auto-generated description by cubic. -->

