### PR TITLE
feat(vscode): add keybindings for Session, History, Context & fix Mod…

### DIFF
--- a/core/protocol/ideWebview.ts
+++ b/core/protocol/ideWebview.ts
@@ -115,4 +115,5 @@ export type ToWebviewFromIdeProtocol = ToWebviewFromIdeOrCoreProtocol & {
   focusEdit: [undefined, void];
   generateRule: [undefined, void];
   addToChat: [AddToChatPayload, void];
+  openModelSelect: [undefined, void];
 };

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -381,6 +381,12 @@
         "category": "Continue",
         "title": "Open in new window",
         "group": "Continue"
+      },
+      {
+        "command": "continue.focusModelSelect",
+        "category": "Continue",
+        "title": "Select Model",
+        "group": "Continue"
       }
     ],
     "keybindings": [
@@ -499,6 +505,30 @@
         "command": "continue.rejectJump",
         "key": "escape",
         "when": "editorTextFocus && continue.jumpDecorationVisible"
+      },
+      {
+        "command": "continue.focusModelSelect",
+        "mac": "cmd+alt+m",
+        "win": "ctrl+alt+m",
+        "linux": "ctrl+alt+m"
+      },
+      {
+        "command": "continue.viewHistory",
+        "mac": "cmd+alt+h",
+        "win": "ctrl+alt+h",
+        "linux": "ctrl+alt+h"
+      },
+      {
+        "command": "continue.selectFilesAsContext",
+        "mac": "cmd+alt+a",
+        "win": "ctrl+alt+a",
+        "linux": "ctrl+alt+a"
+      },
+      {
+        "command": "continue.newSession",
+        "mac": "cmd+alt+n",
+        "win": "ctrl+alt+n",
+        "linux": "ctrl+alt+n"
       }
     ],
     "submenus": [

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -523,12 +523,6 @@
         "mac": "cmd+alt+a",
         "win": "ctrl+alt+a",
         "linux": "ctrl+alt+a"
-      },
-      {
-        "command": "continue.newSession",
-        "mac": "cmd+alt+n",
-        "win": "ctrl+alt+n",
-        "linux": "ctrl+alt+n"
       }
     ],
     "submenus": [

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -883,6 +883,14 @@ const getCommandsMap: (
         "editor.action.inlineSuggest.trigger",
       );
     },
+    "continue.focusModelSelect": async () => {
+      // 1. Ensure the sidebar is visible/focused
+      vscode.commands.executeCommand("continue.continueGUIView.focus");
+
+      // 2. Send a message to the React app
+      // "openModelSelect" is a custom message type we will define next
+      sidebar.webviewProtocol?.request("openModelSelect", undefined);
+    },
   };
 };
 

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -885,7 +885,7 @@ const getCommandsMap: (
     },
     "continue.focusModelSelect": async () => {
       // 1. Ensure the sidebar is visible/focused
-      vscode.commands.executeCommand("continue.continueGUIView.focus");
+      focusGUI();
 
       // 2. Send a message to the React app
       // "openModelSelect" is a custom message type we will define next

--- a/gui/src/components/modelSelection/ModelSelect.tsx
+++ b/gui/src/components/modelSelection/ModelSelect.tsx
@@ -9,6 +9,7 @@ import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../../context/Auth";
 import { AddModelForm } from "../../forms/AddModelForm";
+import { useWebviewListener } from "../../hooks/useWebviewListener";
 import { useAppDispatch, useAppSelector } from "../../redux/hooks";
 import { setDialogMessage, setShowDialog } from "../../redux/slices/uiSlice";
 import { updateSelectedModelByRole } from "../../redux/thunks/updateSelectedModelByRole";
@@ -129,6 +130,13 @@ function ModelSelect() {
   const [sortedOptions, setSortedOptions] = useState<Option[]>([]);
   const { selectedProfile } = useAuth();
   const tinyFont = useFontSize(-4);
+
+  useWebviewListener("openModelSelect", async () => {
+    if (buttonRef.current) {
+      buttonRef.current.click();
+      buttonRef.current.focus();
+    }
+  });
 
   let selectedModel = null;
   let allModels = null;

--- a/gui/src/components/modelSelection/ModelSelect.tsx
+++ b/gui/src/components/modelSelection/ModelSelect.tsx
@@ -13,7 +13,11 @@ import { useWebviewListener } from "../../hooks/useWebviewListener";
 import { useAppDispatch, useAppSelector } from "../../redux/hooks";
 import { setDialogMessage, setShowDialog } from "../../redux/slices/uiSlice";
 import { updateSelectedModelByRole } from "../../redux/thunks/updateSelectedModelByRole";
-import { getMetaKeyLabel, isMetaEquivalentKeyPressed } from "../../util";
+import {
+  getAltKeyLabel,
+  getMetaKeyLabel,
+  isMetaEquivalentKeyPressed,
+} from "../../util";
 import { CONFIG_ROUTES } from "../../util/navigation";
 import {
   Button,
@@ -258,6 +262,7 @@ function ModelSelect() {
           data-testid="model-select-button"
           ref={buttonRef}
           className="text-description h-[18px] gap-1 border-none"
+          title={`Select Model (${getMetaKeyLabel()} + ${getAltKeyLabel()} + M)`}
         >
           <span className="line-clamp-1 break-all hover:brightness-110">
             {modelSelectTitle(selectedModel) || "Select model"}

--- a/gui/src/components/ui/Listbox.tsx
+++ b/gui/src/components/ui/Listbox.tsx
@@ -11,6 +11,7 @@ import { FontSizeModifier, useFontSize } from "./font";
 
 type ListboxButtonProps = React.ComponentProps<typeof HLButton> & {
   fontSizeModifier?: FontSizeModifier;
+  title?: string;
 };
 
 const ListboxButton = React.forwardRef<HTMLButtonElement, ListboxButtonProps>(


### PR DESCRIPTION
## Description

- Improves keyboard accessibility by adding default shortcuts for essential commands.
- Added New Command: Implemented continue.focusModelSelect (Cmd+Alt+M) to quickly toggle the model selection dropdown.
- Added Keybindings: Assigned new shortcuts to existing commands:
1. continue.newSession: Cmd+Alt+N (reverted)
2. continue.viewHistory: Cmd+Alt+H
3. continue.selectFilesAsContext: Cmd+Alt+A

## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue-stage.tools/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F10225&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds default shortcuts for viewing history, selecting context files, and focusing the model selector to improve keyboard navigation in the Continue VS Code extension. Removes the new session shortcut.

- **New Features**
  - New command: `continue.focusModelSelect`
    - Shortcut: Cmd+Alt+M (mac), Ctrl+Alt+M (win/linux)
    - Opens and focuses the model selector in the sidebar
  - Keybindings:
    - `continue.viewHistory`: Cmd/Ctrl+Alt+H
    - `continue.selectFilesAsContext`: Cmd/Ctrl+Alt+A
  - Removed keybinding: `continue.newSession`

- **Bug Fixes**
  - Model selector reliably opens and receives focus via shortcut.
  - Added tooltip showing the model selection shortcut on the Select Model button.

<sup>Written for commit 5f1c6256315c0a6e1d3a3ab62dd3310aebe754ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



