### PR TITLE
fix: Use environment variables to prevent escaping issues in continue-agents workflow

### DIFF
--- a/.github/workflows/continue-agents.yml
+++ b/.github/workflows/continue-agents.yml
@@ -29,8 +29,10 @@ jobs:
 
       - name: Discover agents
         id: discover
+        env:
+          AGENTS_PATH: ${{ inputs.agents-path }}
         run: |
-          AGENTS_DIR="${{ inputs.agents-path }}"
+          AGENTS_DIR="$AGENTS_PATH"
           if [ -d "$AGENTS_DIR" ]; then
             # Use -sc for compact single-line JSON (required for GitHub Actions output)
             FILES=$(find "$AGENTS_DIR" -name "*.md" -type f 2>/dev/null | jq -R . | jq -sc .)
@@ -67,20 +69,24 @@ jobs:
 
       - name: Extract agent name
         id: agent-name
+        env:
+          AGENT_FILE: ${{ matrix.agent }}
         run: |
-          AGENT_FILE="${{ matrix.agent }}"
           AGENT_NAME=$(basename "$AGENT_FILE" .md)
           echo "name=$AGENT_NAME" >> $GITHUB_OUTPUT
 
       - name: Create Check Run
         id: check
         uses: actions/github-script@v7
+        env:
+          AGENT_NAME: ${{ steps.agent-name.outputs.name }}
         with:
           script: |
+            const agentName = process.env.AGENT_NAME || 'unknown';
             const { data: check } = await github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name: `Continue: ${{ steps.agent-name.outputs.name }}`,
+              name: `Continue: ${agentName}`,
               head_sha: context.sha,
               status: 'in_progress',
               started_at: new Date().toISOString(),
@@ -91,9 +97,8 @@ jobs:
         id: run
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          AGENT_FILE: ${{ matrix.agent }}
         run: |
-          AGENT_FILE="${{ matrix.agent }}"
-
           # Run agent in non-interactive mode (-p flag)
           if OUTPUT=$(cn -p --agent "$AGENT_FILE" 2>&1); then
             echo "success=true" >> $GITHUB_OUTPUT
@@ -117,22 +122,27 @@ jobs:
 
       - name: Write job summary
         if: always()
+        env:
+          AGENT_NAME: ${{ steps.agent-name.outputs.name }}
+          AGENT_SUCCESS: ${{ steps.run.outputs.success }}
+          AGENT_OUTPUT: ${{ steps.run.outputs.output }}
+          AGENT_ERROR: ${{ steps.run.outputs.error }}
         run: |
-          echo "## 🤖 Agent: ${{ steps.agent-name.outputs.name }}" >> $GITHUB_STEP_SUMMARY
+          echo "## 🤖 Agent: $AGENT_NAME" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ steps.run.outputs.success }}" == "true" ]; then
+          if [ "$AGENT_SUCCESS" == "true" ]; then
             echo "✅ **Status:** Completed successfully" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Output" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "${{ steps.run.outputs.output }}" >> $GITHUB_STEP_SUMMARY
+            echo "$AGENT_OUTPUT" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
           else
             echo "❌ **Status:** Failed" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Error" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "${{ steps.run.outputs.error }}" >> $GITHUB_STEP_SUMMARY
+            echo "$AGENT_ERROR" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
           fi
 
@@ -143,16 +153,22 @@ jobs:
       - name: Update Check Run
         if: always()
         uses: actions/github-script@v7
+        env:
+          AGENT_SUCCESS: ${{ steps.run.outputs.success }}
+          AGENT_OUTPUT: ${{ steps.run.outputs.output }}
+          AGENT_ERROR: ${{ steps.run.outputs.error }}
+          CHECK_RUN_ID: ${{ steps.check.outputs.id }}
         with:
           script: |
-            const success = '${{ steps.run.outputs.success }}' === 'true';
-            const output = `${{ steps.run.outputs.output }}`;
-            const error = `${{ steps.run.outputs.error }}`;
+            const success = process.env.AGENT_SUCCESS === 'true';
+            const output = process.env.AGENT_OUTPUT || '';
+            const error = process.env.AGENT_ERROR || '';
+            const checkRunId = parseInt(process.env.CHECK_RUN_ID, 10);
 
             await github.rest.checks.update({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              check_run_id: ${{ steps.check.outputs.id }},
+              check_run_id: checkRunId,
               status: 'completed',
               conclusion: success ? 'success' : 'failure',
               completed_at: new Date().toISOString(),


### PR DESCRIPTION
## Summary

- Fixed workflow escaping issues that caused failures when agent output contains backticks
- Changed from direct GitHub expression interpolation to environment variables throughout the workflow

## Problem

When agent output contains markdown with backticks (e.g., `LogsTabContent.tsx`), the workflow failed with errors like:

```
LogsTabContent.tsx: command not found
SyntaxError: Unexpected identifier 'LogsTabContent'
```

This happened because:
1. **Shell issue**: Backticks in echo statements triggered command substitution
2. **JavaScript issue**: Backticks in template literals broke JavaScript syntax

## Solution

Pass all dynamic values via `env:` blocks instead of direct interpolation. Environment variables are properly escaped by GitHub Actions, preventing both shell and JavaScript parsing issues.

## Test plan

- [ ] Trigger workflow with agent output containing backticks in markdown
- [ ] Verify job summary renders correctly
- [ ] Verify check run updates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented failures in the continue-agents workflow when agent output includes backticks by routing all dynamic values through environment variables. This ensures proper escaping, fixes shell substitution and JS template literal errors, and keeps job summaries and check runs working.

- **Bug Fixes**
  - Updated steps to read values from env: Discover agents, Extract agent name, Create Check Run, Run agent, Write job summary, Update Check Run.
  - Use process.env in github-script and env vars in shell to avoid unsafe interpolation.
  - Job summary and check run updates now safely handle markdown and backticks.

<sup>Written for commit 98254b1f328fb8628f63cdb1f848cad0c6912779. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

