### PR TITLE
fix: llm-info preferred provider

### DIFF
--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -213,7 +213,7 @@ export abstract class BaseLLM implements ILLM {
       this.providerName === "continue-proxy"
         ? this.model?.split("/").pop() || this.model
         : this.model;
-    const llmInfo = findLlmInfo(modelSearchString);
+    const llmInfo = findLlmInfo(modelSearchString, this.underlyingProviderName);
 
     const templateType =
       options.template ?? autodetectTemplateType(options.model);

--- a/packages/llm-info/src/index.ts
+++ b/packages/llm-info/src/index.ts
@@ -31,7 +31,19 @@ export const allLlms: LlmInfo[] = allModelProviders.flatMap((provider) =>
   provider.models.map((model) => ({ ...model, provider: provider.id })),
 );
 
-export function findLlmInfo(model: string): LlmInfo | undefined {
+export function findLlmInfo(
+  model: string,
+  preferProviderId?: string,
+): LlmInfo | undefined {
+  if (preferProviderId) {
+    const provider = allModelProviders.find((p) => p.id === preferProviderId);
+    const info = provider?.models.find((llm) =>
+      llm.regex ? llm.regex.test(model) : llm.model === model,
+    );
+    if (info) {
+      return info;
+    }
+  }
   return allLlms.find((llm) =>
     llm.regex ? llm.regex.test(model) : llm.model === model,
   );


### PR DESCRIPTION
## Description
When 2 providers offer the same model but have different api limitations conflicts can arise. Should try to find info in provider and then fall back.
Fixes https://github.com/continuedev/continue/actions/runs/17993730030/job/51188936181