### PR TITLE
fix: useSlashCommand telemetry

### DIFF
--- a/core/llm/streamChat.ts
+++ b/core/llm/streamChat.ts
@@ -60,13 +60,6 @@ export async function* llmStreamChat(
       if (!slashCommand) {
         throw new Error(`Unknown slash command ${command.name}`);
       }
-      void Telemetry.capture(
-        "useSlashCommand",
-        {
-          name: command.name,
-        },
-        true,
-      );
       if (!slashCommand.run) {
         console.error(
           `Slash command ${command.name} (${command.source}) has no run function`,

--- a/gui/src/components/mainInput/TipTapEditor/utils/renderSlashCommand.ts
+++ b/gui/src/components/mainInput/TipTapEditor/utils/renderSlashCommand.ts
@@ -1,5 +1,6 @@
 import { MessagePart, RangeInFile, SlashCommandDescWithSource } from "core";
 import { stripImages } from "core/util/messageContent";
+import posthog from "posthog-js";
 import { IIdeMessenger } from "../../../../context/IdeMessenger";
 import { renderMcpPrompt } from "./renderMcpPrompt";
 import { getRenderedV1Prompt } from "./renderPromptv1";
@@ -34,6 +35,16 @@ export async function renderSlashCommandPrompt(
   const command = availableSlashCommands.find((c) => c.name === commandName);
   if (!command) {
     return NO_COMMAND;
+  }
+
+  try {
+    posthog.capture("useSlashCommand", {
+      name: command.name,
+      source: command.source,
+      isLegacy: command.isLegacy,
+    });
+  } catch (e) {
+    console.error(e);
   }
 
   const nonTextParts = parts.filter((part) => part.type !== "text");


### PR DESCRIPTION
## Description
Fixes https://github.com/continuedev/continue/issues/8403

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move useSlashCommand telemetry to the client so it fires for all slash commands and includes more context. Fixes #8403.

- **Bug Fixes**
  - Capture useSlashCommand in renderSlashCommandPrompt via posthog with name, source, and isLegacy.
  - Remove server-side Telemetry.capture from llmStreamChat to avoid missed or duplicate events.
  - Add try/catch around capture to prevent UI errors.

<sup>Written for commit e6541b63da2da08e0a55a93dbc8a00a529057897. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

