### PR TITLE
fix: drop thinking messages without signature

### DIFF
--- a/gui/src/redux/util/constructMessages.ts
+++ b/gui/src/redux/util/constructMessages.ts
@@ -97,10 +97,13 @@ export function constructMessages(
         },
       });
     } else if (item.message.role === "thinking") {
-      msgs.push({
-        ctxItems: item.contextItems,
-        message: item.message,
-      });
+      // Only include thinking messages that are complete (either regular thinking with signature or if it is redacted thinking)
+      if (item.message.signature || item.message.redactedThinking) {
+        msgs.push({
+          ctxItems: item.contextItems,
+          message: item.message,
+        });
+      }
     } else if (item.message.role === "assistant") {
       // When using system message tools, convert tool calls/states to text content
       if (item.toolCallStates?.length && useSystemToolsFramework) {


### PR DESCRIPTION
## Description

Prevent thinking messages without signatures to be sent to the LLM.

resolves CON-4363

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

https://github.com/user-attachments/assets/804928cf-e814-4cd4-af4d-16e607dc36f1

https://github.com/user-attachments/assets/3e888b71-f766-49c4-a5bf-797b00ffec57






## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevent sending “thinking” messages without a signature to the LLM to avoid incomplete thoughts being processed. Only include messages with a signature or redactedThinking (addresses Linear CON-4363).

<!-- End of auto-generated description by cubic. -->

