### PR TITLE
fix: add noreply@continue.dev to CLA exclusions

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -27,5 +27,5 @@ jobs:
           path-to-document: "https://github.com/continuedev/continue/blob/main/CLA.md"
           branch: cla-signatures
           # Bots and CLAs signed outside of GitHub
-          allowlist: dependabot[bot],fbricon,panyamkeerthana,Jazzcort,owtaylor,halfline,agent@continue.dev,action@github.com,snyk-bot
+          allowlist: dependabot[bot],fbricon,panyamkeerthana,Jazzcort,owtaylor,halfline,agent@continue.dev,action@github.com,snyk-bot,noreply@continue.dev
           signed-commit-message: "CLA signed in $pullRequestNo"


### PR DESCRIPTION
## Description
For bot commits

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Excludes noreply@continue.dev from CLA checks to prevent false failures on bot commits. Added the address to the CLA workflow allowlist.

<sup>Written for commit a72c05a61e2c222808cc16b8506a5a59c4949d74. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

