### PR TITLE
feat: add OpenRouter API with Anthropic prompt caching support

### DIFF
--- a/packages/openai-adapters/src/apis/OpenRouter.test.ts
+++ b/packages/openai-adapters/src/apis/OpenRouter.test.ts
@@ -1,0 +1,319 @@
+import { ChatCompletionCreateParams } from "openai/resources/index";
+import { describe, expect, it } from "vitest";
+
+import { OpenRouterApi } from "./OpenRouter.js";
+import { applyAnthropicCachingToOpenRouterBody } from "./OpenRouterCaching.js";
+
+describe("OpenRouterApi Anthropic caching", () => {
+  const baseConfig = {
+    provider: "openrouter" as const,
+    apiKey: "test-key",
+  };
+
+  it("adds cache_control to last two user messages by default", () => {
+    const api = new OpenRouterApi(baseConfig);
+
+    const body: ChatCompletionCreateParams = {
+      model: "anthropic/claude-3.5-sonnet",
+      messages: [
+        { role: "user", content: "First" },
+        { role: "assistant", content: "Resp" },
+        { role: "user", content: "Second" },
+        { role: "assistant", content: "Resp 2" },
+        { role: "user", content: "Third" },
+      ],
+    };
+
+    const modifiedBody = api["modifyChatBody"]({ ...body });
+
+    const userMessages = modifiedBody.messages.filter(
+      (message) => message.role === "user",
+    );
+
+    expect(userMessages[0].content).toBe("First");
+    expect(userMessages[1].content).toEqual([
+      {
+        type: "text",
+        text: "Second",
+        cache_control: { type: "ephemeral" },
+      },
+    ]);
+    expect(userMessages[2].content).toEqual([
+      {
+        type: "text",
+        text: "Third",
+        cache_control: { type: "ephemeral" },
+      },
+    ]);
+  });
+
+  it("adds cache_control to system message via strategy", () => {
+    const api = new OpenRouterApi(baseConfig);
+
+    const body: ChatCompletionCreateParams = {
+      model: "claude-3-5-sonnet-latest",
+      messages: [
+        { role: "system", content: "System message" },
+        { role: "user", content: "Hi" },
+      ],
+    };
+
+    const modifiedBody = api["modifyChatBody"]({ ...body });
+
+    expect(modifiedBody.messages[0]).toEqual({
+      role: "system",
+      content: [
+        {
+          type: "text",
+          text: "System message",
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+    });
+    expect(modifiedBody.messages[1]).toEqual(body.messages[1]);
+  });
+
+  it("respects cachingStrategy when set to none", () => {
+    const api = new OpenRouterApi({
+      ...baseConfig,
+      cachingStrategy: "none",
+    });
+
+    const body: ChatCompletionCreateParams = {
+      model: "claude-3-5-sonnet-latest",
+      messages: [
+        { role: "system", content: "System" },
+        { role: "user", content: "First" },
+        { role: "assistant", content: "Resp" },
+        { role: "user", content: "Second" },
+      ],
+    };
+
+    const modifiedBody = api["modifyChatBody"]({ ...body });
+
+    // System message should remain unchanged when strategy is none
+    expect(modifiedBody.messages[0]).toEqual(body.messages[0]);
+
+    const userMessages = modifiedBody.messages.filter(
+      (message) => message.role === "user",
+    );
+
+    expect(userMessages[0].content).toEqual([
+      {
+        type: "text",
+        text: "First",
+        cache_control: { type: "ephemeral" },
+      },
+    ]);
+    expect(userMessages[1].content).toEqual([
+      {
+        type: "text",
+        text: "Second",
+        cache_control: { type: "ephemeral" },
+      },
+    ]);
+  });
+
+  it("leaves messages unchanged for non-Anthropic models", () => {
+    const api = new OpenRouterApi(baseConfig);
+
+    const body: ChatCompletionCreateParams = {
+      model: "gpt-4o",
+      messages: [
+        { role: "system", content: "System" },
+        { role: "user", content: "Hello" },
+      ],
+    };
+
+    const modifiedBody = api["modifyChatBody"]({ ...body });
+
+    expect(modifiedBody.messages).toEqual(body.messages);
+  });
+
+  it("adds cache_control only to last text block for array content", () => {
+    const api = new OpenRouterApi(baseConfig);
+
+    const body: ChatCompletionCreateParams = {
+      model: "claude-3-5-sonnet-latest",
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Part 1" },
+            { type: "text", text: "Part 2" },
+          ],
+        },
+      ],
+    };
+
+    const modifiedBody = api["modifyChatBody"]({ ...body });
+
+    expect(modifiedBody.messages[0].content).toEqual([
+      { type: "text", text: "Part 1" },
+      {
+        type: "text",
+        text: "Part 2",
+        cache_control: { type: "ephemeral" },
+      },
+    ]);
+  });
+
+  describe("applyAnthropicCachingToOpenRouterBody", () => {
+    it("mutates OpenAI chat body with system and tool caching", () => {
+      const body: ChatCompletionCreateParams = {
+        model: "anthropic/claude-3.5-sonnet",
+        messages: [
+          { role: "system", content: "You are helpful" },
+          { role: "user", content: "Alpha" },
+          { role: "assistant", content: "Response" },
+          { role: "user", content: "Beta" },
+          { role: "assistant", content: "Another" },
+          { role: "user", content: "Gamma" },
+        ],
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "toolA",
+              description: "desc",
+              parameters: { type: "object", properties: {} },
+            },
+          },
+          {
+            type: "function",
+            function: {
+              name: "toolB",
+              description: "desc",
+              parameters: { type: "object", properties: {} },
+            },
+          },
+        ],
+      };
+
+      applyAnthropicCachingToOpenRouterBody(body, "systemAndTools");
+
+      expect(body.messages[0]).toEqual({
+        role: "system",
+        content: [
+          {
+            type: "text",
+            text: "You are helpful",
+            cache_control: { type: "ephemeral" },
+          },
+        ],
+      });
+
+      const userMessages = body.messages.filter((m) => m.role === "user");
+      expect(userMessages[0].content).toBe("Alpha");
+      expect(userMessages[1].content).toEqual([
+        {
+          type: "text",
+          text: "Beta",
+          cache_control: { type: "ephemeral" },
+        },
+      ]);
+      expect(userMessages[2].content).toEqual([
+        {
+          type: "text",
+          text: "Gamma",
+          cache_control: { type: "ephemeral" },
+        },
+      ]);
+
+      expect(body.tools?.[0]).toEqual({
+        type: "function",
+        function: {
+          name: "toolA",
+          description: "desc",
+          parameters: { type: "object", properties: {} },
+        },
+      });
+      expect(body.tools?.[1]).toEqual({
+        type: "function",
+        function: {
+          name: "toolB",
+          description: "desc",
+          parameters: { type: "object", properties: {} },
+        },
+        cache_control: { type: "ephemeral" },
+      });
+    });
+
+    it("leaves system untouched when strategy is none while caching users", () => {
+      const body: ChatCompletionCreateParams = {
+        model: "anthropic/claude-3.5-sonnet",
+        messages: [
+          { role: "system", content: "Stay focused" },
+          { role: "user", content: "Question" },
+          { role: "assistant", content: "Answer" },
+          { role: "user", content: "Follow up" },
+        ],
+      };
+
+      applyAnthropicCachingToOpenRouterBody(body, "none");
+
+      expect(body.messages[0]).toEqual({
+        role: "system",
+        content: "Stay focused",
+      });
+
+      const userMessages = body.messages.filter((m) => m.role === "user");
+      expect(userMessages[0].content).toEqual([
+        {
+          type: "text",
+          text: "Question",
+          cache_control: { type: "ephemeral" },
+        },
+      ]);
+      expect(userMessages[1].content).toEqual([
+        {
+          type: "text",
+          text: "Follow up",
+          cache_control: { type: "ephemeral" },
+        },
+      ]);
+    });
+
+    it("adds cache_control only to final text segment of user arrays", () => {
+      const body: ChatCompletionCreateParams = {
+        model: "anthropic/claude-3.5-sonnet",
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "Part 1" },
+              { type: "text", text: "Part 2" },
+            ],
+          },
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "Segment A" },
+              { type: "text", text: "Segment B" },
+            ],
+          },
+        ],
+      };
+
+      applyAnthropicCachingToOpenRouterBody(body, "systemAndTools");
+
+      expect(body.messages[0].content).toEqual([
+        { type: "text", text: "Part 1" },
+        {
+          type: "text",
+          text: "Part 2",
+          cache_control: { type: "ephemeral" },
+        },
+      ]);
+
+      expect(body.messages[1].content).toEqual([
+        { type: "text", text: "Segment A" },
+        {
+          type: "text",
+          text: "Segment B",
+          cache_control: { type: "ephemeral" },
+        },
+      ]);
+    });
+  });
+});

