### PR TITLE
Update macOS runner from macos-13 to macos-latest in CI workflows

### DIFF
--- a/.github/workflows/jetbrains-release.yaml
+++ b/.github/workflows/jetbrains-release.yaml
@@ -95,7 +95,7 @@ jobs:
     needs: check_release_name
     if: needs.check_release_name.outputs.should_run == 'true' || github.event_name == 'workflow_dispatch'
     name: Build Plugin
-    runs-on: macos-13
+    runs-on: macos-latest
     permissions:
       contents: write
       pull-requests: write
@@ -358,7 +358,7 @@ jobs:
             platform: darwin
             arch: x64
             npm_config_arch: x64
-          - os: macos-13
+          - os: macos-latest
             platform: darwin
             arch: arm64
             npm_config_arch: arm64

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -73,11 +73,11 @@ jobs:
             platform: alpine
             arch: x64
             npm_config_arch: x64
-          - os: macos-13
+          - os: macos-latest
             platform: darwin
             arch: x64
             npm_config_arch: x64
-          - os: macos-13
+          - os: macos-latest
             platform: darwin
             arch: arm64
             npm_config_arch: arm64

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -57,11 +57,11 @@ jobs:
             platform: alpine
             arch: x64
             npm_config_arch: x64
-          - os: macos-13
+          - os: macos-latest
             platform: darwin
             arch: x64
             npm_config_arch: x64
-          - os: macos-13
+          - os: macos-latest
             platform: darwin
             arch: arm64
             npm_config_arch: arm64


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated GitHub Actions workflows to run macOS jobs on macos-latest instead of macos-13. This keeps CI on supported runner images and ensures x64 and arm64 matrix builds use the latest macOS/Xcode.

<sup>Written for commit 3b37ffd7dbca5e7d0900f6da79e2a401e29f3be3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

