### PR TITLE
fix: add Snyk CLI authentication requirements to cookbook

### DIFF
--- a/docs/guides/snyk-mcp-continue-cookbook.mdx
+++ b/docs/guides/snyk-mcp-continue-cookbook.mdx
@@ -33,8 +33,18 @@ For all options, first:
   1. Sign up for a Snyk account at [snyk.io](https://snyk.io/)
   2. Create a new project in Snyk by importing your code repository (Git 
   provider or manual upload)
+  3. Install and authenticate the Snyk CLI locally:
+     ```bash
+     npm install -g snyk
+     snyk auth
+     ```
+     This will open your browser to authenticate with your Snyk account.
   </Step>
 </Steps>
+
+<Note>
+  **Important**: The Snyk MCP requires the Snyk CLI to be authenticated locally. Run `snyk auth` to authenticate before using the Continue agent with Snyk MCP.
+</Note>
  <Warning>
   To use agents in headless mode, you need a [Continue API key](https://hub.continue.dev/settings/api-keys).
   </Warning>
@@ -66,8 +76,8 @@ After ensuring you meet the **Prerequisites** above, you have two paths to get s
       <Step title="Run Your First Security Scan">
         Start with a comprehensive security scan:
         ```bash
-         # TUI mode
-        cn -p "Run a complete security scan on this project including code vulnerabilities, dependencies, and any IaC files. Summarize findings by severity."
+         # Headless mode
+        cn -p "Run a complete security scan on this project including code vulnerabilities, dependencies, and any IaC files. Summarize findings by severity." --auto
         ```
 
         That's it! The agent handles everything automatically.
@@ -159,7 +169,7 @@ You can add prompts to your agent's configuration for easy access in future sess
   **Where to run these workflows:**
   - **IDE Extensions**: Use Continue in VS Code, JetBrains, or other supported IDEs
   - **Terminal (TUI mode)**: Run `cn` to enter interactive mode, then type your prompts
-  - **CLI (headless mode)**: Use `cn -p "your prompt"` for headless commands
+  - **CLI (headless mode)**: Use `cn -p "your prompt" --auto` for headless commands
 
   **Test in Plan Mode First**: Before running security scans that might make
   changes, test your prompts in plan mode (see the [Plan Mode
@@ -182,7 +192,7 @@ and rerun to verify.
 
 **Headless Mode Prompt:**
 ```bash
-cn -p "Run a Snyk Code scan on this repo with severity threshold medium. Summarize issues with file:line. Propose minimal diffs for the top 3 and rerun to verify."
+cn -p "Run a Snyk Code scan on this repo with severity threshold medium. Summarize issues with file:line. Propose minimal diffs for the top 3 and rerun to verify." --auto
 ```
 
 </Card>
@@ -201,7 +211,7 @@ Re-test after the plan (dry run).
 
 **Headless Mode Prompt:**
 ```bash
-cn -p "Run Snyk Open Source on this repo (include dev deps). Summarize vulnerable paths and propose a minimal-risk upgrade plan. Re-test after the plan (dry run)."
+cn -p "Run Snyk Open Source on this repo (include dev deps). Summarize vulnerable paths and propose a minimal-risk upgrade plan. Re-test after the plan (dry run)." --auto
 ```
 
 </Card>
@@ -219,7 +229,7 @@ with exact files/lines. Provide code changes and re-scan to confirm.
 
 **Headless Mode Prompt:**
 ```bash
-cn -p "Scan ./infra with Snyk IaC. Report high/critical misconfigs with exact files/lines. Provide code changes and re-scan to confirm."
+cn -p "Scan ./infra with Snyk IaC. Report high/critical misconfigs with exact files/lines. Provide code changes and re-scan to confirm." --auto
 ```
 
 </Card>
@@ -238,7 +248,7 @@ Re-test after the change (dry run).
 
 **Headless Mode Prompt:**
 ```bash
-cn -p "Scan image my-api:latest. Exclude base image vulns. Print dependency tree. Recommend a safer base image or upgrades. Re-test after the change (dry run)."
+cn -p "Scan image my-api:latest. Exclude base image vulns. Print dependency tree. Recommend a safer base image or upgrades. Re-test after the change (dry run)." --auto
 ```
 
 </Card>
@@ -256,7 +266,7 @@ Block if new high issues would be introduced. Show deltas.
 
 **Headless Mode Prompt:**
 ```bash
-cn -p "Scan only files changed since origin/main with Snyk Code. Block if new high issues would be introduced. Show deltas."
+cn -p "Scan only files changed since origin/main with Snyk Code. Block if new high issues would be introduced. Show deltas." --auto
 ```
 
 </Card>
@@ -273,7 +283,7 @@ Open Snyk Learn lessons related to the top CWE(s) from this scan.
 
 **Headless Mode Prompt:**
 ```bash
-cn -p "Open Snyk Learn lessons related to the top CWE(s) from this scan."
+cn -p "Open Snyk Learn lessons related to the top CWE(s) from this scan." --auto
 ```
 
 </Card>
@@ -282,11 +292,18 @@ cn -p "Open Snyk Learn lessons related to the top CWE(s) from this scan."
 
 This example demonstrates a **Continuous AI workflow** where security scanning runs automatically in your CI/CD pipeline Headless Mode Prompt in headless mode (`cn -p`) with Snyk MCP.
 
+<Info>
+
+  **About the --auto flag**: The `--auto` flag enables tools to run continuously without manual confirmation. This is essential for headless mode where the agent needs to execute multiple tools automatically to complete tasks like security scanning, vulnerability analysis, and fix validation.
+
+</Info>
+
 ### Add GitHub Secrets
 
 Navigate to **Repository Settings → Secrets and variables → Actions** and add:
 
 - `CONTINUE_API_KEY`: Your Continue API key from [hub.continue.dev/settings/api-keys](https://hub.continue.dev/settings/api-keys)
+- `SNYK_TOKEN`: Your Snyk authentication token from [app.snyk.io/account](https://app.snyk.io/account)
 
 ### Create Workflow File
 
@@ -323,28 +340,33 @@ jobs:
       - name: Authenticate Continue CLI
         env:
           CONTINUE_API_KEY: ${{ secrets.CONTINUE_API_KEY }}
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: |
           cn auth login --api-key "$CONTINUE_API_KEY"
           echo "✅ Continue CLI authenticated"
 
       - name: Run Security Scans
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: |
           echo "🔍 Running code vulnerability scan..."
           cn -p "Run Snyk Code scan with severity high on this repo.
-                 Fail if any high issues are present."
+                 Fail if any high issues are present." --auto
 
           echo "📦 Checking dependencies..."
           cn -p "Run Snyk Open Source on this repo.
-                 Fail on fixable high issues."
+                 Fail on fixable high issues." --auto
 
       - name: Generate Security Report
         if: always()
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: |
           cn -p "Generate a markdown security report summarizing:
                  - Total vulnerabilities by severity
                  - Top 3 critical issues (if any)
                  - Recommended next steps
-                 Save to security-report.md"
+                 Save to security-report.md" --auto
 
       - name: Upload Security Report
         uses: actions/upload-artifact@v4
@@ -356,8 +378,8 @@ jobs:
 ```
 
 <Info>
-  The Snyk MCP authentication is handled through Continue Hub. No need to manage
-  Snyk tokens directly in CI - the agent manages authentication.
+  The Snyk MCP requires authentication via the SNYK_TOKEN environment variable in CI/CD environments. 
+  The Continue agent uses this token to authenticate Snyk operations automatically.
 </Info>
 
 ## Security Guardrails


### PR DESCRIPTION
## Summary

This PR fixes authentication issues in the Snyk MCP Continue cookbook by adding proper Snyk CLI setup instructions and GitHub Actions token configuration.

## Changes

- **Added Snyk CLI installation and authentication steps** to prerequisites section
  - Instructions to install Snyk CLI with `npm install -g snyk`
  - Command to authenticate locally with `snyk auth`
  - Note highlighting that Snyk CLI must be authenticated before using the agent

- **Updated GitHub Actions workflow configuration**
  - Added `SNYK_TOKEN` to the list of required GitHub secrets
  - Added `SNYK_TOKEN` environment variable to all security scanning workflow steps
  - Updated authentication documentation for CI/CD environments

- **Fixed misleading comment**
  - Changed "# TUI mode" to "# Headless mode" for command using `-p` flag with `--auto`

## Why these changes are needed

The cookbook would fail without proper Snyk authentication:
1. Local development requires authenticated Snyk CLI for the MCP to work
2. CI/CD pipelines need SNYK_TOKEN environment variable for headless execution
3. Users were missing critical setup steps that would cause the agent to fail

## Testing

- [ ] Verified Snyk CLI authentication steps work locally
- [ ] Tested GitHub Actions workflow with SNYK_TOKEN configured
- [ ] Confirmed agent executes security scans successfully with these changes

Generated with [Continue](https://continue.dev)

Co-Authored-By: Continue <noreply@continue.dev>
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds Snyk CLI install/auth instructions and requires SNYK_TOKEN in CI for the Snyk MCP Continue cookbook, ensuring local and headless scans work. Also clarifies headless mode examples with the --auto flag and fixes a misleading comment.

- **Migration**
  - Install Snyk CLI and run snyk auth locally.
  - Add SNYK_TOKEN as a GitHub Actions secret and pass it to scan/report steps.

<!-- End of auto-generated description by cubic. -->

