### PR TITLE
fix: typecheck write file args

### DIFF
--- a/extensions/cli/src/tools/writeFile.ts
+++ b/extensions/cli/src/tools/writeFile.ts
@@ -49,16 +49,23 @@ export const writeFileTool: Tool = {
   readonly: false,
   isBuiltIn: true,
   preprocess: async (args) => {
+    const filepath = args?.filepath;
+    const content = args?.content ?? "";
+    if (typeof filepath !== "string") {
+      throw new Error("Filepath must be a string");
+    }
+    if (typeof content !== "string") {
+      throw new Error("New file content must be a string");
+    }
     try {
-      if (fs.existsSync(args.filepath)) {
-        const oldContent = fs.readFileSync(args.filepath, "utf-8");
-        const newContent = args.content;
+      if (fs.existsSync(filepath)) {
+        const oldContent = fs.readFileSync(filepath, "utf-8");
 
         const diff = createTwoFilesPatch(
           args.filepath,
           args.filepath,
           oldContent,
-          newContent,
+          content,
           undefined,
           undefined,
           { context: 2 },
@@ -81,7 +88,7 @@ export const writeFileTool: Tool = {
     } catch {
       // do nothing
     }
-    const lines: string[] = args.content.split("\n");
+    const lines: string[] = content.split("\n");
     const previewLines = lines.slice(0, 3);
 
     const preview: ToolCallPreview[] = [
@@ -103,7 +110,10 @@ export const writeFileTool: Tool = {
     }
 
     return {
-      args,
+      args: {
+        filepath,
+        content,
+      },
       preview,
     };
   },


### PR DESCRIPTION
## Description
Fixes https://github.com/continuedev/continue/issues/8382

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds strict arg validation to the writeFile tool to prevent crashes when filepath or content are not strings. Safely generates diffs and previews, fixing #8382.

- **Bug Fixes**
  - Validate filepath is a string; throw clear error if not.
  - Validate content is a string; default to "" when missing.
  - Use sanitized values for fs checks, diff creation, and preview.
  - Return normalized args (filepath, content) from preprocess.

<sup>Written for commit 01bef16c4a23982304b1f89d248a7198408d4c2e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

