### PR TITLE
feat(cli): allow no config during loading

### DIFF
--- a/extensions/cli/src/configLoader.ts
+++ b/extensions/cli/src/configLoader.ts
@@ -133,7 +133,7 @@ function determineConfigSource(
   } else {
     // In headless, user assistant fallback behavior isn't supported
     if (isHeadless) {
-      return { type: "remote-default-config" };
+      return { type: "no-config" };
     }
     // Authenticated: try user assistants first
     return { type: "user-assistant", slug: "" }; // Empty slug means "first available"
@@ -194,8 +194,6 @@ async function loadFromSource(
           injectBlocks,
         );
 
-      // TODO this is currently skipped because we are forcing default config
-      // Because models add on won't work for injected blocks e.g. default model, (only default config)
       case "no-config":
         return await unrollPackageIdentifiersAsConfigYaml(
           injectBlocks,


### PR DESCRIPTION
## Description
The issue for which this ability was reverted was here
https://github.com/continuedev/continue/pull/9496

---

<!-- continue-task-summary-start -->

## Continue Tasks

| Status | Task | Actions |
|:-------|:-----|:--------|
| ▶️ Queued | Create GitHub Issue (OS) | [View](https://hub.continue-stage.tools/tasks/e3c81ed5-cb60-463b-a707-6832ab0724b3) |

<sub>Powered by [Continue](https://hub.continue.dev)</sub>

<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow the CLI to load without a config in headless mode by using a “no-config” source instead of the remote default. This restores injected-blocks-only execution and prevents forcing a default config.

<sup>Written for commit 170a76baa5b79ebcf231f510033ffdbd8ecd694b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

