### PR TITLE
Fix stdio MCP stdio connections failing with ENOENT on remote SSH VSCode

### DIFF
--- a/core/context/mcp/MCPConnection.vitest.ts
+++ b/core/context/mcp/MCPConnection.vitest.ts
@@ -175,6 +175,39 @@ describe("MCPConnection", () => {
       );
       expect(mockResolve).toHaveBeenCalledWith("src", ide);
     });
+
+    it("should convert file:// URIs to filesystem paths", async () => {
+      const conn = new MCPConnection(baseOptions);
+
+      await expect(
+        (conn as any).resolveCwd("file:///home/user/project"),
+      ).resolves.toBe("/home/user/project");
+    });
+
+    it("should convert vscode-remote:// URIs to filesystem paths", async () => {
+      const conn = new MCPConnection(baseOptions);
+
+      await expect(
+        (conn as any).resolveCwd(
+          "vscode-remote://ssh-remote+myserver/home/user/project",
+        ),
+      ).resolves.toBe("/home/user/project");
+    });
+
+    it("should handle workspace URIs from remote IDE", async () => {
+      const ide = {} as any;
+      const mockResolve = vi
+        .spyOn(ideUtils, "resolveRelativePathInDir")
+        .mockResolvedValue(
+          "vscode-remote://ssh-remote+myserver/home/user/workspace/src",
+        );
+      const conn = new MCPConnection(baseOptions, { ide });
+
+      await expect((conn as any).resolveCwd("src")).resolves.toBe(
+        "/home/user/workspace/src",
+      );
+      expect(mockResolve).toHaveBeenCalledWith("src", ide);
+    });
   });
 
   describe("connectClient", () => {

--- a/core/util/shellPath.ts
+++ b/core/util/shellPath.ts
@@ -2,6 +2,19 @@ import { exec } from "child_process";
 import { promisify } from "util";
 
 const execAsync = promisify(exec);
+
+// Common Unix binary paths that should be included in PATH
+const DEFAULT_UNIX_PATHS = [
+  "/usr/local/bin",
+  "/usr/bin",
+  "/bin",
+  "/usr/local/sbin",
+  "/usr/sbin",
+  "/sbin",
+  "/opt/homebrew/bin", // macOS Homebrew on Apple Silicon
+  "/home/linuxbrew/.linuxbrew/bin", // Linux Homebrew
+];
+
 export async function getEnvPathFromUserShell(
   remoteName?: string,
 ): Promise<string | undefined> {
@@ -11,20 +24,34 @@ export async function getEnvPathFromUserShell(
     return undefined;
   }
 
-  if (!process.env.SHELL) {
-    return undefined;
-  }
+  // Try to find a shell to use
+  const shell = process.env.SHELL || "/bin/bash";
 
   try {
     // Source common profile files
-    const command = `${process.env.SHELL} -l -c 'for f in ~/.zprofile ~/.zshrc ~/.bash_profile ~/.bashrc; do [ -f "$f" ] && source "$f" 2>/dev/null; done; echo $PATH'`;
+    const command = `${shell} -l -c 'for f in ~/.zprofile ~/.zshrc ~/.bash_profile ~/.bashrc; do [ -f "$f" ] && source "$f" 2>/dev/null; done; echo $PATH'`;
 
     const { stdout } = await execAsync(command, {
       encoding: "utf8",
+      timeout: 5000, // 5 second timeout
     });
 
-    return stdout.trim();
+    const pathFromShell = stdout.trim();
+    if (pathFromShell) {
+      return pathFromShell;
+    }
   } catch (error) {
-    return process.env.PATH; // Fallback to current PATH
+    // If shell command fails, fall through to default handling
+    console.warn("Failed to get PATH from shell:", error);
   }
+
+  // Fallback: build a reasonable default PATH
+  if (!process.env.PATH) {
+    return DEFAULT_UNIX_PATHS.join(":");
+  }
+
+  // Merge current PATH with common paths (avoiding duplicates)
+  const currentPaths = process.env.PATH.split(":");
+  const allPaths = [...new Set([...currentPaths, ...DEFAULT_UNIX_PATHS])];
+  return allPaths.join(":");
 }


### PR DESCRIPTION
## Explanation

When VSCode connects via Remote SSH, workspace directories use `vscode-remote://` URIs instead of `file://` URIs. The cwd resolution code only handled `file://` URIs, causing these remote URIs to be passed directly to `child_process.spawn()`, which expects filesystem paths - resulting in ENOENT errors.  This is why is spawn noent on any command launched by MCP in stdio mode.


## Description

1. Added `uriToFsPath()` method to properly convert any URI scheme (file://, vscode-remote://, etc.) to filesystem paths
2. Updated `resolveCwd()` and `resolveWorkspaceCwd()` to use the new URI converter
3. Improved `getEnvPathFromUserShell()` to provide sensible PATH defaults when SHELL env var is not set in remote environments


## Checklist

- [X] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [X] The relevant docs, if any, have been updated or created
- [X] The relevant tests, if any, have been updated or created


## Tests

- Added 3 new tests for remote URI handling
- All existing tests pass
- Verified with actual MCP servers on remote SSH connection

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ENOENT when starting MCP servers in stdio mode on VS Code Remote SSH. Converts vscode-remote:// URIs to filesystem paths and ensures PATH is set correctly for remote shells.

- **Bug Fixes**
  - Added uriToFsPath and used it in resolveCwd/resolveWorkspaceCwd to handle file:// and vscode-remote:// URIs.
  - Retrieved PATH from the user’s shell on non-Windows and WSL remotes, with sane defaults when SHELL is missing.
  - Added tests for URI conversion and remote workspace path resolution.

<sup>Written for commit b78709fa37049ecc0722d2c3da05a24569baee6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

