### PR TITLE
fix: clicking on enter button not working after streaming

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor/TipTapEditor.tsx
@@ -57,7 +57,7 @@ function TipTapEditorInner(props: TipTapEditorProps) {
   const historyLength = useAppSelector((store) => store.session.history.length);
   const isInEdit = useAppSelector((store) => store.session.isInEdit);
 
-  const { editor, onEnterRef } = createEditorConfig({
+  const { editor, onEnter } = createEditorConfig({
     props,
     ideMessenger,
     dispatch,
@@ -68,9 +68,16 @@ function TipTapEditorInner(props: TipTapEditorProps) {
     if (props.isMainInput && editor) {
       mainEditorContext.setMainEditor(editor);
       mainEditorContext.setInputId(props.inputId);
-      mainEditorContext.onEnterRef.current = onEnterRef.current;
+      mainEditorContext.onEnterRef.current = onEnter;
     }
-  }, [editor, props.isMainInput, props.inputId, mainEditorContext, onEnterRef]);
+  }, [
+    editor,
+    props.isMainInput,
+    props.inputId,
+    mainEditorContext,
+    onEnter,
+    isStreaming,
+  ]);
 
   const [shouldHideToolbar, setShouldHideToolbar] = useState(true);
 
@@ -272,7 +279,7 @@ function TipTapEditorInner(props: TipTapEditorProps) {
           activeKey={activeKey}
           hidden={shouldHideToolbar && !props.isMainInput}
           onAddContextItem={() => insertCharacterWithWhitespace("@")}
-          onEnter={onEnterRef.current}
+          onEnter={onEnter}
           onImageFileSelected={(file) => {
             void handleImageFile(ideMessenger, file).then((result) => {
               if (!editor) {

--- a/gui/src/components/mainInput/TipTapEditor/utils/editorConfig.ts
+++ b/gui/src/components/mainInput/TipTapEditor/utils/editorConfig.ts
@@ -200,7 +200,7 @@ export function createEditorConfig(options: {
                 return false;
               }
 
-              onEnterRef.current({
+              onEnter({
                 useCodebase: false,
                 noContext: !useActiveFile,
               });
@@ -210,7 +210,7 @@ export function createEditorConfig(options: {
             "Mod-Enter": () => {
               posthog.capture("gui_use_active_file_enter");
 
-              onEnterRef.current({
+              onEnter({
                 useCodebase: false,
                 noContext: !!useActiveFile,
               });
@@ -220,7 +220,7 @@ export function createEditorConfig(options: {
             "Alt-Enter": () => {
               posthog.capture("gui_use_active_file_enter");
 
-              onEnterRef.current({
+              onEnter({
                 useCodebase: false,
                 noContext: !!useActiveFile,
               });
@@ -346,30 +346,27 @@ export function createEditorConfig(options: {
     editable: !isStreaming || props.isMainInput,
   });
 
-  const onEnterRef = useUpdatingRef(
-    (modifiers: InputModifiers) => {
-      if (!editor) {
-        return;
-      }
-      if (isStreaming || (codeToEdit.length === 0 && isInEdit)) {
-        return;
-      }
+  const onEnter = (modifiers: InputModifiers) => {
+    if (!editor) {
+      return;
+    }
+    if (isStreaming || (codeToEdit.length === 0 && isInEdit)) {
+      return;
+    }
 
-      const json = editor.getJSON();
+    const json = editor.getJSON();
 
-      // Don't do anything if input box doesn't have valid content
-      if (!hasValidEditorContent(json)) {
-        return;
-      }
+    // Don't do anything if input box doesn't have valid content
+    if (!hasValidEditorContent(json)) {
+      return;
+    }
 
-      if (props.isMainInput) {
-        addRef.current(json);
-      }
+    if (props.isMainInput) {
+      addRef.current(json);
+    }
 
-      props.onEnter(json, modifiers, editor);
-    },
-    [props.onEnter, editor, props.isMainInput, codeToEdit, isInEdit],
-  );
+    props.onEnter(json, modifiers, editor);
+  };
 
-  return { editor, onEnterRef };
+  return { editor, onEnter };
 }


### PR DESCRIPTION
## Description

When clicking on the send enter button in the chat input, it prevents sending the input because `isStreaming` is true in the [inner MainEditorProvider's ref](https://github.com/continuedev/continue/blob/698ad370081802647b51cba2d9c714276819d715/gui/src/components/mainInput/TipTapEditor/MainEditorProvider.tsx/#L51). This PR fixes it.

closes https://github.com/continuedev/continue/issues/8203

resolves CON-4375

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

https://github.com/user-attachments/assets/c8c698ab-fbac-4a12-8038-caae3b2a1eb7

https://github.com/user-attachments/assets/a964e13b-fee6-4af2-9c2d-61a260dac466




## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the chat input send button and Enter shortcuts not working after a streamed response by using a stable onEnter handler instead of a ref. Resolves CON-4375.

- **Bug Fixes**
  - Replaced onEnterRef with onEnter across editorConfig and TipTapEditor.
  - Hooked toolbar and keyboard shortcuts (Enter, Mod-Enter, Alt-Enter) to onEnter.
  - Updated main editor context to use onEnter and added isStreaming to dependencies to avoid stale state.

<!-- End of auto-generated description by cubic. -->

