### PR TITLE
chore: add continue to CLA exclusions

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -27,5 +27,5 @@ jobs:
           path-to-document: "https://github.com/continuedev/continue/blob/main/CLA.md"
           branch: cla-signatures
           # Bots and CLAs signed outside of GitHub
-          allowlist: dependabot[bot],fbricon,panyamkeerthana,Jazzcort,owtaylor,halfline,agent@continue.dev,action@github.com,continue,snyk-bot,noreply@continue.dev
+          allowlist: dependabot[bot],fbricon,panyamkeerthana,Jazzcort,owtaylor,halfline,agent@continue.dev,action@github.com,continue[bot],snyk-bot,noreply@continue.dev
           signed-commit-message: "CLA signed in $pullRequestNo"


### PR DESCRIPTION
## Description
to fix e.g. https://github.com/continuedev/continue/actions/runs/19683289204/job/56382416497?pr=8881




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added continue[bot] to the CLA workflow allowlist so PRs opened by the Continue bot don’t fail the CLA check. Fixes recent CI runs where the CLA job errored for Continue-originated PRs.

<sup>Written for commit 517b576c076d7ba109ab7e58d276a74adf5f7e30. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



