### PR TITLE
chore: reduce stale branch detection threshold to 60 days

### DIFF
--- a/.github/workflows/delete-stale-branches.yaml
+++ b/.github/workflows/delete-stale-branches.yaml
@@ -19,7 +19,7 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           # When it goes "stale" an issue is created
           # We don't want this, so we delete first
-          days-before-stale: 61
+          days-before-stale: 60
           days-before-delete: 60
           pr-check: true
           dry-run: true


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Lowered stale branch detection in the delete-stale-branches workflow from 61 to 60 days to match the 60-day deletion window. This keeps stale detection in sync with deletion and avoids creating unnecessary stale issues.

<!-- End of auto-generated description by cubic. -->

