### PR TITLE
fix: prevent sensitive files in next edit diffs

### DIFF
--- a/core/nextEdit/context/processSmallEdit.ts
+++ b/core/nextEdit/context/processSmallEdit.ts
@@ -1,6 +1,7 @@
 import { IDE, Position } from "../..";
 import { GetLspDefinitionsFunction } from "../../autocomplete/types";
 import { ConfigHandler } from "../../config/ConfigHandler";
+import { isSecurityConcern } from "../../indexing/ignore.js";
 import { NextEditProvider } from "../NextEditProvider";
 import { EditAggregator } from "./aggregateEdits";
 import { BeforeAfterDiff, createDiff, DiffFormatType } from "./diffFormatting";
@@ -23,16 +24,18 @@ export const processSmallEdit = async (
     recentlyVisitedRanges: [],
   };
 
-  NextEditProvider.getInstance().addDiffToContext(
-    createDiff({
-      beforeContent: beforeAfterdiff.beforeContent,
-      afterContent: beforeAfterdiff.afterContent,
-      filePath: beforeAfterdiff.filePath,
-      diffType: DiffFormatType.Unified,
-      contextLines: 3, // NOTE: This can change depending on experiments!
-      workspaceDir: currentData.workspaceDir,
-    }),
-  );
+  if (!isSecurityConcern(beforeAfterdiff.filePath)) {
+    NextEditProvider.getInstance().addDiffToContext(
+      createDiff({
+        beforeContent: beforeAfterdiff.beforeContent,
+        afterContent: beforeAfterdiff.afterContent,
+        filePath: beforeAfterdiff.filePath,
+        diffType: DiffFormatType.Unified,
+        contextLines: 3, // NOTE: This can change depending on experiments!
+        workspaceDir: currentData.workspaceDir,
+      }),
+    );
+  }
 
   void processNextEditData({
     filePath: beforeAfterdiff.filePath,


### PR DESCRIPTION
## Description

Prevent sensitive files like .env to be not included in next edit diffs.

closes https://github.com/continuedev/continue/issues/8363

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent sensitive files (e.g., .env) from being included in Next Edit diffs. We now skip diff creation when isSecurityConcern(filePath) returns true.

<sup>Written for commit c77a10a1918de249cd20c6bc9242672b013fec64. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

