### PR TITLE
fix: issue 3753 for .js and .ts file types 

### DIFF
--- a/extensions/vscode/tree-sitter/code-snippet-queries/javascript.scm
+++ b/extensions/vscode/tree-sitter/code-snippet-queries/javascript.scm
@@ -1,12 +1,12 @@
 (
-  (comment)? @comment
+  (comment)? @comment .
   (class_declaration
     name: (_) @name
   ) @definition
 )
 
 (
-  (comment)? @comment
+  (comment)? @comment .
   (function_declaration
     name: (_) @name
     parameters: (_) @parameters
@@ -14,7 +14,7 @@
 )
 
 (
-  (comment)? @comment
+  (comment)? @comment .
   (method_definition
     name: (_) @name
     parameters: (_) @parameters

--- a/extensions/vscode/tree-sitter/code-snippet-queries/typescript.scm
+++ b/extensions/vscode/tree-sitter/code-snippet-queries/typescript.scm
@@ -1,12 +1,12 @@
 (
-  (comment)? @comment
+  (comment)? @comment .
   (class_declaration
     name: (_) @name
   ) @definition
 )
 
 (
-  (comment)? @comment
+  (comment)? @comment .
   (function_declaration
     name: (_) @name
     parameters: (_) @parameters
@@ -14,7 +14,7 @@
 )
 
 (
-  (comment)? @comment
+  (comment)? @comment .
   (method_definition
     name: (_) @name
     parameters: (_) @parameters
@@ -22,7 +22,7 @@
 )
 
 (
-  (comment)? @comment
+  (comment)? @comment .
   (interface_declaration
     name: (_) @name) @definition
 ) 


### PR DESCRIPTION
## Description

Extension host was getting stuck due to redundant tree-sitter lookups in .js and .ts files. with many comments 
See  https://github.com/continuedev/continue/issues/3753#issuecomment-3224977558 for details and timings.

**What changed?** 
- Modified .scm files for javascript and typescript, so extension host no longer becomes unresponsive. 
 
Now only comment block preceding a code block (class, method, function, interface declarations) will yield a pattern match. 
W/o the dot every comment preceding a code block would yield a pattern match , performing n<sup>2</sup> more ops than the number of relevant matches.  This resulted in extension host being stuck for extended duration and hence all other installed extension being unresponsive.

To demonstrate , consider the following example, where we have a  js/ts file with 10 functions each preceded by a commented line: 
```
//comment0
func0() {}
....
//comment9
funct9() {} 
```
Before this PR there would be 55 = 10+9+8+..+1 matches, with this fix only 10 matches. For my local testing the performance gain was 16200 %. 

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

See the original issue for recording of the bug and performance improvement measurements.

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
This PR doesnt introduce any new features, but changes the performance of existing.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes extension host freezes in .js and .ts files by updating tree-sitter queries to match only the comment directly before declarations. Addresses #3753 and restores normal performance in files with many comments.

- **Bug Fixes**
  - Updated javascript.scm and typescript.scm to require the preceding comment be adjacent to the class/function/method/interface declaration.
  - Eliminates combinatorial matches (e.g., 10! → 10), preventing the extension host from getting stuck.

<sup>Written for commit cb4db878b89828d01880251cb490af50d15dbd44. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



