### PR TITLE
chore: reduce stale branch detection to 59 days

### DIFF
--- a/.github/workflows/delete-stale-branches.yaml
+++ b/.github/workflows/delete-stale-branches.yaml
@@ -19,7 +19,7 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           # When it goes "stale" an issue is created
           # We don't want this, so we delete first
-          days-before-stale: 60
+          days-before-stale: 59
           days-before-delete: 60
           pr-check: true
           dry-run: true


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Lowered stale branch detection in the GitHub workflow from 60 to 59 days. Branches are marked stale one day before the 60-day deletion, keeping cleanup predictable.

<!-- End of auto-generated description by cubic. -->

