### PR TITLE
fix: update global directory path conversion to use localPathToUri

### DIFF
--- a/core/config/workspace/workspaceBlocks.ts
+++ b/core/config/workspace/workspaceBlocks.ts
@@ -1,13 +1,13 @@
 import {
   BlockType,
   ConfigYaml,
-  createRuleMarkdown,
   createPromptMarkdown,
-  RULE_FILE_EXTENSION,
+  createRuleMarkdown,
 } from "@continuedev/config-yaml";
 import * as YAML from "yaml";
 import { IDE } from "../..";
 import { getContinueGlobalPath } from "../../util/paths";
+import { localPathToUri } from "../../util/pathToUri";
 import { joinPathsToUri } from "../../util/uri";
 
 const BLOCK_TYPE_CONFIG: Record<
@@ -165,7 +165,7 @@ export async function createNewWorkspaceBlockFile(
 
 export async function createNewGlobalRuleFile(ide: IDE): Promise<void> {
   try {
-    const globalDir = getContinueGlobalPath();
+    const globalDir = localPathToUri(getContinueGlobalPath());
 
     // Create the rules subdirectory within the global directory
     const rulesDir = joinPathsToUri(globalDir, "rules");


### PR DESCRIPTION
## Description

Function createNewGlobalRuleFile need fileUri to be uri, not path.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed path-to-URI conversion in createNewGlobalRuleFile by using localPathToUri for the global directory, ensuring rules are created with a proper URI and preventing path-related errors.

<sup>Written for commit 71e22ab977f7d17dc6abe3c5a174975f3f360da5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

