### PR TITLE
feat(cli): add /accept and /reject commands for remote mode

### DIFF
--- a/extensions/cli/src/commands/commands.ts
+++ b/extensions/cli/src/commands/commands.ts
@@ -119,6 +119,16 @@ export const REMOTE_MODE_SLASH_COMMANDS: SlashCommand[] = [
     description: "Apply the current diff to the local working tree",
     category: "system",
   },
+  {
+    name: "accept",
+    description: "Accept changes (use --local to apply locally)",
+    category: "system",
+  },
+  {
+    name: "reject",
+    description: "Reject the agent's changes",
+    category: "system",
+  },
 ];
 
 /**

--- a/extensions/cli/src/commands/remote.ts
+++ b/extensions/cli/src/commands/remote.ts
@@ -113,7 +113,7 @@ async function connectExistingAgent(
   console.info(
     chalk.white(`Connecting to remote agent tunnel at: ${tunnel.url}`),
   );
-  await launchRemoteTUI(tunnel.url, prompt);
+  await launchRemoteTUI(tunnel.url, prompt, agentId);
 }
 
 async function createAndConnectRemoteEnvironment(
@@ -159,7 +159,7 @@ async function createAndConnectRemoteEnvironment(
   console.info(
     chalk.white(`Connecting to remote environment at: ${result.url}`),
   );
-  await launchRemoteTUI(result.url, prompt);
+  await launchRemoteTUI(result.url, prompt, result.id);
 }
 
 function buildAgentRequestBody(
@@ -199,12 +199,16 @@ async function fetchAgentTunnel(agentId: string) {
   }
 }
 
-async function launchRemoteTUI(remoteUrl: string, prompt: string | undefined) {
+async function launchRemoteTUI(
+  remoteUrl: string,
+  prompt: string | undefined,
+  sessionId?: string,
+) {
   telemetryService.recordSessionStart();
   telemetryService.startActiveTime();
 
   try {
-    await startRemoteTUIChat(remoteUrl, prompt);
+    await startRemoteTUIChat(remoteUrl, prompt, sessionId);
   } finally {
     telemetryService.stopActiveTime();
   }

--- a/extensions/cli/src/ui/AppRoot.tsx
+++ b/extensions/cli/src/ui/AppRoot.tsx
@@ -5,6 +5,7 @@ import { TUIChat } from "./TUIChat.js";
 
 interface AppRootProps {
   remoteUrl?: string;
+  remoteSessionId?: string;
   configPath?: string;
   initialPrompt?: string;
   resume?: boolean;

--- a/extensions/cli/src/ui/TUIChat.tsx
+++ b/extensions/cli/src/ui/TUIChat.tsx
@@ -40,6 +40,7 @@ import {
 interface TUIChatProps {
   // Remote mode props
   remoteUrl?: string;
+  remoteSessionId?: string;
 
   // Local mode props - now optional since we'll get them from services
   configPath?: string;
@@ -186,6 +187,7 @@ function useChatHandlers(
 // eslint-disable-next-line complexity
 const TUIChat: React.FC<TUIChatProps> = ({
   remoteUrl,
+  remoteSessionId,
   configPath,
   initialPrompt,
   resume,
@@ -289,6 +291,7 @@ const TUIChat: React.FC<TUIChatProps> = ({
     // Remote mode configuration
     isRemoteMode,
     remoteUrl,
+    remoteSessionId,
     onShowDiff: handleShowDiff,
     onShowStatusMessage: handleShowStatusMessage,
   });

--- a/extensions/cli/src/ui/hooks/useChat.ts
+++ b/extensions/cli/src/ui/hooks/useChat.ts
@@ -62,6 +62,7 @@ export function useChat({
   onRefreshStatic,
   isRemoteMode = false,
   remoteUrl,
+  remoteSessionId,
   onShowDiff,
   onShowStatusMessage,
 }: UseChatProps) {
@@ -465,6 +466,7 @@ export function useChat({
       message,
       isRemoteMode,
       remoteUrl,
+      remoteSessionId,
       onShowConfigSelector,
       exit,
       onShowDiff,

--- a/extensions/cli/src/ui/hooks/useChat.types.ts
+++ b/extensions/cli/src/ui/hooks/useChat.types.ts
@@ -24,6 +24,7 @@ export interface UseChatProps {
   // Remote mode props
   isRemoteMode?: boolean;
   remoteUrl?: string;
+  remoteSessionId?: string;
   onShowDiff?: (diffContent: string) => void;
   onShowStatusMessage?: (message: string) => void;
 }

--- a/extensions/cli/src/ui/index.ts
+++ b/extensions/cli/src/ui/index.ts
@@ -128,6 +128,7 @@ export async function startTUIChat(
 export async function startRemoteTUIChat(
   remoteUrl: string,
   initialPrompt?: string,
+  remoteSessionId?: string,
 ) {
   // Critical safeguard: Prevent TUI initialization in TTY-less environment
   if (isTTYless()) {
@@ -157,6 +158,7 @@ export async function startRemoteTUIChat(
     React.createElement(ServiceContainerProvider, {
       children: React.createElement(AppRoot, {
         remoteUrl,
+        remoteSessionId,
         initialPrompt,
       }),
     }),


### PR DESCRIPTION
## Summary
Add `/accept` and `/reject` slash commands to remote mode CLI:
- `/accept` - Accept changes and push to GitHub
- `/accept --local` - Accept and apply locally (user commits themselves)
- `/reject` - Reject the agent's changes

## Related PR
Backend endpoints: https://github.com/continuedev/remote-config-server/pull/2959

## Implementation
- Add commands to `REMOTE_MODE_SLASH_COMMANDS` in `commands.ts`
- Add `handleRemoteAcceptCommand()` and `handleRemoteRejectCommand()` handlers
- Pass `remoteSessionId` through TUI component hierarchy for backend API calls
- Update `remote.ts` to pass session ID when launching TUI

## Test plan
- [ ] Run `cn remote` and start an agent session
- [ ] Let agent make changes
- [ ] Test `/accept --local`: should apply diff locally and show "Changes accepted and applied locally"
- [ ] Test `/accept`: should push to GitHub and show "Changes accepted and pushed to GitHub"
- [ ] Test `/reject`: should mark as rejected and show "Changes rejected"
- [ ] Verify Hub UI shows correct status after each command

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds /accept and /reject commands to remote mode so users can accept or reject agent changes. Passes the remote session ID through the TUI to call backend endpoints for the active session.

- **New Features**
  - /accept — accept changes and push to GitHub
  - /accept --local — apply diff locally and mark accepted (no push)
  - /reject — mark changes as rejected
  - Status messages for success and error paths

<sup>Written for commit f4fa215a0fb5fcdcec3bab41246f0bd8e7866bea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

