### PR TITLE
fix: Typo in openai instruction doc

### DIFF
--- a/docs/customize/model-providers/top-level/openai.mdx
+++ b/docs/customize/model-providers/top-level/openai.mdx
@@ -110,7 +110,7 @@ To force usage of `completions` instead of `chat/completions` endpoint you can s
   models:
     - name: <OPENAI_API_COMPATIBLE_PROVIDER_MODEL>
       provider: openai
-      model: <MODEL_NAME>>
+      model: <MODEL_NAME>
       apiBase: http://localhost:8000/v1
       useLegacyCompletionsEndpoint: true
   ```


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a typo in the OpenAI provider docs example by removing an extra ">" from the model field, so users can copy-paste the config without errors.

<sup>Written for commit a1bfbab28a65a2ae0c2b5c2be141be98f5a1a4a6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

