### PR TITLE
feat(mcp): add Supabase-specific OAuth scopes to mcp-remote fallback

### DIFF
--- a/extensions/cli/src/services/MCPService.ts
+++ b/extensions/cli/src/services/MCPService.ts
@@ -503,11 +503,33 @@ Org-level secrets can only be used for MCP by Background Agents (https://docs.co
       } catch (error: unknown) {
         // If token refresh didn't work and it's a 401, fall back to mcp-remote
         if (isAuthError(error) && !this.isHeadless) {
+          // Build mcp-remote args with Supabase-specific OAuth scopes if needed
+          const mcpRemoteArgs = ["-y", "mcp-remote", serverConfig.url];
+
+          // Detect Supabase MCP and add custom OAuth scopes
+          if (serverConfig.url.includes("mcp.supabase.com")) {
+            const supabaseScopes = [
+              "organizations:read",
+              "projects:read",
+              "database:read",
+              "analytics:read",
+              "secrets:read",
+              "edge_functions:read",
+              "environment:read",
+              "storage:read",
+            ].join(" ");
+
+            mcpRemoteArgs.push(
+              "--static-oauth-client-metadata",
+              JSON.stringify({ scope: supabaseScopes }),
+            );
+          }
+
           const transport = this.constructStdioTransport(
             {
               name: serverConfig.name,
               command: "npx",
-              args: ["-y", "mcp-remote", serverConfig.url],
+              args: mcpRemoteArgs,
             },
             connection,
           );


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Supabase-specific OAuth scopes to the mcp-remote fallback so Supabase MCP can authenticate with the right permissions after a 401. Sends static OAuth client metadata with required read scopes (organizations, projects, database, analytics, secrets, edge functions, environment, storage) to prevent scope-related auth errors.

<sup>Written for commit 24f585992449b07c7e18ccdc55203efd940fb56f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





