### PR TITLE
fix: Resolve generic model IDs in agent files

### DIFF
--- a/extensions/cli/src/services/AgentFileService.ts
+++ b/extensions/cli/src/services/AgentFileService.ts
@@ -16,6 +16,7 @@ import {
   loadModelFromHub,
   loadPackageFromHub,
 } from "../hubLoader.js";
+import { resolveModelSlug } from "../util/genericModels.js";
 import { logger } from "../util/logger.js";
 
 import { BaseService, ServiceWithDependencies } from "./BaseService.js";
@@ -122,7 +123,9 @@ export class AgentFileService
             "Cannot load agent model, failed to load api client service",
           );
         }
-        const model = await loadModelFromHub(agentFile.model);
+        // Resolve generic model IDs (like "claude-haiku") to full hub slugs
+        const resolvedModelSlug = resolveModelSlug(agentFile.model);
+        const model = await loadModelFromHub(resolvedModelSlug);
         this.setState({
           agentFileModel: model,
         });

--- a/extensions/cli/src/util/genericModels.test.ts
+++ b/extensions/cli/src/util/genericModels.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getAllGenericModels,
+  isGenericModelId,
+  resolveModelSlug,
+} from "./genericModels.js";
+
+describe("genericModels", () => {
+  describe("resolveModelSlug", () => {
+    it("should resolve claude-haiku to anthropic/claude-haiku-4-5", () => {
+      expect(resolveModelSlug("claude-haiku")).toBe(
+        "anthropic/claude-haiku-4-5",
+      );
+    });
+
+    it("should resolve claude-sonnet to anthropic/claude-sonnet-4-5", () => {
+      expect(resolveModelSlug("claude-sonnet")).toBe(
+        "anthropic/claude-sonnet-4-5",
+      );
+    });
+
+    it("should resolve claude-opus to anthropic/claude-opus-4-5", () => {
+      expect(resolveModelSlug("claude-opus")).toBe("anthropic/claude-opus-4-5");
+    });
+
+    it("should pass through slugs that already contain /", () => {
+      expect(resolveModelSlug("anthropic/claude-haiku-4-5")).toBe(
+        "anthropic/claude-haiku-4-5",
+      );
+      expect(resolveModelSlug("openai/gpt-4")).toBe("openai/gpt-4");
+    });
+
+    it("should pass through unknown model IDs unchanged", () => {
+      expect(resolveModelSlug("unknown-model")).toBe("unknown-model");
+      expect(resolveModelSlug("gpt-4")).toBe("gpt-4");
+    });
+  });
+
+  describe("isGenericModelId", () => {
+    it("should return true for known generic model IDs", () => {
+      expect(isGenericModelId("claude-haiku")).toBe(true);
+      expect(isGenericModelId("claude-sonnet")).toBe(true);
+      expect(isGenericModelId("claude-opus")).toBe(true);
+    });
+
+    it("should return false for unknown model IDs", () => {
+      expect(isGenericModelId("unknown-model")).toBe(false);
+      expect(isGenericModelId("gpt-4")).toBe(false);
+      expect(isGenericModelId("anthropic/claude-haiku-4-5")).toBe(false);
+    });
+  });
+
+  describe("getAllGenericModels", () => {
+    it("should return all defined generic models", () => {
+      const models = getAllGenericModels();
+      expect(models.length).toBeGreaterThan(0);
+      expect(models.some((m) => m.id === "claude-haiku")).toBe(true);
+      expect(models.some((m) => m.id === "claude-sonnet")).toBe(true);
+      expect(models.some((m) => m.id === "claude-opus")).toBe(true);
+    });
+
+    it("should include all required fields for each model", () => {
+      const models = getAllGenericModels();
+      for (const model of models) {
+        expect(model.id).toBeDefined();
+        expect(model.displayName).toBeDefined();
+        expect(model.provider).toBeDefined();
+        expect(model.description).toBeDefined();
+        expect(model.currentModelPackageSlug).toBeDefined();
+        expect(model.currentModelPackageSlug).toContain("/");
+      }
+    });
+  });
+});

