### PR TITLE
fix: don't crash config loading for one block failure

### DIFF
--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -1,9 +1,9 @@
 import {
   AssistantUnrolled,
+  AssistantUnrolledNonNullable,
   BLOCK_TYPES,
   ConfigResult,
   ConfigValidationError,
-  isAssistantUnrolledNonNullable,
   mergeConfigYamlRequestOptions,
   mergeUnrolledAssistants,
   ModelRole,
@@ -145,8 +145,8 @@ async function loadConfigYaml(options: {
     }
   }
 
-  if (config && isAssistantUnrolledNonNullable(config)) {
-    errors.push(...validateConfigYaml(config));
+  if (config) {
+    errors.push(...validateConfigYaml(nonNullifyConfigYaml(config)));
   }
 
   if (errors?.some((error) => error.fatal)) {
@@ -165,15 +165,30 @@ async function loadConfigYaml(options: {
   };
 }
 
+function nonNullifyConfigYaml(
+  unrolledAssistant: AssistantUnrolled,
+): AssistantUnrolledNonNullable {
+  return {
+    ...unrolledAssistant,
+    data: unrolledAssistant.data?.filter((k) => !!k),
+    context: unrolledAssistant.context?.filter((k) => !!k),
+    docs: unrolledAssistant.docs?.filter((k) => !!k),
+    mcpServers: unrolledAssistant.mcpServers?.filter((k) => !!k),
+    models: unrolledAssistant.models?.filter((k) => !!k),
+    prompts: unrolledAssistant.prompts?.filter((k) => !!k),
+    rules: unrolledAssistant.rules?.filter((k) => !!k).map((k) => k!),
+  };
+}
+
 export async function configYamlToContinueConfig(options: {
-  config: AssistantUnrolled;
+  unrolledAssistant: AssistantUnrolled;
   ide: IDE;
   ideInfo: IdeInfo;
   uniqueId: string;
   llmLogger: ILLMLogger;
   workOsAccessToken: string | undefined;
 }): Promise<{ config: ContinueConfig; errors: ConfigValidationError[] }> {
-  let { config, ide, ideInfo, uniqueId, llmLogger } = options;
+  let { unrolledAssistant, ide, ideInfo, uniqueId, llmLogger } = options;
 
   const localErrors: ConfigValidationError[] = [];
 
@@ -203,22 +218,10 @@ export async function configYamlToContinueConfig(options: {
       subagent: null,
     },
     rules: [],
-    requestOptions: { ...config.requestOptions },
+    requestOptions: { ...unrolledAssistant.requestOptions },
   };
 
-  // Right now, if there are any missing packages in the config, then we will just throw an error
-  if (!isAssistantUnrolledNonNullable(config)) {
-    return {
-      config: continueConfig,
-      errors: [
-        {
-          message:
-            "Failed to load config due to missing blocks, see which blocks are missing below",
-          fatal: true,
-        },
-      ],
-    };
-  }
+  const config = nonNullifyConfigYaml(unrolledAssistant);
 
   for (const rule of config.rules ?? []) {
     const convertedRule = convertYamlRuleToContinueRule(rule);
@@ -447,7 +450,7 @@ export async function loadContinueConfigFromYaml(options: {
 
   const { config: continueConfig, errors: localErrors } =
     await configYamlToContinueConfig({
-      config: configYamlResult.config,
+      unrolledAssistant: configYamlResult.config,
       ide,
       ideInfo,
       uniqueId,


### PR DESCRIPTION
## Description
See https://github.com/continuedev/continue/pull/10127#pullrequestreview-3743728927

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F10140&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents YAML config loading from crashing when a single block fails. Null or missing blocks are filtered out, validation runs on the remaining config, and loading continues.

- **Bug Fixes**
  - Filter out null entries in data, context, docs, mcpServers, models, prompts, and rules before validation.
  - Remove fatal error on missing blocks; report errors without aborting the load.

- **Refactors**
  - Added a helper to normalize configs and updated configYamlToContinueConfig to take unrolledAssistant; adjusted call site.

<sup>Written for commit 5a5f5f8908817516c95687fa62432b346186bc8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

