### PR TITLE
Revert workflow trigger branch to main

### DIFF
--- a/.github/workflows/continue-general-review.yaml
+++ b/.github/workflows/continue-general-review.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - nate/fix-continue-review-workflow-branch
   pull_request:
     types: [opened, ready_for_review]
   issue_comment:


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switched the Continue General Review workflow to trigger on pushes to main instead of a temporary branch. Restores normal review automation on the default branch.

<!-- End of auto-generated description by cubic. -->

