### PR TITLE
fix: change 'Agent:' to 'Config:' in intro message and update tests

### DIFF
--- a/extensions/cli/src/ui/IntroMessage.test.tsx
+++ b/extensions/cli/src/ui/IntroMessage.test.tsx
@@ -53,12 +53,12 @@ describe("IntroMessage", () => {
     expect(lastFrame()).not.toContain("Mocked TipsDisplay");
   });
 
-  it("renders agent name when config is provided", () => {
+  it("renders config name when config is provided", () => {
     const config = { name: "Test Agent", version: "1.0.0", rules: [] };
 
     const { lastFrame } = render(<IntroMessage config={config} />);
 
-    expect(lastFrame()).toContain("Agent:");
+    expect(lastFrame()).toContain("Config:");
     expect(lastFrame()).toContain("Test Agent");
   });
 

--- a/extensions/cli/src/ui/IntroMessage.tsx
+++ b/extensions/cli/src/ui/IntroMessage.tsx
@@ -110,7 +110,7 @@ const IntroMessage: React.FC<IntroMessageProps> = ({
       {/* Agent name */}
       {config && (
         <Text color="blue">
-          <Text bold>Agent:</Text> <Text color="white">{config.name}</Text>
+          <Text bold>Config:</Text> <Text color="white">{config.name}</Text>
         </Text>
       )}
 

--- a/extensions/cli/src/ui/ServiceDebugger.tsx
+++ b/extensions/cli/src/ui/ServiceDebugger.tsx
@@ -47,7 +47,7 @@ const ServiceDebugger: React.FC<ServiceDebuggerProps> = ({
           ? `User: ${service.authConfig.email || "unknown"}`
           : "No auth config";
       case "config":
-        return service?.config ? `Agent: ${service.config.name}` : "No config";
+        return service?.config ? `Config: ${service.config.name}` : "No config";
       case "model":
         return service?.model ? `Model: ${service.model.name}` : "No model";
       case "mcp":


### PR DESCRIPTION
## Description

Reimplements the changes from PR #9088 that were reverted. This changes the label from 'Agent:' to 'Config:' in the CLI intro message for clearer terminology.

## Changes Made

- Updated IntroMessage.tsx to display 'Config:' instead of 'Agent:'
- Updated IntroMessage.test.tsx to check for 'Config:' label instead of 'Agent:'
- Updated ServiceDebugger.tsx to use consistent 'Config:' label

## Fixes

Addresses the failing test that was checking for the old 'Agent:' label after the copy change in #9088.

---

This [task](https://hub.continue.dev/task/39a8a599-fdbe-4d6d-bff8-40ef104a9fca) was co-authored by dallin and [Continue](https://continue.dev).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changed the CLI intro message label from "Agent:" to "Config:" for clearer terminology. Updated ServiceDebugger and tests to match, fixing the failing test.

<sup>Written for commit c1e466836acd0b2a5e81f2925c5d2e14691543d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

