### PR TITLE
Add GitHub workflow to delete stale branches

### DIFF
--- a/.github/workflows/delete-stale-branches.yaml
+++ b/.github/workflows/delete-stale-branches.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Stale Branches
-        uses: crs-k/stale-branches@v5.0.0
+        uses: crs-k/stale-branches@v8.2.2
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           pr-check: true


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a GitHub Actions workflow to flag stale branches on a weekday schedule and via manual trigger. It runs in dry-run mode, so no branches are deleted yet.

- **New Features**
  - Runs at 06:00 UTC, Monday–Friday, plus manual dispatch.
  - Uses crs-k/stale-branches with PR checks; ignores issue activity.
  - Dry run enabled to preview results before enabling deletions.

<!-- End of auto-generated description by cubic. -->

