### PR TITLE
fix: detect WSL remote for shell PATH resolution

### DIFF
--- a/core/context/mcp/MCPConnection.ts
+++ b/core/context/mcp/MCPConnection.ts
@@ -563,10 +563,15 @@ Org-level secrets can only be used for MCP by Background Agents (https://docs.co
       // Set the initial PATH from process.env
       env.PATH = process.env.PATH;
 
-      // For non-Windows platforms, try to get the PATH from user shell
-      if (process.platform !== "win32") {
+      // For non-Windows platforms or WSL remotes, try to get the PATH from user shell
+      const ideInfo = await this.extras?.ide?.getIdeInfo();
+      const isWindowsHostWithWslRemote =
+        process.platform === "win32" && ideInfo?.remoteName === "wsl";
+      if (process.platform !== "win32" || isWindowsHostWithWslRemote) {
         try {
-          const shellEnvPath = await getEnvPathFromUserShell();
+          const shellEnvPath = await getEnvPathFromUserShell(
+            ideInfo?.remoteName,
+          );
           if (shellEnvPath && shellEnvPath !== process.env.PATH) {
             env.PATH = shellEnvPath;
           }

--- a/core/util/shellPath.ts
+++ b/core/util/shellPath.ts
@@ -2,9 +2,12 @@ import { exec } from "child_process";
 import { promisify } from "util";
 
 const execAsync = promisify(exec);
-export async function getEnvPathFromUserShell(): Promise<string | undefined> {
-  if (process.platform === "win32") {
-    console.warn(`${getEnvPathFromUserShell.name} not implemented for Windows`);
+export async function getEnvPathFromUserShell(
+  remoteName?: string,
+): Promise<string | undefined> {
+  const isWindowsHostWithWslRemote =
+    process.platform === "win32" && remoteName === "wsl";
+  if (process.platform === "win32" && !isWindowsHostWithWslRemote) {
     return undefined;
   }
 


### PR DESCRIPTION
## Summary
- Add optional `remoteName` parameter to `getEnvPathFromUserShell()`
- Use `isWindowsHostWithWslRemote` pattern (consistent with `resolveCommandForPlatform`) to allow shell PATH detection for WSL remotes

## Problem
When Windows host connects to WSL remote, `getEnvPathFromUserShell()` was returning `undefined` because it only checked `process.platform === "win32"`.

This caused MCP servers running in WSL to not get the user's shell PATH, potentially missing tools like `npx`, `node`, etc.

## Test plan
- [x] Existing MCP tests pass
- [ ] Manual: Windows host → WSL remote, MCP server resolves PATH from WSL shell

Fixes #9737

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued · ▶️ 1 not started — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F9934&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect WSL remotes when resolving PATH from the user's shell. Ensures MCP servers running in WSL get the correct PATH on Windows hosts.

- **Bug Fixes**
  - Added optional remoteName to getEnvPathFromUserShell and handled Windows host + WSL remote.
  - Used isWindowsHostWithWslRemote (consistent with resolveCommandForPlatform) to fetch PATH from the WSL shell.

<sup>Written for commit 939b44b39fbe1eeea0d4c501e820f23ea5079c87. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

