### PR TITLE
fix: open hub org settings

### DIFF
--- a/gui/src/pages/config/sections/OrganizationsSection.tsx
+++ b/gui/src/pages/config/sections/OrganizationsSection.tsx
@@ -38,7 +38,7 @@ export function OrganizationsSection() {
 
   function handleConfigureOrganization(org: SerializedOrgWithProfiles) {
     let path: string;
-    if (org.id === "personal") {
+    if (org.id === "personal" || org.slug === undefined) {
       path = "/settings";
     } else {
       path = `/organizations/${org.slug}/settings`;


### PR DESCRIPTION
## Description

Open the correct hub org settings link.

resolves CON-4318

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot





https://github.com/user-attachments/assets/f4c4d8cf-2768-42d3-a755-9d59c4acd214

https://github.com/user-attachments/assets/2d69b8bf-cf32-4698-9aab-9a5e5b491eab

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes Hub organization settings navigation to open the correct settings page for personal accounts and organizations (Linear CON-4318).

- **Bug Fixes**
  - Routes personal accounts to /settings; routes orgs to /organizations/{slug}/settings.
  - Updates the click handler to accept the full org object.

<!-- End of auto-generated description by cubic. -->

