### PR TITLE
chore: bump VSCode extension version to 1.3.16

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "1.3.15",
+  "version": "1.3.16",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Bumped the VSCode extension version from 1.3.15 to 1.3.16 to prepare the prerelease build and enable publishing.
No functional changes.

<!-- End of auto-generated description by cubic. -->

