### PR TITLE
feat: show mcp warning message with configured mcps

### DIFF
--- a/gui/src/pages/config/sections/ToolsSection.tsx
+++ b/gui/src/pages/config/sections/ToolsSection.tsx
@@ -511,29 +511,32 @@ export function ToolsSection() {
           <Card>
             <EmptyState message="MCP servers are disabled in your organization" />
           </Card>
-        ) : mode === "chat" ? (
-          <Alert type="info" size="sm">
-            <span className="text-2xs italic">
-              All MCPs are disabled in Chat, switch to Plan or Agent mode to use
-              MCPs
-            </span>
-          </Alert>
-        ) : mergedBlocks.length > 0 ? (
-          mergedBlocks.map(({ block, blockFromYaml }) => {
-            return (
-              <MCPServerPreview
-                key={block.name}
-                server={block}
-                serverFromYaml={blockFromYaml}
-                allToolsOff={allToolsOff}
-                duplicateDetection={duplicateDetection}
-              />
-            );
-          })
         ) : (
-          <Card>
-            <EmptyState message="No MCP servers configured. Click the + button to add your first server." />
-          </Card>
+          <>
+            {mode === "chat" && (
+              <Alert type="info" size="sm">
+                <span className="text-2xs italic">
+                  All MCPs are disabled in Chat, switch to Plan or Agent mode to
+                  use MCPs
+                </span>
+              </Alert>
+            )}
+            {mergedBlocks.length > 0 ? (
+              mergedBlocks.map(({ block, blockFromYaml }) => (
+                <MCPServerPreview
+                  key={block.name}
+                  server={block}
+                  serverFromYaml={blockFromYaml}
+                  allToolsOff={allToolsOff}
+                  duplicateDetection={duplicateDetection}
+                />
+              ))
+            ) : (
+              <Card>
+                <EmptyState message="No MCP servers configured. Click the + button to add your first server." />
+              </Card>
+            )}
+          </>
         )}
       </div>
     </>


### PR DESCRIPTION
## Description

Show the MCP warning message without hiding the mcp servers.

resolves CON-4497

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

**before**

<img width="483" height="826" alt="image" src="https://github.com/user-attachments/assets/52e3c999-9fd9-4837-ac01-e357968aff41" />


**after**

<img width="512" height="875" alt="image" src="https://github.com/user-attachments/assets/43de5af3-0e75-4cda-a6e7-f142e9ab4337" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the “MCPs are disabled in Chat” warning without hiding configured MCP servers in the Tools settings. Clarifies chat-mode behavior and aligns with CON-4497.

- **Bug Fixes**
  - Always render the chat-mode MCP info alert alongside the server list.
  - Preserve existing empty states (org-wide MCPs disabled, or no servers configured).

<!-- End of auto-generated description by cubic. -->

