### PR TITLE
feat: split large blocks of chat history to reduce flickering

### DIFF
--- a/extensions/cli/src/ui/components/MemoizedMessage.tsx
+++ b/extensions/cli/src/ui/components/MemoizedMessage.tsx
@@ -44,10 +44,11 @@ function formatMessageContentForDisplay(
 interface MemoizedMessageProps {
   item: ChatHistoryItem;
   index: number;
+  hideBullet?: boolean;
 }
 
 export const MemoizedMessage = memo<MemoizedMessageProps>(
-  ({ item, index }) => {
+  ({ item, index, hideBullet = false }) => {
     const { message, toolCallStates, conversationSummary } = item;
     const isUser = message.role === "user";
     const isSystem = message.role === "system";
@@ -93,7 +94,7 @@ export const MemoizedMessage = memo<MemoizedMessageProps>(
           {/* Render assistant message content if any */}
           {message.content && (
             <Box marginBottom={1}>
-              <Text color="white">●</Text>
+              <Text color="white">{hideBullet ? " " : "●"}</Text>
               <Text> </Text>
               <MarkdownRenderer
                 content={formatMessageContentForDisplay(message.content)}
@@ -166,7 +167,7 @@ export const MemoizedMessage = memo<MemoizedMessageProps>(
 
     return (
       <Box key={index} marginBottom={1}>
-        <Text color={isUser ? "blue" : "white"}>●</Text>
+        <Text color={isUser ? "blue" : "white"}>{hideBullet ? " " : "●"}</Text>
         <Text> </Text>
         {isUser ? (
           <Text color="gray">
@@ -195,7 +196,8 @@ export const MemoizedMessage = memo<MemoizedMessageProps>(
       JSON.stringify(prevToolStates) === JSON.stringify(nextToolStates) &&
       prevProps.item.conversationSummary ===
         nextProps.item.conversationSummary &&
-      prevProps.index === nextProps.index
+      prevProps.index === nextProps.index &&
+      prevProps.hideBullet === nextProps.hideBullet
     );
   },
 );

--- a/extensions/cli/src/ui/components/StaticChatContent.tsx
+++ b/extensions/cli/src/ui/components/StaticChatContent.tsx
@@ -7,6 +7,7 @@ import type { MCPService } from "../../services/MCPService.js";
 import type { QueuedMessage } from "../../stream/messageQueue.js";
 import { useTerminalSize } from "../hooks/useTerminalSize.js";
 import { IntroMessage } from "../IntroMessage.js";
+import { splitChatHistory } from "../utils/historySplitting.js";
 
 interface StaticChatContentProps {
   showIntroMessage: boolean;
@@ -15,8 +16,12 @@ interface StaticChatContentProps {
   mcpService?: MCPService;
   chatHistory: ChatHistoryItem[];
   queuedMessages?: QueuedMessage[];
-  renderMessage: (item: ChatHistoryItem, index: number) => React.ReactElement;
-  refreshTrigger?: number; // Add a prop to trigger refresh from parent
+  renderMessage: (
+    item: ChatHistoryItem,
+    index: number,
+    allMessages?: ChatHistoryItem[],
+  ) => React.ReactElement;
+  refreshTrigger?: number;
 }
 
 export const StaticChatContent: React.FC<StaticChatContentProps> = ({
@@ -32,7 +37,7 @@ export const StaticChatContent: React.FC<StaticChatContentProps> = ({
   const { columns, rows } = useTerminalSize();
   const { stdout } = useStdout();
 
-  // State for managing static refresh with key-based remounting (gemini-cli approach)
+  // State for managing static refresh with key-based remounting
   const [staticKey, setStaticKey] = useState(0);
   const isInitialMount = useRef(true);
 
@@ -69,15 +74,18 @@ export const StaticChatContent: React.FC<StaticChatContentProps> = ({
     }
   }, [refreshTrigger, refreshStatic]);
 
-  // Filter out system messages without content
-  const filteredChatHistory = React.useMemo(() => {
-    return chatHistory.filter(
+  // Filter out system messages without content and split large messages
+  const processedChatHistory = React.useMemo(() => {
+    const filtered = chatHistory.filter(
       (item) => item.message.role !== "system" || item.message.content,
     );
-  }, [chatHistory]);
+
+    // Split large messages into multiple history items
+    return splitChatHistory(filtered, columns);
+  }, [chatHistory, columns]);
 
   // Split chat history into stable and pending items
-  // The last two items may have pending tool calls
+  // Keep more items static now that we've split large messages
   const { staticItems, pendingItems } = React.useMemo(() => {
     // Add intro message as first item if it should be shown
     const staticItems: React.ReactElement[] = [];
@@ -92,22 +100,24 @@ export const StaticChatContent: React.FC<StaticChatContentProps> = ({
       );
     }
 
+    // Since messages are now split into reasonably-sized chunks,
+    // we can keep more items static (only last 1-2 items dynamic)
     const PENDING_ITEMS_COUNT = 1;
     const stableCount = Math.max(
       0,
-      filteredChatHistory.length - PENDING_ITEMS_COUNT,
+      processedChatHistory.length - PENDING_ITEMS_COUNT,
     );
-    const stableHistory = filteredChatHistory.slice(0, stableCount);
-    const pendingHistory = filteredChatHistory.slice(stableCount);
+    const stableHistory = processedChatHistory.slice(0, stableCount);
+    const pendingHistory = processedChatHistory.slice(stableCount);
 
     // Add stable messages to static items
     stableHistory.forEach((item, index) => {
-      staticItems.push(renderMessage(item, index));
+      staticItems.push(renderMessage(item, index, processedChatHistory));
     });
 
     // Pending items will be rendered dynamically outside Static
     const pendingItems = pendingHistory.map((item, index) =>
-      renderMessage(item, stableCount + index),
+      renderMessage(item, stableCount + index, processedChatHistory),
     );
 
     return {
@@ -119,7 +129,7 @@ export const StaticChatContent: React.FC<StaticChatContentProps> = ({
     config,
     model,
     mcpService,
-    filteredChatHistory,
+    processedChatHistory,
     renderMessage,
   ]);
 

--- a/extensions/cli/src/ui/hooks/useMessageRenderer.tsx
+++ b/extensions/cli/src/ui/hooks/useMessageRenderer.tsx
@@ -4,22 +4,38 @@ import type { ChatHistoryItem } from "../../../../../core/index.js";
 import { MemoizedMessage } from "../components/MemoizedMessage.js";
 
 export function useMessageRenderer() {
-  const renderMessage = useCallback((item: ChatHistoryItem, index: number) => {
-    // Generate a unique key by combining message role, content hash, and timestamp
-    // This provides a stable identifier that won't change during re-renders
-    const messageContent =
-      typeof item.message.content === "string"
-        ? item.message.content
-        : JSON.stringify(item.message.content);
+  const renderMessage = useCallback(
+    (item: ChatHistoryItem, index: number, allMessages?: ChatHistoryItem[]) => {
+      // Generate a unique key by combining message role, content hash, and timestamp
+      // This provides a stable identifier that won't change during re-renders
+      const messageContent =
+        typeof item.message.content === "string"
+          ? item.message.content
+          : JSON.stringify(item.message.content);
 
-    const toolCallsKey = item.toolCallStates
-      ? item.toolCallStates.map((tc) => tc.toolCallId).join("-")
-      : "";
+      const toolCallsKey = item.toolCallStates
+        ? item.toolCallStates.map((tc) => tc.toolCallId).join("-")
+        : "";
 
-    const uniqueKey = `${item.message.role}-${messageContent.slice(0, 50)}-${toolCallsKey}-${index}`;
+      // Check if this is a continuation of the previous message (same role)
+      const previousMessage =
+        allMessages && index > 0 ? allMessages[index - 1] : null;
+      const isContinuation =
+        previousMessage?.message.role === item.message.role;
 
-    return <MemoizedMessage key={uniqueKey} item={item} index={index} />;
-  }, []);
+      const uniqueKey = `${item.message.role}-${messageContent.slice(0, 50)}-${toolCallsKey}-${index}`;
+
+      return (
+        <MemoizedMessage
+          key={uniqueKey}
+          item={item}
+          index={index}
+          hideBullet={isContinuation}
+        />
+      );
+    },
+    [],
+  );
 
   return { renderMessage };
 }

--- a/extensions/cli/src/ui/utils/historySplitting.test.ts
+++ b/extensions/cli/src/ui/utils/historySplitting.test.ts
@@ -1,0 +1,58 @@
+import type { ChatHistoryItem } from "core";
+import { describe, expect, it } from "vitest";
+
+import { splitChatHistory } from "./historySplitting.js";
+
+// Helper to create a mock chat history item
+function createMockChatHistoryItem(
+  content: string,
+  role: "user" | "assistant" = "assistant",
+): ChatHistoryItem {
+  return {
+    message: {
+      role,
+      content,
+    },
+  } as ChatHistoryItem;
+}
+
+describe("messageHistorySplitting", () => {
+  describe("splitChatHistory", () => {
+    it("should split multiple large messages in chat history", () => {
+      const chatHistory = [
+        createMockChatHistoryItem("Short message 1"),
+        createMockChatHistoryItem(
+          Array(30).fill("Long message 1").join("\n\n"),
+        ),
+        createMockChatHistoryItem("Short message 2"),
+        createMockChatHistoryItem(
+          Array(25).fill("Long message 2").join("\n\n"),
+        ),
+      ];
+
+      const result = splitChatHistory(chatHistory, 80);
+
+      // Should have more items than the original (due to splits)
+      expect(result.length).toBeGreaterThan(chatHistory.length);
+
+      // First and third messages should remain unchanged
+      expect(result[0].message.content).toBe("Short message 1");
+    });
+
+    it("should maintain order after splitting", () => {
+      const chatHistory = [
+        createMockChatHistoryItem("First"),
+        createMockChatHistoryItem(Array(30).fill("Long middle").join("\n\n")),
+        createMockChatHistoryItem("Last"),
+      ];
+
+      const result = splitChatHistory(chatHistory, 80);
+
+      // First message should still be first
+      expect(result[0].message.content).toBe("First");
+
+      // Last message should still be last
+      expect(result[result.length - 1].message.content).toBe("Last");
+    });
+  });
+});

--- a/extensions/cli/src/ui/utils/historySplitting.ts
+++ b/extensions/cli/src/ui/utils/historySplitting.ts
@@ -1,0 +1,170 @@
+import type { ChatHistoryItem } from "core";
+
+import { findLastSafeSplitPoint } from "./messageSplitting.js";
+
+const MAX_HEIGHT_BEFORE_SPLIT = 20;
+
+/**
+ * Splits a chat history item into multiple items if its content is too large.
+ *
+ * This function prevents UI flickering by breaking large messages into manageable chunks.
+ * It only splits at safe markdown boundaries (paragraph breaks: \n\n) to preserve formatting.
+ *
+ * Splitting behavior:
+ * - User messages: Split only when they have natural paragraph breaks (\n\n)
+ * - Assistant messages: Split when content exceeds height threshold
+ * - System messages: Never split
+ * - Messages with tool calls: Never split
+ *
+ * Common use cases:
+ * - User pastes multiple paragraphs of text -> Split at paragraph boundaries
+ * - User writes one long paragraph -> Keep as single message
+ * - Assistant generates long response -> Split at paragraph breaks (\n\n)
+ */
+function splitChatHistoryItem(
+  item: ChatHistoryItem,
+  terminalWidth: number,
+): ChatHistoryItem[] {
+  // Don't split non-text messages or messages with tool calls
+  if (item.toolCallStates?.length || typeof item.message.content !== "string") {
+    return [item];
+  }
+
+  // Don't split system messages
+  if (item.message.role === "system") {
+    return [item];
+  }
+
+  const content = item.message.content;
+
+  if (!shouldSplitContent(content, terminalWidth)) {
+    return [item];
+  }
+
+  return splitContentIntoHistoryItems(item, content, terminalWidth);
+}
+
+/**
+ * Splits content into multiple chat history items at safe markdown boundaries.
+ */
+function splitContentIntoHistoryItems(
+  originalItem: ChatHistoryItem,
+  content: string,
+  terminalWidth: number,
+): ChatHistoryItem[] {
+  const items: ChatHistoryItem[] = [];
+  let remainingContent = content;
+  let itemIndex = 0;
+
+  while (remainingContent.length > 0) {
+    if (!shouldSplitContent(remainingContent, terminalWidth)) {
+      // Remaining content is small enough, add it as the final item
+      if (remainingContent.trim()) {
+        items.push({
+          ...originalItem,
+          message: {
+            ...originalItem.message,
+            content: remainingContent,
+          },
+        });
+      }
+      break;
+    }
+
+    // Find safe split point
+    const splitPoint = findLastSafeSplitPoint(remainingContent);
+
+    if (splitPoint === remainingContent.length) {
+      // No safe split point found, add as single large item
+      if (remainingContent.trim()) {
+        items.push({
+          ...originalItem,
+          message: {
+            ...originalItem.message,
+            content: remainingContent,
+          },
+        });
+      }
+      break;
+    }
+
+    // Split at the safe point
+    const beforeText = remainingContent.slice(0, splitPoint).trim();
+    remainingContent = remainingContent.slice(splitPoint).trim();
+
+    if (beforeText) {
+      items.push({
+        ...originalItem,
+        message: {
+          ...originalItem.message,
+          content: beforeText,
+        },
+      });
+    }
+
+    itemIndex++;
+
+    // Prevent infinite loops
+    if (itemIndex > 50) {
+      console.warn("Message splitting exceeded maximum iterations, stopping");
+      if (remainingContent.trim()) {
+        items.push({
+          ...originalItem,
+          message: {
+            ...originalItem.message,
+            content: remainingContent,
+          },
+        });
+      }
+      break;
+    }
+  }
+
+  return items;
+}
+
+/**
+ * Processes an entire chat history array, splitting large items into multiple items.
+ */
+export function splitChatHistory(
+  chatHistory: ChatHistoryItem[],
+  terminalWidth: number,
+): ChatHistoryItem[] {
+  const result: ChatHistoryItem[] = [];
+
+  for (const item of chatHistory) {
+    const splitItems = splitChatHistoryItem(item, terminalWidth);
+    result.push(...splitItems);
+  }
+
+  return result;
+}
+
+/**
+ * Estimates the height in terminal rows that content will take when rendered.
+ */
+function estimateContentHeight(content: string, terminalWidth: number): number {
+  if (!content) return 0;
+
+  const lines = content.split("\n");
+  let totalHeight = 0;
+
+  for (const line of lines) {
+    if (line.length === 0) {
+      totalHeight += 1; // Empty line
+    } else {
+      // Account for line wrapping
+      totalHeight += Math.ceil(line.length / Math.max(terminalWidth - 2, 40));
+    }
+  }
+
+  return totalHeight;
+}
+
+/**
+ * Determines if content should be split based on its estimated height.
+ */
+function shouldSplitContent(content: string, terminalWidth: number): boolean {
+  const estimatedHeight = estimateContentHeight(content, terminalWidth);
+  return estimatedHeight > MAX_HEIGHT_BEFORE_SPLIT;
+}

--- a/extensions/cli/src/ui/utils/messageSplitting.test.ts
+++ b/extensions/cli/src/ui/utils/messageSplitting.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * NOTICE: This file has been modified from the original Gemini CLI source
+ * for integration with Continue CLI (cn)
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { findLastSafeSplitPoint } from "./messageSplitting.js";
+
+describe("markdownUtilities", () => {
+  describe("findLastSafeSplitPoint", () => {
+    it("should split at the last double newline if not in a code block", () => {
+      const content = "paragraph1\n\nparagraph2\n\nparagraph3";
+      expect(findLastSafeSplitPoint(content)).toBe(24); // After the second \n\n
+    });
+
+    it("should return content.length if no safe split point is found", () => {
+      const content = "longstringwithoutanysafesplitpoint";
+      expect(findLastSafeSplitPoint(content)).toBe(content.length);
+    });
+
+    it("should prioritize splitting at \n\n over being at the very end of the string if the end is not in a code block", () => {
+      const content = "Some text here.\n\nAnd more text here.";
+      expect(findLastSafeSplitPoint(content)).toBe(17); // after the \n\n
+    });
+
+    it("should return content.length if the only \n\n is inside a code block and the end of content is not", () => {
+      const content = "```\nignore this\n\nnewline\n```KeepThis";
+      expect(findLastSafeSplitPoint(content)).toBe(content.length);
+    });
+
+    it("should correctly identify the last \n\n even if it is followed by text not in a code block", () => {
+      const content =
+        "First part.\n\nSecond part.\n\nThird part, then some more text.";
+      // Split should be after "Second part.\n\n"
+      // "First part.\n\n" is 13 chars. "Second part.\n\n" is 14 chars. Total 27.
+      expect(findLastSafeSplitPoint(content)).toBe(27);
+    });
+
+    it("should return content.length if content is empty", () => {
+      const content = "";
+      expect(findLastSafeSplitPoint(content)).toBe(0);
+    });
+
+    it("should return content.length if content has no newlines and no code blocks", () => {
+      const content = "Single line of text";
+      expect(findLastSafeSplitPoint(content)).toBe(content.length);
+    });
+  });
+});

--- a/extensions/cli/src/ui/utils/messageSplitting.ts
+++ b/extensions/cli/src/ui/utils/messageSplitting.ts
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * NOTICE: This file has been modified from the original Gemini CLI source
+ * for integration with Continue CLI (cn)
+ */
+
+/*
+**Background & Purpose:**
+
+The `findSafeSplitPoint` function is designed to address the challenge of displaying or processing large, potentially streaming, pieces of Markdown text. When content (e.g., from an LLM like Gemini) arrives in chunks or grows too large for a single display unit (like a message bubble), it needs to be split. A naive split (e.g., just at a character limit) can break Markdown formatting, especially critical for multi-line elements like code blocks, lists, or blockquotes, leading to incorrect rendering.
+
+This function aims to find an *intelligent* or "safe" index within the provided `content` string at which to make such a split, prioritizing the preservation of Markdown integrity.
+
+**Key Expectations & Behavior (Prioritized):**
+
+1.  **No Split if Short Enough:**
+    * If `content.length` is less than or equal to `idealMaxLength`, the function should return `content.length` (indicating no split is necessary for length reasons).
+
+2.  **Code Block Integrity (Highest Priority for Safety):**
+    * The function must try to avoid splitting *inside* a fenced code block (i.e., between ` ``` ` and ` ``` `).
+    * If `idealMaxLength` falls within a code block:
+        * The function will attempt to return an index that splits the content *before* the start of that code block.
+        * If a code block starts at the very beginning of the `content` and `idealMaxLength` falls within it (meaning the block itself is too long for the first chunk), the function might return `0`. This effectively makes the first chunk empty, pushing the entire oversized code block to the second part of the split.
+    * When considering splits near code blocks, the function prefers to keep the entire code block intact in one of the resulting chunks.
+
+3.  **Markdown-Aware Newline Splitting (If Not Governed by Code Block Logic):**
+    * If `idealMaxLength` does not fall within a code block (or after code block considerations have been made), the function will look for natural break points by scanning backwards from `idealMaxLength`:
+        * **Paragraph Breaks:** It prioritizes splitting after a double newline (`\n\n`), as this typically signifies the end of a paragraph or a block-level element.
+        * **Single Line Breaks:** If no double newline is found in a suitable range, it will look for a single newline (`\n`).
+    * Any newline chosen as a split point must also not be inside a code block.
+
+4.  **Fall back to `idealMaxLength`:**
+    * If no "safer" split point (respecting code blocks or finding suitable newlines) is identified before or at `idealMaxLength`, and `idealMaxLength` itself is not determined to be an unsafe split point (e.g., inside a code block), the function may return a length larger than `idealMaxLength`, again it CANNOT break markdown formatting. This could happen with very long lines of text without Markdown block structures or newlines.
+
+**In essence, `findSafeSplitPoint` tries to be a good Markdown citizen when forced to divide content, preferring structural boundaries over arbitrary character limits, with a strong emphasis on not corrupting code blocks.**
+*/
+
+/**
+ * Checks if a given character index within a string is inside a fenced (```) code block.
+ * @param content The full string content.
+ * @param indexToTest The character index to test.
+ * @returns True if the index is inside a code block's content, false otherwise.
+ */
+const isIndexInsideCodeBlock = (
+  content: string,
+  indexToTest: number,
+): boolean => {
+  let fenceCount = 0;
+  let searchPos = 0;
+  while (searchPos < content.length) {
+    const nextFence = content.indexOf("```", searchPos);
+    if (nextFence === -1 || nextFence >= indexToTest) {
+      break;
+    }
+    fenceCount++;
+    searchPos = nextFence + 3;
+  }
+  return fenceCount % 2 === 1;
+};
+
+/**
+ * Finds the starting index of the code block that encloses the given index.
+ * Returns -1 if the index is not inside a code block.
+ * @param content The markdown content.
+ * @param index The index to check.
+ * @returns Start index of the enclosing code block or -1.
+ */
+const findEnclosingCodeBlockStart = (
+  content: string,
+  index: number,
+): number => {
+  if (!isIndexInsideCodeBlock(content, index)) {
+    return -1;
+  }
+  let currentSearchPos = 0;
+  while (currentSearchPos < index) {
+    const blockStartIndex = content.indexOf("```", currentSearchPos);
+    if (blockStartIndex === -1 || blockStartIndex >= index) {
+      break;
+    }
+    const blockEndIndex = content.indexOf("```", blockStartIndex + 3);
+    if (blockStartIndex < index) {
+      if (blockEndIndex === -1 || index < blockEndIndex + 3) {
+        return blockStartIndex;
+      }
+    }
+    if (blockEndIndex === -1) break;
+    currentSearchPos = blockEndIndex + 3;
+  }
+  return -1;
+};
+
+export const findLastSafeSplitPoint = (content: string): number => {
+  const enclosingBlockStart = findEnclosingCodeBlockStart(
+    content,
+    content.length,
+  );
+  if (enclosingBlockStart !== -1) {
+    // The end of the content is contained in a code block. Split right before.
+    return enclosingBlockStart;
+  }
+
+  // Search for the last double newline (\n\n) not in a code block.
+  let searchStartIndex = content.length;
+  while (searchStartIndex >= 0) {
+    const dnlIndex = content.lastIndexOf("\n\n", searchStartIndex);
+    if (dnlIndex === -1) {
+      // No more double newlines found.
+      break;
+    }
+
+    const potentialSplitPoint = dnlIndex + 2;
+    if (!isIndexInsideCodeBlock(content, potentialSplitPoint)) {
+      return potentialSplitPoint;
+    }
+
+    // If potentialSplitPoint was inside a code block,
+    // the next search should start *before* the \n\n we just found to ensure progress.
+    searchStartIndex = dnlIndex - 1;
+  }
+
+  // If no safe double newline is found, return content.length
+  // to keep the entire content as one piece.
+  return content.length;
+};


### PR DESCRIPTION
## Description

Simpler approach to help reduce flickering. We split chat history content at `\n\n` and avoid splitting inside code blocks, to get smaller chunks that'll fit inside terminal height. This does not affect tool call results. Flickering can still occur if terminal font size is very large or if your terminal is very tall/narrow, but I think this should be a more safe/conservative strategy that should solve the particularly bad flickering. Play around with it and see if you see any improvements.

The hideBullet logic is for when a single message is split into multiple we hide the bullet so it looks like one cohesive message.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Split large chat messages into smaller, markdown-safe chunks to reduce flickering and keep the CLI chat view stable. Addresses Linear CON-3862 by keeping more messages static while streaming.

- **New Features**
  - Added message/history splitting that breaks content at paragraph boundaries, respects code blocks, and avoids splitting system or tool-call messages.
  - Renderer now hides the bullet for continuation chunks; comprehensive tests added for splitting logic.

- **Refactors**
  - StaticChatContent processes history via splitChatHistory and renders only the last item dynamically; renderMessage now receives allMessages.
  - MemoizedMessage supports a hideBullet prop and includes it in memoization for stable rendering.

<!-- End of auto-generated description by cubic. -->

