### PR TITLE
add if statement to check url starts with "http" then go to url directly

### DIFF
--- a/core/core.ts
+++ b/core/core.ts
@@ -458,6 +458,10 @@ export class Core {
 
     on("controlPlane/openUrl", async (msg) => {
       const env = await getControlPlaneEnv(this.ide.getIdeSettings());
+      if (msg.data.path.startsWith("http")) {
+        await this.messenger.request("openUrl", msg.data.path);
+        return;
+      }
       const urlPath = msg.data.path.startsWith("/")
         ? msg.data.path.slice(1)
         : msg.data.path;


### PR DESCRIPTION
## Description

Fixes #7873

- Added `if` statement in `controlPlane/openUrl` to check if URL starts with `http`
- Directly opens external links instead of prepending `hub.continue.dev`

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screenshots

For context, see issue #7873 for broken link screenshots.

<img width="1518" height="300" alt="image" src="https://github.com/user-attachments/assets/d5769f4b-acb2-4768-bb6f-3c6c9f7191a1" />
