### PR TITLE
fix: ansi terminal tests

### DIFF
--- a/gui/src/components/UnifiedTerminal/UnifiedTerminal.test.tsx
+++ b/gui/src/components/UnifiedTerminal/UnifiedTerminal.test.tsx
@@ -178,9 +178,14 @@ describe("UnifiedTerminalCommand", () => {
     expect(container.textContent).toMatch(/Bold text/);
     expect(container.textContent).toMatch(/Underlined text/);
 
-    // Verify ANSI processing created styled spans
-    const styledSpans = container.querySelectorAll('span[class*="sc-esYiGF"]');
-    expect(styledSpans.length).toBeGreaterThan(0);
+    // Verify ANSI processing created span elements within the code block
+    // The AnsiRenderer creates spans for each ANSI segment
+    const codeElement = container.querySelector("code");
+    expect(codeElement).toBeInTheDocument();
+
+    // Count all spans inside the code element (ANSI creates multiple spans)
+    const spans = codeElement?.querySelectorAll("span");
+    expect(spans?.length).toBeGreaterThan(0);
   });
 
   test("handles links in output", async () => {


### PR DESCRIPTION
## Description
Generated hash probably changed with a package bump

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix ANSI terminal test by checking for spans inside the code element instead of relying on a hashed class selector. This makes the test resilient to package bumps that change generated class names.

<sup>Written for commit 7bcfd1a68133b4526d8c4c9922a656d5e231d19c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

