### PR TITLE
feat: allow selecting images using cmd+a

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor/TipTapEditor.css
+++ b/gui/src/components/mainInput/TipTapEditor/TipTapEditor.css
@@ -39,3 +39,7 @@
 .tiptap img.ProseMirror-selectednode {
   border: 1px solid var(--vscode-badge-background, #bfe2b6);
 }
+
+.tiptap img.selected-image {
+  outline: 3px solid var(--vscode-badge-background, #bfe2b6);
+}


### PR DESCRIPTION
## Description

Allow selecting images using cmd/ctrl+a.

resolves CON-5056

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot




https://github.com/user-attachments/assets/ebad6233-5206-4967-9593-633c28e42314



https://github.com/user-attachments/assets/9a7c266a-1087-43ef-9666-5016aececc11



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Cmd/Ctrl+A to select all content in the TipTap editor, including images, with a clear outline on selected images. Resolves CON-5056.

- **New Features**
  - Override Mod-a to select the full document (text and images).
  - Add selection decorations for image nodes and a .selected-image CSS outline for visual feedback.

<sup>Written for commit e31605aaf06353dfbf34559595b4664b576fd5d6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

