### PR TITLE
fix: re-throw hub error for non-markdown hub slugs

### DIFF
--- a/extensions/cli/src/services/AgentFileService.test.ts
+++ b/extensions/cli/src/services/AgentFileService.test.ts
@@ -739,7 +739,9 @@ You are a helpful agent`;
         ).rejects.toThrow("File not found");
       });
 
-      it("should throw error for non-markdown paths without trying file fallback", async () => {
+      it("should re-throw hub error for non-markdown hub slugs", async () => {
+        // Reset mock to clear any queued values from previous tests
+        mockLoadPackageFromHub.mockReset();
         mockLoadPackageFromHub.mockRejectedValue(new Error("Hub error"));
 
         await expect(
@@ -747,7 +749,7 @@ You are a helpful agent`;
         ).rejects.toThrow("Failed to load agent from owner/agent");
         await expect(
           agentFileService.getAgentFile("owner/agent"),
-        ).rejects.toThrow("Not a markdown file");
+        ).rejects.toThrow("Hub error");
       });
 
       it("should handle permission errors when reading files", async () => {

--- a/extensions/cli/src/services/AgentFileService.ts
+++ b/extensions/cli/src/services/AgentFileService.ts
@@ -54,18 +54,27 @@ export class AgentFileService
 
   async getAgentFile(agentPath: string): Promise<AgentFile> {
     try {
+      const isMarkdownPath =
+        agentPath.endsWith(".md") || agentPath.endsWith(".markdown");
+
       const parts = agentPath.split("/");
-      if (parts.length === 2 && parts[0] && parts[1] && !parts.includes(".")) {
+      const looksLikeHubSlug =
+        parts.length === 2 && parts[0] && parts[1] && !parts.includes(".");
+
+      if (looksLikeHubSlug) {
         try {
           return await loadPackageFromHub(agentPath, agentFileProcessor);
-        } catch {
-          // slug COULD be path, fall back to relative path
+        } catch (hubError) {
+          // Hub loading failed - only fall back to file if it's a markdown path
+          if (!isMarkdownPath) {
+            // Not a markdown path, so re-throw the hub error
+            throw hubError;
+          }
+          // It's a markdown path, fall through to try loading as file
         }
       }
 
-      const isMarkdownPath =
-        agentPath.endsWith(".md") || agentPath.endsWith(".markdown");
-      // Only fall back to relative path for markdown files
+      // Only load from file path for markdown files
       if (!isMarkdownPath) {
         throw new Error(
           `Failed to load agent from ${agentPath}. Not a markdown file`,


### PR DESCRIPTION
## Summary
Fixes issue where hub loading errors were being swallowed and replaced with "Not a markdown file" error message.

When hub loading fails for a path that looks like a hub slug (e.g., `continuedev/default-hub-cloud-agent`) and is NOT a markdown file, the code now re-throws the actual hub error instead of showing "Not a markdown file". This preserves the real error (e.g., network error, auth error, not found) instead of a confusing generic message.

## Test plan
- [x] Existing tests updated to match new behavior
- [x] All tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes error handling for hub slugs by re-throwing the actual hub error for non-markdown paths instead of showing "Not a markdown file", so users see the real network/auth/not-found error.

- **Bug Fixes**
  - Only fall back to loading from a file when the path is a markdown file; otherwise re-throw the hub error for hub slugs (owner/agent).
  - Updated tests to assert the new behavior.

<sup>Written for commit f644c8873e09f8efa912eefeb1a03e5d8708f24f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

