### PR TITLE
Revert "docs: create IDE Extensions tab with Customize and Reference sections"

### DIFF
--- a/docs/customize/overview.mdx
+++ b/docs/customize/overview.mdx
@@ -35,6 +35,11 @@ Give your agent the power of tools using [Agent mode in the extensions](/ide-ext
 
 [Learn more about MCP tools →](/customize/mcp-tools)
 
+## Customize VS Code Settings
+
+Adjust IDE-specific settings to optimize your Continue experience.
+
+[Learn more about settings →](/ide-extensions/settings)
 
 ## Deep Dives
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -96,45 +96,16 @@
             ]
           },
           {
-            "group": "Help",
-            "icon": "book-open",
-            "expanded": false,
-            "pages": ["faqs", "troubleshooting", "CONTRIBUTING"]
-          },
-          {
             "group": "IDE Extensions",
-            "icon": "puzzle-piece",
-            "pages": [
-              {
-                "page": "ide-extensions/install",
-                "href": "/ide-extensions/install"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "IDE Extensions",
-        "groups": [
-          {
-            "group": "Getting Started",
-            "icon": "rocket-launch",
+            "icon": "star",
+            "expanded": false,
             "pages": [
               "ide-extensions/install",
               "ide-extensions/quick-start",
-              {
-                "page": "Customization",
-                "href": "/customize/overview"
-              }
-            ]
-          },
-          {
-            "group": "Features",
-            "expanded": false,
-            "icon": "star",
-            "pages": [
+              "ide-extensions/settings",
               {
                 "group": "Agent",
+                "expanded": false,
                 "icon": "robot",
                 "pages": [
                   "ide-extensions/agent/quick-start",
@@ -147,6 +118,7 @@
               },
               {
                 "group": "Chat",
+                "expanded": false,
                 "icon": "messages",
                 "pages": [
                   "ide-extensions/chat/quick-start",
@@ -158,6 +130,8 @@
               },
               {
                 "group": "Autocomplete",
+                "expanded": false,
+
                 "icon": "sparkles",
                 "pages": [
                   "ide-extensions/autocomplete/quick-start",
@@ -170,6 +144,8 @@
               },
               {
                 "group": "Edit",
+                "expanded": false,
+
                 "icon": "pen-to-square",
                 "pages": [
                   "ide-extensions/edit/quick-start",
@@ -181,10 +157,20 @@
               }
             ]
           },
+
+          {
+            "group": "Help",
+            "icon": "book-open",
+            "expanded": false,
+            "pages": ["faqs", "troubleshooting", "CONTRIBUTING"]
+          }
+        ]
+      },
+      {
+        "tab": "Customize",
+        "groups": [
           {
             "group": "Customize",
-            "expanded": false,
-            "icon": "sliders",
             "pages": [
               "customize/overview",
               "customize/models",
@@ -244,6 +230,7 @@
                   "customize/model-roles/reranking"
                 ]
               },
+
               {
                 "group": "Deep Dives",
                 "icon": "microscope",
@@ -259,20 +246,6 @@
                 ]
               },
               "customize/telemetry"
-            ]
-          },
-          {
-            "group": "Reference",
-            "expanded": false,
-            "icon": "code",
-            "pages": [
-              "reference",
-              "reference/yaml-migration",
-              "reference/continue-mcp",
-              "reference/json-reference",
-              "reference/deprecated-context-providers",
-              "reference/deprecated-codebase",
-              "reference/deprecated-docs"
             ]
           }
         ]
@@ -354,6 +327,24 @@
                   "guides/klavis-mcp-continue-cookbook"
                 ]
               }
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Reference",
+        "groups": [
+          {
+            "group": "Reference",
+            "icon": "code",
+            "pages": [
+              "reference",
+              "reference/yaml-migration",
+              "reference/continue-mcp",
+              "reference/json-reference",
+              "reference/deprecated-context-providers",
+              "reference/deprecated-codebase",
+              "reference/deprecated-docs"
             ]
           }
         ]
@@ -550,11 +541,7 @@
     },
     {
       "source": "/customization/settings",
-      "destination": "/customize/overview"
-    },
-    {
-      "source": "/ide-extensions/settings",
-      "destination": "/customize/overview"
+      "destination": "/ide-extensions/settings"
     },
     {
       "source": "/customize/tools",

--- a/docs/ide-extensions/settings.mdx
+++ b/docs/ide-extensions/settings.mdx
@@ -1,0 +1,188 @@
+---
+title: Settings
+description: Configure Continue through VS Code's streamlined settings interface
+---
+
+
+
+## Quick Access
+
+<CardGroup cols={3}>
+  <Card title="Settings Icon" icon="gear">
+    Click the gear in the Continue sidebar
+  </Card>
+  <Card title="VS Code Settings" icon="sliders">
+    File → Preferences → Settings → Extensions → Continue
+  </Card>
+  <Card title="Config File" icon="code">
+    Edit `config.yml` directly for advanced options
+  </Card>
+</CardGroup>
+
+<Tip>
+  Use the toolbar buttons for quick access to specific settings: - **Rules**
+  (pencil icon) - Custom coding preferences - **Tools** (wrench icon) - Manage
+  integrations - **Models** (cube icon) - Configure AI providers
+</Tip>
+<img
+  src="/images/continue-settings-card-layout.png"
+  alt="Continue Settings Panel - Card-based Layout"
+/>
+## Core Settings
+
+<Tabs>
+  <Tab title="Interface">
+    <AccordionGroup>
+      <Accordion title="Display Options" icon="display">
+        | Setting | Description |
+        |---------|-------------|
+        | Session Tabs | Manage multiple chat sessions |
+        | Code Wrapping | Auto-wrap long code lines |
+        | Markdown Display | Show raw markdown vs rendered |
+        | Chat Scrollbar | Toggle scrollbar visibility |
+      </Accordion>
+      
+      <Accordion title="Behavior" icon="wand-magic-sparkles">
+        | Setting | Description |
+        |---------|-------------|
+        | Auto-accept Diffs | Apply code changes automatically |
+        | Tool Rejection | Continue after tool rejection |
+        | Auto-naming | Generate session titles automatically |
+      </Accordion>
+    </AccordionGroup>
+  </Tab>
+
+  <Tab title="Autocomplete">
+    Configure code completions:
+
+    <img
+      src="/images/autocomplete-settings.png"
+      alt="Continue Autocomplete Settings"
+    />
+
+    <Note>
+      Autocomplete models need to be added to your config to enable selecting an autocomplete model. If none is available, you will be linked to the docs showing recommended models. See our [model recommendations](/customize/model-roles/autocomplete) for the best autocomplete models.
+    </Note>
+
+    <img
+      src="/images/autocomplete-model-selection.png"
+      alt="Autocomplete Model Selection"
+    />
+
+    <Info>
+      To better understand how to set up configs and models, see our [Understanding Configs guide](/guides/understanding-configs).
+    </Info>
+
+  </Tab>
+
+  <Tab title="Indexing">
+    Control how Continue understands your codebase:
+
+    <img
+      src="/images/indexing-settings.png"
+      alt="Continue Indexing Settings"
+    />
+
+    <Steps>
+      <Step title="Enable Indexing">
+        Toggle codebase indexing in the settings panel
+      </Step>
+      <Step title="Monitor Progress">
+        Watch real-time status in the UI
+      </Step>
+      <Step title="Verify Coverage">
+        Check which files are indexed via the status indicator
+      </Step>
+    </Steps>
+
+    <Note>
+      Indexing enables Continue to understand your entire codebase structure, significantly improving context awareness and suggestions.
+    </Note>
+
+  </Tab>
+
+    <Tab title="Experimental">
+    <Warning>
+      These features are in beta and may change or have stability issues.
+    </Warning>
+
+    | Feature | Purpose |
+    |---------|---------|  
+    | Add Current File by Default | The currently open file is added as context in every new conversation |
+    | Enable experimental tools | Enables access to experimental tools that are still in development |
+    | Only use system message tools | Continue will not attempt to use native tool calling and will only use system message tools |
+    | @Codebase: use tool calling only | @codebase context provider will only use tool calling for code retrieval |
+    | Stream after tool rejection | Streaming will continue after the tool call is rejected |
+
+  </Tab>
+</Tabs>
+
+## Model & Assistant Selection
+
+<img
+  src="/images/assistant-selector-dropdown.png"
+  alt="New assistant dropdown with cleaner icons and improved organization display"
+/>
+
+The refined assistant selector features:
+
+- **Organization badges** for easy provider identification
+- **Smart error handling** that sorts problematic configurations while keeping them selectable
+- **Keyboard navigation** for quick model switching
+
+## Privacy & Data
+
+<CardGroup cols={3}>
+  <Card title="Local Processing" icon="lock">
+    All code analysis happens locally unless explicitly shared
+  </Card>
+  <Card title="Telemetry Control" icon="chart-line">
+    Opt in/out of anonymous usage statistics
+  </Card>
+  <Card title="Session Management" icon="database">
+    Sessions auto-save and restore between IDE restarts
+  </Card>
+</CardGroup>
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="Model Connection Issues" icon="plug">
+    - Verify API keys in `config.yml` - Check network connectivity - Confirm
+    endpoint URLs are correct
+  </Accordion>
+
+<Accordion title="Tool Loading Failures" icon="wrench">
+  - Review MCP server configurations - Check tool permissions - Verify tool
+  dependencies are installed
+</Accordion>
+
+    <Accordion title="Indexing Problems" icon="magnifying-glass">
+    - Check file permissions
+    - Review `.gitignore` patterns
+    - Verify sufficient disk space
+
+  </Accordion>
+</AccordionGroup>
+
+<Info>
+  Still having issues? Check our comprehensive [troubleshooting
+  guide](/troubleshooting) or visit the [FAQs](/faqs) for more solutions.
+</Info>
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Configure Models" icon="robot" href="/customize/models">
+    Set up your AI providers
+  </Card>
+  <Card title="Add Tools" icon="wrench" href="/customize/mcp-tools">
+    Extend Continue with MCP tools
+  </Card>
+  <Card title="Custom Rules" icon="pencil" href="/customize/rules">
+    Define coding preferences
+  </Card>
+  <Card title="Prompts" icon="message" href="/customize/prompts">
+    Customize AI behavior
+  </Card>
+</CardGroup>


### PR DESCRIPTION
Reverts continuedev/continue#9539

---

<!-- continue-task-summary-start -->

## Continue Tasks

| Status | Task | Actions |
|:-------|:-----|:--------|
| ▶️ Queued | Create GitHub Issue (OS) | [View](https://hub.continue-stage.tools/tasks/809e57a6-8fb7-40dd-b17f-1640ae0e6c86) |
| ▶️ Queued | Update PostHog Dashboards | [View](https://hub.continue-stage.tools/tasks/d4655ce6-807f-4c7d-bca6-686e21cf4ff9) |

<sub>Powered by [Continue](https://hub.continue.dev)</sub>

<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the docs reorg that merged Customize and Reference into the IDE Extensions tab, restoring them as separate top-level tabs. Adds a dedicated IDE Extensions Settings page and links to it from Customize.

- **Refactors**
  - Split Customize and Reference into their own tabs in docs.json.
  - Moved Help group back under IDE Extensions and set feature groups to collapsed by default.
  - Updated routes: /customization/settings now points to /ide-extensions/settings; removed the old redirect from /ide-extensions/settings.

- **New Features**
  - Added IDE Extensions > Settings page (VS Code-focused configuration, autocomplete, indexing, experimental options, privacy, troubleshooting).
  - Linked the new settings page from Customize > Overview.
  - Included the settings page in the IDE Extensions navigation.

<sup>Written for commit 9e3ea2c1636475e481eddadab2450701cb8013f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

