### PR TITLE
feat: add more robust context length validation

### DIFF
--- a/core/llm/countTokens.ts
+++ b/core/llm/countTokens.ts
@@ -85,7 +85,7 @@ function encodingForModel(modelName: string): Encoding {
 
 function countImageTokens(content: MessagePart): number {
   if (content.type === "imageUrl") {
-    return 85;
+    return 1024;
   }
   throw new Error("Non-image content type");
 }

--- a/extensions/cli/src/stream/streamChatResponse.ts
+++ b/extensions/cli/src/stream/streamChatResponse.ts
@@ -16,9 +16,11 @@ import { telemetryService } from "../telemetry/telemetryService.js";
 import { ToolCall } from "../tools/index.js";
 import {
   chatCompletionStreamWithBackoff,
+  isContextLengthError,
   withExponentialBackoff,
 } from "../util/exponentialBackoff.js";
 import { logger } from "../util/logger.js";
+import { validateContextLength } from "../util/tokenizer.js";
 
 import { getAllTools, handleToolCalls } from "./handleToolCalls.js";
 import { handleAutoCompaction } from "./streamChatResponse.autoCompaction.js";
@@ -147,6 +149,12 @@ export async function processStreamingResponse(
     isHeadless,
     tools,
   } = options;
+
+  // Validate context length before making the request
+  const validation = validateContextLength(chatHistory, model);
+  if (!validation.isValid) {
+    throw new Error(`Context length validation failed: ${validation.error}`);
+  }
 
   // Get fresh system message and inject it
   const systemMessage = await systemMessageService.getSystemMessage();
@@ -277,6 +285,13 @@ export async function processStreamingResponse(
         shouldContinue: false,
       };
     }
+
+    // Handle context length errors with helpful message
+    if (isContextLengthError(error)) {
+      logger.debug(`Context length exceeded: ${error}`);
+      throw new Error(`Context length exceeded: ${error}`);
+    }
+
     throw error;
   }
 

--- a/extensions/cli/src/util/tokenizer.contextValidation.test.ts
+++ b/extensions/cli/src/util/tokenizer.contextValidation.test.ts
@@ -1,0 +1,62 @@
+import { ModelConfig } from "@continuedev/config-yaml";
+import { describe, expect, it } from "vitest";
+
+import { validateContextLength } from "./tokenizer.js";
+
+describe("validateContextLength", () => {
+  const createMockModel = (
+    contextLength: number,
+    maxTokens?: number,
+  ): ModelConfig => ({
+    name: "test-model",
+    model: "test",
+    provider: "openai",
+    defaultCompletionOptions: {
+      contextLength,
+      maxTokens,
+    },
+  });
+
+  const createMockHistory = (messageCount: number, contentLength = 100) => {
+    return Array.from({ length: messageCount }, (_, i) => ({
+      message: {
+        role: "user" as const,
+        content: "x".repeat(contentLength), // Roughly contentLength/4 tokens
+      },
+      contextItems: [],
+    }));
+  };
+
+  it("should pass validation when within context limits", () => {
+    const model = createMockModel(1000, 200);
+    const chatHistory = createMockHistory(5, 40); // ~50 tokens total
+
+    const result = validateContextLength(chatHistory, model);
+
+    expect(result.isValid).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("should fail validation when input + maxTokens exceeds context limit", () => {
+    const model = createMockModel(1000, 800);
+    const chatHistory = createMockHistory(20, 100); // ~500+ tokens
+
+    const result = validateContextLength(chatHistory, model);
+
+    expect(result.isValid).toBe(false);
+    expect(result.error).toContain("Context length exceeded");
+    expect(result.error).toContain("input");
+    expect(result.error).toContain("max_tokens");
+    expect(result.error).toContain("context_limit");
+  });
+
+  it("should handle large models with appropriate scaling", () => {
+    const model = createMockModel(200_000, 64_000); // Claude-like model
+    const chatHistory = createMockHistory(100, 1000); // Large conversation
+
+    const result = validateContextLength(chatHistory, model);
+
+    expect(result.contextLimit).toBe(200_000);
+    expect(result.maxTokens).toBe(64_000);
+  });
+});

--- a/extensions/cli/src/util/tokenizer.test.ts
+++ b/extensions/cli/src/util/tokenizer.test.ts
@@ -78,14 +78,14 @@ describe("tokenizer", () => {
           role: "user",
           content: [
             { type: "text", text: "Hello" }, // 5 chars -> ~2 tokens
-            { type: "imageUrl", imageUrl: { url: "test.jpg" } }, // +85 tokens
+            { type: "imageUrl", imageUrl: { url: "test.jpg" } }, // +1024 tokens
           ],
         },
         contextItems: [],
       };
 
       const tokenCount = countChatHistoryItemTokens(historyItem);
-      expect(tokenCount).toBe(89); // 2 + 85 + 2 role tokens
+      expect(tokenCount).toBe(1028); // 2 + 1024 + 2 role tokens
     });
 
     it("should count tokens for tool calls", () => {


### PR DESCRIPTION
## Description

Addresses so users don't accidentally exceed context length and get error 
```
Error: 500 "Chat completion error:
{"type":"error","error":{"type":"invalid_request_error","message":"input length and max_tokens
exceed context limit: 144048 + 64000 > 200000, decrease input length or max_tokens and try
again"},"request_id":"req_011CSqdU1MDjnk1hh7FAxnnE"}"
```

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
