### PR TITLE
chore: adjust stale branch deletion timing to avoid issue creation

### DIFF
--- a/.github/workflows/delete-stale-branches.yaml
+++ b/.github/workflows/delete-stale-branches.yaml
@@ -17,8 +17,10 @@ jobs:
         uses: crs-k/stale-branches@v8.2.2
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          days-before-stale: 60
-          days-before-delete: 90
+          # When it goes "stale" an issue is created
+          # We don't want this, so we delete first
+          days-before-stale: 61
+          days-before-delete: 60
           pr-check: true
           dry-run: true
           ignore-issue-interaction: true


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adjusted the stale branch cleanup workflow to delete branches at 60 days, before they are marked stale, to prevent auto-created issues. Set days-before-delete to 60 and days-before-stale to 61.

<!-- End of auto-generated description by cubic. -->

