### PR TITLE
fix(cli): exit after printing response when using -p

### DIFF
--- a/extensions/cli/src/commands/chat.ts
+++ b/extensions/cli/src/commands/chat.ts
@@ -521,6 +521,9 @@ async function runHeadlessMode(
       compactionIndex = result.compactionIndex;
     }
   }
+
+  // exit after headless mode completes
+  await gracefulExit(0);
 }
 
 export async function chat(prompt?: string, options: ChatOptions = {}) {


### PR DESCRIPTION
## Description

When using the -p mode, the cli was not exiting. This PR adds a graceful exit.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot


https://github.com/user-attachments/assets/cce29116-f827-4da0-bf1d-8e22fa7c953f



https://github.com/user-attachments/assets/6c2803e3-a3e1-4bb2-a8b2-df7b5710cb6b



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes CLI print mode (-p) so the process exits after printing the response, preventing hangs in scripts and CI.

- **Bug Fixes**
  - Call gracefulExit(0) after headless mode completes in extensions/cli/src/commands/chat.ts.

<!-- End of auto-generated description by cubic. -->

