### PR TITLE
Add debug logging to feedback capture in NextEditLoggingService

### DIFF
--- a/core/nextEdit/NextEditLoggingService.ts
+++ b/core/nextEdit/NextEditLoggingService.ts
@@ -246,6 +246,9 @@ export class NextEditLoggingService {
           }),
         },
       );
-    } catch (error) {}
+      console.debug("Feedback: ", resp);
+    } catch (error: any) {
+      console.debug(`Error capturing feedback: ${error.message}`);
+    }
   }
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add debug logging to feedback capture in NextEditLoggingService to make troubleshooting easier. Logs the feedback response on success and a clear error message on failure.

<!-- End of auto-generated description by cubic. -->

