### PR TITLE
fix: update branch filter regex to exclude cla-signatures branch

### DIFF
--- a/.github/workflows/delete-stale-branches.yaml
+++ b/.github/workflows/delete-stale-branches.yaml
@@ -22,4 +22,4 @@ jobs:
           pr-check: true
           dry-run: true
           ignore-issue-interaction: true
-          branches-filter-regex: "cla-signatures"
+          branches-filter-regex: "^(?!cla-signatures$).*"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Update stale-branch cleanup workflow to exclude the cla-signatures branch using a negative lookahead regex. Prevents accidental deletion of the CLA signatures branch while keeping cleanup active for all other branches.

<!-- End of auto-generated description by cubic. -->

