### PR TITLE
Fix wrong document about Force Legacy Completions Endpoint

### DIFF
--- a/docs/customize/model-providers/top-level/openai.mdx
+++ b/docs/customize/model-providers/top-level/openai.mdx
@@ -90,7 +90,7 @@ If you are using an OpenAI API compatible providers, you can change the `apiBase
 
 ### How to Force Legacy Completions Endpoint Usage
 
-To force usage of `chat/completions` instead of `completions` endpoint you can set:
+To force usage of `completions` instead of `chat/completions` endpoint you can set:
 
 <Tabs>
   <Tab title="YAML">


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Corrected the OpenAI provider docs to accurately describe how to force the legacy completions endpoint. The text now correctly instructs to use completions instead of chat/completions.

<!-- End of auto-generated description by cubic. -->

