### PR TITLE
feat: show gradient border in edit mode

### DIFF
--- a/gui/src/components/mainInput/ContinueInputBox.tsx
+++ b/gui/src/components/mainInput/ContinueInputBox.tsx
@@ -115,9 +115,11 @@ function ContinueInputBox(props: ContinueInputBoxProps) {
       <div className={`relative flex flex-col px-2`}>
         {props.isMainInput && <Lump />}
         <GradientBorder
-          loading={isStreaming && props.isLastUserInput ? 1 : 0}
+          loading={isStreaming && (props.isLastUserInput || isInEdit) ? 1 : 0}
           borderColor={
-            isStreaming && props.isLastUserInput ? undefined : vscBackground
+            isStreaming && (props.isLastUserInput || isInEdit)
+              ? undefined
+              : vscBackground
           }
           borderRadius={defaultBorderRadius}
         >


### PR DESCRIPTION
## Description

Show the gradient loading border for edit mode also.

resolves https://github.com/continuedev/continue/discussions/8457

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot


https://github.com/user-attachments/assets/4b680e87-3261-4f87-8ff8-c47262b26317



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the gradient loading border in edit mode while streaming, not just for the last user input. This makes the edit experience consistent and clearly indicates when a response is in progress.

<!-- End of auto-generated description by cubic. -->

