### PR TITLE
feat: select org profile on sign in

### DIFF
--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -118,8 +118,12 @@ export class ConfigHandler {
       const workspaceId = await this.getWorkspaceId();
       const selectedOrgs =
         this.globalContext.get("lastSelectedOrgIdForWorkspace") ?? {};
-      // reset selected org to first available org on login, otherwise use saved selection
-      const currentSelection = isLogin ? null : selectedOrgs[workspaceId];
+      let currentSelection = selectedOrgs[workspaceId];
+
+      // reset personal org to first available non-personal org on login
+      if (isLogin && currentSelection === "personal") {
+        currentSelection = null;
+      }
 
       const firstNonPersonal = orgs.find(
         (org) => org.id !== this.PERSONAL_ORG_DESC.id,


### PR DESCRIPTION
## Description

Select organization profile on sign in. If organization profile is not available, select the personal profile.

resolves CON-4960

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot


https://github.com/user-attachments/assets/3723228c-a470-435e-8422-d917edfc5c91




https://github.com/user-attachments/assets/a909cfc2-d001-4698-a46b-67422df25bf9





## Tests

[ What tests were added or updated to ensure the changes work as expected? ]






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically select the organization profile on sign in. If no org profile exists, fall back to the personal profile. Resolves CON-4960.

- **New Features**
  - On login, ignore the saved org selection so cascade init picks the first non-personal org; otherwise use the saved selection.

<sup>Written for commit aa0f50f222498e3a902d008a874443cf63b27ca2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





