### PR TITLE
feat: include mcp loading errors in config loading errors

### DIFF
--- a/core/config/profile/doLoadConfig.ts
+++ b/core/config/profile/doLoadConfig.ts
@@ -210,6 +210,13 @@ export default async function doLoadConfig(options: {
   newConfig.mcpServerStatuses = serializableStatuses;
 
   for (const server of mcpServerStatuses) {
+    server.errors.forEach((error) => {
+      // MCP errors will also show as config loading errors
+      errors.push({
+        fatal: false,
+        message: error,
+      });
+    });
     if (server.status === "connected") {
       const serverTools: Tool[] = server.tools.map((tool) => ({
         displayTitle: server.name + " " + tool.name,


### PR DESCRIPTION
## Description
So that the little error icon in the notch will show if there's mcp loading errors
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Surface MCP server loading errors as config loading errors so the notch error icon shows when MCP fails to load. Addresses CON-1836.

<!-- End of auto-generated description by cubic. -->