--- a/packages/openai-adapters/src/apis/OpenRouter.ts
+++ b/packages/openai-adapters/src/apis/OpenRouter.ts
@@ -1,0 +1,43 @@
+import { ChatCompletionCreateParams } from "openai/resources/index";
+
+import { OpenAIConfig } from "../types.js";
+import { OpenAIApi } from "./OpenAI.js";
+import { applyAnthropicCachingToOpenRouterBody } from "./OpenRouterCaching.js";
+
+export interface OpenRouterConfig extends OpenAIConfig {
+  cachingStrategy?: import("./AnthropicCachingStrategies.js").CachingStrategyName;
+}
+
+export class OpenRouterApi extends OpenAIApi {
+  constructor(config: OpenRouterConfig) {
+    super({
+      ...config,
+      apiBase: config.apiBase ?? "https://openrouter.ai/api/v1/",
+    });
+  }
+
+  private isAnthropicModel(model?: string): boolean {
+    if (!model) {
+      return false;
+    }
+    const modelLower = model.toLowerCase();
+    return modelLower.includes("claude");
+  }
+
+  override modifyChatBody<T extends ChatCompletionCreateParams>(body: T): T {
+    const modifiedBody = super.modifyChatBody(body);
+
+    if (!this.isAnthropicModel(modifiedBody.model)) {
+      return modifiedBody;
+    }
+
+    applyAnthropicCachingToOpenRouterBody(
+      modifiedBody as unknown as ChatCompletionCreateParams,
+      (this.config as OpenRouterConfig).cachingStrategy ?? "systemAndTools",
+    );
+
+    return modifiedBody;
+  }
+}
+
+export default OpenRouterApi;

