### PR TITLE
fix: parallel edit clarity

### DIFF
--- a/core/tools/definitions/editFile.ts
+++ b/core/tools/definitions/editFile.ts
@@ -8,7 +8,7 @@ export interface EditToolArgs {
 }
 
 export const NO_PARALLEL_TOOL_CALLING_INSTRUCTION =
-  "This tool CANNOT be called in parallel with other tools or itself. I.e., whenever you call this tool, it must be the only tool call.";
+  "This tool CANNOT be called in parallel with any other tools, including itself";
 
 const CHANGES_DESCRIPTION =
   "Any modifications to the file, showing only needed changes. Do NOT wrap this in a codeblock or write anything besides the code changes. In larger files, use brief language-appropriate placeholders for large unmodified sections, e.g. '// ... existing code ...'";


### PR DESCRIPTION
## Description
Opus is smart enough to interpret the previous prompt as "can only call in parallel with itself"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the editFile tool’s parallel-calling instruction to explicitly forbid running in parallel with any tools, including itself. Prevents misinterpretation and avoids concurrent edit conflicts.

<sup>Written for commit 41c4f297f3bef3a43f12833d3d2e0d6c84888ec7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

