### PR TITLE
fix: increase jetbrains autocomplete timeout

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/ContinueCompletionService.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/ContinueCompletionService.kt
@@ -16,7 +16,7 @@ class ContinueCompletionService(private val project: Project) : CompletionServic
     override suspend fun getAutocomplete(uuid: String, url: String, line: Int, column: Int): String? {
         val requestInput = getCompletionInput(uuid, url, line, column)
         val modelTimeout = project.service<ProfileInfoService>().fetchModelTimeoutOrNull() ?: 1000.0
-        return withTimeoutOrNull(modelTimeout.milliseconds) {
+        return withTimeoutOrNull(modelTimeout.milliseconds * 3) {
             suspendCancellableCoroutine { continuation ->
                 project.service<ContinuePluginService>().coreMessenger?.request(
                     "autocomplete/complete",


### PR DESCRIPTION
## Description

There is a misalignment in the timeout handling logic for code autocompletion between the `intellij` and `core`.
The `intellij` utilizes modelTimeout as a strict, overall timeout for the entire process.
The `core`, however, sets the autocomplete timeout to 2.5 * modelTimeout, with the intention of displaying partial results after the initial modelTimeout is reached.

Here propose to increase the `intellij`'s timeout to ensure it would not break before `core`

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
