### PR TITLE
fix: only show free trial dialog for freetrial secrettype

### DIFF
--- a/core/config/usesFreeTrialApiKey.ts
+++ b/core/config/usesFreeTrialApiKey.ts
@@ -36,7 +36,5 @@ const modelUsesCreditsBasedApiKey = (model: ModelDescription) => {
 
   const secretType = decodeSecretLocation(model.apiKeyLocation).secretType;
 
-  return (
-    secretType === SecretType.FreeTrial || secretType === SecretType.ModelsAddOn
-  );
+  return secretType === SecretType.FreeTrial;
 };


### PR DESCRIPTION
## Description

The free trial popup keeps showing up even when using organization's models. This PR fixes by only checking for the free trial secret type.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

https://github.com/user-attachments/assets/6004bf76-14c6-483a-9cc7-f317c5eb1441



https://github.com/user-attachments/assets/85e7621f-ec57-4c8a-89c8-814b0692b128



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Show the free trial dialog only for the FreeTrial secret type. This prevents the popup when using org models or Models Add-On keys.

<!-- End of auto-generated description by cubic. -->

