### PR TITLE
chore: bump prerelease versions

### DIFF
--- a/extensions/intellij/gradle.properties
+++ b/extensions/intellij/gradle.properties
@@ -1,5 +1,5 @@
 pluginGroup=com.github.continuedev.continueintellijextension
-pluginVersion=1.0.57
+pluginVersion=1.0.58
 platformVersion=2024.1
 kotlin.stdlib.default.dependency=false
 org.gradle.configuration-cache=true

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "1.3.28",
+  "version": "1.3.29",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION
## Description
vscode 29, jetbrains 58

---

<!-- continue-task-summary-start -->

## Continue Tasks

| Status | Task | Actions |
|:-------|:-----|:--------|
| ▶️ Queued | Update docs on PR | [View](https://hub.continue.dev/tasks/066f31b2-861f-4b61-b8de-b260121f0518) |
| ▶️ Queued | Optimize Website Performance | [View](https://hub.continue.dev/tasks/7a5af6ca-14d6-457e-9ce7-96f8086da778) |

<sub>Powered by [Continue](https://hub.continue.dev)</sub>

<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped prerelease versions for VS Code to 1.3.29 and IntelliJ to 1.0.58 to prepare the next extension releases.

<sup>Written for commit 81d5c5ac971c69cfb39aa6b4ee45fe5aec1d97d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

