### PR TITLE
Fixed `usage` handling in OpenAI.ts

### DIFF
--- a/packages/openai-adapters/src/apis/OpenAI.ts
+++ b/packages/openai-adapters/src/apis/OpenAI.ts
@@ -271,19 +271,8 @@ export class OpenAIApi implements BaseLlmApi {
         signal,
       },
     );
-    let lastChunkWithUsage: ChatCompletionChunk | undefined;
     for await (const result of response) {
-      // Check if this chunk contains usage information
-      if (result.usage && result.finish_reason === "stop") {
-        // Store it to emit after all content chunks
-        lastChunkWithUsage = result;
-      } else {
-        yield result;
-      }
-    }
-    // Emit the usage chunk at the end if we have one
-    if (lastChunkWithUsage) {
-      yield lastChunkWithUsage;
+      yield result;
     }
   }
 


### PR DESCRIPTION
The presence of `usage` doesn't always mean it's the last chunk.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove special handling of usage in streaming: yield every chunk as it arrives instead of deferring usage to the end. This avoids misordering when usage appears mid-stream.

<sup>Written for commit c2ded53ab86f6adfaf72446432c4a9eb84fa5d94. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 7 not started · 🔴 1 closed — [View all](https://hub.continue.dev/inbox/pr/continuedev/continue/9134?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->