### PR TITLE
fix: pass pre-read content to bypass fs.existsSync for WSL agent configs

### DIFF
--- a/core/config/profile/LocalProfileLoader.ts
+++ b/core/config/profile/LocalProfileLoader.ts
@@ -64,6 +64,9 @@ export default class LocalProfileLoader implements IProfileLoader {
       packageIdentifier: {
         uriType: "file",
         fileUri: this.overrideAssistantFile?.path ?? getPrimaryConfigFilePath(),
+        // Pass pre-read content to bypass fs.readFileSync, which fails for
+        // vscode-remote:// URIs when Windows host connects to WSL (#10450)
+        content: this.overrideAssistantFile?.content,
       },
     });
 

--- a/core/config/profile/LocalProfileLoader.vitest.ts
+++ b/core/config/profile/LocalProfileLoader.vitest.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ControlPlaneClient } from "../../control-plane/client.js";
+import { LLMLogger } from "../../llm/logger.js";
+import { testIde } from "../../test/fixtures.js";
+import LocalProfileLoader from "./LocalProfileLoader.js";
+
+// Mock doLoadConfig to capture the arguments it receives
+const mockDoLoadConfig = vi.fn().mockResolvedValue({
+  config: undefined,
+  errors: [],
+  configLoadInterrupted: false,
+});
+
+vi.mock("./doLoadConfig.js", () => ({
+  default: (...args: any[]) => mockDoLoadConfig(...args),
+}));
+
+describe("LocalProfileLoader", () => {
+  const controlPlaneClient = new ControlPlaneClient(
+    Promise.resolve(undefined),
+    testIde,
+  );
+  const llmLogger = new LLMLogger();
+
+  it("should pass pre-read content in packageIdentifier for override files", async () => {
+    const overrideFile = {
+      path: "vscode-remote://wsl+Ubuntu/home/user/.continue/agents/test.yaml",
+      content: "name: Test\nversion: 1.0.0\nschema: v1\n",
+    };
+
+    const loader = new LocalProfileLoader(
+      testIde,
+      controlPlaneClient,
+      llmLogger,
+      overrideFile,
+    );
+
+    await loader.doLoadConfig();
+
+    expect(mockDoLoadConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        packageIdentifier: expect.objectContaining({
+          uriType: "file",
+          fileUri: overrideFile.path,
+          content: overrideFile.content,
+        }),
+      }),
+    );
+  });
+
+  it("should not include content in packageIdentifier when no override file", async () => {
+    const loader = new LocalProfileLoader(
+      testIde,
+      controlPlaneClient,
+      llmLogger,
+    );
+
+    await loader.doLoadConfig();
+
+    expect(mockDoLoadConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        packageIdentifier: expect.objectContaining({
+          uriType: "file",
+          content: undefined,
+        }),
+      }),
+    );
+  });
+});

