### PR TITLE
Combine policy-rc.d setup commands into single line in runloop blueprint

### DIFF
--- a/.github/workflows/runloop-blueprint-template.json
+++ b/.github/workflows/runloop-blueprint-template.json
@@ -3,8 +3,7 @@
   "system_setup_commands": [
     "npm i -g @continuedev/cli@latest",
     "sudo apt update",
-    "echo '#!/bin/sh\nexit 101' | sudo tee /usr/sbin/policy-rc.d > /dev/null",
-    "sudo chmod +x /usr/sbin/policy-rc.d",
+    "printf '#!/bin/sh\\nexit 101\\n' | sudo tee /usr/sbin/policy-rc.d > /dev/null && sudo chmod +x /usr/sbin/policy-rc.d",
     "sudo apt install -y --no-install-recommends ripgrep chromium chromium-driver xvfb docker.io docker-compose",
     "sudo rm /usr/sbin/policy-rc.d",
     "sudo mkdir -p /opt/google/chrome",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched to printf and combined the policy-rc.d setup into a single system_setup_commands entry in the runloop blueprint. This ensures the script has correct newlines, sets the executable bit in one step, and simplifies the setup.

<sup>Written for commit 210924de96dfab1cf159c82c2020c29d1eccf868. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

