### PR TITLE
fix(cli): compaction for missing tool results

### DIFF
--- a/core/util/messageConversion.ts
+++ b/core/util/messageConversion.ts
@@ -327,13 +327,19 @@ export function convertFromUnifiedHistory(
 
     messages.push(baseMessage);
 
-    // Add tool result messages if there are completed tool calls
+    // Add tool result messages if there are completed tool calls, and fallback when tool output is missing
     if (item.toolCallStates) {
       for (const toolState of item.toolCallStates) {
         if (toolState.output && toolState.output.length > 0) {
           messages.push({
             role: "tool",
             content: toolState.output.map((o: any) => o.content).join("\n"),
+            tool_call_id: toolState.toolCallId,
+          });
+        } else {
+          messages.push({
+            role: "tool",
+            content: "Tool cancelled",
             tool_call_id: toolState.toolCallId,
           });
         }


### PR DESCRIPTION
## Description

When output is missing from tool result, add a placeholder output to prevent compaction for dangling tool calls.

resolves CON-5032
resolves CON-5064

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

https://github.com/user-attachments/assets/bbe5804b-d4a0-47c7-9c3f-459d1a140e4b



https://github.com/user-attachments/assets/5aa5e4da-bb4a-446f-b80f-dc35db71efc7



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fallback tool result message when a tool call has no output, preventing compaction of dangling tool calls and keeping CLI transcripts consistent. Resolves CON-5032.

- **Bug Fixes**
  - In convertFromUnifiedHistory, emit a role: "tool" message with "Tool cancelled" when tool output is missing.
  - Prevents dropped tool calls and history compaction when a tool is cancelled or returns no output.

<sup>Written for commit 0792b949bdf629fd14dac45478b2027962b77454. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

---

<!-- continue-task-summary-start -->

## Continue Tasks

| Status | Task | Actions |
|:-------|:-----|:--------|
| ▶️ Queued | Optimize Website Performance | [View](https://hub.continue.dev/tasks/ae39444b-ac83-4553-84f8-917259055c62) |
| ▶️ Not Started | Update docs on PR | [Run](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F9130) |

<sub>Powered by [Continue](https://hub.continue.dev)</sub>

<!-- continue-task-summary-end -->