### PR TITLE
fix: subsequent tool call args are empty for gpt-5

### DIFF
--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -598,7 +598,6 @@ export const sessionSlice = createSlice({
               },
               contextItems: [],
             };
-            handleToolCallsInMessage(message, historyItem);
             state.history.push(historyItem);
             lastItem = state.history[state.history.length - 1];
             lastMessage = lastItem.message;


### PR DESCRIPTION
## Description

Previously, the subsequent tool calls for gpt-5 models always produced empty tool arguments. This PR fixes that

#### Diagnosis:

GPT-5 models tend to be less verbose between tool calls - meaning they do tool calls without explanations in between.

`streamUpdate` was transforming the second tool call message twice [here](https://github.com/continuedev/continue/blob/e12ecadf017f9b1186a8ef0e4ea2fd8d7993a625/gui/src/redux/slices/sessionSlice.ts#L601) and [here](https://github.com/continuedev/continue/blob/e12ecadf017f9b1186a8ef0e4ea2fd8d7993a625/gui/src/redux/slices/sessionSlice.ts#L651) for the same first message after the tool call. 
This added an extra character (for example, `"{\` at the beginning of `"{\"{\"command\":\"pwd\",\"waitForCompletion\":true"`) for which parsing the arguments failed.


resolves CON-4997

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot



https://github.com/user-attachments/assets/f1614a41-13cb-4367-aef5-a4c32970f7a2



https://github.com/user-attachments/assets/78a041c6-a076-4b68-90d3-b72c9ad4e857



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed empty tool arguments on subsequent GPT-5 tool calls by removing duplicate processing of the first message after a tool call. This prevents a stray leading character that broke JSON parsing and ensures tools receive correct args across consecutive calls (CON-4997).

<sup>Written for commit de5062fa85268a4248f039339204de432ed9d61b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

