### PR TITLE
docs: update Instinct blog post URL to specific article

### DIFF
--- a/docs/guides/instinct.mdx
+++ b/docs/guides/instinct.mdx
@@ -9,7 +9,7 @@ description: "Learn how to run Instinct, Continue's leading open Next Edit model
   [HuggingFace model card](https://huggingface.co/continuedev/instinct).
 </Warning>
 
-We recently released Instinct, a state-of-the-art open Next Edit model. Robustly fine-tuned from Qwen2.5-Coder-7B, Instinct intelligently predicts your next move to keep you in flow. To learn more about the model, check out [our blog post](https://blog.continue.dev).
+We recently released Instinct, a state-of-the-art open Next Edit model. Robustly fine-tuned from Qwen2.5-Coder-7B, Instinct intelligently predicts your next move to keep you in flow. To learn more about the model, check out [our blog post](https://blog.continue.dev/instinct/).
 
 <Frame>
   <img src="/images/instinct.gif" />
@@ -17,7 +17,7 @@ We recently released Instinct, a state-of-the-art open Next Edit model. Robustly
 
 ### 1. Install Ollama
 
-If you haven't already installed Ollama, see our guide [here](./ollama-guide.mdx).
+If you haven't already installed Ollama, see our guide [here](./ollama-guide).
 
 ### 2. Download Instinct
 


### PR DESCRIPTION
## Description

The blog post seems like not precise.

Feel free to close the PR if I am wrong.

Relate PR: https://github.com/continuedev/continue/pull/7584

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Update the Instinct guide to link directly to the Instinct blog article (https://blog.continue.dev/instinct/) instead of the blog homepage for accurate reference.

<!-- End of auto-generated description by cubic. -->

