### PR TITLE
feat(cli): always show context percentage

### DIFF
--- a/extensions/cli/src/ui/components/BottomStatusBar.tsx
+++ b/extensions/cli/src/ui/components/BottomStatusBar.tsx
@@ -64,7 +64,7 @@ export const BottomStatusBar: React.FC<BottomStatusBarProps> = ({
           </React.Fragment>
         )}
         <ModeIndicator />
-        {contextPercentage !== undefined && (
+        {contextPercentage !== undefined && contextPercentage > 0 && (
           <React.Fragment>
             <Text key="context-separator" color="dim">
               {" "}

--- a/extensions/cli/src/ui/components/ContextPercentageDisplay.tsx
+++ b/extensions/cli/src/ui/components/ContextPercentageDisplay.tsx
@@ -7,10 +7,14 @@ interface ContextPercentageDisplayProps {
 
 /**
  * Component to display the current context usage percentage
- * Shows the percentage in gray color for consistency with other status indicators
+ * Shows the non-zero percentage in gray color for consistency with other status indicators
  */
 export const ContextPercentageDisplay: React.FC<
   ContextPercentageDisplayProps
 > = ({ percentage }) => {
+  if (percentage === 0) {
+    return null;
+  }
+
   return <Text color="dim">Context: {percentage}%</Text>;
 };


### PR DESCRIPTION
## Description

Whenever there is context percentage is above 0, show it in the bottombar. Previously it was only shown when it was below 75%.

resolves CON-4682

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always show the context usage percentage in the CLI bottom bar when it’s above 0, instead of only when it exceeds 75%. Improves visibility of context usage and aligns with CON-4517.

<sup>Written for commit 9548d055377736a57a3023b503314a241dea1e87. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

