### PR TITLE
fix: send highlighted code with Ctrl+Shift+J action

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/actions/ContinuePluginActions.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/actions/ContinuePluginActions.kt
@@ -61,26 +61,13 @@ class RejectDiffAction : AnAction() {
 
 class FocusContinueInputWithoutClearAction : ContinueToolbarAction() {
     override fun toolbarActionPerformed(project: Project) {
-        project.getBrowser()?.sendToWebview("focusContinueInputWithoutClear")
-        project.getBrowser()?.focusOnInput()
+        FocusActionUtil.sendHighlightedCodeWithMessageToWebview(project, "focusContinueInputWithoutClear")
     }
 }
 
 class FocusContinueInputAction : ContinueToolbarAction() {
-    override fun toolbarActionPerformed(project: Project) =
-        focusContinueInput(project)
-
-    companion object {
-        fun focusContinueInput(project: Project?) {
-            val browser = project?.getBrowser()
-                ?: return
-            browser.sendToWebview("focusContinueInputWithNewSession")
-            browser.focusOnInput()
-            val rif = EditorUtils.getEditor(project)?.getHighlightedRIF()
-                ?: return
-            val code = HighlightedCodePayload(RangeInFileWithContents(rif.filepath, rif.range, rif.contents))
-            browser.sendToWebview("highlightedCode", code)
-        }
+    override fun toolbarActionPerformed(project: Project) {
+        FocusActionUtil.sendHighlightedCodeWithMessageToWebview(project, "focusContinueInputWithNewSession")
     }
 }
 
@@ -115,5 +102,16 @@ class OpenLogsAction : AnAction() {
     }
 }
 
-
+object FocusActionUtil {
+    fun sendHighlightedCodeWithMessageToWebview(project: Project?, messageType: String) {
+        val browser = project?.getBrowser()
+            ?: return
+        browser.sendToWebview(messageType)
+        browser.focusOnInput()
+        val rif = EditorUtils.getEditor(project)?.getHighlightedRIF()
+            ?: return
+        val code = HighlightedCodePayload(RangeInFileWithContents(rif.filepath, rif.range, rif.contents))
+        browser.sendToWebview("highlightedCode", code)
+    }
+}
 

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/ToolTipComponent.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/ToolTipComponent.kt
@@ -1,4 +1,4 @@
-import com.github.continuedev.continueintellijextension.actions.FocusContinueInputAction
+import com.github.continuedev.continueintellijextension.actions.FocusActionUtil
 import com.github.continuedev.continueintellijextension.editor.openInlineEdit
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.colors.EditorColorsManager
@@ -92,7 +92,7 @@ class ToolTipComponent(editor: Editor, x: Int, y: Int) :
         editButton = StyledButton("Edit (${cmdCtrlChar}+I)")
 
         addToChatButton.addActionListener { e: ActionEvent? ->
-            FocusContinueInputAction.focusContinueInput(editor.project)
+            FocusActionUtil.sendHighlightedCodeWithMessageToWebview(editor.project, "focusContinueInputWithNewSession")
             editor.contentComponent.remove(this)
         }
         editButton.addActionListener { e: ActionEvent? ->


### PR DESCRIPTION
Related to #7747

### Ctrl + J (no regression)

![Peek 2025-09-18 19-36](https://github.com/user-attachments/assets/940a6004-f1fb-4221-bf90-576b50f9b168)

### Ctrl + Shift + J (this one is fixed now; chat conversation is preserved)

![Peek 2025-09-18 19-35](https://github.com/user-attachments/assets/f3b1d1dd-850c-4139-9e95-7476612a400b)
