### PR TITLE
Prevent service auto-start during apt install in runloop blueprint

### DIFF
--- a/.github/workflows/runloop-blueprint-template.json
+++ b/.github/workflows/runloop-blueprint-template.json
@@ -3,7 +3,10 @@
   "system_setup_commands": [
     "npm i -g @continuedev/cli@latest",
     "sudo apt update",
+    "echo '#!/bin/sh\nexit 101' | sudo tee /usr/sbin/policy-rc.d > /dev/null",
+    "sudo chmod +x /usr/sbin/policy-rc.d",
     "sudo apt install -y --no-install-recommends ripgrep chromium chromium-driver xvfb docker.io docker-compose",
+    "sudo rm /usr/sbin/policy-rc.d",
     "sudo mkdir -p /opt/google/chrome",
     "sudo ln -s /usr/bin/chromium /opt/google/chrome/chrome"
   ],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent services from auto-starting during apt installs in the runloop blueprint by adding a temporary /usr/sbin/policy-rc.d that exits 101, then removing it after install. This avoids unexpected daemon starts (e.g., Docker) during setup and makes the workflow more reliable.

<sup>Written for commit 704ca44003dbd25068b51bc6b31444742a10bf8a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

