### PR TITLE
fix(vscode-readme): use repo-relative paths for gifs in extensions\vscode\README.md

### DIFF
--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -32,25 +32,25 @@
 
 [Agent](https://docs.continue.dev/features/agent/quick-start) to work on development tasks together with AI
 
-![agent](docs/images/agent.gif)
+![agent](../../docs/images/agent.gif)
 
 ## Chat
 
 [Chat](https://docs.continue.dev/features/chat/quick-start) to ask general questions and clarify code sections
 
-![chat](docs/images/chat.gif)
+![chat](../../docs/images/chat.gif)
 
 ## Edit
 
 [Edit](https://docs.continue.dev/features/edit/quick-start) to modify a code section without leaving your current file
 
-![edit](docs/images/edit.gif)
+![edit](../../docs/images/edit.gif)
 
 ## Autocomplete
 
 [Autocomplete](https://docs.continue.dev/features/autocomplete/quick-start) to receive inline code suggestions as you type
 
-![autocomplete](docs/images/autocomplete.gif)
+![autocomplete](../../docs/images/autocomplete.gif)
 
 </div>
 


### PR DESCRIPTION
…code/README.md

## Description

Updated four gif image links in [README.md](vscode-file://vscode-app/c:/Users/mysore/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to use ../../docs/images/*.gif so the gifs render correctly when viewing the README from the extensions/vscode folder.


## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs have been updated (extensions/vscode/README.md)
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Before:
<img width="1496" height="958" alt="image" src="https://github.com/user-attachments/assets/e18b70c2-7006-478d-9576-ab2c44bae467" />


Now:
<img width="1514" height="964" alt="image" src="https://github.com/user-attachments/assets/e073fc82-9c86-4f9e-a68e-47dcf1a722f6" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
None — documentation link fix only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix broken GIFs in the VS Code extension README by switching to repo‑relative paths. Updated four links to ../../docs/images/*.gif so images render correctly when viewing README in extensions/vscode.

<sup>Written for commit 8f70f7b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

