### PR TITLE
fix: use 0600 permissions on config.yaml

### DIFF
--- a/core/util/paths.ts
+++ b/core/util/paths.ts
@@ -14,6 +14,16 @@ import Types from "../config/types";
 
 dotenv.config();
 
+export function setConfigFilePermissions(filePath: string): void {
+  try {
+    if (os.platform() !== "win32") {
+      fs.chmodSync(filePath, 0o600);
+    }
+  } catch (error) {
+    console.warn(`Failed to set permissions on ${filePath}:`, error);
+  }
+}
+
 const CONTINUE_GLOBAL_DIR = (() => {
   const configPath = process.env.CONTINUE_GLOBAL_DIR;
   if (configPath) {
@@ -113,10 +123,11 @@ export function getConfigYamlPath(ideType?: IdeType): string {
       // https://github.com/continuedev/continue/pull/7224
       // This was here because we had different context provider support between jetbrains and vs code
       // Leaving so we could differentiate later but for now configs are the same between IDEs
-      fs.writeFileSync(p, YAML.stringify(defaultConfig), { mode: 0o600 });
+      fs.writeFileSync(p, YAML.stringify(defaultConfig));
     } else {
-      fs.writeFileSync(p, YAML.stringify(defaultConfig), { mode: 0o600 });
+      fs.writeFileSync(p, YAML.stringify(defaultConfig));
     }
+    setConfigFilePermissions(p);
   }
   return p;
 }
@@ -261,7 +272,8 @@ function editConfigYaml(callback: (config: ConfigYaml) => ConfigYaml): void {
   // Check if it's an object
   if (typeof configYaml === "object" && configYaml !== null) {
     configYaml = callback(configYaml as any) as any;
-    fs.writeFileSync(configPath, YAML.stringify(configYaml), { mode: 0o600 });
+    fs.writeFileSync(configPath, YAML.stringify(configYaml));
+    setConfigFilePermissions(configPath);
   } else {
     console.warn("config.yaml is not a valid object");
   }

--- a/extensions/cli/src/freeTrialTransition.ts
+++ b/extensions/cli/src/freeTrialTransition.ts
@@ -3,6 +3,7 @@ import * as fs from "fs";
 import * as path from "path";
 
 import chalk from "chalk";
+import { setConfigFilePermissions } from "core/util/paths.js";
 import open from "open";
 
 import { env } from "./env.js";
@@ -31,7 +32,8 @@ async function createOrUpdateConfig(apiKey: string): Promise<void> {
     : "";
 
   const updatedContent = updateAnthropicModelInYaml(existingContent, apiKey);
-  fs.writeFileSync(CONFIG_PATH, updatedContent, { mode: 0o600 });
+  fs.writeFileSync(CONFIG_PATH, updatedContent);
+  setConfigFilePermissions(CONFIG_PATH);
 }
 
 /**

--- a/extensions/cli/src/onboarding.ts
+++ b/extensions/cli/src/onboarding.ts
@@ -2,6 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 
 import chalk from "chalk";
+import { setConfigFilePermissions } from "core/util/paths.js";
 
 import { AuthConfig, login } from "./auth/workos.js";
 import { getApiClient } from "./config.js";
@@ -43,7 +44,8 @@ export async function createOrUpdateConfig(apiKey: string): Promise<void> {
     : "";
 
   const updatedContent = updateAnthropicModelInYaml(existingContent, apiKey);
-  fs.writeFileSync(CONFIG_PATH, updatedContent, { mode: 0o600 });
+  fs.writeFileSync(CONFIG_PATH, updatedContent);
+  setConfigFilePermissions(CONFIG_PATH);
 }
 
 export async function runOnboardingFlow(

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -8,16 +8,20 @@ import { EXTENSION_NAME } from "core/control-plane/env";
 import { Core } from "core/core";
 import { walkDirAsync } from "core/indexing/walkDir";
 import { isModelInstaller } from "core/llm";
+import { NextEditLoggingService } from "core/nextEdit/NextEditLoggingService";
 import { startLocalLemonade } from "core/util/lemonadeHelper";
 import { startLocalOllama } from "core/util/ollamaHelper";
-import { getConfigJsonPath, getConfigYamlPath } from "core/util/paths";
+import {
+  getConfigJsonPath,
+  getConfigYamlPath,
+  setConfigFilePermissions,
+} from "core/util/paths";
 import { Telemetry } from "core/util/posthog";
 import * as vscode from "vscode";
 import * as YAML from "yaml";
 
 import { convertJsonToYamlConfig } from "../../../packages/config-yaml/dist";
 
-import { NextEditLoggingService } from "core/nextEdit/NextEditLoggingService";
 import {
   getAutocompleteStatusBarDescription,
   getAutocompleteStatusBarTitle,
@@ -715,9 +719,8 @@ const getCommandsMap: (
       const configYaml = convertJsonToYamlConfig(parsed);
 
       const configYamlPath = getConfigYamlPath();
-      fs.writeFileSync(configYamlPath, YAML.stringify(configYaml), {
-        mode: 0o600,
-      });
+      fs.writeFileSync(configYamlPath, YAML.stringify(configYaml));
+      setConfigFilePermissions(configYamlPath);
 
       // Open config.yaml
       await openEditorAndRevealRange(


### PR DESCRIPTION
## Description

Add 0600 file permission (only owner can read and write) to config.yaml when creating a new one or updating it (in both cli and extension).

closes CON-4236

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Set config.yaml to 0600 on creation and updates across core, CLI, and VS Code so only the owner can read/write. Meets Linear issue CON-4236.

- **Bug Fixes**
  - core/util/paths.ts: apply mode 0o600 when creating default config and when editing YAML.
  - CLI (onboarding, freeTrialTransition): write updated config with 0o600.
  - VS Code commands: save generated YAML config with 0o600.

<!-- End of auto-generated description by cubic. -->

