### PR TITLE
Add GitHub workflow to upload Runloop blueprint on changes

### DIFF
--- a/.github/workflows/runloop-blueprint-template.json
+++ b/.github/workflows/runloop-blueprint-template.json
@@ -9,11 +9,9 @@
   ],
   "launch_parameters": {
     "launch_commands": [
+      "export DISPLAY=:99",
       "nohup Xvfb :99 -screen 0 1920x1080x24 > /tmp/xvfb.log 2>&1 &",
       "sleep 2"
-    ],
-    "environment_variables": {
-      "DISPLAY": ":99"
-    }
+    ]
   }
 }

--- a/.github/workflows/upload-runloop-blueprint.yml
+++ b/.github/workflows/upload-runloop-blueprint.yml
@@ -1,0 +1,59 @@
+name: Upload Runloop Blueprint
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/runloop-blueprint-template.json'
+
+permissions:
+  contents: read
+
+jobs:
+  upload-blueprint:
+    name: Upload Blueprint to Runloop
+    runs-on: ubuntu-latest
+    # Only run this workflow on the main repository (continuedev/continue)
+    if: github.repository == 'continuedev/continue'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Publish Blueprint to Runloop
+        env:
+          RUNLOOP_API_KEY: ${{ secrets.RUNLOOP_API_KEY }}
+        run: |
+          echo "Publishing blueprint 'cn' to Runloop API"
+
+          # Use blueprint configuration from template file
+          cp .github/workflows/runloop-blueprint-template.json blueprint.json
+
+          # Publish to Runloop API
+          response=$(curl -X POST "https://api.runloop.ai/v1/blueprints" \
+            -H "Authorization: Bearer $RUNLOOP_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d @blueprint.json \
+            -w "%{http_code}" \
+            -s)
+
+          http_code=$(echo "$response" | tail -c 4)
+          response_body=$(echo "$response" | head -c -4)
+
+          if [[ "$http_code" == "200" ]] || [[ "$http_code" == "201" ]]; then
+            echo "✅ Successfully published blueprint to Runloop API"
+            echo "Response: $response_body"
+
+            # Extract blueprint ID if available
+            blueprint_id=$(echo "$response_body" | jq -r '.id // empty')
+            if [[ -n "$blueprint_id" ]]; then
+              echo "Blueprint ID: $blueprint_id"
+              echo "blueprint_id=$blueprint_id" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "❌ Failed to publish blueprint to Runloop API"
+            echo "HTTP Code: $http_code"
+            echo "Response: $response_body"
+            exit 1
+          fi


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Automates publishing the Runloop blueprint via GitHub Actions when the template changes on main. Also updates the template to export DISPLAY in launch commands for reliable headless runs.

- **New Features**
  - Adds upload-runloop-blueprint.yml to publish the blueprint on push to main (when the template file changes) and via manual dispatch.
  - Runs only on the main repo (continuedev/continue).
  - Uses RUNLOOP_API_KEY to POST blueprint.json to the Runloop API and surfaces blueprint_id on success.

- **Refactors**
  - Moves DISPLAY setup into launch_commands with `export DISPLAY=:99`; removes the environment_variables block.

<sup>Written for commit 03c487db30b4b6e7d6f764b29ed75041fe93d670. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

