### PR TITLE
refactor: specify grep search tool to use regex

### DIFF
--- a/core/tools/definitions/grepSearch.ts
+++ b/core/tools/definitions/grepSearch.ts
@@ -21,7 +21,7 @@ export const grepSearchTool: Tool = {
         query: {
           type: "string",
           description:
-            "The search query to use. Must be a valid ripgrep regex expression. Use regex with alternation (e.g., 'word1|word2|word3) or character classes to find multiple potential words in a single search.",
+            "The search query to use. Must be the exact string to be searched or a valid ripgrep expression. Use regex with alternation (e.g., 'word1|word2|word3) or character classes to find multiple potential words in a single search.",
         },
       },
     },


### PR DESCRIPTION
## Description

The extension's grep search tool is already capable of performing regex searches properly. Only the tool definition had to be tweaked to specifically perform grep searches.

References: https://github.com/microsoft/vscode-copilot-chat/blob/ea022466b2cae07c6c1665266abcabfa007b3312/package.json#L294C4-L327C6

Resolves CON-3903

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

**before**

<img width="490" height="658" alt="image" src="https://github.com/user-attachments/assets/b3369804-a701-432d-a7d7-2b51fcf6d2b6" />

**after**

<img width="507" height="658" alt="image" src="https://github.com/user-attachments/assets/88db89d2-20d0-45c7-9c0e-703e8e11230e" />

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Clarified the grep search tool to explicitly use ripgrep regex and improved query help for exact strings and common regex patterns. Addresses Linear CON-3903.

<!-- End of auto-generated description by cubic. -->

