### PR TITLE
fix: add max depth to file indexing

### DIFF
--- a/extensions/cli/src/services/FileIndexService.ts
+++ b/extensions/cli/src/services/FileIndexService.ts
@@ -2,6 +2,7 @@ import { fdir } from "fdir";
 import { AsyncFzf, FzfResultItem } from "fzf";
 
 import { FILE_IGNORE_PATTERNS } from "../util/filePatterns.js";
+import { isGitRepo } from "../util/git.js";
 import { logger } from "../util/logger.js";
 
 import { BaseService } from "./BaseService.js";
@@ -131,10 +132,15 @@ export class FileIndexService extends BaseService<FileIndexServiceState> {
       const currentDir = process.cwd();
       logger.debug(`Starting file index in directory: ${currentDir}`);
 
+      // Determine max depth based on git repository status
+      const inGitRepo = isGitRepo();
+      const maxDepth = inGitRepo ? 10 : 3;
+
       // Create file indexing promise
       const fileIndexPromise = new fdir()
         .withFullPaths()
         .withRelativePaths()
+        .withMaxDepth(maxDepth)
         .filter((path) => {
           // Use the helper function that implements original FILE_PATTERNS logic
           return this.shouldIncludeFile(path);


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Limit CLI file indexing depth to 10 levels in Git repos and 3 elsewhere to prevent deep scans. Speeds up startup and reduces timeouts in large projects (CON-4174).

<!-- End of auto-generated description by cubic. -->

