### PR TITLE
Add Infisical CLI installation to Runloop blueprint setup

### DIFF
--- a/.github/workflows/runloop-blueprint-template.json
+++ b/.github/workflows/runloop-blueprint-template.json
@@ -8,7 +8,9 @@
     "sudo apt install -y --no-install-recommends ripgrep chromium chromium-driver xvfb",
     "sudo rm /usr/sbin/policy-rc.d",
     "sudo mkdir -p /opt/google/chrome",
-    "sudo ln -s /usr/bin/chromium /opt/google/chrome/chrome"
+    "sudo ln -s /usr/bin/chromium /opt/google/chrome/chrome",
+    "curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | sudo -E bash",
+    "sudo apt-get install -y infisical"
   ],
   "launch_parameters": {
     "launch_commands": [


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Installs Infisical CLI during Runloop blueprint setup to enable secrets management in Runloop jobs. Adds commands to add the Infisical apt repository and install the infisical package.

<sup>Written for commit eb4100071c1f6e7f5653b612c740b99ae761e42b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

