### PR TITLE
feat: keep stream error toggle open by default

### DIFF
--- a/gui/src/components/ToggleDiv.tsx
+++ b/gui/src/components/ToggleDiv.tsx
@@ -7,6 +7,7 @@ interface ToggleProps {
   title: React.ReactNode;
   icon?: ComponentType<React.SVGProps<SVGSVGElement>>;
   testId?: string;
+  defaultOpen?: boolean;
 }
 
 function ToggleDiv({
@@ -14,8 +15,9 @@ function ToggleDiv({
   title,
   icon: Icon,
   testId = "context-items-peek",
+  defaultOpen = false,
 }: ToggleProps) {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(defaultOpen);
   const [isHovered, setIsHovered] = useState(false);
 
   return (

--- a/gui/src/pages/gui/StreamError.tsx
+++ b/gui/src/pages/gui/StreamError.tsx
@@ -250,7 +250,11 @@ const StreamErrorDialog = ({ error }: StreamErrorProps) => {
       {/* Expandable technical details using ToggleDiv */}
       {message && (
         <div className="mb-2">
-          <ToggleDiv title="View error output" testId="error-output-toggle">
+          <ToggleDiv
+            title="View error output"
+            testId="error-output-toggle"
+            defaultOpen
+          >
             <div className="flex flex-col gap-0 rounded-sm">
               <code className="text-editor-foreground block max-h-48 overflow-y-auto p-3 font-mono text-xs">
                 {parsedError}


### PR DESCRIPTION
## Description

Keep the error dialog toggle open by default.

resolves CON-4376
related to https://github.com/continuedev/continue/issues/8215

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot



https://github.com/user-attachments/assets/fe3967a9-815f-4f4a-b5b8-d3e383cfe474


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Open the stream error details by default so error output is visible immediately and debugging is faster. Addresses CON-4376.

- **New Features**
  - Added a defaultOpen prop to ToggleDiv to control initial open state.
  - Enabled defaultOpen in StreamError for the “View error output” section.

<sup>Written for commit 3118030038adc291931a4599a094957789701f9a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

