### PR TITLE
feat: add support for completion track for online rl training

### DIFF
--- a/core/autocomplete/util/AutocompleteLoggingService.ts
+++ b/core/autocomplete/util/AutocompleteLoggingService.ts
@@ -3,7 +3,7 @@ import { COUNT_COMPLETION_REJECTED_AFTER } from "../../util/parameters";
 import { Telemetry } from "../../util/posthog";
 import { getUriFileExtension } from "../../util/uri";
 
-import { AutocompleteOutcome } from "./types";
+import { AutocompleteOutcome, CompletionTrackingData } from "./types";
 
 export class AutocompleteLoggingService {
   // Key is completionId
@@ -40,6 +40,10 @@ export class AutocompleteLoggingService {
       const outcome = this._outcomes.get(completionId)!;
       outcome.accepted = true;
       this.logAutocompleteOutcome(outcome);
+      
+      // 发送补全跟踪数据
+      this.sendCompletionTrackingData(outcome);
+      
       this._outcomes.delete(completionId);
       return outcome;
     }
@@ -61,6 +65,7 @@ export class AutocompleteLoggingService {
       // Wait 10 seconds, then assume it wasn't accepted
       outcome.accepted = false;
       this.logAutocompleteOutcome(outcome);
+      this.sendCompletionTrackingData(outcome);
       this._logRejectionTimeouts.delete(completionId);
     }, COUNT_COMPLETION_REJECTED_AFTER);
     this._outcomes.set(completionId, outcome);
@@ -127,5 +132,49 @@ export class AutocompleteLoggingService {
           enabledStaticContextualization: true,
         })
       : void Telemetry.capture("autocomplete", toLog);
+  }
+
+  private async sendCompletionTrackingData(outcome: AutocompleteOutcome) {
+    if (!(outcome as any).enableCompletionTracking || !(outcome as any).completionTrackingUrl) {
+      return;
+    }
+
+    // prepare the data to send
+    const trackingData: CompletionTrackingData = {
+      completionId: outcome.completionId,
+      filepath: outcome.filepath,
+      prefix: outcome.prefix,
+      suffix: outcome.suffix,
+      prompt: outcome.prompt,
+      completion: outcome.completion,
+      modelProvider: outcome.modelProvider,
+      modelName: outcome.modelName,
+      accepted: outcome.accepted ?? false,
+      timestamp: outcome.timestamp,
+      time: outcome.time,
+      gitRepo: outcome.gitRepo,
+      uniqueId: outcome.uniqueId,
+      numLines: outcome.numLines,
+      cacheHit: outcome.cacheHit,
+    };
+
+    try {
+      const headers = {
+        'Content-Type': 'application/json',
+        ...((outcome as any).completionTrackingHeaders || {}),
+      };
+
+      const response = await fetch((outcome as any).completionTrackingUrl, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(trackingData),
+      });
+
+      if (!response.ok) {
+        console.warn(`send completion tracking data failed: ${response.status} ${response.statusText}`);
+      }
+    } catch (error) {
+      console.warn('send completion tracking data error: ', error);
+    }
   }
 }

--- a/core/autocomplete/util/types.ts
+++ b/core/autocomplete/util/types.ts
@@ -44,3 +44,21 @@ export interface AutocompleteOutcome extends TabAutocompleteOptions {
   timestamp: string;
   enabledStaticContextualization?: boolean;
 }
+
+export interface CompletionTrackingData {
+  completionId: string;
+  filepath: string;
+  prefix: string;
+  suffix: string;
+  prompt: string;
+  completion: string;
+  modelProvider: string;
+  modelName: string;
+  accepted: boolean;
+  timestamp: string;
+  time: number;
+  gitRepo?: string;
+  uniqueId: string;
+  numLines: number;
+  cacheHit: boolean;
+}

--- a/core/config/sharedConfig.ts
+++ b/core/config/sharedConfig.ts
@@ -40,6 +40,8 @@ export const sharedConfigSchema = z
     disableAutocompleteInFiles: z.array(z.string()),
     modelTimeout: z.number(),
     debounceDelay: z.number(),
+    enableCompletionTracking: z.boolean(),
+    completionTrackingUrl: z.string(),
   })
   .partial();
 
