### PR TITLE
feat: resubmit overloaded errors

### DIFF
--- a/gui/src/redux/thunks/streamThunkWrapper.tsx
+++ b/gui/src/redux/thunks/streamThunkWrapper.tsx
@@ -51,6 +51,7 @@ export const streamThunkWrapper = createAsyncThunk<
         await new Promise((resolve) => setTimeout(resolve, delayMs));
         await dispatch(cancelStream());
       } else {
+        await dispatch(cancelStream());
         dispatch(setDialogMessage(<StreamErrorDialog error={e} />));
         dispatch(setShowDialog(true));
 
@@ -62,6 +63,7 @@ export const streamThunkWrapper = createAsyncThunk<
         };
 
         posthog.capture("gui_stream_error", errorData);
+        return;
       }
     }
   }


### PR DESCRIPTION
## Description

Retry overloaded errors from the model provider's server with an exponential backoff.

resolves CON-5040

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

https://github.com/user-attachments/assets/43b32f40-f429-44fd-aa45-82e2d00ae86c




## Tests

[ What tests were added or updated to ensure the changes work as expected? ]




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add automatic retries with exponential backoff when the model provider is overloaded to reduce failed chats and improve reliability. Addresses CON-5040.

- **New Features**
  - Retries up to 3 times with a 1s base delay (1s, 2s, 4s).
  - Detects overload via error messages containing “overloaded” or “malformed json”.
  - Cancels the stream before retry; on final failure, shows the error dialog and logs gui_stream_error to PostHog with metadata.

<sup>Written for commit c391353709ad4367fb333680190e0ba73c868ef0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

---

<!-- continue-task-summary-start -->

## Continue Tasks

| Status | Task | Actions |
|:-------|:-----|:--------|
| ▶️ Queued | Optimize Website Performance | [View](https://hub.continue.dev/tasks/1def1af6-5e06-4ad0-aa85-3d4661a4a1c6) |
| ▶️ Not Started | Update docs on PR | [Run](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F9082) |

<sub>Powered by [Continue](https://hub.continue.dev)</sub>

<!-- continue-task-summary-end -->