### PR TITLE
fix: address headless loading bug

### DIFF
--- a/extensions/cli/src/configLoader.ts
+++ b/extensions/cli/src/configLoader.ts
@@ -133,7 +133,7 @@ function determineConfigSource(
   } else {
     // In headless, user assistant fallback behavior isn't supported
     if (isHeadless) {
-      return { type: "no-config" };
+      return { type: "default-agent" };
     }
     // Authenticated: try user assistants first
     return { type: "user-assistant", slug: "" }; // Empty slug means "first available"


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes headless mode loading by selecting the default agent instead of returning no-config. Headless CLI sessions now start with a usable agent and no longer fail when user assistants aren’t supported.

- **Bug Fixes**
  - In configLoader.determineConfigSource, return { type: "default-agent" } when isHeadless.

<sup>Written for commit 0f9890235c1986dd26ddb4e33299d46bc2dd6323. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

