### PR TITLE
fix(cli): restart cli for manual update

### DIFF
--- a/extensions/cli/src/services/UpdateService.ts
+++ b/extensions/cli/src/services/UpdateService.ts
@@ -170,17 +170,15 @@ export class UpdateService extends BaseService<UpdateServiceState> {
 
       this.setState({
         status: UpdateStatus.UPDATED,
-        message: `${isAutoUpdate ? "Auto-updated to" : "Restart for"} v${this.currentState.latestVersion}`,
+        message: `Updated to v${this.currentState.latestVersion}`,
         isUpdateAvailable: false,
       });
-      if (isAutoUpdate) {
-        this.restartCLI();
-      }
+      this.restartCLI();
     } catch (error: any) {
       logger.error("Error updating CLI:", error);
       this.setState({
         status: UpdateStatus.ERROR,
-        message: isAutoUpdate ? "Auto-update failed" : "Update failed",
+        message: "Update failed",
         error,
       });
       setTimeout(() => {


### PR DESCRIPTION
## Description

After running manual update with `/update`, the cli should automatically restart (just like in auto-update). This PR fixes that.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes manual update flow so the CLI restarts automatically after running /update, matching auto-update behavior. Simplifies update status messages for consistency.

- **Bug Fixes**
  - Always call restartCLI after a successful update (manual and auto).
  - Unified messages to “Updated to v{version}” and “Update failed”.

<sup>Written for commit 595986a6fb46ccd4e023078e9e3a8aeb911629c7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

