### PR TITLE
fix: json mcp loading

### DIFF
--- a/core/context/mcp/json/loadJsonMcpConfigs.ts
+++ b/core/context/mcp/json/loadJsonMcpConfigs.ts
@@ -111,29 +111,24 @@ export async function loadJsonMcpConfigs(
             ),
           );
         }
-        if (claudeCodeFileParsed.data.projects) {
-          const projectServers = Object.values(
-            claudeCodeFileParsed.data.projects,
-          ).map((v) => v.mcpServers);
-          for (const mcpServers of projectServers) {
-            if (mcpServers) {
-              validJsonConfigs.push(
-                ...Object.entries(mcpServers).map(([name, mcpJson]) => ({
-                  name,
-                  mcpJson,
-                  uri,
-                })),
-              );
-            }
+        const projectServers = Object.values(
+          claudeCodeFileParsed.data.projects,
+        ).map((v) => v.mcpServers);
+        for (const mcpServers of projectServers) {
+          if (mcpServers) {
+            validJsonConfigs.push(
+              ...Object.entries(mcpServers).map(([name, mcpJson]) => ({
+                name,
+                mcpJson,
+                uri,
+              })),
+            );
           }
         }
       } else {
         const claudeDesktopFileParsed =
           claudeDesktopLikeConfigFileSchema.safeParse(json);
-        if (
-          claudeDesktopFileParsed.success &&
-          claudeDesktopFileParsed.data.mcpServers
-        ) {
+        if (claudeDesktopFileParsed.success) {
           validJsonConfigs.push(
             ...Object.entries(claudeDesktopFileParsed.data.mcpServers).map(
               ([name, mcpJson]) => ({

--- a/packages/config-yaml/src/schemas/mcp/json.ts
+++ b/packages/config-yaml/src/schemas/mcp/json.ts
@@ -31,7 +31,7 @@ export const mcpServersRecordSchema = z.record(
 export type McpServersJsonConfigRecord = z.infer<typeof mcpServersRecordSchema>;
 
 export const claudeDesktopLikeConfigFileSchema = z.object({
-  mcpServers: mcpServersRecordSchema.optional(),
+  mcpServers: mcpServersRecordSchema,
 });
 export type McpServersJsonConfigFile = z.infer<
   typeof claudeDesktopLikeConfigFileSchema
@@ -39,14 +39,12 @@ export type McpServersJsonConfigFile = z.infer<
 
 export const claudeCodeLikeConfigFileSchema = z.object({
   mcpServers: mcpServersRecordSchema.optional(),
-  projects: z
-    .record(
-      z.string(),
-      z.object({
-        mcpServers: mcpServersRecordSchema.optional(),
-      }),
-    )
-    .optional(),
+  projects: z.record(
+    z.string(),
+    z.object({
+      mcpServers: mcpServersRecordSchema.optional(),
+    }),
+  ),
 });
 export type claudeCodeLikeConfigFileSchema = z.infer<
   typeof claudeCodeLikeConfigFileSchema


### PR DESCRIPTION
## Description
last commit pushed to https://github.com/continuedev/continue/pull/7956 broke it
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix JSON MCP config loading by aligning schemas with actual config shapes and updating the loader to always parse project and desktop mcpServers. Restores MCP discovery for Claude Code and Claude Desktop JSON configs.

- **Bug Fixes**
  - Schemas: mcpServers is required in Desktop configs; projects is required in Code configs (project mcpServers remain optional).
  - Loader: removed conditional guards and now consistently collects mcpServers from projects and desktop configs after a successful parse.

<!-- End of auto-generated description by cubic. -->

