### PR TITLE
docs: add GitHub trigger event types for workflows

### DIFF
--- a/docs/mission-control/integrations/github.mdx
+++ b/docs/mission-control/integrations/github.mdx
@@ -57,9 +57,16 @@ When creating a workflow with a GitHub trigger, you can choose from the followin
 | **PR Review Comment** | Triggers when a review comment is added to a pull request |
 | **Check Failed** | Triggers when a CI check suite fails |
 
-<Info>
-  **PR Review Comment** triggers provide context about the comment including the file path, comment body, and author. **Check Failed** triggers include the names of failed checks and a link to the check details.
-</Info>
+A task kicked off by a trigger receives a summary of the event, which is appended to the Agent's prompt.
+
+For example, an agent triggered by an `Issue Opened` trigger would see:
+
+```
+Issue #123 was opened: Login page crashes on mobile devices
+Issue URL: https://github.com/acme/webapp/issues/123
+```
+
+You can see the full initial prompt for a specific task in its logs.
 
 ---
 


### PR DESCRIPTION
That PR adds two new GitHub workflow trigger types:
- **PR Review Comment** (`pr_review_comment`): Triggers when a new review comment is created on a PR
- **Check Failed** (`check_failed`): Triggers when a CI check suite fails

## Changes:
- Added new "GitHub Trigger Event Types" section to `/docs/mission-control/integrations/github.mdx`
- Documents all 6 available GitHub trigger event types in a table format
- Added Info callout explaining the context provided by the new trigger types

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F10213&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a "GitHub Trigger Event Types" section to Mission Control → Integrations → GitHub docs, listing all six supported workflow triggers and documenting the two new events: PR Review Comment and Check Failed. Adds an example of the event summary appended to agent prompts and notes where to view the full initial prompt in task logs.

<sup>Written for commit c38c81a66acf2374e1591fd285909fb18ac732a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



