### PR TITLE
feat: Add CLI support for agent notepads

### DIFF
--- a/extensions/cli/src/commands/BaseCommandOptions.ts
+++ b/extensions/cli/src/commands/BaseCommandOptions.ts
@@ -27,6 +27,8 @@ export interface BaseCommandOptions {
   betaUploadArtifactTool?: boolean;
   /** Enable beta Subagent tool */
   betaSubagentTool?: boolean;
+  /** Enable beta Notepad feature */
+  betaNotepad?: boolean;
 }
 
 /**

--- a/extensions/cli/src/services/index.ts
+++ b/extensions/cli/src/services/index.ts
@@ -1,6 +1,7 @@
 import { loadAuthConfig } from "../auth/workos.js";
 import { initializeWithOnboarding } from "../onboarding.js";
 import {
+  setBetaNotepadToolEnabled,
   setBetaSubagentToolEnabled,
   setBetaUploadArtifactToolEnabled,
 } from "../tools/toolsConfig.js";
@@ -67,6 +68,9 @@ export async function initializeServices(initOptions: ServiceInitOptions = {}) {
   }
   if (commandOptions.betaSubagentTool) {
     setBetaSubagentToolEnabled(true);
+  }
+  if (commandOptions.betaNotepad) {
+    setBetaNotepadToolEnabled(true);
   }
   // Handle onboarding for TUI mode (headless: false) unless explicitly skipped
   if (!initOptions.headless && !initOptions.skipOnboarding) {

--- a/extensions/cli/src/shared-options.ts
+++ b/extensions/cli/src/shared-options.ts
@@ -15,6 +15,7 @@ export function addCommonOptions(command: Command): Command {
     .option("--auto", "Start in auto mode (all tools allowed)")
     .option("--verbose", "Enable verbose logging")
     .option("--beta-status-tool", "Enable beta status tool")
+    .option("--beta-notepad", "Enable beta notepad feature")
     .option(
       "--rule <rule>",
       "Add a rule (can be a file path, hub slug, or string content). Can be specified multiple times.",
@@ -104,6 +105,8 @@ export function mergeParentOptions(parentCommand: Command, options: any): any {
     "auto",
     "tools",
     "verbose",
+    "betaStatusTool",
+    "betaNotepad",
     "rule",
     "mcp",
     "model",

--- a/extensions/cli/src/tools/allBuiltIns.ts
+++ b/extensions/cli/src/tools/allBuiltIns.ts
@@ -15,6 +15,7 @@ import { uploadArtifactTool } from "./uploadArtifact.js";
 import { viewDiffTool } from "./viewDiff.js";
 import { writeChecklistTool } from "./writeChecklist.js";
 import { writeFileTool } from "./writeFile.js";
+import { workflowNotepadTool } from "./workflowNotepad.js";
 
 // putting in here for circular import issue
 export const ALL_BUILT_IN_TOOLS = [
@@ -35,3 +36,5 @@ export const ALL_BUILT_IN_TOOLS = [
   writeChecklistTool,
   writeFileTool,
 ];
+
+export { workflowNotepadTool };

--- a/extensions/cli/src/tools/index.tsx
+++ b/extensions/cli/src/tools/index.tsx
@@ -18,7 +18,7 @@ import type {
 import { telemetryService } from "../telemetry/telemetryService.js";
 import { logger } from "../util/logger.js";
 
-import { ALL_BUILT_IN_TOOLS } from "./allBuiltIns.js";
+import { ALL_BUILT_IN_TOOLS, workflowNotepadTool } from "./allBuiltIns.js";
 import { editTool } from "./edit.js";
 import { exitTool } from "./exit.js";
 import { fetchTool } from "./fetch.js";
@@ -31,6 +31,7 @@ import { checkIfRipgrepIsInstalled, searchCodeTool } from "./searchCode.js";
 import { skillsTool } from "./skills.js";
 import { subagentTool } from "./subagent.js";
 import {
+  isBetaNotepadToolEnabled,
   isBetaSubagentToolEnabled,
   isBetaUploadArtifactToolEnabled,
 } from "./toolsConfig.js";
@@ -92,6 +93,11 @@ export async function getAllAvailableTools(
     if (isBetaUploadArtifactToolEnabled()) {
       tools.push(uploadArtifactTool);
     }
+  }
+
+  // Add workflow notepad tool if WORKFLOW_ID is present and beta flag is enabled
+  if (process.env.WORKFLOW_ID && isBetaNotepadToolEnabled()) {
+    tools.push(workflowNotepadTool);
   }
 
   // If model is capable, exclude editTool in favor of multiEditTool

--- a/extensions/cli/src/tools/toolsConfig.ts
+++ b/extensions/cli/src/tools/toolsConfig.ts
@@ -5,6 +5,7 @@
 
 let betaUploadArtifactToolEnabled = false;
 let betaSubagentToolEnabled = false;
+let betaNotepadToolEnabled = false;
 
 export function setBetaUploadArtifactToolEnabled(enabled: boolean): void {
   betaUploadArtifactToolEnabled = enabled;
@@ -20,4 +21,12 @@ export function setBetaSubagentToolEnabled(enabled: boolean): void {
 
 export function isBetaSubagentToolEnabled(): boolean {
   return betaSubagentToolEnabled;
+}
+
+export function setBetaNotepadToolEnabled(enabled: boolean): void {
+  betaNotepadToolEnabled = enabled;
+}
+
+export function isBetaNotepadToolEnabled(): boolean {
+  return betaNotepadToolEnabled;
 }

--- a/extensions/cli/src/tools/workflowNotepad.ts
+++ b/extensions/cli/src/tools/workflowNotepad.ts
@@ -1,0 +1,47 @@
+import type { Tool } from "./types.js";
+
+function getWorkflowIdFromEnv(): string | undefined {
+  return process.env.WORKFLOW_ID;
+}
+
+export const workflowNotepadTool: Tool = {
+  name: "WorkflowNotepad",
+  displayName: "Workflow Notepad",
+  description:
+    "Update your persistent notepad for this workflow. The current notepad content is already visible in your system prompt under <context name='workflowNotepad'>. Use this tool to replace the notepad with new content.",
+  parameters: {
+    type: "object",
+    required: ["content"],
+    properties: {
+      content: {
+        type: "string",
+        description:
+          "New content to write to notepad (max 100KB). This will replace the entire notepad.",
+      },
+    },
+  },
+  readonly: false,
+  isBuiltIn: true,
+  run: async (args: { content: string }) => {
+    const workflowId = getWorkflowIdFromEnv();
+    if (!workflowId) {
+      throw new Error(
+        "Workflow notepad only available when running in a workflow",
+      );
+    }
+
+    if (!args.content) {
+      throw new Error("content is required");
+    }
+
+    // Import dynamically to avoid circular dependencies
+    const { put } = await import("../util/apiClient.js");
+
+    // PUT /workflows/:workflowId/notepad
+    await put(`workflows/${workflowId}/notepad`, {
+      notepad: args.content,
+    });
+
+    return "Notepad updated successfully. Note: The updated content will be visible in the system prompt when you restart or in your next workflow run.";
+  },
+};


### PR DESCRIPTION
## Summary

Adds CLI support for the agent notepads feature, allowing agents to read and update persistent notes across workflow runs.

**Feature flagged**: Only available when `--beta-notepad` flag is present (auto-injected for @continue.dev users by remote-config-server).

## Changes

### Tools & Configuration
- Added `--beta-notepad` CLI flag to shared options
- Added beta flag configuration system in `toolsConfig.ts`
- Added `betaNotepad` to `BaseCommandOptions` interface

### System Prompt Injection
- Fetches workflow notepad from API when `WORKFLOW_ID` env var is set
- Injects notepad content into system prompt as `<context name="workflowNotepad">`
- Gated behind `--beta-notepad` flag + `WORKFLOW_ID`

### WorkflowNotepad Tool
- New tool for updating notepad content (write-only)
- Makes PUT request to `/workflows/:workflowId/notepad` endpoint
- Conditionally available when both flag and WORKFLOW_ID are present

## Test Plan
- [ ] Verify tool appears only when both WORKFLOW_ID and --beta-notepad flag are set
- [ ] Verify notepad content appears in system prompt
- [ ] Test updating notepad via tool
- [ ] Verify feature is disabled without --beta-notepad flag

Related: Remote-config-server backend changes in https://github.com/continuedev/remote-config-server/pull/2908

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue-stage.tools/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F9836&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CLI support for agent notepads so agents can read and update persistent workflow notes. Enabled only with --beta-notepad and when WORKFLOW_ID is set.

- **New Features**
  - Adds --beta-notepad flag and config toggle.
  - Fetches workflow notepad and injects it into the system prompt as <context name="workflowNotepad">.
  - Introduces WorkflowNotepad tool to replace notepad content via PUT /workflows/:workflowId/notepad.
  - Tool and prompt injection appear only when both --beta-notepad and WORKFLOW_ID are present (fetch failures are ignored).

<sup>Written for commit f480ca0dfc23f84302a6a78962f51339b661ee21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

