### PR TITLE
fix(cli): validate required parameters in tool call

### DIFF
--- a/extensions/cli/src/tools/index.tsx
+++ b/extensions/cli/src/tools/index.tsx
@@ -235,11 +235,10 @@ export async function executeToolCall(
 // Only checks top-level required
 export function validateToolCallArgsPresent(toolCall: ToolCall, tool: Tool) {
   const requiredParams = tool.parameters.required ?? [];
-  for (const [paramName] of Object.entries(tool.parameters)) {
+  for (const paramName of requiredParams) {
     if (
-      requiredParams.includes(paramName) &&
-      (toolCall.arguments[paramName] === undefined ||
-        toolCall.arguments[paramName] === null)
+      toolCall.arguments[paramName] === undefined ||
+      toolCall.arguments[paramName] === null
     ) {
       throw new Error(
         `Required parameter "${paramName}" missing for tool "${toolCall.name}"`,


### PR DESCRIPTION
## Description

Previously, `validateToolCallArgsPresent` was iterating over Tool.Parameters instead of Tool.Parameters.properites
This PR fixes that

resolves CON-4775

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

**before**

<img width="1090" height="126" alt="image" src="https://github.com/user-attachments/assets/d865422d-999c-41e0-8002-864a482a2017" />

**after**

<img width="1196" height="140" alt="image" src="https://github.com/user-attachments/assets/0e7e0667-27df-49f7-9dab-5a254d3461e8" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
