### PR TITLE
docs: added the link to open router models instead of inception

### DIFF
--- a/docs/customize/model-providers/top-level/openrouter.mdx
+++ b/docs/customize/model-providers/top-level/openrouter.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "OpenRouter"
 ---
 
 <Tip>
-  **Discover Inception models [here](https://hub.continue.dev/inceptionlabs)**
+  **Discover OpenRouter models [here](https://hub.continue.dev/openrouter)**
 </Tip>
 
 <Info>


### PR DESCRIPTION
## Description

Fixed the copy and paste error in #7794  

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

<img width="1299" height="691" alt="image" src="https://github.com/user-attachments/assets/1aa6cc59-e3a1-4fb4-aee9-4654bc72a588" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the OpenRouter provider docs to link to the correct OpenRouter models page instead of the Inception page, so users can find the right models.

<!-- End of auto-generated description by cubic. -->

