### PR TITLE
Update runloop blueprint template for Chrome support

### DIFF
--- a/.github/workflows/runloop-blueprint-template.json
+++ b/.github/workflows/runloop-blueprint-template.json
@@ -3,6 +3,17 @@
   "system_setup_commands": [
     "npm i -g @continuedev/cli@latest",
     "sudo apt update",
-    "sudo apt install -y ripgrep"
-  ]
+    "sudo apt install -y --no-install-recommends ripgrep chromium chromium-driver xvfb",
+    "sudo mkdir -p /opt/google/chrome",
+    "sudo ln -s /usr/bin/chromium /opt/google/chrome/chrome"
+  ],
+  "launch_parameters": {
+    "launch_commands": [
+      "nohup Xvfb :99 -screen 0 1920x1080x24 > /tmp/xvfb.log 2>&1 &",
+      "sleep 2"
+    ],
+    "environment_variables": {
+      "DISPLAY": ":99"
+    }
+  }
 }


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add headless Chrome support to the runloop blueprint by installing Chromium/ChromeDriver and starting Xvfb, enabling browser automation in CI.

- **New Features**
  - Install chromium, chromium-driver, and xvfb (with no-install-recommends).
  - Add symlink to /opt/google/chrome/chrome for tools expecting Chrome’s default path.
  - Start Xvfb and set DISPLAY=:99 via launch_parameters for headless runs.

<sup>Written for commit f6de2c2e649edf79dff71f9377f17adc48bfd636. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

