### PR TITLE
Add daily Snyk security scan workflow with Continue CLI agent

### DIFF
--- a/.github/workflows/snyk-agent.yaml
+++ b/.github/workflows/snyk-agent.yaml
@@ -25,6 +25,6 @@ jobs:
         run: npm install -g @continuedev/cli@latest
 
       - name: Run Snyk Agent
-        run: cd extensions/cli && cn --agent continuedev/snyk-code-scan-agent "The current directory"
+        run: cd extensions/cli && cn -p --agent continuedev/snyk-code-scan-agent "The current directory"
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a scheduled GitHub Actions workflow to run daily Snyk Code scans using the Continue CLI agent at 9:00 AM UTC. Supports manual runs via workflow_dispatch.

- **New Features**
  - Runs continuedev/snyk-code-scan-agent against the extensions/cli directory.
  - Installs @continuedev/cli and uses Node.js 20.
  - Uses SNYK_TOKEN from repo secrets.

- **Migration**
  - Add SNYK_TOKEN to repository secrets before merging.

<!-- End of auto-generated description by cubic. -->

