### PR TITLE
docs: add metrics snapshot sharing documentation

### DIFF
--- a/docs/mission-control/metrics.mdx
+++ b/docs/mission-control/metrics.mdx
@@ -57,27 +57,9 @@ Instead of logs and latency, agent observability focuses on:
 
 </CardGroup>
 
-## Sharing Metrics
+## Sharing Cloud Agent Metrics
 
-Share your metrics with stakeholders, team members, or external collaborators using shareable snapshot links.
-
-### Creating a Share Link
-
-<Steps>
-  <Step title="Navigate to Metrics">
-    Go to [continue.dev/metrics](https://continue.dev/metrics) while logged in.
-  </Step>
-
-  <Step title="Click Share">
-    Click the **Share** button in the page header. This creates a point-in-time snapshot of your current metrics view.
-  </Step>
-
-  <Step title="Copy the Link">
-    The share URL is automatically copied to your clipboard. Share it with anyone who needs to see your metrics.
-  </Step>
-</Steps>
-
-### How Shared Metrics Work
+Share your metrics with stakeholders, team members, or external collaborators using shareable snapshot links by clicking the **Share** button on your metrics page.
 
 <AccordionGroup>
   <Accordion title="Point-in-Time Snapshots">


### PR DESCRIPTION
That PR adds the ability to share metrics via unique, time-limited URLs. Users can click a Share button on the metrics page to create a point-in-time snapshot that can be viewed without authentication.

## Changes

- Added "Sharing Metrics" section to `/docs/mission-control/metrics.mdx`
- Documented how to create share links (3-step process)
- Explained how shared metrics work:
  - Point-in-time snapshots (what's included)
  - No authentication required for viewers
  - 30-day default expiration

## Source PR Details

The source PR adds:
- Share button in the metrics page header
- `createMetricsShareToken` mutation that captures current metrics
- `getSharedMetrics` public query for unauthenticated access
- New `/metrics/share/[token]` public page
- Tokens expire after 30 days (configurable 1-90 days)

Generated with [Continue](https://continue.dev)

Co-authored-by: bekah-hawrot-weigel <bekah@continue.dev>

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue-stage.tools/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F10157&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add docs for metrics snapshot sharing, showing how to create and share time-limited links from the Metrics page. Covers what's included, no-login viewing, read-only snapshots, and the 30‑day default expiration.

<sup>Written for commit 114ac021058d343ab4c8b072d78eaabde2e17d0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



