### PR TITLE
Add Puppeteer executable path environment variable to runloop blueprint

### DIFF
--- a/.github/workflows/runloop-blueprint-template.json
+++ b/.github/workflows/runloop-blueprint-template.json
@@ -20,6 +20,7 @@
   "launch_parameters": {
     "launch_commands": [
       "export DISPLAY=:99",
+      "export PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium",
       "nohup Xvfb :99 -screen 0 1920x1080x24 > /tmp/xvfb.log 2>&1 &",
       "sleep 2",
       "sudo mkdir -p /home/user",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set PUPPETEER_EXECUTABLE_PATH to /usr/bin/chromium in the runloop blueprint launch commands so Puppeteer uses the system Chromium. This prevents Puppeteer downloads and avoids launch failures under Xvfb.

<sup>Written for commit 4905bd59056ac0ec94ac45e77d0c8877f1307cc8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

