### PR TITLE
feat: --id flag for cn serve

### DIFF
--- a/extensions/cli/docs/storage-sync.md
+++ b/extensions/cli/docs/storage-sync.md
@@ -1,0 +1,55 @@
+# Storage Sync Flow for `cn serve`
+
+## Overview
+
+The `--id <storageId>` flag enables the `cn serve` command to periodically persist session state to an external Continue-managed storage bucket. On startup, the CLI exchanges the provided `storageId` for two pre-signed S3 URLs - one for `session.json` and one for `diff.txt` - and then pushes fresh copies of those files every 30 seconds.
+
+This document captures the responsibilities for both the CLI and backend components so we can iterate on the feature together.
+
+## CLI Responsibilities
+
+- **Flag plumbing**: When `cn serve` is invoked with `--id <storageId>`, the CLI treats that value as an opaque identifier.
+- **API key auth**: The CLI attaches the user-level Continue API key (same mechanism we already use for other authenticated requests) to backend calls.
+- **Presign handshake**:
+  1. On startup, issue `POST https://api.continue.dev/agents/storage/presigned-url` with JSON payload `{ "storageId": "<storageId>" }`.
+  2. Expect a response payload containing two pre-signed `PUT` URLs and their target object keys:
+     ```json
+     {
+       "session": {
+         "key": "sessions/<sessionId>/session.json",
+         "putUrl": "https://<s3-host>/..."
+       },
+       "diff": {
+         "key": "sessions/<sessionId>/diff.txt",
+         "putUrl": "https://<s3-host>/..."
+       }
+     }
+     ```
+  3. If the call fails, log and continue without remote storage (no retries yet).
+- **Periodic uploads**:
+  - Every 30 seconds (configurable later), serialize the in-memory session to `session.json` and fetch the `/diff` payload to produce `diff.txt`.
+  - Upload both artifacts using their respective `PUT` URLs. For now we overwrite the same objects each cycle.
+  - Errors should be logged but non-fatal; the server keeps running.
+  - If the repo check fails (no git repo or missing `main`), `diff.txt` uploads an empty string and we log the condition once for debugging.
+
+## Backend Responsibilities
+
+- **Endpoint surface**: `POST /agents/storage/presigned-url` accepts a JSON body `{ "storageId": string }`.
+- **Authentication**: Leverage the caller's Continue API key (the request arrives with the standard `Authorization: Bearer <apiKey>` header). Apply normal auth/tenant validation so users can only request URLs tied to their account/org.
+- **URL issuance**:
+  - Resolve `storageId` into the desired S3 prefix (e.g., `sessions/<org>/<storageId>/`).
+  - Generate two short-lived pre-signed `PUT` URLs: one for `session.json`, one for `diff.txt`.
+  - Return both URLs and their keys in the response payload described above.
+- **Expiration**: The initial implementation can hand out URLs with a generous TTL (e.g., 60 minutes). Later we will add CLI-side refresh logic before expiry.
+
+## Open Questions & Future Enhancements
+
+- **URL refresh**: When the presigned URLs expire we currently have no refresh cycle. We'd need either a renewal endpoint or to re-call the existing endpoint on failure.
+- **Upload cadence**: The 30-second interval is hard-coded for now. Consider making it configurable in both CLI and backend policies.
+- **Error telemetry**: Decide if repeated upload failures should trip analytics or circuit breakers.
+- **Diff source**: `diff.txt` currently mirrors the `/diff` endpoint response. Confirm backend expectations for format and size limits.
+- **Security**: We might want to sign responses or enforce stricter scope on `storageId` mapping (e.g., require both org + storageId and validate ownership).
+
+---
+
+This document should evolve alongside implementation details; update it whenever the API contract or client behavior changes.

--- a/extensions/cli/src/commands/BaseCommandOptions.ts
+++ b/extensions/cli/src/commands/BaseCommandOptions.ts
@@ -33,6 +33,4 @@ export interface ExtendedCommandOptions extends BaseCommandOptions {
   readonly?: boolean;
   /** Start in auto mode (all tools allowed) */
   auto?: boolean;
-  /** Storage identifier for remote sync */
-  id?: string;
 }

