### PR TITLE
fix: merge yaml.schemas settings

### DIFF
--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -59,6 +59,7 @@ export async function activateExtension(context: vscode.ExtensionContext) {
   // Register config.yaml schema by removing old entries and adding new one (uri.fsPath changes with each version)
   const yamlMatcher = ".continue/**/*.yaml";
   const yamlConfig = vscode.workspace.getConfiguration("yaml");
+  const yamlSchemas = yamlConfig.get<object>("schemas", {});
 
   const newPath = vscode.Uri.joinPath(
     context.extension.extensionUri,
@@ -68,7 +69,10 @@ export async function activateExtension(context: vscode.ExtensionContext) {
   try {
     await yamlConfig.update(
       "schemas",
-      { [newPath]: [yamlMatcher] },
+      {
+        ...yamlSchemas,
+        [newPath]: [yamlMatcher],
+      },
       vscode.ConfigurationTarget.Global,
     );
   } catch (error) {


### PR DESCRIPTION
## Description

Users may already have `yaml.schemas` preferences and the extension should not be overwriting user settings.

The code is however free to control keys for `extensionUri`, as long as it leaves other entries alone.

See also #7080

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A

## Tests

N/A

---

<!-- continue-task-summary-start -->

## Continue Tasks

| Status | Task | Actions |
|:-------|:-----|:--------|
| ▶️ Queued | Update docs on PR | [View](https://hub.continue.dev/tasks/82956909-6387-4968-8ca8-998ebe30fc06) |
| ▶️ Queued | Optimize Website Performance | [View](https://hub.continue.dev/tasks/098ba8d5-c318-40e9-b642-3c119669231d) |

<sub>Powered by [Continue](https://hub.continue.dev)</sub>

<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserve user-defined yaml.schemas settings by merging instead of overwriting when registering the extension’s schema. The extension only adds/updates its own entry keyed by extensionUri and leaves other schema mappings unchanged.

<sup>Written for commit a0729bd6ec7f5a7b8cdf187baac8abf3156b9f75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

