### PR TITLE
fix: HOTFIX :ambulance: Fix crypto error

### DIFF
--- a/core/context/mcp/MCPOauth.ts
+++ b/core/context/mcp/MCPOauth.ts
@@ -12,7 +12,7 @@ import { IDE, MCPServerStatus, SSEOptions } from "../..";
 
 import http from "http";
 import url from "url";
-import crypto from "crypto";
+import { v4 as uuidv4 } from "uuid";
 import { GlobalContext, GlobalContextType } from "../../util/GlobalContext";
 
 // Use a Map to support concurrent authentications for different servers
@@ -249,7 +249,7 @@ export async function performAuth(mcpServer: MCPServerStatus, ide: IDE) {
   await authProvider.ensureRedirectUrl();
 
   // Generate a unique state parameter for this auth flow
-  const state = crypto.randomUUID();
+  const state = uuidv4();
 
   // Store context for this specific server with state
   authenticatingContexts.set(mcpServerUrl, {

--- a/core/llm/utils/getSecureID.test.ts
+++ b/core/llm/utils/getSecureID.test.ts
@@ -1,11 +1,12 @@
+import { v4 as uuidv4 } from "uuid";
 import { getSecureID } from "./getSecureID";
 
-// Mock the crypto.randomUUID function
-const mockRandomUUID = jest.fn();
-global.crypto = {
-  ...global.crypto,
-  randomUUID: mockRandomUUID,
-};
+// Mock the uuid function
+jest.mock("uuid", () => ({
+  v4: jest.fn(),
+}));
+
+const mockUuidv4 = uuidv4 as jest.MockedFunction<typeof uuidv4>;
 
 describe("getSecureID", () => {
   beforeEach(() => {
@@ -13,14 +14,14 @@ describe("getSecureID", () => {
     (getSecureID as any).uuid = undefined;
 
     // Reset the mock implementation
-    mockRandomUUID.mockReset();
+    mockUuidv4.mockReset();
     // Setup a mock implementation that returns a fixed value for testing
-    mockRandomUUID.mockReturnValue("test-uuid-1234");
+    mockUuidv4.mockReturnValue("test-uuid-1234");
   });
 
   test("should generate a UUID on first call", () => {
     const result = getSecureID();
-    expect(mockRandomUUID).toHaveBeenCalledTimes(1);
+    expect(mockUuidv4).toHaveBeenCalledTimes(1);
     expect(result).toBe("<!-- SID: test-uuid-1234 -->");
   });
 
@@ -29,7 +30,7 @@ describe("getSecureID", () => {
     const secondResult = getSecureID();
 
     // The UUID generation should only happen once
-    expect(mockRandomUUID).toHaveBeenCalledTimes(1);
+    expect(mockUuidv4).toHaveBeenCalledTimes(1);
 
     // Both results should be identical
     expect(firstResult).toBe(secondResult);
@@ -43,7 +44,7 @@ describe("getSecureID", () => {
     const result = getSecureID();
 
     // No new UUID should be generated
-    expect(mockRandomUUID).not.toHaveBeenCalled();
+    expect(mockUuidv4).not.toHaveBeenCalled();
     expect(result).toBe("<!-- SID: persistent-uuid -->");
   });
 });

--- a/core/llm/utils/getSecureID.test.ts
+++ b/core/llm/utils/getSecureID.test.ts
@@ -1,50 +1,47 @@
-import { v4 as uuidv4 } from "uuid";
 import { getSecureID } from "./getSecureID";
-
-// Mock the uuid function
-jest.mock("uuid", () => ({
-  v4: jest.fn(),
-}));
-
-const mockUuidv4 = uuidv4 as jest.MockedFunction<typeof uuidv4>;
 
 describe("getSecureID", () => {
   beforeEach(() => {
     // Reset the static property before each test
     (getSecureID as any).uuid = undefined;
-
-    // Reset the mock implementation
-    mockUuidv4.mockReset();
-    // Setup a mock implementation that returns a fixed value for testing
-    mockUuidv4.mockReturnValue("test-uuid-1234");
   });
 
   test("should generate a UUID on first call", () => {
     const result = getSecureID();
-    expect(mockUuidv4).toHaveBeenCalledTimes(1);
-    expect(result).toBe("<!-- SID: test-uuid-1234 -->");
+
+    // Should return a properly formatted string with SID comment
+    expect(result).toMatch(
+      /^<!-- SID: [0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12} -->$/,
+    );
+
+    // Should have set the static uuid property
+    expect((getSecureID as any).uuid).toBeDefined();
+    expect(typeof (getSecureID as any).uuid).toBe("string");
   });
 
   test("should reuse the same UUID on subsequent calls", () => {
     const firstResult = getSecureID();
     const secondResult = getSecureID();
 
-    // The UUID generation should only happen once
-    expect(mockUuidv4).toHaveBeenCalledTimes(1);
-
     // Both results should be identical
     expect(firstResult).toBe(secondResult);
-    expect(firstResult).toBe("<!-- SID: test-uuid-1234 -->");
+
+    // Should match UUID format
+    expect(firstResult).toMatch(
+      /^<!-- SID: [0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12} -->$/,
+    );
   });
 
   test("should maintain the same UUID across different test cases if not reset", () => {
-    // Don't reset the UUID here to test persistence
+    // Set a specific UUID to test persistence
     (getSecureID as any).uuid = "persistent-uuid";
 
     const result = getSecureID();
 
-    // No new UUID should be generated
-    expect(mockUuidv4).not.toHaveBeenCalled();
+    // Should use the pre-existing UUID
     expect(result).toBe("<!-- SID: persistent-uuid -->");
+
+    // The static property should remain unchanged
+    expect((getSecureID as any).uuid).toBe("persistent-uuid");
   });
 });

--- a/core/llm/utils/getSecureID.ts
+++ b/core/llm/utils/getSecureID.ts
@@ -1,8 +1,10 @@
+import { v4 as uuidv4 } from "uuid";
+
 // Utility function to get or generate UUID for LLM prompts
 export function getSecureID(): string {
   // Adding a type declaration for the static property
   if (!(getSecureID as any).uuid) {
-    (getSecureID as any).uuid = crypto.randomUUID();
+    (getSecureID as any).uuid = uuidv4();
   }
   return `<!-- SID: ${(getSecureID as any).uuid} -->`;
 }

--- a/gui/src/hooks/useLLMLog.ts
+++ b/gui/src/hooks/useLLMLog.ts
@@ -10,6 +10,7 @@ import {
   LLMInteractionSuccess,
 } from "core";
 import { useEffect, useReducer } from "react";
+import { v4 as uuidv4 } from "uuid";
 
 declare const vscode: any;
 
@@ -231,7 +232,7 @@ export default function useLLMLog() {
     // messages from the previous generation. In particular, this
     // avoids problems when React.StrictMode runs this effect
     // twice - we don't want to process two "init" messages.
-    const uuid = crypto.randomUUID();
+    const uuid = uuidv4();
     const onMessage = (event: MessageEvent<ToConsoleView>) => {
       if (event.data.uuid !== uuid) {
         return;

--- a/packages/openai-adapters/src/apis/Bedrock.ts
+++ b/packages/openai-adapters/src/apis/Bedrock.ts
@@ -40,11 +40,12 @@ import {
   RerankCreateParams,
 } from "./base.js";
 
+
 // Utility function to get or generate UUID for prompt caching
 function getSecureID(): string {
   // Adding a type declaration for the static property
   if (!(getSecureID as any).uuid) {
-    (getSecureID as any).uuid = crypto.randomUUID();
+    (getSecureID as any).uuid = uuidv4();
   }
   return `<!-- SID: ${(getSecureID as any).uuid} -->`;
 }

--- a/packages/openai-adapters/src/apis/Bedrock.ts
+++ b/packages/openai-adapters/src/apis/Bedrock.ts
@@ -40,7 +40,6 @@ import {
   RerankCreateParams,
 } from "./base.js";
 
-
 // Utility function to get or generate UUID for prompt caching
 function getSecureID(): string {
   // Adding a type declaration for the static property


### PR DESCRIPTION
## Description

Created to resolve #7807 

## Root Cause: IntelliJ Extension Compatibility Issue with Web Crypto API

### Problem
The Continue IntelliJ extension was throwing a "crypto is not defined" error when AWS Bedrock prompt caching was enabled, causing the extension to fail in the IntelliJ environment. The problem was introduced when AWS bedrock prompt caching was fixed in a recent PR.

### Root Cause Analysis
1. **Environment Limitation**: IntelliJ extensions run in JCEF (Java Chromium Embedded Framework), which has a limited JavaScript runtime that doesn't include the full Web Crypto API.

2. **Specific Trigger**: The error occurred when AWS Bedrock prompt caching was enabled, following this call path:
   ```
   Bedrock caching → _addCachingToLastTwoUserMessages() → getSecureID() → crypto.randomUUID()
   ```

3. **API Availability**: `crypto.randomUUID()` is a Web Crypto API method that's available in modern browsers and Node.js but not in IntelliJ's restricted JavaScript environment.

### Solution
Replaced all instances of `crypto.randomUUID()` with `uuidv4()` from the existing `uuid` package dependency, which provides cross-platform UUID generation that works in all JavaScript environments including IntelliJ's JCEF.

### Files Modified
- `packages/openai-adapters/src/apis/Bedrock.ts` (Critical - Bedrock prompt caching)
- `gui/src/hooks/useLLMLog.ts` (High priority - GUI hooks)
- `core/llm/utils/getSecureID.ts` (Core utilities)
- `core/context/mcp/MCPOauth.ts` (OAuth state generation)
- Updated corresponding test files

This ensures the Continue extension works reliably across all supported IDE environments, including IntelliJ, while maintaining identical UUID generation functionality.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

Updated tests as needed.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced crypto.randomUUID with uuid v4 to fix crypto import errors in IntelliJ and ensure consistent UUID generation across the app.

- **Bug Fixes**
  - Swapped crypto.randomUUID -> uuidv4 in MCPOauth, getSecureID, useLLMLog, and Bedrock adapter.
  - Added uuid imports and updated tests to mock uuid.v4.

<!-- End of auto-generated description by cubic. -->

