### PR TITLE
fix: close the model select dropdown automatically

### DIFF
--- a/gui/src/components/modelSelection/ModelSelect.tsx
+++ b/gui/src/components/modelSelection/ModelSelect.tsx
@@ -5,17 +5,15 @@ import {
   CubeIcon,
   PlusIcon,
 } from "@heroicons/react/24/outline";
-import { useContext, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../../context/Auth";
-import { IdeMessengerContext } from "../../context/IdeMessenger";
 import { AddModelForm } from "../../forms/AddModelForm";
 import { useAppDispatch, useAppSelector } from "../../redux/hooks";
 import { setDialogMessage, setShowDialog } from "../../redux/slices/uiSlice";
 import { updateSelectedModelByRole } from "../../redux/thunks/updateSelectedModelByRole";
 import { getMetaKeyLabel, isMetaEquivalentKeyPressed } from "../../util";
 import { CONFIG_ROUTES } from "../../util/navigation";
-import { ToolTip } from "../gui/Tooltip";
 import {
   Button,
   Listbox,
@@ -50,6 +48,15 @@ function modelSelectTitle(model: any): string {
     return model?.model;
   }
   return model?.class_name;
+}
+
+/**makeshift way to close the headlessui listbox due to absence of open state on the listbox */
+function closeDropDown(button: HTMLButtonElement | null) {
+  if (!button) return;
+  button.classList.add("hidden");
+  setTimeout(() => {
+    button.classList.remove("hidden");
+  });
 }
 
 function ModelOption({
@@ -117,7 +124,6 @@ function ModelSelect() {
   const isInEdit = useAppSelector((store) => store.session.isInEdit);
   const config = useAppSelector((state) => state.config.config);
   const isConfigLoading = useAppSelector((state) => state.config.loading);
-  const ideMessenger = useContext(IdeMessengerContext);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const [options, setOptions] = useState<Option[]>([]);
   const [sortedOptions, setSortedOptions] = useState<Option[]>([]);
@@ -201,10 +207,8 @@ function ModelSelect() {
     e.stopPropagation();
     e.preventDefault();
 
-    // Close the dropdown
-    if (buttonRef.current) {
-      buttonRef.current.click();
-    }
+    closeDropDown(buttonRef.current);
+
     dispatch(setShowDialog(true));
     dispatch(
       setDialogMessage(
@@ -221,10 +225,7 @@ function ModelSelect() {
     e.stopPropagation();
     e.preventDefault();
 
-    // Close the dropdown
-    if (buttonRef.current) {
-      buttonRef.current.click();
-    }
+    closeDropDown(buttonRef.current);
 
     navigate(CONFIG_ROUTES.MODELS);
   }


### PR DESCRIPTION
## Description

Close the model select dropdown when the add model opens.

This involves a makeshift way to close the listbox options because currently open state is not exposed. https://github.com/tailwindlabs/headlessui/discussions/975

resolves CON-4058

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

https://github.com/user-attachments/assets/f0532e2f-b19d-421c-aef3-ba90b7c1850e

https://github.com/user-attachments/assets/0e304dea-c79a-436b-8db5-bffc67e43f21






## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Automatically close the model select dropdown when opening “Add model” or navigating to Models, preventing the listbox from staying open. This improves UX and matches CON-4058.

- **Bug Fixes**
  - Added a small helper to temporarily hide/show the Listbox button to force-close Headless UI’s dropdown (workaround due to no exposed open state).
  - Replaced direct button.click calls with the new closeDropDown helper in both “Add model” and “Manage models” actions.
  - Removed unused imports and context references.

<!-- End of auto-generated description by cubic. -->

