### PR TITLE
fix(cli): wait for tui to update in test 

### DIFF
--- a/extensions/cli/vitest.config.ts
+++ b/extensions/cli/vitest.config.ts
@@ -20,7 +20,6 @@ export default defineConfig({
     },
     testTimeout: 30000,
     hookTimeout: 30000,
-    retry: process.env.CI && process.platform === "darwin" ? 2 : 0,
   },
   resolve: {
     extensions: [".js", ".ts", ".tsx", ".json"],

--- a/extensions/cli/vitest.e2e.config.ts
+++ b/extensions/cli/vitest.e2e.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
     include: ["src/e2e/**/*.test.ts"],
     testTimeout: 30000,
     hookTimeout: 30000,
-    retry: process.env.CI && process.platform === "darwin" ? 2 : 0,
   },
   resolve: {
     extensions: [".js", ".ts", ".tsx", ".json"],


### PR DESCRIPTION
## Description

In macos github runners, updating of the terminal interface can be slow and inconsistent. We need to use a waitFor until the element appears. This PR fixes that.

closes CON-4927

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace fixed timeouts with polling in the TUIChat edit message test to wait for the selector to open/close, reducing macOS CI flakiness; addresses Linear CON-4927.

<sup>Written for commit 163b004ce0c51a346cc0ceb47d67c7c5d4235c7d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





