### PR TITLE
Add cache_write_tokens and cache_read_tokens to Anthropic prompt token details

### DIFF
--- a/packages/openai-adapters/src/apis/Anthropic.ts
+++ b/packages/openai-adapters/src/apis/Anthropic.ts
@@ -366,9 +366,13 @@ export class AnthropicApi implements BaseLlmApi {
           const startEvent = rawEvent as RawMessageStartEvent;
           usage.prompt_tokens = startEvent.message.usage?.input_tokens ?? 0;
           usage.prompt_tokens_details = {
+            cache_write_tokens:
+              startEvent.message.usage?.cache_creation_input_tokens ?? 0,
+            cache_read_tokens:
+              startEvent.message.usage?.cache_read_input_tokens ?? 0,
             cached_tokens:
               startEvent.message.usage?.cache_read_input_tokens ?? 0,
-          };
+          } as any;
           break;
         case "message_delta":
           const deltaEvent = rawEvent as RawMessageDeltaEvent;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add cache_write_tokens and cache_read_tokens to Anthropic prompt_tokens_details so clients can see cache creation vs read usage in prompt token metrics. Keeps existing cached_tokens behavior for backward compatibility.

- New Features
  - prompt_tokens_details.cache_write_tokens maps to usage.cache_creation_input_tokens
  - prompt_tokens_details.cache_read_tokens maps to usage.cache_read_input_tokens
  - prompt_tokens_details.cached_tokens still maps to read tokens

<!-- End of auto-generated description by cubic. -->

