### PR TITLE
fix(cli): agent injected blocks ignored

### DIFF
--- a/extensions/cli/src/services/ConfigService.test.ts
+++ b/extensions/cli/src/services/ConfigService.test.ts
@@ -68,11 +68,9 @@ describe("ConfigService", () => {
     vi.mocked(
       configLoader.unrollPackageIdentifiersAsConfigYaml,
     ).mockResolvedValue({
-      block: {
-        name: "default-chat-model",
-        version: "1.0.0",
-        models: [defaultModel],
-      },
+      name: "default-chat-model",
+      version: "1.0.0",
+      models: [defaultModel],
     });
   });
 
@@ -520,11 +518,9 @@ describe("ConfigService", () => {
       vi.mocked(
         configLoader.unrollPackageIdentifiersAsConfigYaml,
       ).mockResolvedValue({
-        block: {
-          name: "default",
-          version: "1.0.0",
-          models: [defaultModel],
-        },
+        name: "default",
+        version: "1.0.0",
+        models: [defaultModel],
       });
 
       const result = await service.addDefaultChatModelIfNone(
@@ -616,11 +612,9 @@ describe("ConfigService", () => {
       vi.mocked(
         configLoader.unrollPackageIdentifiersAsConfigYaml,
       ).mockResolvedValue({
-        block: {
-          name: "default",
-          version: "1.0.0",
-          models: [defaultModel],
-        },
+        name: "default",
+        version: "1.0.0",
+        models: [defaultModel],
       });
 
       const result = await service.addDefaultChatModelIfNone(
@@ -643,11 +637,9 @@ describe("ConfigService", () => {
       vi.mocked(
         configLoader.unrollPackageIdentifiersAsConfigYaml,
       ).mockResolvedValue({
-        block: {
-          name: "default",
-          version: "1.0.0",
-          models: [defaultModel],
-        },
+        name: "default",
+        version: "1.0.0",
+        models: [defaultModel],
       });
 
       const result = await service.addDefaultChatModelIfNone(
@@ -695,11 +687,9 @@ describe("ConfigService", () => {
       vi.mocked(
         configLoader.unrollPackageIdentifiersAsConfigYaml,
       ).mockResolvedValue({
-        block: {
-          name: "default",
-          version: "1.0.0",
-          models: [], // Empty models array
-        },
+        name: "default",
+        version: "1.0.0",
+        models: [], // Empty models array
       });
 
       await expect(
@@ -724,11 +714,9 @@ describe("ConfigService", () => {
       vi.mocked(
         configLoader.unrollPackageIdentifiersAsConfigYaml,
       ).mockResolvedValue({
-        block: {
-          name: "default",
-          version: "1.0.0",
-          models: [defaultModel],
-        },
+        name: "default",
+        version: "1.0.0",
+        models: [defaultModel],
       });
 
       const result = await service.addDefaultChatModelIfNone(

--- a/extensions/cli/src/services/ConfigService.ts
+++ b/extensions/cli/src/services/ConfigService.ts
@@ -228,7 +228,7 @@ export class ConfigService
           authConfig?.organizationId ?? null,
           apiClient,
         );
-        const defaultModel = modelConfig?.block?.models?.[0];
+        const defaultModel = modelConfig?.models?.[0];
         if (!defaultModel) {
           throw new Error("Loaded default model contained no model block");
         }


### PR DESCRIPTION
## Description
Fixes injected blocks from `--agent` being ignored when there is no other config source specified
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the CLI so agent blocks passed via --agent are applied even when no other config is provided. Injected blocks now merge into the loaded assistant across all config load paths.

- **Bug Fixes**
  - Handle “no-config” by unrolling and merging injected blocks instead of returning a placeholder.
  - Make unrollPackageIdentifiersAsConfigYaml return AssistantUnrolled directly; update merge calls.
  - Improve errors during unroll; throw clear failures when config is missing or fatal errors occur.
  - Update tests and ConfigService to use the new return type and access models via .models[0].

<!-- End of auto-generated description by cubic. -->

