### PR TITLE
fix: simplify config error

### DIFF
--- a/gui/src/pages/config/sections/ConfigsSection.tsx
+++ b/gui/src/pages/config/sections/ConfigsSection.tsx
@@ -75,7 +75,7 @@ export function ConfigsSection() {
                                   : "bg-yellow-500/10 text-yellow-500"
                               } break-all rounded border border-solid border-transparent px-2 py-1 text-xs ${error.uri ? "cursor-pointer " + (error.fatal ? "hover:border-error" : "hover:border-yellow-500") : ""}`}
                             >
-                              {error.message}
+                              {error.message.split("\n")[0]}
                             </div>
                           ))}
                         </div>


### PR DESCRIPTION
## Description

Earlier the entire error stack trace was shown when config.yaml had errors. This PR fixes that by showing only the error message which is the first line of the error.

closes https://github.com/continuedev/continue/issues/9547

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

**Earlier**

<img width="772" height="1392" alt="image" src="https://github.com/user-attachments/assets/6195aefa-0f9d-4bcb-9660-a872f11d239a" />


**Now**

<img width="788" height="644" alt="image" src="https://github.com/user-attachments/assets/a49407a9-d009-492e-a322-25d574f605c8" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

---

<!-- continue-task-summary-start -->

## Continue Tasks

| Status | Task | Actions |
|:-------|:-----|:--------|
| ▶️ Queued | Update docs on PR | [View](https://hub.continue.dev/tasks/e207215c-25e3-4920-8414-a82a10cbd847) |
| ▶️ Queued | Optimize Website Performance | [View](https://hub.continue.dev/tasks/92721759-6cdb-4981-9039-1bcb5d84a55f) |

<sub>Powered by [Continue](https://hub.continue.dev)</sub>

<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show only the first line of config.yaml error messages in the Configs section, preventing full stack traces and making errors easier to scan.

<sup>Written for commit e3a8711ed90b1c3026726c80fecff92e449bb79b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

