### PR TITLE
fix: set keepAliveMsecs to 1000ms to prevent premature close

### DIFF
--- a/packages/fetch/src/getAgentOptions.test.ts
+++ b/packages/fetch/src/getAgentOptions.test.ts
@@ -50,7 +50,8 @@ test("getAgentOptions returns basic configuration with default values", async ()
   // Check default timeout (7200 seconds = 2 hours = 7,200,000 ms)
   expect(options.timeout).toBe(7200000);
   expect(options.sessionTimeout).toBe(7200000);
-  expect(options.keepAliveMsecs).toBe(7200000);
+  // keepAliveMsecs is always 1000ms (1 second) to prevent premature close errors
+  expect(options.keepAliveMsecs).toBe(1000);
   expect(options.keepAlive).toBe(true);
 
   // Verify certificates array exists and contains items
@@ -71,7 +72,8 @@ test("getAgentOptions respects custom timeout", async () => {
   // Check timeout values (300 seconds = 300,000 ms)
   expect(options.timeout).toBe(300000);
   expect(options.sessionTimeout).toBe(300000);
-  expect(options.keepAliveMsecs).toBe(300000);
+  // keepAliveMsecs is always 1000ms regardless of custom timeout
+  expect(options.keepAliveMsecs).toBe(1000);
 });
 
 test("getAgentOptions uses verifySsl setting", async () => {

--- a/packages/fetch/src/getAgentOptions.ts
+++ b/packages/fetch/src/getAgentOptions.ts
@@ -21,7 +21,11 @@ export async function getAgentOptions(
     timeout,
     sessionTimeout: timeout,
     keepAlive: true,
-    keepAliveMsecs: timeout,
+    // keepAliveMsecs: Delay before sending TCP keep-alive probes (node default = 1000ms)
+    // Setting this to 1s ensures connections stay alive through network devices
+    // (proxies, load balancers, firewalls) that close idle connections after 30-350s
+    // This should prevent "premature close" errors during long LLM streaming responses
+    keepAliveMsecs: 1000,
   };
 
   // Handle ClientCertificateOptions
@@ -38,9 +42,8 @@ export async function getAgentOptions(
 
   if (process.env.VERBOSE_FETCH) {
     console.log(`Fetch agent options:`);
-    console.log(
-      `\tTimeout (sessionTimeout/keepAliveMsecs): ${agentOptions.timeout}`,
-    );
+    console.log(`\tTimeout (sessionTimeout): ${agentOptions.timeout}`);
+    console.log(`\tkeepAliveMsecs: ${agentOptions.keepAliveMsecs}`);
     console.log(`\tTotal CA certs: ${ca.length}`);
     console.log(`\tGlobal/Root CA certs: ${certsCache.fixedCa.length}`);
     console.log(`\tCustom CA certs: ${ca.length - certsCache.fixedCa.length}`);


### PR DESCRIPTION
## Description

Set keepAliveMsecs lower so TCP keep-alive probes prevent network devices from prematurely closing idle streaming connections. Using node's default of 1000ms:

<img width="803" height="247" alt="image" src="https://github.com/user-attachments/assets/7df45c8c-3801-4e67-91ac-6e01c578a90c" />

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Set keepAliveMsecs to 1000ms to keep streaming connections alive and stop “premature close” errors behind proxies and firewalls. Addresses Linear CON-4298 for long-running LLM streams.

- **Bug Fixes**
  - Force keepAliveMsecs=1000ms regardless of timeout to send regular TCP keep-alive probes.
  - Updated tests to expect fixed keepAliveMsecs and improved verbose logs (separate timeout vs keepAliveMsecs).

<!-- End of auto-generated description by cubic. -->

