### PR TITLE
Bump version to 1.3.17

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Bump VS Code extension version to 1.3.17 to publish a patch release. No functional changes.

<!-- End of auto-generated description by cubic. -->