--- a/packages/openai-adapters/src/apis/OpenRouterCaching.ts
+++ b/packages/openai-adapters/src/apis/OpenRouterCaching.ts
@@ -1,0 +1,294 @@
+import {
+  ContentBlockParam,
+  MessageCreateParams,
+  MessageParam,
+} from "@anthropic-ai/sdk/resources";
+import {
+  ChatCompletionCreateParams,
+  ChatCompletionMessageParam,
+} from "openai/resources/index";
+
+import {
+  CACHING_STRATEGIES,
+  CachingStrategyName,
+} from "./AnthropicCachingStrategies.js";
+import {
+  addCacheControlToLastTwoUserMessages,
+  openaiToolToAnthropicTool,
+} from "./AnthropicUtils.js";
+
+interface SystemMapping {
+  openaiIndex: number;
+  start: number;
+  length: number;
+  wasString: boolean;
+  originalContent: ChatCompletionMessageParam["content"];
+  textPartIndices: (number | null)[];
+}
+
+interface MessageMapping {
+  openaiIndex: number;
+  anthropicIndex: number;
+  role: string;
+  wasString: boolean;
+  originalContent: ChatCompletionMessageParam["content"];
+  textPartIndices: (number | null)[];
+}
+
+interface ConversionResult {
+  anthropicBody: MessageCreateParams;
+  systemMappings: SystemMapping[];
+  messageMappings: MessageMapping[];
+}
+
+const convertContentToBlocks = (
+  content: ChatCompletionMessageParam["content"],
+): {
+  blocks: ContentBlockParam[];
+  textPartIndices: (number | null)[];
+  wasString: boolean;
+} => {
+  if (typeof content === "string" || typeof content === "number") {
+    const text = String(content);
+    return {
+      blocks: [
+        {
+          type: "text",
+          text,
+        } as ContentBlockParam,
+      ],
+      textPartIndices: [null],
+      wasString: true,
+    };
+  }
+
+  if (!Array.isArray(content)) {
+    return {
+      blocks: [],
+      textPartIndices: [],
+      wasString: false,
+    };
+  }
+
+  const blocks: ContentBlockParam[] = [];
+  const textPartIndices: (number | null)[] = [];
+
+  content.forEach((part: any, idx: number) => {
+    if (part?.type === "text") {
+      blocks.push({
+        type: "text",
+        text: part.text ?? "",
+      } as ContentBlockParam);
+      textPartIndices.push(idx);
+    } else {
+      blocks.push({ ...(part ?? {}) } as any);
+      textPartIndices.push(null);
+    }
+  });
+
+  return {
+    blocks,
+    textPartIndices,
+    wasString: false,
+  };
+};
+
+const convertToAnthropic = (
+  body: ChatCompletionCreateParams,
+): ConversionResult => {
+  const systemBlocks: ContentBlockParam[] = [];
+  const systemMappings: SystemMapping[] = [];
+  const messages: MessageParam[] = [];
+  const messageMappings: MessageMapping[] = [];
+
+  let systemOffset = 0;
+
+  body.messages.forEach((message, index) => {
+    const { blocks, textPartIndices, wasString } = convertContentToBlocks(
+      message.content,
+    );
+
+    if (message.role === "system") {
+      const length = blocks.length;
+      systemMappings.push({
+        openaiIndex: index,
+        start: systemOffset,
+        length,
+        wasString,
+        originalContent: message.content,
+        textPartIndices,
+      });
+      systemBlocks.push(...blocks);
+      systemOffset += length;
+    } else {
+      messages.push({
+        role: message.role as MessageParam["role"],
+        content: blocks as any,
+      });
+      messageMappings.push({
+        openaiIndex: index,
+        anthropicIndex: messages.length - 1,
+        role: message.role,
+        wasString,
+        originalContent: message.content,
+        textPartIndices,
+      });
+    }
+  });
+
+  const tools = body.tools
+    ?.filter((tool) => tool.type === "function")
+    .map((tool) => openaiToolToAnthropicTool(tool));
+
+  const anthropicBody: MessageCreateParams = {
+    model: body.model,
+    messages,
+    max_tokens: body.max_tokens ?? 1,
+    system: systemBlocks.length > 0 ? (systemBlocks as any) : undefined,
+    tools,
+  };
+
+  return { anthropicBody, systemMappings, messageMappings };
+};
+
+export const applyAnthropicCachingToOpenRouterBody = (
+  body: ChatCompletionCreateParams,
+  strategy: CachingStrategyName,
+): void => {
+  const { anthropicBody, systemMappings, messageMappings } =
+    convertToAnthropic(body);
+
+  const cachingStrategy =
+    CACHING_STRATEGIES[strategy] ?? CACHING_STRATEGIES.systemAndTools;
+  const cachedBody = cachingStrategy({ ...anthropicBody });
+
+  cachedBody.messages = cachedBody.messages ?? [];
+  addCacheControlToLastTwoUserMessages(cachedBody.messages);
+
+  const cachedSystem = Array.isArray(cachedBody.system)
+    ? cachedBody.system
+    : [];
+
+  systemMappings.forEach((mapping) => {
+    const openaiMessage = body.messages[mapping.openaiIndex] as any;
+    if (!openaiMessage) {
+      return;
+    }
+
+    const slice = cachedSystem.slice(
+      mapping.start,
+      mapping.start + mapping.length,
+    );
+    const hasCache = slice.some((block: any) => block?.cache_control);
+
+    if (!hasCache) {
+      openaiMessage.content = mapping.originalContent;
+      return;
+    }
+
+    if (mapping.wasString) {
+      openaiMessage.content = slice.map((block: any) => ({
+        type: "text",
+        text: block?.text ?? "",
+        ...(block?.cache_control ? { cache_control: block.cache_control } : {}),
+      }));
+      return;
+    }
+
+    if (Array.isArray(mapping.originalContent)) {
+      const newParts = mapping.originalContent.map((part: any) => ({
+        ...part,
+      }));
+
+      slice.forEach((block: any, idx: number) => {
+        const originalIndex = mapping.textPartIndices[idx];
+        if (
+          originalIndex === null ||
+          originalIndex === undefined ||
+          !block?.cache_control
+        ) {
+          return;
+        }
+
+        newParts[originalIndex] = {
+          ...newParts[originalIndex],
+          cache_control: block.cache_control,
+          ...(block.text !== undefined ? { text: block.text } : {}),
+        };
+      });
+
+      openaiMessage.content = newParts;
+    }
+  });
+
+  const cachedMessages = cachedBody.messages ?? [];
+  messageMappings.forEach((mapping) => {
+    const openaiMessage = body.messages[mapping.openaiIndex] as any;
+    const cachedMessage = cachedMessages[mapping.anthropicIndex] as any;
+    if (!openaiMessage || !cachedMessage) {
+      return;
+    }
+
+    if (cachedMessage.role !== "user") {
+      openaiMessage.content = mapping.originalContent;
+      return;
+    }
+
+    const contentArray = Array.isArray(cachedMessage.content)
+      ? cachedMessage.content
+      : [];
+    const hasCache = contentArray.some((block: any) => block?.cache_control);
+
+    if (!hasCache) {
+      openaiMessage.content = mapping.originalContent;
+      return;
+    }
+
+    if (mapping.wasString) {
+      openaiMessage.content = contentArray.map((block: any) => ({
+        type: "text",
+        text: block?.text ?? "",
+        ...(block?.cache_control ? { cache_control: block.cache_control } : {}),
+      }));
+      return;
+    }
+
+    if (Array.isArray(mapping.originalContent)) {
+      const newParts = mapping.originalContent.map((part: any) => ({
+        ...part,
+      }));
+
+      contentArray.forEach((block: any, idx: number) => {
+        const originalIndex = mapping.textPartIndices[idx];
+        if (
+          originalIndex === null ||
+          originalIndex === undefined ||
+          !block?.cache_control
+        ) {
+          return;
+        }
+
+        newParts[originalIndex] = {
+          ...newParts[originalIndex],
+          cache_control: block.cache_control,
+          ...(block.text !== undefined ? { text: block.text } : {}),
+        };
+      });
+
+      openaiMessage.content = newParts;
+    }
+  });
+
+  if (body.tools?.length && cachedBody.tools?.length) {
+    body.tools = body.tools.map((tool, idx) => {
+      const cachedTool = (cachedBody.tools ?? [])[idx] as any;
+      if (!cachedTool?.cache_control) {
+        return tool;
+      }
+      return {
+        ...tool,
+        cache_control: cachedTool.cache_control,
+      } as any;
+    });
+  }
+};

