### PR TITLE
Dallin/posthog mcp tweaks

### DIFF
--- a/docs/guides/posthog-github-continuous-ai.mdx
+++ b/docs/guides/posthog-github-continuous-ai.mdx
@@ -166,7 +166,7 @@ You only need to configure the PostHog MCP credential - it automatically handles
   <Steps>
     <Step title="Add PostHog MCP to Continue CLI">
       First, install the [PostHog MCP](https://hub.continue.dev/posthog/http-mcp) to the Continue CLI by
-      1. Adding it to a [hub config]() OR
+      1. Adding it to a Hub Config by clicking "Use MCP Server" and selecting a Config
       2. Adding it to your [Local Config](/reference#mcpservers)
     </Step>
     <Step title="Add PostHog + GitHub Analysis Rules">


### PR DESCRIPTION
## Description
Updates docs for posthog guide for mcp installation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the PostHog GitHub Continuous AI guide to use the current MCP setup and rule install flow. Replaced the old npx mcp-remote command with Hub/Local config steps, linked to the http-mcp server, and clarified how to add rules via “Use Rule”, CLI flag, or local rules folder.

<sup>Written for commit fb8a834a2511e88c6a31367657697377962825ed. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

