### PR TITLE
Rename 'Edit file' to 'Edit existing file' in docs

### DIFF
--- a/docs/ide-extensions/agent/how-it-works.mdx
+++ b/docs/ide-extensions/agent/how-it-works.mdx
@@ -46,7 +46,7 @@ In Plan mode, only these read-only tools are available:
 In Agent mode, all tools are available including the read-only tools above plus:
 
 - **Create new file** (`create_new_file`): Create a new file within the project
-- **Edit file** (`edit_file`): Make changes to existing files
+- **Edit file** (`edit_existing_file`): Make changes to existing files
 - **Run terminal command** (`run_terminal_command`): Run commands from the workspace root
 - **Create Rule Block** (`create_rule_block`): Create a new rule block in `.continue/rules`
 - All other write/execute tools for modifying the codebase


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated Agent mode docs to use the correct tool identifier, changing edit_file to edit_existing_file for the “Edit file” tool so users call the right command.

<sup>Written for commit 722127bc46e1e18e2772b4be94dee44300b49730. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





