### PR TITLE
Add snyk-bot to CLA allowlist

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -27,5 +27,5 @@ jobs:
           path-to-document: "https://github.com/continuedev/continue/blob/main/CLA.md"
           branch: cla-signatures
           # Bots and CLAs signed outside of GitHub
-          allowlist: dependabot[bot],fbricon,panyamkeerthana,Jazzcort,owtaylor,halfline,agent@continue.dev,action@github.com
+          allowlist: dependabot[bot],fbricon,panyamkeerthana,Jazzcort,owtaylor,halfline,agent@continue.dev,action@github.com,snyk-bot
           signed-commit-message: "CLA signed in $pullRequestNo"


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added snyk-bot to the CLA allowlist so Snyk’s automated security PRs pass CLA checks and don’t get blocked.

<sup>Written for commit 968f538a72b95098fac899c427f3496c209582ed. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

