### PR TITLE
feat: Add reusable Continue Agents workflow

### DIFF
--- a/.github/workflows/continue-agents.yml
+++ b/.github/workflows/continue-agents.yml
@@ -1,0 +1,165 @@
+name: Continue Agents
+
+on:
+  workflow_call:
+    inputs:
+      agents-path:
+        description: 'Path to agents folder'
+        required: false
+        default: '.continue/agents'
+        type: string
+    secrets:
+      ANTHROPIC_API_KEY:
+        description: 'Anthropic API key for Claude'
+        required: true
+
+permissions:
+  contents: write
+  checks: write
+  pull-requests: write
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.discover.outputs.matrix }}
+      has-agents: ${{ steps.discover.outputs.has_agents }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Discover agents
+        id: discover
+        run: |
+          AGENTS_DIR="${{ inputs.agents-path }}"
+          if [ -d "$AGENTS_DIR" ]; then
+            # Use -sc for compact single-line JSON (required for GitHub Actions output)
+            FILES=$(find "$AGENTS_DIR" -name "*.md" -type f 2>/dev/null | jq -R . | jq -sc .)
+            COUNT=$(echo "$FILES" | jq 'length')
+            HAS_AGENTS=$([[ $COUNT -gt 0 ]] && echo "true" || echo "false")
+          else
+            FILES="[]"
+            COUNT=0
+            HAS_AGENTS="false"
+          fi
+
+          echo "matrix=$FILES" >> $GITHUB_OUTPUT
+          echo "has_agents=$HAS_AGENTS" >> $GITHUB_OUTPUT
+          echo "Found $COUNT agent(s)"
+
+  run-agent:
+    needs: discover
+    if: needs.discover.outputs.has-agents == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        agent: ${{ fromJson(needs.discover.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+
+      - name: Install Continue CLI
+        run: npm i -g @continuedev/cli
+
+      - name: Extract agent name
+        id: agent-name
+        run: |
+          AGENT_FILE="${{ matrix.agent }}"
+          AGENT_NAME=$(basename "$AGENT_FILE" .md)
+          echo "name=$AGENT_NAME" >> $GITHUB_OUTPUT
+
+      - name: Create Check Run
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: check } = await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: `Continue: ${{ steps.agent-name.outputs.name }}`,
+              head_sha: context.sha,
+              status: 'in_progress',
+              started_at: new Date().toISOString(),
+            });
+            core.setOutput('id', check.id);
+
+      - name: Run agent
+        id: run
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          AGENT_FILE="${{ matrix.agent }}"
+
+          # Run agent in non-interactive mode (-p flag)
+          if OUTPUT=$(cn -p --agent "$AGENT_FILE" 2>&1); then
+            echo "success=true" >> $GITHUB_OUTPUT
+            echo "output<<EOF" >> $GITHUB_OUTPUT
+            echo "$OUTPUT" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            echo "✅ Agent completed successfully"
+            echo ""
+            echo "--- Agent Output ---"
+            echo "$OUTPUT"
+          else
+            echo "success=false" >> $GITHUB_OUTPUT
+            echo "error<<EOF" >> $GITHUB_OUTPUT
+            echo "$OUTPUT" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            echo "❌ Agent failed"
+            echo ""
+            echo "--- Agent Output ---"
+            echo "$OUTPUT"
+          fi
+
+      - name: Write job summary
+        if: always()
+        run: |
+          echo "## 🤖 Agent: ${{ steps.agent-name.outputs.name }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.run.outputs.success }}" == "true" ]; then
+            echo "✅ **Status:** Completed successfully" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### Output" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "${{ steps.run.outputs.output }}" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          else
+            echo "❌ **Status:** Failed" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### Error" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "${{ steps.run.outputs.error }}" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Fail if agent failed
+        if: steps.run.outputs.success != 'true'
+        run: exit 1
+
+      - name: Update Check Run
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const success = '${{ steps.run.outputs.success }}' === 'true';
+            const output = `${{ steps.run.outputs.output }}`;
+            const error = `${{ steps.run.outputs.error }}`;
+
+            await github.rest.checks.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              check_run_id: ${{ steps.check.outputs.id }},
+              status: 'completed',
+              conclusion: success ? 'success' : 'failure',
+              completed_at: new Date().toISOString(),
+              output: {
+                title: success ? 'Agent completed' : 'Agent failed',
+                summary: success
+                  ? `Agent completed successfully.\n\n<details><summary>Output</summary>\n\n\`\`\`\n${output.slice(0, 60000)}\n\`\`\`\n</details>`
+                  : `Agent failed.\n\n\`\`\`\n${error.slice(0, 60000)}\n\`\`\``,
+              },
+            });


### PR DESCRIPTION
## Summary

Adds a reusable GitHub Actions workflow that discovers and runs Continue agent files from `.continue/agents/` on pull requests.

## Usage

Users can add this to their repository:

```yaml
name: Run Continue Agents
on:
  pull_request:
    types: [opened, synchronize]

jobs:
  agents:
    uses: continuedev/continue/.github/workflows/continue-agents.yml@main
    secrets:
      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
```

## Features

- Discovers all `.md` agent files in `.continue/agents/`
- Runs each agent in parallel via matrix strategy
- Shows agent output in job logs, job summary, and check runs
- Properly fails jobs when agents fail
- Configurable agents path via `agents-path` input

## Requirements

Users need:
1. `ANTHROPIC_API_KEY` in repository secrets
2. Agent markdown files in `.continue/agents/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable GitHub Actions workflow that auto-discovers and runs Continue agent Markdown files on pull requests. Runs agents in parallel and surfaces results in logs, job summaries, and per-agent check runs, failing the job when an agent fails.

- **New Features**
  - Reusable workflow_call with agents-path input (default .continue/agents)
  - Discovers .md agents and runs each via matrix with the Continue CLI
  - Creates/updates a Check Run per agent with captured output
  - Writes a concise job summary
  - Fails the job if any agent fails

- **Migration**
  - Create a workflow that triggers on pull_request and calls this reusable workflow
  - Set the ANTHROPIC_API_KEY repository secret
  - Add agent .md files in .continue/agents (or set agents-path)

<sup>Written for commit 526b0b6672abe22567a7f54ed8274e00db19824e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

