### PR TITLE
fix: retrieve reasoning toggle from local storage

### DIFF
--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -15,9 +15,9 @@ import { useAppDispatch, useAppSelector } from "../../redux/hooks";
 import { selectUseActiveFile } from "../../redux/selectors";
 import { selectSelectedChatModel } from "../../redux/slices/configSlice";
 import { setHasReasoningEnabled } from "../../redux/slices/sessionSlice";
+import { setReasoningSetting } from "../../redux/slices/uiSlice";
 import { exitEdit } from "../../redux/thunks/edit";
 import { getMetaKeyLabel, isMetaEquivalentKeyPressed } from "../../util";
-import { setLocalStorage } from "../../util/localStorage";
 import { ToolTip } from "../gui/Tooltip";
 import ModelSelect from "../modelSelection/ModelSelect";
 import { ModeSelect } from "../ModeSelect";
@@ -140,9 +140,11 @@ function InputToolbar(props: InputToolbarProps) {
                 onClick={() => {
                   dispatch(setHasReasoningEnabled(!hasReasoningEnabled));
                   if (defaultModel?.title) {
-                    setLocalStorage(
-                      `hasReasoningEnabled_${defaultModel.title}`,
-                      !hasReasoningEnabled,
+                    dispatch(
+                      setReasoningSetting({
+                        modelTitle: defaultModel.title,
+                        enabled: !hasReasoningEnabled,
+                      }),
                     );
                   }
                 }}

--- a/gui/src/hooks/ParallelListeners.tsx
+++ b/gui/src/hooks/ParallelListeners.tsx
@@ -31,7 +31,7 @@ import {
   setDocumentStylesFromTheme,
 } from "../styles/theme";
 import { isJetBrains } from "../util";
-import { getLocalStorage, setLocalStorage } from "../util/localStorage";
+import { setLocalStorage } from "../util/localStorage";
 import { migrateLocalStorage } from "../util/migrateLocalStorage";
 import { useWebviewListener } from "./useWebviewListener";
 
@@ -42,6 +42,9 @@ function ParallelListeners() {
   const isInEdit = useAppSelector((store) => store.session.isInEdit);
   const selectedProfileId = useAppSelector(
     (store) => store.profiles.selectedProfileId,
+  );
+  const reasoningSettings = useAppSelector(
+    (store) => store.ui.reasoningSettings,
   );
   const hasDoneInitialConfigLoad = useRef(false);
 
@@ -88,8 +91,8 @@ function ParallelListeners() {
       const supportsReasoning = modelSupportsReasoning(chatModel);
       const isReasoningDisabled =
         chatModel?.completionOptions?.reasoning === false;
-      const wasReasoningPreviouslyEnabled = chatModel
-        ? getLocalStorage(`hasReasoningEnabled_${chatModel.title}`) !== false
+      const wasReasoningPreviouslyEnabled = chatModel?.title
+        ? reasoningSettings[chatModel.title] !== false
         : true;
       dispatch(
         setHasReasoningEnabled(
@@ -99,7 +102,7 @@ function ParallelListeners() {
         ),
       );
     },
-    [dispatch, hasDoneInitialConfigLoad, selectedProfileId],
+    [dispatch, hasDoneInitialConfigLoad, selectedProfileId, reasoningSettings],
   );
 
   // Load config from the IDE

--- a/gui/src/redux/slices/uiSlice.ts
+++ b/gui/src/redux/slices/uiSlice.ts
@@ -15,6 +15,7 @@ export type ToolGroupPolicy = "include" | "exclude";
 export type ToolPolicies = { [toolName: string]: ToolPolicy };
 export type RulePolicies = { [ruleName: string]: RulePolicy };
 export type ToolGroupPolicies = { [toolGroupName: string]: ToolGroupPolicy };
+export type ReasoningSettings = { [modelTitle: string]: boolean };
 
 type UIState = {
   showDialog: boolean;
@@ -26,6 +27,7 @@ type UIState = {
   toolSettings: ToolPolicies;
   toolGroupSettings: ToolGroupPolicies;
   ruleSettings: RulePolicies;
+  reasoningSettings: ReasoningSettings;
   ttsActive: boolean;
 };
 
@@ -46,6 +48,7 @@ export const DEFAULT_UI_SLICE: UIState = {
     [BUILT_IN_GROUP_NAME]: "include",
   },
   ruleSettings: {},
+  reasoningSettings: {},
 };
 
 export const uiSlice = createSlice({
@@ -139,6 +142,13 @@ export const uiSlice = createSlice({
     setTTSActive: (state, { payload }: PayloadAction<boolean>) => {
       state.ttsActive = payload;
     },
+    setReasoningSetting: (
+      state,
+      action: PayloadAction<{ modelTitle: string; enabled: boolean }>,
+    ) => {
+      state.reasoningSettings[action.payload.modelTitle] =
+        action.payload.enabled;
+    },
   },
 });
 
@@ -155,6 +165,7 @@ export const {
   addRule,
   toggleRuleSetting,
   setTTSActive,
+  setReasoningSetting,
 } = uiSlice.actions;
 
 export default uiSlice.reducer;

--- a/gui/src/redux/store.ts
+++ b/gui/src/redux/store.ts
@@ -52,7 +52,12 @@ const saveSubsetFilters = [
     "codeToEdit",
   ]),
   createFilter("config", []),
-  createFilter("ui", ["toolSettings", "toolGroupSettings", "ruleSettings"]),
+  createFilter("ui", [
+    "toolSettings",
+    "toolGroupSettings",
+    "ruleSettings",
+    "reasoningSettings",
+  ]),
   createFilter("indexing", []),
   createFilter("tabs", ["tabs"]),
   createFilter("profiles", [

--- a/gui/src/util/localStorage.ts
+++ b/gui/src/util/localStorage.ts
@@ -17,7 +17,6 @@ type LocalStorageTypes = {
   disableIndexing: boolean;
   hasExitedFreeTrial: boolean;
   hasDismissedCliInstallBanner: boolean;
-  [key: `hasReasoningEnabled_${string}`]: boolean;
 };
 
 export enum LocalStorageKey {


### PR DESCRIPTION
## Description




Get and store `hasReasoningEnabled` in local storage so that when thinking toggle is manually turned off, it does not turn on workspace reload.


closes https://github.com/continuedev/continue/issues/9675

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

https://github.com/user-attachments/assets/ea2168b2-a2b3-4cae-930c-ec5c5893ef70

https://github.com/user-attachments/assets/07da136b-b206-448a-9c3f-3ecf7cd3bc88


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued · ▶️ 1 not started — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F9688&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist and restore the reasoning toggle per model using the Redux UI slice so the user’s choice sticks across reloads and doesn’t auto-enable when switching to reasoning-capable models.

- **Bug Fixes**
  - Save hasReasoningEnabled per model via ui.reasoningSettings on toggle in InputToolbar.
  - Read per-model setting from Redux in ParallelListeners and combine with model support and reasoning=false configs.

<sup>Written for commit 649491abacdc14f4d7f6ceabe3f7803a1bce18a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

