### PR TITLE
fix: temporarily disable RecentlyVisited, RecentlyEdited, and DocumentHistoryTracker

### DIFF
--- a/extensions/vscode/src/autocomplete/RecentlyVisitedRangesService.ts
+++ b/extensions/vscode/src/autocomplete/RecentlyVisitedRangesService.ts
@@ -4,7 +4,6 @@ import {
   AutocompleteSnippetType,
 } from "core/autocomplete/snippets/types";
 import { isSecurityConcern } from "core/indexing/ignore";
-import { PosthogFeatureFlag, Telemetry } from "core/util/posthog";
 import { LRUCache } from "lru-cache";
 import * as vscode from "vscode";
 
@@ -34,19 +33,18 @@ export class RecentlyVisitedRangesService {
   }
 
   private async initWithPostHog() {
-    const recentlyVisitedRangesNumSurroundingLines =
-      await Telemetry.getValueForFeatureFlag(
-        PosthogFeatureFlag.RecentlyVisitedRangesNumSurroundingLines,
-      );
-
-    if (recentlyVisitedRangesNumSurroundingLines) {
-      this.isEnabled = true;
-      this.numSurroundingLines = recentlyVisitedRangesNumSurroundingLines;
-    }
-
-    vscode.window.onDidChangeTextEditorSelection(
-      this.cacheCurrentSelectionContext,
-    );
+    // TODO merge this and re-enable https://github.com/continuedev/continue/pull/8364
+    // const recentlyVisitedRangesNumSurroundingLines =
+    //   await Telemetry.getValueForFeatureFlag(
+    //     PosthogFeatureFlag.RecentlyVisitedRangesNumSurroundingLines,
+    //   );
+    // if (recentlyVisitedRangesNumSurroundingLines) {
+    //   this.isEnabled = true;
+    //   this.numSurroundingLines = recentlyVisitedRangesNumSurroundingLines;
+    // }
+    // vscode.window.onDidChangeTextEditorSelection(
+    //   this.cacheCurrentSelectionContext,
+    // );
   }
 
   private cacheCurrentSelectionContext = async (

--- a/extensions/vscode/src/autocomplete/recentlyEdited.ts
+++ b/extensions/vscode/src/autocomplete/recentlyEdited.ts
@@ -24,25 +24,24 @@ export class RecentlyEditedTracker {
   private static maxRecentlyEditedDocuments = 10;
 
   constructor(private ideUtils: VsCodeIdeUtils) {
-    vscode.workspace.onDidChangeTextDocument((event) => {
-      event.contentChanges.forEach((change) => {
-        const editedRange = {
-          uri: event.document.uri,
-          range: new vscode.Range(
-            new vscode.Position(change.range.start.line, 0),
-            new vscode.Position(change.range.end.line + 1, 0),
-          ),
-          timestamp: Date.now(),
-        };
-        this.insertRange(editedRange);
-      });
-
-      this.insertDocument(event.document.uri);
-    });
-
-    setInterval(() => {
-      this.removeOldEntries();
-    }, 1000 * 15);
+    // TODO merge this and re-enable https://github.com/continuedev/continue/pull/8364
+    // vscode.workspace.onDidChangeTextDocument((event) => {
+    //   event.contentChanges.forEach((change) => {
+    //     const editedRange = {
+    //       uri: event.document.uri,
+    //       range: new vscode.Range(
+    //         new vscode.Position(change.range.start.line, 0),
+    //         new vscode.Position(change.range.end.line + 1, 0),
+    //       ),
+    //       timestamp: Date.now(),
+    //     };
+    //     this.insertRange(editedRange);
+    //   });
+    //   this.insertDocument(event.document.uri);
+    // });
+    // setInterval(() => {
+    //   this.removeOldEntries();
+    // }, 1000 * 15);
   }
 
   private async insertRange(

--- a/extensions/vscode/src/extension/VsCodeExtension.ts
+++ b/extensions/vscode/src/extension/VsCodeExtension.ts
@@ -44,13 +44,10 @@ import { VsCodeIde } from "../VsCodeIde";
 import { ConfigYamlDocumentLinkProvider } from "./ConfigYamlDocumentLinkProvider";
 import { VsCodeMessenger } from "./VsCodeMessenger";
 
-import { getAst } from "core/autocomplete/util/ast";
 import { modelSupportsNextEdit } from "core/llm/autodetect";
 import { NEXT_EDIT_MODELS } from "core/llm/constants";
-import { DocumentHistoryTracker } from "core/nextEdit/DocumentHistoryTracker";
 import { NextEditProvider } from "core/nextEdit/NextEditProvider";
 import { isNextEditTest } from "core/nextEdit/utils";
-import { localPathOrUriToPath } from "core/util/pathToUri";
 import { JumpManager } from "../activation/JumpManager";
 import setupNextEditWindowManager, {
   NextEditWindowManager,
@@ -534,16 +531,17 @@ export class VsCodeExtension {
       });
     });
 
-    vscode.workspace.onDidOpenTextDocument(async (event) => {
-      const ast = await getAst(event.fileName, event.getText());
-      if (ast) {
-        DocumentHistoryTracker.getInstance().addDocument(
-          localPathOrUriToPath(event.fileName),
-          event.getText(),
-          ast,
-        );
-      }
-    });
+    // TODO merge this and re-enable https://github.com/continuedev/continue/pull/8364
+    // vscode.workspace.onDidOpenTextDocument(async (event) => {
+    //   const ast = await getAst(event.fileName, event.getText());
+    //   if (ast) {
+    //     DocumentHistoryTracker.getInstance().addDocument(
+    //       localPathOrUriToPath(event.fileName),
+    //       event.getText(),
+    //       ast,
+    //     );
+    //   }
+    // });
 
     // When GitHub sign-in status changes, reload config
     vscode.authentication.onDidChangeSessions(async (e) => {


### PR DESCRIPTION
## Description
Causing massive performance issues in large files which will be resolved by https://github.com/continuedev/continue/pull/8364
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Temporarily disable RecentlyVisited, RecentlyEdited, and Next Edit document history tracking to stop severe performance issues in large files. This removes expensive event listeners and AST work until the fix in PR #8364 is merged.

- **Bug Fixes**
  - Commented out PostHog-gated init and selection tracking in RecentlyVisitedRangesService.
  - Paused text change tracking and cleanup timer in RecentlyEditedTracker.
  - Disabled onDidOpenTextDocument hook that feeds DocumentHistoryTracker with AST data.

<!-- End of auto-generated description by cubic. -->

