### PR TITLE
docs: add metrics sharing feature

### DIFF
--- a/docs/mission-control/metrics.mdx
+++ b/docs/mission-control/metrics.mdx
@@ -56,3 +56,13 @@ Instead of logs and latency, agent observability focuses on:
   </Card>
 
 </CardGroup>
+
+## Sharing Metrics
+
+Share a read-only view of your metrics with stakeholders outside your organization.
+
+Click **Share** on the Metrics page to open the sharing dialog. Toggle **Public link enabled** to generate a shareable URL.
+
+<Note>
+Public viewers can see aggregate metrics (total runs, merge rate, activity, workflow breakdown) but not cost data or user identities. Links expire after 30 days.
+</Note>


### PR DESCRIPTION
Updates docs for continuedev/remote-config-server#3088

That PR adds a ShareMetricsDialog component that replaces direct copy-to-clipboard with a modal dialog for sharing metrics.

**Changes:**
- Added "Sharing Metrics" section to `/docs/mission-control/metrics.mdx`
- Documents the Share button behavior and public link toggle
- Documents what public viewers can/cannot see (no cost data, no user identities)
- Documents 30-day link expiration

**No TODOs** - all information was clearly specified in the PR code.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F10224&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Sharing Metrics” section to Mission Control docs that explains the new Share dialog for read-only metric links.
Covers the Share button and public link toggle, what public viewers can/can’t see (aggregate only, no cost data or identities), and 30‑day link expiration.

<sup>Written for commit 9bfe5c07d424789cf4feb82ec8d4d49b28adaf83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

