### PR TITLE
feat: add back fullscreen cmd

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -373,6 +373,12 @@
         "category": "Continue",
         "title": "Generate Rule",
         "group": "Continue"
+      },
+      {
+        "command": "continue.openInNewWindow",
+        "category": "Continue",
+        "title": "Open in new window",
+        "group": "Continue"
       }
     ],
     "keybindings": [
@@ -444,6 +450,12 @@
         "key": "ctrl+shift+r"
       },
       {
+        "command": "continue.openInNewWindow",
+        "mac": "cmd+k cmd+m",
+        "key": "ctrl+k ctrl+m",
+        "when": "!terminalFocus"
+      },
+      {
         "command": "continue.toggleTabAutocompleteEnabled",
         "mac": "cmd+k cmd+a",
         "key": "ctrl+k ctrl+a",
@@ -512,6 +524,9 @@
         },
         {
           "command": "continue.generateRule"
+        },
+        {
+          "command": "continue.openInNewWindow"
         }
       ],
       "editor/context": [

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -46,6 +46,15 @@ import { getMetaKeyLabel } from "./util/util";
 import { openEditorAndRevealRange } from "./util/vscode";
 import { VsCodeIde } from "./VsCodeIde";
 
+let fullScreenPanel: vscode.WebviewPanel | undefined;
+
+function getFullScreenTab() {
+  const tabs = vscode.window.tabGroups.all.flatMap((tabGroup) => tabGroup.tabs);
+  return tabs.find((tab) =>
+    (tab.input as any)?.viewType?.endsWith("continue.continueGUIView"),
+  );
+}
+
 type TelemetryCaptureParams = Parameters<typeof Telemetry.capture>;
 
 /**
@@ -59,15 +68,27 @@ function captureCommandTelemetry(
 }
 
 function focusGUI() {
-  // focus sidebar
-  vscode.commands.executeCommand("continue.continueGUIView.focus");
-  // vscode.commands.executeCommand("workbench.action.focusAuxiliaryBar");
+  const fullScreenTab = getFullScreenTab();
+  if (fullScreenTab) {
+    // focus fullscreen
+    fullScreenPanel?.reveal();
+  } else {
+    // focus sidebar
+    vscode.commands.executeCommand("continue.continueGUIView.focus");
+    // vscode.commands.executeCommand("workbench.action.focusAuxiliaryBar");
+  }
 }
 
 function hideGUI() {
-  // focus sidebar
-  vscode.commands.executeCommand("workbench.action.closeAuxiliaryBar");
-  // vscode.commands.executeCommand("workbench.action.toggleAuxiliaryBar");
+  const fullScreenTab = getFullScreenTab();
+  if (fullScreenTab) {
+    // focus fullscreen
+    fullScreenPanel?.dispose();
+  } else {
+    // focus sidebar
+    vscode.commands.executeCommand("workbench.action.closeAuxiliaryBar");
+    // vscode.commands.executeCommand("workbench.action.toggleAuxiliaryBar");
+  }
 }
 
 function waitForSidebarReady(
@@ -603,6 +624,11 @@ const getCommandsMap: (
           description: getMetaKeyLabel() + " + L",
         },
         {
+          label: "$(screen-full) Open full screen chat",
+          description:
+            getMetaKeyLabel() + " + K, " + getMetaKeyLabel() + " + M",
+        },
+        {
           label: quickPickStatusText(targetStatus),
           description:
             getMetaKeyLabel() + " + K, " + getMetaKeyLabel() + " + A",
@@ -644,6 +670,8 @@ const getCommandsMap: (
           }
         } else if (selectedOption === "$(comment) Open chat") {
           vscode.commands.executeCommand("continue.focusContinueInput");
+        } else if (selectedOption === "$(screen-full) Open full screen chat") {
+          vscode.commands.executeCommand("continue.openInNewWindow");
         } else if (selectedOption === "$(gear) Open settings") {
           vscode.commands.executeCommand("continue.navigateTo", "/config");
         }
@@ -769,6 +797,74 @@ const getCommandsMap: (
         !nextEditEnabled,
         vscode.ConfigurationTarget.Global,
       );
+    },
+    "continue.openInNewWindow": async () => {
+      focusGUI();
+
+      const sessionId = await sidebar.webviewProtocol.request(
+        "getCurrentSessionId",
+        undefined,
+      );
+      // Check if full screen is already open by checking open tabs
+      const fullScreenTab = getFullScreenTab();
+
+      if (fullScreenTab && fullScreenPanel) {
+        // Full screen open, but not focused - focus it
+        fullScreenPanel.reveal();
+        return;
+      }
+
+      // Clear the sidebar to prevent overwriting changes made in fullscreen
+      vscode.commands.executeCommand("continue.newSession");
+
+      // Full screen not open - open it
+      captureCommandTelemetry("openInNewWindow");
+
+      // Create the full screen panel
+      let panel = vscode.window.createWebviewPanel(
+        "continue.continueGUIView",
+        "Continue",
+        vscode.ViewColumn.One,
+        {
+          retainContextWhenHidden: true,
+          enableScripts: true,
+        },
+      );
+      fullScreenPanel = panel;
+
+      // Add content to the panel
+      panel.webview.html = sidebar.getSidebarContent(
+        extensionContext,
+        panel,
+        undefined,
+        undefined,
+        true,
+      );
+
+      const sessionLoader = panel.onDidChangeViewState(() => {
+        vscode.commands.executeCommand("continue.newSession");
+        if (sessionId) {
+          vscode.commands.executeCommand(
+            "continue.focusContinueSessionId",
+            sessionId,
+          );
+        }
+        panel.reveal();
+        sessionLoader.dispose();
+      });
+
+      // When panel closes, reset the webview and focus
+      panel.onDidDispose(
+        () => {
+          sidebar.resetWebviewProtocolWebview();
+          vscode.commands.executeCommand("continue.focusContinueInput");
+        },
+        null,
+        extensionContext.subscriptions,
+      );
+
+      vscode.commands.executeCommand("workbench.action.copyEditorToNewWindow");
+      vscode.commands.executeCommand("workbench.action.closeAuxiliaryBar");
     },
     "continue.forceNextEdit": async () => {
       captureCommandTelemetry("forceNextEdit");

--- a/extensions/vscode/src/extension/VsCodeMessenger.ts
+++ b/extensions/vscode/src/extension/VsCodeMessenger.ts
@@ -113,6 +113,9 @@ export class VsCodeMessenger {
     this.onWebview("focusEditor", (msg) => {
       vscode.commands.executeCommand("workbench.action.focusActiveEditorGroup");
     });
+    this.onWebview("toggleFullScreen", (msg) => {
+      vscode.commands.executeCommand("continue.openInNewWindow");
+    });
 
     this.onWebview("acceptDiff", async ({ data: { filepath, streamId } }) => {
       await vscode.commands.executeCommand(

--- a/packages/openai-adapters/package-lock.json
+++ b/packages/openai-adapters/package-lock.json
@@ -15179,6 +15179,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
Addresses some of the feedback in https://github.com/continuedev/continue/issues/7858

Note that this is a clean revert of the changes made in https://github.com/continuedev/continue/pull/7667 to remove full screen, with the exception that we are still not adding back the dedicated button the the toolbar. We're just adding back the command palette action.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Brings back a full-screen chat option. Adds a command and keybinding to open Continue in a new window, with better focus and session handling.

- New Features
  - Added continue.openInNewWindow to open the chat as a full-screen webview in a new window; available in the Command Palette and via Cmd+K, Cmd+M (Mac) / Ctrl+K, Ctrl+M (Win/Linux).
  - Reuses the existing full-screen panel if open; otherwise creates one and focuses it. Closing the panel resets the webview and returns focus to the sidebar input.
  - Preserves the current session when switching; clears the sidebar copy to avoid overwriting changes made in full screen.
  - Updated focus/hide behavior to target the full-screen view when open. Added a toggleFullScreen webview message that triggers the new command.

<!-- End of auto-generated description by cubic. -->

