### PR TITLE
hotfix(autocomplete): remove mercury model special handling and adjust code block extraction

### DIFF
--- a/core/autocomplete/postprocessing/index.ts
+++ b/core/autocomplete/postprocessing/index.ts
@@ -150,7 +150,7 @@ export function postprocessCompletion({
     completion = completion.replace(/^\n+|\n+$/g, "");
   }
 
-  if (llm.model.includes("mercury") || llm.model.includes("granite")) {
+  if (llm.model.includes("granite")) {
     // Granite tends to repeat the start of the line in the completion output
     let prefixEnd = prefix.split("\n").pop();
     if (prefixEnd) {

--- a/core/nextEdit/providers/MercuryCoderNextEditProvider.ts
+++ b/core/nextEdit/providers/MercuryCoderNextEditProvider.ts
@@ -43,7 +43,7 @@ export class MercuryCoderProvider extends BaseNextEditModelProvider {
     // Extract the code between the markdown code blocks.
     return message.slice(
       message.indexOf("```\n") + "```\n".length,
-      message.lastIndexOf("\n\n```"),
+      message.lastIndexOf("\n```"),
     );
   }
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removes Mercury-specific autocomplete postprocessing and fixes code fence parsing so Mercury code blocks are extracted correctly. Improves completion accuracy for Mercury outputs.

- **Bug Fixes**
  - Limit repeated-line trimming to Granite models; remove Mercury special case.
  - Extract code up to the last "\n```" (not "\n\n```") to handle single-newline fences and avoid truncation.

<!-- End of auto-generated description by cubic. -->

