### PR TITLE
fix: OpenAI Responses API parallel tool calls losing call_ids

### DIFF
--- a/core/llm/openaiTypeConverters.test.ts
+++ b/core/llm/openaiTypeConverters.test.ts
@@ -1,0 +1,511 @@
+import { toResponsesInput } from "./openaiTypeConverters";
+import { ChatMessage } from "..";
+import type { ResponseInputItem } from "openai/resources/responses/responses.mjs";
+
+// Types for test assertions (simplified from OpenAI types)
+type FunctionCallItem = {
+  type: "function_call";
+  id: string;
+  name: string;
+  arguments: string;
+  call_id: string;
+};
+
+type FunctionCallOutputItem = {
+  type: "function_call_output";
+  call_id: string;
+  output: string;
+};
+
+type MessageItem = {
+  role: string;
+  content: unknown;
+};
+
+// Helper functions for filtering results
+function getFunctionCalls(items: ResponseInputItem[]): FunctionCallItem[] {
+  return items.filter(
+    (item) => (item as { type?: string }).type === "function_call",
+  ) as unknown as FunctionCallItem[];
+}
+
+function getFunctionCallOutputs(
+  items: ResponseInputItem[],
+): FunctionCallOutputItem[] {
+  return items.filter(
+    (item) => (item as { type?: string }).type === "function_call_output",
+  ) as unknown as FunctionCallOutputItem[];
+}
+
+function getMessagesByRole(
+  items: ResponseInputItem[],
+  role: string,
+): MessageItem[] {
+  return items.filter((item) => {
+    const msg = item as { role?: string; type?: string };
+    return msg.role === role && (!msg.type || msg.type === "message");
+  }) as unknown as MessageItem[];
+}
+
+describe("openaiTypeConverters", () => {
+  describe("toResponsesInput", () => {
+    describe("tool calls handling - OpenAI Responses API", () => {
+      it("should emit function_call items when fc_ ID is in metadata", () => {
+        const messages: ChatMessage[] = [
+          {
+            role: "user",
+            content: "List files in current directory",
+          },
+          {
+            role: "assistant",
+            content: "",
+            toolCalls: [
+              {
+                id: "call_abc123",
+                type: "function",
+                function: {
+                  name: "filesystem_list_directory",
+                  arguments: '{"path": "."}',
+                },
+              },
+            ],
+            metadata: { responsesOutputItemId: "fc_abc123" },
+          } as ChatMessage,
+        ];
+
+        const result = toResponsesInput(messages);
+
+        const functionCalls = getFunctionCalls(result);
+        expect(functionCalls.length).toBe(1);
+        expect(functionCalls[0].id).toBe("fc_abc123");
+        expect(functionCalls[0].call_id).toBe("call_abc123");
+        expect(functionCalls[0].name).toBe("filesystem_list_directory");
+      });
+
+      it("should NOT emit function_call when no fc_ ID in metadata", () => {
+        const messages: ChatMessage[] = [
+          {
+            role: "assistant",
+            content: "I'll help.",
+            toolCalls: [
+              {
+                id: "call_xyz",
+                type: "function",
+                function: {
+                  name: "some_tool",
+                  arguments: "{}",
+                },
+              },
+            ],
+            // No metadata with fc_ ID
+          } as ChatMessage,
+        ];
+
+        const result = toResponsesInput(messages);
+
+        const functionCalls = getFunctionCalls(result);
+        expect(functionCalls.length).toBe(0);
+
+        // Text should still be emitted
+        const assistantMessages = getMessagesByRole(result, "assistant");
+        expect(assistantMessages.length).toBe(1);
+      });
+
+      it("should emit text content alongside tool calls", () => {
+        const messages: ChatMessage[] = [
+          {
+            role: "assistant",
+            content: "Let me help you with that.",
+            toolCalls: [
+              {
+                id: "call_xyz",
+                type: "function",
+                function: {
+                  name: "some_tool",
+                  arguments: "{}",
+                },
+              },
+            ],
+            metadata: { responsesOutputItemId: "fc_xyz" },
+          } as ChatMessage,
+        ];
+
+        const result = toResponsesInput(messages);
+
+        const functionCalls = getFunctionCalls(result);
+        const assistantMessages = getMessagesByRole(result, "assistant");
+
+        expect(functionCalls.length).toBe(1);
+        expect(assistantMessages.length).toBe(1);
+        expect(assistantMessages[0].content).toBe("Let me help you with that.");
+      });
+    });
+
+    describe("function_call_output handling", () => {
+      it("should emit function_call_output for tool role messages", () => {
+        const messages: ChatMessage[] = [
+          {
+            role: "tool",
+            content: '{"files": ["a.txt", "b.txt"]}',
+            toolCallId: "call_abc123",
+          } as ChatMessage,
+        ];
+
+        const result = toResponsesInput(messages);
+
+        const outputs = getFunctionCallOutputs(result);
+        expect(outputs.length).toBe(1);
+        expect(outputs[0].call_id).toBe("call_abc123");
+      });
+    });
+
+    // Complete conversation flow tests (moved out of describe block to reduce nesting)
+    it("should handle full tool call cycle with fc_ IDs", () => {
+      const messages: ChatMessage[] = [
+        {
+          role: "user",
+          content: "List files",
+        },
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [
+            {
+              id: "call_list",
+              type: "function",
+              function: {
+                name: "list_files",
+                arguments: "{}",
+              },
+            },
+          ],
+          metadata: { responsesOutputItemId: "fc_list" },
+        } as ChatMessage,
+        {
+          role: "tool",
+          content: '["file1.txt", "file2.txt"]',
+          toolCallId: "call_list",
+        } as ChatMessage,
+      ];
+
+      const result = toResponsesInput(messages);
+
+      const userMsgs = getMessagesByRole(result, "user");
+      const functionCalls = getFunctionCalls(result);
+      const functionOutputs = getFunctionCallOutputs(result);
+
+      expect(userMsgs.length).toBe(1);
+      expect(functionCalls.length).toBe(1);
+      expect(functionOutputs.length).toBe(1);
+
+      expect(functionCalls[0].id).toBe("fc_list");
+      expect(functionCalls[0].call_id).toBe("call_list");
+      expect(functionOutputs[0].call_id).toBe("call_list");
+    });
+
+    it("should handle parallel tool calls merged into ONE message with responsesOutputItemIds array", () => {
+      // This is the REAL scenario: streaming parallel tool calls get merged into
+      // ONE ChatMessage with multiple toolCalls and an array of fc_ IDs
+      const messages: ChatMessage[] = [
+        {
+          role: "user",
+          content: "Read these 3 files",
+        },
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [
+            {
+              id: "call_001",
+              type: "function",
+              function: {
+                name: "read_file",
+                arguments: '{"path":"test.py"}',
+              },
+            },
+            {
+              id: "call_002",
+              type: "function",
+              function: {
+                name: "read_file",
+                arguments: '{"path":"test.js"}',
+              },
+            },
+            {
+              id: "call_003",
+              type: "function",
+              function: {
+                name: "read_file",
+                arguments: '{"path":"test.ts"}',
+              },
+            },
+          ],
+          metadata: {
+            // Array of fc_ IDs, one per tool call
+            responsesOutputItemIds: ["fc_001", "fc_002", "fc_003"],
+            responsesOutputItemId: "fc_003", // Also keep last one for backwards compat
+          },
+        } as ChatMessage,
+        // Tool results
+        {
+          role: "tool",
+          content: "# Python code",
+          toolCallId: "call_001",
+        } as ChatMessage,
+        {
+          role: "tool",
+          content: "// JS code",
+          toolCallId: "call_002",
+        } as ChatMessage,
+        {
+          role: "tool",
+          content: "// TS code",
+          toolCallId: "call_003",
+        } as ChatMessage,
+      ];
+
+      const result = toResponsesInput(messages);
+
+      const functionCalls = getFunctionCalls(result);
+      expect(functionCalls.length).toBe(3);
+
+      // Verify each function_call has correct fc_ ID and call_id
+      expect(functionCalls[0].id).toBe("fc_001");
+      expect(functionCalls[0].call_id).toBe("call_001");
+      expect(functionCalls[1].id).toBe("fc_002");
+      expect(functionCalls[1].call_id).toBe("call_002");
+      expect(functionCalls[2].id).toBe("fc_003");
+      expect(functionCalls[2].call_id).toBe("call_003");
+
+      const functionOutputs = getFunctionCallOutputs(result);
+      expect(functionOutputs.length).toBe(3);
+    });
+
+    it("should handle 3 parallel tool calls when each has its own fc_ ID (separate messages)", () => {
+      // Legacy scenario: Each function_call from OpenAI creates a separate ChatMessage
+      const messages: ChatMessage[] = [
+        {
+          role: "user",
+          content: "Read these 3 files",
+        },
+        // First tool call
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [
+            {
+              id: "call_001",
+              type: "function",
+              function: {
+                name: "read_file",
+                arguments: '{"path":"test.py"}',
+              },
+            },
+          ],
+          metadata: { responsesOutputItemId: "fc_001" },
+        } as ChatMessage,
+        // Second tool call
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [
+            {
+              id: "call_002",
+              type: "function",
+              function: {
+                name: "read_file",
+                arguments: '{"path":"test.js"}',
+              },
+            },
+          ],
+          metadata: { responsesOutputItemId: "fc_002" },
+        } as ChatMessage,
+        // Third tool call
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [
+            {
+              id: "call_003",
+              type: "function",
+              function: {
+                name: "read_file",
+                arguments: '{"path":"test.ts"}',
+              },
+            },
+          ],
+          metadata: { responsesOutputItemId: "fc_003" },
+        } as ChatMessage,
+        // Tool results
+        {
+          role: "tool",
+          content: "# Python code",
+          toolCallId: "call_001",
+        } as ChatMessage,
+        {
+          role: "tool",
+          content: "// JS code",
+          toolCallId: "call_002",
+        } as ChatMessage,
+        {
+          role: "tool",
+          content: "// TS code",
+          toolCallId: "call_003",
+        } as ChatMessage,
+      ];
+
+      const result = toResponsesInput(messages);
+
+      const functionCalls = getFunctionCalls(result);
+      expect(functionCalls.length).toBe(3);
+
+      const fcIds = functionCalls.map((fc) => fc.id);
+      expect(fcIds).toContain("fc_001");
+      expect(fcIds).toContain("fc_002");
+      expect(fcIds).toContain("fc_003");
+
+      const functionOutputs = getFunctionCallOutputs(result);
+      expect(functionOutputs.length).toBe(3);
+    });
+
+    describe("edge cases", () => {
+      it("should handle empty messages array", () => {
+        const result = toResponsesInput([]);
+        expect(result).toEqual([]);
+      });
+
+      it("should handle assistant message with empty toolCalls array", () => {
+        const messages: ChatMessage[] = [
+          {
+            role: "assistant",
+            content: "No tools needed",
+            toolCalls: [],
+            metadata: { responsesOutputItemId: "fc_empty" },
+          } as ChatMessage,
+        ];
+
+        const result = toResponsesInput(messages);
+
+        const functionCalls = getFunctionCalls(result);
+        expect(functionCalls.length).toBe(0);
+
+        // Should emit as regular message instead
+        const assistantMessages = getMessagesByRole(result, "assistant");
+        expect(assistantMessages.length).toBe(1);
+      });
+
+      it("should handle assistant message with undefined metadata", () => {
+        const messages: ChatMessage[] = [
+          {
+            role: "assistant",
+            content: "Hello",
+            toolCalls: [
+              {
+                id: "call_test",
+                type: "function",
+                function: {
+                  name: "test_tool",
+                  arguments: "{}",
+                },
+              },
+            ],
+            // metadata is undefined
+          } as ChatMessage,
+        ];
+
+        const result = toResponsesInput(messages);
+
+        // Should not emit function_call without fc_ ID
+        const functionCalls = getFunctionCalls(result);
+        expect(functionCalls.length).toBe(0);
+      });
+
+      it("should handle more toolCalls than responsesOutputItemIds", () => {
+        const messages: ChatMessage[] = [
+          {
+            role: "assistant",
+            content: "",
+            toolCalls: [
+              {
+                id: "call_001",
+                type: "function",
+                function: { name: "tool1", arguments: "{}" },
+              },
+              {
+                id: "call_002",
+                type: "function",
+                function: { name: "tool2", arguments: "{}" },
+              },
+              {
+                id: "call_003",
+                type: "function",
+                function: { name: "tool3", arguments: "{}" },
+              },
+            ],
+            metadata: {
+              // Only 2 IDs for 3 tool calls
+              responsesOutputItemIds: ["fc_001", "fc_002"],
+            },
+          } as ChatMessage,
+        ];
+
+        const result = toResponsesInput(messages);
+
+        // Should only emit 2 function_calls (matching the available IDs)
+        const functionCalls = getFunctionCalls(result);
+        expect(functionCalls.length).toBe(2);
+        expect(functionCalls[0].id).toBe("fc_001");
+        expect(functionCalls[1].id).toBe("fc_002");
+      });
+
+      it("should handle toolCall with missing function name", () => {
+        const messages: ChatMessage[] = [
+          {
+            role: "assistant",
+            content: "",
+            toolCalls: [
+              {
+                id: "call_001",
+                type: "function",
+                function: { name: "", arguments: "{}" }, // Empty name
+              },
+            ],
+            metadata: { responsesOutputItemIds: ["fc_001"] },
+          } as ChatMessage,
+        ];
+
+        const result = toResponsesInput(messages);
+
+        // Should skip tool calls with empty name
+        const functionCalls = getFunctionCalls(result);
+        expect(functionCalls.length).toBe(0);
+      });
+
+      it("should handle user message with various content types", () => {
+        const messages: ChatMessage[] = [
+          { role: "user", content: "Simple string" },
+          {
+            role: "user",
+            content: [{ type: "text", text: "Array content" }],
+          } as ChatMessage,
+        ];
+
+        const result = toResponsesInput(messages);
+
+        const userMessages = getMessagesByRole(result, "user");
+        expect(userMessages.length).toBe(2);
+      });
+
+      it("should handle system message (converted to developer role)", () => {
+        const messages: ChatMessage[] = [
+          { role: "system", content: "You are a helpful assistant" },
+        ];
+
+        const result = toResponsesInput(messages);
+
+        const devMessages = getMessagesByRole(result, "developer");
+        expect(devMessages.length).toBe(1);
+      });
+    });
+  });
+});

