### PR TITLE
chore: jetgrains 1.0.55

### DIFF
--- a/extensions/intellij/gradle.properties
+++ b/extensions/intellij/gradle.properties
@@ -1,5 +1,5 @@
 pluginGroup=com.github.continuedev.continueintellijextension
-pluginVersion=1.0.52
+pluginVersion=1.0.55
 platformVersion=2024.1
 kotlin.stdlib.default.dependency=false
 org.gradle.configuration-cache=true


### PR DESCRIPTION
## Description
Bump jetbrains version

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped IntelliJ plugin version to 1.0.55 to release the latest build and keep alignment with the 2024.1 platform. No functional changes; configuration-only update.

<sup>Written for commit 09e1ad5873135877274fc770238a382b49ee23cb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

