### PR TITLE
feat: Add --id option to connect to existing remote agents via tunnel

### DIFF
--- a/extensions/cli/src/commands/remote.ts
+++ b/extensions/cli/src/commands/remote.ts
@@ -9,155 +9,258 @@ import { getRepoUrl } from "../util/git.js";
 import { logger } from "../util/logger.js";
 import { readStdinSync } from "../util/stdin.js";
 
+type RemoteCommandOptions = {
+  url?: string;
+  id?: string;
+  idempotencyKey?: string;
+  start?: boolean;
+  branch?: string;
+  repo?: string;
+  config?: string;
+};
+
+type TunnelResponse = {
+  url: string;
+  port?: number;
+};
+
+type AgentCreationResponse = TunnelResponse & {
+  id: string;
+};
+
+class AuthenticationRequiredError extends Error {
+  constructor() {
+    super("Not authenticated. Please run 'cn login' first.");
+  }
+}
+
 export async function remote(
   prompt: string | undefined,
-  options: {
-    url?: string;
-    idempotencyKey?: string;
-    start?: boolean;
-    branch?: string;
-    repo?: string;
-    config?: string;
-  } = {},
+  options: RemoteCommandOptions = {},
 ) {
-  // Check if prompt should come from stdin instead of parameter
-  let actualPrompt = prompt;
-  if (prompt) {
-    // If prompt is provided, still check for stdin and combine them
-    const stdinInput = readStdinSync();
-    if (stdinInput) {
-      // Combine stdin and prompt argument - stdin comes first in XML block
-      actualPrompt = `<stdin>\n${stdinInput}\n</stdin>\n\n${prompt}`;
+  const actualPrompt = resolvePrompt(prompt);
+
+  try {
+    if (options.url) {
+      await connectToRemoteUrl(options.url, actualPrompt, options.start);
+      return;
     }
-  } else {
-    // Try to read from stdin (for piped input like: echo "hello" | cn remote -s)
-    const stdinInput = readStdinSync();
-    if (stdinInput) {
-      actualPrompt = stdinInput;
-    }
-  }
-  // If --url is provided, connect directly to that URL
-  if (options.url) {
-    if (options.start) {
-      // In start mode, output connection details as JSON and exit
-      console.log(
-        JSON.stringify({
-          status: "success",
-          message: "Remote environment connection details",
-          url: options.url,
-          mode: "direct_url",
-        }),
+
+    const accessToken = requireAccessToken();
+
+    if (options.id) {
+      await connectExistingAgent(
+        options.id,
+        accessToken,
+        actualPrompt,
+        options.start,
       );
       return;
     }
 
-    console.info(
-      chalk.white(`Connecting to remote environment at: ${options.url}`),
-    );
+    await createAndConnectRemoteEnvironment(accessToken, actualPrompt, options);
+  } catch (error) {
+    await handleRemoteError(error);
+  }
+}
 
-    // Record session start
-    telemetryService.recordSessionStart();
-    telemetryService.startActiveTime();
+function resolvePrompt(prompt: string | undefined): string | undefined {
+  const stdinInput = readStdinSync();
 
-    try {
-      // Start the TUI in remote mode
-      await startRemoteTUIChat(options.url, actualPrompt);
-    } finally {
-      telemetryService.stopActiveTime();
-    }
+  if (!stdinInput) {
+    return prompt;
+  }
+
+  if (!prompt) {
+    return stdinInput;
+  }
+
+  return `<stdin>\n${stdinInput}\n</stdin>\n\n${prompt}`;
+}
+
+async function connectToRemoteUrl(
+  remoteUrl: string,
+  prompt: string | undefined,
+  startOnly?: boolean,
+) {
+  if (startOnly) {
+    printStartJson({
+      status: "success",
+      message: "Remote environment connection details",
+      url: remoteUrl,
+      mode: "direct_url",
+    });
     return;
   }
 
-  try {
-    const authConfig = loadAuthConfig();
+  console.info(
+    chalk.white(`Connecting to remote environment at: ${remoteUrl}`),
+  );
+  await launchRemoteTUI(remoteUrl, prompt);
+}
 
-    // Check if we have any valid authentication (file-based or environment variable)
-    if (!authConfig || !getAccessToken(authConfig)) {
-      console.error(
-        chalk.red("Not authenticated. Please run 'cn login' first."),
-      );
-      await gracefulExit(1);
-    }
+function requireAccessToken(): string {
+  const authConfig = loadAuthConfig();
 
-    const accessToken = getAccessToken(authConfig);
+  if (!authConfig) {
+    throw new AuthenticationRequiredError();
+  }
 
-    const requestBody: any = {
-      repoUrl: options.repo || getRepoUrl(),
-      name: `devbox-${Date.now()}`,
-      prompt: actualPrompt,
-      idempotencyKey: options.idempotencyKey,
-      agent: options.config,
-      config: options.config,
-    };
+  const accessToken = getAccessToken(authConfig);
 
-    // Add branchName to request body if branch option is provided
-    if (options.branch) {
-      requestBody.branchName = options.branch;
-    }
+  if (!accessToken) {
+    throw new AuthenticationRequiredError();
+  }
 
-    const response = await fetch(new URL("agents", env.apiBase), {
+  return accessToken;
+}
+
+async function connectExistingAgent(
+  agentId: string,
+  accessToken: string,
+  prompt: string | undefined,
+  startOnly?: boolean,
+) {
+  const tunnel = await fetchAgentTunnel(agentId, accessToken);
+
+  if (startOnly) {
+    printStartJson({
+      status: "success",
+      message: "Remote agent tunnel connection details",
+      url: tunnel.url,
+      containerPort: tunnel.port,
+      agentId,
+      mode: "existing_agent",
+    });
+    return;
+  }
+
+  console.info(
+    chalk.white(`Connecting to remote agent tunnel at: ${tunnel.url}`),
+  );
+  await launchRemoteTUI(tunnel.url, prompt);
+}
+
+async function createAndConnectRemoteEnvironment(
+  accessToken: string,
+  prompt: string | undefined,
+  options: RemoteCommandOptions,
+) {
+  const requestBody = buildAgentRequestBody(options, prompt);
+
+  const response = await fetch(new URL("agents", env.apiBase), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify(requestBody),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      `Failed to create remote environment: ${response.status} ${errorText}`,
+    );
+  }
+
+  const result = (await response.json()) as AgentCreationResponse;
+
+  if (options.start) {
+    printStartJson({
+      status: "success",
+      message: "Remote development environment created successfully",
+      url: `${env.appUrl}/agents/${result.id}`,
+      containerUrl: result.url,
+      containerPort: result.port,
+      name: requestBody.name,
+      mode: "new_environment",
+    });
+    return;
+  }
+
+  console.info(
+    chalk.green("✅ Remote development environment created successfully!"),
+  );
+
+  if (!result.url) {
+    throw new Error("No URL returned from remote environment creation");
+  }
+
+  console.info(
+    chalk.white(`Connecting to remote environment at: ${result.url}`),
+  );
+  await launchRemoteTUI(result.url, prompt);
+}
+
+function buildAgentRequestBody(
+  options: RemoteCommandOptions,
+  prompt: string | undefined,
+) {
+  const body: Record<string, unknown> = {
+    repoUrl: options.repo ?? getRepoUrl(),
+    name: `devbox-${Date.now()}`,
+    prompt,
+    agent: options.config,
+    config: options.config,
+  };
+
+  if (options.idempotencyKey) {
+    body.idempotencyKey = options.idempotencyKey;
+  }
+
+  if (options.branch) {
+    body.branchName = options.branch;
+  }
+
+  return body;
+}
+
+async function fetchAgentTunnel(agentId: string, accessToken: string) {
+  const response = await fetch(
+    new URL(`agents/${agentId}/tunnel`, env.apiBase),
+    {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${accessToken}`,
       },
-      body: JSON.stringify(requestBody),
-    });
+    },
+  );
 
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(
-        `Failed to create remote environment: ${response.status} ${errorText}`,
-      );
-    }
-
-    const result = await response.json();
-
-    if (options.start) {
-      // In start mode, output connection details as JSON and exit
-      console.log(
-        JSON.stringify({
-          status: "success",
-          message: "Remote development environment created successfully",
-          url: `${env.appUrl}/agents/${result.id}`,
-          containerUrl: result.url,
-          containerPort: result.port,
-          name: requestBody.name,
-          mode: "new_environment",
-        }),
-      );
-      return;
-    }
-
-    console.info(
-      chalk.green("✅ Remote development environment created successfully!"),
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      `Failed to create tunnel for agent ${agentId}: ${response.status} ${errorText}`,
     );
-
-    if (result.url && result.port) {
-      const remoteUrl = result.url;
-      console.info(
-        chalk.white(`Connecting to remote environment at: ${remoteUrl}`),
-      );
-
-      // Record session start
-      telemetryService.recordSessionStart();
-      telemetryService.startActiveTime();
-
-      try {
-        // Start the TUI in remote mode (prompt is optional)
-        await startRemoteTUIChat(remoteUrl, actualPrompt);
-      } finally {
-        telemetryService.stopActiveTime();
-      }
-    } else {
-      throw new Error(
-        "No URL or port returned from remote environment creation",
-      );
-    }
-  } catch (error: any) {
-    logger.error(
-      chalk.red(`Failed to create remote environment: ${error.message}`),
-    );
-    await gracefulExit(1);
   }
+
+  return (await response.json()) as TunnelResponse;
+}
+
+async function launchRemoteTUI(remoteUrl: string, prompt: string | undefined) {
+  telemetryService.recordSessionStart();
+  telemetryService.startActiveTime();
+
+  try {
+    await startRemoteTUIChat(remoteUrl, prompt);
+  } finally {
+    telemetryService.stopActiveTime();
+  }
+}
+
+function printStartJson(payload: Record<string, unknown>) {
+  console.log(JSON.stringify(payload));
+}
+
+async function handleRemoteError(error: unknown) {
+  if (error instanceof AuthenticationRequiredError) {
+    logger.error(chalk.red(error.message));
+  } else if (error instanceof Error) {
+    logger.error(chalk.red(error.message));
+  } else {
+    logger.error(chalk.red("An unknown error occurred while starting remote"));
+  }
+
+  await gracefulExit(1);
 }

--- a/extensions/cli/src/index.ts
+++ b/extensions/cli/src/index.ts
@@ -278,6 +278,10 @@ addCommonOptions(
     "Connect directly to the specified URL instead of creating a new remote environment",
   )
   .option(
+    "--id <id>",
+    "Connect to an existing remote agent by id and establish a tunnel",
+  )
+  .option(
     "--idempotency-key <key>",
     "Idempotency key for session management - allows resuming existing sessions",
   )


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a --id option to connect to an existing remote agent via a tunnel, with improved flow and error handling for the remote command. Also updates start-mode JSON output and tests.

- **New Features**
  - Add --id <id> to connect via POST /agents/:id/tunnel.
  - Support --id with --start to print JSON and skip TUI.
  - Keep direct URL mode; prints JSON in --start.
  - Update CLI help text to include --id.

- **Refactors**
  - Split logic into small functions (prompt resolution, URL connect, agent tunnel, environment creation, TUI launch, error handling).
  - Add AuthenticationRequiredError and consistent gracefulExit.
  - Build request body only includes idempotencyKey when provided; branchName optional.
  - Add tests for --id flow and --id + --start JSON output.

<!-- End of auto-generated description by cubic. -->

