### PR TITLE
Fix typo in context providers recommendation

### DIFF
--- a/docs/customize/deep-dives/custom-providers.mdx
+++ b/docs/customize/deep-dives/custom-providers.mdx
@@ -183,7 +183,7 @@ You'll then be able to type "@" and see "MCP" in the context providers dropdown.
 ## Deprecated Context Providers
 
 <Note>
-  To provide conext beyond the built-in context providers, we now recommend
+  To provide context beyond the built-in context providers, we now recommend
   using [MCP Servers](/customize/mcp-tools)
 </Note>
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed a typo in the custom providers documentation to improve clarity: "conext" → "context" in the Deprecated Context Providers note.

<sup>Written for commit 7cd5c2ee23a4c492d4e056d1f1e266b5961ad2e7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

