### PR TITLE
Rename continue-config to continue-agent in workflow

### DIFF
--- a/.github/workflows/continue-general-review.yaml
+++ b/.github/workflows/continue-general-review.yaml
@@ -25,4 +25,4 @@ jobs:
         with:
           continue-api-key: ${{ secrets.CONTINUE_API_KEY }}
           continue-org: "continuedev"
-          continue-config: "continuedev/empty-agent"
+          continue-agent: "continuedev/empty-agent"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Renamed the workflow parameter from continue-config to continue-agent to match the latest Continue action input and avoid config errors.

<!-- End of auto-generated description by cubic. -->

