### PR TITLE
chore: update slashCommands tests with waitForCondition

### DIFF
--- a/extensions/cli/src/ui/__tests__/TUIChat.slashCommands.test.tsx
+++ b/extensions/cli/src/ui/__tests__/TUIChat.slashCommands.test.tsx
@@ -1,5 +1,5 @@
 import { renderInMode, testBothModes } from "./TUIChat.dualModeHelper.js";
-import { waitForCondition, waitForNextRender } from "./TUIChat.testHelper.js";
+import { waitForCondition } from "./TUIChat.testHelper.js";
 
 describe("TUIChat - Slash Commands Tests", () => {
   testBothModes("shows slash when user types /", async (mode) => {
@@ -7,9 +7,12 @@ describe("TUIChat - Slash Commands Tests", () => {
 
     // Type / to trigger slash command
     stdin.write("/");
-    await waitForNextRender();
 
-    const frame = lastFrame();
+    let frame = "";
+    await waitForCondition(() => {
+      frame = lastFrame() ?? "";
+      return frame.includes("/");
+    });
 
     // Should show the slash character
     expect(frame).toContain("/");
@@ -51,14 +54,21 @@ describe("TUIChat - Slash Commands Tests", () => {
   testBothModes("handles tab key after slash command", async (mode) => {
     const { lastFrame, stdin } = renderInMode(mode);
 
-    // Type /exi and then tab
     stdin.write("/exi");
-    await waitForNextRender();
+
+    let frame = "";
+    await waitForCondition(() => {
+      frame = lastFrame() ?? "";
+      return frame.includes("/exi");
+    });
 
     stdin.write("\t");
-    await waitForNextRender();
 
-    const frameAfterTab = lastFrame();
+    let frameAfterTab = "";
+    await waitForCondition(() => {
+      frameAfterTab = lastFrame() ?? "";
+      return frameAfterTab.length > 0;
+    });
 
     // Should not crash after tab
     expect(frameAfterTab).toBeDefined();
@@ -77,11 +87,13 @@ describe("TUIChat - Slash Commands Tests", () => {
   testBothModes("shows slash command menu when typing /", async (mode) => {
     const { lastFrame, stdin } = renderInMode(mode);
 
-    // Type just /
     stdin.write("/");
-    await waitForNextRender();
 
-    const frame = lastFrame();
+    let frame = "";
+    await waitForCondition(() => {
+      frame = lastFrame() ?? "";
+      return frame.includes("/");
+    });
 
     // Should show the slash
     expect(frame).toContain("/");
@@ -111,9 +123,18 @@ describe("TUIChat - Slash Commands Tests", () => {
 
       // Type a complete command name first
       stdin.write("/title");
-      await waitForNextRender();
 
-      const frameAfterCommand = lastFrame();
+      let frameAfterCommand = lastFrame();
+      await waitForCondition(() => {
+        frameAfterCommand = lastFrame();
+
+        return (
+          frameAfterCommand?.includes(
+            mode === "remote" ? "Remote Mode" : "/title",
+          ) ?? false
+        );
+      });
+
       if (mode === "remote") {
         // In remote mode, /title might not be a valid command, so just check we're in remote mode
         expect(frameAfterCommand).toContain("Remote Mode");
@@ -124,9 +145,12 @@ describe("TUIChat - Slash Commands Tests", () => {
 
       // Now add a space and arguments
       stdin.write(" My Session Title");
-      await waitForNextRender();
 
-      const frameAfterArgs = lastFrame();
+      let frameAfterArgs = lastFrame();
+      await waitForCondition(() => {
+        frameAfterArgs = lastFrame() ?? "";
+        return frameAfterArgs.includes("My Session Title");
+      });
 
       // Check that the UI is still functional after adding arguments
       if (mode === "remote") {
@@ -145,19 +169,27 @@ describe("TUIChat - Slash Commands Tests", () => {
     async (mode) => {
       const { lastFrame, stdin } = renderInMode(mode);
 
-      // Type a complete command with arguments
       stdin.write("/title Test Session");
-      await waitForNextRender();
 
-      const frameBeforeEnter = lastFrame();
+      let frameBeforeEnter = lastFrame();
+      await waitForCondition(() => {
+        frameBeforeEnter = lastFrame() ?? "";
+        return (
+          frameBeforeEnter.includes("/title") &&
+          frameBeforeEnter.includes("Test Session")
+        );
+      });
+
       expect(frameBeforeEnter).toContain("/title");
       expect(frameBeforeEnter).toContain("Test Session");
 
-      // Press Enter - this should execute the command, not try to autocomplete
       stdin.write("\r");
-      await waitForNextRender();
 
-      const frameAfterEnter = lastFrame();
+      let frameAfterEnter = lastFrame();
+      await waitForCondition(() => {
+        frameAfterEnter = lastFrame() ?? "";
+        return frameAfterEnter.length > 0;
+      });
 
       // Should not crash and should clear the input (or show command execution)
       expect(frameAfterEnter).toBeDefined();


### PR DESCRIPTION
## Description


Another followup PR on https://github.com/continuedev/continue/pull/8909/files to update cli tests

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilized CLI slash command tests by switching to waitForCondition and polling for expected UI output. This reduces flakiness and ensures consistent behavior in both local and remote modes.

- **Refactors**
  - Replaced waitForNextRender with waitForCondition in TUIChat.slashCommands.test.tsx.
  - Poll for expected frame content to verify slash, tab, arguments, and enter flows without crashes.

<sup>Written for commit bf2a8a4addc0c6d82a42204dc53f5ecd10dc1d56. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

