### PR TITLE
feat(cli): skip checking for updates in dev mode

### DIFF
--- a/extensions/cli/src/services/UpdateService.ts
+++ b/extensions/cli/src/services/UpdateService.ts
@@ -50,6 +50,15 @@ export class UpdateService extends BaseService<UpdateServiceState> {
     });
 
     try {
+      // skip checking for updates in dev
+      if (this.currentState.currentVersion === "0.0.0-dev") {
+        this.setState({
+          status: UpdateStatus.IDLE,
+          message: `Continue CLI`,
+        });
+        return; // Uncomment to test auto-update behavior in dev
+      }
+
       // Check for updates
       this.setState({
         status: UpdateStatus.CHECKING,
@@ -78,16 +87,6 @@ export class UpdateService extends BaseService<UpdateServiceState> {
       this.setState({
         isUpdateAvailable,
       });
-
-      if (this.currentState.currentVersion === "0.0.0-dev") {
-        this.setState({
-          status: UpdateStatus.IDLE,
-          message: `Continue CLI`,
-          isUpdateAvailable,
-          latestVersion,
-        });
-        return; // Uncomment to test auto-update behavior in dev
-      }
 
       // If update is available, automatically update
       if (


### PR DESCRIPTION
## Description

Skip checking for updates when running cli in dev mode.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

https://github.com/user-attachments/assets/89752f8d-44cb-4062-8832-a33627017b49



https://github.com/user-attachments/assets/8d3aba87-78b0-46f0-ad06-f5632f75427f



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The CLI now skips update checks in dev mode to avoid noise and prevent auto-updates during local development. Detects version "0.0.0-dev" and immediately sets status to idle without checking for updates.

<sup>Written for commit 28e09e1c71751a4c6dd035bf16dfc52b65973973. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