--- a/core/llm/openaiTypeConverters.ts
+++ b/core/llm/openaiTypeConverters.ts
@@ -774,6 +774,90 @@ function toResponseInputContentList(
   return list;
 }
 
+/**
+ * Emits function_call items for each tool call that has a corresponding fc_ ID.
+ * Extracted to reduce cyclomatic complexity in toResponsesInput.
+ */
+function emitFunctionCallsFromToolCalls(
+  toolCalls: ToolCallDelta[],
+  respIds: string[],
+  input: ResponseInput,
+): void {
+  for (let i = 0; i < toolCalls.length; i++) {
+    const tc = toolCalls[i];
+    const fcId = respIds[i];
+
+    if (!fcId) continue; // Skip if no fc_ ID for this tool call
+
+    const name = tc?.function?.name as string | undefined;
+    const args = tc?.function?.arguments as string | undefined;
+    const call_id = tc?.id as string | undefined;
+
+    if (name && call_id) {
+      const functionCallItem: ResponseFunctionToolCall = {
+        id: fcId,
+        type: "function_call",
+        name,
+        arguments: typeof args === "string" ? args : "{}",
+        call_id,
+      };
+      input.push(functionCallItem);
+    }
+  }
+}
+
+/**
+ * Converts a thinking message's reasoning_details into a ResponseReasoningItem.
+ * Extracted to reduce cyclomatic complexity in toResponsesInput.
+ */
+function convertThinkingMessageToReasoningItem(
+  msg: ThinkingChatMessage,
+): ResponseReasoningItem | undefined {
+  const details = msg.reasoning_details ?? [];
+  if (!details.length) return undefined;
+
+  let id: string | undefined;
+  let summaryText = "";
+  let encrypted: string | undefined;
+  let reasoningText = "";
+
+  for (const raw of details as Array<Record<string, unknown>>) {
+    const d = raw as {
+      type?: string;
+      id?: string;
+      text?: string;
+      encrypted_content?: string;
+    };
+    if (d.type === "reasoning_id" && d.id) id = d.id;
+    else if (d.type === "encrypted_content" && d.encrypted_content)
+      encrypted = d.encrypted_content;
+    else if (d.type === "summary_text" && typeof d.text === "string")
+      summaryText += d.text;
+    else if (d.type === "reasoning_text" && typeof d.text === "string")
+      reasoningText += d.text;
+  }
+
+  if (!id) return undefined;
+
+  const reasoningItem: ResponseReasoningItem = {
+    id,
+    type: "reasoning",
+    summary: [],
+  } as ResponseReasoningItem;
+
+  if (summaryText) {
+    reasoningItem.summary = [{ type: "summary_text", text: summaryText }];
+  }
+  if (reasoningText) {
+    reasoningItem.content = [{ type: "reasoning_text", text: reasoningText }];
+  }
+  if (encrypted) {
+    reasoningItem.encrypted_content = encrypted;
+  }
+
+  return reasoningItem;
+}
+
 export function toResponsesInput(messages: ChatMessage[]): ResponseInput {
   const input: ResponseInput = [];
 
@@ -817,21 +901,25 @@ export function toResponsesInput(messages: ChatMessage[]): ResponseInput {
           | string
           | undefined;
         const toolCalls = msg.toolCalls as ToolCallDelta[] | undefined;
+        // Get array of fc_ IDs for parallel tool calls, fallback to single respId
+        // NOTE: responsesOutputItemIds is accumulated in sessionSlice.ts during streaming.
+        // We rely on OpenAI streaming events arriving in order, so respIds[i] corresponds
+        // to toolCalls[i] by position. See: https://platform.openai.com/docs/guides/function-calling
+        const respIds =
+          (msg.metadata?.responsesOutputItemIds as string[] | undefined) ||
+          (respId ? [respId] : []);
 
-        if (respId && Array.isArray(toolCalls) && toolCalls.length > 0) {
-          // Emit full function_call output item
-          const tc = toolCalls[0];
-          const name = tc?.function?.name as string | undefined;
-          const args = tc?.function?.arguments as string | undefined;
-          const call_id = tc?.id as string | undefined;
-          const functionCallItem: ResponseFunctionToolCall = {
-            id: respId,
-            type: "function_call",
-            name: name || "",
-            arguments: typeof args === "string" ? args : "{}",
-            call_id: call_id || respId,
-          };
-          input.push(functionCallItem);
+        if (
+          Array.isArray(toolCalls) &&
+          toolCalls.length > 0 &&
+          respIds.length > 0
+        ) {
+          // Emit function_call for EACH tool call (supports parallel tool calls)
+          emitFunctionCallsFromToolCalls(toolCalls, respIds, input);
+          // Also emit text content if present alongside tool calls
+          if (text && text.trim()) {
+            pushMessage("assistant", text);
+          }
         } else if (respId) {
           // Emit full assistant output message item
           const outputMessageItem: ResponseOutputMessage = {
@@ -869,48 +957,11 @@ export function toResponsesInput(messages: ChatMessage[]): ResponseInput {
         break;
       }
       case "thinking": {
-        const details = (msg as ThinkingChatMessage).reasoning_details ?? [];
-        if (details.length) {
-          let id: string | undefined;
-          let summaryText = "";
-          let encrypted: string | undefined;
-          let reasoningText = "";
-          for (const raw of details as Array<Record<string, unknown>>) {
-            const d = raw as {
-              type?: string;
-              id?: string;
-              text?: string;
-              encrypted_content?: string;
-            };
-            if (d.type === "reasoning_id" && d.id) id = d.id;
-            else if (d.type === "encrypted_content" && d.encrypted_content)
-              encrypted = d.encrypted_content;
-            else if (d.type === "summary_text" && typeof d.text === "string")
-              summaryText += d.text;
-            else if (d.type === "reasoning_text" && typeof d.text === "string")
-              reasoningText += d.text;
-          }
-          if (id) {
-            const reasoningItem: ResponseReasoningItem = {
-              id,
-              type: "reasoning",
-              summary: [],
-            } as ResponseReasoningItem;
-            if (summaryText) {
-              reasoningItem.summary = [
-                { type: "summary_text", text: summaryText },
-              ];
-            }
-            if (reasoningText) {
-              reasoningItem.content = [
-                { type: "reasoning_text", text: reasoningText },
-              ];
-            }
-            if (encrypted) {
-              reasoningItem.encrypted_content = encrypted;
-            }
-            input.push(reasoningItem as ResponseInputItem);
-          }
+        const reasoningItem = convertThinkingMessageToReasoningItem(
+          msg as ThinkingChatMessage,
+        );
+        if (reasoningItem) {
+          input.push(reasoningItem as ResponseInputItem);
         }
         break;
       }

--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -658,6 +658,14 @@ export const sessionSlice = createSlice({
             message.metadata?.responsesOutputItemId
           ) {
             lastMessage.metadata = lastMessage.metadata || {};
+            // Accumulate fc_ IDs for parallel tool calls (OpenAI Responses API)
+            if (!lastMessage.metadata.responsesOutputItemIds) {
+              lastMessage.metadata.responsesOutputItemIds = [];
+            }
+            (lastMessage.metadata.responsesOutputItemIds as string[]).push(
+              message.metadata.responsesOutputItemId as string,
+            );
+            // Also keep singular for backwards compatibility
             lastMessage.metadata.responsesOutputItemId = message.metadata
               .responsesOutputItemId as string;
           }


### PR DESCRIPTION
Fixes #8773

When GPT-5 makes parallel tool calls via the Responses API, each `function_call` has a unique `call_id` (fc_*). These IDs were being overwritten instead of accumulated, causing:

> "No tool call found for function call output with call_id fc_xxx"

## Changes

- `gui/src/redux/slices/sessionSlice.ts`: Accumulate IDs in `responsesOutputItemIds[]` array during streaming
- `core/llm/openaiTypeConverters.ts`: Emit `function_call` for each tool call with positional ID matching
- `core/llm/openaiTypeConverters.test.ts`: Added comprehensive tests for parallel tool call scenarios

## How it works

1. During streaming, when `fromResponsesChunk` sets `message.metadata.responsesOutputItemId`, we now accumulate these into an array `responsesOutputItemIds[]`
2. When converting to Responses API input format, we iterate over all tool calls and match each one with its corresponding fc_ ID by position
3. This ensures each parallel tool call gets its correct `call_id` when sent back to OpenAI

## Test plan

- [x] Unit tests pass (14 new tests covering parallel tool calls, edge cases)
- [x] Manual testing with GPT-5 and GPT-5.1 parallel tool calls

Related: #8935

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued · ▶️ 1 not started — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F9659&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lost call_id mapping for parallel tool calls in the OpenAI Responses API, preventing “No tool call found for function call output” errors and restoring correct pairing between function_call and tool outputs.

- **Bug Fixes**
  - Accumulate fc_ IDs during streaming in responsesOutputItemIds[] (keeps the singular field for backward compatibility).
  - Emit a function_call item for each tool call, matching IDs by position; also emit assistant text when present.
  - Add unit tests covering parallel calls, legacy scenarios, and edge cases.

<sup>Written for commit 540e15f60e4bfdbb46e2fba534d4dc1543743492. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

