### PR TITLE
fix: HOTFIX gemini model add form

### DIFF
--- a/gui/src/pages/AddNewModel/configs/providers.ts
+++ b/gui/src/pages/AddNewModel/configs/providers.ts
@@ -603,7 +603,6 @@ Select the \`GPT-4o\` model below to complete your provider configuration, but n
       models.gemini20Flash,
       models.gemini20FlashLite,
       models.gemini20FlashImageGeneration,
-      models.gemini25ProExp,
       models.gemini3ProPreview,
     ],
     apiKeyUrl: "https://aistudio.google.com/app/apikey",


### PR DESCRIPTION
## Description
Nonexistent value for gemini 2.5 pro exp was breaking selector
Fixes #8896, #8846, #8893, #8880, #8943, #8932, #8946, #8947

Let's fix types on this soon so doesn't happen again

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the Add New Model selector by removing the nonexistent “Gemini 2.5 Pro Exp” option from the Gemini provider list. This prevents the form from breaking when choosing a Gemini model.

<sup>Written for commit bc6f599ca8d0576264c76c1ca08332551dcff303. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

