### PR TITLE
fix: show the correct number of pending tools

### DIFF
--- a/gui/src/pages/gui/ToolCallDiv/index.tsx
+++ b/gui/src/pages/gui/ToolCallDiv/index.tsx
@@ -29,8 +29,9 @@ export function ToolCallDiv({
 
   const shouldShowGroupedUI = toolCallStates.length > 1 && isStreamingComplete;
   const activeCalls = toolCallStates.filter(
-    (call) => call.status !== "canceled" && call.status !== "done",
+    (call) => call.status !== "canceled",
   );
+  const pendingCalls = toolCallStates.filter((call) => call.status !== "done");
 
   const renderToolCall = (toolCallState: ToolCallState) => {
     const tool = availableTools.find(
@@ -92,7 +93,7 @@ export function ToolCallDiv({
       <div className="border-border rounded-lg border px-4 py-3 pb-0">
         <GroupedToolCallHeader
           toolCallStates={toolCallStates}
-          activeCalls={activeCalls}
+          activeCalls={pendingCalls.length > 0 ? pendingCalls : activeCalls}
           open={open}
           onToggle={() => setOpen(!open)}
         />


### PR DESCRIPTION
## Description

For pending tools, the count of tools not yet completed. This PR fixes that.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created





## Screen recording or screenshot




https://github.com/user-attachments/assets/21c7b83e-c45f-4ab8-844e-9875daa659fc


https://github.com/user-attachments/assets/0ad7ac8b-e4f1-469b-995c-207e66535a20

## Tests



[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the pending tools count in ToolCallDiv so the grouped header shows the number of tools not yet completed. Uses a new pendingCalls list (status !== "done") and passes it to GroupedToolCallHeader, falling back to activeCalls when none are pending.

<sup>Written for commit 3d7be8a55a31ff32de19452572d512e96b3a901e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

