### PR TITLE
fix: Remove redirect

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -356,10 +356,6 @@
       "destination": "/hub/blocks/intro"
     },
     {
-      "source": "/hub/agents/intro",
-      "destination": "/hub/agents/intro"
-    },
-    {
       "source": "/customize",
       "destination": "/customization/overview"
     },


### PR DESCRIPTION
## Description

`hub/agents/intro` was broken bc we had it redirecting itself to itself. I removed that redirect.
## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the broken /hub/agents/intro page by removing a self-redirect. The page now loads normally instead of looping.

- **Bug Fixes**
  - Removed redirect from /hub/agents/intro to itself in docs/docs.json.

<!-- End of auto-generated description by cubic. -->

