### PR TITLE
Add isSignedIn to config reload telemetry

### DIFF
--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -537,6 +537,7 @@ export class ConfigHandler {
     // Track config loading telemetry
     const endTime = performance.now();
     const duration = endTime - startTime;
+    const isSignedIn = await this.controlPlaneClient.isSignedIn();
 
     const profileDescription = this.currentProfile.profileDescription;
     const telemetryData: Record<string, any> = {
@@ -547,6 +548,7 @@ export class ConfigHandler {
       profileType: profileDescription.profileType,
       isPersonalOrg: this.currentOrg?.id === this.PERSONAL_ORG_DESC.id,
       errorCount: errors.length,
+      isSignedIn,
     };
 
     void Telemetry.capture("config_reload", telemetryData);


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added isSignedIn to config_reload telemetry to capture whether the user is signed in during config reloads. This helps segment reload duration and error rates by auth state.

<!-- End of auto-generated description by cubic. -->

