### PR TITLE
chore: prerelease version bumps - jetbrains 57, vs code 28

### DIFF
--- a/extensions/intellij/gradle.properties
+++ b/extensions/intellij/gradle.properties
@@ -1,5 +1,5 @@
 pluginGroup=com.github.continuedev.continueintellijextension
-pluginVersion=1.0.56
+pluginVersion=1.0.57
 platformVersion=2024.1
 kotlin.stdlib.default.dependency=false
 org.gradle.configuration-cache=true

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "1.3.27",
+  "version": "1.3.28",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION
## Description


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump prerelease versions for IntelliJ and VS Code extensions; no functional changes. IntelliJ plugin to 1.0.57 and VS Code extension to 1.3.28.

<sup>Written for commit 84a58d776ff43e25d630e15ca7e002ee9c417cc6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

