### PR TITLE
chore: bump version to 1.3.25

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "1.3.24",
+  "version": "1.3.25",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump the VS Code extension version from 1.3.24 to 1.3.25 to prepare a patch release and publish to the Marketplace.

<sup>Written for commit 2d735716a46df56e51208970781de00e85ed8efd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

