### PR TITLE
fix: use system prompts for default endpoint type instances in next edit

### DIFF
--- a/core/nextEdit/NextEditProvider.ts
+++ b/core/nextEdit/NextEditProvider.ts
@@ -461,9 +461,13 @@ export class NextEditProvider {
     // prompts[1] extracts the user prompt from the system-user prompt pair.
     // NOTE: Stream is currently set to false, but this should ideally be a per-model flag.
     // Mercury Coder currently does not support streaming.
-    const msg: ChatMessage = await llm.chat([prompts[1]], token, {
-      stream: false,
-    });
+    const msg: ChatMessage = await llm.chat(
+      this.endpointType === "fineTuned" ? [prompts[1]] : prompts,
+      token,
+      {
+        stream: false,
+      },
+    );
 
     if (typeof msg.content !== "string") {
       return undefined;


### PR DESCRIPTION
## Description

For default endpoint type instances in next edit, send both the user and system prompts.

closes https://github.com/continuedev/continue/issues/8590
resolves CON-4802

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Next Edit now sends both the system and user prompts to default endpoint type models; fine-tuned models still receive only the user prompt. Fixes missing system context to improve responses; resolves CON-4802 and closes #8590.

<sup>Written for commit d62bb21a47cfc6f739e9342a62057a418dc53286. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

