### PR TITLE
fix: HOTFIX useHistory currentIndex more than MAX_HISTORY_LENGTH cause replace fail

### DIFF
--- a/gui/src/hooks/useInputHistory.ts
+++ b/gui/src/hooks/useInputHistory.ts
@@ -54,7 +54,7 @@ export function useInputHistory(historyKey: string) {
       return;
     }
 
-    setCurrentIndex(inputHistory.length + 1);
+    setCurrentIndex(Math.min(inputHistory.length + 1, MAX_HISTORY_LENGTH));
     setInputHistory((prev) => {
       return [...prev, inputValue].slice(-MAX_HISTORY_LENGTH);
     });


### PR DESCRIPTION
## Description

When add input history more than MAX_HISTORY_LENGTH, cause `pre()` fail, because `currentIndex = MAX_HISTORY_LENGTH + 1`: 

```
function prev(currentInput: JSONContent) {
  let index = currentIndex;

  if (index === inputHistory.length) {
    setPendingInput(currentInput);
  }

  if (index > 0 && index <= inputHistory.length) {
    setCurrentIndex((prevState) => prevState - 1);
    return inputHistory[index - 1];
  }
}
```

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

Small fix without unit test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limit currentIndex to MAX_HISTORY_LENGTH to prevent history navigation from breaking when the list exceeds the cap.

- **Bug Fixes**
  - Clamp setCurrentIndex to MAX_HISTORY_LENGTH when adding a new entry.
  - Prevents prev() from hitting an out-of-range index and keeps replace behavior working.

<sup>Written for commit ff480a3783d18242227dca788080a01705a2c71c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

