### PR TITLE
fix: use env vars for safe string handling in continue-agents workflow

### DIFF
--- a/.github/workflows/continue-agents.yml
+++ b/.github/workflows/continue-agents.yml
@@ -143,16 +143,21 @@ jobs:
       - name: Update Check Run
         if: always()
         uses: actions/github-script@v8
+        env:
+          AGENT_OUTPUT: ${{ steps.run.outputs.output }}
+          AGENT_ERROR: ${{ steps.run.outputs.error }}
+          AGENT_SUCCESS: ${{ steps.run.outputs.success }}
+          CHECK_RUN_ID: ${{ steps.check.outputs.id }}
         with:
           script: |
-            const success = '${{ steps.run.outputs.success }}' === 'true';
-            const output = `${{ steps.run.outputs.output }}`;
-            const error = `${{ steps.run.outputs.error }}`;
+            const success = process.env.AGENT_SUCCESS === 'true';
+            const output = process.env.AGENT_OUTPUT || '';
+            const error = process.env.AGENT_ERROR || '';
 
             await github.rest.checks.update({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              check_run_id: ${{ steps.check.outputs.id }},
+              check_run_id: parseInt(process.env.CHECK_RUN_ID, 10),
               status: 'completed',
               conclusion: success ? 'success' : 'failure',
               completed_at: new Date().toISOString(),


### PR DESCRIPTION
## Summary

- Fixes JavaScript parsing errors in the `continue-agents.yml` workflow when agent output contains special characters
- Changes the "Update Check Run" step to use environment variables instead of direct string interpolation

## Problem

The workflow was failing with errors like `SyntaxError: Unexpected identifier 'mobile'` because agent output was being interpolated directly into JavaScript template literals:

```javascript
const output = `${{ steps.run.outputs.output }}`;  // ❌ Breaks with special chars
```

When the output contains backticks, `${}` sequences, or certain line breaks, it breaks the JavaScript syntax.

## Solution

Pass outputs as environment variables and access them via `process.env`:

```yaml
env:
  AGENT_OUTPUT: ${{ steps.run.outputs.output }}
```

```javascript
const output = process.env.AGENT_OUTPUT || '';  // ✅ Safe handling
```

Environment variables are passed as-is without string parsing issues.

## Test plan

- [x] Verified locally that env var approach correctly handles: multi-line text, backticks, template literal syntax, quotes
- [ ] Re-run the failing workflow in remote-config-server to confirm the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use environment variables in the continue-agents workflow to safely handle agent output and prevent JavaScript parsing errors. This avoids failures when output includes backticks, ${}, or multi-line content and ensures the check run updates reliably.

- **Bug Fixes**
  - Pass outputs as env vars: AGENT_OUTPUT, AGENT_ERROR, AGENT_SUCCESS, CHECK_RUN_ID.
  - Read values via process.env and parse CHECK_RUN_ID as an integer.
  - Remove template-literal interpolation to avoid syntax errors from special characters.

<sup>Written for commit fe1a35a33e0a54ae32a2fc97991a26a21b53ea09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

