### PR TITLE
fix: HOTFIX r.map is not a function

### DIFF
--- a/gui/src/pages/gui/ToolCallDiv/FindAndReplace.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/FindAndReplace.tsx
@@ -119,7 +119,10 @@ export function FindAndReplaceDisplay({
     if (editingFileContents) {
       return editingFileContents;
     }
-    return edits?.map((edit) => edit.old_string ?? "").join("\n");
+    if (Array.isArray(edits)) {
+      return edits.map((edit) => edit.old_string ?? "").join("\n");
+    }
+    return "";
   }, [editingFileContents, edits]);
 
   const diffResult = useMemo(() => {


### PR DESCRIPTION
## Description
Fixes https://github.com/continuedev/continue/issues/7838
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes a runtime error in FindAndReplaceDisplay where map was called on a non-array edits value, causing the UI to crash.
We now guard with Array.isArray and return an empty string when invalid, preventing crashes and stabilizing diff rendering.

<!-- End of auto-generated description by cubic. -->

