### PR TITLE
feat: pr tool

### DIFF
--- a/extensions/cli/src/tools/pr.test.ts
+++ b/extensions/cli/src/tools/pr.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { spawn } from "child_process";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { prTool } from "./pr.js";
 
 // Mock child_process.spawn
@@ -13,6 +13,38 @@ vi.mock("../telemetry/telemetryService.js", () => ({
   },
 }));
 
+// Mock services - getService returns a Promise
+vi.mock("../services/index.js", () => ({
+  getService: vi.fn(),
+  getServiceSync: vi.fn(),
+  SERVICE_NAMES: {
+    STORAGE_SYNC: "storageSync",
+    AUTH: "auth",
+  },
+}));
+
+// Mock env
+vi.mock("../env.js", () => ({
+  env: {
+    apiBase: "https://api.continue.dev/",
+  },
+}));
+
+// Mock formatError and logger
+vi.mock("../util/formatError.js", () => ({
+  formatError: vi.fn((e) => String(e)),
+}));
+
+vi.mock("../util/logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+  },
+}));
+
+import { getService, getServiceSync } from "../services/index.js";
+const mockGetService = vi.mocked(getService);
+const mockGetServiceSync = vi.mocked(getServiceSync);
+
 // Mock EventEmitter for child process
 class MockChildProcess {
   stdout = { on: vi.fn() };
@@ -22,8 +54,80 @@ class MockChildProcess {
 }
 
 describe("PR Tool", () => {
+  // Helper to set up active agent session
+  const setupActiveSession = (
+    sessionId = "test-session-123",
+    accessToken = "test-access-token",
+  ) => {
+    mockGetService.mockImplementation(async (serviceName: string) => {
+      if (serviceName === "storageSync") {
+        return {
+          isEnabled: true,
+          storageId: sessionId,
+        };
+      }
+      if (serviceName === "auth") {
+        return {
+          authConfig: {
+            accessToken,
+          },
+        };
+      }
+      throw new Error(`Service ${serviceName} not found`);
+    });
+
+    // Also mock getServiceSync for the tools index
+    mockGetServiceSync.mockImplementation((serviceName: string) => {
+      if (serviceName === "storageSync") {
+        return {
+          state: "ready",
+          value: {
+            isEnabled: true,
+            storageId: sessionId,
+          },
+        };
+      }
+      return { state: "idle", value: null };
+    });
+  };
+
+  // Helper to set up no active session
+  const setupNoSession = () => {
+    mockGetService.mockImplementation(async (serviceName: string) => {
+      if (serviceName === "storageSync") {
+        return {
+          isEnabled: false,
+          storageId: undefined,
+        };
+      }
+      if (serviceName === "auth") {
+        return {
+          authConfig: {
+            accessToken: "test-access-token",
+          },
+        };
+      }
+      throw new Error(`Service ${serviceName} not found`);
+    });
+
+    // Also mock getServiceSync for the tools index
+    mockGetServiceSync.mockImplementation((serviceName: string) => {
+      if (serviceName === "storageSync") {
+        return {
+          state: "ready",
+          value: {
+            isEnabled: false,
+            storageId: undefined,
+          },
+        };
+      }
+      return { state: "idle", value: null };
+    });
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
+    setupNoSession(); // Default to no active session
   });
 
   it("should have correct metadata", () => {
@@ -38,16 +142,16 @@ describe("PR Tool", () => {
   });
 
   it("should validate required parameters in preprocess", async () => {
-    await expect(
-      prTool.preprocess!({ body: "test body" })
-    ).rejects.toThrow("title is required and must be a non-empty string");
+    await expect(prTool.preprocess!({ body: "test body" })).rejects.toThrow(
+      "title is required and must be a non-empty string",
+    );
+
+    await expect(prTool.preprocess!({ title: "test title" })).rejects.toThrow(
+      "body is required and must be a non-empty string",
+    );
 
     await expect(
-      prTool.preprocess!({ title: "test title" })
-    ).rejects.toThrow("body is required and must be a non-empty string");
-
-    await expect(
-      prTool.preprocess!({ title: "", body: "test body" })
+      prTool.preprocess!({ title: "", body: "test body" }),
     ).rejects.toThrow("title is required and must be a non-empty string");
   });
 
@@ -83,14 +187,35 @@ describe("PR Tool", () => {
 
     const result = await prTool.preprocess!({
       title: "Test PR Title",
-      body: "Test PR Body", 
+      body: "Test PR Body",
       draft: true,
     });
 
     expect(result.preview![0].content).toContain("(as draft)");
   });
 
-  it("should execute gh pr create command successfully", async () => {
+  it("should reject when no active agent session", async () => {
+    setupNoSession();
+
+    const result = await prTool.run({
+      title: "Test PR",
+      body: "Test description",
+      draft: false,
+    });
+
+    expect(result).toContain(
+      "PR tool is only available when running with an agent session ID",
+    );
+  });
+
+  it("should execute gh pr create command successfully with agent session", async () => {
+    setupActiveSession();
+
+    // Mock fetch for agent session endpoint
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ metadata: { createdBySlug: "testuser" } }),
+    });
     const mockChild = new MockChildProcess();
     mockSpawn.mockReturnValue(mockChild as any);
 
@@ -98,7 +223,7 @@ describe("PR Tool", () => {
     mockSpawn.mockImplementation(() => {
       const child = new MockChildProcess();
       currentCall++;
-      
+
       process.nextTick(() => {
         if (currentCall === 1) {
           // First call: git branch --show-current
@@ -106,11 +231,13 @@ describe("PR Tool", () => {
           child.on.mock.calls.find(([event]) => event === "close")?.[1](0);
         } else {
           // Second call: gh pr create
-          child.stdout.on.mock.calls[0][1]("https://github.com/owner/repo/pull/123\n");
+          child.stdout.on.mock.calls[0][1](
+            "https://github.com/owner/repo/pull/123\n",
+          );
           child.on.mock.calls.find(([event]) => event === "close")?.[1](0);
         }
       });
-      
+
       return child as any;
     });
 
@@ -122,19 +249,44 @@ describe("PR Tool", () => {
 
     expect(result).toContain("Successfully created pull request");
     expect(result).toContain("https://github.com/owner/repo/pull/123");
-    
-    // Verify gh command was called with correct arguments (including suffix)
-    const expectedBody = "Test description\n\n---\n\nGenerated with [Continue](https://continue.dev)\n\nCo-Authored-By: Continue <noreply@continue.dev>";
+
+    // Verify gh command was called with correct arguments (including agent session info)
+    const expectedBody =
+      "Test description\n\n---\n\nThis [agent session](https://hub.continue.dev/agents/test-session-123) was created by testuser and co-authored by Continue <noreply@continue.dev>.";
     expect(mockSpawn).toHaveBeenCalledWith("gh", [
       "pr",
-      "create", 
-      "--head", "feature-branch",
-      "--title", "Test PR",
-      "--body", expectedBody,
+      "create",
+      "--head",
+      "feature-branch",
+      "--title",
+      "Test PR",
+      "--body",
+      expectedBody,
     ]);
+
+    // Verify agent session API was called
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        href: "https://api.continue.dev/agents/test-session-123",
+      }),
+      {
+        method: "GET",
+        headers: {
+          Authorization: "Bearer test-access-token",
+        },
+      },
+    );
   });
 
   it("should include draft flag when draft is true", async () => {
+    setupActiveSession();
+
+    // Mock fetch for agent session endpoint
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ metadata: { createdBySlug: "testuser" } }),
+    });
+
     const mockChild = new MockChildProcess();
     mockSpawn.mockReturnValue(mockChild as any);
 
@@ -142,7 +294,7 @@ describe("PR Tool", () => {
     mockSpawn.mockImplementation(() => {
       const child = new MockChildProcess();
       currentCall++;
-      
+
       process.nextTick(() => {
         if (currentCall === 1) {
           // First call: git branch --show-current
@@ -150,11 +302,13 @@ describe("PR Tool", () => {
           child.on.mock.calls.find(([event]) => event === "close")?.[1](0);
         } else {
           // Second call: gh pr create
-          child.stdout.on.mock.calls[0][1]("https://github.com/owner/repo/pull/123\n");
+          child.stdout.on.mock.calls[0][1](
+            "https://github.com/owner/repo/pull/123\n",
+          );
           child.on.mock.calls.find(([event]) => event === "close")?.[1](0);
         }
       });
-      
+
       return child as any;
     });
 
@@ -163,20 +317,26 @@ describe("PR Tool", () => {
       body: "Test description",
       draft: true,
     });
-    
-    // Verify gh command was called with draft flag (including suffix)
-    const expectedBody = "Test description\n\n---\n\nGenerated with [Continue](https://continue.dev)\n\nCo-Authored-By: Continue <noreply@continue.dev>";
+
+    // Verify gh command was called with draft flag (including agent session info)
+    const expectedBody =
+      "Test description\n\n---\n\nThis [agent session](https://hub.continue.dev/agents/test-session-123) was created by testuser and co-authored by Continue <noreply@continue.dev>.";
     expect(mockSpawn).toHaveBeenCalledWith("gh", [
       "pr",
-      "create", 
-      "--head", "feature-branch",
-      "--title", "Test PR",
-      "--body", expectedBody,
+      "create",
+      "--head",
+      "feature-branch",
+      "--title",
+      "Test PR",
+      "--body",
+      expectedBody,
       "--draft",
     ]);
   });
 
   it("should handle git branch command failure", async () => {
+    setupActiveSession();
+
     const mockChild = new MockChildProcess();
     mockSpawn.mockReturnValue(mockChild as any);
 
@@ -194,7 +354,15 @@ describe("PR Tool", () => {
     expect(result).toContain("Not in a git repository");
   });
 
-  it("should add standard suffix to PR body", async () => {
+  it("should add agent session info and standard suffix to PR body", async () => {
+    setupActiveSession();
+
+    // Mock fetch for agent session endpoint
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ metadata: { createdBySlug: "testuser" } }),
+    });
+
     const mockChild = new MockChildProcess();
     mockSpawn.mockReturnValue(mockChild as any);
 
@@ -203,7 +371,7 @@ describe("PR Tool", () => {
     mockSpawn.mockImplementation((...args) => {
       const child = new MockChildProcess();
       currentCall++;
-      
+
       // Capture the body argument from gh pr create command
       if (currentCall === 2) {
         const [, ghArgs] = args;
@@ -212,7 +380,7 @@ describe("PR Tool", () => {
           capturedBody = ghArgs[bodyIndex + 1];
         }
       }
-      
+
       process.nextTick(() => {
         if (currentCall === 1) {
           // First call: git branch --show-current
@@ -220,11 +388,13 @@ describe("PR Tool", () => {
           child.on.mock.calls.find(([event]) => event === "close")?.[1](0);
         } else {
           // Second call: gh pr create
-          child.stdout.on.mock.calls[0][1]("https://github.com/owner/repo/pull/123\n");
+          child.stdout.on.mock.calls[0][1](
+            "https://github.com/owner/repo/pull/123\n",
+          );
           child.on.mock.calls.find(([event]) => event === "close")?.[1](0);
         }
       });
-      
+
       return child as any;
     });
 
@@ -233,15 +403,23 @@ describe("PR Tool", () => {
       body: "Original PR description",
       draft: false,
     });
-    
-    // Verify the body contains both original content and standard suffix
+
+    // Verify the body contains original content, agent session info, and standard suffix
     expect(capturedBody).toContain("Original PR description");
-    expect(capturedBody).toContain("Generated with [Continue](https://continue.dev)");
-    expect(capturedBody).toContain("Co-Authored-By: Continue <noreply@continue.dev>");
-    expect(capturedBody).toMatch(/---\n\nGenerated with \[Continue\]/);
+    expect(capturedBody).toContain("agent session");
+    expect(capturedBody).toContain(
+      "https://hub.continue.dev/agents/test-session-123",
+    );
+    expect(capturedBody).toContain("created by testuser");
+    expect(capturedBody).toContain(
+      "co-authored by Continue <noreply@continue.dev>",
+    );
+    expect(capturedBody).toMatch(/---\n\nThis \[agent session\]/);
   });
 
   it("should handle gh command not found", async () => {
+    setupActiveSession();
+
     const mockChild = new MockChildProcess();
     mockSpawn.mockReturnValue(mockChild as any);
 
@@ -249,7 +427,7 @@ describe("PR Tool", () => {
     mockSpawn.mockImplementation(() => {
       const child = new MockChildProcess();
       currentCall++;
-      
+
       process.nextTick(() => {
         if (currentCall === 1) {
           // First call: git branch --show-current (success)
@@ -261,7 +439,7 @@ describe("PR Tool", () => {
           child.on.mock.calls.find(([event]) => event === "close")?.[1](127);
         }
       });
-      
+
       return child as any;
     });
 
@@ -271,5 +449,63 @@ describe("PR Tool", () => {
     });
 
     expect(result).toContain("GitHub CLI (gh) is not installed");
+  });
+
+  it("should handle agent session API failure gracefully", async () => {
+    setupActiveSession();
+
+    // Mock fetch failure for agent session endpoint
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+    });
+
+    const mockChild = new MockChildProcess();
+    mockSpawn.mockReturnValue(mockChild as any);
+
+    let currentCall = 0;
+    mockSpawn.mockImplementation(() => {
+      const child = new MockChildProcess();
+      currentCall++;
+
+      process.nextTick(() => {
+        if (currentCall === 1) {
+          // First call: git branch --show-current
+          child.stdout.on.mock.calls[0][1]("feature-branch\n");
+          child.on.mock.calls.find(([event]) => event === "close")?.[1](0);
+        } else {
+          // Second call: gh pr create
+          child.stdout.on.mock.calls[0][1](
+            "https://github.com/owner/repo/pull/123\n",
+          );
+          child.on.mock.calls.find(([event]) => event === "close")?.[1](0);
+        }
+      });
+
+      return child as any;
+    });
+
+    const result = await prTool.run({
+      title: "Test PR",
+      body: "Test description",
+      draft: false,
+    });
+
+    expect(result).toContain("Successfully created pull request");
+
+    // Verify the body still contains session info but no creator
+    const expectedBody =
+      "Test description\n\n---\n\nThis [agent session](https://hub.continue.dev/agents/test-session-123) was created by unknown and co-authored by Continue <noreply@continue.dev>.";
+    expect(mockSpawn).toHaveBeenCalledWith("gh", [
+      "pr",
+      "create",
+      "--head",
+      "feature-branch",
+      "--title",
+      "Test PR",
+      "--body",
+      expectedBody,
+    ]);
   });
 });

--- a/extensions/cli/src/tools/pr.ts
+++ b/extensions/cli/src/tools/pr.ts
@@ -1,6 +1,14 @@
 import { spawn } from "child_process";
 
+import { env } from "../env.js";
+import { getService, SERVICE_NAMES } from "../services/index.js";
+import {
+  AuthServiceState,
+  StorageSyncServiceState,
+} from "../services/types.js";
 import { telemetryService } from "../telemetry/telemetryService.js";
+import { formatError } from "../util/formatError.js";
+import { logger } from "../util/logger.js";
 
 import { Tool } from "./types.js";
 
@@ -62,6 +70,75 @@ function executeGhCommand(args: string[]): Promise<string> {
       reject(new Error(`Error executing gh command: ${error.message}`));
     });
   });
+}
+
+// Helper function to get session creator information
+async function getSessionCreator(
+  sessionId: string,
+  accessToken: string,
+): Promise<string | null> {
+  try {
+    const url = new URL(`agents/${encodeURIComponent(sessionId)}`, env.apiBase);
+
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      logger.debug(
+        `Failed to get agent session: ${response.status} ${response.statusText}`,
+      );
+      return null;
+    }
+
+    const data = await response.json();
+    return data.metadata?.createdBySlug || null;
+  } catch (error) {
+    logger.debug(`Error fetching agent session: ${formatError(error)}`);
+    return null;
+  }
+}
+
+// Helper function to check if the PR tool should be available
+async function isAgentSessionActive(): Promise<{
+  isActive: boolean;
+  sessionId?: string;
+  accessToken?: string;
+}> {
+  try {
+    const storageSyncState = await getService<StorageSyncServiceState>(
+      SERVICE_NAMES.STORAGE_SYNC,
+    );
+
+    if (storageSyncState.isEnabled && storageSyncState.storageId) {
+      // Get access token from auth service
+      let accessToken: string | undefined;
+      try {
+        const authState = await getService<AuthServiceState>(
+          SERVICE_NAMES.AUTH,
+        );
+        if (authState.authConfig?.accessToken) {
+          accessToken = authState.authConfig.accessToken;
+        }
+      } catch (error) {
+        logger.debug(`Failed to get access token: ${formatError(error)}`);
+      }
+
+      return {
+        isActive: true,
+        sessionId: storageSyncState.storageId,
+        accessToken,
+      };
+    }
+
+    return { isActive: false };
+  } catch (error) {
+    logger.debug(`Error checking agent session: ${formatError(error)}`);
+    return { isActive: false };
+  }
 }
 
 export const prTool: Tool = {
@@ -136,12 +213,30 @@ The GitHub CLI must be configured and authenticated for this to work.`,
     draft?: boolean;
   }): Promise<string> => {
     try {
+      // Check if this tool should be available (agent session active)
+      const sessionInfo = await isAgentSessionActive();
+      if (!sessionInfo.isActive || !sessionInfo.sessionId) {
+        return "Error: PR tool is only available when running with an agent session ID (use the --id flag with 'cn serve').";
+      }
+
       // Get current branch
       const currentBranch = await getCurrentBranch();
 
-      // Add standard suffix to the PR body
-      const standardSuffix = "\n\n---\n\nGenerated with [Continue](https://continue.dev)\n\nCo-Authored-By: Continue <noreply@continue.dev>";
-      const enhancedBody = body + standardSuffix;
+      // Try to get creator information if access token is available
+      let creatorSlug = "unknown";
+      if (sessionInfo.accessToken) {
+        const creator = await getSessionCreator(
+          sessionInfo.sessionId,
+          sessionInfo.accessToken,
+        );
+        if (creator) {
+          creatorSlug = creator;
+        }
+      }
+
+      // Add agent session information
+      const agentSessionUrl = `https://hub.continue.dev/agents/${sessionInfo.sessionId}`;
+      const enhancedBody = `${body}\n\n---\n\nThis [agent session](${agentSessionUrl}) was created by ${creatorSlug} and co-authored by Continue <noreply@continue.dev>.`;
 
       // Build gh CLI arguments
       const args = [


### PR DESCRIPTION
## Description

introduces a new PR tool that is used only in continue remote so that we can add relevant information to the PR
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a PR creation tool to the CLI that’s only available during Continue Remote (agent) sessions. It creates PRs via GitHub CLI and appends agent session details to the PR body.

- New Features
  - New PR tool (name: PR) with title, body, and draft params.
  - Uses current git branch and runs gh pr create; supports --draft.
  - Augments body with agent session link and creator slug; records telemetry.
  - Tool is hidden unless a StorageSync agent session is active.
  - Helpful errors for missing gh, unauthenticated gh, and non-git repos.
  - Comprehensive tests covering validation, preview, session checks, API fallback, and error cases.

<!-- End of auto-generated description by cubic. -->

