### PR TITLE
Add worktree copy configuration and ignore copy status files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,6 @@ keys
 
 .channels_cache.json
 .users_cache.json
+.copy-status
+.copy-log
+

--- a/worktree-config.yaml
+++ b/worktree-config.yaml
@@ -1,0 +1,24 @@
+# Worktree Copy Configuration
+# Edit this file to customize what gets copied when creating new worktrees
+#
+# Supports glob patterns:
+#   - packages/*/node_modules  (matches all package node_modules)
+#   - **/.next                  (matches .next in any subdirectory)
+#   - services/**/*.env         (matches all .env files in services)
+
+# Large directories - copied using Copy-on-Write (fast, space-efficient)
+cowCopyTargets:
+  - node_modules
+  - app/node_modules
+  - core/node_modules
+  - core/dist
+  - extensions/*/node_modules # Glob: all services
+  - packages/*/node_modules # Glob: all packages
+  - packages/*/dist # Glob: all package dist builds
+  - packages/*/out # Glob: all package out builds
+
+# Small files - copied with regular cp (fast for individual files)
+regularCopyTargets:
+  - .env
+  - core/.env
+


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add worktree-config.yaml to control which files use copy-on-write vs regular copy when creating worktrees. Also ignore .copy-status and .copy-log files.

- **New Features**
  - Added worktree-config.yaml with cowCopyTargets and regularCopyTargets.
  - Supports glob patterns (e.g., packages/*, extensions/*, **/.next).
  - Defaults include node_modules, dist/out builds, and .env files.

<sup>Written for commit 5679b1e5de1ef8032fd80c03ce9062ea2aa82b60. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