@@ -118,6 +120,14 @@ export function modifyAnyConfigWithSharedConfig<
   if (sharedConfig.debounceDelay !== undefined) {
     configCopy.tabAutocompleteOptions.debounceDelay =
       sharedConfig.debounceDelay;
+  }
+  if (sharedConfig.enableCompletionTracking !== undefined) {
+    configCopy.tabAutocompleteOptions.enableCompletionTracking =
+      sharedConfig.enableCompletionTracking;
+  }
+  if (sharedConfig.completionTrackingUrl !== undefined) {
+    configCopy.tabAutocompleteOptions.completionTrackingUrl =
+      sharedConfig.completionTrackingUrl;
   }
 
   configCopy.ui = {

--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -1001,6 +1001,10 @@ declare global {
     disableInFiles?: string[];
     useImports?: boolean;
     showWhateverWeHaveAtXMs?: number;
+    // send completion tracking data
+    enableCompletionTracking?: boolean;
+    completionTrackingUrl?: string;
+    completionTrackingHeaders?: { [key: string]: string };
   }
   
   interface StdioOptions {

--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -173,6 +173,7 @@ async function configYamlToContinueConfig(options: {
     tools: getBaseToolDefinitions(),
     mcpServerStatuses: [],
     contextProviders: [],
+    tabAutocompleteOptions: (config as any).tabAutocompleteOptions,
     modelsByRole: {
       chat: [],
       edit: [],

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1240,6 +1240,10 @@ export interface TabAutocompleteOptions {
   experimental_includeRecentlyEditedRanges: boolean | number;
   experimental_includeDiff: boolean | number;
   experimental_enableStaticContextualization: boolean;
+  // 补全信息发送配置
+  enableCompletionTracking?: boolean;
+  completionTrackingUrl?: string;
+  completionTrackingHeaders?: { [key: string]: string };
 }
 
 export interface StdioOptions {

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -152,10 +152,10 @@
     },
     "../packages/config-yaml": {
       "name": "@continuedev/config-yaml",
-      "version": "1.0.96",
+      "version": "1.14.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@continuedev/config-types": "file:../config-types",
+        "@continuedev/config-types": "^1.0.14",
         "yaml": "^2.6.1",
         "zod": "^3.24.2"
       },
@@ -179,17 +179,22 @@
     },
     "../packages/fetch": {
       "name": "@continuedev/fetch",
-      "version": "1.0.16",
+      "version": "1.0.17",
       "license": "Apache-2.0",
       "dependencies": {
-        "@continuedev/config-types": "file:../config-types",
+        "@continuedev/config-types": "^1.0.14",
         "follow-redirects": "^1.15.6",
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.5",
         "node-fetch": "^3.3.2"
       },
       "devDependencies": {
+        "@semantic-release/changelog": "^6.0.3",
+        "@semantic-release/git": "^10.0.1",
+        "@semantic-release/github": "^9.2.6",
+        "@semantic-release/npm": "^10.0.6",
         "@types/follow-redirects": "^1.14.4",
+        "semantic-release": "^21.1.2",
         "typescript": "^5.0.0",
         "vitest": "^3.2.0"
       }
@@ -199,7 +204,12 @@
       "version": "1.0.9",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@semantic-release/changelog": "^6.0.3",
+        "@semantic-release/git": "^10.0.1",
+        "@semantic-release/github": "^9.2.6",
+        "@semantic-release/npm": "^10.0.6",
         "@types/node": "^22.15.29",
+        "semantic-release": "^21.1.2",
         "typescript": "^5.5.2"
       }
     },

--- a/core/util/parameters.ts
+++ b/core/util/parameters.ts
@@ -26,6 +26,10 @@ export const DEFAULT_AUTOCOMPLETE_OPTS: TabAutocompleteOptions = {
   experimental_includeRecentlyEditedRanges: true,
   experimental_includeDiff: true,
   experimental_enableStaticContextualization: false,
+  // send completion tracking data
+  enableCompletionTracking: false,
+  completionTrackingUrl: undefined,
+  completionTrackingHeaders: undefined,
 };
 
 export const COUNT_COMPLETION_REJECTED_AFTER = 10_000;

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "1.3.3",
+  "version": "1.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "1.3.3",
+      "version": "1.3.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "file:../../packages/config-types",
@@ -231,17 +231,22 @@
     },
     "../../packages/fetch": {
       "name": "@continuedev/fetch",
-      "version": "1.0.16",
+      "version": "1.0.17",
       "license": "Apache-2.0",
       "dependencies": {
-        "@continuedev/config-types": "file:../config-types",
+        "@continuedev/config-types": "^1.0.14",
         "follow-redirects": "^1.15.6",
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.5",
         "node-fetch": "^3.3.2"
       },
       "devDependencies": {
+        "@semantic-release/changelog": "^6.0.3",
+        "@semantic-release/git": "^10.0.1",
+        "@semantic-release/github": "^9.2.6",
+        "@semantic-release/npm": "^10.0.6",
         "@types/follow-redirects": "^1.14.4",
+        "semantic-release": "^21.1.2",
         "typescript": "^5.0.0",
         "vitest": "^3.2.0"
       }
@@ -7576,18 +7581,6 @@
         }
       }
     },
