### PR TITLE
fix: show full right side gradient border

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor/components/StyledComponents.ts
+++ b/gui/src/components/mainInput/TipTapEditor/components/StyledComponents.ts
@@ -17,7 +17,6 @@ export const InputBoxDiv = styled.div<{}>`
   padding-bottom: 1px;
   margin: 0;
   height: auto;
-  width: 100%;
   background-color: ${vscInputBackground};
   color: ${vscForeground};
 


### PR DESCRIPTION
## Description

Prevent the right side input border from being trimmed during streaming.

closes https://github.com/continuedev/continue/issues/9549

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot



https://github.com/user-attachments/assets/efe5c75b-f2b6-47c4-a1ed-712793f618aa

https://github.com/user-attachments/assets/ee10a024-b513-4d91-954e-e02038501de2




## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

---

<!-- continue-task-summary-start -->

## Continue Tasks

| Status | Task | Actions |
|:-------|:-----|:--------|
| ▶️ Queued | Update docs on PR | [View](https://hub.continue.dev/tasks/4b229676-96d1-468f-b778-d388068d6cf5) |
| ▶️ Queued | Optimize Website Performance | [View](https://hub.continue.dev/tasks/502e966a-6aa8-4f40-a2a8-41d6855d93e5) |

<sub>Powered by [Continue](https://hub.continue.dev)</sub>

<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent the input’s right-side gradient border from being clipped during streaming by removing width: 100% from InputBoxDiv so the border renders fully.

<sup>Written for commit 7f46011e7c277d570907cfc733639f4a2f944d1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

