### PR TITLE
fix: omit native button styles from think button

### DIFF
--- a/gui/src/components/mainInput/belowMainInput/ThinkingBlockPeek.tsx
+++ b/gui/src/components/mainInput/belowMainInput/ThinkingBlockPeek.tsx
@@ -61,7 +61,7 @@ function ThinkingBlockPeek({
         <div className="flex min-w-0 flex-row items-center justify-between gap-2">
           <button
             type="button"
-            className="text-description hover:text- flex min-w-0 cursor-pointer flex-row items-center gap-1.5 border-0 text-xs shadow-none transition-colors duration-200 ease-in-out"
+            className="text-description hover:text-foreground flex min-w-0 cursor-pointer flex-row items-center gap-1.5 border-0 text-xs shadow-none transition-colors duration-200 ease-in-out"
             style={{ backgroundColor: vscBackground }}
             data-testid="thinking-block-peek"
             aria-expanded={open}


### PR DESCRIPTION
## Description

Correct thinking button style to have transparent background.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

| before | after |
|--------|--------|
| <img width="449" height="337" alt="image" src="https://github.com/user-attachments/assets/6e510e98-3e27-45d4-9af4-1d7fd40d0eaa" /> | <img width="462" height="346" alt="image" src="https://github.com/user-attachments/assets/c5f3f0b0-1ce3-4424-b660-cd48d45f1e79" /> |

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the Thinking peek button styling to remove native button chrome and match the editor background. Removed border and shadow, set background to vscBackground, and changed hover to text color for a consistent look.

<sup>Written for commit 3b2891b86550f17c0912047e15adbf4a48de8445. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

