### PR TITLE
chore: prerelease bumps

### DIFF
--- a/extensions/intellij/gradle.properties
+++ b/extensions/intellij/gradle.properties
@@ -1,5 +1,5 @@
 pluginGroup=com.github.continuedev.continueintellijextension
-pluginVersion=1.0.48
+pluginVersion=1.0.49
 platformVersion=2024.1
 kotlin.stdlib.default.dependency=false
 org.gradle.configuration-cache=true

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "1.3.19",
+  "version": "1.3.20",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION
## Description
jetbrains 1.0.49, vs cdoe 1.3.20
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prepare prerelease by bumping extension versions: JetBrains plugin to 1.0.49 and VS Code extension to 1.3.20. This ensures correct marketplace publishing and version tracking.

<!-- End of auto-generated description by cubic. -->

