### PR TITLE
Add configurable timeout parameter to runTerminalCommand tool

### DIFF
--- a/extensions/cli/src/tools/runTerminalCommand.ts
+++ b/extensions/cli/src/tools/runTerminalCommand.ts
@@ -48,7 +48,7 @@ IMPORTANT: To edit files, use Edit/MultiEdit tools instead of bash commands (sed
       timeout: {
         type: "number",
         description:
-          "Optional timeout in seconds (max 600). Only use this parameter when a command takes too long and times out with the default 120 second timeout.",
+          "Optional timeout in seconds (max 600). Use this parameter for commands that take longer than the default 180 second timeout.",
       },
     },
   },


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a configurable timeout parameter to the runTerminalCommand tool so callers can control command execution time. Default timeout is now 180 seconds, with support for up to 600 seconds when needed.

- **New Features**
  - Added a timeout (seconds) input, capped at 600.
  - If not provided, uses TEST_TERMINAL_TIMEOUT in test environments; otherwise defaults to 180s.

<sup>Written for commit 19292759383a90ebd2d42516060c57030490baff. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



