### PR TITLE
docs: update Discord invite link in sharing page

### DIFF
--- a/docs/hub/sharing.mdx
+++ b/docs/hub/sharing.mdx
@@ -7,7 +7,7 @@ description: "Connect with the Continue community to discover, share, and collab
 
 Join thousands of developers using Continue. Share experiences, get help, and contribute to the ecosystem.
 
-[Join our Discord Community →](https://discord.gg/continue)
+[Join our Discord Community →](https://discord.gg/vapESyrFmJ)
 
 ## Publishing
 


### PR DESCRIPTION
## Description

Updates the outdated Discord vanity link in `docs/hub/sharing.mdx` from `discord.gg/continue` to `discord.gg/vapESyrFmJ` for consistency with other documentation files.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [N/A] The relevant tests, if any, have been updated or created (no tests needed for link update)

## Screen recording or screenshot

Not applicable - this is a simple documentation link update.

## Tests

No tests needed for this change as it's only updating a Discord invite URL in the documentation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Discord invite link in docs/hub/sharing.mdx from discord.gg/continue to https://discord.gg/vapESyrFmJ for consistency with other docs.

<!-- End of auto-generated description by cubic. -->

