### PR TITLE
docs: add metrics sharing feature

### DIFF
--- a/docs/mission-control/metrics.mdx
+++ b/docs/mission-control/metrics.mdx
@@ -56,3 +56,18 @@ Instead of logs and latency, agent observability focuses on:
   </Card>
 
 </CardGroup>
+
+## Sharing Metrics
+
+Share a snapshot of your metrics with teammates or stakeholders who don't have Continue access.
+
+Click **Share** on the Metrics page to generate a unique URL. The link:
+
+- Captures a point-in-time snapshot of your current metrics view
+- Works without authentication (safe for external sharing)
+- Expires after 30 days by default
+- Shows summary stats, activity grid, and charts in read-only mode
+
+<Warning>
+Shared links expose metrics data to anyone with the URL. Only share with people you trust.
+</Warning>


### PR DESCRIPTION
That PR adds the ability to share metrics via unique, time-limited URLs using the docs "concise" agent.

<img width="601" height="423" alt="image" src="https://github.com/user-attachments/assets/37d090e3-f9cf-423e-a61d-4cdf23d74238" />


**Changes:**
- Added "Sharing Metrics" section to /docs/mission-control/metrics.mdx
- Documents the Share button functionality
- Notes 30-day default expiry and read-only access
- Includes privacy warning about sharing links

Generated with [Continue](https://continue.dev)

Co-Authored-By: Continue <noreply@continue.dev>

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F10197&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates Mission Control metrics docs to include the new Sharing Metrics feature. Describes generating a unique, time-limited (30-day default) read-only link to a snapshot, plus a privacy warning.

<sup>Written for commit 7230a71b0497f8e424e0226a4ca755851250758e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

