### PR TITLE
fix: resolve issue with lsTool listing fs root instead of current folder

### DIFF
--- a/core/tools/implementations/lsTool.ts
+++ b/core/tools/implementations/lsTool.ts
@@ -2,12 +2,12 @@ import ignore from "ignore";
 
 import { ToolImpl } from ".";
 import { walkDir } from "../../indexing/walkDir";
-import { resolveInputPath } from "../../util/pathResolver";
 import { ContinueError, ContinueErrorReason } from "../../util/errors";
+import { resolveInputPath } from "../../util/pathResolver";
 
 export function resolveLsToolDirPath(dirPath: string | undefined) {
   if (!dirPath || dirPath === ".") {
-    return "/";
+    return ".";
   }
   // Don't strip leading slash from absolute paths - let the resolver handle it
   if (dirPath.startsWith(".") && !dirPath.startsWith("./")) {

--- a/core/tools/implementations/lsTool.vitest.ts
+++ b/core/tools/implementations/lsTool.vitest.ts
@@ -13,15 +13,15 @@ const mockExtras = {
 } as unknown as ToolExtras;
 
 test("resolveLsToolDirPath handles undefined path", () => {
-  expect(resolveLsToolDirPath(undefined)).toBe("/");
+  expect(resolveLsToolDirPath(undefined)).toBe(".");
 });
 
 test("resolveLsToolDirPath handles empty string", () => {
-  expect(resolveLsToolDirPath("")).toBe("/");
+  expect(resolveLsToolDirPath("")).toBe(".");
 });
 
 test("resolveLsToolDirPath handles dot", () => {
-  expect(resolveLsToolDirPath(".")).toBe("/");
+  expect(resolveLsToolDirPath(".")).toBe(".");
 });
 
 test("resolveLsToolDirPath handles dot relative", () => {


### PR DESCRIPTION
## Description

fixed issue with lsTool listing root folder instead of current folder. (Resolves #9188) 

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Tests
- verified local build that it is behaving properly
- test cases were updated accordingly 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed lsTool so it lists the current directory instead of the filesystem root when the path is undefined, empty, or ".". Updated resolveLsToolDirPath to return "." and adjusted tests accordingly.

<sup>Written for commit c078d772ebbbf166d43886a52e2ee93512eeb3e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

---

<!-- continue-task-summary-start -->

## Continue Tasks

| Status | Task | Actions |
|:-------|:-----|:--------|
| ▶️ Queued | Update docs on PR | [View](https://hub.continue.dev/tasks/4e6af1eb-bc2e-4f05-ab7a-9a563616e498) |
| ▶️ Queued | Optimize Website Performance | [View](https://hub.continue.dev/tasks/d5d3aaaf-219c-47ec-8e11-da17c0464707) |

<sub>Powered by [Continue](https://hub.continue.dev)</sub>

<!-- continue-task-summary-end -->