### PR TITLE
docs: document GitHub trigger workflows and runOnSynchronize option

### DIFF
--- a/docs/mission-control/workflows.mdx
+++ b/docs/mission-control/workflows.mdx
@@ -77,7 +77,8 @@ description: "Cloud agents that are triggered on a schedule or when events occur
     Pick how this Workflow should run:
 
     - Cron – run on a schedule (daily, weekly, hourly, custom)  
-    - Webhook – run when an external system sends a request (e.g. GitHub PR event)
+    - GitHub – run when GitHub events occur (PR opened, merged, issue opened, label added)
+    - Webhook – run when an external system sends a request
 
   </Step>
 
@@ -103,23 +104,43 @@ description: "Cloud agents that are triggered on a schedule or when events occur
 
       </Accordion>
 
+      <Accordion title="GitHub Trigger Workflow">
+
+        For GitHub event-based Workflows:
+
+        1. Select GitHub as the trigger type
+        2. Choose your connected GitHub App installation
+        3. Select the event type:
+           - **PR opened** – triggers when a pull request is opened
+           - **PR merged** – triggers when a pull request is merged
+           - **Issue opened** – triggers when an issue is created
+           - **Label added** – triggers when a specific label is added to a PR or issue
+
+        **Re-run on new commits (PR opened only):**  
+        When using the "PR opened" event type, enable **Re-run on new commits** to send a follow-up message to the active agent session whenever new commits are pushed to the PR. The agent receives commit details (SHA, message, author) and can continue working on the updated code without creating a duplicate session.
+
+        Example use cases:
+        - Run an Agent on every new pull request for automated review
+        - Trigger code quality checks when PRs are opened
+        - Keep agents updated on PR changes with the re-run option
+
+      </Accordion>
+
       <Accordion title="Webhook Workflow">
 
-        For event-based Workflows:
+        For custom webhook-based Workflows:
 
         1. Select Webhook as the trigger type  
         2. (Optional) Set a Secret Header (e.g. `X-Webhook-Secret`)  
         3. (Optional) Set a Secret Value (token your external system must send)  
 
-        You’ll receive a webhook URL to call from:
-        - GitHub Actions
-        - GitHub webhooks
+        You'll receive a webhook URL to call from:
         - CI/CD pipelines
         - Any external system that can send HTTP requests
 
         Example use cases:
-        - Run an Agent whenever a pull request is opened  
         - Kick off a workflow when Snyk or Sentry detects an issue  
+        - Integrate with custom internal tools
 
       </Accordion>
 


### PR DESCRIPTION
That PR adds a new `runOnSynchronize` option for GitHub-triggered workflows with the "PR opened" event type. When enabled, the agent receives follow-up messages with commit details whenever new commits are pushed to the PR.

## Changes

- Added GitHub as a trigger type in the "Choose Trigger Type" step (alongside Cron and Webhook)
- Created a new "GitHub Trigger Workflow" accordion documenting:
  - All GitHub event types: PR opened, PR merged, Issue opened, Label added
  - The new "Re-run on new commits" option and its behavior
- Reorganized Webhook section to avoid redundancy with GitHub triggers

## Notes

The code PR adds a UI toggle labeled "Re-run on new commits" that appears when "PR opened" is selected. When enabled, the badge shows "PR opened + commits" and the webhook handler sends commit details (SHA, message, author) to the active agent session.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue-stage.tools/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F10214&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented GitHub-triggered workflows and the new “Re-run on new commits” option for PR opened events. Clarifies setup, event types, and streamlines webhook docs.

- **New Features**
  - Added GitHub as a trigger type.
  - New “GitHub Trigger Workflow” docs for PR opened, PR merged, Issue opened, Label added.
  - Explained “Re-run on new commits” (PR opened only): follow-up messages send commit SHA, message, author to the active agent session.

- **Refactors**
  - Simplified Webhook docs to focus on custom webhooks, CI/CD, and internal tools.

<sup>Written for commit fe06ed750fafa328f351a488da6d30a5146b085c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

