### PR TITLE
fix: update PR review bot config name from code-reviewer to review-bot

### DIFF
--- a/docs/guides/github-pr-review-bot.mdx
+++ b/docs/guides/github-pr-review-bot.mdx
@@ -42,6 +42,12 @@ Before starting, ensure you have:
 - A Continue API key from [hub.continue.dev/settings/api-keys](https://hub.continue.dev/settings/api-keys)
 - Continue assistant configured for code reviews (or use our recommended default)
 
+<Info>
+  **Want to customize the review bot?**
+  
+  You can remix the default review bot configuration at [hub.continue.dev/continuedev/review-bot](https://hub.continue.dev/continuedev/review-bot) to create your own personalized version with custom prompts, rules, and behaviors.
+</Info>
+
 ## Quick Setup (10 Minutes)
 
 <Steps>
@@ -181,7 +187,7 @@ jobs:
           Format as markdown suitable for a GitHub pull request comment."
 
           # Run Continue CLI in headless mode
-          cn --config continuedev/code-reviewer \
+          cn --config continuedev/review-bot \
              -p "$PROMPT" \
              --auto > review_output.md
 
@@ -336,7 +342,7 @@ The workflow will respond with a targeted review based on your request.
 <Tabs>
   <Tab title="Use Your Own Continue Config">
     
-  By default, the workflow uses the `continuedev/code-reviewer` config optimized for code reviews. Replace `continuedev/code-reviewer` with your own config:
+  By default, the workflow uses the `continuedev/review-bot` config optimized for code reviews. Replace `continuedev/review-bot` with your own config:
 
   ```yaml
   - name: Run Continue Review


### PR DESCRIPTION
## Description

This PR updates the incorrect config name in the PR review bot documentation from `continuedev/code-reviewer` to `continuedev/review-bot`. The `code-reviewer` config doesn't exist or isn't publicly accessible on Continue Hub, which causes the review bot to fail.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Changes

- Updated `docs/guides/github-pr-review-bot.mdx` to use `continuedev/review-bot` instead of `continuedev/code-reviewer` (2 occurrences)
- Added an info block encouraging users to remix the bot configuration at https://hub.continue.dev/continuedev/review-bot

## Context

This fixes the issue reported by @bekahhw in https://github.com/bdougie/contributor.info/pull/1151#issuecomment-3432344006 where the documented config name causes the review bot to fail with "Failed to load config from 'continuedev/code-reviewer'" error.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A - Documentation-only change

## Tests

N/A - Documentation-only change

Generated with [Continue](https://continue.dev)

Co-Authored-By: Continue <noreply@continue.dev>
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the PR review bot guide by replacing the invalid continuedev/code-reviewer config with continuedev/review-bot to prevent workflow failures. Also adds an info block linking to the review-bot page so users can remix and customize the config.

<!-- End of auto-generated description by cubic. -->

