### PR TITLE
fix: bracket stripping in gemini responses

### DIFF
--- a/core/llm/llms/VertexAI.ts
+++ b/core/llm/llms/VertexAI.ts
@@ -287,7 +287,7 @@ class VertexAI extends BaseLLM {
       body: JSON.stringify(body),
       signal,
     });
-    yield* this.geminiInstance.processGeminiResponse(streamSse(response));
+    yield* this.geminiInstance.processGeminiResponse(response);
   }
 
   private async *streamChatBison(


### PR DESCRIPTION
## Description

Use streamSse instead of processGeminiResponse when receiving responses from Gemini streamChat .

resolves CON-4266
closes https://github.com/continuedev/continue/issues/2651

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot


https://github.com/user-attachments/assets/5bdc06f0-455f-41c1-97ef-dccdae2eabb8

https://github.com/user-attachments/assets/20589cfd-e968-4567-9170-ecb45f76acfc







## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switched Gemini streamChat to use streamSse for proper SSE handling and direct chunk streaming, fixing broken/laggy responses and simplifying the streaming path.

- **Bug Fixes**
  - Iterate streamSse(response) and yield chunks directly.
  - Remove processGeminiResponse in the Gemini streaming flow.

<!-- End of auto-generated description by cubic. -->

