### PR TITLE
fix: prevent anthropic 3.5 models from use thinking

### DIFF
--- a/core/llm/autodetect.ts
+++ b/core/llm/autodetect.ts
@@ -143,7 +143,11 @@ function modelSupportsReasoning(
     return false;
   }
   // do not turn reasoning on by default for claude 3 models
-  if (model.model.includes("claude") && !model.model.includes("-3-")) {
+  if (
+    model.model.includes("claude") &&
+    !model.model.includes("-3-") &&
+    !model.model.includes("-3.5-")
+  ) {
     return true;
   }
   if (model.model.includes("deepseek-r")) {


### PR DESCRIPTION
## Description

Sonnet 3.5 and Haiku 3.5 do not support thinking and hence should not auto enable the thinking tag. This PR fixes that.

resolves CON-4428

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

**before**

<img width="575" height="658" alt="image" src="https://github.com/user-attachments/assets/0b639291-df19-4ada-a67d-9f4392cd01c0" />


**after**

<img width="591" height="811" alt="image" src="https://github.com/user-attachments/assets/0effc3ea-0bdf-4173-980c-ab2444d79713" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
