### PR TITLE
fix(cli): flaky hub loader tests

### DIFF
--- a/extensions/cli/src/hubLoader.test.ts
+++ b/extensions/cli/src/hubLoader.test.ts
@@ -345,66 +345,82 @@ describe("hubLoader", () => {
       vi.unmock("jszip");
     });
 
-    it("should load rule from real hub: sanity/sanity-opinionated", async () => {
-      const result = await loadPackageFromHub(
-        "sanity/sanity-opinionated",
-        ruleProcessor,
-      );
+    it(
+      "should load rule from real hub: sanity/sanity-opinionated",
+      { retry: 3, timeout: 30000 },
+      async () => {
+        const result = await loadPackageFromHub(
+          "sanity/sanity-opinionated",
+          ruleProcessor,
+        );
 
-      expect(result).toBeDefined();
-      expect(typeof result).toBe("string");
-      expect(result.length).toBeGreaterThan(0);
-      // Rules are markdown, should contain some markdown elements
-      expect(result).toMatch(/[#\-\*]/);
-    }, 30000);
+        expect(result).toBeDefined();
+        expect(typeof result).toBe("string");
+        expect(result.length).toBeGreaterThan(0);
+        // Rules are markdown, should contain some markdown elements
+        expect(result).toMatch(/[#\-\*]/);
+      },
+    );
 
-    it("should load MCP from real hub: upstash/context7-mcp", async () => {
-      // Restore real fetch and JSZip for this test
-      global.fetch = originalFetch;
-      vi.unmock("jszip");
+    it(
+      "should load MCP from real hub: upstash/context7-mcp",
+      { retry: 3, timeout: 30000 },
+      async () => {
+        // Restore real fetch and JSZip for this test
+        global.fetch = originalFetch;
+        vi.unmock("jszip");
 
-      const testSlug = "upstash/context7-mcp";
-      const result = await loadPackageFromHub(testSlug, mcpProcessor);
+        const testSlug = "upstash/context7-mcp";
+        const result = await loadPackageFromHub(testSlug, mcpProcessor);
 
-      expect(result).toBeDefined();
-      expect(typeof result).toBe("object");
-      // Should now return the parsed MCP configuration
-      expect(result).toHaveProperty("name");
-      expect(typeof result.name).toBe("string");
-      // The MCP should have type and url properties
-      expect(result).toHaveProperty("type");
-      expect(result).toHaveProperty("url");
-    }, 30000);
+        expect(result).toBeDefined();
+        expect(typeof result).toBe("object");
+        // Should now return the parsed MCP configuration
+        expect(result).toHaveProperty("name");
+        expect(typeof result.name).toBe("string");
+        // The MCP should have type and url properties
+        expect(result).toHaveProperty("type");
+        expect(result).toHaveProperty("url");
+      },
+    );
 
-    it("should load model from real hub: openai/gpt-5", async () => {
-      // Restore real fetch and JSZip for this test
-      global.fetch = originalFetch;
-      vi.unmock("jszip");
+    it(
+      "should load model from real hub: openai/gpt-5",
+      { retry: 3, timeout: 30000 },
+      async () => {
+        // Restore real fetch and JSZip for this test
+        global.fetch = originalFetch;
+        vi.unmock("jszip");
 
-      const testSlug = "openai/gpt-5";
-      const result = await loadPackageFromHub(testSlug, modelProcessor);
+        const testSlug = "openai/gpt-5";
+        const result = await loadPackageFromHub(testSlug, modelProcessor);
 
-      expect(result).toBeDefined();
-      expect(typeof result).toBe("object");
-      // Should now return the extracted model from the models array
-      expect(result).toHaveProperty("name");
-      expect(result).toHaveProperty("provider");
-      expect(result).toHaveProperty("model");
-      // Check that the model properties are correct
-      expect(result.provider).toBe("openai");
-      expect(result.model).toBe("gpt-5");
-      expect(result.name).toBe("GPT-5");
-    }, 30000);
+        expect(result).toBeDefined();
+        expect(typeof result).toBe("object");
+        // Should now return the extracted model from the models array
+        expect(result).toHaveProperty("name");
+        expect(result).toHaveProperty("provider");
+        expect(result).toHaveProperty("model");
+        // Check that the model properties are correct
+        expect(result.provider).toBe("openai");
+        expect(result.model).toBe("gpt-5");
+        expect(result.name).toBe("GPT-5");
+      },
+    );
 
-    it("should load prompt from real hub: launchdarkly/using-flags", async () => {
-      const result = await loadPackageFromHub(
-        "launchdarkly/using-flags",
-        promptProcessor,
-      );
+    it(
+      "should load prompt from real hub: launchdarkly/using-flags",
+      { retry: 3, timeout: 30000 },
+      async () => {
+        const result = await loadPackageFromHub(
+          "launchdarkly/using-flags",
+          promptProcessor,
+        );
 
-      expect(result).toBeDefined();
-      expect(typeof result).toBe("string");
-      expect(result.length).toBeGreaterThan(0);
-    }, 30000);
+        expect(result).toBeDefined();
+        expect(typeof result).toBe("string");
+        expect(result.length).toBeGreaterThan(0);
+      },
+    );
   });
 });


### PR DESCRIPTION
## Description

Retry the flaky hub loader tests which call the real hub api.

References:
https://github.com/continuedev/continue/actions/runs/21159052442/job/60849878998
https://github.com/continuedev/continue/actions/runs/21159052442/job/60849879018

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue-stage.tools/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F9923&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add retries to CLI hub loader tests that call the live Hub API to reduce CI flakiness. Each affected test now retries up to 3 times with a 30s timeout.

<sup>Written for commit 2fb88307caeb6e72979396f70de17af087a27536. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

