### PR TITLE
docs: fixing render

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ Get started in [Mission Control](https://hub.continue.dev/hub?type=agents), [CLI
 
 ```bash
 npm i -g @continuedev/cli
+```
+
+### Usage
+
+```bash
 cn
 ```
 


### PR DESCRIPTION
Add usage section to README

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed README rendering for CLI by properly closing the install code block and adding a Usage section with the cn command. Install and usage commands now show as separate code blocks.

<sup>Written for commit e20eea19ffbed990e46f30fed487750e7bad1524. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

