### PR TITLE
feat: indicate excluded tools in MCP server # tools badge

### DIFF
--- a/gui/src/pages/config/components/ToolPoliciesGroup.tsx
+++ b/gui/src/pages/config/components/ToolPoliciesGroup.tsx
@@ -39,9 +39,25 @@ export function ToolPoliciesGroup({
   const toolGroupSettings = useAppSelector(
     (state) => state.ui.toolGroupSettings,
   );
+  const toolSettings = useAppSelector((state) => state.ui.toolSettings);
   const isGroupEnabled = useMemo(() => {
     return toolGroupSettings[groupName] !== "exclude";
   }, [toolGroupSettings, groupName]);
+
+  const { enabledCount, totalCount } = useMemo(() => {
+    const total = tools.length;
+    const enabled = tools.filter(
+      (tool) => toolSettings[tool.function.name] !== "disabled",
+    ).length;
+    return { enabledCount: enabled, totalCount: total };
+  }, [tools, toolSettings]);
+
+  const badgeText = useMemo(() => {
+    if (enabledCount === totalCount) {
+      return totalCount.toString();
+    }
+    return `${enabledCount}/${totalCount}`;
+  }, [enabledCount, totalCount]);
 
   return (
     <Card className="flex flex-1 flex-col p-0">
@@ -60,8 +76,8 @@ export function ToolPoliciesGroup({
               <WrenchScrewdriverIcon className="h-4 w-4 flex-shrink-0" />
             )}
             <span className="text-sm font-semibold">{displayName}</span>
-            <div className="flex h-5 w-5 items-center justify-center rounded-md bg-gray-600 px-0.5 text-xs font-medium text-white">
-              {tools.length}
+            <div className="flex h-5 min-w-5 items-center justify-center rounded-md bg-gray-600 px-1 text-xs font-medium text-white">
+              {badgeText}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
This PR updates the MCP server tools badge in the settings page to show the number of enabled tools vs total tools.

Before
<img width="244" height="78" alt="image" src="https://github.com/user-attachments/assets/bae23061-421c-49ae-a925-0920977a014b" />

After 
<img width="210" height="91" alt="image" src="https://github.com/user-attachments/assets/9d16a678-f0c4-40ee-b361-242395f015f4" />


## Changes
- Modified `ToolPoliciesGroup` component to calculate and display enabled/total tool counts
- Badge now shows `x/y` format where:
  - `x` = number of tools NOT currently excluded
  - `y` = total number of tools from MCP server
- When all tools are enabled (`x === y`), badge shows just `x`
- Updated badge styling to use `min-w-5` and `px-1` to accommodate longer text

## Visual Example
- If MCP server has 5 tools and 2 are excluded: shows `3/5`
- If MCP server has 5 tools and all are enabled: shows `5`

## Testing
Tested in the tools section of the settings page with MCP servers that have various tool exclusion states.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue-stage.tools/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F9970&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the MCP server tools badge in Settings to show enabled vs total tools (x/y), and show a single number when all tools are enabled. This makes it easier to see how many tools are active at a glance.

- **New Features**
  - Badge displays enabled/total (x/y); shows just x when x === y.
  - Counts computed from toolSettings per tool (disabled vs not).
  - Tweaked badge styling (min-w-5, px-1) to fit longer text.

<sup>Written for commit 8140ec89a286980fb2e939218f20398b756d8386. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