-    "node_modules/inquirer/node_modules/@types/node": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
-      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.10.0"
-      }
-    },
     "node_modules/inquirer/node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -7610,15 +7603,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/inquirer/node_modules/undici-types": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/ip-address": {
       "version": "9.0.5",
@@ -14455,17 +14439,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/vite-node/node_modules/@types/node": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.1.tgz",
-      "integrity": "sha512-MX4Zioh39chHlDJbKmEgydJDS3tspMP/lnQC67G3SWsTnb9NeYVWOjkxpOSy4oMfPs4StcWHwBrvUb4ybfnuaw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.8.0"
-      }
-    },
     "node_modules/vite-node/node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -14587,14 +14560,6 @@
         "@rollup/rollup-win32-x64-msvc": "4.43.0",
         "fsevents": "~2.3.2"
       }
-    },
-    "node_modules/vite-node/node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/vite-node/node_modules/vite": {
       "version": "6.3.5",

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -234,10 +234,11 @@
       }
     },
     "../packages/config-yaml": {
-      "version": "1.0.96",
+      "name": "@continuedev/config-yaml",
+      "version": "1.14.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@continuedev/config-types": "file:../config-types",
+        "@continuedev/config-types": "^1.0.14",
         "yaml": "^2.6.1",
         "zod": "^3.24.2"
       },
@@ -260,6 +261,7 @@
       }
     },
     "../packages/terminal-security": {
+      "name": "@continuedev/terminal-security",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -269,7 +271,7 @@
         "@types/node": "^20.11.19",
         "@types/shell-quote": "^1.7.5",
         "typescript": "^5.5.2",
-        "vitest": "^1.6.0"
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/gui/src/components/mainInput/Lump/EditBlockButton.tsx
+++ b/gui/src/components/mainInput/Lump/EditBlockButton.tsx
@@ -6,7 +6,7 @@ import { IdeMessengerContext } from "../../../context/IdeMessenger";
 
 type SectionKey = Exclude<
   keyof ConfigYaml,
-  "name" | "version" | "schema" | "metadata" | "env"
+  "name" | "version" | "schema" | "metadata" | "env" | "tabAutocompleteOptions"
 >;
 
 interface EditBlockButtonProps<T extends SectionKey> {

--- a/packages/config-types/src/index.ts
+++ b/packages/config-types/src/index.ts
@@ -161,6 +161,10 @@ export const tabAutocompleteOptionsSchema = z.object({
     .optional(),
   experimental_includeDiff: z.union([z.boolean(), z.number()]).optional(),
   experimental_enableStaticContextualization: z.boolean().optional(),
+  // send completion tracking data
+  enableCompletionTracking: z.boolean().optional(),
+  completionTrackingUrl: z.string().optional(),
+  completionTrackingHeaders: z.record(z.string()).optional(),
 });
 export type TabAutocompleteOptions = z.infer<
   typeof tabAutocompleteOptionsSchema

--- a/packages/config-yaml/src/load/merge.ts
+++ b/packages/config-yaml/src/load/merge.ts
@@ -14,7 +14,12 @@ export function mergePackages(
     prompts: [...(current.prompts ?? []), ...(incoming.prompts ?? [])],
     docs: [...(current.docs ?? []), ...(incoming.docs ?? [])],
     env: { ...current.env, ...incoming.env },
-  };
+    // Merge tabAutocompleteOptions - incoming overrides current
+    tabAutocompleteOptions: {
+      ...(current as any).tabAutocompleteOptions,
+      ...(incoming as any).tabAutocompleteOptions,
+    },
+  } as ConfigYaml;
 }
 
 export function mergeUnrolledAssistants(
@@ -31,5 +36,10 @@ export function mergeUnrolledAssistants(
     mcpServers: [...(current.mcpServers ?? []), ...(incoming.mcpServers ?? [])],
     prompts: [...(current.prompts ?? []), ...(incoming.prompts ?? [])],
     env: { ...current.env, ...incoming.env },
-  };
+    // Merge tabAutocompleteOptions - incoming overrides current
+    tabAutocompleteOptions: {
+      ...(current as any).tabAutocompleteOptions,
+      ...(incoming as any).tabAutocompleteOptions,
+    },
+  } as AssistantUnrolled;
 }

