### PR TITLE
fix: point Continue review hash to latest main

### DIFF
--- a/.github/workflows/continue-detailed-review.yaml
+++ b/.github/workflows/continue-detailed-review.yaml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Run Detailed PR Review
-        uses: continuedev/continue/actions/detailed-review@3ebd8232440080aa8891909753f69d75a87b2c86
+        uses: continuedev/continue/actions/detailed-review@e3ed0b6218e5d339e2fb265d06a267e98e7c7585
         with:
           continue-api-key: ${{ secrets.CONTINUE_API_KEY }}
           continue-org: continuedev

--- a/.github/workflows/continue-general-review.yaml
+++ b/.github/workflows/continue-general-review.yaml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Run Continue PR Review Action
-        uses: continuedev/continue/actions/general-review@3ebd8232440080aa8891909753f69d75a87b2c86
+        uses: continuedev/continue/actions/general-review@e3ed0b6218e5d339e2fb265d06a267e98e7c7585
         with:
           continue-api-key: ${{ secrets.CONTINUE_API_KEY }}
           continue-org: "continuedev"


### PR DESCRIPTION
## Description

Followup PR from https://github.com/continuedev/continue/pull/7836, should hopefully [fix these kinds of failing tests](https://github.com/continuedev/continue/actions/runs/17810262892/job/50713918167#logs)

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
