### PR TITLE
fix: explicit haiku 4.5 tool support

### DIFF
--- a/core/llm/toolSupport.ts
+++ b/core/llm/toolSupport.ts
@@ -387,6 +387,7 @@ export function isRecommendedAgentModel(modelName: string): boolean {
     [/gpt-5/],
     [/claude/, /sonnet/, /3\.7|3-7|-4/],
     [/claude/, /opus/, /-4/],
+    [/claude/, /4-5/],
   ];
   for (const combo of recs) {
     if (combo.every((regex) => modelName.toLowerCase().match(regex))) {


### PR DESCRIPTION
## Description
Explicit tool support for Haiku 4-5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable tool support for Anthropic Claude 4.5 models (including Haiku) by expanding model detection. Tools now activate for 4.5 variants even if the model name varies.

- **Bug Fixes**
  - Normalize model names to lowercase before matching.
  - Treat any Anthropic model containing "claude" and "4-5" as tool-capable.

<!-- End of auto-generated description by cubic. -->

