### PR TITLE
fix: corrected the issues with the replicate integration

### DIFF
--- a/gui/src/pages/AddNewModel/configs/models.ts
+++ b/gui/src/pages/AddNewModel/configs/models.ts
@@ -1155,7 +1155,7 @@ export const models: { [key: string]: ModelPackage } = {
       title: "Claude 4 Sonnet",
       apiKey: "",
     },
-    providerOptions: ["anthropic"],
+    providerOptions: ["anthropic", "replicate"],
     icon: "anthropic.png",
     isOpenSource: false,
   },

--- a/gui/src/pages/AddNewModel/configs/providers.ts
+++ b/gui/src/pages/AddNewModel/configs/providers.ts
@@ -725,6 +725,7 @@ Select the \`GPT-4o\` model below to complete your provider configuration, but n
       models.codeLlamaInstruct,
       models.wizardCoder,
       models.mistralOs,
+      models.claude4Sonnet,
     ],
     apiKeyUrl: "https://replicate.com/account/api-tokens",
   },


### PR DESCRIPTION
## Description
In #5561 there was a problem with the Replicate integration for Claude. I fixed the integration issue. 

After fixing the specific claude integration issues, I noticed that it still wasn't working because there was a deeper issue with the Replicate integration. The API wasn't accepting the signal parameter. So I also fixed that issue and the integration is working fine. 

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

<img width="399" height="444" alt="image" src="https://github.com/user-attachments/assets/04896014-2ebc-4b7c-b6c3-dee056893efa" />

<img width="414" height="479" alt="image" src="https://github.com/user-attachments/assets/9836c916-21b5-4600-8da9-3452ed2c91ac" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the Replicate integration for Claude by removing the unsupported signal parameter, adding chat streaming, and mapping Claude 4 Sonnet correctly. This enables using Claude via Replicate in the app and improves error handling.

- **Bug Fixes**
  - Removed the signal parameter from Replicate API calls to match the API.
  - Corrected prompt handling for chat (system and user/assistant roles).
  - Added clear errors for invalid API keys and missing models.
  - Fixed docs tip to link to OpenRouter models.

- **New Features**
  - Streamed chat responses from Replicate with proper prompt formatting.
  - Enabled Claude 4 Sonnet selection under the Replicate provider in the model picker.

<!-- End of auto-generated description by cubic. -->

