### PR TITLE
feat(cli): mcp oauth using mcp-remote

### DIFF
--- a/extensions/cli/src/services/MCPService.ts
+++ b/extensions/cli/src/services/MCPService.ts
@@ -1,6 +1,9 @@
 import { type AssistantConfig } from "@continuedev/sdk";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import {
+  SSEClientTransport,
+  SseError,
+} from "@modelcontextprotocol/sdk/client/sse.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import {
@@ -20,6 +23,14 @@ import {
   MCPServiceState,
   SERVICE_NAMES,
 } from "./types.js";
+
+function is401Error(error: unknown) {
+  return (
+    (error instanceof SseError && error.code === 401) ||
+    (error instanceof Error && error.message.includes("401")) ||
+    (error instanceof Error && error.message.includes("Unauthorized"))
+  );
+}
 
 interface ServerConnection extends MCPConnectionInfo {
   client: Client | null;
@@ -366,15 +377,27 @@ export class MCPService
         url: serverConfig.url,
       });
 
-      if (serverConfig.type === "sse") {
-        const transport = this.constructSseTransport(serverConfig);
-        await client.connect(transport, {});
-      } else if (serverConfig.type === "streamable-http") {
-        const transport = this.constructHttpTransport(serverConfig);
-        await client.connect(transport, {});
-      } else if (serverConfig.type) {
-        throw new Error(`Unsupported transport type: ${serverConfig.type}`);
-      } else {
+      try {
+        if (serverConfig.type === "sse") {
+          const transport = this.constructSseTransport(serverConfig);
+          await client.connect(transport, {});
+        } else if (serverConfig.type === "streamable-http") {
+          const transport = this.constructHttpTransport(serverConfig);
+          await client.connect(transport, {});
+        }
+      } catch (error: unknown) {
+        // on authorization error, use "mcp-remote" with stdio transport to connect
+        if (is401Error(error)) {
+          const transport = this.constructStdioTransport({
+            name: serverConfig.name,
+            command: "npx",
+            args: ["-y", "mcp-remote", serverConfig.url],
+          });
+          await client.connect(transport, {});
+        }
+      }
+
+      if (typeof serverConfig.type === "undefined") {
         try {
           const transport = this.constructHttpTransport(serverConfig);
           await client.connect(transport, {});
@@ -394,6 +417,10 @@ export class MCPService
             );
           }
         }
+      } else if (
+        !["streamable-http", "sse", "stdio"].includes(serverConfig.type)
+      ) {
+        throw new Error(`Unsupported transport type: ${serverConfig.type}`);
       }
     }
 

--- a/extensions/cli/src/services/MCPService.ts
+++ b/extensions/cli/src/services/MCPService.ts
@@ -394,6 +394,8 @@ export class MCPService
             args: ["-y", "mcp-remote", serverConfig.url],
           });
           await client.connect(transport, {});
+        } else {
+          throw error;
         }
       }
 


### PR DESCRIPTION
## Description

authenticate using mcp-remote for mcp servers requiring authorization

resolves CON-4179

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot



https://github.com/user-attachments/assets/b60f0492-c826-4af0-8f92-8a1632bb992a



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add OAuth handling for MCP servers in the CLI by falling back to mcp-remote (stdio) when SSE/HTTP connections return 401. Enables authentication to protected MCP endpoints and aligns with Linear CON-4179.

- **New Features**
  - Detect 401/Unauthorized errors from SSE/HTTP transports.
  - On auth failure, automatically invoke `npx -y mcp-remote <url>` via stdio to complete auth and connect.

- **Bug Fixes**
  - Validate transport types and throw a clear error for unsupported values.

<!-- End of auto-generated description by cubic. -->

