### PR TITLE
fix: remove prepended fim_prefix tag in mercury coder

### DIFF
--- a/core/autocomplete/templating/AutocompleteTemplate.ts
+++ b/core/autocomplete/templating/AutocompleteTemplate.ts
@@ -192,7 +192,7 @@ const mercuryMultifileFimTemplate: AutocompleteTemplate = {
           suffix,
         ];
       }
-      return [`<|fim_prefix|>${prefix}`, suffix];
+      return [`${prefix}`, suffix];
     }
 
     const relativePaths = getShortestUniqueRelativeUriPaths(


### PR DESCRIPTION
## Description

fim_prefix tag was being added in the prefix of autocomplete requests to mercury coder which were unnecessary. This PR fixes that.

resolves CON-4805

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

**before**



<img width="1369" height="720" alt="511129160-50206225-f458-481d-8f7f-6242630a4472" src="https://github.com/user-attachments/assets/651ebf62-14c3-4b80-8fe4-f20401f07697" />

**after**


<img width="1268" height="666" alt="image" src="https://github.com/user-attachments/assets/3f748fca-eb17-4e8f-b888-422ff0c7c69e" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the fim_prefix marker from Mercury coder autocomplete prefixes to stop sending an unnecessary tag and fix prompt formatting. Aligns the FIM template with model expectations and resolves CON-4805.

<sup>Written for commit df363f5199de085ac27c85008e06ca3badfe1064. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

