### PR TITLE
fix: HOTIFX notify config listeners when no config available

### DIFF
--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -502,11 +502,13 @@ export class ConfigHandler {
     this.totalConfigReloads += 1;
     // console.log(`Reloading config (#${this.totalConfigLoads}): ${reason}`); // Uncomment to see config loading logs
     if (!this.currentProfile) {
-      return {
+      const out = {
         config: undefined,
         errors: injectErrors,
         configLoadInterrupted: true,
       };
+      this.notifyConfigListeners(out);
+      return out;
     }
 
     for (const org of this.organizations) {


### PR DESCRIPTION
Otherwise GUI gets out of sync with core when no configs are loaded e.g. for an org

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the GUI stays in sync with core when no configs are loaded by notifying config listeners even when no profile is available. ConfigHandler now calls notifyConfigListeners with { config: undefined, errors: injectErrors, configLoadInterrupted: true } before returning.

<sup>Written for commit d8021f5c5a1e440a5058312f49e604917967fd50. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

