### PR TITLE
fix: context length error detection

### DIFF
--- a/extensions/cli/src/util/exponentialBackoff.ts
+++ b/extensions/cli/src/util/exponentialBackoff.ts
@@ -80,7 +80,10 @@ function isConnectionError(errorMessage: string): boolean {
 /**
  * Checks if the error indicates a context length issue (non-retryable)
  */
-export function isContextLengthError(error: any): boolean {
+export function isContextLengthError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
   const errorMessage = error.message?.toLowerCase() || "";
 
   if (errorMessage.includes("invalid_request_error")) {


### PR DESCRIPTION
## Description
Not all `invalid_request_error`s are context length errors.

---

<!-- continue-task-summary-start -->

## Continue Tasks

| Status | Task | Actions |
|:-------|:-----|:--------|
| ▶️ Queued | Update docs on PR | [View](https://hub.continue.dev/tasks/e7773b52-882d-4b9c-8f7e-77d473efedc4) |
| ▶️ Queued | Optimize Website Performance | [View](https://hub.continue.dev/tasks/cb099aea-10de-4919-ac62-624978bd96a1) |

<sub>Powered by [Continue](https://hub.continue.dev)</sub>

<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened context-length error detection so we only flag errors as context-related when the message includes both "invalid_request_error" and "context". This avoids false positives and prevents mis-handling of other request errors.

Removed the generic "invalid_request_error" pattern and added a targeted check for "context" within those errors.

<sup>Written for commit fa5bea12414209d481b6ffe15f2fab786f801be6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

