### PR TITLE
fix: HOTFIX include message content when tool calls present

### DIFF
--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -537,18 +537,14 @@ export abstract class BaseLLM implements ILLM {
   }
 
   private _formatChatMessage(msg: ChatMessage): string {
-    let contentToShow = "";
-    if (msg.role === "tool") {
-      contentToShow = msg.content;
-    } else if (msg.role === "assistant" && msg.toolCalls?.length) {
-      contentToShow = msg.toolCalls
+    let contentToShow = renderChatMessage(msg);
+    if (msg.role === "assistant" && msg.toolCalls?.length) {
+      contentToShow += msg.toolCalls
         ?.map(
           (toolCall) =>
             `${toolCall.function?.name}(${toolCall.function?.arguments})`,
         )
         .join("\n");
-    } else if ("content" in msg) {
-      contentToShow = renderChatMessage(msg);
     }
 
     return `<${msg.role}>\n${contentToShow}\n\n`;


### PR DESCRIPTION
## Description
an obstructive type of looping is happening with anthropic models where it repeats text
<img width="720" height="506" alt="image" src="https://github.com/user-attachments/assets/0f3b7b66-873b-48b7-88fa-eeaf5c9192a4" />

This was happening because when tool calls were present, it was losing content text parts
<img width="720" height="400" alt="image" src="https://github.com/user-attachments/assets/b12228fb-2ad3-437e-8f75-ed8f0d74d75b" />

This is a hotfix, I will push a more thorough/tested fix soon