### PR TITLE
fix: remove dead isTelemetryEnabled code for jetbrains

### DIFF
--- a/core/config/profile/doLoadConfig.ts
+++ b/core/config/profile/doLoadConfig.ts
@@ -348,7 +348,12 @@ export default async function doLoadConfig(options: {
     }
   });
 
-  if (newConfig.allowAnonymousTelemetry !== false) {
+  // VS Code has an IDE telemetry setting
+  // Since it's a security concern we use OR behavior on false
+  if (
+    newConfig.allowAnonymousTelemetry !== false &&
+    ideInfo.ideType === "vscode"
+  ) {
     if ((await ide.isTelemetryEnabled()) === false) {
       newConfig.allowAnonymousTelemetry = false;
     }

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/MessageTypes.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/MessageTypes.kt
@@ -4,7 +4,6 @@ class MessageTypes {
     companion object {
         val IDE_MESSAGE_TYPES = listOf(
             "readRangeInFile",
-            "isTelemetryEnabled",
             "getUniqueId",
             "getDiff",
             "getTerminalContents",

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IdeProtocolClient.kt
@@ -162,11 +162,6 @@ class IdeProtocolClient(
                         respond(contents)
                     }
 
-                    "isTelemetryEnabled" -> {
-                        val isEnabled = ide.isTelemetryEnabled()
-                        respond(isEnabled)
-                    }
-
                     "readRangeInFile" -> {
                         val params = gsonService.gson.fromJson(
                             dataElement.toString(),

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IntelliJIde.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IntelliJIde.kt
@@ -191,10 +191,6 @@ class IntelliJIDE(
         return mapOf("text" to text)
     }
 
-    override suspend fun isTelemetryEnabled(): Boolean {
-        return true
-    }
-
     override suspend fun isWorkspaceRemote(): Boolean {
         return this.getIdeInfo().remoteName != "local"
     }

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/types.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/types.kt
@@ -166,8 +166,6 @@ interface IDE {
 
     suspend fun getClipboardContent(): Map<String, String>
 
-    suspend fun isTelemetryEnabled(): Boolean
-
     suspend fun isWorkspaceRemote(): Boolean
 
     suspend fun getUniqueId(): String


### PR DESCRIPTION
## Description
This setting wasn't being used. It was hardcoded to true because we use (user settings === false OR ide settings === false) logic to be safe. But a user interpreted that as hardcoding telemetry to always be on, which is not the case.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed dead JetBrains telemetry code and limited IDE telemetry checks to VS Code. This clarifies telemetry behavior and avoids confusion about it being always on in JetBrains.

- **Refactors**
  - Removed isTelemetryEnabled from the IntelliJ IDE interface, implementation, and protocol handler.
  - Dropped the "isTelemetryEnabled" message type.
  - Updated doLoadConfig to only read IDE telemetry when ideType is "vscode".

<sup>Written for commit 12213fb42534a2d484a713a74ba55733eb01c76f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