--- a/packages/openai-adapters/src/index.ts
+++ b/packages/openai-adapters/src/index.ts
@@ -4,6 +4,7 @@ import { AnthropicApi } from "./apis/Anthropic.js";
 import { AzureApi } from "./apis/Azure.js";
 import { BedrockApi } from "./apis/Bedrock.js";
 import { CohereApi } from "./apis/Cohere.js";
+import { CometAPIApi } from "./apis/CometAPI.js";
 import { ContinueProxyApi } from "./apis/ContinueProxy.js";
 import { DeepSeekApi } from "./apis/DeepSeek.js";
 import { GeminiApi } from "./apis/Gemini.js";
@@ -13,12 +14,12 @@ import { LlamastackApi } from "./apis/LlamaStack.js";
 import { MockApi } from "./apis/Mock.js";
 import { MoonshotApi } from "./apis/Moonshot.js";
 import { OpenAIApi } from "./apis/OpenAI.js";
+import { OpenRouterApi } from "./apis/OpenRouter.js";
 import { RelaceApi } from "./apis/Relace.js";
 import { VertexAIApi } from "./apis/VertexAI.js";
 import { WatsonXApi } from "./apis/WatsonX.js";
 import { BaseLlmApi } from "./apis/base.js";
 import { LLMConfig, OpenAIConfigSchema } from "./types.js";
