### PR TITLE
refactor: use ide.readFile instead of fs.readFile in static context service

### DIFF
--- a/core/autocomplete/context/static-context/StaticContextService.ts
+++ b/core/autocomplete/context/static-context/StaticContextService.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import { pathToFileURL } from "url";
 import Parser from "web-tree-sitter";
-import { FileType, IDE, Position } from "../../..";
+import { FileType, IDE, Position } from "../../../";
 import { localPathOrUriToPath } from "../../../util/pathToUri";
 import { getFullLanguageName, getQueryForFile } from "../../../util/treeSitter";
 import {
@@ -854,15 +854,14 @@ export class StaticContextService {
       try {
         const currentUri = pathToFileURL(currentPath).toString();
         const entries = await this.ide.listDir(currentUri);
-
         for (const [name, fileType] of entries) {
           const fullPath = localPathOrUriToPath(path.join(currentPath, name));
 
-          if (fileType === FileType.Directory) {
+          if (fileType === (2 as FileType.Directory)) {
             if (!shouldSkipDirectory(name)) {
               await scanRecursively(fullPath);
             }
-          } else if (fileType === FileType.File) {
+          } else if (fileType === (1 as FileType.File)) {
             const extension = path.extname(name).toLowerCase();
             if (tsExtensions.includes(extension)) {
               tsFiles.push(fullPath);


### PR DESCRIPTION
## Description

Use ide.readfile instead of fs.readfile in StaticContextService

resolves CON-4504

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Refactored StaticContextService to use IDE file APIs for reading files and scanning directories, improving support for URIs and virtual workspaces. Addresses CON-4504 by routing file access through the IDE layer.

- **Refactors**
  - Replaced fs.readFile with ide.readFile and fs.readdir with ide.listDir using FileType.
  - Normalized paths via pathToFileURL/localPathOrUriToPath for consistent URI handling.
  - Removed fs/promises dependency; logic for skipping dirs and filtering TS extensions unchanged.

<!-- End of auto-generated description by cubic. -->

