### PR TITLE
No more docs/docusaurus.config.js

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ You can run the documentation server locally using either of the following metho
 
 #### Method 1: NPM Script
 
-1. Open your terminal and navigate to the `docs` subdirectory of the project. The `docusaurus.config.js` file you'll see
+1. Open your terminal and navigate to the `docs` subdirectory of the project. The `favicon.png` file you'll see
    there is a sign you're in the right place.
 
 2. Run the following command to install the necessary dependencies for the documentation server:


### PR DESCRIPTION
docs/docusaurus.config.js was deleted in an earlier commit which should be accordingly reflected in the CONTRIBUTING.md file.

## Description

I've replaced `docusaurus.config.js` with `favicon.png` in `CONTRIBUTING.md` to reflect an earlier deletion of this file.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created
- [x] I have read the CLA Document and I hereby sign the CLA

## Tests

None




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CONTRIBUTING.md to reference favicon.png instead of the removed docs/docusaurus.config.js, so contributors can confirm they’re in the right docs directory.

<sup>Written for commit 4da9ec6714a1674d9d0940c7a8ac0889f0ee8cd4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

