### PR TITLE
fix: check key type for onboarding modal

### DIFF
--- a/core/config/usesFreeTrialApiKey.ts
+++ b/core/config/usesFreeTrialApiKey.ts
@@ -29,6 +29,31 @@ export function usesCreditsBasedApiKey(
   return false;
 }
 
+/**
+ * Helper function to determine if the config uses specifically a free trial API key (not models add-on)
+ * @param config The serialized config object
+ * @returns true if the config is using any free trial models
+ */
+export function usesFreeTrialApiKey(
+  config: BrowserSerializedContinueConfig | null,
+): boolean {
+  if (!config) {
+    return false;
+  }
+
+  const modelsByRole = config.modelsByRole;
+  const allModels = [...Object.values(modelsByRole)].flat();
+
+  try {
+    const hasFreeTrial = allModels?.some(modelUsesFreeTrialApiKey);
+    return hasFreeTrial;
+  } catch (e) {
+    console.error("Error checking for free trial API key:", e);
+  }
+
+  return false;
+}
+
 const modelUsesCreditsBasedApiKey = (model: ModelDescription) => {
   if (!model.apiKeyLocation) {
     return false;
@@ -39,4 +64,14 @@ const modelUsesCreditsBasedApiKey = (model: ModelDescription) => {
   return (
     secretType === SecretType.FreeTrial || secretType === SecretType.ModelsAddOn
   );
+};
+
+const modelUsesFreeTrialApiKey = (model: ModelDescription) => {
+  if (!model.apiKeyLocation) {
+    return false;
+  }
+
+  const secretType = decodeSecretLocation(model.apiKeyLocation).secretType;
+
+  return secretType === SecretType.FreeTrial;
 };

--- a/core/llm/streamChat.ts
+++ b/core/llm/streamChat.ts
@@ -1,7 +1,7 @@
 import { fetchwithRequestOptions } from "@continuedev/fetch";
 import { ChatMessage, IDE, PromptLog } from "..";
 import { ConfigHandler } from "../config/ConfigHandler";
-import { usesCreditsBasedApiKey } from "../config/usesFreeTrialApiKey";
+import { usesFreeTrialApiKey } from "../config/usesFreeTrialApiKey";
 import { FromCoreProtocol, ToCoreProtocol } from "../protocol";
 import { IMessenger, Message } from "../protocol/messenger";
 import { Telemetry } from "../util/posthog";
@@ -178,7 +178,7 @@ async function checkForOutOfStarterCredits(
     if (
       config &&
       creditStatus &&
-      isOutOfStarterCredits(usesCreditsBasedApiKey(config), creditStatus)
+      isOutOfStarterCredits(usesFreeTrialApiKey(config), creditStatus)
     ) {
       void messenger.request("freeTrialExceeded", undefined);
     }

--- a/core/llm/utils/starterCredits.ts
+++ b/core/llm/utils/starterCredits.ts
@@ -1,11 +1,11 @@
 import { CreditStatus } from "../../control-plane/client";
 
 export function isOutOfStarterCredits(
-  usingModelsAddOnApiKey: boolean,
+  usingFreeTrialApiKey: boolean,
   creditStatus: CreditStatus,
 ): boolean {
   return (
-    usingModelsAddOnApiKey &&
+    usingFreeTrialApiKey &&
     !creditStatus.hasCredits &&
     !creditStatus.hasPurchasedCredits
   );

--- a/gui/src/hooks/useCredits.ts
+++ b/gui/src/hooks/useCredits.ts
@@ -1,4 +1,7 @@
-import { usesCreditsBasedApiKey } from "core/config/usesFreeTrialApiKey";
+import {
+  usesCreditsBasedApiKey,
+  usesFreeTrialApiKey,
+} from "core/config/usesFreeTrialApiKey";
 import { CreditStatus } from "core/control-plane/client";
 import { isOutOfStarterCredits } from "core/llm/utils/starterCredits";
 import { useCallback, useContext, useEffect, useState } from "react";
@@ -13,9 +16,10 @@ export function useCreditStatus() {
 
   const hasExitedFreeTrial = getLocalStorage("hasExitedFreeTrial");
   const usingCreditsBasedApiKey = usesCreditsBasedApiKey(config);
+  const usingFreeTrialApiKey = usesFreeTrialApiKey(config);
   const isUsingFreeTrial = usingCreditsBasedApiKey && !hasExitedFreeTrial;
   const outOfStarterCredits = creditStatus
-    ? isOutOfStarterCredits(usingCreditsBasedApiKey, creditStatus)
+    ? isOutOfStarterCredits(usingFreeTrialApiKey, creditStatus)
     : false;
 
   const refreshCreditStatus = useCallback(async () => {


### PR DESCRIPTION
## Description

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the onboarding modal trigger by correctly detecting free trial API keys vs models add-on, so the “out of starter credits” modal only shows for true free trial users.

- **Bug Fixes**
  - Added usesFreeTrialApiKey to identify free trial keys via secret type.
  - Updated isOutOfStarterCredits to use the free trial key check.
  - Switched streamChat and useCredits to the new check to prevent false triggers for models add-on users.

<!-- End of auto-generated description by cubic. -->

