### PR TITLE
fix: agent -> config for actions

### DIFF
--- a/.github/workflows/run-continue-agent.yml
+++ b/.github/workflows/run-continue-agent.yml
@@ -7,8 +7,8 @@ on:
         description: "The prompt to send to the Continue agent"
         required: true
         type: string
-      agent:
-        description: "The agent to use (e.g., continuedev/default-background-agent)"
+      config:
+        description: "The config to use (e.g., continuedev/default-background-agent)"
         required: false
         type: string
         default: "continuedev/default-background-agent"
@@ -33,7 +33,7 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.CONTINUE_API_KEY }}" \
             -d '{
               "prompt": "${{ inputs.prompt }}",
-              "agent": "${{ inputs.agent }}",
+              "config": "${{ inputs.config }}",
               "branchName": "${{ inputs.branch_name }}",
               "repoUrl": "https://github.com/${{ github.repository }}"
             }')

--- a/.github/workflows/tidy-up-codebase.yml
+++ b/.github/workflows/tidy-up-codebase.yml
@@ -11,7 +11,7 @@ jobs:
     uses: ./.github/workflows/run-continue-agent.yml
     with:
       prompt: "Review every Markdown documentation file and verify that descriptions, examples, or behavior outlines accurately reflect the current code. Only update documentation; do not modify code. Check the corresponding code to confirm behavior before making changes. Correct any inaccuracies or outdated information in descriptions, examples, or behavior outlines. Preserve existing Markdown formatting, style, and structure. Do not add new sections, speculative explanations, or details not present in the code. Only update statements that are clearly incorrect or misleading; do not rewrite text for style or preference. Keep edits minimal and focused, ensuring that the Markdown matches what the code actually does. If verification against the code is ambiguous, leave the documentation unchanged. Use branch name bot/cleanup-<YYMMDD>-<HHMM>"
-      agent: continuedev/default-background-agent
+      config: continuedev/default-background-agent
       branch_name: main
     secrets:
       CONTINUE_API_KEY: ${{ secrets.CONTINUE_API_KEY }}


### PR DESCRIPTION
## Description
Will change back to agent when we move from config to agent for default
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switch GitHub workflows from using the agent parameter to config when calling the Continue API, matching the current API and preventing failed runs.

- **Bug Fixes**
  - Rename workflow input from agent to config in run-continue-agent.yml.
  - Send config in the POST payload instead of agent.
  - Update tidy-up-codebase.yml to pass config.

<!-- End of auto-generated description by cubic. -->

