### PR TITLE
Update agent links and section title in docs index

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -31,19 +31,19 @@ Review this PR and check that:
 3. Open a PR. The agent will show up as a check in GitHub.
 4. If changes are suggested, click the check in GitHub and accept or reject the suggestion to make the check pass.
 
-## Example agents
+## Preconfigured Cloud Agents
 
 <CardGroup cols={2}>
-  <Card title="Code Security Review" icon="shield-check" href="https://continue.dev/continuedev/code-security-review">
+  <Card title="Code Security Review" icon="shield-check" href="https://www.continue.dev/agents/a395928f-1547-409b-bba2-28e968d78c83">
     Performs a comprehensive security audit for OWASP Top 10 vulnerabilities and security best practices.
   </Card>
-  <Card title="Improve Test Coverage" icon="vial" href="https://continue.dev/continuedev/improve-test-coverage">
+  <Card title="Improve Test Coverage" icon="vial" href="https://www.continue.dev/agents/5e88b9a4-8815-4f43-9422-60a1a3c502b0">
     Make incremental improvements to test coverage every day.
   </Card>
-  <Card title="Update AGENTS.md" icon="robot" href="https://continue.dev/continuedev/create-or-update-agentsmd">
+  <Card title="Update AGENTS.md" icon="robot" href="https://www.continue.dev/agents/79bde57b-ee59-4164-9e3e-dbb0f512a95f">
     Keep your AGENTS.md continuously synced with your codebase.
   </Card>
-  <Card title="Draft Changelog Update" icon="file-lines" href="https://continue.dev/continuedev/create-or-update-changelog">
+  <Card title="Draft Changelog Update" icon="file-lines" href="https://www.continue.dev/agents/f58139c5-4f85-4e33-9970-35bbe320c3b6">
     Create a draft update to CHANGELOG.md based on recent changes in a pull request.
   </Card>
 </CardGroup>


### PR DESCRIPTION
Updates the docs index page with new agent URLs and section title:

- Changed section title from 'Example agents' to 'Preconfigured Cloud Agents'
- Updated all agent links to use new URL format with agent UUIDs:
  - Code Security Review: a395928f-1547-409b-bba2-28e968d78c83
  - Changelog: f58139c5-4f85-4e33-9970-35bbe320c3b6
  - Improve Test Coverage: 5e88b9a4-8815-4f43-9422-60a1a3c502b0
  - Update Agents.md: 79bde57b-ee59-4164-9e3e-dbb0f512a95f

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F10194&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the docs index to rename “Example agents” to “Preconfigured Cloud Agents” and switch all agent links to the new /agents/{UUID} format. This keeps the docs accurate and directs users to the correct Cloud Agent pages.

<sup>Written for commit 3e931e0a29966efd4001c4610cf4a2877fd9b1aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

