### PR TITLE
fix: uniform codeblock border

### DIFF
--- a/gui/src/components/UnifiedTerminal/UnifiedTerminal.tsx
+++ b/gui/src/components/UnifiedTerminal/UnifiedTerminal.tsx
@@ -423,7 +423,7 @@ export function UnifiedTerminalCommand({
       className="mb-4"
       data-testid="terminal-container"
     >
-      <div className="outline-command-border -outline-offset-0.5 rounded-default bg-editor !my-2 flex min-w-0 flex-col outline outline-1">
+      <div className="outline-command-border rounded-default bg-editor !my-2 flex min-w-0 flex-col outline outline-1">
         {/* Toolbar */}
         <div
           className={`find-widget-skip bg-editor sticky -top-2 z-10 m-0 flex items-center justify-between gap-3 px-1.5 py-1 ${


### PR DESCRIPTION
## Description

The codeblock toolbar and its content had separate border widths (the content border being wider). This PR fixes it.

resolves CON-3920

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

**before**
<img width="986" height="238" alt="image" src="https://github.com/user-attachments/assets/66e01f4c-3b4c-49a5-90a7-87a6c5afee29" />


**after**
<img width="1004" height="260" alt="image" src="https://github.com/user-attachments/assets/bd8ee60d-c194-4c8b-9d6a-49d0e741f7f0" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes uneven codeblock borders by removing the negative outline offset on the UnifiedTerminal container. Toolbar and content now share the same 1px border for a consistent look.

<!-- End of auto-generated description by cubic. -->

