### PR TITLE
Add CONTINUE_API_KEY to snyk-agent workflow environment

### DIFF
--- a/.github/workflows/snyk-agent.yaml
+++ b/.github/workflows/snyk-agent.yaml
@@ -28,3 +28,4 @@ jobs:
         run: cd extensions/cli && cn -p --agent continuedev/snyk-code-scan-agent "The current directory"
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          CONTINUE_API_KEY: ${{ secrets.CONTINUE_API_KEY }}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add CONTINUE_API_KEY to the snyk-agent workflow so continuedev/snyk-code-scan-agent can authenticate with Continue and run successfully. Prevents scan failures caused by a missing API key.

<!-- End of auto-generated description by cubic. -->

