### PR TITLE
Refactor session snapshot handling to use getCompleteStateSnapshot

### DIFF
--- a/.github/workflows/continue-detailed-review.yaml
+++ b/.github/workflows/continue-detailed-review.yaml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Run Detailed PR Review
-        uses: continuedev/continue/actions/detailed-review@12e933bf9d13736c5f47728c436445ef4127fd52
+        uses: continuedev/continue/actions/detailed-review@main
         with:
           continue-api-key: ${{ secrets.CONTINUE_API_KEY }}
           continue-org: continuedev

--- a/.github/workflows/continue-general-review.yaml
+++ b/.github/workflows/continue-general-review.yaml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Run Continue PR Review Action
-        uses: continuedev/continue/actions/general-review@12e933bf9d13736c5f47728c436445ef4127fd52
+        uses: continuedev/continue/actions/general-review@main
         with:
           continue-api-key: ${{ secrets.CONTINUE_API_KEY }}
           continue-org: "continuedev"

--- a/extensions/cli/src/commands/serve.ts
+++ b/extensions/cli/src/commands/serve.ts
@@ -16,7 +16,7 @@ import {
   ConfigServiceState,
   ModelServiceState,
 } from "../services/types.js";
-import { createSession, getSessionPersistenceSnapshot } from "../session.js";
+import { createSession, getCompleteStateSnapshot } from "../session.js";
 import { constructSystemMessage } from "../systemMessage.js";
 import { telemetryService } from "../telemetry/telemetryService.js";
 import { gracefulExit } from "../util/exit.js";
@@ -160,7 +160,12 @@ export async function serve(prompt?: string, options: ServeOptions = {}) {
     storageOption: options.id,
     accessToken,
     syncSessionHistory,
-    getSessionSnapshot: () => getSessionPersistenceSnapshot(state.session),
+    getCompleteStateSnapshot: () => getCompleteStateSnapshot(
+      state.session,
+      state.isProcessing,
+      state.messageQueue.length,
+      state.pendingPermission,
+    ),
     isActive: () => state.serverRunning,
   });
 
@@ -182,12 +187,13 @@ export async function serve(prompt?: string, options: ServeOptions = {}) {
   app.get("/state", (_req: Request, res: Response) => {
     state.lastActivity = Date.now();
     syncSessionHistory();
-    res.json({
-      session: state.session, // Return session directly instead of converting
-      isProcessing: state.isProcessing,
-      messageQueueLength: state.messageQueue.length,
-      pendingPermission: state.pendingPermission,
-    });
+    const stateSnapshot = getCompleteStateSnapshot(
+      state.session,
+      state.isProcessing,
+      state.messageQueue.length,
+      state.pendingPermission,
+    );
+    res.json(stateSnapshot);
   });
 
   // POST /message - Queue a message and potentially interrupt

--- a/extensions/cli/src/commands/serve.ts
+++ b/extensions/cli/src/commands/serve.ts
@@ -160,12 +160,13 @@ export async function serve(prompt?: string, options: ServeOptions = {}) {
     storageOption: options.id,
     accessToken,
     syncSessionHistory,
-    getCompleteStateSnapshot: () => getCompleteStateSnapshot(
-      state.session,
-      state.isProcessing,
-      state.messageQueue.length,
-      state.pendingPermission,
-    ),
+    getCompleteStateSnapshot: () =>
+      getCompleteStateSnapshot(
+        state.session,
+        state.isProcessing,
+        state.messageQueue.length,
+        state.pendingPermission,
+      ),
     isActive: () => state.serverRunning,
   });
 

--- a/extensions/cli/src/services/StorageSyncService.test.ts
+++ b/extensions/cli/src/services/StorageSyncService.test.ts
@@ -55,7 +55,7 @@ describe("StorageSyncService", () => {
       storageOption: undefined,
       accessToken: "token",
       syncSessionHistory: vi.fn(),
-      getSessionSnapshot: vi.fn(),
+      getCompleteStateSnapshot: vi.fn(),
     });
 
     expect(result).toBe(false);
@@ -69,7 +69,7 @@ describe("StorageSyncService", () => {
       storageOption: "   ",
       accessToken: "token",
       syncSessionHistory: vi.fn(),
-      getSessionSnapshot: vi.fn(),
+      getCompleteStateSnapshot: vi.fn(),
     });
 
     expect(result).toBe(false);
@@ -86,7 +86,7 @@ describe("StorageSyncService", () => {
       storageOption: "session-123",
       accessToken: null,
       syncSessionHistory: vi.fn(),
-      getSessionSnapshot: vi.fn(),
+      getCompleteStateSnapshot: vi.fn(),
     });
 
     expect(result).toBe(false);
