### PR TITLE
docs: update default model to Claude Opus 4.6

### DIFF
--- a/docs/customize/model-roles/chat.mdx
+++ b/docs/customize/model-roles/chat.mdx
@@ -19,13 +19,13 @@ In Continue, these models are used for normal [Chat](../../ide-extensions/chat/q
 
 For the best overall Chat experience, you will want to use a 400B+ parameter model or one of the frontier models.
 
-### Claude Opus 4.5 and Claude Sonnet 4 from Anthropic
+### Claude Opus 4.6 and Claude Sonnet 4 from Anthropic
 
-Our current top recommendations are Claude Opus 4.5 and Claude Sonnet 4 from [Anthropic](../model-providers/top-level/anthropic).
+Our current top recommendations are Claude Opus 4.6 and Claude Sonnet 4 from [Anthropic](../model-providers/top-level/anthropic).
 
 <Tabs>
   <Tab title="Hub">
-  View the [Claude Opus 4.5 model block](https://continue.dev/anthropic/claude-4-5-opus) or [Claude Sonnet 4 model block](https://continue.dev/anthropic/claude-4-sonnet) on the hub.
+  View the [Claude Opus 4.6 model block](https://continue.dev/anthropic/claude-opus-4-6) or [Claude Sonnet 4 model block](https://continue.dev/anthropic/claude-4-sonnet) on the hub.
   </Tab>
   <Tab title="YAML">
   ```yaml title="config.yaml"
@@ -34,9 +34,9 @@ Our current top recommendations are Claude Opus 4.5 and Claude Sonnet 4 from [An
   schema: v1
 
   models:
-    - name: Claude Opus 4.5
+    - name: Claude Opus 4.6
       provider: anthropic
-      model: claude-opus-4-5
+      model: claude-opus-4-6
       apiKey: <YOUR_ANTHROPIC_API_KEY>
   ```
   </Tab>


### PR DESCRIPTION
Updates docs for [continuedev/remote-config-server#3096](https://github.com/continuedev/remote-config-server/pull/3096)

That PR changes the default model from Claude Opus 4.5 to Claude Opus 4.6 across the platform.

## Changes

- Updated `/docs/customize/model-roles/chat.mdx` to recommend Claude Opus 4.6 instead of Claude Opus 4.5
- Updated the Hub link to point to the new model block (`anthropic/claude-opus-4-6`)
- Updated the YAML example with the new model name and ID

## Notes

- Claude Opus 4.5 remains available as a non-default option in the platform
- No user migration required; existing configs using Opus 4.5 continue to work

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F10270&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Chat model docs to make Claude Opus 4.6 the default recommendation, aligning with remote-config-server#3096. Updated the Hub link and YAML example to use claude-opus-4-6; Claude Opus 4.5 remains available and no migration is required.

<sup>Written for commit c12c87062fe0021143b6a27fcc94f0601959fd42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

