### PR TITLE
feat: asciinema recordings setup

### DIFF
--- a/.github/workflows/runloop-blueprint-template.json
+++ b/.github/workflows/runloop-blueprint-template.json
@@ -3,6 +3,7 @@
   "system_setup_commands": [
     "npm i -g @continuedev/cli@latest",
     "sudo apt update",
-    "sudo apt install -y ripgrep"
+    "sudo apt install -y ripgrep",
+    "sudo apt install asciinema"
   ]
 }

--- a/extensions/cli/.gitignore
+++ b/extensions/cli/.gitignore
@@ -11,3 +11,6 @@ chat.log
 config.yaml
 
 .continue-debug/
+
+*.expect
+!demo.expect

--- a/extensions/cli/demo.expect
+++ b/extensions/cli/demo.expect
@@ -1,0 +1,36 @@
+#!/usr/bin/expect -f
+# Automated demo script for Continue TUI
+
+set timeout 30
+log_user 1
+
+# Set terminal environment for better TUI rendering
+set env(TERM) "xterm-256color"
+
+# Spawn cn directly inside an asciinema recording session
+spawn bash -c "asciinema rec --overwrite demo.cast -c 'npm run start'"
+
+# Wait for TUI to load
+sleep 5
+
+# Demo interaction 1: Show help
+send "?"
+sleep 3
+
+# Demo interaction 2: Close help
+send "?"
+sleep 2
+
+# Demo interaction 3: Type a message
+send "Hello, this is a demo!"
+sleep 1
+
+# Submit the message
+send "\r"
+sleep 3
+
+# Exit the application with Ctrl+C
+send "\x03"
+sleep 1
+
+expect eof


### PR DESCRIPTION
## Description

scripts necessary for this workflow to work: https://hub.continue.dev/continuedev/asciinema-recording
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Sets up automated asciinema recording for the Continue CLI/TUI so we can generate consistent terminal demos. Adds an Expect script to drive the TUI and produce a demo.cast.

- **New Features**
  - Added extensions/cli/demo.expect to automate TUI interactions and record demo.cast via asciinema, with TERM set to xterm-256color.
  - Updated .gitignore to ignore *.expect files, keeping demo.expect tracked.

- **Dependencies**
  - Workflow now installs asciinema in system_setup_commands to enable recordings.

<!-- End of auto-generated description by cubic. -->

