### PR TITLE
docs: document undo for agent check suggestions

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -29,7 +29,7 @@ Review this PR and check that:
 1. Connect GitHub at [continue.dev](https://continue.dev/)
 2. [Create an agent](https://continue.dev/agents/new)
 3. Open a PR. The agent will show up as a check in GitHub.
-4. If changes are suggested, click the check in GitHub and accept or reject the suggestion to make the check pass.
+4. If changes are suggested, click the check in GitHub to review. Accept or reject the suggestion to make the check pass. You can undo either action: undoing a rejection resets the check to pending; undoing an acceptance creates a revert commit on the PR.
 
 ## Preconfigured Cloud Agents
 


### PR DESCRIPTION
Updates docs for [continuedev/remote-config-server#3100](https://github.com/continuedev/remote-config-server/pull/3100)

That PR adds undo functionality for accepted/rejected agent check suggestions:
- **Undo reject**: resets status to pending immediately
- **Undo accept**: creates a revert commit on the PR (with confirmation dialog)

## Changes
- Updated `/docs/index.mdx` step 4 to mention undo capability for both accept and reject actions

---

Co-authored-by: bekah-hawrot-weigel <bekah@continue.dev>

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F10274&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented undo actions for agent check suggestions in GitHub to clarify how users can reverse decisions.

Undo reject sets the check back to pending. Undo accept creates a revert commit on the PR (with confirmation).

<sup>Written for commit 39c552d7a0de6c1833147f5525da86d51e62a2f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