--- a/extensions/cli/src/util/genericModels.ts
+++ b/extensions/cli/src/util/genericModels.ts
@@ -1,0 +1,73 @@
+/**
+ * Generic model ID to hub slug mapping.
+ * These allow users to specify simplified model IDs in agent files
+ * that get resolved to their full hub package slugs.
+ */
+
+interface GenericModelDefinition {
+  id: string;
+  displayName: string;
+  provider: string;
+  description: string;
+  currentModelPackageSlug: string;
+}
+
+const GENERIC_MODELS: readonly GenericModelDefinition[] = [
+  {
+    id: "claude-opus",
+    displayName: "Claude Opus 4.5",
+    provider: "anthropic",
+    description: "Most capable, best for complex tasks",
+    currentModelPackageSlug: "anthropic/claude-opus-4-5",
+  },
+  {
+    id: "claude-sonnet",
+    displayName: "Claude Sonnet 4.5",
+    provider: "anthropic",
+    description: "Balanced performance and speed",
+    currentModelPackageSlug: "anthropic/claude-sonnet-4-5",
+  },
+  {
+    id: "claude-haiku",
+    displayName: "Claude Haiku 4.5",
+    provider: "anthropic",
+    description: "Fast and efficient",
+    currentModelPackageSlug: "anthropic/claude-haiku-4-5",
+  },
+];
+
+/**
+ * Resolve a generic model ID to its current package slug.
+ * If the model is already a valid slug (contains "/"), returns it unchanged.
+ * If it's a generic ID, resolves to the full package slug.
+ * Returns the original value if not recognized (to allow hub slugs to pass through).
+ */
+export function resolveModelSlug(modelId: string): string {
+  // If it already looks like a hub slug (contains "/"), return as-is
+  if (modelId.includes("/")) {
+    return modelId;
+  }
+
+  // Try to find a matching generic model
+  const genericModel = GENERIC_MODELS.find((m) => m.id === modelId);
+  if (genericModel) {
+    return genericModel.currentModelPackageSlug;
+  }
+
+  // Return original value - loadModelFromHub will handle validation
+  return modelId;
+}
+
+/**
+ * Check if a model ID is a known generic model ID
+ */
+export function isGenericModelId(modelId: string): boolean {
+  return GENERIC_MODELS.some((m) => m.id === modelId);
+}
+
+/**
+ * Get all available generic models
+ */
+export function getAllGenericModels(): readonly GenericModelDefinition[] {
+  return GENERIC_MODELS;
+}


### PR DESCRIPTION
## Summary

- Add support for generic model IDs (like `claude-haiku`) in agent files
- These get resolved to their full hub slugs (like `anthropic/claude-haiku-4-5`) before loading from the hub
- Fixes "Invalid hub slug format" error when using generic model IDs

## Problem

When an agent file specifies a model like:

```yaml
model: claude-haiku
```

The CLI would fail with:

```
Invalid hub slug format. Expected "owner/package", got: claude-haiku
```

This happened because the CLI tried to load `claude-haiku` directly from the hub, which expects `owner/package` format.

## Solution

Added a `resolveModelSlug` function that maps generic model IDs to their full hub slugs:

- `claude-haiku` -> `anthropic/claude-haiku-4-5`
- `claude-sonnet` -> `anthropic/claude-sonnet-4-5`
- `claude-opus` -> `anthropic/claude-opus-4-5`

If the model already contains `/` (is already a hub slug), it passes through unchanged.

## Test plan

- [x] Added unit tests for `resolveModelSlug`, `isGenericModelId`, and `getAllGenericModels`
- [x] All existing AgentFileService tests pass
- [ ] Manual testing with agent files using generic model IDs

---

Generated with [Claude Code](https://claude.ai/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue-stage.tools/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F9888&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve generic model IDs in agent files to full hub slugs before loading. This fixes the “Invalid hub slug format” error and lets users write model: claude-haiku, sonnet, or opus.

- **Bug Fixes**
  - Added resolveModelSlug and used it in AgentFileService.
  - Mappings: claude-haiku → anthropic/claude-haiku-4-5, claude-sonnet → anthropic/claude-sonnet-4-5, claude-opus → anthropic/claude-opus-4-5; slugs with “/” and unknown IDs pass through.
  - Added unit tests for resolution and generic model helpers.

<sup>Written for commit 5ec3d702a10f11aea69f07c5b48a0e4e7be7b9c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

