### PR TITLE
fix: inline --rule improvements and fix msg queue behavior

### DIFF
--- a/extensions/cli/src/commands/serve.helpers.ts
+++ b/extensions/cli/src/commands/serve.helpers.ts
@@ -119,9 +119,7 @@ export interface ServerState {
   model: any;
   isProcessing: boolean;
   lastActivity: number;
-  messageQueue: string[];
   currentAbortController: AbortController | null;
-  shouldInterrupt: boolean;
   serverRunning: boolean;
   pendingPermission: PendingPermission | null;
   systemMessage?: string;

--- a/extensions/cli/src/commands/serve.ts
+++ b/extensions/cli/src/commands/serve.ts
@@ -17,6 +17,7 @@ import {
   ModelServiceState,
 } from "../services/types.js";
 import { createSession, getSessionPersistenceSnapshot } from "../session.js";
+import { messageQueue } from "../stream/messageQueue.js";
 import { constructSystemMessage } from "../systemMessage.js";
 import { telemetryService } from "../telemetry/telemetryService.js";
 import { gracefulExit } from "../util/exit.js";
@@ -138,9 +139,7 @@ export async function serve(prompt?: string, options: ServeOptions = {}) {
     model,
     isProcessing: false,
     lastActivity: Date.now(),
-    messageQueue: [],
     currentAbortController: null,
-    shouldInterrupt: false,
     serverRunning: true,
     pendingPermission: null,
   };
@@ -185,7 +184,7 @@ export async function serve(prompt?: string, options: ServeOptions = {}) {
     res.json({
       session: state.session, // Return session directly instead of converting
       isProcessing: state.isProcessing,
-      messageQueueLength: state.messageQueue.length,
+      messageQueueLength: messageQueue.getQueueLength(),
       pendingPermission: state.pendingPermission,
     });
   });
@@ -200,17 +199,11 @@ export async function serve(prompt?: string, options: ServeOptions = {}) {
     }
 
     // Queue the message
-    state.messageQueue.push(message);
-
-    // If currently processing, set interrupt flag
-    if (state.isProcessing && state.currentAbortController) {
-      state.shouldInterrupt = true;
-    }
+    await messageQueue.enqueueMessage(message);
 
     res.json({
       queued: true,
-      position: state.messageQueue.length,
-      willInterrupt: state.shouldInterrupt,
+      position: messageQueue.getQueueLength(),
     });
 
     // Process messages if not already processing
@@ -303,9 +296,6 @@ export async function serve(prompt?: string, options: ServeOptions = {}) {
       state.currentAbortController.abort();
     }
 
-    // Clear the message queue
-    state.messageQueue = [];
-
     // Clean up intervals
     if (inactivityChecker) {
       clearInterval(inactivityChecker);
@@ -325,7 +315,7 @@ export async function serve(prompt?: string, options: ServeOptions = {}) {
     setTimeout(handleExitResponse, 100);
   });
 
