### PR TITLE
chore: bump `fetch` for oai adapters

### DIFF
--- a/packages/openai-adapters/package-lock.json
+++ b/packages/openai-adapters/package-lock.json
@@ -14,7 +14,7 @@
         "@aws-sdk/credential-providers": "^3.840.0",
         "@continuedev/config-types": "^1.0.14",
         "@continuedev/config-yaml": "^1.14.0",
-        "@continuedev/fetch": "^1.1.0",
+        "@continuedev/fetch": "^1.5.0",
         "dotenv": "^16.5.0",
         "google-auth-library": "^10.1.0",
         "json-schema": "^0.4.0",
@@ -1469,10 +1469,9 @@
       }
     },
     "node_modules/@continuedev/fetch": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@continuedev/fetch/-/fetch-1.2.1.tgz",
-      "integrity": "sha512-mUq6918QwsutUp65hB/xNLAa0fgjE6JQ5fzMjGlqBp4Q6BQq65HTAtwaBq5PdjPWX72akwhRiGiLOeR0Y2dULg==",
-      "license": "Apache-2.0",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@continuedev/fetch/-/fetch-1.5.0.tgz",
+      "integrity": "sha512-3c0YAEsaJ6tOy8HW07WUiHErrWb5r5ib+iZg7WxI0JcppvruSWMkQ6EosM/KMLkVw7v2VZi3KPBlZq/7gsBs2A==",
       "dependencies": {
         "@continuedev/config-types": "^1.0.14",
         "follow-redirects": "^1.15.6",

--- a/packages/openai-adapters/package.json
+++ b/packages/openai-adapters/package.json
@@ -17,7 +17,7 @@
     "@aws-sdk/credential-providers": "^3.840.0",
     "@continuedev/config-types": "^1.0.14",
     "@continuedev/config-yaml": "^1.14.0",
-    "@continuedev/fetch": "^1.1.0",
+    "@continuedev/fetch": "^1.5.0",
     "dotenv": "^16.5.0",
     "google-auth-library": "^10.1.0",
     "json-schema": "^0.4.0",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Bumps @continuedev/fetch in openai-adapters from ^1.1.0 (locked at 1.2.1) to ^1.5.0 to keep dependencies current and consistent.
No code changes; only dependency updates in package.json and package-lock.json.

<!-- End of auto-generated description by cubic. -->

