### PR TITLE
fix: tool outcome telemetry for preprocessing failures

### DIFF
--- a/core/protocol/core.ts
+++ b/core/protocol/core.ts
@@ -54,6 +54,7 @@ import {
 } from "../control-plane/client";
 import { ProcessedItem } from "../nextEdit/NextEditPrefetchQueue";
 import { NextEditOutcome } from "../nextEdit/types";
+import { ContinueErrorReason } from "../util/errors";
 
 export enum OnboardingModes {
   API_KEY = "API Key",
@@ -317,7 +318,11 @@ export type ToCoreFromIdeOrWebviewProtocol = {
   ];
   "tools/preprocessArgs": [
     { toolName: string; args: Record<string, unknown> },
-    { preprocessedArgs?: Record<string, unknown> },
+    {
+      preprocessedArgs?: Record<string, unknown>;
+      errorReason?: ContinueErrorReason;
+      errorMessage?: string;
+    },
   ];
   "clipboardCache/add": [{ content: string }, void];
   "controlPlane/openUrl": [{ path: string; orgSlug?: string }, void];


### PR DESCRIPTION
## Description
#7992 added a way that tools can fail (args preprocessing) without associated telemetry. This adds telemetry for it
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add telemetry for tool arg preprocessing failures so we can track and surface these errors. Tool outcomes now report failed preprocessing, and the UI marks the tool call as errored.

- **Bug Fixes**
  - Core: Wrap preprocessArgs in try/catch and return errorReason and errorMessage via protocol.
  - Protocol: Extend tools/preprocessArgs response to include optional errorReason and errorMessage.
  - GUI: Capture PostHog "tool_call_outcome" with succeeded=false and dispatch errorToolCall; apply preprocessed args on success.

<!-- End of auto-generated description by cubic. -->

