### PR TITLE
docs: add available charts section to metrics page

### DIFF
--- a/docs/mission-control/metrics.mdx
+++ b/docs/mission-control/metrics.mdx
@@ -43,6 +43,33 @@ Instead of logs and latency, agent observability focuses on:
 
 </AccordionGroup>
 
+## Available Charts
+
+The Metrics page displays time-series charts for analyzing agent performance over configurable date ranges.
+
+### Outcome Breakdown
+
+Stacked bar chart showing daily session outcomes:
+
+- **Accept** – User accepted the suggestion or PR was merged
+- **Reject** – User rejected the suggestion
+- **Skip** – PR was closed without merging, or session completed with uncommitted changes
+- **No Action** – Session completed without creating commits or PRs
+
+Filter by workflow to see outcomes for specific agent configurations.
+
+### PR Velocity
+
+Line chart tracking average time from session creation to merge (in hours). Shows both average and median values per day to help identify bottlenecks in your review process.
+
+### PR Volume
+
+Bar chart showing the number of PRs created per day. Use this to understand agent activity levels and spot trends in automation usage.
+
+### Failure Rate
+
+Line chart displaying the daily percentage of sessions that resulted in reject or skip outcomes. A rising failure rate may indicate agents need better prompts, rules, or tool configurations.
+
 ## Why Metrics Matter
 
 <CardGroup cols={2}>


### PR DESCRIPTION
Updates docs for [continuedev/remote-config-server#3093](https://github.com/continuedev/remote-config-server/pull/3093)

That PR adds 4 new chart types to the metrics pages:
- **Outcome Breakdown** (stacked bar) - daily session outcomes (accept/reject/skip/no_action)
- **PR Velocity** (line) - avg/median hours to merge
- **PR Volume** (bar) - PRs created per day
- **Failure Rate** (line) - daily reject+skip percentage

Changes:
- Added "Available Charts" section to `/docs/mission-control/metrics.mdx`
- Documented each chart type with its purpose and key metrics

Co-authored-by: bekah-hawrot-weigel <bekah@continue.dev>

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F10266&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an “Available Charts” section to the Metrics docs to explain the four new charts from remote-config-server PR #3093, improving clarity around agent performance and PR activity.

- **New Features**
  - Outcome Breakdown (stacked bar): daily session outcomes (accept, reject, skip, no action).
  - PR Velocity (line): average and median hours to merge.
  - PR Volume (bar): PRs created per day.
  - Failure Rate (line): daily percentage of reject+skip.

<sup>Written for commit c081cce5ed3f5634a6d8d4525464d248009be694. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

