### PR TITLE
fix: filter out markdown delimiters from next edit responses

### DIFF
--- a/core/autocomplete/postprocessing/index.test.ts
+++ b/core/autocomplete/postprocessing/index.test.ts
@@ -1,0 +1,118 @@
+import { postprocessCompletion } from "./index";
+
+describe("postprocessCompletion - removeBackticks", () => {
+  const mockLLM = { model: "test-model" } as any;
+
+  it("should remove first line starting with ``` and last line that is ```", () => {
+    const completion =
+      "```typescript\nfunction hello() {\n  return 'world';\n}\n```";
+    const result = postprocessCompletion({
+      completion,
+      llm: mockLLM,
+      prefix: "",
+      suffix: "",
+    });
+    expect(result).toBe("function hello() {\n  return 'world';\n}");
+  });
+
+  it("should remove only first line if it starts with ```", () => {
+    const completion = "```javascript\nconst x = 5;\nconsole.log(x);";
+    const result = postprocessCompletion({
+      completion,
+      llm: mockLLM,
+      prefix: "",
+      suffix: "",
+    });
+    expect(result).toBe("const x = 5;\nconsole.log(x);");
+  });
+
+  it("should remove only last line if it is ```", () => {
+    const completion = "const y = 10;\nconsole.log(y);\n```";
+    const result = postprocessCompletion({
+      completion,
+      llm: mockLLM,
+      prefix: "",
+      suffix: "",
+    });
+    expect(result).toBe("const y = 10;\nconsole.log(y);");
+  });
+
+  it("should not modify completion without backticks", () => {
+    const completion = "function test() {\n  return true;\n}";
+    const result = postprocessCompletion({
+      completion,
+      llm: mockLLM,
+      prefix: "",
+      suffix: "",
+    });
+    expect(result).toBe("function test() {\n  return true;\n}");
+  });
+
+  it("should handle completion with backticks in the middle", () => {
+    const completion = "const str = `template ${literal}`;\nconsole.log(str);";
+    const result = postprocessCompletion({
+      completion,
+      llm: mockLLM,
+      prefix: "",
+      suffix: "",
+    });
+    expect(result).toBe(
+      "const str = `template ${literal}`;\nconsole.log(str);",
+    );
+  });
+
+  it("should handle first line with leading whitespace before ```", () => {
+    const completion = "  ```python\ndef hello():\n  pass\n```";
+    const result = postprocessCompletion({
+      completion,
+      llm: mockLLM,
+      prefix: "",
+      suffix: "",
+    });
+    expect(result).toBe("def hello():\n  pass");
+  });
+
+  it("should handle last line with whitespace around ```", () => {
+    const completion = "```\ncode here\n  ```  ";
+    const result = postprocessCompletion({
+      completion,
+      llm: mockLLM,
+      prefix: "",
+      suffix: "",
+    });
+    expect(result).toBe("code here");
+  });
+
+  it("should handle single line completion", () => {
+    const completion = "const x = 5;";
+    const result = postprocessCompletion({
+      completion,
+      llm: mockLLM,
+      prefix: "",
+      suffix: "",
+    });
+    expect(result).toBe("const x = 5;");
+  });
+
+  it("should handle empty completion", () => {
+    const completion = "";
+    const result = postprocessCompletion({
+      completion,
+      llm: mockLLM,
+      prefix: "",
+      suffix: "",
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("should not remove ``` if it's not on its own line at the end", () => {
+    const completion = "```typescript\nconst x = 5; // end```";
+    const result = postprocessCompletion({
+      completion,
+      llm: mockLLM,
+      prefix: "",
+      suffix: "",
+    });
+    expect(result).toBe("const x = 5; // end```");
+  });
+});

--- a/core/autocomplete/postprocessing/index.ts
+++ b/core/autocomplete/postprocessing/index.ts
@@ -52,6 +52,38 @@ function isBlank(completion: string): boolean {
   return completion.trim().length === 0;
 }
 
+/**
+ * Removes markdown code block delimiters from completion.
+ * Removes the first line if it starts with "```" and the last line if it is exactly "```".
+ */
+function removeBackticks(completion: string): string {
+  const lines = completion.split("\n");
+
+  if (lines.length === 0) {
+    return completion;
+  }
+
+  let startIdx = 0;
+  let endIdx = lines.length;
+
+  // Remove first line if it starts with ```
+  if (lines[0].trimStart().startsWith("```")) {
+    startIdx = 1;
+  }
+
+  // Remove last line if it is exactly ```
+  if (lines.length > startIdx && lines[lines.length - 1].trim() === "```") {
+    endIdx = lines.length - 1;
+  }
+
+  // If we removed lines, return the modified completion
+  if (startIdx > 0 || endIdx < lines.length) {
+    return lines.slice(startIdx, endIdx).join("\n");
+  }
+
+  return completion;
+}
+
 export function postprocessCompletion({
   completion,
   llm,
@@ -155,6 +187,9 @@ export function postprocessCompletion({
   if (prefix.endsWith(" ") && completion.startsWith(" ")) {
     completion = completion.slice(1);
   }
+
+  // Remove markdown code block delimiters
+  completion = removeBackticks(completion);
 
   return completion;
 }

--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -78,8 +78,9 @@ declare global {
   
   export interface ILLM extends LLMOptions {
     get providerName(): string;
-  
+
     uniqueId: string;
+    lastRequestId?: string;
     model: string;
   
     title?: string;

--- a/core/core.ts
+++ b/core/core.ts
@@ -928,7 +928,7 @@ export class Core {
     });
 
     on("files/closed", async ({ data }) => {
-      console.log("deleteChain called from files/closed");
+      console.debug("deleteChain called from files/closed");
       await NextEditProvider.getInstance().deleteChain();
 
       try {

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -99,6 +99,8 @@ export interface ILLM
 
   autocompleteOptions?: Partial<TabAutocompleteOptions>;
 
+  lastRequestId?: string;
+
   complete(
     prompt: string,
     signal: AbortSignal,

--- a/core/nextEdit/NextEditLoggingService.ts
+++ b/core/nextEdit/NextEditLoggingService.ts
@@ -95,7 +95,9 @@ export class NextEditLoggingService {
       outcome.accepted = true;
       outcome.aborted = false;
       this.logNextEditOutcome(outcome);
-      this.logAcceptReject(completionId, true);
+      if (outcome.requestId) {
+        this.logAcceptReject(outcome.requestId, true);
+      }
       this._outcomes.delete(completionId);
       return outcome;
     }
@@ -114,7 +116,9 @@ export class NextEditLoggingService {
       outcome.accepted = false;
       outcome.aborted = false;
       this.logNextEditOutcome(outcome);
-      this.logAcceptReject(completionId, false);
+      if (outcome.requestId) {
+        this.logAcceptReject(outcome.requestId, false);
+      }
       this._outcomes.delete(completionId);
       return outcome;
     }
@@ -147,7 +151,9 @@ export class NextEditLoggingService {
       outcome.accepted = false;
       outcome.aborted = false;
       this.logNextEditOutcome(outcome);
-      void this.logAcceptReject(completionId, false);
+      if (outcome.requestId) {
+        void this.logAcceptReject(outcome.requestId, false);
+      }
       this._logRejectionTimeouts.delete(completionId);
       this._outcomes.delete(completionId);
     }, COUNT_COMPLETION_REJECTED_AFTER);

--- a/core/nextEdit/NextEditLoggingService.ts
+++ b/core/nextEdit/NextEditLoggingService.ts
@@ -257,6 +257,10 @@ export class NextEditLoggingService {
     accepted: boolean,
   ): Promise<void> {
     try {
+      if (!Telemetry.client) {
+        return;
+      }
+
       const controlPlaneEnv = getControlPlaneEnvSync("production");
       await fetchwithRequestOptions(
         new URL("model-proxy/v1/feedback", controlPlaneEnv.CONTROL_PLANE_URL),

--- a/core/nextEdit/NextEditLoggingService.ts
+++ b/core/nextEdit/NextEditLoggingService.ts
@@ -96,7 +96,7 @@ export class NextEditLoggingService {
       outcome.aborted = false;
       this.logNextEditOutcome(outcome);
       if (outcome.requestId) {
-        this.logAcceptReject(outcome.requestId, true);
+        void this.logAcceptReject(outcome.requestId, true);
       }
       this._outcomes.delete(completionId);
       return outcome;
@@ -117,7 +117,7 @@ export class NextEditLoggingService {
       outcome.aborted = false;
       this.logNextEditOutcome(outcome);
       if (outcome.requestId) {
-        this.logAcceptReject(outcome.requestId, false);
+        void this.logAcceptReject(outcome.requestId, false);
       }
       this._outcomes.delete(completionId);
       return outcome;

--- a/core/nextEdit/NextEditLoggingService.ts
+++ b/core/nextEdit/NextEditLoggingService.ts
@@ -96,7 +96,6 @@ export class NextEditLoggingService {
       outcome.aborted = false;
       this.logNextEditOutcome(outcome);
       this.logAcceptReject(completionId, true);
-      console.log("YES");
       this._outcomes.delete(completionId);
       return outcome;
     }
@@ -116,7 +115,6 @@ export class NextEditLoggingService {
       outcome.aborted = false;
       this.logNextEditOutcome(outcome);
       this.logAcceptReject(completionId, false);
-      console.log("NO");
       this._outcomes.delete(completionId);
       return outcome;
     }
@@ -127,6 +125,7 @@ export class NextEditLoggingService {
       clearTimeout(this._logRejectionTimeouts.get(completionId)!);
       this._logRejectionTimeouts.delete(completionId);
     }
+
     if (this._outcomes.has(completionId)) {
       this._outcomes.delete(completionId);
     }
@@ -148,6 +147,7 @@ export class NextEditLoggingService {
       outcome.accepted = false;
       outcome.aborted = false;
       this.logNextEditOutcome(outcome);
+      void this.logAcceptReject(completionId, false);
       this._logRejectionTimeouts.delete(completionId);
       this._outcomes.delete(completionId);
     }, COUNT_COMPLETION_REJECTED_AFTER);

--- a/core/nextEdit/providers/BaseNextEditProvider.ts
+++ b/core/nextEdit/providers/BaseNextEditProvider.ts
@@ -309,6 +309,7 @@ export abstract class BaseNextEditModelProvider {
         outcomeCtx.completionId || outcomeCtx.helper.input.completionId,
       gitRepo: await outcomeCtx.ide.getRepoName(outcomeCtx.helper.filepath),
       uniqueId: await outcomeCtx.ide.getUniqueId(),
+      requestId: outcomeCtx.llm.lastRequestId,
       timestamp: Date.now(),
       fileUri: outcomeCtx.helper.filepath,
       workspaceDirUri:

--- a/core/nextEdit/types.ts
+++ b/core/nextEdit/types.ts
@@ -50,6 +50,7 @@ export interface NextEditOutcome extends TabAutocompleteOptions {
   completionId: string;
   gitRepo?: string;
   uniqueId: string;
+  requestId?: string;
   timestamp: number;
 
   // New for Next Edit.

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"

--- a/extensions/vscode/src/activation/JumpManager.ts
+++ b/extensions/vscode/src/activation/JumpManager.ts
@@ -192,13 +192,13 @@ export class JumpManager {
     // identical to the completion content,
     // then we don't have to jump.
     if (completionContent !== undefined) {
-      console.log("completionContent is not null");
+      console.debug("completionContent is not null");
       const editor = vscode.window.activeTextEditor;
 
       if (editor) {
         try {
           const completionLines = completionContent.split("\n");
-          console.log("completionLines:", completionLines);
+          console.debug("completionLines:", completionLines);
 
           // Get document content at jump location spanning multiple lines.
           const document = editor.document;
@@ -212,7 +212,7 @@ export class JumpManager {
           if (endLine - startLine + 1 < completionLines.length) {
             // Not enough lines in document, so content can't be identical.
             // Proceed to jump!
-            console.log(
+            console.debug(
               "Not enough lines in document to match completion content",
             );
           } else {
@@ -224,12 +224,12 @@ export class JumpManager {
               const lineText = document.lineAt(documentLine).text;
               if (lineText !== completionLines[i]) {
                 contentMatches = false;
-                console.log(`Line ${i + 1} doesn't match`);
+                console.debug(`Line ${i + 1} doesn't match`);
               }
             }
 
             if (contentMatches) {
-              console.log(
+              console.debug(
                 "Skipping jump as content is identical at jump location",
               );
               return false; // Exit early, don't suggest jump.
@@ -242,20 +242,20 @@ export class JumpManager {
       }
     }
 
-    console.log("this._jumpInProgress");
+    console.debug("this._jumpInProgress");
     this._jumpInProgress = true;
     this._oldCursorPosition = currentPosition;
 
     const editor = vscode.window.activeTextEditor;
     if (!editor) {
-      console.log("No active editor, cannot suggest jump");
+      console.debug("No active editor, cannot suggest jump");
       this._jumpInProgress = false;
       return false;
     }
 
     const visibleRanges = editor.visibleRanges;
     if (visibleRanges.length === 0) {
-      console.log("No visible ranges in editor, cannot suggest jump");
+      console.debug("No visible ranges in editor, cannot suggest jump");
       this._jumpInProgress = false;
       return false;
     }
@@ -375,7 +375,7 @@ export class JumpManager {
       "continue.rejectJump",
       async () => {
         if (this._jumpDecorationVisible) {
-          console.log(
+          console.debug(
             "deleteChain from JumpManager.ts: rejectJump and decoration visible",
           );
           NextEditProvider.getInstance().deleteChain();
@@ -447,7 +447,7 @@ export class JumpManager {
       "jumpManager",
       async (e, state) => {
         if (state.jumpInProgress || state.jumpJustAccepted) {
-          console.log(
+          console.debug(
             "JumpManager: jump in progress or just accepted, preserving chain",
           );
           return true;

--- a/extensions/vscode/src/activation/NextEditWindowManager.ts
+++ b/extensions/vscode/src/activation/NextEditWindowManager.ts
@@ -165,7 +165,7 @@ export class NextEditWindowManager {
   private constructor() {
     this.theme = getThemeString();
 
-    console.log(
+    console.debug(
       "Next Edit Theme initialized:",
       this.theme
         ? `Theme exists: ${JSON.stringify(this.theme)}`

--- a/extensions/vscode/src/activation/NextEditWindowManager.ts
+++ b/extensions/vscode/src/activation/NextEditWindowManager.ts
@@ -269,7 +269,7 @@ export class NextEditWindowManager {
 
     // Register HIDE_TOOLTIP_COMMAND and ACCEPT_NEXT_EDIT_COMMAND with their corresponding callbacks.
     this.registerCommandSafely(HIDE_NEXT_EDIT_SUGGESTION_COMMAND, async () => {
-      console.log(
+      console.debug(
         "deleteChain from NextEditWindowManager.ts: hide next edit command",
       );
       NextEditProvider.getInstance().deleteChain();
@@ -616,7 +616,7 @@ export class NextEditWindowManager {
       ) {
         this.theme = getThemeString();
         await this.codeRenderer.setTheme(this.theme);
-        console.log(
+        console.debug(
           "Theme updated:",
           this.theme ? "Theme exists" : "Theme is undefined",
         );
@@ -630,7 +630,7 @@ export class NextEditWindowManager {
     vscode.window.onDidChangeActiveColorTheme(async () => {
       this.theme = getThemeString();
       await this.codeRenderer.setTheme(this.theme);
-      console.log(
+      console.debug(
         "Active theme changed:",
         this.theme ? "Theme exists" : "Theme is undefined",
       );
@@ -792,7 +792,7 @@ export class NextEditWindowManager {
 
     // Check if line numbers are valid.
     if (range.start.line < 0 || range.start.line >= doc.lineCount) {
-      console.log(
+      console.debug(
         "Invalid start line:",
         range.start.line,
         "doc lines:",
@@ -802,7 +802,7 @@ export class NextEditWindowManager {
     }
 
     if (range.end.line < 0 || range.end.line >= doc.lineCount) {
-      console.log(
+      console.debug(
         "Invalid end line:",
         range.end.line,
         "doc lines:",
@@ -819,7 +819,7 @@ export class NextEditWindowManager {
       range.start.character < 0 ||
       range.start.character > startLine.text.length
     ) {
-      console.log(
+      console.debug(
         "Invalid start character:",
         range.start.character,
         "line length:",
@@ -829,7 +829,7 @@ export class NextEditWindowManager {
     }
 
     if (range.end.character < 0 || range.end.character > endLine.text.length) {
-      console.log(
+      console.debug(
         "Invalid end character:",
         range.end.character,
         "line length:",
@@ -884,7 +884,7 @@ export class NextEditWindowManager {
 
     // Check if document changed during async operation.
     if (editor.document.version !== docVersion) {
-      console.log("Document changed during decoration creation, aborting");
+      console.debug("Document changed during decoration creation, aborting");
       decoration.dispose();
       return;
     }
@@ -991,7 +991,7 @@ export class NextEditWindowManager {
       "nextEditWindowManager",
       async (e, state) => {
         if (state.nextEditWindowAccepted) {
-          console.log(
+          console.debug(
             "NextEditWindowManager: Edit was just accepted, preserving chain",
           );
           return true;

--- a/extensions/vscode/src/activation/SelectionChangeManager.ts
+++ b/extensions/vscode/src/activation/SelectionChangeManager.ts
@@ -330,7 +330,7 @@ export class SelectionChangeManager {
       return false;
     }
 
-    console.log(
+    console.debug(
       "defaultFallbackHandler: deleteChain called from onDidChangeTextEditorSelection",
     );
     await NextEditProvider.getInstance().deleteChain();

--- a/extensions/vscode/src/autocomplete/completionProvider.ts
+++ b/extensions/vscode/src/autocomplete/completionProvider.ts
@@ -333,7 +333,7 @@ export class ContinueCompletionProvider
       let chainExists = this.nextEditProvider.chainExists();
       const processedCount = this.prefetchQueue.processedCount;
       const unprocessedCount = this.prefetchQueue.unprocessedCount;
-      console.log("isJumping:", isJumping, "/ chainExists:", chainExists);
+      console.debug("isJumping:", isJumping, "/ chainExists:", chainExists);
       this.prefetchQueue.peekThreeProcessed();
 
       let resetChainInFullFileDiff = false;

--- a/extensions/vscode/src/autocomplete/completionProvider.ts
+++ b/extensions/vscode/src/autocomplete/completionProvider.ts
@@ -351,7 +351,7 @@ export class ContinueCompletionProvider
 
       if (isJumping && chainExists) {
         // Case 2: Jumping (chain exists, jump was taken)
-        console.log("trigger reason: jumping");
+        console.debug("trigger reason: jumping");
 
         // Reset jump state.
         this.jumpManager.setJumpInProgress(false);
@@ -380,7 +380,7 @@ export class ContinueCompletionProvider
         }
       } else if (chainExists) {
         // Case 3: Accepting next edit outcome (chain exists, jump is not taken).
-        console.log("trigger reason: accepting");
+        console.debug("trigger reason: accepting");
 
         // Try suggesting jump for each location.
         let isJumpSuggested = false;
@@ -428,7 +428,7 @@ export class ContinueCompletionProvider
         }
 
         if (!isJumpSuggested) {
-          console.log(
+          console.debug(
             "No suitable jump location found after trying all positions",
           );
           this.nextEditProvider.deleteChain();
@@ -642,7 +642,7 @@ export class ContinueCompletionProvider
 
       if (isFim) {
         if (!fimText) {
-          console.log("deleteChain from completionProvider.ts: !fimText");
+          console.debug("deleteChain from completionProvider.ts: !fimText");
           this.nextEditProvider.deleteChain();
           return undefined;
         }
@@ -679,7 +679,7 @@ export class ContinueCompletionProvider
         // Only time we ever reach this point would be after the jump was taken, or if its after the very first repsonse.
         // In case of jump, this is impossible, as the JumpManager wouldn't have suggested a jump here in the first place.
         // In case of initial response, we suggested a jump.
-        console.log(
+        console.debug(
           "deleteChain from completionProvider.ts: diffLines.length === 0",
         );
         NextEditProvider.getInstance().deleteChain();
@@ -718,7 +718,7 @@ export class ContinueCompletionProvider
     if (selectedCompletionInfo) {
       const { text, range } = selectedCompletionInfo;
       if (!outcome.completion.startsWith(text)) {
-        console.log(
+        console.debug(
           `Won't display completion because text doesn't match: ${text}, ${outcome.completion}`,
           range,
         );

--- a/extensions/vscode/src/extension/VsCodeExtension.ts
+++ b/extensions/vscode/src/extension/VsCodeExtension.ts
@@ -232,7 +232,9 @@ export class VsCodeExtension {
           timeSinceLastDocChange < this.ARBITRARY_TYPING_DELAY &&
           !NextEditWindowManager.getInstance().hasAccepted()
         ) {
-          console.log("VsCodeExtension: typing in progress, preserving chain");
+          console.debug(
+            "VsCodeExtension: typing in progress, preserving chain",
+          );
           return true;
         }
 
@@ -519,7 +521,6 @@ export class VsCodeExtension {
     });
 
     vscode.workspace.onDidOpenTextDocument(async (event) => {
-      console.log("onDidOpenTextDocument");
       const ast = await getAst(event.fileName, event.getText());
       if (ast) {
         DocumentHistoryTracker.getInstance().addDocument(

--- a/packages/config-yaml/src/schemas/data/nextEditOutcome/index.ts
+++ b/packages/config-yaml/src/schemas/data/nextEditOutcome/index.ts
@@ -5,6 +5,7 @@ export const nextEditOutcomeEventAllSchema = baseDevDataAllSchema.extend({
   elapsed: z.number(),
   completionOptions: z.any(),
   completionId: z.string(),
+  requestId: z.string().optional(),
   gitRepo: z.string().optional(),
   uniqueId: z.string(),
   timestamp: z.number(),

--- a/packages/config-yaml/src/schemas/data/nextEditOutcome/v0.2.0.ts
+++ b/packages/config-yaml/src/schemas/data/nextEditOutcome/v0.2.0.ts
@@ -14,6 +14,7 @@ export const nextEditOutcomeEventSchema_0_2_0 =
     elapsed: true,
     completionOptions: true,
     completionId: true,
+    requestId: true,
     gitRepo: true,
     uniqueId: true,
     // timestamp: z.number(),


### PR DESCRIPTION
## Description

Filters out backticks from the start and end of next edit completions, which was happening sometimes in markdown files.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Remove markdown code fences from next edit completions so we don’t insert stray ``` lines in markdown files. This makes generated edits cleaner and avoids malformed code blocks.

- **Bug Fixes**
  - Strip a leading line starting with ``` and a trailing line that is exactly ``` in postprocessCompletion, without touching inline backticks.
  - Added unit tests covering language fences, whitespace, inline backticks, and empty/single-line cases.

<!-- End of auto-generated description by cubic. -->

