### PR TITLE
Add script to analyze file hotspots from git history

### DIFF
--- a/scripts/analyze-file-hotspots.js
+++ b/scripts/analyze-file-hotspots.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+/**
+ * Analyzes git commit history to find file hotspots (most commonly edited files)
+ * Usage: node analyze-file-hotspots.js [days] [limit]
+ * Example: node analyze-file-hotspots.js 30 20
+ */
+
+const { execSync } = require("child_process");
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+const days = parseInt(args[0]) || 30;
+const limit = parseInt(args[1]) || 20;
+
+try {
+  // Calculate the date from N days ago
+  const sinceDate = new Date();
+  sinceDate.setDate(sinceDate.getDate() - days);
+  const sinceDateStr = sinceDate.toISOString().split("T")[0];
+
+  // Get the git log with file change stats
+  const gitCommand = `git log --since="${sinceDateStr}" --name-only --pretty=format:`;
+  const output = execSync(gitCommand, {
+    encoding: "utf-8",
+    maxBuffer: 10 * 1024 * 1024, // 10MB buffer
+  });
+
+  // Parse the output and count file occurrences
+  const fileCount = {};
+  const lines = output.split("\n").filter((line) => line.trim() !== "");
+
+  lines.forEach((line) => {
+    const file = line.trim();
+    if (file) {
+      fileCount[file] = (fileCount[file] || 0) + 1;
+    }
+  });
+
+  // Sort files by edit count (descending)
+  const sortedFiles = Object.entries(fileCount)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit);
+
+  // Display results as tab-separated values
+  sortedFiles.forEach(([file, count]) => {
+    console.log(`${count}\t${file}`);
+  });
+} catch (error) {
+  console.error("Error:", error.message);
+  process.exit(1);
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a simple CLI to find git file hotspots. It lists the most edited files in the last N days, sorted by edit count.

- New Features
  - scripts/analyze-file-hotspots.js: counts file edits since N days and prints top N as TSV (count<TAB>path).
  - Usage: node scripts/analyze-file-hotspots.js [days=30] [limit=20]

<sup>Written for commit e846c7c562fd801fa8c42feb2f30315c66e25885. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

