### PR TITLE
chore: open github issue with details

### DIFF
--- a/gui/src/pages/gui/StreamError.tsx
+++ b/gui/src/pages/gui/StreamError.tsx
@@ -5,7 +5,7 @@ import {
   Cog6ToothIcon,
   KeyIcon,
 } from "@heroicons/react/24/outline";
-import { DISCORD_LINK, GITHUB_LINK } from "core/util/constants";
+import { DISCORD_LINK } from "core/util/constants";
 import { useContext, useMemo } from "react";
 import { GhostButton, SecondaryButton } from "../../components";
 import { useEditModel } from "../../components/mainInput/Lump/useEditBlock";
@@ -290,11 +290,27 @@ const StreamErrorDialog = ({ error }: StreamErrorProps) => {
           <GhostButton
             className="flex flex-row items-center gap-2 rounded px-3 py-1.5"
             onClick={() => {
-              ideMessenger.post("openUrl", GITHUB_LINK);
+              const issueTitle = `Error: ${selectedModel?.title || "Model"} - ${statusCode || "Unknown error"}`;
+              const issueBody = `**Error Details**
+
+Model: ${selectedModel?.title || "Unknown"}
+Provider: ${selectedModel?.provider || "Unknown"}
+Status Code: ${statusCode || "N/A"}
+
+**Error Output**
+\`\`\`
+${parsedError}
+\`\`\`
+
+**Additional Context**
+Please add any additional context about the error here
+`;
+              const url = `https://github.com/continuedev/continue/issues/new?title=${encodeURIComponent(issueTitle)}&body=${encodeURIComponent(issueBody)}`;
+              ideMessenger.post("openUrl", url);
             }}
           >
             <GithubIcon className="h-5 w-5" />
-            <span className="xs:flex hidden">Github</span>
+            <span className="xs:flex hidden">Open GitHub issue</span>
           </GhostButton>
           <GhostButton
             className="flex flex-row items-center gap-2 rounded px-3 py-1.5"


### PR DESCRIPTION
## Description

Change the GitHub link on error output modal to contain the error output, select model and api response.

resolves CON-5035

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

<img width="1080" height="911" alt="image" src="https://github.com/user-attachments/assets/92cc4739-03cf-4633-bab4-6b478dfb52a4" />

<img width="1170" height="902" alt="image" src="https://github.com/user-attachments/assets/cbbb8309-3df9-4d8c-a52f-a58e9927fcc2" />

<img width="1576" height="966" alt="image" src="https://github.com/user-attachments/assets/c43a8296-3210-4ab4-b1a6-f9ea4f9e9f0c" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the error modal to open a prefilled GitHub issue with the error output, selected model, provider, and status code. This makes reporting issues faster and more complete.

- **New Features**
  - Issue title includes model name and status code.
  - Issue body prefilled with error details, output, and a prompt for context.
  - Button label changed to “Open GitHub issue.”
  - Replaced static GITHUB_LINK with dynamic issue URL.

<sup>Written for commit 64f1ee7d4ea6fb0b3ca9ebbf283bb4ad54fe1bec. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

