### PR TITLE
docs: added the fastapply model to the recommendations

### DIFF
--- a/docs/snippets/ModelRecommendations.jsx
+++ b/docs/snippets/ModelRecommendations.jsx
@@ -88,12 +88,14 @@ export const ModelRecommendations = ({ role = "all" }) => {
       notes: "Closed models are slightly better than open models",
     },
     apply: {
-      open: ["N/A"],
+      open: [
+        "[FastApply](https://hub.continue.dev/mdpauley/fast-apply-15b-v10)",
+      ],
       closed: [
         "[Relace Instant Apply](https://hub.continue.dev/relace/instant-apply)",
         "[Morph Fast Apply](https://hub.continue.dev/morphllm/morph-v2)",
       ],
-      notes: "Open models are not good enough for this model role",
+      notes: "Closed models are better than open models",
     },
     embed: {
       open: [


### PR DESCRIPTION
## Description
I added the FastApply model to the Apply recommendations in the continue docs. Based on #7852 there was no open source model for Apply actions. So, I added it to the docs. 

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

<img width="1546" height="741" alt="image" src="https://github.com/user-attachments/assets/25962bc3-ed6b-459c-9ace-003cf294a146" />
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added FastApply to the Apply model recommendations in the docs to provide an open-source option for Apply actions. Updated the note to clarify that closed models perform better than open models for this role.

<!-- End of auto-generated description by cubic. -->

