### PR TITLE
fix: update telemetry docs

### DIFF
--- a/docs/telemetry.mdx
+++ b/docs/telemetry.mdx
@@ -36,15 +36,15 @@ Alternatively in VS Code, you can disable telemetry through your VS Code setting
 
 ### CLI
 
-For `cn`, the Continue CLI, set the environment variable `CONTINUE_CLI_ENABLE_TELEMETRY=0` before running commands:
+For `cn`, the Continue CLI, set the environment variable `CONTINUE_ALLOW_ANONYMOUS_TELEMETRY=0` before running commands:
 
 ```bash
-export CONTINUE_CLI_ENABLE_TELEMETRY=0
+export CONTINUE_ALLOW_ANONYMOUS_TELEMETRY=0
 cn <your prompt>
 ```
 
 Or run it inline:
 
 ```bash
-CONTINUE_CLI_ENABLE_TELEMETRY=0 cn <your prompt>
+CONTINUE_ALLOW_ANONYMOUS_TELEMETRY=0 cn <your prompt>
 ```


### PR DESCRIPTION
## Description
was changed from CONTINUE_CLI_ENABLE_TELEMETRY to CONTINUE_ALLOW_ANONYMOUS_TELEMETRY
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Update CLI telemetry docs to use the correct environment variable name. Replaces CONTINUE_CLI_ENABLE_TELEMETRY with CONTINUE_ALLOW_ANONYMOUS_TELEMETRY in examples so users can disable anonymous telemetry correctly.

<!-- End of auto-generated description by cubic. -->

