### PR TITLE
Publish cn-staging blueprint on stable release

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -220,39 +220,47 @@ jobs:
           gh release edit "v${{ steps.find_beta.outputs.beta_version }}" \
             --notes "This beta version has been promoted to stable as v${{ steps.final_version.outputs.stable_version }}."
 
-      - name: Publish Blueprint to Runloop
+      - name: Publish Blueprints to Runloop
         env:
           RUNLOOP_API_KEY: ${{ secrets.RUNLOOP_API_KEY }}
         run: |
-          echo "Publishing blueprint 'cn' to Runloop API for version ${{ steps.final_version.outputs.stable_version }}"
+          publish_blueprint() {
+            local name=$1
+            local template=$2
 
-          # Use blueprint configuration from template file
-          cp .github/workflows/runloop-blueprint-template.json blueprint.json
+            echo "Publishing blueprint '$name' to Runloop API for version ${{ steps.final_version.outputs.stable_version }}"
 
-          # Publish to Runloop API
-          response=$(curl -X POST "https://api.runloop.ai/v1/blueprints" \
-            -H "Authorization: Bearer $RUNLOOP_API_KEY" \
-            -H "Content-Type: application/json" \
-            -d @blueprint.json \
-            -w "%{http_code}" \
-            -s)
+            # Use blueprint configuration from template file
+            cp ".github/workflows/$template" blueprint.json
 
-          http_code=$(echo "$response" | tail -c 4)
-          response_body=$(echo "$response" | head -c -4)
+            # Publish to Runloop API
+            response=$(curl -X POST "https://api.runloop.ai/v1/blueprints" \
+              -H "Authorization: Bearer $RUNLOOP_API_KEY" \
+              -H "Content-Type: application/json" \
+              -d @blueprint.json \
+              -w "%{http_code}" \
+              -s)
 
-          if [[ "$http_code" == "200" ]] || [[ "$http_code" == "201" ]]; then
-            echo "✅ Successfully published blueprint to Runloop API"
-            echo "Response: $response_body"
-            
-            # Extract blueprint ID if available
-            blueprint_id=$(echo "$response_body" | jq -r '.id // empty')
-            if [[ -n "$blueprint_id" ]]; then
-              echo "Blueprint ID: $blueprint_id"
-              echo "blueprint_id=$blueprint_id" >> $GITHUB_OUTPUT
+            http_code=$(echo "$response" | tail -c 4)
+            response_body=$(echo "$response" | head -c -4)
+
+            if [[ "$http_code" == "200" ]] || [[ "$http_code" == "201" ]]; then
+              echo "✅ Successfully published blueprint '$name' to Runloop API"
+              echo "Response: $response_body"
+
+              # Extract blueprint ID if available
+              blueprint_id=$(echo "$response_body" | jq -r '.id // empty')
+              if [[ -n "$blueprint_id" ]]; then
+                echo "Blueprint ID: $blueprint_id"
+              fi
+            else
+              echo "❌ Failed to publish blueprint '$name' to Runloop API"
+              echo "HTTP Code: $http_code"
+              echo "Response: $response_body"
+              exit 1
             fi
-          else
-            echo "❌ Failed to publish blueprint to Runloop API"
-            echo "HTTP Code: $http_code"
-            echo "Response: $response_body"
-            exit 1
-          fi
+          }
+
+          # Publish both cn and cn-staging blueprints
+          publish_blueprint "cn" "runloop-blueprint-template.json"
+          publish_blueprint "cn-staging" "runloop-blueprint-staging-template.json"


### PR DESCRIPTION
## Summary
- Updates stable release workflow to publish both `cn` and `cn-staging` blueprints
- Previously, `cn-staging` was only rebuilt when the template JSON files were modified, causing staging devboxes to run old CLI code after releases

## Context
The `cn-staging` blueprint was not being updated when CLI releases were published, which meant staging devboxes were running outdated code even after a new version was deployed to npm.

## Test plan
- [ ] Trigger a stable release and verify both blueprints are published successfully in the workflow logs
- [ ] Create a new staging devbox and verify it has the latest CLI version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue-stage.tools/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F9914&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish both cn and cn-staging blueprints during the stable release. This ensures staging devboxes run the latest CLI after each release.

- **Bug Fixes**
  - Always publish cn-staging on stable releases to prevent stale CLI in staging devboxes.

- **Refactors**
  - Introduced a publish_blueprint helper to reuse logic and improve logging/error handling.

<sup>Written for commit 3fa46d876f2aca16087dbb52d89b9c786e6fec6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

