### PR TITLE
Remove error handler registration from plugin.xml

### DIFF
--- a/extensions/intellij/src/main/resources/META-INF/plugin.xml
+++ b/extensions/intellij/src/main/resources/META-INF/plugin.xml
@@ -41,7 +41,6 @@
                            displayType="BALLOON"/>
         <actionPromoter order="last"
                         implementation="com.github.continuedev.continueintellijextension.actions.ContinueActionPromote"/>
-        <errorHandler implementation="com.github.continuedev.continueintellijextension.error.ContinueErrorSubmitter"/>
         <postStartupActivity
                 implementation="com.github.continuedev.continueintellijextension.activities.ContinuePluginStartupActivity"/>
         <postStartupActivity implementation="com.github.continuedev.continueintellijextension.proxy.ProxyPoolingActivity"/>


### PR DESCRIPTION
fixes CON-4679
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the custom error handler from plugin.xml to stop using ContinueErrorSubmitter. The plugin now relies on IntelliJ’s default error reporting to avoid conflicts and unexpected error dialogs.

<!-- End of auto-generated description by cubic. -->

