### PR TITLE
docs: Move Hub from top nav to main docs page

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1240,10 +1240,6 @@
       "destination": "/hub/configs/edit-a-config"
     },
     {
-      "source": "/hub/agents/intro",
-      "destination": "/hub/configs/intro"
-    },
-    {
       "source": "/hub/agents/use-an-agent",
       "destination": "/hub/configs/use-a-config"
     },


### PR DESCRIPTION
## Changes

closes CON-4410

This PR moves the Hub section from its own top-level navigation tab to the main Documentation page, positioned after Getting Started and before CLI.

### What changed:
- Hub section moved from separate tab to main Documentation tab
- Hub is now positioned between "Getting Started" and "CLI" in the sidebar
- Set folder groups to closed state by adding  to:
  - IDE Extensions 
  - Customization
  - Help

### Redirects:
All existing redirects for Hub links are maintained, so no broken links.

### Testing:
- [ ] Verify Hub section appears correctly in main docs navigation
- [ ] Confirm folder groups start in closed state
- [ ] Test that existing Hub links still work via redirects
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Move the Hub from its own top-level tab into the main Documentation sidebar and consolidate Hub content around configs and agents. Navigation is simpler, with redirects in place to keep existing links working.

- **Refactors**
  - Moved Hub into Documentation, positioned between Getting Started and CLI; removed the Hub tab.
  - Set IDE Extensions, Customization, and Help groups to start collapsed.
  - Replaced “Blocks” pages with a unified Hub introduction; removed outdated block pages/images and added a new hub navigation image.
  - Renamed Workflows to Agents; added hub/agents/intro and updated titles/links (e.g., /hub/workflows/intro → /hub/agents/intro).
  - Updated docs to avoid “blocks” terminology and clarified MCP, Rules, and config guidance.
  - Maintained and expanded redirects so existing Hub URLs continue to resolve.

<!-- End of auto-generated description by cubic. -->

