### PR TITLE
Revise build steps in BUILD.md

### DIFF
--- a/extensions/cli/BUILD.md
+++ b/extensions/cli/BUILD.md
@@ -6,8 +6,9 @@ The Continue CLI uses esbuild to bundle the application along with local package
 
 ## Build Steps
 
-1. **Install dependencies**: `npm install`
-2. **Build**: `npm run build`
+1. **Build packages**: `cd ../../ && node ./scripts/build-packages.js`
+2. **Install dependencies**: `npm install`
+3. **Build**: `npm run build`
    - This first builds the local packages
    - Then bundles everything with esbuild
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Update BUILD.md to run build-packages before npm install and build for the CLI. This prevents missing artifacts and aligns the build with the monorepo script flow.

<!-- End of auto-generated description by cubic. -->

