### PR TITLE
feat: env secret rendering for CLI

### DIFF
--- a/docs/customize/deep-dives/mcp.mdx
+++ b/docs/customize/deep-dives/mcp.mdx
@@ -190,54 +190,59 @@ For Continue CLI users, `${{ secrets.SECRET_NAME }}` template variables in your 
 
 <Warning>
 
-  Secret templating only works in **values**, not in object **keys**. For example, `headers: { "Authorization": "Bearer ${{ secrets.TOKEN }}" }` works, but `headers: { "${{ secrets.HEADER_NAME }}": "value" }` does not.
+  Secret templating has important limitations:
+  - Only works in **values**, not in object **keys**
+  - Only works in specific **allowed fields** (see list below)
+  - Does NOT work in `name`, `command`, `cwd`, `faviconUrl`, or other configuration fields
+  
+  For example: `headers: { "Authorization": "Bearer ${{ secrets.TOKEN }}" }` works, but `name: "${{ secrets.SERVER_NAME }}"` does not.
 
 </Warning>
 
 **For STDIO servers (`command` type):**
-- `command` - The executable command
 - `args` - Array of command arguments  
 - `env` - Environment variable values (secrets in keys are not supported)
-- `cwd` - Working directory path
 
 **For HTTP-based servers (`sse` and `streamable-http` types):**
 - `url` - The server endpoint URL
 - `requestOptions.headers` - HTTP header values (secrets in keys are not supported)
-- All other `requestOptions` fields that are strings
 
-**For all server types:**
+**Restricted fields (secrets are NOT rendered):**
 - `name` - Server display name
+- `command` - The executable command (STDIO servers)
+- `cwd` - Working directory path (STDIO servers)
 - `faviconUrl` - Icon URL
-- Any other string fields in the configuration
+- `type` - Server type
+- Any other fields not explicitly listed above
 
 **Example with environment variables:**
 
 ```yaml
 mcpServers:
-  # STDIO server example with secrets in various fields
-  - name: ${{ secrets.SERVER_NAME }}  # Server name from env
-    command: ${{ secrets.CUSTOM_COMMAND }}  # Command from env
+  # STDIO server example with secrets in allowed fields only
+  - name: My Server  # Static name (secrets not supported here)
+    command: node  # Static command (secrets not supported here)
     args:
       - server.js
       - --api-key
-      - ${{ secrets.API_KEY }}  # Command argument
+      - ${{ secrets.API_KEY }}  # ✅ Secrets work in args
       - --config-path
-      - ${{ secrets.CONFIG_PATH }}  # File path
+      - ${{ secrets.CONFIG_PATH }}  # ✅ Secrets work in args
     env:
-      DATABASE_URL: ${{ secrets.DATABASE_URL }}  # Env variable value
-      CUSTOM_SECRET: ${{ secrets.ENV_SECRET }}  # Another env var value
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}  # ✅ Secrets work in env values
+      CUSTOM_SECRET: ${{ secrets.ENV_SECRET }}  # ✅ Secrets work in env values
       LOG_LEVEL: info  # Regular value (no templating)
-    cwd: ${{ secrets.WORKING_DIR }}  # Working directory
+    # cwd: ${{ secrets.WORKING_DIR }}  # ❌ Secrets NOT supported in cwd
     
-  # HTTP server example with secrets in URL and headers
-  - name: Remote API Server
+  # HTTP server example with secrets in allowed fields only
+  - name: Remote API Server  # Static name (secrets not supported here)
     type: sse
-    url: ${{ secrets.API_BASE_URL }}/mcp  # URL with secret
+    url: ${{ secrets.API_BASE_URL }}/mcp  # ✅ Secrets work in URL
     requestOptions:
       headers:
-        Authorization: Bearer ${{ secrets.AUTH_TOKEN }}  # Header value
-        X-Custom-Value: ${{ secrets.CUSTOM_HEADER_VALUE }}  # Another header value
-        X-User-ID: ${{ secrets.USER_ID }}  # Another header
+        Authorization: Bearer ${{ secrets.AUTH_TOKEN }}  # ✅ Secrets work in header values
+        X-Custom-Value: ${{ secrets.CUSTOM_HEADER_VALUE }}  # ✅ Secrets work in header values
+        X-User-ID: ${{ secrets.USER_ID }}  # ✅ Secrets work in header values
         Content-Type: application/json  # Regular header
 ```
 
