### PR TITLE
fix(runloop): hardcode amd64 architecture and update blueprint name to cn-test

### DIFF
--- a/.github/workflows/runloop-blueprint-template.json
+++ b/.github/workflows/runloop-blueprint-template.json
@@ -1,5 +1,5 @@
 {
-  "name": "cn",
+  "name": "cn-test",
   "dockerfile": "FROM runloop:runloop/universal-ubuntu-24.04-x86_64-dnd",
   "system_setup_commands": [
     "npm i -g @continuedev/cli@latest",
@@ -13,7 +13,7 @@
     "sudo apt-get install -y infisical",
     "curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg",
     "sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg",
-    "echo 'deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main' | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null",
+    "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main' | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null",
     "sudo apt update",
     "sudo apt install -y gh"
   ],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardcode amd64 in the GitHub CLI APT source to ensure reliable installs in the runloop image. Renamed the blueprint from cn to cn-test.

<sup>Written for commit d10594f6cda0dea50e1acd03e7af82da0b874e5e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

