### PR TITLE
fix(cli): unskip first slash command output

### DIFF
--- a/extensions/cli/src/ui/components/MemoizedMessage.tsx
+++ b/extensions/cli/src/ui/components/MemoizedMessage.tsx
@@ -56,13 +56,6 @@ export const MemoizedMessage = memo<MemoizedMessageProps>(
 
     // Handle system messages
     if (isSystem) {
-      // TODO: Properly separate LLM system messages from UI informational messages
-      // using discriminated union types. For now, skip displaying the first system
-      // message which is typically the LLM's system prompt.
-      if (index === 0) {
-        return null;
-      }
-
       return (
         <Box key={index} marginBottom={1}>
           <Text color="dim" italic>


### PR DESCRIPTION
## Description

The first slash command in the cli is skipped due to the if condition. This PR fixes it.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot


https://github.com/user-attachments/assets/ec73029e-8e7f-4893-9f18-31d84b5e756b



https://github.com/user-attachments/assets/3df425c3-fddd-4469-ab95-21824514b53b



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the first slash command output in the CLI instead of skipping it. Removes the early return that hid the first system message in MemoizedMessage.tsx.

<!-- End of auto-generated description by cubic. -->

