### PR TITLE
Create invokable markdown prompt instead of .prompt file

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor/utils/getSuggestion.ts
+++ b/gui/src/components/mainInput/TipTapEditor/utils/getSuggestion.ts
@@ -226,10 +226,12 @@ export function getSlashCommandDropdownOptions(
 
     if (query.length === 0 && commandItems.length === 0) {
       commandItems.push({
-        title: "Explore prompts",
+        title: "Create a prompt",
         type: "action",
         action: () =>
-          ideMessenger.post("openUrl", "https://continue.dev/explore/prompts"),
+          ideMessenger.request("config/addLocalWorkspaceBlock", {
+            blockType: "prompts",
+          }),
         description: "",
         name: "",
         id: "",

--- a/gui/src/pages/config/sections/HelpSection.tsx
+++ b/gui/src/pages/config/sections/HelpSection.tsx
@@ -180,15 +180,6 @@ export function HelpSection() {
           <Card className="!p-0">
             <div className="flex flex-col">
               <ConfigRow
-                title="Continue Hub"
-                description="Visit continue.dev to explore custom agents and blocks"
-                icon={LinkIcon}
-                onClick={() =>
-                  ideMessenger.post("openUrl", "https://continue.dev/")
-                }
-              />
-
-              <ConfigRow
                 title="Documentation"
                 description="Learn how to configure and use Continue"
                 icon={LinkIcon}


### PR DESCRIPTION
## Description

Re-implementation of #9677 with fixes:

1. **Changed to create invokable markdown prompt files** instead of legacy .prompt files
   - Uses `config/addLocalWorkspaceBlock` with `blockType: 'prompts'` 
   - Creates markdown-based prompt files in `.continue/prompts/` directory
   - These prompts are invokable via slash commands (e.g., `/new-prompt`)
   - Follows the current Continue configuration system

2. **Removed Continue Hub link** from Help section
   - The hub is no longer actively maintained
   - Removed unhelpful link to reduce UI clutter

## Changes

- `gui/src/components/mainInput/TipTapEditor/utils/getSuggestion.ts`: Changed "Explore prompts" button to "Create a prompt" that creates a local invokable markdown prompt file
- `gui/src/pages/config/sections/HelpSection.tsx`: Removed Continue Hub link from Resources section

## Why markdown prompts instead of .prompt files?

The new system uses markdown files with YAML frontmatter:
- More flexible and maintainable
- Supports `invokable: true` flag for slash command access
- Integrates better with the current workspace block system
- Consistent with rules and other configuration files

## Testing

Manually tested:
1. Empty slash command dropdown shows "Create a prompt" option
2. Clicking creates a new invokable markdown prompt file in `.continue/prompts/`
3. Help section no longer shows Continue Hub link

---

Fixes #9677

Co-authored-by: dallin <dallin@continue.dev>

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F10082&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the legacy .prompt flow with invokable markdown prompts and removed the outdated Continue Hub link. Users can now create local prompts that work with slash commands.

- **New Features**
  - Added “Create a prompt” in the empty slash-command dropdown. Generates a markdown prompt in .continue/prompts via config/addLocalWorkspaceBlock (blockType: prompts). Prompts are invokable (e.g., /new-prompt).

- **Refactors**
  - Removed the Continue Hub link from Help > Resources.

<sup>Written for commit 8e801874d2a2d1ee460156d50f6e781b7febc8a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

