### PR TITLE
fix: accept multiple diffs using cmd+shift+enter

### DIFF
--- a/extensions/vscode/src/diff/processDiff.ts
+++ b/extensions/vscode/src/diff/processDiff.ts
@@ -94,31 +94,30 @@ export async function processDiff(
     core.invoke("cancelApply", undefined);
   }
 
-  if (newFileUri) {
-    await processSingleFileDiff(
-      action,
-      sidebar,
-      ide,
-      verticalDiffManager,
-      newFileUri,
-      streamId,
-      toolCallId,
+  let fileUriToProcess = newFileUri;
+
+  if (!fileUriToProcess) {
+    const allFilesWithDiffs = verticalDiffManager.getAllFilesWithDiffs();
+    if (allFilesWithDiffs.length > 0) {
+      fileUriToProcess = allFilesWithDiffs[0].fileUri;
+      streamId = allFilesWithDiffs[0].streamId;
+    }
+  }
+
+  if (!fileUriToProcess) {
+    console.warn(
+      `No file provided or current file open while attempting to resolve diff`,
     );
     return;
   }
 
-  const allFilesWithDiffs = verticalDiffManager.getAllFilesWithDiffs();
-
-  // accept all diffs in the files
-  for (const { fileUri, streamId: fileStreamId } of allFilesWithDiffs) {
-    await processSingleFileDiff(
-      action,
-      sidebar,
-      ide,
-      verticalDiffManager,
-      fileUri,
-      fileStreamId,
-      toolCallId,
-    );
-  }
+  await processSingleFileDiff(
+    action,
+    sidebar,
+    ide,
+    verticalDiffManager,
+    fileUriToProcess,
+    streamId,
+    toolCallId,
+  );
 }

--- a/extensions/vscode/src/diff/vertical/manager.ts
+++ b/extensions/vscode/src/diff/vertical/manager.ts
@@ -156,16 +156,19 @@ export class VerticalDiffManager {
 
     this.disableDocumentChangeListener();
 
+    const hasRemainingDiffs = this.fileUriToHandler.size > 0;
     void vscode.commands.executeCommand(
       "setContext",
       "continue.diffVisible",
-      false,
+      hasRemainingDiffs,
     );
 
-    void this.webviewProtocol.request(
-      "focusContinueInputWithoutClear",
-      undefined,
-    );
+    if (!hasRemainingDiffs) {
+      void this.webviewProtocol.request(
+        "focusContinueInputWithoutClear",
+        undefined,
+      );
+    }
   }
 
   async acceptRejectVerticalDiffBlock(


### PR DESCRIPTION
## Description

When using cmd+shift+enter to accept diffs, accept all the diffs generated during multi_edit instead of accepting only the first one.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot



https://github.com/user-attachments/assets/05c12945-a6cc-479d-a575-1edd8fe3e86d



## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F10183&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cmd+Shift+Enter now accepts all pending diffs in the visible file, not just the first block. Other files with diffs stay open so you can accept them next.

- **Bug Fixes**
  - Processes one file at a time via processSingleFileDiff; selects the visible/first pending file from VerticalDiffManager.getAllFilesWithDiffs().
  - Keeps remaining diffs visible by setting continue.diffVisible based on leftover handlers; only refocuses input when none remain.
  - Invokes cancelApply only on reject while preserving edit outcome tracking and auto-format detection.

<sup>Written for commit e343eb5d191601eff549625053dcb576f5a1740d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