--- a/core/config/profile/doLoadConfig.ts
+++ b/core/config/profile/doLoadConfig.ts
@@ -114,7 +114,15 @@ export default async function doLoadConfig(options: {
   let errors: ConfigValidationError[] | undefined;
   let configLoadInterrupted = false;
 
-  if (overrideConfigYaml || fs.existsSync(configYamlPath)) {
+  const hasPreReadContent =
+    packageIdentifier.uriType === "file" &&
+    packageIdentifier.content !== undefined;
+
+  if (
+    overrideConfigYaml ||
+    hasPreReadContent ||
+    fs.existsSync(configYamlPath)
+  ) {
     const result = await loadContinueConfigFromYaml({
       ide,
       ideSettings,

--- a/core/config/profile/doLoadConfig.vitest.ts
+++ b/core/config/profile/doLoadConfig.vitest.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { PackageIdentifier } from "@continuedev/config-yaml";
+
+// Mock heavy dependencies before importing doLoadConfig
+const stubConfig = {
+  models: [],
+  rules: [],
+  tools: [],
+  slashCommands: [],
+  contextProviders: [],
+  modelsByRole: { chat: [], edit: [], apply: [], summarize: [], rerank: [] },
+  selectedModelByRole: {},
+  mcpServerStatuses: [],
+  allowAnonymousTelemetry: false,
+  experimental: {},
+};
+const mockLoadYaml = vi.fn().mockResolvedValue({
+  config: { ...stubConfig },
+  errors: [],
+  configLoadInterrupted: false,
+});
+const mockLoadJson = vi.fn().mockResolvedValue({
+  config: { ...stubConfig },
+  errors: [],
+  configLoadInterrupted: false,
+});
+
+vi.mock("../yaml/loadYaml", () => ({
+  loadContinueConfigFromYaml: (...args: any[]) => mockLoadYaml(...args),
+}));
+vi.mock("../load", () => ({
+  loadContinueConfigFromJson: (...args: any[]) => mockLoadJson(...args),
+}));
+vi.mock("../migrateSharedConfig", () => ({
+  migrateJsonSharedConfig: vi.fn(),
+}));
+vi.mock("../getWorkspaceContinueRuleDotFiles", () => ({
+  getWorkspaceContinueRuleDotFiles: vi
+    .fn()
+    .mockResolvedValue({ rules: [], errors: [] }),
+}));
+vi.mock("../markdown/loadMarkdownRules", () => ({
+  loadMarkdownRules: vi.fn().mockResolvedValue({ rules: [], errors: [] }),
+}));
+vi.mock("../markdown/loadCodebaseRules", () => ({
+  CodebaseRulesCache: { getInstance: () => ({ rules: [], errors: [] }) },
+}));
+vi.mock("../selectedModels", () => ({
+  rectifySelectedModelsFromGlobalContext: (c: any) => c,
+}));
+vi.mock("../../context/mcp/MCPManagerSingleton", () => ({
+  MCPManagerSingleton: { getInstance: () => ({ getStatuses: () => [] }) },
+}));
+vi.mock("../../tools", () => ({
+  getConfigDependentToolDefinitions: vi.fn().mockResolvedValue([]),
+}));
+vi.mock("../../tools/callTool", () => ({
+  encodeMCPToolUri: vi.fn(),
+}));
+vi.mock("../../tools/mcpToolName", () => ({
+  getMCPToolName: vi.fn(),
+}));
+vi.mock("../../util/posthog", () => ({
+  Telemetry: { setup: vi.fn() },
+}));
+vi.mock("../../util/sentry/SentryLogger", () => ({
+  SentryLogger: { setup: vi.fn() },
+}));
+vi.mock("../../util/tts", () => ({
+  TTS: { setup: vi.fn() },
+}));
+vi.mock("../../util/GlobalContext", () => ({
+  GlobalContext: class {
+    get() {
+      return {};
+    }
+    update() {}
+  },
+}));
+vi.mock("../../control-plane/env", () => ({
+  getControlPlaneEnv: vi.fn().mockResolvedValue({
+    DEFAULT_CONTROL_PLANE_PROXY_URL: "https://proxy.example.com/",
+  }),
+  getControlPlaneEnvSync: vi.fn().mockReturnValue({
+    CONTROL_PLANE_URL: "https://api.example.com/",
+  }),
+}));
+vi.mock("../../control-plane/PolicySingleton", () => ({
+  PolicySingleton: { getInstance: () => ({ policy: null }) },
+}));
+vi.mock("../../control-plane/TeamAnalytics", () => ({
+  TeamAnalytics: { setup: vi.fn(), shutdown: vi.fn() },
+}));
+vi.mock("../../promptFiles/initPrompt", () => ({
+  initSlashCommand: { name: "init", description: "init" },
+}));
+
+// Mock fs.existsSync to simulate missing file on disk
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync: vi.fn().mockReturnValue(false),
+    },
+  };
+});
+
+import doLoadConfig from "./doLoadConfig.js";
+
+const mockIde = {
+  getIdeInfo: vi.fn().mockResolvedValue({
+    ideType: "vscode",
+    name: "VS Code",
+    version: "1.90.0",
+    remoteName: "wsl",
+    extensionVersion: "1.3.31",
+  }),
+  getUniqueId: vi.fn().mockResolvedValue("test-id"),
+  getIdeSettings: vi.fn().mockResolvedValue({}),
+  showToast: vi.fn(),
+  isTelemetryEnabled: vi.fn().mockResolvedValue(true),
+  isWorkspaceRemote: vi.fn().mockResolvedValue(true),
+} as any;
+
+const mockControlPlaneClient = {
+  getAccessToken: vi.fn().mockResolvedValue("token"),
+  isSignedIn: vi.fn().mockResolvedValue(false),
+  sessionInfoPromise: Promise.resolve(undefined),
+} as any;
+
+const mockLlmLogger = {} as any;
+
+describe("doLoadConfig pre-read content bypass", () => {
+  it("should use YAML loading when packageIdentifier has pre-read content, even if file does not exist on disk", async () => {
+    mockLoadYaml.mockClear();
+    mockLoadJson.mockClear();
+
+    const packageIdentifier: PackageIdentifier = {
+      uriType: "file",
+      fileUri:
+        "vscode-remote://wsl+Ubuntu/home/user/.continue/agents/test.yaml",
+      content: "name: Test\nversion: 1.0.0\nschema: v1\n",
+    };
+
+    await doLoadConfig({
+      ide: mockIde,
+      controlPlaneClient: mockControlPlaneClient,
+      llmLogger: mockLlmLogger,
+      profileId: "test-profile",
+      overrideConfigYamlByPath: packageIdentifier.fileUri,
+      orgScopeId: null,
+      packageIdentifier,
+    });
+
+    expect(mockLoadYaml).toHaveBeenCalled();
+    expect(mockLoadJson).not.toHaveBeenCalled();
+  });
+
+  it("should fall back to JSON loading when no content and file does not exist", async () => {
+    mockLoadYaml.mockClear();
+    mockLoadJson.mockClear();
+
+    const packageIdentifier: PackageIdentifier = {
+      uriType: "file",
+      fileUri:
+        "vscode-remote://wsl+Ubuntu/home/user/.continue/agents/test.yaml",
+    };
+
+    await doLoadConfig({
+      ide: mockIde,
+      controlPlaneClient: mockControlPlaneClient,
+      llmLogger: mockLlmLogger,
+      profileId: "test-profile",
+      overrideConfigYamlByPath: packageIdentifier.fileUri,
+      orgScopeId: null,
+      packageIdentifier,
+    });
+
+    expect(mockLoadYaml).not.toHaveBeenCalled();
+    expect(mockLoadJson).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Pass pre-read `content` from `overrideAssistantFile` through the `PackageIdentifier` in `LocalProfileLoader`, reusing the content bypass added to `RegistryClient` in PR #9739
- Check for pre-read content before the `fs.existsSync` gate in `doLoadConfig`, preventing fallback to the deprecated JSON config loader when the YAML path can't be resolved cross-filesystem

## Context

When VS Code runs on Windows host with a WSL remote workspace (`extensionKind: ["ui", "workspace"]`), selecting an agent config from `.continue/agents/` fails with:
```
Failed to parse config.json: Error: ENOENT: no such file or directory, open 'C:\Users\<user>\.continue\config.json'
```

`localPathOrUriToPath` can't resolve `vscode-remote://` URIs to local paths on the Windows host, so `fs.existsSync` returns false, falling through to the deprecated JSON loader. The content is already available in memory — it just wasn't being passed through.

Same class of issue as #6242, #7810 (fixed in #9739) and #9661 (fixed in #9679).

Fixes #10450

## Test plan

- [x] New unit tests: `LocalProfileLoader` passes content in `packageIdentifier` for override files
- [x] New unit tests: `doLoadConfig` uses YAML loading (not JSON fallback) when pre-read content is available
- [x] All 1654 existing core tests pass
- [x] All 291 config-yaml package tests pass
- [ ] Manual: select agent config from `.continue/agents/` in WSL remote workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass pre-read YAML content from override agent files to the config loader to avoid fs.existsSync checks for vscode-remote URIs. This fixes agent config selection in VS Code on Windows with a WSL remote workspace.

- **Bug Fixes**
  - LocalProfileLoader includes overrideAssistantFile.content in PackageIdentifier to reuse the content bypass path.
  - doLoadConfig checks for pre-read content before fs.existsSync and uses the YAML loader when present, avoiding fallback to the deprecated JSON loader when paths aren’t resolvable across Windows/WSL.

<sup>Written for commit f9714fec084285cd91bfb6421e4070f26a153622. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

