### PR TITLE
feat(cli): detect wsl and spawn appropriate shell

### DIFF
--- a/extensions/cli/src/tools/runTerminalCommand.test.ts
+++ b/extensions/cli/src/tools/runTerminalCommand.test.ts
@@ -1,4 +1,7 @@
-import { runTerminalCommandTool } from "./runTerminalCommand.js";
+import {
+  isRunningInWsl,
+  runTerminalCommandTool,
+} from "./runTerminalCommand.js";
 
 describe("runTerminalCommandTool", () => {
   const isWindows = process.platform === "win32";
@@ -101,6 +104,20 @@ describe("runTerminalCommandTool", () => {
           command: "uname -s",
         });
         expect(result.trim()).toBe("Linux");
+      });
+    }
+  });
+
+  describe("WSL detection", () => {
+    it("should cache the WSL detection result", () => {
+      const firstResult = isRunningInWsl();
+      const secondResult = isRunningInWsl();
+      expect(firstResult).toBe(secondResult);
+    });
+
+    if (!isLinux) {
+      it("should return false on non-Linux platforms", () => {
+        expect(isRunningInWsl()).toBe(false);
       });
     }
   });


### PR DESCRIPTION
## Description

When on a windows machine but cn runs inside WSL, terminal commands should also run inside WSL and not using windows powershell.

closes https://github.com/continuedev/continue/issues/9736
closes https://github.com/continuedev/continue/issues/9731

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F9810&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Terminal commands now run inside WSL when the CLI is used from WSL on Windows. This avoids PowerShell and ensures commands run in the correct Linux environment.

- **New Features**
  - Detect WSL via WSL_DISTRO_NAME and /proc/version.
  - Use bash as a login shell in WSL instead of PowerShell.
  - Added tests for WSL detection and non-Linux behavior.

<sup>Written for commit a9ae4205e12c7974d5b6c0feea964af9b97e1630. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

