### PR TITLE
feat(cli): do not enqueue slash commands

### DIFF
--- a/extensions/cli/src/ui/TUIChat.tsx
+++ b/extensions/cli/src/ui/TUIChat.tsx
@@ -424,6 +424,7 @@ const TUIChat: React.FC<TUIChatProps> = ({
           chatHistory={chatHistory}
           handleEditMessage={handleEditMessage}
           onShowEditSelector={() => navigateTo("edit")}
+          onShowStatusMessage={handleShowStatusMessage}
         />
 
         {/* Resource debug bar - only in verbose mode */}

--- a/extensions/cli/src/ui/components/ChatScreenContent.tsx
+++ b/extensions/cli/src/ui/components/ChatScreenContent.tsx
@@ -26,6 +26,7 @@ interface ChatScreenContentProps {
   isRemoteMode: boolean;
   onImageInClipboardChange?: (hasImage: boolean) => void;
   onShowEditSelector?: () => void;
+  onShowStatusMessage?: (message: string) => void;
 }
 
 export const ChatScreenContent: React.FC<ChatScreenContentProps> = ({
@@ -43,6 +44,7 @@ export const ChatScreenContent: React.FC<ChatScreenContentProps> = ({
   isRemoteMode,
   onImageInClipboardChange,
   onShowEditSelector,
+  onShowStatusMessage,
 }) => {
   if (activePermissionRequest) {
     return (
@@ -71,6 +73,7 @@ export const ChatScreenContent: React.FC<ChatScreenContentProps> = ({
       isRemoteMode={isRemoteMode}
       onImageInClipboardChange={onImageInClipboardChange}
       onShowEditSelector={onShowEditSelector}
+      onShowStatusMessage={onShowStatusMessage}
     />
   );
 };

--- a/extensions/cli/src/ui/components/ScreenContent.tsx
+++ b/extensions/cli/src/ui/components/ScreenContent.tsx
@@ -50,6 +50,7 @@ interface ScreenContentProps {
   chatHistory?: ChatHistoryItem[];
   handleEditMessage?: (messageIndex: number, newContent: string) => void;
   onShowEditSelector?: () => void;
+  onShowStatusMessage?: (message: string) => void;
 }
 
 function hideScreenContent(state?: UpdateServiceState) {
@@ -86,6 +87,7 @@ export const ScreenContent: React.FC<ScreenContentProps> = ({
   chatHistory = [],
   handleEditMessage,
   onShowEditSelector,
+  onShowStatusMessage,
 }) => {
   if (hideScreenContent(services.update)) {
     return null;
@@ -205,6 +207,7 @@ export const ScreenContent: React.FC<ScreenContentProps> = ({
         isRemoteMode={isRemoteMode}
         onImageInClipboardChange={onImageInClipboardChange}
         onShowEditSelector={onShowEditSelector}
+        onShowStatusMessage={onShowStatusMessage}
       />
     );
   }


### PR DESCRIPTION
## Description

Prevent enqueuing of slash commands when streaming. This avoids unexpected behaviour like the slash command not being called or only the last one being called.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

https://github.com/user-attachments/assets/9a840ccd-868a-4b12-8b58-9bf0211fd030


https://github.com/user-attachments/assets/429fc3c5-5e6f-40f3-acc8-517a6672fac1



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block queuing of slash commands in the CLI chat while a response is streaming or compaction is running. This prevents missed or overridden commands and shows a clear status message instead.

- **Bug Fixes**
  - Slash commands submitted during streaming/compaction are not enqueued; a status message is shown and the input stays for resend.
  - Remote mode is unaffected; the server continues to handle queueing.

<sup>Written for commit 207ec5022a4d46ec4ecc8f826fc66946aff4136d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

