### PR TITLE
fix: use env vars in Write job summary step for safe string handling

### DIFF
--- a/.github/workflows/continue-agents.yml
+++ b/.github/workflows/continue-agents.yml
@@ -75,12 +75,14 @@ jobs:
       - name: Create Check Run
         id: check
         uses: actions/github-script@v8
+        env:
+          AGENT_NAME: ${{ steps.agent-name.outputs.name }}
         with:
           script: |
             const { data: check } = await github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name: `Continue: ${{ steps.agent-name.outputs.name }}`,
+              name: `Continue: ${process.env.AGENT_NAME}`,
               head_sha: context.sha,
               status: 'in_progress',
               started_at: new Date().toISOString(),

--- a/.github/workflows/run-continue-agent.yml
+++ b/.github/workflows/run-continue-agent.yml
@@ -28,15 +28,24 @@ jobs:
 
     steps:
       - name: Call agents endpoint
+        env:
+          PROMPT: ${{ inputs.prompt }}
+          AGENT: ${{ inputs.agent }}
+          BRANCH_NAME: ${{ inputs.branch_name }}
+          REPO_URL: https://github.com/${{ github.repository }}
+          CONTINUE_API_KEY: ${{ secrets.CONTINUE_API_KEY }}
         run: |
+          # Use jq to properly construct JSON with safe escaping
+          json_body=$(jq -n \
+            --arg prompt "$PROMPT" \
+            --arg agent "$AGENT" \
+            --arg branchName "$BRANCH_NAME" \
+            --arg repoUrl "$REPO_URL" \
+            '{prompt: $prompt, agent: $agent, branchName: $branchName, repoUrl: $repoUrl}')
+
           response=$(curl -f -X POST https://api.continue.dev/agents \
             -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${{ secrets.CONTINUE_API_KEY }}" \
-            -d '{
-              "prompt": "${{ inputs.prompt }}",
-              "agent": "${{ inputs.agent }}",
-              "branchName": "${{ inputs.branch_name }}",
-              "repoUrl": "https://github.com/${{ github.repository }}"
-            }')
+            -H "Authorization: Bearer $CONTINUE_API_KEY" \
+            -d "$json_body")
           id=$(echo $response | jq -r '.id')
           echo "https://hub.continue.dev/hub?type=agents/$id"


### PR DESCRIPTION
## Summary

- Fixes the "Write job summary" step which was still failing with backticks in agent output
- Uses environment variables + `printf` instead of direct interpolation with `echo`

## Problem

After #9425 fixed the "Update Check Run" step, the "Write job summary" step was still failing with:
```
syntax error near unexpected token `newline'
```

This happened because backticks in the agent output (like `` `<!-- Testing -->` ``) were being interpreted as bash command substitution when using:
```bash
echo "${{ steps.run.outputs.output }}"
```

## Solution

Same pattern as the previous fix:
1. Pass outputs as environment variables
2. Use `printf '%s\n' "$VAR"` instead of `echo "$VAR"` to avoid any special character interpretation

## Test plan

- [x] Verified locally that `printf` correctly handles backticks, quotes, and other special characters
- [ ] Re-run the failing workflow to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix string handling in GitHub workflows to safely handle backticks, quotes, and other special characters and prevent syntax errors.
The job summary now uses env vars and printf; the Check Run step reads the agent name from env; and the agents API request uses jq to build JSON safely.

<sup>Written for commit 2d2147230c28fc8d91a0d4df8a27fbb88c6b0ed5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