-import { CometAPIApi } from "./apis/CometAPI.js";
 import { appendPathToUrlIfNotPresent } from "./util/appendPathToUrl.js";
 
 dotenv.config();
@@ -110,8 +111,6 @@ export function constructLlmApi(config: LLMConfig): BaseLlmApi | undefined {
       return openAICompatible("https://api.sambanova.ai/v1/", config);
     case "text-gen-webui":
       return openAICompatible("http://127.0.0.1:5000/v1/", config);
-    case "openrouter":
-      return openAICompatible("https://openrouter.ai/api/v1/", config);
     case "cerebras":
       return openAICompatible("https://api.cerebras.ai/v1/", config);
     case "kindo":
@@ -139,6 +138,8 @@ export function constructLlmApi(config: LLMConfig): BaseLlmApi | undefined {
       return openAICompatible("https://api.studio.nebius.ai/v1/", config);
     case "function-network":
       return openAICompatible("https://api.function.network/v1/", config);
+    case "openrouter":
+      return new OpenRouterApi(config);
     case "llama.cpp":
     case "llamafile":
       return openAICompatible("http://localhost:8000/", config);


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add an OpenRouter API adapter with Anthropic prompt caching for Claude models. Defaults to caching system and tools, and adds ephemeral caching to the last two user messages; non-Anthropic models are unchanged.

- **New Features**
  - Introduced OpenRouterApi with default base URL and a cachingStrategy option.
  - Applies Anthropic prompt caching for Claude models: caches system and tools per strategy, always adds ephemeral cache_control to the last two user messages, and only the final text block in array content.
  - Switched provider "openrouter" to use OpenRouterApi instead of the generic OpenAI-compatible path.

<!-- End of auto-generated description by cubic. -->

