### PR TITLE
Add detailed logging for metadata endpoint requests

### DIFF
--- a/extensions/cli/src/commands/serve.ts
+++ b/extensions/cli/src/commands/serve.ts
@@ -40,6 +40,8 @@ import { readStdinSync } from "../util/stdin.js";
 
 import { ExtendedCommandOptions } from "./BaseCommandOptions.js";
 import {
+  checkAgentComplete,
+  removePartialAssistantMessage,
   streamChatResponseWithInterruption,
   type ServerState,
 } from "./serve.helpers.js";
@@ -464,28 +466,6 @@ export async function serve(prompt?: string, options: ServeOptions = {}) {
     }
   });
 
-  // Process messages from the queue
-  function removePartialAssistantMessage(state: ServerState) {
-    try {
-      const svcHistory = services.chatHistory.getHistory();
-      const last = svcHistory[svcHistory.length - 1];
-      if (last && last.message.role === "assistant" && !last.message.content) {
-        const trimmed = svcHistory.slice(0, -1);
-        services.chatHistory.setHistory(trimmed);
-      }
-    } catch {
-      const lastMessage =
-        state.session.history[state.session.history.length - 1];
-      if (
-        lastMessage &&
-        lastMessage.message.role === "assistant" &&
-        !lastMessage.message.content
-      ) {
-        state.session.history.pop();
-      }
-    }
-  }
-
   async function processMessages(state: ServerState, llmApi: any) {
     let processedMessage = false;
     while (state.serverRunning) {
@@ -529,21 +509,11 @@ export async function serve(prompt?: string, options: ServeOptions = {}) {
         // Update metadata after successful agent turn
         try {
           const history = services.chatHistory?.getHistory();
-
-          // Check if the agent should be marked as complete
-          // The agent is complete if the last message is from the assistant and has no tool calls
-          let isComplete = false;
-          if (history && history.length > 0) {
-            const lastItem = history[history.length - 1];
-            if (lastItem?.message?.role === "assistant") {
-              const toolCalls = (lastItem.message as any).tool_calls;
-              isComplete = !toolCalls || toolCalls.length === 0;
-            }
-          }
-
-          await updateAgentMetadata({ history, isComplete });
+          await updateAgentMetadata({
+            history,
+            isComplete: checkAgentComplete(history),
+          });
         } catch (metadataErr) {
-          // Non-critical: log but don't fail the agent execution
           logger.debug(
             "Failed to update metadata after turn (non-critical)",
             metadataErr as any,
@@ -552,8 +522,7 @@ export async function serve(prompt?: string, options: ServeOptions = {}) {
       } catch (e: any) {
         if (e.name === "AbortError") {
           logger.debug("Response interrupted");
-          // Remove any partial assistant message
-          removePartialAssistantMessage(state);
+          removePartialAssistantMessage(state.session.history);
         } else {
           logger.error(`Error: ${formatError(e)}`);
 
@@ -655,7 +624,3 @@ export async function serve(prompt?: string, options: ServeOptions = {}) {
     });
   });
 }
-
-// Function moved to serve.helpers.ts - remove implementation
-// async function streamChatResponseWithInterruption - moved to helpers {
-// Implementation moved to serve.helpers.ts


### PR DESCRIPTION
## Summary
- Adds info-level logging for all metadata endpoint requests in `cn` CLI
- Logs include full URL, agent ID, metadata keys, request body, response status, and timing (duration in ms)
- Uses `[metadata]` prefix for easy filtering in logs

## Test plan
- [ ] Run `cn` with an agent ID and verify metadata requests are logged to `~/.continue/logs/cn.log`
- [ ] Filter logs with `grep "[metadata]" ~/.continue/logs/cn.log` to verify prefix works
- [ ] Verify timing information is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue-stage.tools/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F9909&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds info-level logging for metadata endpoint requests in the cn CLI to improve debugging and visibility. Logs include full URL, agent ID, metadata keys, request body, response status, and duration, with a [metadata] prefix for easy filtering.

- **New Features**
  - Logs POST agents/{id}/metadata with full URL, status, and timing (ms).
  - Includes agentId, metadata keys, and request body.
  - Clear messages for auth required and API errors, all prefixed with [metadata].

- **Refactors**
  - Moved interruption cleanup and agent completion check to helpers for reuse and clarity.

<sup>Written for commit 737ac6fc7bbfce9853d086de404ac3c36158385d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

