### PR TITLE
docs: remove on-prem from secrets page

### DIFF
--- a/docs/mission-control/secrets/secret-types.mdx
+++ b/docs/mission-control/secrets/secret-types.mdx
@@ -13,4 +13,4 @@ This allows API requests to be made directly from the IDE extensions. You can us
 
 Org secrets are defined by admins for their organization. Org secrets are available to anyone in the organization to use with configurations in that organization. Org secrets are assumed to not be shareable with the user (e.g. you are a team lead who wants to give team members access to models without passing out API keys).
 
-This is why LLM requests are proxied through api.continue.dev / on-premise proxy and secrets are never sent to the IDE extensions. You can only use org secrets on [Teams](/mission-control/governance/pricing#teams) and [Enterprise](/mission-control/governance/pricing#enterprise). If you are an admin, you can manage secrets for your organization from the org settings page.
+This is why LLM requests are proxied through api.continue.dev and secrets are never sent to the IDE extensions. You can only use org secrets on [Teams](/mission-control/governance/pricing#teams) and [Enterprise](/mission-control/governance/pricing#enterprise). If you are an admin, you can manage secrets for your organization from the org settings page.


### PR DESCRIPTION
## Description

Fixes https://github.com/continuedev/continue/issues/8533

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue-stage.tools/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F9972&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the on-prem proxy mention from the Secrets doc. LLM requests are now documented as proxied only through api.continue.dev, aligning the page with current behavior.

<sup>Written for commit 57f26b2b9de8d436eff5118182c150195247c9f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

