### PR TITLE
fix(intellij): Prevent ConcurrentModificationException in keymap access

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/activities/ContinuePluginStartupActivity.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/activities/ContinuePluginStartupActivity.kt
@@ -88,9 +88,11 @@ private fun getTutorialFileName(): String {
 class ContinuePluginStartupActivity : StartupActivity, DumbAware {
 
     override fun runActivity(project: Project) {
-        removeShortcutFromAction(getPlatformSpecificKeyStroke("J"))
-        removeShortcutFromAction(getPlatformSpecificKeyStroke("shift J"))
-        removeShortcutFromAction(getPlatformSpecificKeyStroke("I"))
+        ApplicationManager.getApplication().invokeLater {
+            removeShortcutFromAction(getPlatformSpecificKeyStroke("J"))
+            removeShortcutFromAction(getPlatformSpecificKeyStroke("shift J"))
+            removeShortcutFromAction(getPlatformSpecificKeyStroke("I"))
+        }
         initializePlugin(project)
     }
 


### PR DESCRIPTION
## Description
Fixes intermittent `ConcurrentModificationException` that occurs during plugin startup when accessing the Keymap API from a background thread.

**Root cause**: `StartupActivity.runActivity()` runs on a coroutine background thread, but `Keymap.getActionIds()` is not fully thread-safe (documented as "weakly consistent when called from background thread").

**Solution**: Wrapped keymap operations in `invokeLater` to ensure execution on EDT.

## AI Code Review
- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist
- [x] I've read the [[contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot
N/A - This is a race condition fix. The bug occurs intermittently and doesn't have visible UI changes. See stack trace below for error evidence.

**Stack trace before fix:**
```
java.util.ConcurrentModificationException
	at java.base/java.util.ArrayList.sort(ArrayList.java:1806)
	at kotlin.collections.CollectionsKt__MutableCollectionsJVMKt.sortWith(MutableCollectionsJVM.kt:42)
	at com.intellij.openapi.keymap.impl.KeymapImplKt.sortInRegistrationOrder(KeymapImpl.kt:821)
	at com.intellij.openapi.keymap.impl.KeymapImpl.getActionIds(KeymapImpl.kt:536)
	at com.github.continuedev.continueintellijextension.activities.ContinuePluginStartupActivity.removeShortcutFromAction
```

## Tests
Manual testing performed:
- Tested on IntelliJ IDEA 2024.3 with multiple IDE restarts
- No `ConcurrentModificationException` occurred after fix
- Verified keymap shortcuts (Cmd+J, Cmd+Shift+J, Cmd+I) still work correctly
- Plugin initialization completes without errors

**Note**: This is a concurrency bug fix. Automated testing for race conditions is difficult, but the fix follows IntelliJ Platform's recommended threading practices (running UI operations on EDT).

**References:**
- IntelliJ Keymap API: https://github.com/JetBrains/intellij-community/blob/master/platform/platform-api/src/com/intellij/openapi/keymap/Keymap.java
- Related issue: #8764

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents intermittent ConcurrentModificationException during IntelliJ plugin startup by running keymap shortcut removal on the EDT. Stabilizes startup while keeping existing shortcuts working.

- **Bug Fixes**
  - Moved J, Shift+J, and I shortcut removal into ApplicationManager.getApplication().invokeLater to ensure Keymap access happens on the EDT.

<sup>Written for commit 5d1cd001039eb2b8b037db7dbdeaf91a11be59b0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

