### PR TITLE
fix: generalize Windows remote detection for terminal commands

### DIFF
--- a/core/tools/implementations/runTerminalCommand.ts
+++ b/core/tools/implementations/runTerminalCommand.ts
@@ -114,15 +114,16 @@ export const runTerminalCommandImpl: ToolImpl = async (args, extras) => {
   const ideInfo = await extras.ide.getIdeInfo();
   const toolCallId = extras.toolCallId || "";
 
-  // When extension host runs on Windows but connects to WSL, we can't spawn
-  // shells directly - the platform is "win32" but commands should run in Linux.
+  // When the extension host runs on Windows but connects to a remote workspace
+  // (WSL, Dev Container, SSH, etc.), we can't spawn shells directly — the
+  // platform is "win32" but commands should run in the remote's Linux/macOS.
   // Use ide.runCommand() instead to let VS Code handle the remote execution.
-  const isWindowsHostWithWslRemote =
-    process.platform === "win32" && ideInfo.remoteName === "wsl";
+  const isWindowsHostWithRemote =
+    process.platform === "win32" && !["", "local"].includes(ideInfo.remoteName);
 
   if (
     ENABLED_FOR_REMOTES.includes(ideInfo.remoteName) &&
-    !isWindowsHostWithWslRemote
+    !isWindowsHostWithRemote
   ) {
     // For streaming output
     if (extras.onPartialOutput) {


### PR DESCRIPTION
## Summary
- Broadens the Windows-with-remote check in `runTerminalCommand.ts` from WSL-only (`remoteName === "wsl"`) to **all non-local remotes** (`!["", "local"].includes(remoteName)`)
- When a Windows host connects to any remote workspace (Dev Container, SSH, Codespaces, etc.), terminal commands now correctly fall back to `ide.runCommand()` instead of trying to spawn `powershell.exe`
- Follows the same pattern established in PR #9679 (WSL terminal fix, merged in v1.8.0)

## Context
The `ENABLED_FOR_REMOTES` list already includes `dev-container`, `devcontainer`, `ssh-remote`, `attached-container`, `codespaces`, and `tunnel` — but the guard only excluded WSL from direct exec. Any other remote type on a Windows host would enter the direct spawn path and fail with `ENOENT` because `powershell.exe` args target the wrong platform.

Fixes #10007
Related: #10067, #9812, #8732

## Test plan
- [ ] Verify terminal tool works on Windows host → WSL remote (existing behavior preserved)
- [ ] Verify terminal tool works on Windows host → Dev Container (no longer ENOENT)
- [ ] Verify terminal tool works on local Windows (direct exec still used)
- [ ] Verify terminal tool works on native Linux/macOS (no change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generalized Windows remote detection in runTerminalCommand to handle all non-local remotes. On Windows with a remote workspace, terminal commands now use ide.runCommand instead of spawning powershell, preventing ENOENT errors across Dev Containers, SSH, Codespaces, etc.

- **Bug Fixes**
  - Detect any non-local remote on Windows and route commands through VS Code to run in the remote environment.
  - Preserve direct spawn on local Windows; no changes on macOS/Linux.

<sup>Written for commit b7c2b4f074b850563541fd9ee7258adb7d87fb0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

