### PR TITLE
Add docker.io and docker-compose to system setup dependencies

### DIFF
--- a/.github/workflows/runloop-blueprint-template.json
+++ b/.github/workflows/runloop-blueprint-template.json
@@ -3,7 +3,7 @@
   "system_setup_commands": [
     "npm i -g @continuedev/cli@latest",
     "sudo apt update",
-    "sudo apt install -y --no-install-recommends ripgrep chromium chromium-driver xvfb",
+    "sudo apt install -y --no-install-recommends ripgrep chromium chromium-driver xvfb docker.io docker-compose",
     "sudo mkdir -p /opt/google/chrome",
     "sudo ln -s /usr/bin/chromium /opt/google/chrome/chrome"
   ],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add docker.io and docker-compose to the runloop system setup so Docker and Compose tasks work out of the box in CI.

Updates the apt install command in the blueprint template to include both packages.

<sup>Written for commit ff08fa20491376f69b0a005dadb028ea7f1304da. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