-  const server = app.listen(port, () => {
+  const server = app.listen(port, async () => {
     console.log(chalk.green(`Server started on http://localhost:${port}`));
     console.log(chalk.dim("Endpoints:"));
     console.log(chalk.dim("  GET  /state      - Get current agent state"));
@@ -354,7 +344,7 @@ export async function serve(prompt?: string, options: ServeOptions = {}) {
     // If initial prompt provided, queue it for processing
     if (actualPrompt) {
       console.log(chalk.dim("\nProcessing initial prompt..."));
-      state.messageQueue.push(actualPrompt);
+      await messageQueue.enqueueMessage(actualPrompt);
       processMessages(state, llmApi);
     }
   });
@@ -383,10 +373,14 @@ export async function serve(prompt?: string, options: ServeOptions = {}) {
 
   async function processMessages(state: ServerState, llmApi: any) {
     let processedMessage = false;
-    while (state.messageQueue.length > 0 && state.serverRunning) {
-      const userMessage = state.messageQueue.shift()!;
+    while (state.serverRunning) {
+      const queuedMessage = messageQueue.getLatestMessage();
+      if (!queuedMessage) {
+        break;
+      }
+
+      const userMessage = queuedMessage.message;
       state.isProcessing = true;
-      state.shouldInterrupt = false;
       state.lastActivity = Date.now();
       processedMessage = true;
 
@@ -410,7 +404,7 @@ export async function serve(prompt?: string, options: ServeOptions = {}) {
           state,
           llmApi,
           state.currentAbortController,
-          () => state.shouldInterrupt,
+          () => false,
         );
 
         // No direct persistence here; ChatHistoryService handles persistence when appropriate
@@ -443,7 +437,7 @@ export async function serve(prompt?: string, options: ServeOptions = {}) {
     if (
       processedMessage &&
       state.serverRunning &&
-      state.messageQueue.length === 0
+      messageQueue.getQueueLength() === 0
     ) {
       await storageSyncService.markAgentStatusUnread();
     }

--- a/extensions/cli/src/commands/serve.ts
+++ b/extensions/cli/src/commands/serve.ts
@@ -374,7 +374,7 @@ export async function serve(prompt?: string, options: ServeOptions = {}) {
   async function processMessages(state: ServerState, llmApi: any) {
     let processedMessage = false;
     while (state.serverRunning) {
-      const queuedMessage = messageQueue.getLatestMessage();
+      const queuedMessage = messageQueue.getNextMessage();
       if (!queuedMessage) {
         break;
       }

--- a/extensions/cli/src/hubLoader.ts
+++ b/extensions/cli/src/hubLoader.ts
@@ -4,6 +4,11 @@ import { env } from "./env.js";
 import { logger } from "./util/logger.js";
 
 /**
+ * Pattern to match valid hub slugs (owner/package format)
+ */
+const HUB_SLUG_PATTERN = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+
+/**
  * Hub package type definitions
  */
 export type HubPackageType = "rule" | "mcp" | "model" | "prompt";
@@ -253,10 +258,7 @@ export async function processRule(ruleSpec: string): Promise<string> {
     const parts = trimmedRuleSpec.split("/");
 
     // If it's exactly 2 parts and matches hub slug pattern, treat as hub slug
-    if (
-      parts.length === 2 &&
-      /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(trimmedRuleSpec)
-    ) {
+    if (parts.length === 2 && HUB_SLUG_PATTERN.test(trimmedRuleSpec)) {
       return await loadRuleFromHub(trimmedRuleSpec);
     }
 

--- a/extensions/cli/src/stream/messageQueue.test.ts
+++ b/extensions/cli/src/stream/messageQueue.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../util/logger.js", () => ({
   logger: {
@@ -16,11 +16,6 @@ vi.mock("../util/logger.js", () => ({
 import { messageQueue } from "./messageQueue.js";
 
 describe("messageQueue", () => {
-  beforeEach(() => {
-    // Drain any leftover items from previous tests
-    while (messageQueue.getAllQueuedMessages()) {}
-  });
-
   it("enqueues and emits messageQueued", async () => {
     const event = new Promise<any>((resolve) =>
       messageQueue.once("messageQueued", resolve),

--- a/extensions/cli/src/stream/messageQueue.test.ts
+++ b/extensions/cli/src/stream/messageQueue.test.ts
@@ -33,30 +33,4 @@ describe("messageQueue", () => {
     const queued = await event;
     expect(queued.message).toBe("hello world");
   });
-
-  it("combines messages, merges image maps, writes history, and clears queue", async () => {
-    const bufA = Buffer.from("A");
-    const bufB = Buffer.from("B");
-
-    const img1 = new Map<string, Buffer>([["a", bufA]]);
-    const img2 = new Map<string, Buffer>([["b", bufB]]);
-
-    const history = { addEntry: vi.fn() } as any;
-
-    await messageQueue.enqueueMessage("one", img1);
-    await messageQueue.enqueueMessage("two", img2, history);
-
-    const combined = messageQueue.getAllQueuedMessages();
-    expect(combined).toBeTruthy();
-    expect(combined!.message).toBe("one\ntwo");
-    expect(combined!.imageMap).toBeDefined();
-    expect(combined!.imageMap!.get("a")).toEqual(bufA);
-    expect(combined!.imageMap!.get("b")).toEqual(bufB);
-
-    // queue should be cleared
-    expect(messageQueue.getQueueLength()).toBe(0);
-
-    // input history should receive the combined message
-    expect(history.addEntry).toHaveBeenCalledWith("one\ntwo");
-  });
 });

--- a/extensions/cli/src/stream/messageQueue.ts
+++ b/extensions/cli/src/stream/messageQueue.ts
@@ -47,7 +47,10 @@ class MessageQueue extends EventEmitter {
     return true;
   }
 
-  public getLatestMessage(): QueuedMessage | undefined {
+  /**
+   * Dequeues and returns the next message to be processed (FIFO - oldest first)
+   */
+  public getNextMessage(): QueuedMessage | undefined {
     return this.queue.shift();
   }
 

--- a/extensions/cli/src/stream/messageQueue.ts
+++ b/extensions/cli/src/stream/messageQueue.ts
@@ -1,12 +1,13 @@
 import { EventEmitter } from "events";
 
-import { InputHistory } from "../util/inputHistory.js";
+import type { InputHistory } from "../util/inputHistory.js";
 import { logger } from "../util/logger.js";
 
 export interface QueuedMessage {
   message: string;
   imageMap?: Map<string, Buffer>;
   timestamp: number;
+  history?: InputHistory;
 }
 
 export interface MessageProcessor {
@@ -18,7 +19,6 @@ export interface MessageProcessor {
  */
 class MessageQueue extends EventEmitter {
   private queue: QueuedMessage[] = [];
-  private inputHistory: InputHistory | undefined;
 
   constructor() {
     super();
@@ -27,14 +27,13 @@ class MessageQueue extends EventEmitter {
   async enqueueMessage(
     message: string,
     imageMap?: Map<string, Buffer>,
-    inputHistory?: InputHistory,
+    history?: InputHistory,
   ): Promise<boolean> {
-    this.inputHistory = inputHistory;
-
     const queuedMessage: QueuedMessage = {
       message,
       imageMap,
       timestamp: Date.now(),
+      history,
     };
 
     this.queue.push(queuedMessage);
@@ -48,42 +47,8 @@ class MessageQueue extends EventEmitter {
     return true;
   }
 
-  public getAllQueuedMessages() {
-    if (this.queue.length === 0) return undefined;
-
-    // Combine all queued messages into one
-    const combinedMessage = this.queue.map((msg) => msg.message).join("\n");
-    const combinedImageMap = new Map<string, Buffer>();
-
-    // Merge all image maps
-    for (const queuedMsg of this.queue) {
-      if (queuedMsg.imageMap) {
-        for (const [key, value] of queuedMsg.imageMap) {
-          combinedImageMap.set(key, value);
-        }
-      }
-    }
-
-    const result = {
-      message: combinedMessage,
-      imageMap: combinedImageMap.size > 0 ? combinedImageMap : undefined,
-      timestamp: Date.now(),
-    };
-
-    // Add to input history and clear the queue
-    this.inputHistory?.addEntry(combinedMessage);
-    this.queue = [];
-
-    logger.debug("MessageQueue: All messages dequeued and combined", {
-      combinedLength: combinedMessage.length,
-      queueLength: this.queue.length,
-    });
-
-    return result;
-  }
-
-  public getLatestMessage() {
-    return this.getAllQueuedMessages();
+  public getLatestMessage(): QueuedMessage | undefined {
+    return this.queue.shift();
   }
 
   getQueueLength(): number {

--- a/extensions/cli/src/ui/UserInput.tsx
+++ b/extensions/cli/src/ui/UserInput.tsx
@@ -548,16 +548,14 @@ const UserInput: React.FC<UserInputProps> = ({
         textBuffer.expandAllPasteBlocks();
         const submittedText = textBuffer.text.trim();
 
-        if (isWaitingForResponse || isCompacting) {
+        inputHistory.addEntry(submittedText);
+
+        // We don't queue, we just send in remote mode because the server handles queeuing
+        if (!isRemoteMode && (isWaitingForResponse || isCompacting)) {
           // Process message later when LLM has responded or compaction is complete
-          void messageQueue.enqueueMessage(
-            submittedText,
-            imageMap,
-            inputHistory,
-          );
+          void messageQueue.enqueueMessage(submittedText, imageMap);
         } else {
           // Submit with images
-          inputHistory.addEntry(submittedText);
           onSubmit(submittedText, imageMap);
         }
 

--- a/extensions/cli/src/ui/hooks/useChat.ts
+++ b/extensions/cli/src/ui/hooks/useChat.ts
@@ -337,13 +337,13 @@ export function useChat({
 
       // Check if there are queued messages and process them after a microtask delay
       // This ensures the GUI state has been updated before processing the next message
-      const queuedMessageData = messageQueue.getLatestMessage();
+      const queuedMessageData = messageQueue.getNextMessage();
       if (queuedMessageData) {
         const { message: latestQueuedMessage, imageMap } = queuedMessageData;
         logger.debug("processing queued message", { latestQueuedMessage });
 
         // Clear queued messages from display since they're about to be processed
-        // Note: messageQueue.getLatestMessage() already cleared the actual queue
+        // Note: messageQueue.getNextMessage() already cleared the actual queue
         setQueuedMessages([]);
 
         await new Promise((resolve) => setTimeout(resolve, 100)); // add timeout for react to render the tui


### PR DESCRIPTION
## Description

can use multi-line --rule now

queueing msgs uses same code now between serve and TUI
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enables multi-line inline --rule values in the CLI and fixes message queue behavior so messages are processed FIFO without merging, aligning server and TUI behavior.

- **New Features**
  - CLI accepts multi-line inline --rule content.
  - processRule: single-line owner/package slugs fetch from Hub; improved path detection; clear error for invalid slugs.

- **Bug Fixes**
  - Unified queueing: server now uses shared messageQueue; removed per-server queue and interrupt flag.
  - Messages are processed one-by-one (no combined messages); accurate queue length in /state and /message.
  - TUI skips local queueing in remote mode; queues only when local and busy.
  - Updated tests for new rule parsing and queue behavior.

<!-- End of auto-generated description by cubic. -->

