### PR TITLE
Rename workflow from 'cn-test' to 'cn'

### DIFF
--- a/.github/workflows/runloop-blueprint-template.json
+++ b/.github/workflows/runloop-blueprint-template.json
@@ -1,5 +1,5 @@
 {
-  "name": "cn-test",
+  "name": "cn",
   "dockerfile": "FROM runloop:runloop/universal-ubuntu-24.04-x86_64-dnd",
   "system_setup_commands": [
     "npm i -g @continuedev/cli@latest",


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the Runloop workflow from "cn-test" to "cn" in the blueprint template to match production naming. This removes the "test" label in CI/UI and keeps logs and workflow lists consistent.

<sup>Written for commit 3a09030a8776805b48591345dfcf5f9d74f805fe. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

