### PR TITLE
Fix formatting inconsistency in FAQs documentation

### DIFF
--- a/docs/faqs.mdx
+++ b/docs/faqs.mdx
@@ -38,7 +38,7 @@ If you're seeing a `fetch failed` error and your network requires custom certifi
 
 You may also set `requestOptions.caBundlePath` to an array of paths to multiple certificates.
 
-**_Windows VS Code Users_**: Installing the [win-ca](https://marketplace.visualstudio.com/items?itemName=ukoloff.win-ca) extension should also correct this issue.
+**Windows VS Code Users**: Installing the [win-ca](https://marketplace.visualstudio.com/items?itemName=ukoloff.win-ca) extension should also correct this issue.
 
 ### VS Code Proxy Settings
 


### PR DESCRIPTION
Improved the formatting of the Windows VS Code Users note by removing mixed bold-italic styling in favor of clean bold formatting. This makes the documentation more consistent with the rest of the file.

## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized the “Windows VS Code Users” note in FAQs by switching from mixed bold-italic to bold, aligning with the rest of the document and improving readability.

<sup>Written for commit 7d7ba6e0c9ed227a602767a30102ddbe436f6adc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

