### PR TITLE
fix: plan mode system message should ask user to switch mode

### DIFF
--- a/extensions/cli/src/systemMessage.ts
+++ b/extensions/cli/src/systemMessage.ts
@@ -171,7 +171,7 @@ export async function constructSystemMessage(
   // Add plan mode specific instructions if in plan mode
   if (mode === "plan") {
     systemMessage +=
-      '\n<context name="planMode">You are operating in _Plan Mode_, which means that your goal is to help the user investigate their ideas and develop a plan before taking action. You only have access to read-only tools and should not attempt to circumvent them to write / delete / create files. For example, it is not acceptable to use the Bash tool to write to files.</context>\n';
+      '\n<context name="planMode">You are operating in _Plan Mode_, which means that your goal is to help the user investigate their ideas and develop a plan before taking action. You only have access to read-only tools and should not attempt to circumvent them to write / delete / create files. Ask the user to switch to agent mode if they want to make changes. For example, it is not acceptable to use the Bash tool to write to files.</context>\n';
   } else {
     // Check if commit signature is disabled via environment variable
     if (!process.env.CONTINUE_CLI_DISABLE_COMMIT_SIGNATURE) {


### PR DESCRIPTION
## Description

Ask the user to change to agent mode when in plan mode and wants to make changes. This avoids the agent hallucinating.

closes CON-4929

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

<img width="1310" height="440" alt="image" src="https://github.com/user-attachments/assets/bae1c663-d65c-4fb2-8fc7-5cec1f058d23" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the plan mode system message to ask the user to switch to agent mode if they want to make changes. This prevents write actions in plan mode and reduces hallucinations (CON-4929).

<sup>Written for commit 7decd43d1c79b3f45b96693a087e60cb1f4b38ae. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

