### PR TITLE
fix: use yolo when applying diff

### DIFF
--- a/gui/src/redux/thunks/handleApplyStateUpdate.ts
+++ b/gui/src/redux/thunks/handleApplyStateUpdate.ts
@@ -44,13 +44,24 @@ export const handleApplyStateUpdate = createAsyncThunk<
 
       // Handle apply status updates - use toolCallId from event payload
       if (applyState.toolCallId) {
-        if (applyState.status === "closed") {
-          // Find the tool call to check if it was canceled
-          const toolCallState = findToolCallById(
-            getState().session.history,
-            applyState.toolCallId,
-          );
+        const toolCallState = findToolCallById(
+          getState().session.history,
+          applyState.toolCallId,
+        );
 
+        if (
+          applyState.status === "done" &&
+          toolCallState?.toolCall.function.name &&
+          getState().ui.toolSettings[toolCallState.toolCall.function.name] ===
+            "allowedWithoutPermission"
+        ) {
+          extra.ideMessenger.post("acceptDiff", {
+            streamId: applyState.streamId,
+            filepath: applyState.filepath,
+          });
+        }
+
+        if (applyState.status === "closed") {
           if (toolCallState) {
             const accepted = toolCallState.status !== "canceled";
 


### PR DESCRIPTION
## Description

Detect "allowWithoutPermission" for the edit tool when applying diff.

resolves CON-4656



## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

https://github.com/user-attachments/assets/ae57c433-d83e-4d45-828c-60cbf05904b5

https://github.com/user-attachments/assets/da5a9a3e-df6d-4ed0-a287-8f37de47b0c9


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-accept edit diffs when the originating tool is set to allowedWithoutPermission (“yolo”), applying changes immediately after the tool finishes. Resolves CON-4656.

- **Bug Fixes**
  - On applyState.status === "done", detect yolo via toolCallId and auto-call acceptDiff with streamId and filepath.
  - Keep existing "closed" handling and canceled vs accepted logic unchanged.

<!-- End of auto-generated description by cubic. -->

