### PR TITLE
Rename continue-config input to continue-agent and update CLI version to latest

### DIFF
--- a/.github/workflows/continue-general-review.yaml
+++ b/.github/workflows/continue-general-review.yaml
@@ -25,4 +25,4 @@ jobs:
         with:
           continue-api-key: ${{ secrets.CONTINUE_API_KEY }}
           continue-org: "continuedev"
-          continue-config: "continuedev/review-bot"
+          continue-config: "continuedev/empty-agent"

--- a/actions/general-review/action.yml
+++ b/actions/general-review/action.yml
@@ -9,8 +9,8 @@ inputs:
   continue-org:
     description: "Organization for Continue config"
     required: true
-  continue-config:
-    description: 'Config path to use (e.g., "myorg/review-bot")'
+  continue-agent:
+    description: 'Agent path to use (e.g., "myorg/review-bot")'
     required: true
 
 runs:
@@ -113,7 +113,7 @@ runs:
     - name: Install Continue CLI
       if: env.SHOULD_RUN == 'true'
       shell: bash
-      run: npm install -g @continuedev/cli@1.4.30
+      run: npm install -g @continuedev/cli@latest
 
     - name: Post Initial Comment
       if: env.SHOULD_RUN == 'true'
@@ -227,7 +227,7 @@ runs:
       env:
         CONTINUE_API_KEY: ${{ inputs.continue-api-key }}
         CONTINUE_ORG: ${{ inputs.continue-org }}
-        CONTINUE_CONFIG: ${{ inputs.continue-config }}
+        CONTINUE_AGENT: ${{ inputs.continue-agent }}
         GITHUB_TOKEN: ${{ github.token }}
       run: |
         echo "Running Continue CLI with prompt:"
@@ -253,7 +253,7 @@ runs:
           exit 1
         fi
 
-        if [[ ! "$CONTINUE_CONFIG" =~ ^[a-zA-Z0-9_/-]+$ ]]; then
+        if [[ ! "$CONTINUE_AGENT" =~ ^[a-zA-Z0-9_/-]+$ ]]; then
           echo "Error: Invalid config path. Must contain only alphanumeric characters, hyphens, underscores, and forward slashes."
           exit 1
         fi
@@ -273,7 +273,7 @@ runs:
 
         # Run the CLI with validated config and error handling
         if [ "$SKIP_CLI" != "true" ]; then
-          echo "Executing Continue CLI with config: $CONTINUE_ORG/$CONTINUE_CONFIG"
+          echo "Executing Continue CLI with config: $CONTINUE_ORG/$CONTINUE_AGENT"
           
           # Write prompt to temp file for headless mode
           PROMPT_FILE="/tmp/continue-review-$RANDOM.txt"
@@ -282,9 +282,9 @@ runs:
           echo "Prompt length: $(wc -c < "$PROMPT_FILE") characters"
           
           # Use timeout to prevent hanging (360 seconds = 6 minutes)
-          echo "Executing command: cn --config $CONTINUE_ORG/$CONTINUE_CONFIG -p @$PROMPT_FILE --allow Bash"
+          echo "Executing command: cn --config $CONTINUE_ORG/$CONTINUE_AGENT -p @$PROMPT_FILE --allow Bash"
           
-          if timeout 360 cn --config "$CONTINUE_ORG/$CONTINUE_CONFIG" -p "@$PROMPT_FILE" --allow Bash > code_review_raw.md 2>cli_error.log; then
+          if timeout 360 cn --config "$CONTINUE_ORG/$CONTINUE_AGENT" -p "@$PROMPT_FILE" --allow Bash > code_review_raw.md 2>cli_error.log; then
             echo "Continue CLI completed successfully"
             echo "Raw output length: $(wc -c < code_review_raw.md) characters"
             


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Renamed the action input from continue-config to continue-agent and updated env references to match. Also bumped the Continue CLI install to latest and switched the workflow to use continuedev/empty-agent.

- **Refactors**
  - Renamed input: continue-config -> continue-agent (and CONTINUE_CONFIG -> CONTINUE_AGENT).
  - Updated CLI install: @continuedev/cli@latest.
  - Workflow now uses continuedev/empty-agent as the agent path.

- **Migration**
  - Update workflow calls to pass continue-agent instead of continue-config.
  - Replace any CONTINUE_CONFIG references with CONTINUE_AGENT.

<!-- End of auto-generated description by cubic. -->

