### PR TITLE
feat: add GPT-5 Codex model support

### DIFF
--- a/gui/src/pages/AddNewModel/configs/models.ts
+++ b/gui/src/pages/AddNewModel/configs/models.ts
@@ -1079,6 +1079,19 @@ export const models: { [key: string]: ModelPackage } = {
     icon: "openai.png",
     isOpenSource: false,
   },
+  gpt5Codex: {
+    title: "GPT-5 Codex",
+    description:
+      "OpenAI's most advanced code generation model, optimized for programming tasks",
+    params: {
+      model: "gpt-5-codex",
+      contextLength: 500_000,
+      title: "GPT-5 Codex",
+    },
+    providerOptions: ["openai"],
+    icon: "openai.png",
+    isOpenSource: false,
+  },
   gpt4turbo: {
     title: "GPT-4 Turbo",
     description:

--- a/gui/src/pages/AddNewModel/configs/providers.ts
+++ b/gui/src/pages/AddNewModel/configs/providers.ts
@@ -118,6 +118,7 @@ export const providers: Partial<Record<string, ProviderInfo>> = {
     tags: [ModelProviderTags.RequiresApiKey],
     packages: [
       models.gpt5,
+      models.gpt5Codex,
       models.gpt4o,
       models.gpt4omini,
       models.gpt4turbo,

--- a/packages/llm-info/src/providers/openai.ts
+++ b/packages/llm-info/src/providers/openai.ts
@@ -84,6 +84,14 @@ export const OpenAi: ModelProvider = {
       regex: /gpt-5/,
       recommendedFor: ["chat"],
     },
+    {
+      model: "gpt-5-codex",
+      displayName: "GPT-5 Codex",
+      contextLength: 500000,
+      maxCompletionTokens: 150000,
+      regex: /gpt-5-codex/,
+      recommendedFor: ["chat", "edit"],
+    },
     // gpt-4o
     {
       model: "gpt-4o",


### PR DESCRIPTION
Blocked by https://github.com/continuedev/continue/pull/7891
Resolves CON-4119

Note that this model will be included automatically in the handful of places we do model specific checks for tools, etc, because we are either checking for `gpt` for `gpt-5`, and this model is named `gpt-5-codex`
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added GPT-5 Codex support so it can be selected under OpenAI. Enables chat and edit workflows with up to 500k context and 150k max completion tokens.

- **New Features**
  - Added GPT-5 Codex to the Add New Model UI and OpenAI provider list.
  - Registered model in llm-info with id gpt-5-codex, display name, 500k context, 150k max tokens, regex, and recommendedFor ["chat", "edit"].
  - Automatically covered by existing gpt/gpt-5 tool-use checks.

<!-- End of auto-generated description by cubic. -->