@@ -98,7 +98,7 @@ describe("StorageSyncService", () => {
 
   it("starts syncing when presign succeeds", async () => {
     const syncSessionHistory = vi.fn();
-    const getSessionSnapshot = vi.fn().mockReturnValue({ foo: "bar" });
+    const getCompleteStateSnapshot = vi.fn().mockReturnValue({ foo: "bar" });
 
     fetchMock.mockResolvedValueOnce({
       ok: true,
@@ -114,13 +114,13 @@ describe("StorageSyncService", () => {
       storageOption: "session-123",
       accessToken: "token",
       syncSessionHistory,
-      getSessionSnapshot,
+      getCompleteStateSnapshot,
       isActive: () => true,
     });
 
     expect(result).toBe(true);
     expect(syncSessionHistory).toHaveBeenCalledTimes(1);
-    expect(getSessionSnapshot).toHaveBeenCalledTimes(1);
+    expect(getCompleteStateSnapshot).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledTimes(3);
     const [presignUrl, presignOptions] = fetchMock.mock.calls[0];
     expect(presignUrl).toBeInstanceOf(URL);
@@ -152,7 +152,7 @@ describe("StorageSyncService", () => {
       storageOption: "session-123",
       accessToken: "token",
       syncSessionHistory: vi.fn(),
-      getSessionSnapshot: vi.fn(),
+      getCompleteStateSnapshot: vi.fn(),
     });
 
     expect(result).toBe(false);
@@ -187,7 +187,7 @@ describe("StorageSyncService", () => {
       storageOption: "session-123",
       accessToken: "token",
       syncSessionHistory: vi.fn(),
-      getSessionSnapshot: vi.fn().mockReturnValue({}),
+      getCompleteStateSnapshot: vi.fn().mockReturnValue({}),
     });
 
     expect(result).toBe(true);
@@ -235,7 +235,7 @@ describe("StorageSyncService", () => {
 
   it("includes server-side encryption header when required by signed headers", async () => {
     const syncSessionHistory = vi.fn();
-    const getSessionSnapshot = vi.fn().mockReturnValue({ test: "data" });
+    const getCompleteStateSnapshot = vi.fn().mockReturnValue({ test: "data" });
 
     // Mock presign response with server-side encryption in signed headers
     const sessionUrlWithSSE =
@@ -256,7 +256,7 @@ describe("StorageSyncService", () => {
       storageOption: "session-123",
       accessToken: "token",
       syncSessionHistory,
-      getSessionSnapshot,
+      getCompleteStateSnapshot,
       isActive: () => true,
     });
 

--- a/extensions/cli/src/services/StorageSyncService.ts
+++ b/extensions/cli/src/services/StorageSyncService.ts
@@ -29,7 +29,7 @@ export interface StorageSyncStartOptions {
   accessToken: string;
   intervalMs?: number;
   syncSessionHistory: () => void;
-  getSessionSnapshot: () => unknown;
+  getCompleteStateSnapshot: () => unknown;
   isActive?: () => boolean;
 }
 
@@ -288,7 +288,7 @@ export class StorageSyncService {
 
     try {
       this.options.syncSessionHistory();
-      const snapshot = this.options.getSessionSnapshot();
+      const snapshot = this.options.getCompleteStateSnapshot();
       const sessionPayload = JSON.stringify(snapshot, null, 2);
       await this.uploadToPresignedUrl(
         this.targets.sessionUrl,

--- a/extensions/cli/src/services/StorageSyncService.ts
+++ b/extensions/cli/src/services/StorageSyncService.ts
@@ -284,14 +284,18 @@ export class StorageSyncService {
       return;
     }
 
+    // Capture references to prevent race condition with stop()
+    const targets = this.targets;
+    const options = this.options;
+
     this.uploadInFlight = true;
 
     try {
-      this.options.syncSessionHistory();
-      const snapshot = this.options.getCompleteStateSnapshot();
+      options.syncSessionHistory();
+      const snapshot = options.getCompleteStateSnapshot();
       const sessionPayload = JSON.stringify(snapshot, null, 2);
       await this.uploadToPresignedUrl(
-        this.targets.sessionUrl,
+        targets.sessionUrl,
         sessionPayload,
         "application/json",
       );
@@ -304,7 +308,7 @@ export class StorageSyncService {
         this.missingRepoLogged = true;
       }
       await this.uploadToPresignedUrl(
-        this.targets.diffUrl,
+        targets.diffUrl,
         diffResult.diff,
         "text/plain",
       );

--- a/extensions/cli/src/session.ts
+++ b/extensions/cli/src/session.ts
@@ -162,6 +162,30 @@ export function getSessionPersistenceSnapshot(session: Session): Session {
 }
 
 /**
+ * Get the complete state snapshot that matches the /state endpoint format
+ */
+export interface StateSnapshot {
+  session: Session;
+  isProcessing: boolean;
+  messageQueueLength: number;
+  pendingPermission: any;
+}
+
+export function getCompleteStateSnapshot(
+  session: Session,
+  isProcessing: boolean = false,
+  messageQueueLength: number = 0,
+  pendingPermission: any = null,
+): StateSnapshot {
+  return {
+    session: getSessionPersistenceSnapshot(session),
+    isProcessing,
+    messageQueueLength,
+    pendingPermission,
+  };
+}
+
+/**
  * Save the current session to file
  */
 export function saveSession(): void {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Centralized state snapshot creation with getCompleteStateSnapshot so the /state endpoint and storage sync use the same payload. This standardizes the format and avoids mismatches between API responses and persisted data.

- **Refactors**
  - Added StateSnapshot and getCompleteStateSnapshot (wraps getSessionPersistenceSnapshot).
  - /state now returns the complete snapshot object.
  - StorageSyncService option renamed to getCompleteStateSnapshot and updated uses in serve.ts.

<!-- End of auto-generated description by cubic. -->

