### PR TITLE
Update docs banner to feature Agents page

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3,7 +3,7 @@
   "theme": "mint",
   "name": "Continue",
   "banner": {
-    "content": "Check out our new look in Mission Control. It's now easier than ever to create [Workflows](https://hub.continue.dev/workflows), [Integrate with the tools you use](https://hub.continue.dev/integrations), and to create a one-off Task.",
+    "content": "**Introducing [Agents page in Mission Control](https://hub.continue.dev/agents).** A single view for all your cloud agents: where they run, how they're triggered, and how to reuse them across your work.",
     "dismissable": true
   },
   "colors": {


### PR DESCRIPTION
This PR updates the banner in the documentation to highlight the new Agents page in Mission Control.

**Changes:**
- Updated banner text from workflow/integrations messaging to Agents page announcement
- New banner: **Introducing [Agents page in Mission Control](https://hub.continue.dev/agents).** A single view for all your cloud agents: where they run, how they're triggered, and how to reuse them across your work.

---

This [task](https://hub.continue.dev/task/7b7d6525-64dd-4ed8-90a2-afc5dd0433be) was co-authored by bekah-hawrot-weigel and [Continue](https://continue.dev).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the docs banner to highlight the new Agents page in Mission Control, replacing the previous workflows/integrations message.
The banner now reads: "Introducing Agents page in Mission Control" and links to https://hub.continue.dev/agents.

<sup>Written for commit 2b2dd5d15dde6030569b8e8b182062f7694f7f1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

