### PR TITLE
fix: only log sentry errors on reload not load

### DIFF
--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -553,6 +553,10 @@ export class ConfigHandler {
 
     void Telemetry.capture("config_reload", telemetryData);
 
+    if (errors.length) {
+      Logger.error("Errors loading config: ", errors);
+    }
+
     return {
       config,
       errors: errors.length ? errors : undefined,
@@ -603,10 +607,6 @@ export class ConfigHandler {
     const config = await this.currentProfile.loadConfig(
       this.additionalContextProviders,
     );
-
-    if (config.errors?.length) {
-      Logger.error("Errors loading config: ", config.errors);
-    }
     return config;
   }
 


### PR DESCRIPTION
## Description
Load is more like `get` config, was spamming terminals
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Log config errors only during reload to avoid terminal spam during normal config loads. Load stays a quiet "get" operation, while reload surfaces issues when present.

- **Bug Fixes**
  - Removed error logging from loadConfig.
  - Added error logging in reload when errors exist.

<!-- End of auto-generated description by cubic. -->

