### PR TITLE
fix: change apply prompt to not remove comments

### DIFF
--- a/core/llm/templates/edit/gpt.ts
+++ b/core/llm/templates/edit/gpt.ts
@@ -76,5 +76,5 @@ export const defaultApplyPrompt: PromptTemplateFunction = (
   history,
   otherData,
 ) => {
-  return `${otherData.original_code}\n\nThe following code was suggested as an edit:\n\`\`\`\n${otherData.new_code}\n\`\`\`\nPlease apply it to the previous code.`;
+  return `${otherData.original_code}\n\nThe following code was suggested as an edit:\n\`\`\`\n${otherData.new_code}\n\`\`\`\nPlease apply it to the previous code. Do not change comments unless explicitly requested.`;
 };


### PR DESCRIPTION
## Description

Specify apply prompt to not remove comments.

resolves CON-2084

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

**before**

<img width="612" height="221" alt="image" src="https://github.com/user-attachments/assets/d9dd3287-6352-4036-808f-faf3cc84505a" />


**after**

<img width="638" height="217" alt="image" src="https://github.com/user-attachments/assets/e9c8b249-70cb-4751-beff-dcf025151b5d" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the apply prompt to preserve comments when applying suggested edits by adding “Do not change comments unless explicitly requested.” Addresses CON-2084 to prevent unintended comment removal.

<sup>Written for commit 2aed9891ed27c81443deaa17d43ebc9d36acbb08. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

