### PR TITLE
Remove docker-compose-v2 from runloop blueprint apt install

### DIFF
--- a/.github/workflows/runloop-blueprint-template.json
+++ b/.github/workflows/runloop-blueprint-template.json
@@ -5,7 +5,7 @@
     "npm i -g @continuedev/cli@latest",
     "sudo apt update",
     "printf '#!/bin/sh\\nexit 101\\n' | sudo tee /usr/sbin/policy-rc.d > /dev/null && sudo chmod +x /usr/sbin/policy-rc.d",
-    "sudo apt install -y --no-install-recommends ripgrep chromium chromium-driver xvfb docker-compose-v2",
+    "sudo apt install -y --no-install-recommends ripgrep chromium chromium-driver xvfb",
     "sudo rm /usr/sbin/policy-rc.d",
     "sudo mkdir -p /opt/google/chrome",
     "sudo ln -s /usr/bin/chromium /opt/google/chrome/chrome",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed docker-compose-v2 from the runloop blueprint apt install list to avoid installing an unnecessary package. This reduces setup time and prevents conflicts on runners with Docker already installed.

<sup>Written for commit 44f08122d6bf1edb20d376e1c0357e5471f3180c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

