### PR TITLE
fix: remove extra spaces before EOF in heredoc delimiters

### DIFF
--- a/.github/workflows/continue-general-review.yaml
+++ b/.github/workflows/continue-general-review.yaml
@@ -1,6 +1,9 @@
 name: Continue General Review
 
 on:
+  push:
+    branches:
+      - nate/fix-wf
   pull_request:
     types: [opened, ready_for_review]
   issue_comment:

--- a/actions/general-review/action.yml
+++ b/actions/general-review/action.yml
@@ -170,62 +170,11 @@ runs:
           PR_NUMBER="${{ github.event.issue.number }}"
         fi
 
-        # Get PR diff
-        gh pr diff $PR_NUMBER > pr_diff.txt
-
-        # Get PR details
-        PR_TITLE=$(gh pr view $PR_NUMBER --json title -q .title)
-        PR_AUTHOR=$(gh pr view $PR_NUMBER --json author -q .author.login)
-        PR_BODY=$(gh pr view $PR_NUMBER --json body -q .body)
-        FILES_CHANGED=$(gh pr view $PR_NUMBER --json files -q '.files | length')
-        
-        # Create review prompt
-        cat > review_prompt.txt << EOF
-        You are reviewing a pull request. Please provide helpful, context-aware feedback.
-
-        CONTEXT:
-        - Repository: ${{ github.repository }}
-        - PR #$PR_NUMBER: $PR_TITLE
-        - Files Changed: $FILES_CHANGED
-        - Author: $PR_AUTHOR
-
-        REVIEW APPROACH:
-        1. First, understand what this PR is trying to accomplish
-        2. Check if similar patterns exist elsewhere in the codebase
-        3. Focus on actual issues that affect functionality
-        4. Be constructive and suggest solutions when possible
-
-        FOCUS ON:
-        - Bugs that will cause failures or incorrect behavior
-        - Security vulnerabilities (exposed secrets, injection risks)
-        - Breaking changes that affect other parts of the system
-        - Performance issues with real impact (memory leaks, O(n²) algorithms)
-        - Missing tests for new features or bug fixes
-        - Missing documentation for APIs or complex logic
-
-        SKIP COMMENTING ON:
-        - Style and formatting (handled by linters)
-        - Alternative approaches unless current is broken
-        - Minor naming unless genuinely confusing
-        - Trivial documentation for self-explanatory code
-
-        Be specific with line numbers and explain why something is an issue.
-
-        PR Description: ${PR_BODY:-No description provided}
-
-        Code Changes:
-EOF
-
-        # Add the diff
-        cat pr_diff.txt >> review_prompt.txt
-        
-        cat >> review_prompt.txt << 'EOF'
-
-        Your Review:
-        Please provide constructive feedback on the code changes.
-        Focus on issues that matter for functionality, security, and maintainability.
-        If the code looks good overall, acknowledge that while noting any minor suggestions.
-EOF
+        # Gather PR context and build prompt without heredocs
+        gh pr diff "$PR_NUMBER" > pr_diff.txt
+        gh pr view "$PR_NUMBER" --json title,author,body,files > pr_data.json
+        node actions/general-review/scripts/buildPrompt.js "$PR_NUMBER"
+        rm -f pr_data.json
 
     - name: Run Continue CLI Review
       if: env.SHOULD_RUN == 'true'
@@ -247,15 +196,7 @@ EOF
         if [ -z "$CONTINUE_API_KEY" ]; then
           echo "Warning: CONTINUE_API_KEY environment variable is not set"
           # Create fallback review and continue
-          cat > code_review.md << 'EOF'
-          ## Code Review Summary
-
-          ⚠️ AI review skipped: CONTINUE_API_KEY not configured.
-
-          ### Configuration Required
-          - Please set the CONTINUE_API_KEY secret in repository settings
-          - Verify that the organization and config path are valid
-EOF
+          node actions/general-review/scripts/writeMarkdown.js code_review.md missing_api_key
           echo "SKIP_CLI=true" >> $GITHUB_ENV
         else
           echo "SKIP_CLI=false" >> $GITHUB_ENV
@@ -277,15 +218,7 @@ EOF
           echo "Testing Continue CLI..."
           if ! which cn > /dev/null 2>&1; then
             echo "Warning: Continue CLI not found or not working"
