### PR TITLE
fix: filter out failure tool if no `--id`

### DIFF
--- a/extensions/cli/src/tools/index.tsx
+++ b/extensions/cli/src/tools/index.tsx
@@ -75,12 +75,12 @@ export async function getAllAvailableTools(
   const agentId = getAgentIdFromArgs();
   if (!agentId) {
     const reportFailureIndex = tools.findIndex(
-      (t) => t.name === "ReportFailure",
+      (t) => t.name === reportFailureTool.name,
     );
     if (reportFailureIndex !== -1) {
       tools.splice(reportFailureIndex, 1);
       logger.debug(
-        "Filtered out ReportFailure tool - no agent ID present (--id flag not provided)",
+        `Filtered out ${reportFailureTool.name} tool - no agent ID present (--id flag not provided)`,
       );
     }
   }


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Remove the ReportFailure tool from available CLI tools when no --id is provided, preventing invalid failure reports and agent confusion. Adds a helper to read the agent ID from args and logs a debug message when the tool is filtered out.

<sup>Written for commit 0335a4854fb06ec7a699adee3181e64d60bb4fa7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



