### PR TITLE
fix: HOTFIX prevent active file sending on click

### DIFF
--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -223,7 +223,7 @@ function InputToolbar(props: InputToolbarProps) {
                     useCodebase: false,
                     noContext: useActiveFile
                       ? isMetaEquivalentKeyPressed(e as any) || e.altKey
-                      : !isMetaEquivalentKeyPressed(e as any) || e.altKey,
+                      : !(isMetaEquivalentKeyPressed(e as any) || e.altKey),
                   });
                 }
               }}


### PR DESCRIPTION
## Description

Fix the active file sending logic when clicking on the send button.

closes https://github.com/continuedev/continue/issues/7941
resolves CON-4195

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

https://github.com/user-attachments/assets/baabddef-9020-4ffa-8fd6-f309f560cc13





https://github.com/user-attachments/assets/d350de51-3c5d-454f-a346-c7d6a2f529dd


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the send button so clicking it no longer unintentionally includes the active file. Behavior now respects the active file toggle and modifier keys, aligning with CON-4195.

- **Bug Fixes**
  - Corrected noContext calculation in InputToolbar to handle click + Meta/Alt states and prevent accidental active file context.

<!-- End of auto-generated description by cubic. -->

