### PR TITLE
Detect invokable rules located in 'prompts' directory

### DIFF
--- a/core/config/markdown/loadMarkdownRules.ts
+++ b/core/config/markdown/loadMarkdownRules.ts
@@ -3,6 +3,7 @@ import {
   markdownToRule,
 } from "@continuedev/config-yaml";
 import { IDE, RuleWithSource } from "../..";
+import { PROMPTS_DIR_NAME, RULES_DIR_NAME } from "../../promptFiles";
 import { joinPathsToUri } from "../../util/uri";
 import { getAllDotContinueDefinitionFiles } from "../loadLocalAssistants";
 
@@ -54,7 +55,7 @@ export async function loadMarkdownRules(ide: IDE): Promise<{
   }
 
   // Load markdown files from both .continue/rules and .continue/prompts
-  const dirsToCheck = ["rules", "prompts"];
+  const dirsToCheck = [RULES_DIR_NAME, PROMPTS_DIR_NAME];
 
   for (const dirName of dirsToCheck) {
     try {

--- a/core/config/markdown/loadMarkdownRules.ts
+++ b/core/config/markdown/loadMarkdownRules.ts
@@ -8,7 +8,7 @@ import { getAllDotContinueDefinitionFiles } from "../loadLocalAssistants";
 
 export const SUPPORTED_AGENT_FILES = ["AGENTS.md", "AGENT.md", "CLAUDE.md"];
 /**
- * Loads rules from markdown files in the .continue/rules directory
+ * Loads rules from markdown files in the .continue/rules and .continue/prompts directories
  * and agent files (AGENTS.md, AGENT.md, CLAUDE.md) at workspace root
  */
 export async function loadMarkdownRules(ide: IDE): Promise<{
@@ -53,37 +53,41 @@ export async function loadMarkdownRules(ide: IDE): Promise<{
     }
   }
 
-  try {
-    // Get all .md files from .continue/rules
-    const markdownFiles = await getAllDotContinueDefinitionFiles(
-      ide,
-      { includeGlobal: true, includeWorkspace: true, fileExtType: "markdown" },
-      "rules",
-    );
+  // Load markdown files from both .continue/rules and .continue/prompts
+  const dirsToCheck = ["rules", "prompts"];
 
-    // Filter to just .md files
-    const mdFiles = markdownFiles.filter((file) => file.path.endsWith(".md"));
+  for (const dirName of dirsToCheck) {
+    try {
+      const markdownFiles = await getAllDotContinueDefinitionFiles(
+        ide,
+        { includeGlobal: true, includeWorkspace: true, fileExtType: "markdown" },
+        dirName,
+      );
 
-    // Process each markdown file
-    for (const file of mdFiles) {
-      try {
-        const rule = markdownToRule(file.content, {
-          uriType: "file",
-          fileUri: file.path,
-        });
-        rules.push({ ...rule, source: "rules-block", sourceFile: file.path });
-      } catch (e) {
-        errors.push({
-          fatal: false,
-          message: `Failed to parse markdown rule file ${file.path}: ${e instanceof Error ? e.message : e}`,
-        });
+      // Filter to just .md files
+      const mdFiles = markdownFiles.filter((file) => file.path.endsWith(".md"));
+
+      // Process each markdown file
+      for (const file of mdFiles) {
+        try {
+          const rule = markdownToRule(file.content, {
+            uriType: "file",
+            fileUri: file.path,
+          });
+          rules.push({ ...rule, source: "rules-block", sourceFile: file.path });
+        } catch (e) {
+          errors.push({
+            fatal: false,
+            message: `Failed to parse markdown rule file ${file.path}: ${e instanceof Error ? e.message : e}`,
+          });
+        }
       }
+    } catch (e) {
+      errors.push({
+        fatal: false,
+        message: `Error loading markdown rule files from ${dirName}: ${e instanceof Error ? e.message : e}`,
+      });
     }
-  } catch (e) {
-    errors.push({
-      fatal: false,
-      message: `Error loading markdown rule files: ${e instanceof Error ? e.message : e}`,
-    });
   }
 
   return { rules, errors };

--- a/core/config/markdown/loadMarkdownRules.ts
+++ b/core/config/markdown/loadMarkdownRules.ts
@@ -61,7 +61,11 @@ export async function loadMarkdownRules(ide: IDE): Promise<{
     try {
       const markdownFiles = await getAllDotContinueDefinitionFiles(
         ide,
-        { includeGlobal: true, includeWorkspace: true, fileExtType: "markdown" },
+        {
+          includeGlobal: true,
+          includeWorkspace: true,
+          fileExtType: "markdown",
+        },
         dirName,
       );
 

--- a/core/promptFiles/getPromptFiles.ts
+++ b/core/promptFiles/getPromptFiles.ts
@@ -1,7 +1,8 @@
+import path from "path";
 import { DEFAULT_PROMPTS_FOLDER_V1 } from ".";
 import { IDE } from "..";
 import { walkDir } from "../indexing/walkDir";
-import { readAllGlobalPromptFiles } from "../util/paths";
+import { getContinueGlobalPath, readAllGlobalPromptFiles } from "../util/paths";
 import { joinPathsToUri } from "../util/uri";
 
 export const DEFAULT_PROMPTS_FOLDER_V2 = ".continue/prompts";
@@ -40,7 +41,7 @@ export async function getAllPromptFiles(
   const workspaceDirs = await ide.getWorkspaceDirs();
   let promptFiles: { path: string; content: string }[] = [];
 
-  let dirsToCheck = [DEFAULT_PROMPTS_FOLDER_V2];
+  let dirsToCheck = [DEFAULT_PROMPTS_FOLDER_V2, ".continue/rules"];
   if (checkV1DefaultFolder) {
     dirsToCheck.push(DEFAULT_PROMPTS_FOLDER_V1);
   }
@@ -56,8 +57,13 @@ export async function getAllPromptFiles(
     await Promise.all(fullDirs.map((dir) => getPromptFilesFromDir(ide, dir)))
   ).flat();
 
-  // Also read from ~/.continue/prompts
+  // Also read from ~/.continue/prompts and ~/.continue/rules
   promptFiles.push(...readAllGlobalPromptFiles());
+
+  const globalRulesPath = readAllGlobalPromptFiles(
+    path.join(getContinueGlobalPath(), "rules"),
+  );
+  promptFiles.push(...globalRulesPath);
 
   return await Promise.all(
     promptFiles.map(async (file) => {

--- a/core/promptFiles/getPromptFiles.ts
+++ b/core/promptFiles/getPromptFiles.ts
@@ -1,11 +1,14 @@
 import path from "path";
-import { DEFAULT_PROMPTS_FOLDER_V1 } from ".";
+import {
+  DEFAULT_PROMPTS_FOLDER_V1,
+  DEFAULT_PROMPTS_FOLDER_V2,
+  DEFAULT_RULES_FOLDER,
+  RULES_DIR_NAME,
+} from ".";
 import { IDE } from "..";
 import { walkDir } from "../indexing/walkDir";
 import { getContinueGlobalPath, readAllGlobalPromptFiles } from "../util/paths";
 import { joinPathsToUri } from "../util/uri";
-
-export const DEFAULT_PROMPTS_FOLDER_V2 = ".continue/prompts";
 
 export async function getPromptFilesFromDir(
   ide: IDE,
@@ -41,7 +44,7 @@ export async function getAllPromptFiles(
   const workspaceDirs = await ide.getWorkspaceDirs();
   let promptFiles: { path: string; content: string }[] = [];
 
-  let dirsToCheck = [DEFAULT_PROMPTS_FOLDER_V2, ".continue/rules"];
+  let dirsToCheck = [DEFAULT_PROMPTS_FOLDER_V2, DEFAULT_RULES_FOLDER];
   if (checkV1DefaultFolder) {
     dirsToCheck.push(DEFAULT_PROMPTS_FOLDER_V1);
   }
@@ -60,10 +63,10 @@ export async function getAllPromptFiles(
   // Also read from ~/.continue/prompts and ~/.continue/rules
   promptFiles.push(...readAllGlobalPromptFiles());
 
-  const globalRulesPath = readAllGlobalPromptFiles(
-    path.join(getContinueGlobalPath(), "rules"),
+  const promptFilesFromRulesDirectory = readAllGlobalPromptFiles(
+    path.join(getContinueGlobalPath(), RULES_DIR_NAME),
   );
-  promptFiles.push(...globalRulesPath);
+  promptFiles.push(...promptFilesFromRulesDirectory);
 
   return await Promise.all(
     promptFiles.map(async (file) => {

--- a/core/promptFiles/index.ts
+++ b/core/promptFiles/index.ts
@@ -2,6 +2,11 @@ import { ContextProviderName } from "..";
 
 export const DEFAULT_PROMPTS_FOLDER_V1 = ".prompts";
 export const DEFAULT_PROMPTS_FOLDER_V2 = ".continue/prompts";
+export const DEFAULT_RULES_FOLDER = ".continue/rules";
+
+// Subdirectory names (without .continue/ prefix)
+export const RULES_DIR_NAME = "rules";
+export const PROMPTS_DIR_NAME = "prompts";
 
 export const SUPPORTED_PROMPT_CONTEXT_PROVIDERS: ContextProviderName[] = [
   "file",


### PR DESCRIPTION
## Description

Make rules and prompts directories interchangeable - detect rules located in 'prompts' directory and detect prompts located in a rules directory.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Makes the prompts and rules directories interchangeable. Rules and prompts now load from both .continue/rules and .continue/prompts in workspace and global paths to prevent missing files.

- **Bug Fixes**
  - Load markdown rules from .continue/rules and .continue/prompts.
  - Read prompt files from .continue/rules and ~/.continue/rules in addition to prompts.
  - Added shared dir name constants and clearer error messages with directory context.

<!-- End of auto-generated description by cubic. -->

