### PR TITLE
fix: use relative path in vscode build task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -108,7 +108,7 @@
       "label": "vscode-extension:continue-ui:build",
       "type": "shell",
       "command": "node",
-      "args": ["${workspaceFolder}/extensions/vscode/scripts/prepackage.js"],
+      "args": ["scripts/prepackage.js"],
       "problemMatcher": ["$tsc"],
       "presentation": {
         "group": "build-tasks",


### PR DESCRIPTION
## Description

The VS Code task: `vscode-extension:continue-ui:build` is failing on Windows due to incorrect path resolution when combining absolute paths with the `cwd` option.

Here is the error: 

```
 Error: Cannot find module 'C:\Users\[UserName]\Desktop...\continue\extensions\vscode\Users[UserName]Desktop...continue\extensions\vscode\scripts\prepackage.js'
      at Module._resolveFilename (node:internal/modules/cjs/loader:1186:15)
      at Module._load (node:internal/modules/cjs/loader:1012:27)
      at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:158:12)
      at node:internal/main/run_main_module:30:49 {
   code: 'MODULE_NOT_FOUND',
   requireStack: []
```

The path is duplicated and concatenated incorrectly, which thus causing this error. Windows path resolution attempts to combine the absolute path with the cwd, resulting in a malformed path. This blocks development on a Windows machine. This affects only windows users though the fix improves cross-platform consistency.




## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

After this fix:
- Tested on Windows 11 - task now runs successfully, and the build is complete.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the VS Code build task on Windows by switching to a relative script path. This prevents malformed paths when combined with cwd and improves cross-platform consistency.

- **Bug Fixes**
  - Changed task args to "scripts/prepackage.js" instead of "${workspaceFolder}/extensions/vscode/scripts/prepackage.js".

<!-- End of auto-generated description by cubic. -->