-            cat > code_review.md << 'EOF'
-            ## Code Review Summary
-
-            ⚠️ AI review skipped: Continue CLI installation failed.
-
-            ### Troubleshooting
-            - Check that npm installation succeeded
-            - Verify @continuedev/cli package is available
-EOF
+            node actions/general-review/scripts/writeMarkdown.js code_review.md cli_install_failed
             echo "SKIP_CLI=true" >> $GITHUB_ENV
           else
             echo "Continue CLI found at: $(which cn)"
@@ -321,11 +254,7 @@ EOF
             # Check if output is empty
             if [ ! -s code_review.md ]; then
               echo "Warning: Continue CLI returned empty output"
-              cat > code_review.md << 'EOF'
-          ## Code Review Summary
-
-          ⚠️ Continue CLI returned an empty response. Please check the configuration.
-EOF
+              node actions/general-review/scripts/writeMarkdown.js code_review.md empty_output
             fi
           else
             echo "Error: Continue CLI command failed with exit code $?"
@@ -334,34 +263,13 @@ EOF
             
             # Check for specific error patterns
             if grep -q "not found\|ENOENT" cli_error.log 2>/dev/null; then
-              cat > code_review.md << 'EOF'
-          ## Code Review Summary
-
-          ⚠️ Continue CLI is not properly installed. Please ensure @continuedev/cli is installed globally.
-EOF
+              node actions/general-review/scripts/writeMarkdown.js code_review.md cli_not_found
             elif grep -q "config\|assistant" cli_error.log 2>/dev/null; then
-              cat > code_review.md << 'EOF'
-          ## Code Review Summary
-
-          ⚠️ Continue configuration error. Please verify that the assistant exists in Continue Hub.
-EOF
+              node actions/general-review/scripts/writeMarkdown.js code_review.md config_error
             elif grep -q "api\|auth" cli_error.log 2>/dev/null; then
-              cat > code_review.md << 'EOF'
-          ## Code Review Summary
-
-          ⚠️ Continue API authentication failed. Please check your CONTINUE_API_KEY.
-EOF
+              node actions/general-review/scripts/writeMarkdown.js code_review.md auth_error
             else
-              cat > code_review.md << 'EOF'
-          ## Code Review Summary
-
-          ⚠️ AI review failed. Please check the Continue API key and configuration.
-
-          ### Troubleshooting
-          - Verify the CONTINUE_API_KEY secret is set correctly
-          - Check that the organization and config path are valid
-          - Ensure the Continue service is accessible
-EOF
+              node actions/general-review/scripts/writeMarkdown.js code_review.md generic_failure
             fi
           fi
           

--- a/actions/general-review/scripts/buildPrompt.js
+++ b/actions/general-review/scripts/buildPrompt.js
@@ -1,0 +1,94 @@
+const fs = require("fs");
+const path = require("path");
+
+function main() {
+  const prNumber = process.argv[2];
+  if (!prNumber) {
+    console.error(
+      "buildPrompt.js requires the PR number as the first argument",
+    );
+    process.exit(1);
+  }
+
+  const prDataPath = path.resolve(process.cwd(), "pr_data.json");
+  const prDiffPath = path.resolve(process.cwd(), "pr_diff.txt");
+  const outputPath = path.resolve(process.cwd(), "review_prompt.txt");
+
+  if (!fs.existsSync(prDataPath)) {
+    console.error(`Missing PR metadata file: ${prDataPath}`);
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(prDiffPath)) {
+    console.error(`Missing PR diff file: ${prDiffPath}`);
+    process.exit(1);
+  }
+
+  const repo = process.env.GITHUB_REPOSITORY || "unknown-repo";
+  let prData;
+
+  try {
+    prData = JSON.parse(fs.readFileSync(prDataPath, "utf8"));
+  } catch (error) {
+    console.error("Failed to parse PR metadata JSON:", error);
+    process.exit(1);
+  }
+
+  const filesChanged = Array.isArray(prData.files) ? prData.files.length : 0;
+  const authorLogin = prData.author?.login || "unknown-author";
+  const title = prData.title || "Untitled";
+  const prBody =
+    prData.body && prData.body.trim()
+      ? prData.body.trim()
+      : "No description provided";
+  const diff = fs.readFileSync(prDiffPath, "utf8");
+
+  const promptSections = [
+    "You are reviewing a pull request. Please provide helpful, context-aware feedback.",
+    "",
+    "CONTEXT:",
+    `- Repository: ${repo}`,
+    `- PR #${prNumber}: ${title}`,
+    `- Files Changed: ${filesChanged}`,
+    `- Author: ${authorLogin}`,
+    "",
+    "REVIEW APPROACH:",
+    "1. First, understand what this PR is trying to accomplish",
+    "2. Check if similar patterns exist elsewhere in the codebase",
+    "3. Focus on actual issues that affect functionality",
+    "4. Be constructive and suggest solutions when possible",
+    "",
+    "FOCUS ON:",
+    "- Bugs that will cause failures or incorrect behavior",
+    "- Security vulnerabilities (exposed secrets, injection risks)",
+    "- Breaking changes that affect other parts of the system",
+    "- Performance issues with real impact (memory leaks, O(n²) algorithms)",
+    "- Missing tests for new features or bug fixes",
+    "- Missing documentation for APIs or complex logic",
+    "",
+    "SKIP COMMENTING ON:",
+    "- Style and formatting (handled by linters)",
+    "- Alternative approaches unless current is broken",
+    "- Minor naming unless genuinely confusing",
+    "- Trivial documentation for self-explanatory code",
+    "",
+    "Be specific with line numbers and explain why something is an issue.",
+    "",
+    `PR Description: ${prBody}`,
+    "",
+    "Code Changes:",
+    diff.trimEnd(),
+    "",
+    "Your Review:",
+    "Please provide constructive feedback on the code changes.",
+    "Focus on issues that matter for functionality, security, and maintainability.",
+    "If the code looks good overall, acknowledge that while noting any minor suggestions.",
+  ];
+
+  const prompt = `${promptSections.join("\n")}\n`;
+
+  fs.writeFileSync(outputPath, prompt, "utf8");
+  console.log(`Wrote review prompt to ${outputPath}`);
+}
+
+main();

