### PR TITLE
fix(cli): append /v1 to ollama endpoint

### DIFF
--- a/packages/openai-adapters/src/index.ts
+++ b/packages/openai-adapters/src/index.ts
@@ -141,6 +141,15 @@ export function constructLlmApi(config: LLMConfig): BaseLlmApi | undefined {
     case "lmstudio":
       return openAICompatible("http://localhost:1234/", config);
     case "ollama":
+      // for openai compaitability, we need to add /v1 to the end of the url
+      // this is required for cli (for core, endpoints are overriden by core/llm/llms/Ollama.ts)
+      if (config.apiBase && !config.apiBase.endsWith("v1")) {
+        if (config.apiBase.endsWith("/")) {
+          config.apiBase += "v1/";
+        } else {
+          config.apiBase += "/v1/";
+        }
+      }
       return openAICompatible("http://localhost:11434/v1/", config);
     case "mock":
       return new MockApi();

--- a/packages/openai-adapters/src/test/main.test.ts
+++ b/packages/openai-adapters/src/test/main.test.ts
@@ -309,4 +309,25 @@ describe("Configuration", () => {
     );
     expect((azure as OpenAIApi).openai.apiKey).toBe("sk-xxx");
   });
+
+  it('should have correct default API base for "ollama"', () => {
+    const ollama = constructLlmApi({
+      provider: "ollama",
+    });
+
+    expect((ollama as OpenAIApi).openai.baseURL).toBe(
+      "http://localhost:11434/v1/",
+    );
+  });
+
+  it('should append /v1 to apiBase for "ollama"', () => {
+    const ollama = constructLlmApi({
+      provider: "ollama",
+      apiBase: "http://localhost:123",
+    });
+
+    expect((ollama as OpenAIApi).openai.baseURL).toBe(
+      "http://localhost:123/v1/",
+    );
+  });
 });


### PR DESCRIPTION
## Description

When using a custom ollama base in config.yaml for cn, `/v1` needed to be appended at the end of the url, whereas the extension did not need it. This created requirement of 2 different configs for the same ollama model. This PR fixes this.

resolves CON-3909

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
