### PR TITLE
Add docker-compose-v2 to runloop blueprint dependencies

### DIFF
--- a/.github/workflows/runloop-blueprint-template.json
+++ b/.github/workflows/runloop-blueprint-template.json
@@ -5,7 +5,7 @@
     "npm i -g @continuedev/cli@latest",
     "sudo apt update",
     "printf '#!/bin/sh\\nexit 101\\n' | sudo tee /usr/sbin/policy-rc.d > /dev/null && sudo chmod +x /usr/sbin/policy-rc.d",
-    "sudo apt install -y --no-install-recommends ripgrep chromium chromium-driver xvfb",
+    "sudo apt install -y --no-install-recommends ripgrep chromium chromium-driver xvfb docker-compose-v2",
     "sudo rm /usr/sbin/policy-rc.d",
     "sudo mkdir -p /opt/google/chrome",
     "sudo ln -s /usr/bin/chromium /opt/google/chrome/chrome",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added docker-compose-v2 to the runloop blueprint setup so Docker Compose commands work in the environment. This prevents failures for projects that rely on Compose v2.

<sup>Written for commit 7dbdb9cce1308a212899b448881fca202e27c1b5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

