### PR TITLE
Stop running tidy-up-codebase.yml on forks

### DIFF
--- a/.github/workflows/tidy-up-codebase.yml
+++ b/.github/workflows/tidy-up-codebase.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   run-cn-task:
+    # Only run this workflow on the main repository (continuedev/continue)
+    if: github.repository == 'continuedev/continue'
     uses: ./.github/workflows/run-continue-agent.yml
     with:
       agent: continuedev/tidy-up-markdown-agent


### PR DESCRIPTION
## Description

This GitHub workflow keeps failing when running on forks. Adding a gate to make sure it only runs on the main repo.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

---

<!-- continue-task-summary-start -->

## Continue Tasks

| Status | Task | Actions |
|:-------|:-----|:--------|
| ▶️ Queued | Update docs on PR | [View](https://hub.continue.dev/tasks/6af9e5f7-58b3-475b-8c87-445e88886677) |
| ▶️ Queued | Optimize Website Performance | [View](https://hub.continue.dev/tasks/5dd2cfb5-4a02-4bc4-bdef-013ebb71e1c2) |

<sub>Powered by [Continue](https://hub.continue.dev)</sub>

<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent the tidy-up-codebase GitHub Actions workflow from running on forks by gating it to only run in continuedev/continue. This avoids failing runs on forked PRs and limits the workflow to the main repository.

<sup>Written for commit 0ee57188f294270f45f4556421d502d9a76c5185. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

