### PR TITLE
feat(cli): add session ID support for serve command to persist chat history

### DIFF
--- a/extensions/cli/src/commands/serve.ts
+++ b/extensions/cli/src/commands/serve.ts
@@ -23,7 +23,11 @@ import {
   ConfigServiceState,
   ModelServiceState,
 } from "../services/types.js";
-import { createSession, getCompleteStateSnapshot } from "../session.js";
+import {
+  createSession,
+  getCompleteStateSnapshot,
+  loadOrCreateSessionById,
+} from "../session.js";
 import { messageQueue } from "../stream/messageQueue.js";
 import { constructSystemMessage } from "../systemMessage.js";
 import { telemetryService } from "../telemetry/telemetryService.js";
@@ -142,7 +146,11 @@ export async function serve(prompt?: string, options: ServeOptions = {}) {
     });
   }
 
-  const session = createSession(initialHistory);
+  const trimmedId = options.id?.trim();
+  const session =
+    trimmedId && trimmedId.length > 0
+      ? loadOrCreateSessionById(trimmedId, initialHistory)
+      : createSession(initialHistory);
 
   // Align ChatHistoryService with server session and enable remote mode
   try {

--- a/extensions/cli/src/session.ts
+++ b/extensions/cli/src/session.ts
@@ -316,9 +316,12 @@ export function loadSession(): Session | null {
 /**
  * Create a new session
  */
-export function createSession(history: ChatHistoryItem[] = []): Session {
+export function createSession(
+  history: ChatHistoryItem[] = [],
+  sessionId?: string,
+): Session {
   const session: Session = {
-    sessionId: uuidv4(),
+    sessionId: sessionId ?? uuidv4(),
     title: DEFAULT_SESSION_TITLE,
     workspaceDirectory: process.cwd(),
     history,
@@ -524,6 +527,24 @@ export function loadSessionById(sessionId: string): Session | null {
     logger.error("Error loading session by ID:", error);
     return null;
   }
+}
+
+/**
+ * Load an existing session by ID or create a new one with that ID.
+ * Useful for long-lived processes (e.g., cn serve) that need to
+ * preserve chat history across restarts for the same storage/agent id.
+ */
+export function loadOrCreateSessionById(
+  sessionId: string,
+  history: ChatHistoryItem[] = [],
+): Session {
+  const existing = loadSessionById(sessionId);
+  if (existing) {
+    SessionManager.getInstance().setSession(existing);
+    return existing;
+  }
+
+  return createSession(history, sessionId);
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added session ID support to the CLI serve command to persist and reuse chat history across restarts. When an ID is provided, the server loads the existing session or creates one with that ID.

- **New Features**
  - Serve uses a trimmed session ID to load an existing session or create a new one; falls back to a new session when no ID is given.
  - Session module adds loadOrCreateSessionById and allows createSession to accept a custom sessionId.

- **Migration**
  - Start serve with the same session ID to keep chat history between restarts.

<sup>Written for commit 09deed45dd252ad5d9abee478ac120551a41699f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

