### PR TITLE
fix: add reasoning content field support in chat body

### DIFF
--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -90,6 +90,7 @@ export abstract class BaseLLM implements ILLM {
   // Provider capabilities (overridable by subclasses)
   protected supportsReasoningField: boolean = false;
   protected supportsReasoningDetailsField: boolean = false;
+  protected supportsReasoningContentField: boolean = false;
 
   get providerName(): string {
     return (this.constructor as typeof BaseLLM).providerName;
@@ -1182,6 +1183,7 @@ export abstract class BaseLLM implements ILLM {
           let body = toChatBody(messages, completionOptions, {
             includeReasoningField: this.supportsReasoningField,
             includeReasoningDetailsField: this.supportsReasoningDetailsField,
+            includeReasoningContentField: this.supportsReasoningContentField,
           });
           body = this.modifyChatBody(body);
 

--- a/core/llm/llms/Deepseek.ts
+++ b/core/llm/llms/Deepseek.ts
@@ -6,8 +6,9 @@ import OpenAI from "./OpenAI.js";
 
 class Deepseek extends OpenAI {
   static providerName = "deepseek";
-  protected supportsReasoningField = true;
+  protected supportsReasoningField = false;
   protected supportsReasoningDetailsField = false;
+  protected supportsReasoningContentField = true;
   static defaultOptions: Partial<LLMOptions> = {
     apiBase: "https://api.deepseek.com/",
     model: "deepseek-coder",

--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -5,6 +5,12 @@ import {
 
 import { streamSse } from "@continuedev/fetch";
 import {
+  ResponseCreateParamsBase,
+  ResponseInputItem,
+  ResponseInputMessageContentList,
+  Tool as ResponsesTool,
+} from "openai/resources/responses/responses.mjs";
+import {
   ChatMessage,
   CompletionOptions,
   LLMOptions,
@@ -19,13 +25,6 @@ import {
   toChatBody,
   toResponsesInput,
 } from "../openaiTypeConverters.js";
-import {
-  ResponseInput,
-  ResponseInputItem,
-  ResponseInputMessageContentList,
-  ResponseCreateParamsBase,
-  Tool as ResponsesTool,
-} from "openai/resources/responses/responses.mjs";
 
 const NON_CHAT_MODELS = [
   "text-davinci-002",
@@ -279,6 +278,7 @@ class OpenAI extends BaseLLM {
     const finalOptions = toChatBody(messages, options, {
       includeReasoningField: this.supportsReasoningField,
       includeReasoningDetailsField: this.supportsReasoningDetailsField,
+      includeReasoningContentField: this.supportsReasoningContentField,
     });
 
     finalOptions.stop = options.stop?.slice(0, this.getMaxStopWords());

--- a/core/llm/openaiTypeConverters.ts
+++ b/core/llm/openaiTypeConverters.ts
@@ -40,6 +40,7 @@ import {
 function appendReasoningFieldsIfSupported(
   msg: ChatCompletionAssistantMessageParam & {
     reasoning?: string;
+    reasoning_content?: string;
     reasoning_details?: any[];
   },
   options: CompletionOptions,
@@ -47,13 +48,16 @@ function appendReasoningFieldsIfSupported(
   providerFlags?: {
     includeReasoningField?: boolean;
     includeReasoningDetailsField?: boolean;
+    includeReasoningContentField?: boolean;
   },
 ) {
   if (!prevMessage || prevMessage.role !== "thinking") return;
 
   const includeReasoning = !!providerFlags?.includeReasoningField;
   const includeReasoningDetails = !!providerFlags?.includeReasoningDetailsField;
-  if (!includeReasoning && !includeReasoningDetails) return;
+  const includeReasoningContent = !!providerFlags?.includeReasoningContentField;
+  if (!includeReasoning && !includeReasoningDetails && !includeReasoningContent)
+    return;
 
   const reasoningDetailsValue =
     prevMessage.reasoning_details ||
@@ -84,6 +88,9 @@ function appendReasoningFieldsIfSupported(
   if (includeReasoning) {
     msg.reasoning = prevMessage.content as string;
   }
+  if (includeReasoningContent) {
+    msg.reasoning_content = prevMessage.content as string;
+  }
 }
 
 export function toChatMessage(
@@ -93,6 +100,7 @@ export function toChatMessage(
   providerFlags?: {
     includeReasoningField?: boolean;
     includeReasoningDetailsField?: boolean;
+    includeReasoningContentField?: boolean;
   },
 ): ChatCompletionMessageParam | null {
   if (message.role === "tool") {
@@ -117,6 +125,7 @@ export function toChatMessage(
     // Base assistant message
     const msg: ChatCompletionAssistantMessageParam & {
       reasoning?: string;
+      reasoning_content?: string;
       reasoning_details?: {
         [key: string]: any;
         signature?: string | undefined;
@@ -191,6 +200,7 @@ export function toChatBody(
   providerFlags?: {
     includeReasoningField?: boolean;
     includeReasoningDetailsField?: boolean;
+    includeReasoningContentField?: boolean;
   },
 ): ChatCompletionCreateParams {
   const params: ChatCompletionCreateParams = {


### PR DESCRIPTION
## Description

Add `reasoning_content` field support. Deepseek requires reasoning support to be passed back when using tool calls.

closes https://github.com/continuedev/continue/issues/8989
resolves CON-5302

verified by changing ContinueProxy.ts
```ts
...
  constructor(options: LLMOptions) {
    super(options);
    this.configEnv = options.env;
    // This it set to `undefined` to handle the case where we are proxying requests to Azure. We pass the correct env vars
    // needed to do this in `extraBodyProperties` below, but if we don't set `apiType` to `undefined`, we end up proxying to
    // `/openai/deployments/` which is invalid since that URL construction happens on the proxy.
    this.apiType = undefined;
    this.actualApiBase = options.apiBase;
    this.apiKeyLocation = options.apiKeyLocation;
    this.envSecretLocations = options.envSecretLocations;
    this.orgScopeId = options.orgScopeId;
    this.onPremProxyUrl = options.onPremProxyUrl;
    if (this.onPremProxyUrl) {
      this.apiBase = new URL("model-proxy/v1/", this.onPremProxyUrl).toString();
    }

    // Set reasoning field support based on underlying provider
    const { provider } = parseProxyModelName(this.model);
    if (provider === "deepseek") {
      this.supportsReasoningContentField = true;
      this.supportsReasoningField = false;
    }
  }
...
```

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F10027&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds reasoning_content support to chat requests and enables it for Deepseek so tool calls receive the model’s reasoning as required. Addresses Linear CON-5302 and fixes the Deepseek tool-call behavior reported in #8989.

- **Bug Fixes**
  - Added supportsReasoningContentField capability to BaseLLM and passed it through chat body creation.
  - Included reasoning_content when the previous message is role "thinking" in openaiTypeConverters, gated by provider support.
  - Configured Deepseek to use reasoning_content (supportsReasoningContentField=true, supportsReasoningField=false).

<sup>Written for commit ac93dd9381021989507b1c724205780074898786. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

