### PR TITLE
fix: show tool call status icons for other search/replace statuses

### DIFF
--- a/gui/src/components/mainInput/Lump/LumpToolbar/LumpToolbar.tsx
+++ b/gui/src/components/mainInput/Lump/LumpToolbar/LumpToolbar.tsx
@@ -12,6 +12,7 @@ import { callToolById } from "../../../../redux/thunks/callToolById";
 import { cancelStream } from "../../../../redux/thunks/cancelStream";
 import { logToolUsage } from "../../../../redux/util";
 import { isJetBrains } from "../../../../util";
+import { useMainEditor } from "../../TipTapEditor";
 import { BlockSettingsTopToolbar } from "./BlockSettingsTopToolbar";
 import { EditOutcomeToolbar } from "./EditOutcomeToolbar";
 import { EditToolbar } from "./EditToolbar";
@@ -64,6 +65,7 @@ export function LumpToolbar() {
     (state) => state.status === "done",
   );
   const isApplying = applyStates.some((state) => state.status === "streaming");
+  const editor = useMainEditor();
 
   // Get ALL running terminal commands
   const runningToolCalls = useAppSelector((state) =>
@@ -140,7 +142,10 @@ export function LumpToolbar() {
           // Stop running terminal commands
           void handleStopAction();
         } else if (firstPendingToolCall) {
-          // Cancel pending tool call
+          // Cancel pending tool call. If last call, focus editor
+          if (pendingToolCalls.length === 1) {
+            editor.mainEditor?.commands.focus();
+          }
           void dispatch(
             cancelToolCall({
               toolCallId: firstPendingToolCall.toolCallId,

--- a/gui/src/components/mainInput/Lump/LumpToolbar/PendingToolCallToolbar.tsx
+++ b/gui/src/components/mainInput/Lump/LumpToolbar/PendingToolCallToolbar.tsx
@@ -4,6 +4,7 @@ import { callToolById } from "../../../../redux/thunks/callToolById";
 import { cancelToolCallThunk } from "../../../../redux/thunks/cancelToolCall";
 import { getAltKeyLabel, getMetaKeyLabel, isJetBrains } from "../../../../util";
 import { Button } from "../../../ui";
+import { useMainEditor } from "../../TipTapEditor";
 
 export const generateToolCallButtonTestId = (
   action: "accept" | "reject",
@@ -16,6 +17,7 @@ export function PendingToolCallToolbar() {
   const dispatch = useAppDispatch();
   const jetbrains = isJetBrains();
   const pendingToolCalls = useAppSelector(selectPendingToolCalls);
+  const editor = useMainEditor();
 
   if (pendingToolCalls.length === 0) {
     return null;
@@ -26,6 +28,10 @@ export function PendingToolCallToolbar() {
   };
 
   const handleReject = (toolCallId: string) => {
+    // put cursor in editor after last rejection
+    if (pendingToolCalls.length === 1) {
+      editor.mainEditor?.commands.focus();
+    }
     void dispatch(cancelToolCallThunk({ toolCallId }));
   };
 

--- a/gui/src/pages/gui/ToolCallDiv/FindAndReplace.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/FindAndReplace.tsx
@@ -185,24 +185,22 @@ export function FindAndReplaceDisplay({
   const statusIcon = useMemo(() => {
     const status = toolCallState?.status;
     if (status) {
-      if (status === "canceled" || status === "errored" || status === "done") {
-        return (
-          <div
-            className={`mr-1 h-4 w-4 flex-shrink-0 ${toolCallState.output ? "cursor-pointer" : ""}`}
-            onClick={(e) => {
-              if (toolCallState.output) {
-                e.stopPropagation();
-                ideMessenger.post("showVirtualFile", {
-                  name: "Edit output",
-                  content: renderContextItems(toolCallState.output),
-                });
-              }
-            }}
-          >
-            {getStatusIcon(toolCallState.status)}
-          </div>
-        );
-      }
+      return (
+        <div
+          className={`mr-1 h-4 w-4 flex-shrink-0 ${toolCallState.output ? "cursor-pointer" : ""}`}
+          onClick={(e) => {
+            if (toolCallState.output) {
+              e.stopPropagation();
+              ideMessenger.post("showVirtualFile", {
+                name: "Edit output",
+                content: renderContextItems(toolCallState.output),
+              });
+            }
+          }}
+        >
+          {getStatusIcon(status)}
+        </div>
+      );
     }
   }, [toolCallState?.status, toolCallState?.output]);
 


### PR DESCRIPTION
## Description
<img width="354" height="151" alt="image" src="https://github.com/user-attachments/assets/633b97ad-a0f4-44d3-b500-d1440e9860ae" />
<img width="147" height="81" alt="image" src="https://github.com/user-attachments/assets/902dbb7c-da49-44be-9dd2-59d8ec552671" />
<img width="372" height="90" alt="image" src="https://github.com/user-attachments/assets/ee8fed60-7cc6-49b8-9af2-127a6baa62bf" />
<img width="369" height="162" alt="image" src="https://github.com/user-attachments/assets/9b828de6-660b-4041-acb1-248b62c1ae55" />

