### PR TITLE
fix: improve tool call display truncation and update fetch dependency

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -225,7 +225,7 @@
         "@aws-sdk/credential-providers": "^3.840.0",
         "@continuedev/config-types": "^1.0.14",
         "@continuedev/config-yaml": "^1.14.0",
-        "@continuedev/fetch": "^1.1.0",
+        "@continuedev/fetch": "^1.5.0",
         "dotenv": "^16.5.0",
         "google-auth-library": "^10.1.0",
         "json-schema": "^0.4.0",

--- a/extensions/cli/src/tools/ToolCallTitle.tsx
+++ b/extensions/cli/src/tools/ToolCallTitle.tsx
@@ -43,7 +43,7 @@ export function ToolCallTitle(props: { toolName: string; args?: any }) {
   }
 
   return (
-    <Text>
+    <Text wrap="truncate">
       <Text bold>{displayName}</Text>({formattedValue})
     </Text>
   );

--- a/extensions/cli/src/ui/components/MemoizedMessage.tsx
+++ b/extensions/cli/src/ui/components/MemoizedMessage.tsx
@@ -116,24 +116,28 @@ export const MemoizedMessage = memo<MemoizedMessageProps>(
                 flexDirection="column"
                 marginBottom={1}
               >
-                <Box>
-                  <Text
-                    color={
-                      isErrored
-                        ? "red"
-                        : isCompleted
-                          ? "green"
-                          : toolState.status === "generated"
-                            ? "yellow"
-                            : "white"
-                    }
-                  >
-                    {isCompleted || isErrored ? "●" : "○"}
-                  </Text>
-                  <Text color="white">
-                    {" "}
-                    <ToolCallTitle toolName={toolName} args={toolArgs} />
-                  </Text>
+                <Box width="100%">
+                  <Box flexShrink={0}>
+                    <Text
+                      color={
+                        isErrored
+                          ? "red"
+                          : isCompleted
+                            ? "green"
+                            : toolState.status === "generated"
+                              ? "yellow"
+                              : "white"
+                      }
+                    >
+                      {isCompleted || isErrored ? "●" : "○"}
+                    </Text>
+                  </Box>
+                  <Box flexGrow={1} flexShrink={1} minWidth={0}>
+                    <Text color="white">
+                      {" "}
+                      <ToolCallTitle toolName={toolName} args={toolArgs} />
+                    </Text>
+                  </Box>
                 </Box>
 
                 {isErrored ? (


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes tool call titles overflowing in the CLI UI by truncating long args and keeping the status icon aligned. Also updates @continuedev/fetch to ^1.5.0.

- **Bug Fixes**
  - Truncate ToolCallTitle with wrap="truncate" to prevent overflow.
  - Adjust MemoizedMessage flex layout (minWidth=0, flexGrow/shrink) so truncation works and the status dot stays visible.

- **Dependencies**
  - Bump @continuedev/fetch from ^1.1.0 to ^1.5.0.

<!-- End of auto-generated description by cubic. -->

