### PR TITLE
docs: add CLI telemetry opt-out instructions

### DIFF
--- a/docs/telemetry.mdx
+++ b/docs/telemetry.mdx
@@ -26,6 +26,23 @@ The following usage information is collected and reported:
 
 ## How to Opt Out
 
+### VS Code Extension
+
 You can disable anonymous telemetry by toggling "Allow Anonymous Telemetry" off in the user settings.
 
 Alternatively in VS Code, you can disable telemetry through your VS Code settings by unchecking the "Continue: Telemetry Enabled" box (this will override the Settings Page settings). VS Code settings can be accessed with `File` > `Preferences` > `Settings` (or use the keyboard shortcut `ctrl` + `,` on Windows/Linux or `cmd` + `,` on macOS).
+
+### CLI
+
+For the Continue CLI, set the environment variable `CONTINUE_CLI_ENABLE_TELEMETRY=0` before running commands:
+
+```bash
+export CONTINUE_CLI_ENABLE_TELEMETRY=0
+cn <your prompt>
+```
+
+Or run it inline:
+
+```bash
+CONTINUE_CLI_ENABLE_TELEMETRY=0 cn <your prompt>
+```


### PR DESCRIPTION
Add documentation for disabling telemetry in the Continue CLI using the CONTINUE_CLI_ENABLE_TELEMETRY=0 environment variable.

Addresses the confusion mentioned in issue #2082 where users couldn't find instructions on how to disable CLI telemetry.

Generated with [Continue](https://continue.dev)