### PR TITLE
Fix OpenAI timeout settings not being applied

### DIFF
--- a/packages/openai-adapters/src/apis/OpenAI.ts
+++ b/packages/openai-adapters/src/apis/OpenAI.ts
@@ -53,7 +53,7 @@ export class OpenAIApi implements BaseLlmApi {
       apiKey: config.apiKey ?? "",
       baseURL: this.apiBase,
       fetch: customFetch(config.requestOptions),
-      timeout: config?.requestOptions?.timeout || undefined
+      timeout: config?.requestOptions?.timeout || undefined,
     });
   }
 


### PR DESCRIPTION
## Description

This PR fixes an issue where timeout settings were not being applied when using OpenAI-compatible backends in a local environment.

Previously, even when custom timeout values were configured, requests would still terminate based on the default timeout behavior of the OpenAI Node SDK. This change ensures that the configured timeout values are correctly propagated and respected by the backend.

## AI Code Review

- **Team members only**: AI review runs automatically when the PR is opened or marked as ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

### Before

<img width="1408" height="209" alt="before" src="https://github.com/user-attachments/assets/b534baf4-0b39-4455-88c1-2eff042f1794" />

### After

<img width="1413" height="211" alt="after" src="https://github.com/user-attachments/assets/e2382ad9-3106-47a8-bccb-7e8842314bea" />

## Tests

Before this change, requests were terminated after 10 minutes, which matches the default timeout behavior described in the OpenAI Node SDK documentation:
https://github.com/openai/openai-node?tab=readme-ov-file#timeouts

This was observed when the downstream client (Continue CLI) exited due to the timeout, even though custom timeout values were configured.

After applying this patch, running the same configuration confirms that the custom timeout settings are correctly applied and requests are no longer terminated at the default 10-minute limit.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F10036&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure configured request timeouts are applied to OpenAI-compatible backends, preventing requests from being cut off at the SDK’s 10-minute default. This makes local runs honor custom timeout settings.

- **Bug Fixes**
  - Pass config.requestOptions.timeout to the OpenAI client.
  - No change when timeout is unset (SDK default applies).

<sup>Written for commit bc206b0b43dc46baf7e57497fd4b006bb5029154. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

