### PR TITLE
Handle unhandled errors by exiting with non-zero code

### DIFF
--- a/extensions/cli/src/util/errorState.ts
+++ b/extensions/cli/src/util/errorState.ts
@@ -1,0 +1,24 @@
+/**
+ * Module to track unhandled errors during CLI execution.
+ * This is in a separate file to avoid circular dependencies between
+ * index.ts and exit.ts.
+ */
+
+// Track whether any unhandled errors occurred during execution
+let hasUnhandledError = false;
+
+/**
+ * Mark that an unhandled error occurred.
+ * Called by global error handlers in index.ts.
+ */
+export function markUnhandledError(): void {
+  hasUnhandledError = true;
+}
+
+/**
+ * Check if any unhandled errors occurred during execution.
+ * Called by gracefulExit() to determine the exit code.
+ */
+export function hadUnhandledError(): boolean {
+  return hasUnhandledError;
+}

--- a/extensions/cli/src/util/exit.ts
+++ b/extensions/cli/src/util/exit.ts
@@ -1,10 +1,10 @@
 import type { ChatHistoryItem } from "core/index.js";
 
-import { hadUnhandledError } from "../index.js";
 import { sentryService } from "../sentry.js";
 import { getSessionUsage } from "../session.js";
 import { telemetryService } from "../telemetry/telemetryService.js";
 
+import { hadUnhandledError } from "./errorState.js";
 import { getGitDiffSnapshot } from "./git.js";
 import { logger } from "./logger.js";
 import {


### PR DESCRIPTION








<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure the CLI exits with a non-zero code when any unhandled error occurs, while still flushing logs and telemetry. We track unhandled rejections/exceptions and coerce gracefulExit(0) to exit with code 1.

- **Bug Fixes**
  - Track unhandledRejection and uncaughtException via a flag in a new errorTracking module to avoid circular dependency build failures.
  - gracefulExit exits with code 1 if an unhandled error occurred and a 0 was requested.
  - Avoid immediate exit on error; log, flush Sentry/telemetry, and report to API in serve mode.

<sup>Written for commit 635aa428116cedd782e2f7ca7e0527a62f3e6767. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







