### PR TITLE
bug(tool-call): lsTools should not default to "/", use "." instead

### DIFF
--- a/core/tools/implementations/lsTool.ts
+++ b/core/tools/implementations/lsTool.ts
@@ -2,12 +2,12 @@ import ignore from "ignore";
 
 import { ToolImpl } from ".";
 import { walkDir } from "../../indexing/walkDir";
-import { resolveInputPath } from "../../util/pathResolver";
 import { ContinueError, ContinueErrorReason } from "../../util/errors";
+import { resolveInputPath } from "../../util/pathResolver";
 
 export function resolveLsToolDirPath(dirPath: string | undefined) {
   if (!dirPath || dirPath === ".") {
-    return "/";
+    return ".";
   }
   // Don't strip leading slash from absolute paths - let the resolver handle it
   if (dirPath.startsWith(".") && !dirPath.startsWith("./")) {


### PR DESCRIPTION
When a tool call want's to list "." it is very likely refering to the current directory and not the root-directory ("/"). Also if the directory parameter is missing it makes more sense to list the current work dir, not root ("/").



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use "." as the default directory in lsTool so listings target the current working directory instead of "/". Prevents accidental root listings when the dir argument is missing or set to ".".

<sup>Written for commit b496e5c9e0d8592f3db4e2ecac3ef9b4c75785b8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

---

<!-- continue-task-summary-start -->

## Continue Tasks

| Status | Task | Actions |
|:-------|:-----|:--------|
| 🔴 Closed | Update docs on PR | [PR](https://github.com/continuedev/continue/pull/9141) · [View](https://hub.continue.dev/tasks/5cd66f79-7d42-4819-8097-9a4b6d21a102) |

<sub>Powered by [Continue](https://hub.continue.dev)</sub>

<!-- continue-task-summary-end -->