### PR TITLE
fix: avoid NPE when failing to create missing dirs on writeFile

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/file/FileUtils.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/file/FileUtils.kt
@@ -4,6 +4,7 @@ import com.github.continuedev.continueintellijextension.FileStats
 import com.github.continuedev.continueintellijextension.FileType
 import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
@@ -24,10 +25,11 @@ class FileUtils(
     fun writeFile(fileUri: String, content: String) {
         val path = VfsUtilCore.urlToPath(fileUri)
         val pathDirectory = VfsUtil.getParentDir(path)
-            ?: return
+            ?: return LOG.warn("Parent directory is null for $path")
         val vfsDirectory = VfsUtil.createDirectories(pathDirectory)
+            ?: return LOG.warn("Could not create directories for $path")
         val pathFilename = VfsUtil.extractFileName(path)
-            ?: return
+            ?: return LOG.warn("Could not get filename for $path")
         runWriteAction {
             val newFile = vfsDirectory.createChildData(this, pathFilename)
             VfsUtil.saveText(newFile, content)
@@ -106,5 +108,9 @@ class FileUtils(
             return "$noAuthorityPrefix$path"
         }
         return fileUri
+    }
+
+    private companion object {
+        private val LOG = Logger.getInstance(FileUtils::class.java)
     }
 }


### PR DESCRIPTION
Related to #7829

We have test coverage for this case (the directory is created automatically if missing), but apparently there's a scenario where it can't be created. This change makes the code handle such situations gracefully: instead of throwing an error, the file simply won't be created.

Added extra logging to help debug this issue further.