### PR TITLE
chore: vscode 1.3.27

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "1.3.26",
+  "version": "1.3.27",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION
## Description
Extension version bump

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped the VS Code extension version to 1.3.27 to prepare for the next release.

<sup>Written for commit 38263d124495f1d0d63a610b21e9f222e28a952f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

