### PR TITLE
fix: validate unicode in model apikey or headers

### DIFF
--- a/packages/config-yaml/src/validation.ts
+++ b/packages/config-yaml/src/validation.ts
@@ -47,7 +47,7 @@ export function validateConfigYaml(
 
     if (model.requestOptions?.headers) {
       for (const [key, value] of Object.entries(model.requestOptions.headers)) {
-        if (containsUnicode(value)) {
+        if (containsUnicode(key) || containsUnicode(value)) {
           errors.push({
             fatal: true,
             message: `Model "${model.name}" has a request header "${key}" containing unicode characters. Request headers should only contain ASCII characters.`,


### PR DESCRIPTION
## Description

model's api key or any of the request headers should not contain unicode characters

closes https://github.com/continuedev/continue/issues/9910
resolves CON-5307

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

<img width="389" height="371" alt="image" src="https://github.com/user-attachments/assets/c68daed9-1606-446b-90b3-a96ca84e3dd5" />


## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add validation to block unicode characters in model API keys and request headers in config-yaml. This prevents invalid auth/headers from reaching LLM APIs and fulfills CON-5307 and issue #9910.

- **Bug Fixes**
  - Check model.apiKey and requestOptions.headers (names and values) for non-ASCII; raise fatal errors with clear messages.
  - Enforce ASCII-only keys and header values to match HTTP/LLM API requirements.

<sup>Written for commit 81607110974eaf69f3d936fc92d604faaa62eba0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

