### PR TITLE
style(cli): adding loading animation when updating version

### DIFF
--- a/extensions/cli/src/ui/UpdateNotification.tsx
+++ b/extensions/cli/src/ui/UpdateNotification.tsx
@@ -1,4 +1,4 @@
-import { Text } from "ink";
+import { Box, Text } from "ink";
 import React, { useMemo } from "react";
 
 import { useServices } from "../hooks/useService.js";
@@ -9,6 +9,7 @@ import {
 } from "../services/types.js";
 
 import { useTerminalSize } from "./hooks/useTerminalSize.js";
+import { LoadingAnimation } from "./LoadingAnimation.js";
 
 interface UpdateNotificationProps {
   isRemoteMode?: boolean;
@@ -46,6 +47,15 @@ const UpdateNotification: React.FC<UpdateNotificationProps> = ({
 
   if (!services.update?.isUpdateAvailable && isRemoteMode) {
     return <Text color="cyan">◉ Remote Mode</Text>;
+  }
+
+  if (services.update?.status === UpdateStatus.UPDATING) {
+    return (
+      <Box columnGap={1}>
+        <LoadingAnimation />
+        <Text color={color}>{`${text}`}</Text>
+      </Box>
+    );
   }
 
   return <Text color={color}>{`◉ ${text}`}</Text>;


### PR DESCRIPTION
## Description

Adding a loading animation when auto updating helps resolve doubt why the chat input is not yet visible.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

**before**




<img width="1245" height="368" alt="Screenshot 2025-10-16 at 12 08 24 PM" src="https://github.com/user-attachments/assets/3c056664-d421-4326-b06c-40d295a7db60" />


**after**

<img width="1244" height="367" alt="image" src="https://github.com/user-attachments/assets/3934bd6f-236f-49ef-a3f9-1738faec5e48" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add a loading animation to the CLI update notification while an auto-update is in progress, making it clear why the chat input isn’t visible yet. When UpdateStatus is UPDATING, UpdateNotification shows LoadingAnimation alongside the status text.

<!-- End of auto-generated description by cubic. -->

