### PR TITLE
Fix npm cache corruption in base blueprint

### DIFF
--- a/.github/workflows/runloop-blueprint-template.json
+++ b/.github/workflows/runloop-blueprint-template.json
@@ -15,7 +15,8 @@
     "sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg",
     "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main' | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null",
     "sudo apt update",
-    "sudo apt install -y gh"
+    "sudo apt install -y gh",
+    "npm cache clean --force"
   ],
   "launch_parameters": {
     "launch_commands": [


### PR DESCRIPTION
## Summary
- Add `npm cache clean --force` at the end of the base blueprint setup commands
- Prevents "idealTree already exists" errors when child blueprints run `npm install`

## Problem
The base blueprint runs `npm i -g @continuedev/cli@latest` which leaves npm cache state that can corrupt child blueprint builds with the error:
```
npm error Tracker "idealTree" already exists
```

## Solution
Clear npm's download cache after all setup commands complete. This doesn't affect installed packages - only clears temporary cache files.

## Test plan
- [ ] Rebuild the base blueprint
- [ ] Create a child blueprint with `npm i && npm run build` install command
- [ ] Verify it builds successfully without the idealTree error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clear npm’s cache at the end of the base blueprint setup to prevent “Tracker 'idealTree' already exists” errors when child blueprints run npm install. This only removes temporary cache files and makes child blueprint installs reliable.

<sup>Written for commit a80c8fc394b07792cb983cd62affc1228be94cd9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

