### PR TITLE
chore: add github actions to CLA allowlist

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -27,5 +27,5 @@ jobs:
           path-to-document: "https://github.com/continuedev/continue/blob/main/CLA.md"
           branch: cla-signatures
           # Bots and CLAs signed outside of GitHub
-          allowlist: dependabot[bot],fbricon,panyamkeerthana,Jazzcort,owtaylor,halfline,agent@continue.dev
+          allowlist: dependabot[bot],fbricon,panyamkeerthana,Jazzcort,owtaylor,halfline,agent@continue.dev,action@github.com
           signed-commit-message: "CLA signed in $pullRequestNo"


### PR DESCRIPTION
For GitHub workflow pre-release automation
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added action@github.com to the CLA allowlist so GitHub Actions can run pre-release automation without being blocked by CLA checks. Prevents CLA failures on bot-generated commits.

<!-- End of auto-generated description by cubic. -->

