### PR TITLE
docs: add Sanity MCP cookbook to navigation and overview

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -261,6 +261,7 @@
             "pages": [
               "guides/posthog-github-continuous-ai",
               "guides/continue-docs-mcp-cookbook",
+              "guides/sanity-mcp-continue-cookbook",
               "guides/snyk-mcp-continue-cookbook",
               "guides/dlt-mcp-continue-cookbook",
               "guides/netlify-mcp-continuous-deployment"

--- a/docs/guides/overview.mdx
+++ b/docs/guides/overview.mdx
@@ -22,6 +22,7 @@ Step-by-step guides for integrating Model Context Protocol (MCP) servers with Co
 - [Continue Docs MCP Cookbook](/guides/continue-docs-mcp-cookbook) - Use the Continue Docs MCP to write cookbooks, guides, and documentation with AI-powered workflows
 - [PostHog Session Analysis Cookbook](/guides/posthog-github-continuous-ai) - Analyze user behavior data to optimize your codebase with automatic issue creation
 - [Netlify Performance Optimization Cookbook](/guides/netlify-mcp-continuous-deployment) - Optimize web performance with A/B testing and automated monitoring using Netlify MCP
+- [Sanity CMS Integration Cookbook](/guides/sanity-mcp-continue-cookbook) - Manage headless CMS content with AI-powered workflows using Sanity MCP
 - [Snyk + Continue Hub Agent Cookbook (MCP)](/guides/snyk-mcp-continue-cookbook) - Integrate Snyk MCP via Continue Hub to scan code, deps, IaC, and containers
 - [dlt Data Pipelines Cookbook](/guides/dlt-mcp-continue-cookbook) - Build AI-powered data pipelines with dlt MCP for pipeline inspection, schema management, and debugging
 

--- a/docs/guides/snyk-mcp-continue-cookbook.mdx
+++ b/docs/guides/snyk-mcp-continue-cookbook.mdx
@@ -649,10 +649,10 @@ then rerun the same Snyk scan to confirm resolution."
 
 After completing this guide, you have a complete **AI-powered security system** that:
 
-✅ Uses natural language — Simple prompts instead of complex CLI commands
-✅ Fixes automatically — AI suggests and validates security fixes
-✅ Runs continuously — Automated scanning in CI/CD pipelines
-✅ Enforces guardrails — Security rules prevent vulnerable code from shipping
+- ✅ Uses natural language — Simple prompts instead of complex CLI commands
+- ✅ Fixes automatically — AI suggests and validates security fixes
+- ✅ Runs continuously — Automated scanning in CI/CD pipelines
+- ✅ Enforces guardrails — Security rules prevent vulnerable code from shipping
 
 <Card title="Continuous AI" icon="rocket">
   Your security workflow now operates at **[Level 2 Continuous


### PR DESCRIPTION
## Description
This PR adds the Sanity MCP Continue Cookbook to the documentation navigation, making it discoverable alongside other MCP integration guides.

## Changes
- Added Sanity MCP Continue Cookbook to the guides overview page under the MCP Integration Cookbooks section
- Added the cookbook to sidebar navigation in docs.json under the Cookbooks group
- Positioned alphabetically between Continue Docs and Snyk cookbooks

## Context
The Sanity cookbook was previously created but not linked in the documentation navigation, making it hard to discover. This fix ensures users can find it through both the overview page and the sidebar.

## Testing
- Verified the cookbook file exists at 
- Links follow the same pattern as other cookbooks
- No breaking changes to existing navigation

Generated with [Continue](https://continue.dev)