### PR TITLE
feat: handle environment.json file in cn serve

### DIFF
--- a/extensions/cli/src/commands/serve.ts
+++ b/extensions/cli/src/commands/serve.ts
@@ -25,6 +25,7 @@ import { formatError } from "../util/formatError.js";
 import { getGitDiffSnapshot } from "../util/git.js";
 import { logger } from "../util/logger.js";
 import { readStdinSync } from "../util/stdin.js";
+import { runEnvironmentInstall } from "../environment/environmentHandler.js";
 
 import { ExtendedCommandOptions } from "./BaseCommandOptions.js";
 import {
@@ -54,6 +55,16 @@ export async function serve(prompt?: string, options: ServeOptions = {}) {
   const timeoutSeconds = parseInt(options.timeout || "300", 10);
   const timeoutMs = timeoutSeconds * 1000;
   const port = parseInt(options.port || "8000", 10);
+
+  // Run environment install script if available
+  try {
+    await runEnvironmentInstall();
+  } catch (error) {
+    console.error(
+      chalk.red("Failed to run environment install script:"),
+      formatError(error),
+    );
+  }
 
   // Initialize services with tool permission overrides
   const { permissionOverrides } = processCommandFlags(options);

--- a/extensions/cli/src/environment/environmentHandler.ts
+++ b/extensions/cli/src/environment/environmentHandler.ts
@@ -1,0 +1,88 @@
+import { execSync } from "child_process";
+import { existsSync, readFileSync } from "fs";
+import path from "path";
+
+import chalk from "chalk";
+
+import { formatError } from "../util/formatError.js";
+import { logger } from "../util/logger.js";
+
+interface EnvironmentConfig {
+  install?: string;
+}
+
+const ENVIRONMENT_FILE_NAME = "environment.json";
+const ENVIRONMENT_SEARCH_PATHS = [".continue"];
+
+/**
+ * Finds and reads the environment.json file
+ */
+function findEnvironmentFile(): EnvironmentConfig | null {
+  for (const searchPath of ENVIRONMENT_SEARCH_PATHS) {
+    const environmentPath = path.join(
+      process.cwd(),
+      searchPath,
+      ENVIRONMENT_FILE_NAME,
+    );
+
+    if (existsSync(environmentPath)) {
+      try {
+        const content = readFileSync(environmentPath, "utf-8");
+        const config = JSON.parse(content) as EnvironmentConfig;
+        logger.debug(`Found environment.json at: ${environmentPath}`);
+        return config;
+      } catch (error) {
+        logger.error(
+          `Failed to parse environment.json at ${environmentPath}: ${formatError(error)}`,
+        );
+        return null;
+      }
+    }
+  }
+
+  logger.debug("No environment.json file found");
+  return null;
+}
+
+/**
+ * Runs the install script from environment.json if present
+ */
+export async function runEnvironmentInstall(): Promise<void> {
+  const environmentConfig = findEnvironmentFile();
+
+  if (!environmentConfig || !environmentConfig.install) {
+    logger.debug("No install script found in environment.json, skipping...");
+    return;
+  }
+
+  const installScript = environmentConfig.install;
+  logger.debug(
+    chalk.blue(
+      `\nRunning environment install script: ${chalk.dim(installScript)}`,
+    ),
+  );
+
+  try {
+    execSync(installScript, {
+      stdio: "inherit",
+      cwd: process.cwd(),
+      encoding: "utf-8",
+    });
+
+    logger.debug(
+      chalk.green("✓ Environment install script completed successfully"),
+    );
+  } catch (error) {
+    logger.error(`Environment install script failed: ${formatError(error)}`);
+    throw new Error(
+      `Failed to run environment install script: ${formatError(error)}`,
+    );
+  }
+}
+
+/**
+ * Gets the environment configuration if available
+ */
+export function getEnvironmentConfig(): EnvironmentConfig | null {
+  return findEnvironmentFile();
+}


### PR DESCRIPTION
## Description

this was shortest path to set up the husky pre-commit hook in background
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds support for .continue/environment.json in cn serve. If the file defines an install command, it runs before the server starts to auto-setup the local environment (e.g., Husky hooks).

- **New Features**
  - Detects .continue/environment.json with an install script.
  - Executes the script with inherited stdio.
  - Logs failures but does not block cn serve.

<!-- End of auto-generated description by cubic. -->