--- a/packages/config-yaml/src/load/unroll.ts
+++ b/packages/config-yaml/src/load/unroll.ts
@@ -363,11 +363,12 @@ export async function unrollBlocks(
   const unrolledAssistant: AssistantUnrolled = {
     name: assistant.name,
     version: assistant.version,
+    tabAutocompleteOptions: assistant.tabAutocompleteOptions,
   };
 
   const sections: (keyof Omit<
     ConfigYaml,
-    "name" | "version" | "rules" | "schema" | "metadata" | "env"
+    "name" | "version" | "rules" | "schema" | "metadata" | "env" | "tabAutocompleteOptions"
   >)[] = ["models", "context", "data", "mcpServers", "prompts", "docs"];
 
   // Process all sections in parallel

--- a/packages/config-yaml/src/schemas/index.ts
+++ b/packages/config-yaml/src/schemas/index.ts
@@ -2,6 +2,7 @@ import * as z from "zod";
 import { commonModelSlugs } from "./commonSlugs.js";
 import { dataSchema } from "./data/index.js";
 import {
+  autocompleteOptionsSchema,
   modelSchema,
   partialModelSchema,
   requestOptionsSchema,
@@ -152,6 +153,7 @@ export const configYamlSchema = baseConfigYamlSchema.extend({
     .optional(),
   prompts: z.array(blockOrSchema(promptSchema)).optional(),
   docs: z.array(blockOrSchema(docSchema)).optional(),
+  tabAutocompleteOptions: autocompleteOptionsSchema.optional(),
 });
 
 export type ConfigYaml = z.infer<typeof configYamlSchema>;
@@ -164,6 +166,7 @@ export const assistantUnrolledSchema = baseConfigYamlSchema.extend({
   rules: z.array(ruleSchema.nullable()).optional(),
   prompts: z.array(promptSchema.nullable()).optional(),
   docs: z.array(docSchema.nullable()).optional(),
+  tabAutocompleteOptions: autocompleteOptionsSchema.optional(),
 });
 
 export type AssistantUnrolled = z.infer<typeof assistantUnrolledSchema>;
@@ -176,6 +179,7 @@ export const assistantUnrolledSchemaNonNullable = baseConfigYamlSchema.extend({
   rules: z.array(ruleSchema).optional(),
   prompts: z.array(promptSchema).optional(),
   docs: z.array(docSchema).optional(),
+  tabAutocompleteOptions: autocompleteOptionsSchema.optional(),
 });
 
 export type AssistantUnrolledNonNullable = z.infer<

--- a/packages/config-yaml/src/schemas/models.ts
+++ b/packages/config-yaml/src/schemas/models.ts
@@ -134,6 +134,10 @@ export const autocompleteOptionsSchema = z.object({
   experimental_includeRecentlyEditedRanges: z.boolean().optional(),
   experimental_includeDiff: z.boolean().optional(),
   experimental_enableStaticContextualization: z.boolean().optional(),
+  // send completion tracking data
+  enableCompletionTracking: z.boolean().optional(),
+  completionTrackingUrl: z.string().optional(),
+  completionTrackingHeaders: z.record(z.string()).optional(),
 });
 
 /** Prompt templates use Handlebars syntax */

--- a/packages/openai-adapters/package-lock.json
+++ b/packages/openai-adapters/package-lock.json
@@ -55,17 +55,22 @@
     },
     "../fetch": {
       "name": "@continuedev/fetch",
-      "version": "1.0.16",
+      "version": "1.0.17",
       "license": "Apache-2.0",
       "dependencies": {
-        "@continuedev/config-types": "file:../config-types",
+        "@continuedev/config-types": "^1.0.14",
         "follow-redirects": "^1.15.6",
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.5",
         "node-fetch": "^3.3.2"
       },
       "devDependencies": {
+        "@semantic-release/changelog": "^6.0.3",
+        "@semantic-release/git": "^10.0.1",
+        "@semantic-release/github": "^9.2.6",
+        "@semantic-release/npm": "^10.0.6",
         "@types/follow-redirects": "^1.14.4",
+        "semantic-release": "^21.1.2",
         "typescript": "^5.0.0",
         "vitest": "^3.2.0"
       }

--- a/update-vscode-extension.sh
+++ b/update-vscode-extension.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Continue VSCode 扩展更新脚本
+# 使用方法: ./update-vscode-extension.sh [quick|full]
+
+set -e  # 遇到错误时停止
+
+echo "🔄 开始更新 Continue VSCode 扩展..."
+
+# 获取脚本所在目录的绝对路径
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$SCRIPT_DIR"
+
+# 检查更新类型
+UPDATE_TYPE="${1:-quick}"
+
+echo "📍 项目根目录: $PROJECT_ROOT"
+echo "🎯 更新类型: $UPDATE_TYPE"
+
+cd "$PROJECT_ROOT"
+
+if [ "$UPDATE_TYPE" = "full" ]; then
+    echo "🔨 执行完整构建..."
+    
+    # 1. 构建所有依赖包
+    echo "📦 构建依赖包..."
+    cd packages/config-types && npm run build
+    cd ../fetch && npm run build  
+    cd ../llm-info && npm run build
+    cd ../openai-adapters && npm run build
+    cd ../terminal-security && npm run build
+    cd ../config-yaml && npm run build
+    
+    # 2. 构建 core
+    echo "🏗️ 构建 core 模块..."
+    cd ../../core && npm run build
+    
+    # 3. 构建 GUI
+    echo "🎨 构建 GUI..."
+    cd ../gui && npm run build
+    
+    # 4. 构建和打包扩展
+    echo "📱 构建 VSCode 扩展..."
+    cd ../extensions/vscode
+    npm run package
+    
+elif [ "$UPDATE_TYPE" = "quick" ]; then
+    echo "⚡ 执行快速构建..."
+    
+    # 只重新构建 GUI 和扩展
+    echo "🎨 重新构建 GUI..."
+    cd gui && npm run build
+    
+    echo "📱 重新构建 VSCode 扩展..."
+    cd ../extensions/vscode
+    npm run package
+    
+else
+    echo "❌ 未知的更新类型: $UPDATE_TYPE"
+    echo "使用方法: $0 [quick|full]"
+    exit 1
+fi
+
+echo "✅ VSCode 扩展更新完成!"
+echo "📦 VSIX 文件位置: $PROJECT_ROOT/extensions/vscode/build/continue-1.3.9.vsix"
+echo ""
+echo "安装方法:"
+echo "  方法1: code --install-extension $PROJECT_ROOT/extensions/vscode/build/continue-1.3.9.vsix"
+echo "  方法2: 在 VSCode 中按 Cmd+Shift+P，输入 'Extensions: Install from VSIX'，选择上述文件"
+echo ""
+echo "🔄 如需重新加载扩展，请在 VSCode 中按 Cmd+Shift+P，输入 'Developer: Reload Window'"


### PR DESCRIPTION
## Description

Added a completion tracking feature to track accepted or not in order to improv code completion performance.
This feature can be totally controlled by user so there is no need to worry about privacy issues.
Inspired by [cursor online rl](https://cursor.com/cn/blog/tab-rl).

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-general-review` or `@continue-detailed-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

enable completion tracking and set tracking url:
<img width="1172" height="906" alt="image" src="https://github.com/user-attachments/assets/2477a3ee-f9af-481f-8828-e2ed024de618" />

when we press tab to accept a completion:
<img width="2966" height="970" alt="image" src="https://github.com/user-attachments/assets/60a6f203-5005-43cf-8154-546075361010" />

then we can use it to do online ppo training to reproduce [the cursor online rl](https://cursor.com/cn/blog/tab-rl)

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
