### PR TITLE
chore: deprecate continue.telemetryEnabled in vscode preferences

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -89,7 +89,9 @@
         "continue.telemetryEnabled": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "Continue collects anonymous usage data, cleaned of PII, to help us improve the product for our users. Read more  at [continue.dev › Telemetry](https://docs.continue.dev/telemetry)."
+          "markdownDescription": "Continue collects anonymous usage data, cleaned of PII, to help us improve the product for our users. Read more  at [continue.dev › Telemetry](https://docs.continue.dev/telemetry).",
+          "markdownDeprecationMessage": "This setting is deprecated and will be removed in a later version. Please use the _Telemetry > Allow Anonymous Telemetry_ setting in the extension's User Settings page.",
+          "deprecationMessage": "Please use the _Telemetry > Allow Anonymous Telemetry_ setting in the extension's User Settings page."
         },
         "continue.showInlineTip": {
           "type": "boolean",


### PR DESCRIPTION
## Description

The gui settings for telemetry enabling was in sync with the vscode ide settings only when the ide restarted. This PR fixes that.

Resolves CON-4319

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot


https://github.com/user-attachments/assets/61509bab-132b-452d-aa60-a15d2b4d2e73



https://github.com/user-attachments/assets/f34518d1-f3f8-4c2f-a99a-1aca7e325f4b



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]










<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deprecates the continue.telemetryEnabled setting in VS Code and points users to Telemetry > Allow Anonymous Telemetry so the in-app toggle and IDE settings stay in sync (CON-4319). This ensures changes apply immediately without a restart.

<sup>Written for commit d0cd4193c0e6142e6df8372860149a2b14936a7b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









