### PR TITLE
feat: display shortcuts for accept reject diff buttons

### DIFF
--- a/gui/src/components/AcceptRejectDiffButtons.tsx
+++ b/gui/src/components/AcceptRejectDiffButtons.tsx
@@ -67,6 +67,9 @@ export default function AcceptRejectAllButtons({
           <div className="flex flex-row items-center gap-1">
             <XMarkIcon className="text-error h-4 w-4" />
             <span className="hidden sm:inline">Reject</span>
+            <span className="text-lightgray -ml-1.5 hidden scale-75 text-xs md:inline">
+              {rejectShortcut}
+            </span>
           </div>
         </button>
       </ToolTip>
@@ -80,6 +83,9 @@ export default function AcceptRejectAllButtons({
           <div className="flex flex-row items-center gap-1">
             <CheckIcon className="text-success h-4 w-4" />
             <span className="hidden sm:inline">Accept</span>
+            <span className="text-lightgray -ml-1.5 hidden scale-75 text-xs md:inline">
+              {acceptShortcut}
+            </span>
           </div>
         </button>
       </ToolTip>


### PR DESCRIPTION
## Description

Show the accept reject shortcut buttons on the notch for md wide screens.

resolves CON-3830

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

<img width="721" height="378" alt="Screenshot 2025-09-18 at 9 47 03 AM" src="https://github.com/user-attachments/assets/d7c994ce-05f7-4c73-993e-3c73b4899b02" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds keyboard shortcut hints next to the Accept and Reject diff buttons in the notch on medium+ screens to improve discoverability. Addresses CON-3830.

- **New Features**
  - Displays {acceptShortcut} and {rejectShortcut} beside the button labels, visible from the md breakpoint.
  - No changes to button behavior or shortcuts.

<!-- End of auto-generated description by cubic. -->

