### PR TITLE
remove hub link, create local prompt

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor/utils/getSuggestion.ts
+++ b/gui/src/components/mainInput/TipTapEditor/utils/getSuggestion.ts
@@ -226,13 +226,9 @@ export function getSlashCommandDropdownOptions(
 
     if (query.length === 0 && commandItems.length === 0) {
       commandItems.push({
-        title: "Explore prompts",
+        title: "Create a prompt",
         type: "action",
-        action: () =>
-          ideMessenger.post(
-            "openUrl",
-            "https://hub.continue.dev/explore/prompts",
-          ),
+        action: () => ideMessenger.post("config/newPromptFile", undefined),
         description: "",
         name: "",
         id: "",

--- a/gui/src/pages/config/sections/HelpSection.tsx
+++ b/gui/src/pages/config/sections/HelpSection.tsx
@@ -180,15 +180,6 @@ export function HelpSection() {
           <Card className="!p-0">
             <div className="flex flex-col">
               <ConfigRow
-                title="Continue Hub"
-                description="Visit hub.continue.dev to explore custom agents and blocks"
-                icon={LinkIcon}
-                onClick={() =>
-                  ideMessenger.post("openUrl", "https://hub.continue.dev/")
-                }
-              />
-
-              <ConfigRow
                 title="Documentation"
                 description="Learn how to configure and use Continue"
                 icon={LinkIcon}


### PR DESCRIPTION
## Description

Button in empty slash commands dropdown creates a local prompt instead of going to hub. Remove unhelpful link from the help section.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued · 🔴 1 closed — [View all](https://hub.continue-stage.tools/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F9677&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Empty slash command dropdown now creates a local prompt instead of opening the Hub. Removed the Continue Hub link from the Help section.

<sup>Written for commit fe6316318d3b6dd0042d345205ce7b342f76d761. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

