### PR TITLE
fix: use parsed arguments instead of toolcall.arguments

### DIFF
--- a/gui/src/redux/thunks/callToolById.ts
+++ b/gui/src/redux/thunks/callToolById.ts
@@ -86,7 +86,13 @@ export const callToolById = createAsyncThunk<
   } else {
     // Tool is called on core side
     const result = await extra.ideMessenger.request("tools/call", {
-      toolCall: toolCallState.toolCall,
+      toolCall: {
+        ...toolCallState.toolCall,
+        function: {
+          ...toolCallState.toolCall.function,
+          arguments: JSON.stringify(toolCallState.parsedArgs),
+        },
+      },
     });
     if (result.status === "error") {
       throw new Error(result.error);


### PR DESCRIPTION
## Description

When createnewfile is sent without the `contents` parameter, the error shows that "`filepath` is missing". This PR fixes that by showing the correct missing parameter.

resolves CON-5065

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect missing-field errors for createnewfile by sending parsed arguments to core, so validation reports the right parameter. Addresses CON-5065.

- **Bug Fixes**
  - Use parsedArgs (JSON) for function.arguments in tools/call.
  - Missing-parameter errors now correctly point to contents instead of filepath.

<sup>Written for commit 6222d35735a1be9044e6f9be50aef398466f9c98. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

