### PR TITLE
feat: hardcoded default config

### DIFF
--- a/extensions/cli/src/util/filePatterns.ts
+++ b/extensions/cli/src/util/filePatterns.ts
@@ -61,3 +61,22 @@ export const FILE_PATTERNS = [
   "**/.gitignore",
   "**/.env*",
 ];
+
+/**
+ * Determines if a config path is a file path vs assistant slug
+ */
+export function isFilePath(configPath: string): boolean {
+  return (
+    configPath.startsWith(".") ||
+    configPath.startsWith("/") ||
+    configPath.startsWith("~") ||
+    // Windows absolute paths (C:\, D:\, etc.)
+    /^[A-Za-z]:[/\\]/.test(configPath) ||
+    // UNC paths (\\server\share)
+    configPath.startsWith("\\\\") ||
+    // Contains file extension
+    configPath.includes(".yaml") ||
+    configPath.includes(".yml") ||
+    configPath.includes(".json")
+  );
+}


### PR DESCRIPTION
## Description
This is an idea to reduce latency but leaving in draft since might not and might cause issues with secret resolution

---

<!-- continue-task-summary-start -->

## Continue Tasks

| Status | Task | Actions |
|:-------|:-----|:--------|
| ▶️ Queued | changelog | [View](http://localhost:3000/tasks/e64192a8-990b-407c-aafe-798fd634523f) |
| ▶️ Queued | test coverage | [View](http://localhost:3000/tasks/f52768a8-3018-4dbd-9ef0-6171fa9f6cf2) |
| ▶️ Queued | Review Agent | [View](http://localhost:3000/tasks/87267b34-c607-4f0b-9518-8a739d4bc2ea) |
| ▶️ Queued | test | [View](http://localhost:3000/tasks/3206b0c3-53a4-4206-8c29-af79346e1c89) |

<sub>Powered by [Continue](https://hub.continue.dev)</sub>

<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Load the default CLI config from a hardcoded YAML string instead of fetching from the registry, cutting startup latency and removing a network dependency.

- **New Features**
  - Hardcoded default CLI config (Anthropic Claude Opus 4.5) unrolled locally with secrets rendering and injectBlocks support.
  - Improved error handling for default config load.

- **Refactors**
  - Renamed config source from "remote-default-config" to "default-config".
  - Moved isFilePath to extensions/cli/src/util/filePatterns.ts and imported where used.

<sup>Written for commit 0a419e9000adfb2a0af7d6c01a22692162f8957b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

