### PR TITLE
Allow terminal commands on remote/code-server.

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "continue",
   "icon": "media/icon.png",
-  "author": "Continue Dev, Inc",
-  "version": "1.2.11",
+  "author": "Continue Dev, Inc/SkillerWhale",
+  "version": "1000.2.11",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION
- Also change version to stop auto-update.

## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable terminal commands and streamed output in remote/code-server sessions by removing the local-only restriction. Improves default cwd handling and colorized output.

- **New Features**
  - runTerminalCommand now works in remote/code-server (SSH, devcontainer, Codespaces, etc.).
  - Supports streaming output, background execution, and cancellation in remotes.
  - Better cwd fallback when no workspace is open, plus consistent color output.

- **Dependencies**
  - Set VS Code extension version to 1000.2.11 to prevent auto-update.

<sup>Written for commit 34b61aebfd3f1d36f87b45d1d106b15699a95504. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