--- a/actions/general-review/scripts/writeMarkdown.js
+++ b/actions/general-review/scripts/writeMarkdown.js
@@ -1,0 +1,68 @@
+const fs = require("fs");
+const path = require("path");
+
+const messages = {
+  missing_api_key: `## Code Review Summary
+
+⚠️ AI review skipped: CONTINUE_API_KEY not configured.
+
+### Configuration Required
+- Please set the CONTINUE_API_KEY secret in repository settings
+- Verify that the organization and config path are valid
+`,
+  cli_install_failed: `## Code Review Summary
+
+⚠️ AI review skipped: Continue CLI installation failed.
+
+### Troubleshooting
+- Check that npm installation succeeded
+- Verify @continuedev/cli package is available
+`,
+  empty_output: `## Code Review Summary
+
+⚠️ Continue CLI returned an empty response. Please check the configuration.
+`,
+  cli_not_found: `## Code Review Summary
+
+⚠️ Continue CLI is not properly installed. Please ensure @continuedev/cli is installed globally.
+`,
+  config_error: `## Code Review Summary
+
+⚠️ Continue configuration error. Please verify that the assistant exists in Continue Hub.
+`,
+  auth_error: `## Code Review Summary
+
+⚠️ Continue API authentication failed. Please check your CONTINUE_API_KEY.
+`,
+  generic_failure: `## Code Review Summary
+
+⚠️ AI review failed. Please check the Continue API key and configuration.
+
+### Troubleshooting
+- Verify the CONTINUE_API_KEY secret is set correctly
+- Check that the organization and config path are valid
+- Ensure the Continue service is accessible
+`,
+};
+
+function main() {
+  const [outputPath, messageKey] = process.argv.slice(2);
+
+  if (!outputPath || !messageKey) {
+    console.error("Usage: node writeMarkdown.js <outputPath> <messageKey>");
+    process.exit(1);
+  }
+
+  const message = messages[messageKey];
+
+  if (!message) {
+    console.error(`Unknown message key: ${messageKey}`);
+    process.exit(1);
+  }
+
+  const absolutePath = path.resolve(process.cwd(), outputPath);
+  fs.writeFileSync(absolutePath, message, "utf8");
+  console.log(`Wrote ${messageKey} message to ${absolutePath}`);
+}
+
+main();


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed heredoc termination in actions/general-review/action.yml by removing indentation before closing EOF markers. This prevents failed or hanging steps and ensures review_prompt.txt and code_review.md are written correctly.

- **Bug Fixes**
  - Unindented all closing EOF markers to comply with shell heredoc rules.
  - Prevents unmatched heredocs that cause empty outputs or job failures.

<!-- End of auto-generated description by cubic. -->

