### PR TITLE
Add Dockerfile and remove Docker installation from system setup

### DIFF
--- a/.github/workflows/runloop-blueprint-template.json
+++ b/.github/workflows/runloop-blueprint-template.json
@@ -1,10 +1,11 @@
 {
   "name": "cn",
+  "dockerfile": "FROM runloop:runloop/universal-ubuntu-24.04-x86_64-dnd",
   "system_setup_commands": [
     "npm i -g @continuedev/cli@latest",
     "sudo apt update",
     "printf '#!/bin/sh\\nexit 101\\n' | sudo tee /usr/sbin/policy-rc.d > /dev/null && sudo chmod +x /usr/sbin/policy-rc.d",
-    "sudo apt install -y --no-install-recommends ripgrep chromium chromium-driver xvfb docker.io docker-compose",
+    "sudo apt install -y --no-install-recommends ripgrep chromium chromium-driver xvfb",
     "sudo rm /usr/sbin/policy-rc.d",
     "sudo mkdir -p /opt/google/chrome",
     "sudo ln -s /usr/bin/chromium /opt/google/chrome/chrome"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a Dockerfile to the runloop blueprint and remove Docker from system setup. This reduces dependencies and avoids Docker-in-Docker.

- **Refactors**
  - Set "dockerfile" to use runloop/universal-ubuntu-24.04-x86_64-dnd.
  - Removed docker.io and docker-compose from apt install commands.

<sup>Written for commit b46509b0bb06ce9c659af0ff647b461de7a047b7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

