### PR TITLE
Remove debug logging and comment out console statements

### DIFF
--- a/core/nextEdit/NextEditLoggingService.ts
+++ b/core/nextEdit/NextEditLoggingService.ts
@@ -246,7 +246,8 @@ export class NextEditLoggingService {
           }),
         },
       );
-      console.debug("Feedback: ", resp);
+      const text = await resp.text();
+      console.debug("Feedback: ", text);
     } catch (error: any) {
       console.debug(`Error capturing feedback: ${error.message}`);
     }

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "1.3.15",
+  "version": "1.3.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "1.3.15",
+      "version": "1.3.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "file:../../packages/config-types",

--- a/extensions/vscode/src/activation/SelectionChangeManager.ts
+++ b/extensions/vscode/src/activation/SelectionChangeManager.ts
@@ -330,9 +330,9 @@ export class SelectionChangeManager {
       return false;
     }
 
-    console.debug(
-      "defaultFallbackHandler: deleteChain called from onDidChangeTextEditorSelection",
-    );
+    // console.debug(
+    //   "defaultFallbackHandler: deleteChain called from onDidChangeTextEditorSelection",
+    // );
     await NextEditProvider.getInstance().deleteChain();
 
     if (!this.usingFullFileDiff) {

--- a/extensions/vscode/src/autocomplete/completionProvider.ts
+++ b/extensions/vscode/src/autocomplete/completionProvider.ts
@@ -333,7 +333,7 @@ export class ContinueCompletionProvider
       let chainExists = this.nextEditProvider.chainExists();
       const processedCount = this.prefetchQueue.processedCount;
       const unprocessedCount = this.prefetchQueue.unprocessedCount;
-      console.debug("isJumping:", isJumping, "/ chainExists:", chainExists);
+      // console.debug("isJumping:", isJumping, "/ chainExists:", chainExists);
       this.prefetchQueue.peekThreeProcessed();
 
       let resetChainInFullFileDiff = false;
@@ -351,7 +351,7 @@ export class ContinueCompletionProvider
 
       if (isJumping && chainExists) {
         // Case 2: Jumping (chain exists, jump was taken)
-        console.debug("trigger reason: jumping");
+        // console.debug("trigger reason: jumping");
 
         // Reset jump state.
         this.jumpManager.setJumpInProgress(false);
@@ -380,7 +380,7 @@ export class ContinueCompletionProvider
         }
       } else if (chainExists) {
         // Case 3: Accepting next edit outcome (chain exists, jump is not taken).
-        console.debug("trigger reason: accepting");
+        // console.debug("trigger reason: accepting");
 
         // Try suggesting jump for each location.
         let isJumpSuggested = false;
@@ -428,9 +428,9 @@ export class ContinueCompletionProvider
         }
 
         if (!isJumpSuggested) {
-          console.debug(
-            "No suitable jump location found after trying all positions",
-          );
+          // console.debug(
+          //   "No suitable jump location found after trying all positions",
+          // );
           this.nextEditProvider.deleteChain();
           return undefined;
         }
@@ -642,7 +642,7 @@ export class ContinueCompletionProvider
 
       if (isFim) {
         if (!fimText) {
-          console.debug("deleteChain from completionProvider.ts: !fimText");
+          // console.debug("deleteChain from completionProvider.ts: !fimText");
           this.nextEditProvider.deleteChain();
           return undefined;
         }
@@ -679,9 +679,9 @@ export class ContinueCompletionProvider
         // Only time we ever reach this point would be after the jump was taken, or if its after the very first repsonse.
         // In case of jump, this is impossible, as the JumpManager wouldn't have suggested a jump here in the first place.
         // In case of initial response, we suggested a jump.
-        console.debug(
-          "deleteChain from completionProvider.ts: diffLines.length === 0",
-        );
+        // console.debug(
+        //   "deleteChain from completionProvider.ts: diffLines.length === 0",
+        // );
         NextEditProvider.getInstance().deleteChain();
       }
 
@@ -718,10 +718,10 @@ export class ContinueCompletionProvider
     if (selectedCompletionInfo) {
       const { text, range } = selectedCompletionInfo;
       if (!outcome.completion.startsWith(text)) {
-        console.debug(
-          `Won't display completion because text doesn't match: ${text}, ${outcome.completion}`,
-          range,
-        );
+        // console.debug(
+        //   `Won't display completion because text doesn't match: ${text}, ${outcome.completion}`,
+        //   range,
+        // );
         return false;
       }
     }

--- a/extensions/vscode/src/extension/VsCodeExtension.ts
+++ b/extensions/vscode/src/extension/VsCodeExtension.ts
@@ -234,9 +234,9 @@ export class VsCodeExtension {
           timeSinceLastDocChange < this.ARBITRARY_TYPING_DELAY &&
           !NextEditWindowManager.getInstance().hasAccepted()
         ) {
-          console.debug(
-            "VsCodeExtension: typing in progress, preserving chain",
-          );
+          // console.debug(
+          //   "VsCodeExtension: typing in progress, preserving chain",
+          // );
           return true;
         }
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Reduce noisy debug logging in the VS Code extension by commenting out console.debug calls and making feedback logging clearer. This cleans up the console without changing behavior.

- **Refactors**
  - Commented out debug logs in SelectionChangeManager, completionProvider, and VsCodeExtension.
  - Log feedback response text instead of the Response object in NextEditLoggingService.
  - Bumped extension version in package-lock.json to 1.3.16.

<!-- End of auto-generated description by cubic. -->

