### PR TITLE
Fix tool call arguments initialization and validation to use empty object instead of null

### DIFF
--- a/extensions/cli/src/stream/streamChatResponse.helpers.ts
+++ b/extensions/cli/src/stream/streamChatResponse.helpers.ts
@@ -226,7 +226,7 @@ export function processToolCallDelta(
     toolCallsMap.set(toolCallId, {
       id: toolCallId,
       name: "",
-      arguments: null,
+      arguments: {},
       argumentsStr: "",
       startNotified: false,
     });

--- a/extensions/cli/src/stream/streamChatResponse.ts
+++ b/extensions/cli/src/stream/streamChatResponse.ts
@@ -299,7 +299,7 @@ export async function processStreamingResponse(
 
   // Validate tool calls have complete arguments
   const validToolCalls = toolCalls.filter((tc) => {
-    if (!tc.arguments || !tc.name) {
+    if (!tc.name) {
       logger.error("Incomplete tool call", {
         id: tc.id,
         name: tc.name,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Initialize tool call arguments as {} and validate only by name to prevent false “Incomplete tool call” errors and dropped tool calls during streaming.

- **Bug Fixes**
  - Default tool call arguments to {} in processToolCallDelta for safe incremental merges.
  - Validate tool calls by name only in processStreamingResponse, allowing partial arguments until complete.

<!-- End of auto-generated description by cubic. -->

