### PR TITLE
fix: compact conversation with dangling tool calls

### DIFF
--- a/core/util/conversationCompaction.ts
+++ b/core/util/conversationCompaction.ts
@@ -55,15 +55,14 @@ export async function compactConversation({
     messages.push(item.message);
     // toolcalls only exist in an assistant message
     if (item.message.role === "assistant" && item.message.toolCalls) {
-      // for every toolcall, if there is no toolcallstate or its output, add a chat message saying that it is empty
+      // for every toolcall, if there is no tool message with a tool call id already, add a chat message saying that it is empty
       item.message.toolCalls.forEach((toolCall) => {
-        const foundToolCallState = item.toolCallStates?.find(
-          (toolCallState) => toolCallState.toolCallId === toolCall.id,
-        );
         if (
-          !foundToolCallState ||
-          !foundToolCallState.output ||
-          !foundToolCallState.output.length
+          !filteredHistory.find(
+            (item) =>
+              item.message.role === "tool" &&
+              item.message.toolCallId === toolCall.id,
+          )
         ) {
           messages.push({
             role: "tool",


### PR DESCRIPTION
## Description

Remove dangling tool calls when compacting conversation.


resolves CON-5063
resolves CON-4969

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

https://github.com/user-attachments/assets/f257219c-41a2-4c6d-be86-dbc0d8745eb8






https://github.com/user-attachments/assets/2e300319-61dc-4eec-ab9b-0d9ab0b0192f


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue-stage.tools/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F9465)
<!-- continue-task-summary-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix conversation compaction to handle dangling tool calls by inserting "Tool cancelled" tool messages when a tool call has no output. Assistant messages now only reference tool calls with a corresponding result or cancellation (resolves CON-5063, CON-4969).

- **Bug Fixes**
  - Insert "Tool cancelled" tool messages for assistant toolCalls with no matching tool message in the filtered history.
  - Build compacted messages from the cleaned history to avoid orphan “waiting for approval” tool calls.

<sup>Written for commit e08aa8533adc016084bdd29e9f4d31741ab1815e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



