### PR TITLE
Copy updates for Slack App compliance

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -37,7 +37,7 @@
                   "mission-control/integrations/github",
                   "mission-control/integrations/sentry",
                   "mission-control/integrations/snyk",
-                  "mission-control/integrations/slack-agent",
+                  "mission-control/integrations/slack",
                   "mission-control/integrations/posthog",
                   "mission-control/integrations/atlassian",
                   "mission-control/integrations/netlify",
@@ -1482,11 +1482,15 @@
     },
     {
       "source": "/hub/agents/slack-agent",
-      "destination": "/mission-control/integrations/slack-agent"
+      "destination": "/mission-control/integrations/slack"
     },
     {
       "source": "/hub/integrations/slack-agent",
-      "destination": "/mission-control/integrations/slack-agent"
+      "destination": "/mission-control/integrations/slack"
+    },
+    {
+      "source": "/mission-control/integrations/slack-agent",
+      "destination": "/mission-control/integrations/slack"
     },
     {
       "source": "/hub/integrations/github",

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -37,7 +37,7 @@ description: "Create, run, and automate AI agents across Mission Control, termin
   <Card title="GitHub" icon="github" href="/mission-control/integrations/github">
     Enable repository access for Agents to read and create PRs.
   </Card>
-  <Card title="Slack" icon="slack" href="/mission-control/integrations/slack-agent">
+  <Card title="Slack" icon="slack" href="/mission-control/integrations/slack">
     Mention <code>@Continue</code> in Slack to trigger Agents and receive updates.
   </Card>
   <Card title="Sentry" icon="alert-triangle" href="/mission-control/integrations/sentry">

--- a/docs/mission-control/integrations/index.mdx
+++ b/docs/mission-control/integrations/index.mdx
@@ -16,7 +16,7 @@ Mission Control currently supports these first-class Cloud Agent integrations:
     Required for PR creation, repo access, diffs, and workflow triggers.
   </Card>
 
-  <Card title="Slack" icon="slack" href="/mission-control/integrations/slack-agent">
+  <Card title="Slack" icon="slack" href="/mission-control/integrations/slack">
     Mention @continue to kick off Agents directly from Slack.
   </Card>
 

--- a/docs/mission-control/integrations/slack.mdx
+++ b/docs/mission-control/integrations/slack.mdx
@@ -1,15 +1,19 @@
 ---
-title: "Slack Agent"
+title: "Agent for Slack"
 description: "Kick off Cloud Agents from Slack by mentioning @Continue"
 ---
 
 <Warning>
 
-  The Continue Slack app is currently in beta development and undergoing Slack's approval process.
+  Continue uses AI to generate code, issues, and pull requests. AI-generated content may contain inaccuracies, errors, or unexpected results. Always review AI-generated code and changes before merging. Human oversight is recommended for all automated development tasks.
+
+  Please review our Privacy policy here https://www.continue.dev/privacy
+  
+  The Continue App for Slack is currently in beta development and undergoing Slack's approval process.
 
 </Warning>
 
-<Card title="Connect the Slack Integration to Help You Complete:" icon="slack" href="https://hub.continue.dev/integrations/slack">
+<Card title="Connect Continue to Slack to Help You Complete:" icon="slack" href="https://hub.continue.dev/integrations/slack">
 
   - Quick bug fixes and feature implementations
   - Code reviews and refactoring
@@ -80,17 +84,17 @@ You can also click the Slack icon in the agents page to return to the Slack mess
 
 ## Disconnecting
 
-To remove the Slack integration:
+To remove your Slack connection:
 
 1. Go to [hub.continue.dev/settings/integrations](https://hub.continue.dev/settings/integrations)
-2. Find your Slack integration
+2. Find your Slack connection
 3. Click "Disconnect"
 
 ## Support
 
 <Warning>
 
-  The Slack integration is in active development. We'd love to hear your feedback:
+  Our integration with Slack is in active development. We'd love to hear your feedback:
   - Report issues: [GitHub Issues](https://github.com/continuedev/continue/issues)
   - Feature requests: [GitHub Discussions](https://github.com/continuedev/continue/discussions)
 
@@ -113,3 +117,7 @@ To remove the Slack integration:
   </Card>
 
 </CardGroup>
+
+## Support
+
+See our support page for more details: https://continue.dev/support


### PR DESCRIPTION
This PR reimplements the exact changes from #9444.

## Changes
- Renamed 'Slack Agent' to 'Agent for Slack' and updated copy across pages
- Updated nav links and redirects from /slack-agent to /slack
- Added safety disclaimer with privacy policy link
- Clarified connection/disconnection wording and support notes

## Files Changed
- `docs/docs.json`: Updated navigation links and redirects
- `docs/index.mdx`: Updated Slack integration link
- `docs/mission-control/integrations/index.mdx`: Updated Slack integration link
- `docs/mission-control/integrations/slack-agent.mdx` → `docs/mission-control/integrations/slack.mdx`: Renamed file and updated content

---

This [task](https://hub.continue.dev/task/e7f1e866-adae-4987-96f6-9245aeedafae) was co-authored by dallin and [Continue](https://continue.dev).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Slack docs and routing to meet Slack App compliance. Renamed "Slack Agent" to "Agent for Slack", moved docs to /mission-control/integrations/slack with redirects from /slack-agent, added a safety disclaimer with a privacy policy link, and clarified connection/disconnection and support copy.

<sup>Written for commit 75857a8c92e572964993a623090ea45f5db4aed9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

