### PR TITLE
Filter out .md files when loading agent configs

### DIFF
--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -360,12 +360,12 @@ export class ConfigHandler {
     if (options.includeWorkspace) {
       const assistantFiles = await getAllDotContinueDefinitionFiles(
         this.ide,
-        options,
+        { ...options, fileExtType: "yaml" },
         "assistants",
       );
       const agentFiles = await getAllDotContinueDefinitionFiles(
         this.ide,
-        options,
+        { ...options, fileExtType: "yaml" },
         "agents",
       );
       const profiles = [...assistantFiles, ...agentFiles].map((assistant) => {


### PR DESCRIPTION
During config loading in core, if any non-YAML files are in .continue/agents or .continue/assistants directories, it tries to load them as configs. This change filters out .md files by explicitly setting fileExtType to 'yaml' when loading agent and assistant config profiles.

The getAllDotContinueDefinitionFiles function already supports filtering by file extension type, but it wasn't being used in ConfigHandler. This ensures only .yaml and .yml files are loaded as config profiles, preventing errors when markdown documentation files exist in the agents/assistants directories.

---

This [task](https://hub.continue.dev/task/73336ea9-1465-4c42-a610-6ce363be4496) was co-authored by dallin and [Continue](https://continue.dev).

---

<!-- continue-task-summary-start -->

## Continue Tasks

| Status | Task | Actions |
|:-------|:-----|:--------|
| ▶️ Queued | Update docs on PR | [View](https://hub.continue.dev/tasks/39385e57-8c30-44f5-baed-dfe09af3ea84) |
| ▶️ Queued | Optimize Website Performance | [View](https://hub.continue.dev/tasks/144a2e38-f5c9-4ebb-8aa4-65cdf99aea81) |

<sub>Powered by [Continue](https://hub.continue.dev)</sub>

<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure only YAML agent and assistant configs are loaded, preventing errors when .md docs exist in .continue/agents and .continue/assistants.
Sets fileExtType: "yaml" in ConfigHandler when calling getAllDotContinueDefinitionFiles.

<sup>Written for commit 529d50a9be4ebcc1b849364e71f2e9f700c89cfc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

