### PR TITLE
style: restrict to max height for generated code preview

### DIFF
--- a/gui/src/components/StyledMarkdownPreview/SyntaxHighlightedPre.tsx
+++ b/gui/src/components/StyledMarkdownPreview/SyntaxHighlightedPre.tsx
@@ -23,6 +23,8 @@ const StyledPre = styled.pre<{ theme: any }>`
   margin-top: 0;
   margin-bottom: 0;
   border-radius: 0 0 ${defaultBorderRadius} ${defaultBorderRadius} !important;
+  max-height: 40vh;
+  overflow-y: scroll !important;
 
   ${(props) => generateThemeStyles(props.theme)}
 `;


### PR DESCRIPTION
## Description

Add a max height for the generated code div.

resolves CON-5047

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

**before**

<img width="488" height="755" alt="image" src="https://github.com/user-attachments/assets/29565f8a-0d80-45ff-83e7-68ff372d9ce7" />


**after**
<img width="491" height="833" alt="image" src="https://github.com/user-attachments/assets/b8f939a3-b364-431b-a31a-d9b37d5ba656" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts the generated code preview to a 40vh max height and adds vertical scrolling so long snippets don’t take over the page. Addresses CON-5047 by improving readability and keeping the layout consistent.

<sup>Written for commit 28380993154bcfe6a9013496839b2ad6d0166c0f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

