### PR TITLE
fix: pass pre-read content to RegistryClient for WSL compatibility

### DIFF
--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -64,6 +64,8 @@ async function loadConfigYaml(options: {
   } = options;
 
   // Add local .continue blocks
+  // Use "content" field to pass pre-read content directly, avoiding
+  // fs.readFileSync which fails for vscode-remote:// URIs in WSL (#6242, #7810)
   const localBlockPromises = BLOCK_TYPES.map(async (blockType) => {
     const localBlocks = await getAllDotContinueDefinitionFiles(
       ide,
@@ -73,6 +75,7 @@ async function loadConfigYaml(options: {
     return localBlocks.map((b) => ({
       uriType: "file" as const,
       fileUri: b.path,
+      content: b.content,
     }));
   });
   const localPackageIdentifiers: PackageIdentifier[] = (

--- a/packages/config-yaml/src/interfaces/slugs.ts
+++ b/packages/config-yaml/src/interfaces/slugs.ts
@@ -68,6 +68,8 @@ interface FullSlugIdentifier extends BasePackageIdentifier {
 interface FileIdentifier extends BasePackageIdentifier {
   uriType: "file";
   fileUri: string;
+  /** Pre-read content - bypasses fs.readFileSync for vscode-remote:// URIs in WSL */
+  content?: string;
 }
 
 export type PackageIdentifier = FullSlugIdentifier | FileIdentifier;

--- a/packages/config-yaml/src/registryClient.test.ts
+++ b/packages/config-yaml/src/registryClient.test.ts
@@ -131,6 +131,20 @@ describe("RegistryClient", () => {
         "Unknown package identifier type: unknown",
       );
     });
+
+    it("should return pre-read content directly for file with content field", async () => {
+      const client = new RegistryClient();
+
+      const id: PackageIdentifier = {
+        uriType: "file",
+        fileUri: "/nonexistent/path.yaml",
+        content: "pre-read yaml content",
+      };
+
+      // Should return content without trying to read the nonexistent file
+      const result = await client.getContent(id);
+      expect(result).toBe("pre-read yaml content");
+    });
   });
 
   describe("getContentFromFilePath", () => {

--- a/packages/config-yaml/src/registryClient.ts
+++ b/packages/config-yaml/src/registryClient.ts
@@ -24,6 +24,11 @@ export class RegistryClient implements Registry {
   }
 
   async getContent(id: PackageIdentifier): Promise<string> {
+    // Return pre-read content if available (for vscode-remote:// URIs in WSL)
+    if (id.uriType === "file" && id.content !== undefined) {
+      return id.content;
+    }
+
     switch (id.uriType) {
       case "file":
         return this.getContentFromFilePath(id.fileUri);


### PR DESCRIPTION
## Summary
- Fixes workspace `.continue/` files failing to load when Windows VS Code connects to WSL
- Root cause: `loadYaml.ts` discarded pre-read content and passed only URIs to `RegistryClient`, which tried `fs.readFileSync()` (fails for `vscode-remote://` URIs)
- Solution: Added `ContentIdentifier` type to pass pre-read content directly through the loading pipeline

Fixes #6242, Fixes #7810

## Test plan
- [x] Unit tests pass (297 tests in config-yaml)
- [x] Built Linux vsix, installed in WSL via `code --install-extension`
- [x] Created `.continue/docs/test.yaml` in WSL workspace
- [x] Verified config loads without ENOENT errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued · ▶️ 1 not started — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F9739&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WSL config loading by passing pre-read YAML content through the pipeline to avoid fs reads on vscode-remote:// URIs (Fixes #6242, #7810).

- **Bug Fixes**
  - Added optional content field to FileIdentifier; loadYaml now includes it.
  - RegistryClient.getContent returns pre-read content when present.
  - Added tests for file identifiers using pre-read content.

<sup>Written for commit 1c74659568a6dfb8dba0becc357896cf2a5bf7e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

