### PR TITLE
feat: add Mercury Apply endpoint support to Inception LLM

### DIFF
--- a/core/core.ts
+++ b/core/core.ts
@@ -17,8 +17,8 @@ import { DataLogger } from "./data/log";
 import { CodebaseIndexer } from "./indexing/CodebaseIndexer";
 import DocsService from "./indexing/docs/DocsService";
 import { countTokens } from "./llm/countTokens";
-import Ollama from "./llm/llms/Ollama";
 import Lemonade from "./llm/llms/Lemonade";
+import Ollama from "./llm/llms/Ollama";
 import { EditAggregator } from "./nextEdit/context/aggregateEdits";
 import { createNewPromptFileV2 } from "./promptFiles/createNewPromptFile";
 import { callTool } from "./tools/callTool";
@@ -729,20 +729,13 @@ export class Core {
         data.fileUri ?? "current-file-stream",
       ); // not super important since currently cancelling apply will cancel all streams it's one file at a time
 
-      return streamDiffLines({
-        highlighted: data.highlighted,
-        prefix: data.prefix,
-        suffix: data.suffix,
+      return streamDiffLines(
+        data,
         llm,
-        // rules included for edit, NOT apply
-        rulesToInclude: data.includeRulesInSystemMessage
-          ? config.rules
-          : undefined,
-        input: data.input,
-        language: data.language,
-        overridePrompt: undefined,
         abortController,
-      });
+        undefined,
+        data.includeRulesInSystemMessage ? config.rules : undefined,
+      );
     });
 
     on("cancelApply", async (msg) => {

--- a/core/edit/constants.ts
+++ b/core/edit/constants.ts
@@ -1,1 +1,3 @@
 export const EDIT_MODE_STREAM_ID = "edit-mode";
+
+export const APPLY_UNIQUE_TOKEN = "<|!@#IS_APPLY!@#|>";

--- a/core/edit/lazy/applyCodeBlock.ts
+++ b/core/edit/lazy/applyCodeBlock.ts
@@ -1,7 +1,10 @@
 import { DiffLine, ILLM } from "../..";
+import { generateLines } from "../../diff/util";
 import { supportedLanguages } from "../../util/treeSitter";
 import { getUriFileExtension } from "../../util/uri";
+import { deterministicApplyLazyEdit } from "./deterministic";
 import { streamLazyApply } from "./streamLazyApply";
+import { applyUnifiedDiff, isUnifiedDiffFormat } from "./unifiedDiffApply";
 
 function canUseInstantApply(filename: string) {
   const fileExtension = getUriFileExtension(filename);
@@ -18,34 +21,34 @@ export async function applyCodeBlock(
   isInstantApply: boolean;
   diffLinesGenerator: AsyncGenerator<DiffLine>;
 }> {
-  // if (canUseInstantApply(filename)) {
-  //   const diffLines = await deterministicApplyLazyEdit({
-  //     oldFile,
-  //     newLazyFile,
-  //     filename,
-  //     onlyFullFileRewrite: true,
-  //   });
+  if (canUseInstantApply(filename)) {
+    const diffLines = await deterministicApplyLazyEdit({
+      oldFile,
+      newLazyFile,
+      filename,
+      onlyFullFileRewrite: true,
+    });
 
-  //   if (diffLines !== undefined) {
-  //     return {
-  //       isInstantApply: true,
-  //       diffLinesGenerator: generateLines(diffLines!),
-  //     };
-  //   }
-  // }
+    if (diffLines !== undefined) {
+      return {
+        isInstantApply: true,
+        diffLinesGenerator: generateLines(diffLines!),
+      };
+    }
+  }
 
-  // // If the code block is a diff
-  // if (isUnifiedDiffFormat(newLazyFile)) {
-  //   try {
-  //     const diffLines = applyUnifiedDiff(oldFile, newLazyFile);
-  //     return {
-  //       isInstantApply: true,
-  //       diffLinesGenerator: generateLines(diffLines!),
-  //     };
-  //   } catch (e) {
-  //     console.error("Failed to apply unified diff", e);
-  //   }
-  // }
+  // If the code block is a diff
+  if (isUnifiedDiffFormat(newLazyFile)) {
+    try {
+      const diffLines = applyUnifiedDiff(oldFile, newLazyFile);
+      return {
+        isInstantApply: true,
+        diffLinesGenerator: generateLines(diffLines!),
+      };
+    } catch (e) {
+      console.error("Failed to apply unified diff", e);
+    }
+  }
 
   return {
     isInstantApply: false,

--- a/core/edit/lazy/applyCodeBlock.ts
+++ b/core/edit/lazy/applyCodeBlock.ts
@@ -1,10 +1,7 @@
 import { DiffLine, ILLM } from "../..";
-import { generateLines } from "../../diff/util";
 import { supportedLanguages } from "../../util/treeSitter";
 import { getUriFileExtension } from "../../util/uri";
-import { deterministicApplyLazyEdit } from "./deterministic";
 import { streamLazyApply } from "./streamLazyApply";
-import { applyUnifiedDiff, isUnifiedDiffFormat } from "./unifiedDiffApply";
 
 function canUseInstantApply(filename: string) {
   const fileExtension = getUriFileExtension(filename);
@@ -21,34 +18,34 @@ export async function applyCodeBlock(
   isInstantApply: boolean;
   diffLinesGenerator: AsyncGenerator<DiffLine>;
 }> {
-  if (canUseInstantApply(filename)) {
-    const diffLines = await deterministicApplyLazyEdit({
-      oldFile,
-      newLazyFile,
-      filename,
-      onlyFullFileRewrite: true,
-    });
+  // if (canUseInstantApply(filename)) {
+  //   const diffLines = await deterministicApplyLazyEdit({
+  //     oldFile,
+  //     newLazyFile,
+  //     filename,
+  //     onlyFullFileRewrite: true,
+  //   });
 
-    if (diffLines !== undefined) {
-      return {
-        isInstantApply: true,
-        diffLinesGenerator: generateLines(diffLines!),
-      };
-    }
-  }
+  //   if (diffLines !== undefined) {
+  //     return {
+  //       isInstantApply: true,
+  //       diffLinesGenerator: generateLines(diffLines!),
+  //     };
+  //   }
+  // }
 
-  // If the code block is a diff
-  if (isUnifiedDiffFormat(newLazyFile)) {
-    try {
-      const diffLines = applyUnifiedDiff(oldFile, newLazyFile);
-      return {
-        isInstantApply: true,
-        diffLinesGenerator: generateLines(diffLines!),
-      };
-    } catch (e) {
-      console.error("Failed to apply unified diff", e);
-    }
-  }
+  // // If the code block is a diff
+  // if (isUnifiedDiffFormat(newLazyFile)) {
+  //   try {
+  //     const diffLines = applyUnifiedDiff(oldFile, newLazyFile);
+  //     return {
+  //       isInstantApply: true,
+  //       diffLinesGenerator: generateLines(diffLines!),
+  //     };
+  //   } catch (e) {
+  //     console.error("Failed to apply unified diff", e);
+  //   }
+  // }
 
   return {
     isInstantApply: false,

--- a/core/edit/recursiveStream.ts
+++ b/core/edit/recursiveStream.ts
@@ -122,7 +122,9 @@ export async function* recursiveStream(
 
 function shouldInjectApplyToken(llm: ILLM): boolean {
   const model = llm.model?.toLowerCase() ?? "";
-  return llm.providerName === "inception" && model.includes("mercury");
+  return (
+    llm.underlyingProviderName === "inception" && model.includes("mercury")
+  );
 }
 
 function appendTokenToLastMessage(

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1392,7 +1392,9 @@ export interface ApplyState {
   autoFormattingDiff?: string;
 }
 
-export interface StreamDiffLinesPayload {
+export type StreamDiffLinesType = "edit" | "apply";
+interface StreamDiffLinesOptionsBase {
+  type: StreamDiffLinesType;
   prefix: string;
   highlighted: string;
   suffix: string;
@@ -1402,6 +1404,19 @@ export interface StreamDiffLinesPayload {
   includeRulesInSystemMessage: boolean;
   fileUri?: string;
 }
+
+interface StreamDiffLinesOptionsEdit extends StreamDiffLinesOptionsBase {
+  type: "edit";
+}
+
+interface StreamDiffLinesOptionsApply extends StreamDiffLinesOptionsBase {
+  type: "apply";
+  newCode: string;
+}
+
+type StreamDiffLinesPayload =
+  | StreamDiffLinesOptionsApply
+  | StreamDiffLinesOptionsEdit;
 
 export interface HighlightedCodePayload {
   rangeInFileWithContents: RangeInFileWithContents;

--- a/core/llm/templates/edit/gpt.ts
+++ b/core/llm/templates/edit/gpt.ts
@@ -71,3 +71,10 @@ export const gptEditPrompt: PromptTemplateFunction = (history, otherData) => {
 
   return paragraphs.join("\n\n");
 };
+
+export const defaultApplyPrompt: PromptTemplateFunction = (
+  history,
+  otherData,
+) => {
+  return `${otherData.original_code}\n\nThe following code was suggested as an edit:\n\`\`\`\n${otherData.new_code}\n\`\`\`\nPlease apply it to the previous code.`;
+};

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/ApplyToFileHandler.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/ApplyToFileHandler.kt
@@ -91,7 +91,8 @@ class ApplyToFileHandler(
             highlighted = currentContent, // Current file content
             suffix = "",                  // No suffix since we're rewriting the whole file
             modelTitle = null,            // No model needed for search/replace instant apply
-            includeRulesInSystemMessage = false // No LLM involved, just diff generation
+            includeRulesInSystemMessage = false, // No LLM involved, just diff generation
+            isApply = true
         )
     }
 
@@ -145,7 +146,7 @@ class ApplyToFileHandler(
 
         // Stream the diffs
         diffStreamHandler.streamDiffLinesToEditor(
-            prompt, prefix, highlighted, suffix, llmTitle, false
+            prompt, prefix, highlighted, suffix, llmTitle, false, true
         )
     }
 

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/DiffStreamHandler.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/DiffStreamHandler.kt
@@ -97,7 +97,8 @@ class DiffStreamHandler(
         highlighted: String,
         suffix: String,
         modelTitle: String?,
-        includeRulesInSystemMessage: Boolean
+        includeRulesInSystemMessage: Boolean,
+        isApply: Boolean
     ) {
         isRunning = true
         sendUpdate(ApplyStateStatus.STREAMING)
@@ -112,7 +113,8 @@ class DiffStreamHandler(
                 language = virtualFile?.fileType?.name,
                 modelTitle = modelTitle,
                 includeRulesInSystemMessage = includeRulesInSystemMessage,
-                fileUri = virtualFile?.url
+                fileUri = virtualFile?.url,
+                isApply = isApply
             ),
             null
         ) { response ->

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/InlineEditPanel.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/InlineEditPanel.kt
@@ -205,7 +205,7 @@ fun openInlineEdit(project: Project?, editor: Editor) {
         val selectedModelStrippedOfCaret = (comboBoxRef.get().selectedItem as String).removeSuffix(DOWN_ARROW)
         customPanelRef.get().enter()
         diffStreamHandler.streamDiffLinesToEditor(
-            textArea.text, prefix, highlighted, suffix, selectedModelStrippedOfCaret, true
+            textArea.text, prefix, highlighted, suffix, selectedModelStrippedOfCaret, true, false
         )
     }
 

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/types.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/types.kt
@@ -306,7 +306,8 @@ data class StreamDiffLinesPayload(
     val language: String?,
     val modelTitle: String?,
     val includeRulesInSystemMessage: Boolean,
-    val fileUri: String?
+    val fileUri: String?,
+    val isApply: Boolean
 )
 
 data class AcceptOrRejectDiffPayload(

--- a/extensions/vscode/src/apply/ApplyManager.ts
+++ b/extensions/vscode/src/apply/ApplyManager.ts
@@ -244,6 +244,7 @@ export class ApplyManager {
         newCode: text,
         toolCallId,
         rulesToInclude: undefined, // No rules for apply
+        isApply: true,
       });
     } else {
       // Non-streaming: accumulate LLM output, then apply via Myers diff
@@ -295,17 +296,23 @@ export class ApplyManager {
       const streamedLines: string[] = [];
 
       // Use streamDiffLines to get the LLM output
-      const stream = streamDiffLines({
-        highlighted: rangeContent,
-        prefix,
-        suffix,
+      const stream = streamDiffLines(
+        {
+          highlighted: rangeContent,
+          prefix,
+          suffix,
+          input: prompt,
+          language: getMarkdownLanguageTagForFile(fileUri),
+          type: "apply",
+          newCode,
+          includeRulesInSystemMessage: false,
+          modelTitle: llm.title ?? llm.model,
+        },
         llm,
-        rulesToInclude: undefined, // No rules for apply
-        input: prompt,
-        language: getMarkdownLanguageTagForFile(fileUri),
-        overridePrompt: undefined,
         abortController,
-      });
+        undefined,
+        undefined,
+      );
 
       // Accumulate all the streamed content
       for await (const line of stream) {

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -8,8 +8,8 @@ import { EXTENSION_NAME } from "core/control-plane/env";
 import { Core } from "core/core";
 import { walkDirAsync } from "core/indexing/walkDir";
 import { isModelInstaller } from "core/llm";
-import { startLocalOllama } from "core/util/ollamaHelper";
 import { startLocalLemonade } from "core/util/lemonadeHelper";
+import { startLocalOllama } from "core/util/ollamaHelper";
 import { getConfigJsonPath, getConfigYamlPath } from "core/util/paths";
 import { Telemetry } from "core/util/posthog";
 import * as vscode from "vscode";
@@ -153,6 +153,7 @@ const getCommandsMap: (
       llm,
       range,
       rulesToInclude: config.rules,
+      isApply: false,
     });
   }
 

--- a/extensions/vscode/src/diff/vertical/manager.ts
+++ b/extensions/vscode/src/diff/vertical/manager.ts
@@ -302,6 +302,7 @@ export class VerticalDiffManager {
     newCode,
     toolCallId,
     rulesToInclude,
+    isApply,
   }: {
     input: string;
     llm: ILLM;
@@ -311,6 +312,7 @@ export class VerticalDiffManager {
     newCode?: string;
     toolCallId?: string;
     rulesToInclude: undefined | RuleWithSource[];
+    isApply: boolean;
   }): Promise<string | undefined> {
     void vscode.commands.executeCommand(
       "setContext",
@@ -468,17 +470,23 @@ export class VerticalDiffManager {
       const streamedLines: string[] = [];
 
       async function* recordedStream() {
-        const stream = streamDiffLines({
-          highlighted: rangeContent,
-          prefix,
-          suffix,
+        const stream = streamDiffLines(
+          {
+            highlighted: rangeContent,
+            prefix,
+            suffix,
+            input,
+            language: getMarkdownLanguageTagForFile(fileUri),
+            type: isApply ? "apply" : "edit",
+            newCode: newCode ?? "",
+            includeRulesInSystemMessage: !!rulesToInclude && !isApply,
+            modelTitle: llm.title ?? llm.model,
+          },
           llm,
-          rulesToInclude,
-          input,
-          language: getMarkdownLanguageTagForFile(fileUri),
-          overridePrompt,
           abortController,
-        });
+          overridePrompt,
+          rulesToInclude,
+        );
 
         for await (const line of stream) {
           if (line.type === "new" || line.type === "same") {

--- a/extensions/vscode/src/extension/VsCodeMessenger.ts
+++ b/extensions/vscode/src/extension/VsCodeMessenger.ts
@@ -229,6 +229,7 @@ export class VsCodeMessenger {
           new vscode.Position(end.line, end.character),
         ),
         rulesToInclude: config.rules,
+        isApply: false,
       });
 
       // Log dev data

--- a/extensions/vscode/src/quickEdit/QuickEditQuickPick.ts
+++ b/extensions/vscode/src/quickEdit/QuickEditQuickPick.ts
@@ -332,6 +332,7 @@ export class QuickEdit {
       quickEdit: this.previousInput,
       range: this.range,
       rulesToInclude: rules,
+      isApply: false,
     });
   }
 

--- a/packages/config-yaml/package-lock.json
+++ b/packages/config-yaml/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@continuedev/config-yaml",
-  "version": "1.14.0",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@continuedev/config-yaml",
-      "version": "1.14.0",
+      "version": "1.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",

--- a/packages/continue-sdk/package-lock.json
+++ b/packages/continue-sdk/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../config-yaml": {
       "name": "@continuedev/config-yaml",
-      "version": "1.14.0",
+      "version": "1.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",

--- a/packages/openai-adapters/src/apis/Inception.ts
+++ b/packages/openai-adapters/src/apis/Inception.ts
@@ -23,6 +23,7 @@ import { FimCreateParamsStreaming } from "./base.js";
 //   };
 
 export const UNIQUE_TOKEN = "<|!@#IS_NEXT_EDIT!@#|>";
+export const APPLY_UNIQUE_TOKEN = "<|!@#IS_APPLY!@#|>";
 export const INCEPTION_API_BASE = "https://api.inceptionlabs.ai/v1/";
 export class InceptionApi extends OpenAIApi {
   constructor(config: InceptionConfig) {
@@ -38,37 +39,7 @@ export class InceptionApi extends OpenAIApi {
     body: ChatCompletionCreateParamsStreaming,
     signal: AbortSignal,
   ): AsyncGenerator<ChatCompletionChunk, any, unknown> {
-    const endpoint = new URL("edit/completions", this.apiBase);
-    const resp = await customFetch(this.config.requestOptions)(endpoint, {
-      method: "POST",
-      body: JSON.stringify({
-        model: body.model,
-        messages: body.messages,
-        max_tokens: body.max_tokens,
-        temperature: body.temperature,
-        top_p: body.top_p,
-        frequency_penalty: body.frequency_penalty,
-        presence_penalty: body.presence_penalty,
-        stop: body.stop,
-        stream: true,
-      }),
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-        Authorization: `Bearer ${this.config.apiKey}`,
-      },
-      signal,
-    });
-
-    for await (const chunk of streamSse(resp as any)) {
-      if (chunk.choices?.[0]?.delta?.content) {
-        yield chatChunk({
-          content: chunk.choices[0].delta.content,
-          finish_reason: chunk.choices[0].finish_reason || null,
-          model: body.model,
-        });
-      }
-    }
+    yield* this.streamCustomEndpoint("edit/completions", body, signal);
   }
 
   // Add custom edit completions method (non-streaming).
@@ -76,30 +47,7 @@ export class InceptionApi extends OpenAIApi {
     body: ChatCompletionCreateParamsNonStreaming,
     signal: AbortSignal,
   ): Promise<ChatCompletion> {
-    const endpoint = new URL("edit/completions", this.apiBase);
-    const resp = await customFetch(this.config.requestOptions)(endpoint, {
-      method: "POST",
-      body: JSON.stringify({
-        model: body.model,
-        messages: body.messages,
-        max_tokens: body.max_tokens,
-        temperature: body.temperature,
-        top_p: body.top_p,
-        frequency_penalty: body.frequency_penalty,
-        presence_penalty: body.presence_penalty,
-        stop: body.stop,
-        stream: false, // Set to false for non-streaming
-      }),
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-        Authorization: `Bearer ${this.config.apiKey}`,
-      },
-      signal,
-    });
-
-    const data = await resp.json();
-    return data as ChatCompletion;
+    return this.nonStreamCustomEndpoint("edit/completions", body, signal);
   }
 
   // Override the regular chat stream method to route to edit endpoint for next edit requests.
@@ -108,8 +56,11 @@ export class InceptionApi extends OpenAIApi {
     signal: AbortSignal,
   ): AsyncGenerator<ChatCompletionChunk, any, unknown> {
     if (this.isNextEdit(body.messages)) {
-      body.messages = this.removeNextEditToken(body.messages);
+      body.messages = this.removeToken(body.messages, UNIQUE_TOKEN);
       yield* this.editCompletionStream(body, signal);
+    } else if (this.isApply(body.messages)) {
+      body.messages = this.removeToken(body.messages, APPLY_UNIQUE_TOKEN);
+      yield* this.applyCompletionStream(body, signal);
     } else {
       yield* super.chatCompletionStream(body, signal);
     }
@@ -121,11 +72,28 @@ export class InceptionApi extends OpenAIApi {
     signal: AbortSignal,
   ): Promise<ChatCompletion> {
     if (this.isNextEdit(body.messages)) {
-      body.messages = this.removeNextEditToken(body.messages);
+      body.messages = this.removeToken(body.messages, UNIQUE_TOKEN);
       return this.editCompletionNonStream(body, signal);
+    } else if (this.isApply(body.messages)) {
+      body.messages = this.removeToken(body.messages, APPLY_UNIQUE_TOKEN);
+      return this.applyCompletionNonStream(body, signal);
     } else {
       return super.chatCompletionNonStream(body, signal);
     }
+  }
+
+  async *applyCompletionStream(
+    body: ChatCompletionCreateParamsStreaming,
+    signal: AbortSignal,
+  ): AsyncGenerator<ChatCompletionChunk, any, unknown> {
+    yield* this.streamCustomEndpoint("apply/completions", body, signal);
+  }
+
+  async applyCompletionNonStream(
+    body: ChatCompletionCreateParamsNonStreaming,
+    signal: AbortSignal,
+  ): Promise<ChatCompletion> {
+    return this.nonStreamCustomEndpoint("apply/completions", body, signal);
   }
 
   async *fimStream(
@@ -179,24 +147,103 @@ export class InceptionApi extends OpenAIApi {
     );
   }
 
+  private isApply(messages: ChatCompletionMessageParam[]): boolean {
+    return messages.some(
+      (message) =>
+        typeof message.content === "string" &&
+        message.content.endsWith(APPLY_UNIQUE_TOKEN),
+    );
+  }
+
   // Remove the unique token from messages.
-  private removeNextEditToken(
+  private removeToken(
     messages: ChatCompletionMessageParam[],
+    token: string,
   ): ChatCompletionMessageParam[] {
     const lastMessage = messages[messages.length - 1];
 
     if (
       typeof lastMessage?.content === "string" &&
-      lastMessage.content.endsWith(UNIQUE_TOKEN)
+      lastMessage.content.endsWith(token)
     ) {
       const cleanedMessages = [...messages];
       cleanedMessages[cleanedMessages.length - 1] = {
         ...lastMessage,
-        content: lastMessage.content.slice(0, -UNIQUE_TOKEN.length),
+        content: lastMessage.content.slice(0, -token.length),
       };
       return cleanedMessages;
     }
 
     return messages;
+  }
+
+  private async *streamCustomEndpoint(
+    path: string,
+    body: ChatCompletionCreateParamsStreaming,
+    signal: AbortSignal,
+  ): AsyncGenerator<ChatCompletionChunk, any, unknown> {
+    const endpoint = new URL(path, this.apiBase);
+    const resp = await customFetch(this.config.requestOptions)(endpoint, {
+      method: "POST",
+      body: JSON.stringify({
+        model: body.model,
+        messages: body.messages,
+        max_tokens: body.max_tokens,
+        temperature: body.temperature,
+        top_p: body.top_p,
+        frequency_penalty: body.frequency_penalty,
+        presence_penalty: body.presence_penalty,
+        stop: body.stop,
+        stream: true,
+      }),
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        Authorization: `Bearer ${this.config.apiKey}`,
+      },
+      signal,
+    });
+
+    for await (const chunk of streamSse(resp as any)) {
+      const deltaContent = chunk.choices?.[0]?.delta?.content;
+      if (deltaContent) {
+        yield chatChunk({
+          content: deltaContent,
+          finish_reason: chunk.choices[0].finish_reason || null,
+          model: body.model,
+        });
+      }
+    }
+  }
+
+  private async nonStreamCustomEndpoint(
+    path: string,
+    body: ChatCompletionCreateParamsNonStreaming,
+    signal: AbortSignal,
+  ): Promise<ChatCompletion> {
+    const endpoint = new URL(path, this.apiBase);
+    const resp = await customFetch(this.config.requestOptions)(endpoint, {
+      method: "POST",
+      body: JSON.stringify({
+        model: body.model,
+        messages: body.messages,
+        max_tokens: body.max_tokens,
+        temperature: body.temperature,
+        top_p: body.top_p,
+        frequency_penalty: body.frequency_penalty,
+        presence_penalty: body.presence_penalty,
+        stop: body.stop,
+        stream: false,
+      }),
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        Authorization: `Bearer ${this.config.apiKey}`,
+      },
+      signal,
+    });
+
+    const data = await resp.json();
+    return data as ChatCompletion;
   }
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds Mercury Apply support to Inception by routing eligible chats to the new apply/completions endpoint. Automatically tags and strips a unique apply token to enable seamless streaming apply for Mercury Coder models.

- New Features
  - Introduced APPLY_UNIQUE_TOKEN and auto-injection for Inception models containing "mercury-coder".
  - Inception LLM and SDK route apply requests to apply/completions (streaming and non-streaming).
  - Tokens are removed before sending to the API; next-edit flow remains unchanged.

- Refactors
  - Shared helper for streaming/non-streaming custom endpoints in Inception adapters.
  - Disabled instant/unified diff apply in applyCodeBlock to always use streaming apply.

<!-- End of auto-generated description by cubic. -->

