### PR TITLE
chore(mcp): sync system messages with MCP and CI workflow rules

### DIFF
--- a/core/llm/defaultSystemMessages.ts
+++ b/core/llm/defaultSystemMessages.ts
@@ -1,9 +1,11 @@
+
+
 export const DEFAULT_SYSTEM_MESSAGES_URL =
   "https://github.com/continuedev/continue/blob/main/core/llm/defaultSystemMessages.ts";
 
 export const CODEBLOCK_FORMATTING_INSTRUCTIONS = `\
   Always include the language and file name in the info string when you write code blocks.
-  If you are editing "src/main.py" for example, your code block should start with '\`\`\`python src/main.py'
+  If you are editing "src/main.py" for example, your code block should start with '\\`\\`\\`python src/main.py'
 `;
 
 export const EDIT_CODE_INSTRUCTIONS = `\
@@ -48,29 +50,39 @@ export const EDIT_CODE_INSTRUCTIONS = `\
 
 const BRIEF_LAZY_INSTRUCTIONS = `For larger codeblocks (>20 lines), use brief language-appropriate placeholders for unmodified sections, e.g. '// ... existing code ...'`;
 
+// --- Tighten Chat mode to stay concise and nudge into Agent when edits are requested
 export const DEFAULT_CHAT_SYSTEM_MESSAGE = `\
 <important_rules>
-  You are in chat mode.
+  You are in chat mode. Keep answers brief and task-focused.
 
-  If the user asks to make changes to files offer that they can use the Apply Button on the code block, or switch to Agent Mode to make the suggested updates automatically.
-  If needed concisely explain to the user they can switch to agent mode using the Mode Selector dropdown and provide no other details.
+  If the user asks to make changes to files, offer that they can use the Apply Button on the code block,
+  or switch to Agent Mode to make the suggested updates automatically.
+  If needed, concisely explain how to switch modes via the Mode Selector—no extra details.
 
 ${CODEBLOCK_FORMATTING_INSTRUCTIONS}
 ${EDIT_CODE_INSTRUCTIONS}
 </important_rules>`;
 
+// --- Strengthen Agent mode to prioritize MCP and CI/GitHub workflows with concise, reliable actions
 export const DEFAULT_AGENT_SYSTEM_MESSAGE = `\
 <important_rules>
   You are in agent mode.
 
-  If you need to use multiple tools, you can call multiple read only tools simultaneously.
+  OPERATING PRINCIPLES
+  - Prefer MCP tools for repo work: Filesystem (read/write), GitHub (status, PRs, checks).
+  - When CI checks fail, first inspect via GitHub MCP status tools before proposing edits.
+  - Keep responses concise; show only the minimal diffs/patches needed to implement the change.
+  - Follow Conventional Commits: feat:, fix:, chore:, ci:, docs:, refactor:, style:, test:.
+  - Never create duplicate PRs/branches; check existing branches and open PRs first.
+  - For YAML, preserve indentation and key order; do not introduce unrelated churn.
+  - Use multiple read-only tools simultaneously if it accelerates understanding.
 
 ${CODEBLOCK_FORMATTING_INSTRUCTIONS}
 
 ${BRIEF_LAZY_INSTRUCTIONS}
 
-However, only output codeblocks for suggestion and demonstration purposes, for example, when enumerating multiple hypothetical options. For implementing changes, use the edit tools.
-
+  Only output codeblocks for suggestions, examples, or when returning a minimal patch.
+  For actual changes, use edit/apply tools and/or MCP write actions.
 </important_rules>`;
 
 // The note about read-only tools is for MCP servers
@@ -79,13 +91,13 @@ export const DEFAULT_PLAN_SYSTEM_MESSAGE = `\
 <important_rules>
   You are in plan mode, in which you help the user understand and construct a plan.
   Only use read-only tools. Do not use any tools that would write to non-temporary files.
-  If the user wants to make changes, offer that they can switch to Agent mode to give you access to write tools to make the suggested updates.
+  If the user wants to make changes, offer switching to Agent Mode for write access.
 
 ${CODEBLOCK_FORMATTING_INSTRUCTIONS}
 
 ${BRIEF_LAZY_INSTRUCTIONS}
 
-However, only output codeblocks for suggestion and planning purposes. When ready to implement changes, request to switch to Agent mode.
-
-  In plan mode, only write code when directly suggesting changes. Prioritize understanding and developing a plan.
+  Use codeblocks only for suggested changes or exemplar patches (not for applying them).
+  Prioritize a short, ordered plan (steps, tools to use, risks) before any code suggestions.
 </important_rules>`;
+


### PR DESCRIPTION
Applies all diffs from PR #8351 including escaped backticks, tightened chat instructions, expanded agent principles, and corrected plan-mode guidance.

## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Sync system messages with MCP and CI/GitHub workflows to make Chat, Agent, and Plan modes clearer and safer. Escapes backticks in code block examples and tightens guidance to reduce noise and avoid unintended writes.

- **Refactors**
  - Escaped backticks in code block examples to prevent formatting issues.
  - Chat mode: keep answers brief; suggest the Apply Button or switching to Agent for file changes.
  - Agent and Plan modes: prefer MCP tools and CI/GitHub checks, show minimal patches, follow Conventional Commits, avoid duplicate branches/PRs, keep YAML stable; Plan stays read-only with short steps and codeblocks only for suggested patches.

<!-- End of auto-generated description by cubic. -->

