### PR TITLE
Pass all environment variables to MCP server instead of just PATH

### DIFF
--- a/extensions/cli/src/services/MCPService.ts
+++ b/extensions/cli/src/services/MCPService.ts
@@ -509,8 +509,12 @@ export class MCPService
     serverConfig: StdioMcpServer,
   ): StdioClientTransport {
     const env: Record<string, string> = serverConfig.env || {};
-    if (process.env.PATH !== undefined) {
-      env.PATH = process.env.PATH;
+    if (process.env) {
+      for (const [key, value] of Object.entries(process.env)) {
+        if (!(key in env) && !!value) {
+          env[key] = value;
+        }
+      }
     }
 
     return new StdioClientTransport({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pass all environment variables to MCP servers instead of only PATH to improve compatibility and reduce startup failures. We merge process.env into serverConfig.env, keep explicit overrides, and skip empty values.

<sup>Written for commit 1aa83f2dcad7e214e62fb37ce5f986ce050bcc66. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