@@ -245,13 +250,11 @@ mcpServers:
 
 ```bash
 # Set environment variables before running Continue CLI
-export SERVER_NAME="My Custom Server"
-export CUSTOM_COMMAND="node"
+# Only set environment variables for fields that support secrets
 export API_KEY="your-secret-api-key"
 export CONFIG_PATH="/path/to/config.json"
 export DATABASE_URL="postgresql://user:pass@host:5432/db"
 export ENV_SECRET="custom-env-value"
-export WORKING_DIR="/app/workspace"
 export API_BASE_URL="https://api.example.com"
 export AUTH_TOKEN="bearer-token-123"
 export CUSTOM_HEADER_VALUE="custom-header-value"

--- a/docs/customize/deep-dives/mcp.mdx
+++ b/docs/customize/deep-dives/mcp.mdx
@@ -78,26 +78,24 @@ server block to your [config file](./configuration.md):
         - "-y"
         - "mcp-sqlite"
         - "/path/to/your/database.db"
-
-````
-</Tab>
-<Tab title="JSON">
-```json title="config.json"
-{
-  "experimental": {
-    "modelContextProtocolServers": [
-      {
-        "transport": {
-          "type": "stdio",
-          "command": "uvx",
-          "args": ["mcp-server-sqlite", "--db-path", "/path/to/your/database.db"]
-        }
+  ```
+  </Tab>
+  <Tab title="JSON">
+  ```json title="config.json"
+  {
+    "experimental": {
+      "modelContextProtocolServers": [
+        {
+          "transport": {
+            "type": "stdio",
+            "command": "uvx",
+            "args": ["mcp-server-sqlite", "--db-path", "/path/to/your/database.db"]
+          }
       }
-    ]
+      ]
+    }
   }
-}
-````
-
+  ```
   </Tab>
 </Tabs>
 
@@ -179,3 +177,94 @@ mcpServers:
     env:
       GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
 ```
+
+#### Environment Variable Secret Resolution
+
+<Info>
+
+  When using Continue CLI with MCP servers, secrets are automatically resolved from your local environment variables. This provides a secure way to use sensitive data without hardcoding it in your configuration.
+
+</Info>
+
+For Continue CLI users, `${{ secrets.SECRET_NAME }}` template variables in your MCP server configuration will be automatically replaced with values from `process.env.SECRET_NAME`. This works in **all string values** of your MCP server configuration, including:
+
+<Warning>
+
+  Secret templating only works in **values**, not in object **keys**. For example, `headers: { "Authorization": "Bearer ${{ secrets.TOKEN }}" }` works, but `headers: { "${{ secrets.HEADER_NAME }}": "value" }` does not.
+
+</Warning>
+
+**For STDIO servers (`command` type):**
+- `command` - The executable command
+- `args` - Array of command arguments  
+- `env` - Environment variable values (secrets in keys are not supported)
+- `cwd` - Working directory path
+
+**For HTTP-based servers (`sse` and `streamable-http` types):**
+- `url` - The server endpoint URL
+- `requestOptions.headers` - HTTP header values (secrets in keys are not supported)
+- All other `requestOptions` fields that are strings
+
+**For all server types:**
+- `name` - Server display name
+- `faviconUrl` - Icon URL
+- Any other string fields in the configuration
+
+**Example with environment variables:**
+
+```yaml
+mcpServers:
+  # STDIO server example with secrets in various fields
+  - name: ${{ secrets.SERVER_NAME }}  # Server name from env
+    command: ${{ secrets.CUSTOM_COMMAND }}  # Command from env
+    args:
+      - server.js
+      - --api-key
+      - ${{ secrets.API_KEY }}  # Command argument
+      - --config-path
+      - ${{ secrets.CONFIG_PATH }}  # File path
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}  # Env variable value
+      CUSTOM_SECRET: ${{ secrets.ENV_SECRET }}  # Another env var value
+      LOG_LEVEL: info  # Regular value (no templating)
+    cwd: ${{ secrets.WORKING_DIR }}  # Working directory
+    
+  # HTTP server example with secrets in URL and headers
+  - name: Remote API Server
+    type: sse
+    url: ${{ secrets.API_BASE_URL }}/mcp  # URL with secret
+    requestOptions:
+      headers:
+        Authorization: Bearer ${{ secrets.AUTH_TOKEN }}  # Header value
+        X-Custom-Value: ${{ secrets.CUSTOM_HEADER_VALUE }}  # Another header value
+        X-User-ID: ${{ secrets.USER_ID }}  # Another header
+        Content-Type: application/json  # Regular header
+```
+
+**Setting environment variables:**
+
+```bash
+# Set environment variables before running Continue CLI
+export SERVER_NAME="My Custom Server"
+export CUSTOM_COMMAND="node"
+export API_KEY="your-secret-api-key"
+export CONFIG_PATH="/path/to/config.json"
+export DATABASE_URL="postgresql://user:pass@host:5432/db"
+export ENV_SECRET="custom-env-value"
+export WORKING_DIR="/app/workspace"
+export API_BASE_URL="https://api.example.com"
+export AUTH_TOKEN="bearer-token-123"
+export CUSTOM_HEADER_VALUE="custom-header-value"
+export USER_ID="user123"
+
+# Then run Continue CLI - secrets will be automatically resolved
+continue
+```
+
+**Validation and warnings:**
+
+- If an environment variable is not found, the original template variable is preserved (e.g., `${{ secrets.MISSING_KEY }}`)
+- The CLI will display warnings for any unrendered secrets to help with debugging
+- All secret resolution happens at connection time, ensuring fresh values on server restarts
+
+This approach provides a secure way to manage secrets locally while maintaining compatibility with the template variable syntax used in Continue Hub configurations.

--- a/extensions/cli/src/services/mcpSecretRenderer.integration.test.ts
+++ b/extensions/cli/src/services/mcpSecretRenderer.integration.test.ts
@@ -1,0 +1,223 @@
+import { SseMcpServer, StdioMcpServer } from "@continuedev/config-yaml";
+import { type AssistantConfig } from "@continuedev/sdk";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { MCPService } from "./MCPService.js";
+
+describe("MCPService Secret Rendering Integration", () => {
+  let mcpService: MCPService;
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    mcpService = new MCPService();
+    // Reset process.env
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(async () => {
+    await mcpService.cleanup();
+    process.env = originalEnv;
+  });
+
+  it("should render secrets from environment in STDIO server", async () => {
+    process.env.TEST_API_KEY = "test-secret-key";
+    process.env.TEST_SECRET_PATH = "/path/to/secret";
+
+    const assistantConfig: AssistantConfig = {
+      name: "test-assistant",
+      version: "1.0.0",
+      mcpServers: [
+        {
+          name: "test-stdio-server",
+          command: "node",
+          args: ["server.js", "--token", "${{ secrets.TEST_API_KEY }}"],
+          env: {
+            SECRET_FILE: "${{ secrets.TEST_SECRET_PATH }}",
+            NODE_ENV: "production",
+          },
+        } as StdioMcpServer,
+      ],
+    };
+
+    // Mock the client connection to avoid actually connecting
+    const originalGetConnectedClient = mcpService["getConnectedClient"];
+    mcpService["getConnectedClient"] = async () => {
+      throw new Error("Connection failed (expected for test)");
+    };
+
+    await mcpService.doInitialize(assistantConfig, true);
+    const state = mcpService.getState();
+
+    // Check that the server config was rendered with secrets
+    expect(state.connections).toHaveLength(1);
+    const connection = state.connections[0];
+
+    expect(connection.config.name).toBe("test-stdio-server");
+
+    if ("command" in connection.config) {
+      const stdioConfig = connection.config as StdioMcpServer;
+      expect(stdioConfig.command).toBe("node");
+      expect(stdioConfig.args).toEqual([
+        "server.js",
+        "--token",
+        "test-secret-key",
+      ]);
+      expect(stdioConfig.env).toEqual({
+        SECRET_FILE: "/path/to/secret",
+        NODE_ENV: "production",
+      });
+    } else {
+      throw new Error("Expected STDIO config");
+    }
+
+    // Should have no warnings for unrendered secrets
+    expect(connection.warnings).toHaveLength(0);
+  });
+
+  it("should render secrets from environment in SSE server", async () => {
+    process.env.AUTH_TOKEN = "bearer-token-123";
+
+    const assistantConfig: AssistantConfig = {
+      name: "test-assistant",
+      version: "1.0.0",
+      mcpServers: [
+        {
+          name: "test-sse-server",
+          url: "https://api.example.com/mcp",
+          type: "sse",
+          requestOptions: {
+            headers: {
+              Authorization: "Bearer ${{ secrets.AUTH_TOKEN }}",
+              "User-Agent": "continue-cli",
+            },
+          },
+        } as SseMcpServer,
+      ],
+    };
+
+    // Mock the client connection to avoid actually connecting
+    mcpService["getConnectedClient"] = async () => {
+      throw new Error("Connection failed (expected for test)");
+    };
+
+    await mcpService.doInitialize(assistantConfig, true);
+    const state = mcpService.getState();
+
+    // Check that the server config was rendered with secrets
+    expect(state.connections).toHaveLength(1);
+    const connection = state.connections[0];
+
+    expect(connection.config.name).toBe("test-sse-server");
+
+    if ("url" in connection.config) {
+      const sseConfig = connection.config as SseMcpServer;
+      expect(sseConfig.url).toBe("https://api.example.com/mcp");
+      expect(sseConfig.requestOptions?.headers).toEqual({
+        Authorization: "Bearer bearer-token-123",
+        "User-Agent": "continue-cli",
+      });
+    } else {
+      throw new Error("Expected SSE config");
+    }
+
+    // Should have no warnings for unrendered secrets
+    expect(connection.warnings).toHaveLength(0);
+  });
+
+  it("should warn about unrendered secrets when environment variables are missing", async () => {
+    // Don't set the environment variable
+
+    const assistantConfig: AssistantConfig = {
+      name: "test-assistant",
+      version: "1.0.0",
+      mcpServers: [
+        {
+          name: "test-missing-secret",
+          command: "node",
+          args: ["server.js", "--token", "${{ secrets.MISSING_SECRET }}"],
+        } as StdioMcpServer,
+      ],
+    };
+
+    // Mock the client connection to avoid actually connecting
+    mcpService["getConnectedClient"] = async () => {
+      throw new Error("Connection failed (expected for test)");
+    };
+
+    await mcpService.doInitialize(assistantConfig, true);
+    const state = mcpService.getState();
+
+    // Check that the server has warnings about unrendered secrets
+    expect(state.connections).toHaveLength(1);
+    const connection = state.connections[0];
+
+    expect(connection.warnings).toHaveLength(1);
+    expect(connection.warnings[0]).toContain(
+      "Unrendered secrets found: MISSING_SECRET",
+    );
+
+    // The original template should be preserved
+    if ("command" in connection.config) {
+      const stdioConfig = connection.config as StdioMcpServer;
+      expect(stdioConfig.args).toEqual([
+        "server.js",
+        "--token",
+        "${{ secrets.MISSING_SECRET }}",
+      ]);
+    } else {
+      throw new Error("Expected STDIO config");
+    }
+  });
+
+  it("should handle mixed rendered and unrendered secrets", async () => {
+    process.env.FOUND_SECRET = "found-value";
+    // Don't set MISSING_SECRET
+
+    const assistantConfig: AssistantConfig = {
+      name: "test-assistant",
+      version: "1.0.0",
+      mcpServers: [
+        {
+          name: "test-mixed-secrets",
+          command: "node",
+          args: [
+            "server.js",
+            "--found",
+            "${{ secrets.FOUND_SECRET }}",
+            "--missing",
+            "${{ secrets.MISSING_SECRET }}",
+          ],
+        } as StdioMcpServer,
+      ],
+    };
+
+    // Mock the client connection to avoid actually connecting
+    mcpService["getConnectedClient"] = async () => {
+      throw new Error("Connection failed (expected for test)");
+    };
+
+    await mcpService.doInitialize(assistantConfig, true);
+    const state = mcpService.getState();
+
+    // Check mixed rendering
+    expect(state.connections).toHaveLength(1);
+    const connection = state.connections[0];
+
+    expect(connection.warnings).toHaveLength(1);
+    expect(connection.warnings[0]).toContain(
+      "Unrendered secrets found: MISSING_SECRET",
+    );
+
+    if ("command" in connection.config) {
+      const stdioConfig = connection.config as StdioMcpServer;
+      expect(stdioConfig.args).toEqual([
+        "server.js",
+        "--found",
+        "found-value",
+        "--missing",
+        "${{ secrets.MISSING_SECRET }}",
+      ]);
+    } else {
+      throw new Error("Expected STDIO config");
+    }
+  });
+});

--- a/extensions/cli/src/services/mcpSecretRenderer.test.ts
+++ b/extensions/cli/src/services/mcpSecretRenderer.test.ts
@@ -1,0 +1,410 @@
+import {
+  MCPServer,
+  SseMcpServer,
+  StdioMcpServer,
+} from "@continuedev/config-yaml";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getSecretVariables,
+  hasUnrenderedSecrets,
+  renderMcpServerEnv,
+  renderMcpServerHeaders,
+  renderMcpServerSecrets,
+  renderMcpServersSecrets,
+  renderSecretsFromEnv,
+  validateMcpServerSecretsRendered,
+} from "./mcpSecretRenderer.js";
+
+describe("mcpSecretRenderer", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // Reset process.env
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe("getSecretVariables", () => {
+    it("should extract secret variable names from template strings", () => {
+      const template = "Bearer ${{ secrets.API_KEY }}";
+      const result = getSecretVariables(template);
+      expect(result).toEqual(["API_KEY"]);
+    });
+
+    it("should extract multiple secret variables", () => {
+      const template = "${{ secrets.USER }}:${{ secrets.PASSWORD }}";
+      const result = getSecretVariables(template);
+      expect(result).toEqual(["USER", "PASSWORD"]);
+    });
+
+    it("should ignore non-secret variables", () => {
+      const template = "${{ secrets.API_KEY }} and ${{ inputs.name }}";
+      const result = getSecretVariables(template);
+      expect(result).toEqual(["API_KEY"]);
+    });
+
+    it("should return empty array when no secrets found", () => {
+      const template = "no secrets here";
+      const result = getSecretVariables(template);
+      expect(result).toEqual([]);
+    });
+
+    it("should handle whitespace in template variables", () => {
+      const template = "${{  secrets.API_KEY  }}";
+      const result = getSecretVariables(template);
+      expect(result).toEqual(["API_KEY"]);
+    });
+  });
+
+  describe("renderSecretsFromEnv", () => {
+    it("should replace secret variables with environment values", () => {
+      process.env.API_KEY = "secret-value";
+      const template = "Bearer ${{ secrets.API_KEY }}";
+      const result = renderSecretsFromEnv(template);
+      expect(result).toBe("Bearer secret-value");
+    });
+
+    it("should handle multiple secrets", () => {
+      process.env.USER = "john";
+      process.env.PASSWORD = "secret123";
+      const template = "${{ secrets.USER }}:${{ secrets.PASSWORD }}";
+      const result = renderSecretsFromEnv(template);
+      expect(result).toBe("john:secret123");
+    });
+
+    it("should preserve original template when env var not found", () => {
+      const template = "Bearer ${{ secrets.MISSING_KEY }}";
+      const result = renderSecretsFromEnv(template);
+      expect(result).toBe("Bearer ${{ secrets.MISSING_KEY }}");
+    });
+
+    it("should handle mixed found and missing secrets", () => {
+      process.env.API_KEY = "found";
+      const template = "${{ secrets.API_KEY }} and ${{ secrets.MISSING }}";
+      const result = renderSecretsFromEnv(template);
+      expect(result).toBe("found and ${{ secrets.MISSING }}");
+    });
+
+    it("should return original string when no secrets present", () => {
+      const template = "no secrets here";
+      const result = renderSecretsFromEnv(template);
+      expect(result).toBe("no secrets here");
+    });
+  });
+
+  describe("renderMcpServerHeaders", () => {
+    it("should render secrets in headers", () => {
+      process.env.API_TOKEN = "token123";
+      const headers = {
+        Authorization: "Bearer ${{ secrets.API_TOKEN }}",
+        "Content-Type": "application/json",
+      };
+      const result = renderMcpServerHeaders(headers);
+      expect(result).toEqual({
+        Authorization: "Bearer token123",
+        "Content-Type": "application/json",
+      });
+    });
+
+    it("should return undefined when headers is undefined", () => {
+      const result = renderMcpServerHeaders(undefined);
+      expect(result).toBeUndefined();
+    });
+
+    it("should handle empty headers object", () => {
+      const result = renderMcpServerHeaders({});
+      expect(result).toEqual({});
+    });
+  });
+
+  describe("renderMcpServerEnv", () => {
+    it("should render secrets in environment variables", () => {
+      process.env.DB_PASSWORD = "dbpass123";
+      const env = {
+        DATABASE_URL: "postgres://user:${{ secrets.DB_PASSWORD }}@host/db",
+        NODE_ENV: "production",
+      };
+      const result = renderMcpServerEnv(env);
+      expect(result).toEqual({
+        DATABASE_URL: "postgres://user:dbpass123@host/db",
+        NODE_ENV: "production",
+      });
+    });
+
+    it("should return undefined when env is undefined", () => {
+      const result = renderMcpServerEnv(undefined);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("renderMcpServerSecrets", () => {
+    it("should render secrets in STDIO MCP server", () => {
+      process.env.API_KEY = "key123";
+      process.env.SECRET_PATH = "/path/to/secret";
+
+      const server: StdioMcpServer = {
+        name: "test-stdio",
+        command: "node",
+        args: ["server.js", "--token", "${{ secrets.API_KEY }}"],
+        env: {
+          SECRET_FILE: "${{ secrets.SECRET_PATH }}",
+          NODE_ENV: "production",
+        },
+      };
+
+      const result = renderMcpServerSecrets(server);
+      expect(result).toEqual({
+        name: "test-stdio",
+        command: "node",
+        args: ["server.js", "--token", "key123"],
+        env: {
+          SECRET_FILE: "/path/to/secret",
+          NODE_ENV: "production",
+        },
+      });
+    });
+
+    it("should render secrets in SSE MCP server", () => {
+      process.env.AUTH_TOKEN = "auth123";
+
+      const server: SseMcpServer = {
+        name: "test-sse",
+        url: "https://api.example.com/mcp",
+        requestOptions: {
+          headers: {
+            Authorization: "Bearer ${{ secrets.AUTH_TOKEN }}",
+            "User-Agent": "continue-cli",
+          },
+        },
+      };
+
+      const result = renderMcpServerSecrets(server);
+      expect(result).toEqual({
+        name: "test-sse",
+        url: "https://api.example.com/mcp",
+        requestOptions: {
+          headers: {
+            Authorization: "Bearer auth123",
+            "User-Agent": "continue-cli",
+          },
+        },
+      });
+    });
+
+    it("should preserve structure for servers without secrets", () => {
+      const server: StdioMcpServer = {
+        name: "test-no-secrets",
+        command: "node",
+        args: ["server.js"],
+      };
+
+      const result = renderMcpServerSecrets(server);
+      expect(result).toEqual(server);
+    });
+  });
+
+  describe("renderMcpServersSecrets", () => {
+    it("should render secrets for multiple servers", () => {
+      process.env.TOKEN1 = "token1";
+      process.env.TOKEN2 = "token2";
+
+      const servers: MCPServer[] = [
+        {
+          name: "server1",
+          command: "node",
+          args: ["--token", "${{ secrets.TOKEN1 }}"],
+        },
+        {
+          name: "server2",
+          url: "https://api.example.com",
+          requestOptions: {
+            headers: {
+              Authorization: "Bearer ${{ secrets.TOKEN2 }}",
+            },
+          },
+        },
+      ];
+
+      const result = renderMcpServersSecrets(servers);
+      expect(result).toHaveLength(2);
+      expect(result?.[0]).toEqual({
+        name: "server1",
+        command: "node",
+        args: ["--token", "token1"],
+      });
+      expect(result?.[1]).toEqual({
+        name: "server2",
+        url: "https://api.example.com",
+        requestOptions: {
+          headers: {
+            Authorization: "Bearer token2",
+          },
+        },
+      });
+    });
+
+    it("should return undefined when servers is undefined", () => {
+      const result = renderMcpServersSecrets(undefined);
+      expect(result).toBeUndefined();
+    });
+
+    it("should handle empty servers array", () => {
+      const result = renderMcpServersSecrets([]);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("hasUnrenderedSecrets", () => {
+    it("should return true when string contains unrendered secrets", () => {
+      const value = "Bearer ${{ secrets.API_KEY }}";
+      expect(hasUnrenderedSecrets(value)).toBe(true);
+    });
+
+    it("should return false when string has no secrets", () => {
+      const value = "Bearer token123";
+      expect(hasUnrenderedSecrets(value)).toBe(false);
+    });
+
+    it("should return false when string has non-secret template vars", () => {
+      const value = "Hello ${{ inputs.name }}";
+      expect(hasUnrenderedSecrets(value)).toBe(false);
+    });
+
+    it("should return false for empty string", () => {
+      expect(hasUnrenderedSecrets("")).toBe(false);
+    });
+  });
+
+  describe("validateMcpServerSecretsRendered", () => {
+    it("should return valid when all secrets are rendered", () => {
+      const server: StdioMcpServer = {
+        name: "test",
+        command: "node",
+        args: ["server.js", "--token", "rendered-token"],
+        env: {
+          SECRET: "rendered-secret",
+        },
+      };
+
+      const result = validateMcpServerSecretsRendered(server);
+      expect(result.isValid).toBe(true);
+      expect(result.unrenderedSecrets).toEqual([]);
+    });
+
+    it("should return invalid when secrets are unrendered", () => {
+      const server: StdioMcpServer = {
+        name: "test",
+        command: "node",
+        args: ["server.js", "--token", "${{ secrets.API_KEY }}"],
+        env: {
+          SECRET: "${{ secrets.SECRET_KEY }}",
+          NORMAL: "value",
+        },
+      };
+
+      const result = validateMcpServerSecretsRendered(server);
+      expect(result.isValid).toBe(false);
+      expect(result.unrenderedSecrets).toContain("API_KEY");
+      expect(result.unrenderedSecrets).toContain("SECRET_KEY");
+    });
+
+    it("should handle SSE server validation", () => {
+      const server: SseMcpServer = {
+        name: "test-sse",
+        url: "https://api.example.com/mcp",
+        requestOptions: {
+          headers: {
+            Authorization: "Bearer ${{ secrets.AUTH_TOKEN }}",
+          },
+        },
+      };
+
+      const result = validateMcpServerSecretsRendered(server);
+      expect(result.isValid).toBe(false);
+      expect(result.unrenderedSecrets).toContain("AUTH_TOKEN");
+    });
+
+    it("should handle complex nested structures", () => {
+      const server: StdioMcpServer = {
+        name: "test",
+        command: "${{ secrets.COMMAND }}",
+        args: ["${{ secrets.ARG1 }}", "normal-arg"],
+        env: {
+          SECRET1: "${{ secrets.SECRET1 }}",
+          SECRET2: "${{ secrets.SECRET2 }}",
+          NORMAL: "normal-value",
+        },
+      };
+
+      const result = validateMcpServerSecretsRendered(server);
+      expect(result.isValid).toBe(false);
+      expect(result.unrenderedSecrets).toHaveLength(4);
+      expect(result.unrenderedSecrets).toContain("COMMAND");
+      expect(result.unrenderedSecrets).toContain("ARG1");
+      expect(result.unrenderedSecrets).toContain("SECRET1");
+      expect(result.unrenderedSecrets).toContain("SECRET2");
+    });
+
+    it("should handle all documented secret locations", () => {
+      const server: StdioMcpServer = {
+        name: "${{ secrets.SERVER_NAME }}",
+        command: "${{ secrets.CUSTOM_COMMAND }}",
+        args: [
+          "server.js",
+          "--token",
+          "${{ secrets.API_KEY }}",
+          "--config",
+          "${{ secrets.CONFIG_PATH }}",
+        ],
+        env: {
+          DATABASE_URL: "${{ secrets.DATABASE_URL }}",
+          CUSTOM_SECRET: "${{ secrets.ENV_SECRET }}", // Secret in value
+          LOG_LEVEL: "info", // No secret
+        },
+        cwd: "${{ secrets.WORKING_DIR }}",
+        faviconUrl: "${{ secrets.ICON_URL }}",
+      };
+
+      const result = validateMcpServerSecretsRendered(server);
+      expect(result.isValid).toBe(false);
+      expect(result.unrenderedSecrets).toContain("SERVER_NAME");
+      expect(result.unrenderedSecrets).toContain("CUSTOM_COMMAND");
+      expect(result.unrenderedSecrets).toContain("API_KEY");
+      expect(result.unrenderedSecrets).toContain("CONFIG_PATH");
+      expect(result.unrenderedSecrets).toContain("DATABASE_URL");
+      expect(result.unrenderedSecrets).toContain("ENV_SECRET");
+      expect(result.unrenderedSecrets).toContain("WORKING_DIR");
+      expect(result.unrenderedSecrets).toContain("ICON_URL");
+    });
+
+    it("should handle HTTP server with all documented secret locations", () => {
+      const server: SseMcpServer = {
+        name: "${{ secrets.SERVER_NAME }}",
+        url: "${{ secrets.API_BASE_URL }}/mcp",
+        type: "sse",
+        faviconUrl: "${{ secrets.ICON_URL }}",
+        requestOptions: {
+          headers: {
+            Authorization: "Bearer ${{ secrets.AUTH_TOKEN }}",
+            "X-Custom-Value": "${{ secrets.CUSTOM_HEADER_VALUE }}", // Secret in value
+            "X-User-ID": "${{ secrets.USER_ID }}",
+            "Content-Type": "application/json", // No secret
+          },
+        },
+      };
+
+      const result = validateMcpServerSecretsRendered(server);
+      expect(result.isValid).toBe(false);
+      expect(result.unrenderedSecrets).toContain("SERVER_NAME");
+      expect(result.unrenderedSecrets).toContain("API_BASE_URL");
+      expect(result.unrenderedSecrets).toContain("ICON_URL");
+      expect(result.unrenderedSecrets).toContain("AUTH_TOKEN");
+      expect(result.unrenderedSecrets).toContain("CUSTOM_HEADER_VALUE");
+      expect(result.unrenderedSecrets).toContain("USER_ID");
+    });
+  });
+});

--- a/extensions/cli/src/services/mcpSecretRenderer.ts
+++ b/extensions/cli/src/services/mcpSecretRenderer.ts
@@ -1,0 +1,208 @@
+import {
+  fillTemplateVariables,
+  getTemplateVariables,
+  HttpMcpServer,
+  MCPServer,
+  SseMcpServer,
+  StdioMcpServer,
+} from "@continuedev/config-yaml";
+import { logger } from "../util/logger.js";
+
+/**
+ * Extracts secret variables from template strings, specifically looking for secrets.SECRET_NAME pattern
+ */
+export function getSecretVariables(templatedString: string): string[] {
+  const variables = getTemplateVariables(templatedString);
+  return variables
+    .filter((v) => v.startsWith("secrets."))
+    .map((v) => v.replace("secrets.", ""));
+}
+
+/**
+ * Renders secrets from process.env for MCP server configurations
+ */
+export function renderSecretsFromEnv(templatedString: string): string {
+  const secretVars = getSecretVariables(templatedString);
+  const secretData: Record<string, string> = {};
+
+  for (const secretName of secretVars) {
+    const envValue = process.env[secretName];
+    if (envValue !== undefined) {
+      secretData[`secrets.${secretName}`] = envValue;
+      logger.debug("Rendered secret from environment", { secretName });
+    } else {
+      logger.warn("Secret not found in environment", { secretName });
+      // Keep the original template variable if not found
+      secretData[`secrets.${secretName}`] = `\${{ secrets.${secretName} }}`;
+    }
+  }
+
+  return fillTemplateVariables(templatedString, secretData);
+}
+
+/**
+ * Recursively renders secrets in an object structure
+ */
+function renderSecretsInObject(obj: unknown): unknown {
+  if (typeof obj === "string") {
+    return renderSecretsFromEnv(obj);
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(renderSecretsInObject);
+  }
+
+  if (obj && typeof obj === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(obj)) {
+      result[key] = renderSecretsInObject(value);
+    }
+    return result;
+  }
+
+  return obj;
+}
+
+/**
+ * Renders secrets in MCP server headers from process.env
+ */
+export function renderMcpServerHeaders(
+  headers: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!headers) {
+    return headers;
+  }
+
+  const renderedHeaders: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    renderedHeaders[key] = renderSecretsFromEnv(value);
+  }
+
+  return renderedHeaders;
+}
+
+/**
+ * Renders secrets in MCP server environment variables from process.env
+ */
+export function renderMcpServerEnv(
+  env: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!env) {
+    return env;
+  }
+
+  const renderedEnv: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    renderedEnv[key] = renderSecretsFromEnv(value);
+  }
+
+  return renderedEnv;
+}
+
+/**
+ * Renders all secrets in an MCP server configuration from process.env
+ */
+export function renderMcpServerSecrets(serverConfig: MCPServer): MCPServer {
+  const rendered = renderSecretsInObject(serverConfig) as MCPServer;
+
+  // Log which secrets were processed
+  const allSecrets = new Set<string>();
+
+  if ("command" in rendered) {
+    // STDIO server
+    const stdioConfig = rendered as StdioMcpServer;
+
+    // Check command and args
+    getSecretVariables(stdioConfig.command).forEach((s) => allSecrets.add(s));
+    stdioConfig.args?.forEach((arg) => {
+      getSecretVariables(arg).forEach((s) => allSecrets.add(s));
+    });
+
+    // Check env variables
+    if (stdioConfig.env) {
+      Object.values(stdioConfig.env).forEach((value) => {
+        getSecretVariables(value).forEach((s) => allSecrets.add(s));
+      });
+    }
+  } else {
+    // SSE/HTTP server
+    const httpConfig = rendered as SseMcpServer | HttpMcpServer;
+
+    // Check URL
+    getSecretVariables(httpConfig.url).forEach((s) => allSecrets.add(s));
+
+    // Check headers
+    if (httpConfig.requestOptions?.headers) {
+      Object.values(httpConfig.requestOptions.headers).forEach((value) => {
+        getSecretVariables(value).forEach((s) => allSecrets.add(s));
+      });
+    }
+  }
+
+  if (allSecrets.size > 0) {
+    logger.debug("Processed secrets for MCP server", {
+      serverName: rendered.name,
+      secretCount: allSecrets.size,
+      secrets: Array.from(allSecrets),
+    });
+  }
+
+  return rendered;
+}
+
+/**
+ * Renders secrets for an array of MCP servers
+ */
+export function renderMcpServersSecrets(
+  servers: MCPServer[] | undefined,
+): MCPServer[] | undefined {
+  if (!servers) {
+    return servers;
+  }
+
+  return servers.map(renderMcpServerSecrets);
+}
+
+/**
+ * Checks if a string contains any unrendered secrets
+ */
+export function hasUnrenderedSecrets(value: string): boolean {
+  // Create a fresh regex to avoid global state issues
+  const templateRegex = /\${{[\s]*([^}\s]+)[\s]*}}/g;
+  return templateRegex.test(value) && getSecretVariables(value).length > 0;
+}
+
+/**
+ * Validates that all secrets in MCP server config have been rendered
+ */
+export function validateMcpServerSecretsRendered(serverConfig: MCPServer): {
+  isValid: boolean;
+  unrenderedSecrets: string[];
+} {
+  const unrenderedSecrets = new Set<string>();
+
+  function checkValue(value: string) {
+    if (hasUnrenderedSecrets(value)) {
+      getSecretVariables(value).forEach((secret) =>
+        unrenderedSecrets.add(secret),
+      );
+    }
+  }
+
+  function checkObject(obj: unknown) {
+    if (typeof obj === "string") {
+      checkValue(obj);
+    } else if (Array.isArray(obj)) {
+      obj.forEach(checkObject);
+    } else if (obj && typeof obj === "object") {
+      Object.values(obj).forEach(checkObject);
+    }
+  }
+
+  checkObject(serverConfig);
+
+  return {
+    isValid: unrenderedSecrets.size === 0,
+    unrenderedSecrets: Array.from(unrenderedSecrets),
+  };
+}

--- a/packages/config-yaml/src/browser.ts
+++ b/packages/config-yaml/src/browser.ts
@@ -15,6 +15,7 @@ export * from "./modelName.js";
 export * from "./schemas/data/index.js";
 export * from "./schemas/index.js";
 export * from "./schemas/mcp/convertJson.js";
+export * from "./schemas/mcp/index.js";
 export * from "./schemas/mcp/json.js";
 export * from "./schemas/models.js";
 export * from "./schemas/policy.js";

--- a/packages/config-yaml/src/schemas/index.ts
+++ b/packages/config-yaml/src/schemas/index.ts
@@ -14,8 +14,6 @@ export const contextSchema = z.object({
   params: z.any().optional(),
 });
 
-export { MCPServer } from "./mcp/index.js";
-
 const promptSchema = z.object({
   name: z.string(),
   description: z.string().optional(),


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds environment-based secret rendering for MCP servers in the Continue CLI. Secrets in configs like ${{ secrets.NAME }} are resolved from process.env, with validation and helpful warnings for missing values.

- **New Features**
  - Renders secrets in allowed fields only:
    - STDIO: args, env
    - HTTP (sse, streamable-http): url, requestOptions.headers
  - Preserves templates when env vars are missing and shows warnings for unrendered secrets.
  - Rendering occurs at connection time so restarts pick up fresh values.
  - Updated MCP deep-dive docs with examples and caveats; added unit and integration tests.
  - MCPService now renders and validates configs before connecting.

- **Bug Fixes**
  - Restricts secret rendering to values in safe fields; no rendering in name, command, cwd, faviconUrl, type, or header/env keys.

<!-- End of auto-generated description by cubic. -->

