### PR TITLE
fix: HOTFIX make errors fetching secrets nonblocking for local configs

### DIFF
--- a/core/config/yaml/LocalPlatformClient.ts
+++ b/core/config/yaml/LocalPlatformClient.ts
@@ -97,7 +97,12 @@ export class LocalPlatformClient implements PlatformClient {
       return [];
     }
 
-    const results = await this.client.resolveFQSNs(fqsns, this.orgScopeId);
+    let results: (SecretResult | undefined)[] = [];
+    try {
+      results = await this.client.resolveFQSNs(fqsns, this.orgScopeId);
+    } catch (e) {
+      console.error("Error getting secrets from control plane", e);
+    }
 
     // For any secret that isn't found, look in .env files, then process.env
     for (let i = 0; i < results.length; i++) {


### PR DESCRIPTION
## Description

Makes this error non blocking (console only) for local configs
<img width="359" height="308" alt="image" src="https://github.com/user-attachments/assets/3f03c79f-73ee-476a-bd0d-e228a779afde" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make secret fetch errors non-blocking in local configs. If resolving FQSNs fails, we log to console and continue, allowing .env/process.env fallbacks to provide secrets.

<sup>Written for commit d9f577d9ed173c57a5e4371882c1a988f5b07f08. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

