### PR TITLE
Remove scheduled cron job from stable release workflow

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -1,9 +1,6 @@
 name: Stable Release
 
 on:
-  schedule:
-    # Run every Monday at 10am UTC (1 hour after beta release)
-    - cron: "0 10 * * 1"
   workflow_dispatch:
     inputs:
       release_type:


### PR DESCRIPTION
Removed scheduled cron job for stable release.

## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the scheduled cron trigger from the stable-release GitHub Actions workflow to prevent automatic Monday runs. Stable releases now run only when manually dispatched via workflow_dispatch.

<sup>Written for commit 4a8026be59cf7cb70b3307965d01c8e606679094. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

