### PR TITLE
feat: report cache write tokens from anthropic oai adapter

### DIFF
--- a/packages/openai-adapters/src/apis/Anthropic.ts
+++ b/packages/openai-adapters/src/apis/Anthropic.ts
@@ -322,7 +322,9 @@ export class AnthropicApi implements BaseLlmApi {
         prompt_tokens: usage?.input_tokens ?? 0,
         prompt_tokens_details: {
           cached_tokens: usage?.cache_read_input_tokens ?? 0,
-        },
+          cache_read_tokens: usage?.cache_read_input_tokens ?? 0,
+          cache_write_tokens: usage?.cache_creation_input_tokens ?? 0,
+        } as any,
       },
       choices: [
         {


### PR DESCRIPTION
## Description

feat: report cache write tokens from anthropic oai adapter
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add cache write and read token reporting to the Anthropic OpenAI adapter for more accurate usage metrics.

- **New Features**
  - Added prompt_tokens_details.cache_write_tokens from usage.cache_creation_input_tokens.
  - Added prompt_tokens_details.cache_read_tokens (keeps cached_tokens for backward compatibility).

<!-- End of auto-generated description by cubic. -->

