### PR TITLE
Add extension features and customization links to docs index

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -112,7 +112,7 @@ You can go to [Mission Control Integrations](https://hub.continue.dev/integratio
   Optional IDE extensions for real-time code editing and assistance.
 </Note>
 
-Learn more about [extension features](https://docs.continue.dev/ide-extensions/) and how to [customize](https://docs.continue.dev/customize/overview) →
+Learn more about [extension features](https://docs.continue.dev/ide-extensions/quick-start) and how to [customize](https://docs.continue.dev/customize/overview) →
 
 <CardGroup cols={2}>
   <Card


### PR DESCRIPTION
## Summary
- Added a line under the IDE Extensions callout on the docs index page linking to extension features and customization documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue-stage.tools/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F9798)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added links under the IDE Extensions callout on the docs index to extension features and customization pages. This makes it easier for users to learn what the extensions do and how to configure them.

<sup>Written for commit b73fefe7000cedd45431ca4cdade539bee1d0832. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

