### PR TITLE
fix: HOTFIX stop thinking animation if cancelled mid stream

### DIFF
--- a/gui/src/pages/gui/Chat.tsx
+++ b/gui/src/pages/gui/Chat.tsx
@@ -328,7 +328,7 @@ export function Chat() {
               redactedThinking={message.redactedThinking}
               index={index}
               prevItem={index > 0 ? history[index - 1] : null}
-              inProgress={index === history.length - 1}
+              inProgress={index === history.length - 1 && isStreaming}
               signature={message.signature}
             />
           </div>
@@ -356,7 +356,7 @@ export function Chat() {
         </div>
       );
     },
-    [sendInput, isLastUserInput, history, stepsOpen],
+    [sendInput, isLastUserInput, history, stepsOpen, isStreaming],
   );
 
   const showScrollbar = showChatScrollbar ?? window.innerHeight > 5000;


### PR DESCRIPTION
If streaming was canceled mid-think, it kept blinking the 3 dots with "thinking". Simple fix on second commit


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the "thinking" indicator so it stops when a stream is canceled. The last message is only marked in progress while isStreaming is true, preventing the dots from blinking after cancellation.

- **Bug Fixes**
  - Tie inProgress to isStreaming and add isStreaming to useMemo deps for correct re-render on cancel.

<!-- End of auto-generated description by cubic. -->

