### PR TITLE
fix: openai provider empty Bearer when no apiKey configured

### DIFF
--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -174,7 +174,7 @@ class OpenAI extends BaseLLM {
   protected _getHeaders() {
     return {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${this.apiKey}`,
+      ...(this.apiKey && { Authorization: `Bearer ${this.apiKey}` }),
       "api-key": this.apiKey ?? "", // For Azure
     };
   }


### PR DESCRIPTION
## Description

Should fix issue #7047

TL;DR: In openai provider, do not include an empty `Authorization: Bearer` header if `apiKey` has not been configured.

This enables using OpenAI-compatible APIs using other authentication methods than Bearer. I'm personally using basic auth with vLLM by configuring `Authorization: Basic ...` in config.yaml which is thwarted by the openai provider adding an empty `Authorization: Bearer` even when no `apiKey` is configured which interferes with my custom Authorization header.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

This is what HTTP headers used to look like for me before this fix:

```
...
Authorization: Bearer
Authorization: Basic <my-credentials>
...
```

## Tests

None