### PR TITLE
Enable automatic deletion of stale branches

### DIFF
--- a/.github/workflows/delete-stale-branches.yaml
+++ b/.github/workflows/delete-stale-branches.yaml
@@ -17,11 +17,8 @@ jobs:
         uses: crs-k/stale-branches@v8.2.2
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          # When it goes "stale" an issue is created
-          # We don't want this, so we delete first
           days-before-stale: 59
           days-before-delete: 60
           pr-check: true
-          dry-run: true
           ignore-issue-interaction: true
           branches-filter-regex: "^(?!cla-signatures$).*"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Enable automatic deletion of stale branches by removing the dry-run flag in the delete-stale-branches workflow. Branches go stale after 59 days and are deleted at 60 days, with PR checks enforced and the cla-signatures branch excluded.

<!-- End of auto-generated description by cubic. -->

