### PR TITLE
fix: update command title from View History to View Logs

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -257,7 +257,7 @@
       {
         "command": "continue.viewLogs",
         "category": "Continue",
-        "title": "View History",
+        "title": "View Logs",
         "group": "Continue"
       },
       {


### PR DESCRIPTION
## Description

Shoul be View Logs. Check line 253, it's duplicate.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the VS Code command title from "View History" to "View Logs" to match the continue.viewLogs command and reduce confusion in the Command Palette. This fixes the incorrect duplicate label so users see the right action.

<sup>Written for commit 0f91776655b94e67909d72e09ef7985f53927737. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



