### PR TITLE
fix: make config-yaml compatible with browser

### DIFF
--- a/packages/config-yaml/src/interfaces/slugs.test.ts
+++ b/packages/config-yaml/src/interfaces/slugs.test.ts
@@ -158,4 +158,62 @@ describe("PackageIdentifier", () => {
       "Unknown URI type: invalid",
     );
   });
+
+  it("should expand leading tilde when HOME is available", () => {
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+
+    try {
+      process.env.HOME = "/tmp/test-home";
+      delete process.env.USERPROFILE;
+
+      const decoded = decodePackageIdentifier("~/package.yaml");
+
+      expect(decoded).toEqual({
+        uriType: "file" as const,
+        fileUri: "/tmp/test-home/package.yaml",
+      });
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+
+      if (originalUserProfile === undefined) {
+        delete process.env.USERPROFILE;
+      } else {
+        process.env.USERPROFILE = originalUserProfile;
+      }
+    }
+  });
+
+  it("should leave leading tilde when no home directory is available", () => {
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+
+    try {
+      delete process.env.HOME;
+      delete process.env.USERPROFILE;
+
+      const decoded = decodePackageIdentifier("~/package.yaml");
+
+      expect(decoded).toEqual({
+        uriType: "file" as const,
+        fileUri: "~/package.yaml",
+      });
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+
+      if (originalUserProfile === undefined) {
+        delete process.env.USERPROFILE;
+      } else {
+        process.env.USERPROFILE = originalUserProfile;
+      }
+    }
+  });
 });


### PR DESCRIPTION
## Description

avoid importing node:os to make config-yaml compatible with browser for remote-config-server
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Make config-yaml work in the browser by removing the node:os dependency and safely handling "~" path expansion. This unblocks remote-config-server in browser contexts.

- **Bug Fixes**
  - Replaced os.homedir() with environment-based helpers that read HOME/USERPROFILE only if available; no Node imports.
  - Expanded only a leading "~"; if no home dir is found, the path is left unchanged.
  - Added tests for both cases (HOME present and absent).

<!-- End of auto-generated description by cubic. -->

