### PR TITLE
Add fallback to prevent git symlink loop failure in Runloop blueprint

### DIFF
--- a/.github/workflows/runloop-blueprint-template.json
+++ b/.github/workflows/runloop-blueprint-template.json
@@ -23,7 +23,7 @@
       "nohup Xvfb :99 -screen 0 1920x1080x24 > /tmp/xvfb.log 2>&1 &",
       "sleep 2",
       "sudo mkdir -p /home/user",
-      "for dir in /root/*; do [ -d \"$dir\" ] && [ -d \"$dir/.git\" ] && sudo ln -sf \"$dir\" \"/home/user/$(basename \"$dir\")\"; done"
+      "for dir in /root/*; do [ -d \"$dir\" ] && [ -d \"$dir/.git\" ] && sudo ln -sf \"$dir\" \"/home/user/$(basename \"$dir\")\"; done || true"
     ]
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add error tolerance to the symlink creation loop in the Runloop blueprint so the workflow doesn’t fail on git symlink loops. Appends `|| true` to the loop to ignore non-zero exits.

<sup>Written for commit 1f986723e8ff2fac802d7da75f0fe7c7b487949c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

