### PR TITLE
perf(cli): long start due to synchronous config init in normal flow run

### DIFF
--- a/extensions/cli/src/services/index.ts
+++ b/extensions/cli/src/services/index.ts
@@ -23,7 +23,6 @@ import {
   ConfigServiceState,
   SERVICE_NAMES,
   ServiceInitOptions,
-  ServiceInitResult,
   WorkflowServiceState,
 } from "./types.js";
 import { UpdateService } from "./UpdateService.js";
@@ -48,23 +47,19 @@ const systemMessageService = new SystemMessageService();
  * Initialize all services and register them with the service container
  * Handles onboarding internally for TUI mode unless skipOnboarding is true
  */
-export async function initializeServices(
-  initOptions: ServiceInitOptions = {},
-): Promise<ServiceInitResult> {
+export async function initializeServices(initOptions: ServiceInitOptions = {}) {
   logger.debug("Initializing service registry");
 
-  let wasOnboarded = false;
   const commandOptions = initOptions.options || {};
 
   // Handle onboarding for TUI mode (headless: false) unless explicitly skipped
   if (!initOptions.headless && !initOptions.skipOnboarding) {
     const authConfig = loadAuthConfig();
-    const onboardingResult = await initializeWithOnboarding(
+    await initializeWithOnboarding(
       authConfig,
       commandOptions.config,
       commandOptions.rule,
     );
-    wasOnboarded = onboardingResult.wasOnboarded;
   }
 
   // Handle ANTHROPIC_API_KEY in headless mode when no config path is provided
@@ -287,8 +282,6 @@ export async function initializeServices(
   await serviceContainer.initializeAll();
 
   logger.debug("Service registry initialized");
-
-  return { wasOnboarded };
 }
 
 /**


### PR DESCRIPTION
## Description

When doing `runNormalFlow`, we need the config only for [rules injection](https://github.com/continuedev/continue/blob/f0d02e704273b5f926cd4e7d5aca2f5a4d1d343b/extensions/cli/src/onboarding.ts/#L298-L300).

We already fetch the config again when [initializing services for config](https://github.com/continuedev/continue/blob/f0d02e704273b5f926cd4e7d5aca2f5a4d1d343b/extensions/cli/src/services/index.ts/#L166-L167).

resolves CON-4174

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

reduction of init time by approx 2 seconds

**before**

<img width="702" height="394" alt="image" src="https://github.com/user-attachments/assets/cf6f65d2-d3fd-4bd3-8e61-eec93704ea73" />


**after**
<img width="817" height="386" alt="image" src="https://github.com/user-attachments/assets/1da3cb2d-0315-41be-bec9-ec1881aebd71" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