--- a/extensions/cli/src/commands/BaseCommandOptions.ts
+++ b/extensions/cli/src/commands/BaseCommandOptions.ts
@@ -33,4 +33,6 @@ export interface ExtendedCommandOptions extends BaseCommandOptions {
   readonly?: boolean;
   /** Start in auto mode (all tools allowed) */
   auto?: boolean;
+  /** Storage identifier for remote sync */
+  id?: string;
 }

--- a/extensions/cli/src/commands/serve.ts
+++ b/extensions/cli/src/commands/serve.ts
@@ -1,11 +1,8 @@
-import { exec } from "child_process";
-import { promisify } from "util";
-
 import chalk from "chalk";
 import type { ChatHistoryItem } from "core/index.js";
 import express, { Request, Response } from "express";
 
-import { getAssistantSlug } from "../auth/workos.js";
+import { getAccessToken, getAssistantSlug } from "../auth/workos.js";
 import { processCommandFlags } from "../flags/flagProcessor.js";
 import { toolPermissionManager } from "../permissions/permissionManager.js";
 import {
@@ -19,11 +16,12 @@ import {
   ConfigServiceState,
   ModelServiceState,
 } from "../services/types.js";
-import { createSession } from "../session.js";
+import { createSession, getSessionPersistenceSnapshot } from "../session.js";
 import { constructSystemMessage } from "../systemMessage.js";
 import { telemetryService } from "../telemetry/telemetryService.js";
 import { gracefulExit } from "../util/exit.js";
 import { formatError } from "../util/formatError.js";
+import { getGitDiffSnapshot } from "../util/git.js";
 import { logger } from "../util/logger.js";
 import { readStdinSync } from "../util/stdin.js";
 
@@ -32,8 +30,6 @@ import {
   streamChatResponseWithInterruption,
   type ServerState,
 } from "./serve.helpers.js";
-
-const execAsync = promisify(exec);
 
 interface ServeOptions extends ExtendedCommandOptions {
   timeout?: string;
@@ -86,6 +82,7 @@ export async function serve(prompt?: string, options: ServeOptions = {}) {
   if (authState.organizationId) {
     telemetryService.updateOrganization(authState.organizationId);
   }
+  const accessToken = getAccessToken(authState.authConfig);
 
   // Log configuration information
   const organizationId = authState.organizationId || "personal";
@@ -146,6 +143,32 @@ export async function serve(prompt?: string, options: ServeOptions = {}) {
     pendingPermission: null,
   };
 
+  const syncSessionHistory = () => {
+    try {
+      state.session.history = services.chatHistory.getHistory();
+    } catch (e) {
+      logger.debug(
+        `Failed to sync session history from ChatHistoryService: ${formatError(e)}`,
+      );
+    }
+  };
+
+  const storageSyncService = services.storageSync;
+  let storageSyncActive = await storageSyncService.startFromOptions({
+    storageOption: options.id,
+    accessToken,
+    syncSessionHistory,
+    getSessionSnapshot: () => getSessionPersistenceSnapshot(state.session),
+    isActive: () => state.serverRunning,
+  });
+
+  const stopStorageSync = () => {
+    if (storageSyncActive) {
+      storageSyncService.stop();
+      storageSyncActive = false;
+    }
+  };
+
   // Record session start
   telemetryService.recordSessionStart();
   telemetryService.startActiveTime();
@@ -156,14 +179,7 @@ export async function serve(prompt?: string, options: ServeOptions = {}) {
   // GET /state - Return the current state
   app.get("/state", (_req: Request, res: Response) => {
     state.lastActivity = Date.now();
-    // Ensure session history reflects ChatHistoryService state
-    try {
-      state.session.history = services.chatHistory.getHistory();
-    } catch (e) {
-      logger.debug(
-        `Failed to sync session history from ChatHistoryService: ${formatError(e)}`,
-      );
-    }
+    syncSessionHistory();
     res.json({
       session: state.session, // Return session directly instead of converting
       isProcessing: state.isProcessing,
@@ -239,34 +255,25 @@ export async function serve(prompt?: string, options: ServeOptions = {}) {
     state.lastActivity = Date.now();
 
     try {
-      // First check if we're in a git repository
-      await execAsync("git rev-parse --git-dir");
+      const diffResult = await getGitDiffSnapshot();
 
-      // Get the diff against main branch
-      const { stdout } = await execAsync("git diff main");
-
-      res.json({
-        diff: stdout,
-      });
-    } catch (error: any) {
-      // Git diff returns exit code 1 when there are differences, which is normal
-      if (error.code === 1 && error.stdout) {
-        res.json({
-          diff: error.stdout,
-        });
-      } else if (error.code === 128) {
-        // Handle case where we're not in a git repo or main branch doesn't exist
+      if (!diffResult.repoFound) {
         res.status(404).json({
           error: "Not in a git repository or main branch doesn't exist",
           diff: "",
         });
-      } else {
-        logger.error(`Git diff error: ${formatError(error)}`);
-        res.status(500).json({
-          error: `Failed to get git diff: ${formatError(error)}`,
-          diff: "",
-        });
+        return;
       }
+
+      res.json({
+        diff: diffResult.diff,
+      });
+    } catch (error) {
+      logger.error(`Git diff error: ${formatError(error)}`);
+      res.status(500).json({
+        error: `Failed to get git diff: ${formatError(error)}`,
+        diff: "",
+      });
     }
   });
 
@@ -287,6 +294,7 @@ export async function serve(prompt?: string, options: ServeOptions = {}) {
 
     // Set server running flag to false to stop processing
     state.serverRunning = false;
+    stopStorageSync();
 
     // Abort any current processing
     if (state.currentAbortController) {
@@ -438,6 +446,7 @@ export async function serve(prompt?: string, options: ServeOptions = {}) {
         ),
       );
       state.serverRunning = false;
+      stopStorageSync();
       server.close(() => {
         telemetryService.stopActiveTime();
         gracefulExit(0).catch((err) => {
@@ -456,6 +465,7 @@ export async function serve(prompt?: string, options: ServeOptions = {}) {
   process.on("SIGINT", () => {
     console.log(chalk.yellow("\nShutting down server..."));
     state.serverRunning = false;
+    stopStorageSync();
     if (inactivityChecker) {
       clearInterval(inactivityChecker);
       inactivityChecker = null;

--- a/extensions/cli/src/commands/serve.ts
+++ b/extensions/cli/src/commands/serve.ts
@@ -34,6 +34,8 @@ import {
 interface ServeOptions extends ExtendedCommandOptions {
   timeout?: string;
   port?: string;
+  /** Storage identifier for remote sync */
+  id?: string;
 }
 
 // eslint-disable-next-line max-statements

--- a/extensions/cli/src/index.ts
+++ b/extensions/cli/src/index.ts
@@ -312,6 +312,10 @@ program
     "300",
   )
   .option("--port <port>", "Port to run the server on (default: 8000)", "8000")
+  .option(
+    "--id <storageId>",
+    "Upload session snapshots to Continue-managed storage using the provided identifier",
+  )
   .action(async (prompt, options) => {
     // Telemetry: record command invocation
     await posthogService.capture("cliCommand", { command: "serve" });

--- a/extensions/cli/src/services/StorageSyncService.test.ts
+++ b/extensions/cli/src/services/StorageSyncService.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { StorageSyncService } from "./StorageSyncService.js";
-import { logger } from "../util/logger.js";
 import { getGitDiffSnapshot } from "../util/git.js";
+import { logger } from "../util/logger.js";
+
+import { StorageSyncService } from "./StorageSyncService.js";
 
 vi.mock("../util/logger.js", () => ({
   logger: {

--- a/extensions/cli/src/services/StorageSyncService.test.ts
+++ b/extensions/cli/src/services/StorageSyncService.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { StorageSyncService } from "./StorageSyncService.js";
+import { logger } from "../util/logger.js";
+import { getGitDiffSnapshot } from "../util/git.js";
+
+vi.mock("../util/logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../env.js", () => ({
+  env: { apiBase: "https://api.test/" },
+}));
+
+vi.mock("../util/git.js", () => ({
+  getGitDiffSnapshot: vi.fn(),
+}));
+
+describe("StorageSyncService", () => {
+  const fetchMock = vi.fn();
+  const gitDiffMock = vi.mocked(getGitDiffSnapshot);
+  let service: StorageSyncService;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    fetchMock.mockReset();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    gitDiffMock.mockReset();
+
+    service = new StorageSyncService();
+    await service.initialize();
+  });
+
+  afterEach(() => {
+    service.stop();
+    delete (globalThis as { fetch?: typeof fetch }).fetch;
+  });
+
+  it("returns false when no storage option provided", async () => {
+    const result = await service.startFromOptions({
+      storageOption: undefined,
+      accessToken: "token",
+      syncSessionHistory: vi.fn(),
+      getSessionSnapshot: vi.fn(),
+    });
+
+    expect(result).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("warns when storage identifier trims to empty", async () => {
+    const warnSpy = vi.spyOn(logger, "warn");
+
+    const result = await service.startFromOptions({
+      storageOption: "   ",
+      accessToken: "token",
+      syncSessionHistory: vi.fn(),
+      getSessionSnapshot: vi.fn(),
+    });
+
+    expect(result).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("storage identifier was empty"),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("warns when storage requested without access token", async () => {
+    const warnSpy = vi.spyOn(logger, "warn");
+
+    const result = await service.startFromOptions({
+      storageOption: "session-123",
+      accessToken: null,
+      syncSessionHistory: vi.fn(),
+      getSessionSnapshot: vi.fn(),
+    });
+
+    expect(result).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("no Continue API key"),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("starts syncing when presign succeeds", async () => {
+    const syncSessionHistory = vi.fn();
+    const getSessionSnapshot = vi.fn().mockReturnValue({ foo: "bar" });
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        session: { putUrl: "https://upload/session", key: "session.json" },
+        diff: { putUrl: "https://upload/diff", key: "diff.txt" },
+      }),
+    });
+    fetchMock.mockResolvedValue({ ok: true });
+    gitDiffMock.mockResolvedValue({ diff: "diff", repoFound: true });
+
+    const result = await service.startFromOptions({
+      storageOption: "session-123",
+      accessToken: "token",
+      syncSessionHistory,
+      getSessionSnapshot,
+      isActive: () => true,
+    });
+
+    expect(result).toBe(true);
+    expect(syncSessionHistory).toHaveBeenCalledTimes(1);
+    expect(getSessionSnapshot).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const [presignUrl, presignOptions] = fetchMock.mock.calls[0];
+    expect(presignUrl).toBeInstanceOf(URL);
+    expect((presignUrl as URL).toString()).toBe(
+      "https://api.test/agents/storage/presigned-url",
+    );
+    expect(presignOptions).toMatchObject({ method: "POST" });
+
+    const [sessionUrl, sessionOptions] = fetchMock.mock.calls[1];
+    expect(sessionUrl).toBe("https://upload/session");
+    expect(sessionOptions).toMatchObject({
+      method: "PUT",
+      body: expect.any(String),
+    });
+
+    service.stop();
+    expect(service.getState().isEnabled).toBe(false);
+  });
+
+  it("returns false when presign request fails", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Server Error",
+    });
+
+    const warnSpy = vi.spyOn(logger, "warn");
+    const result = await service.startFromOptions({
+      storageOption: "session-123",
+      accessToken: "token",
+      syncSessionHistory: vi.fn(),
+      getSessionSnapshot: vi.fn(),
+    });
+
+    expect(result).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("presign request failed"),
+    );
+    expect(service.getState().lastError).toBe(
+      "Failed to obtain presigned URLs",
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("records upload error details when PUT fails", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        session: { putUrl: "https://upload/session", key: "session.json" },
+        diff: { putUrl: "https://upload/diff", key: "diff.txt" },
+      }),
+    });
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+    });
+    gitDiffMock.mockResolvedValue({ diff: "", repoFound: true });
+
+    const warnSpy = vi.spyOn(logger, "warn");
+
+    const result = await service.startFromOptions({
+      storageOption: "session-123",
+      accessToken: "token",
+      syncSessionHistory: vi.fn(),
+      getSessionSnapshot: vi.fn().mockReturnValue({}),
+    });
+
+    expect(result).toBe(true);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Storage upload failed"),
+    );
+    const state = service.getState();
+    expect(state.isEnabled).toBe(true);
+    expect(state.lastError).toContain("Storage upload failed");
+
+    service.stop();
+    warnSpy.mockRestore();
+  });
+});

--- a/extensions/cli/src/services/StorageSyncService.test.ts
+++ b/extensions/cli/src/services/StorageSyncService.test.ts
@@ -26,10 +26,14 @@ describe("StorageSyncService", () => {
   const fetchMock = vi.fn();
   const gitDiffMock = vi.mocked(getGitDiffSnapshot);
   let service: StorageSyncService;
+  let originalFetch: typeof fetch | undefined;
+  let hadFetch = false;
 
   beforeEach(async () => {
     vi.clearAllMocks();
     fetchMock.mockReset();
+    hadFetch = "fetch" in globalThis;
+    originalFetch = globalThis.fetch;
     globalThis.fetch = fetchMock as unknown as typeof fetch;
     gitDiffMock.mockReset();
 
@@ -39,7 +43,11 @@ describe("StorageSyncService", () => {
 
   afterEach(() => {
     service.stop();
-    delete (globalThis as { fetch?: typeof fetch }).fetch;
+    if (hadFetch) {
+      globalThis.fetch = originalFetch!;
+    } else {
+      delete (globalThis as { fetch?: typeof fetch }).fetch;
+    }
   });
 
   it("returns false when no storage option provided", async () => {

--- a/extensions/cli/src/services/StorageSyncService.ts
+++ b/extensions/cli/src/services/StorageSyncService.ts
@@ -124,7 +124,7 @@ export class StorageSyncService {
     });
 
     const intervalMs = options.intervalMs ?? DEFAULT_UPLOAD_INTERVAL_MS;
-    console.log(
+    logger.info(
       chalk.dim(
         `Storage sync enabled (uploading every ${Math.round(intervalMs / 1000)}s)`,
       ),

--- a/extensions/cli/src/services/StorageSyncService.ts
+++ b/extensions/cli/src/services/StorageSyncService.ts
@@ -1,0 +1,283 @@
+import chalk from "chalk";
+
+import { env } from "../env.js";
+import { formatError } from "../util/formatError.js";
+import { getGitDiffSnapshot } from "../util/git.js";
+import { logger } from "../util/logger.js";
+
+import type { StorageSyncServiceState } from "./types.js";
+
+const DEFAULT_UPLOAD_INTERVAL_MS = 30_000;
+
+type StoragePresignedLocation = {
+  key: string;
+  putUrl: string;
+};
+
+type StoragePresignResponse = {
+  session?: StoragePresignedLocation;
+  diff?: StoragePresignedLocation;
+};
+
+type StorageTargets = {
+  sessionUrl: string;
+  diffUrl: string;
+};
+
+export interface StorageSyncStartOptions {
+  storageId: string;
+  accessToken: string;
+  intervalMs?: number;
+  syncSessionHistory: () => void;
+  getSessionSnapshot: () => unknown;
+  isActive?: () => boolean;
+}
+
+export class StorageSyncService {
+  private state: StorageSyncServiceState = {
+    isEnabled: false,
+    lastError: null,
+  };
+
+  private intervalHandle: NodeJS.Timeout | null = null;
+  private stopped = true;
+  private uploadInFlight = false;
+  private missingRepoLogged = false;
+  private targets: StorageTargets | null = null;
+  private options: StorageSyncStartOptions | null = null;
+
+  async initialize(): Promise<StorageSyncServiceState> {
+    this.stop();
+    return this.getState();
+  }
+
+  getState(): StorageSyncServiceState {
+    return { ...this.state };
+  }
+
+  getDefaultInterval(): number {
+    return DEFAULT_UPLOAD_INTERVAL_MS;
+  }
+
+  async startFromOptions(
+    options: {
+      storageOption?: string;
+      accessToken?: string | null;
+    } & Omit<StorageSyncStartOptions, "storageId" | "accessToken">,
+  ): Promise<boolean> {
+    const { storageOption, accessToken, ...rest } = options;
+
+    if (!storageOption) {
+      return false;
+    }
+
+    const storageId = storageOption.trim();
+    if (!storageId) {
+      logger.warn(
+        "Storage sync requested but the provided storage identifier was empty; skipping uploads.",
+      );
+      return false;
+    }
+
+    if (!accessToken) {
+      logger.warn(
+        "Storage sync requested but no Continue API key is available; skipping uploads.",
+      );
+      return false;
+    }
+
+    return this.start({
+      storageId,
+      accessToken,
+      ...rest,
+    });
+  }
+
+  async start(options: StorageSyncStartOptions): Promise<boolean> {
+    // Ensure any existing sync loop is stopped before starting a new one
+    this.stop();
+
+    const targets = await this.requestStorageTargets(
+      options.storageId,
+      options.accessToken,
+    );
+
+    if (!targets) {
+      this.setState({
+        isEnabled: false,
+        storageId: options.storageId,
+        lastError: "Failed to obtain presigned URLs",
+      });
+      return false;
+    }
+
+    this.targets = targets;
+    this.options = options;
+    this.stopped = false;
+    this.uploadInFlight = false;
+    this.missingRepoLogged = false;
+    this.setState({
+      isEnabled: true,
+      storageId: options.storageId,
+      lastError: null,
+      lastUploadAt: undefined,
+    });
+
+    const intervalMs = options.intervalMs ?? DEFAULT_UPLOAD_INTERVAL_MS;
+    console.log(
+      chalk.dim(
+        `Storage sync enabled (uploading every ${Math.round(intervalMs / 1000)}s)`,
+      ),
+    );
+
+    await this.performUpload();
+
+    this.intervalHandle = setInterval(() => {
+      void this.performUpload();
+    }, intervalMs);
+
+    return true;
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.targets = null;
+    this.options = null;
+    this.uploadInFlight = false;
+
+    if (this.intervalHandle) {
+      clearInterval(this.intervalHandle);
+      this.intervalHandle = null;
+    }
+
+    if (this.state.isEnabled) {
+      this.setState({
+        isEnabled: false,
+        storageId: this.state.storageId,
+        lastError: null,
+        lastUploadAt: this.state.lastUploadAt,
+      });
+    }
+  }
+
+  private setState(next: StorageSyncServiceState): void {
+    this.state = { ...next };
+  }
+
+  private async requestStorageTargets(
+    storageId: string,
+    accessToken: string,
+  ): Promise<StorageTargets | null> {
+    const url = new URL("agents/storage/presigned-url", env.apiBase);
+
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({ storageId }),
+      });
+
+      if (!response.ok) {
+        const statusText = `${response.status} ${response.statusText}`.trim();
+        logger.warn(
+          `Storage sync presign request failed (${statusText}). Storage uploads disabled for this session.`,
+        );
+        return null;
+      }
+
+      const body = (await response.json()) as StoragePresignResponse;
+
+      if (!body.session?.putUrl || !body.diff?.putUrl) {
+        logger.warn(
+          "Storage sync presign response missing required URLs. Storage uploads disabled for this session.",
+        );
+        return null;
+      }
+
+      return {
+        sessionUrl: body.session.putUrl,
+        diffUrl: body.diff.putUrl,
+      };
+    } catch (error) {
+      logger.warn(
+        `Storage sync presign request failed: ${formatError(error)}. Storage uploads disabled for this session.`,
+      );
+      return null;
+    }
+  }
+
+  private async uploadToPresignedUrl(
+    url: string,
+    body: string,
+    contentType: string,
+  ): Promise<void> {
+    const response = await fetch(url, {
+      method: "PUT",
+      headers: {
+        "Content-Type": contentType,
+      },
+      body,
+    });
+
+    if (!response.ok) {
+      const statusText = `${response.status} ${response.statusText}`.trim();
+      throw new Error(`Storage upload failed (${statusText})`);
+    }
+  }
+
+  private async performUpload(): Promise<void> {
+    if (this.stopped || this.uploadInFlight || !this.targets || !this.options) {
+      return;
+    }
+
+    if (this.options.isActive && !this.options.isActive()) {
+      return;
+    }
+
+    this.uploadInFlight = true;
+
+    try {
+      this.options.syncSessionHistory();
+      const snapshot = this.options.getSessionSnapshot();
+      const sessionPayload = JSON.stringify(snapshot, null, 2);
+      await this.uploadToPresignedUrl(
+        this.targets.sessionUrl,
+        sessionPayload,
+        "application/json",
+      );
+
+      const diffResult = await getGitDiffSnapshot();
+      if (!diffResult.repoFound && !this.missingRepoLogged) {
+        logger.debug(
+          "Storage sync diff upload skipped: not in a git repository or main branch missing.",
+        );
+        this.missingRepoLogged = true;
+      }
+      await this.uploadToPresignedUrl(
+        this.targets.diffUrl,
+        diffResult.diff,
+        "text/plain",
+      );
+
+      this.setState({
+        isEnabled: true,
+        storageId: this.state.storageId,
+        lastUploadAt: Date.now(),
+        lastError: null,
+      });
+    } catch (error) {
+      this.setState({
+        isEnabled: true,
+        storageId: this.state.storageId,
+        lastUploadAt: this.state.lastUploadAt,
+        lastError: formatError(error),
+      });
+      logger.warn(`Storage sync upload failed: ${formatError(error)}`);
+    } finally {
+      this.uploadInFlight = false;
+    }
+  }
+}

--- a/extensions/cli/src/services/index.ts
+++ b/extensions/cli/src/services/index.ts
@@ -12,6 +12,7 @@ import { ModelService } from "./ModelService.js";
 import { modeService } from "./ModeService.js";
 import { ResourceMonitoringService } from "./ResourceMonitoringService.js";
 import { serviceContainer } from "./ServiceContainer.js";
+import { StorageSyncService } from "./StorageSyncService.js";
 import { systemMessageService } from "./SystemMessageService.js";
 import {
   ApiClientServiceState,
@@ -33,6 +34,7 @@ const fileIndexService = new FileIndexService();
 const resourceMonitoringService = new ResourceMonitoringService();
 const chatHistoryService = new ChatHistoryService();
 const updateService = new UpdateService();
+const storageSyncService = new StorageSyncService();
 
 /**
  * Initialize all services and register them with the service container
@@ -252,6 +254,12 @@ export async function initializeServices(
   );
 
   serviceContainer.register(
+    SERVICE_NAMES.STORAGE_SYNC,
+    () => storageSyncService.initialize(),
+    [],
+  );
+
+  serviceContainer.register(
     SERVICE_NAMES.CHAT_HISTORY,
     () => chatHistoryService.initialize(undefined, initOptions.headless),
     [], // No dependencies for now, but could depend on SESSION in future
@@ -318,6 +326,7 @@ export const services = {
   systemMessage: systemMessageService,
   chatHistory: chatHistoryService,
   updateService: updateService,
+  storageSync: storageSyncService,
 } as const;
 
 // Export the service container for advanced usage

--- a/extensions/cli/src/services/types.ts
+++ b/extensions/cli/src/services/types.ts
@@ -111,6 +111,13 @@ export interface ToolPermissionServiceState {
   originalPolicies?: ToolPermissions;
 }
 
+export interface StorageSyncServiceState {
+  isEnabled: boolean;
+  storageId?: string;
+  lastUploadAt?: number;
+  lastError?: string | null;
+}
+
 export type { ChatHistoryState } from "./ChatHistoryService.js";
 export type { FileIndexServiceState } from "./FileIndexService.js";
 
@@ -129,6 +136,7 @@ export const SERVICE_NAMES = {
   SYSTEM_MESSAGE: "systemMessage",
   CHAT_HISTORY: "chatHistory",
   UPDATE: "update",
+  STORAGE_SYNC: "storageSync",
 } as const;
 
 /**

--- a/extensions/cli/src/session.ts
+++ b/extensions/cli/src/session.ts
@@ -157,13 +157,17 @@ function modifySessionBeforeSave(session: Session): Session {
   };
 }
 
+export function getSessionPersistenceSnapshot(session: Session): Session {
+  return modifySessionBeforeSave(session);
+}
+
 /**
  * Save the current session to file
  */
 export function saveSession(): void {
   try {
     const session = SessionManager.getInstance().getCurrentSession();
-    const sessionToSave = modifySessionBeforeSave(session);
+    const sessionToSave = getSessionPersistenceSnapshot(session);
     historyManager.save(sessionToSave);
   } catch (error) {
     logger.error("Error saving session:", error);

--- a/extensions/cli/src/util/git.ts
+++ b/extensions/cli/src/util/git.ts
@@ -1,4 +1,7 @@
-import { execSync } from "child_process";
+import { exec, execSync } from "child_process";
+import { promisify } from "util";
+
+const execAsync = promisify(exec);
 
 /**
  * Get the git remote URL for the current repository
@@ -109,4 +112,40 @@ export function getRepoUrl(): string {
   const remoteUrl = getGitRemoteUrl();
   const url = remoteUrl || process.cwd();
   return url.endsWith(".git") ? url.slice(0, -4) : url;
+}
+
+export interface GitDiffSnapshot {
+  diff: string;
+  repoFound: boolean;
+}
+
+function isExecError(
+  error: unknown,
+): error is { code?: number; stdout?: string } {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    ("code" in error || "stdout" in error)
+  );
+}
+
+export async function getGitDiffSnapshot(): Promise<GitDiffSnapshot> {
+  try {
+    await execAsync("git rev-parse --git-dir");
+  } catch (error) {
+    if (isExecError(error) && error.code === 128) {
+      return { diff: "", repoFound: false };
+    }
+    throw error;
+  }
+
+  try {
+    const { stdout } = await execAsync("git diff main");
+    return { diff: stdout, repoFound: true };
+  } catch (error) {
+    if (isExecError(error) && error.code === 1 && error.stdout) {
+      return { diff: error.stdout, repoFound: true };
+    }
+    throw error;
+  }
 }


### PR DESCRIPTION
## Description

--id flag helps cn serve sync with backend if needed
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a new --id flag to cn serve that periodically uploads session.json and the repo diff to Continue-managed storage using presigned URLs. Keeps the backend in sync with the CLI without affecting the local server.

- **New Features**
  - --id <storageId> enables 30s uploads of session.json and diff.txt via POST /agents/storage/presigned-url using the user’s Continue API key.
  - New StorageSyncService handles presign handshake, periodic uploads, and clean shutdown; errors are logged and non-fatal; unit tests included.
  - Added getGitDiffSnapshot to standardize git diff behavior and error handling; /diff now uses it.
  - Added docs (docs/storage-sync.md) and CLI help text.

- **Migration**
  - No changes needed unless you use --id.
  - To use: set CONTINUE_API_KEY, ensure backend implements /agents/storage/presigned-url, then run cn serve --id <storageId>.

<!-- End of auto-generated description by cubic. -->

