### PR TITLE
fix: Compatibility fixes necessary to run 'npm install -g' for CLI

### DIFF
--- a/extensions/cli/src/services/ToolPermissionService.ts
+++ b/extensions/cli/src/services/ToolPermissionService.ts
@@ -86,12 +86,10 @@ export class ToolPermissionService
     }
 
     const policies: ToolPermissionPolicy[] = [];
-    const servers = Array.from(mcpServiceState?.connections ?? []);
+    const servers = Array.from(mcpServiceState?.connections?.values() ?? []);
     for (const mcpServer of parsedTools.mcpServers) {
       const server = servers?.find(
-        (s) =>
-          (s.config as any)?.sourceSlug &&
-          (s.config as any).sourceSlug === mcpServer,
+        (s) => s.config?.sourceSlug && s.config.sourceSlug === mcpServer,
       );
       if (!server) {
         logger.warn("No connected MCP server found ");

--- a/extensions/cli/src/telemetry/posthogService.test.ts
+++ b/extensions/cli/src/telemetry/posthogService.test.ts
@@ -27,8 +27,8 @@ vi.mock("dns/promises", () => {
   return { default: { lookup } };
 });
 
+// eslint-disable-next-line import/order
 import { isAuthenticatedConfig, loadAuthConfig } from "../auth/workos.js";
-
 import { PosthogService } from "./posthogService.js";
 
 describe("PosthogService", () => {


### PR DESCRIPTION
# Fix Compatibility Issues After Main Branch Merge

## Description

This PR fixes compatibility issues that arose after merging the latest changes from the main branch. The changes ensure the CLI continues to work correctly with updated dependencies.

## Changes Made

### exponentialBackoff.ts
- Removed usage of deprecated `isResponsesModel` and `responsesStream` from `@continuedev/openai-adapters`
- Simplified the chat completion streaming logic to use only the standard `chatCompletionStream` method
- This aligns with the latest openai-adapters API changes

## Why These Changes Are Needed

These compatibility fixes became necessary after merging recent main branch changes that included updates to the openai-adapters package API. Without this fix, the CLI would fail to build due to the removal of the `isResponsesModel` export.

## Testing

- The CLI builds successfully with `npm run build`
- All existing functionality is preserved

## Related Issues

These changes are compatibility fixes and prevent build failures after main branch merges.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CLI compatibility with the latest @continuedev/openai-adapters so global installs (npm install -g) work again. Removed deprecated responsesStream/isResponsesModel usage and now always stream via chatCompletionStream.

<!-- End of auto-generated description by cubic. -->

