### PR TITLE
fix: harden system message tools and wire toolOverrides to system message path

### DIFF
--- a/core/config/load.ts
+++ b/core/config/load.ts
@@ -651,6 +651,7 @@ function llmToSerializedModelDescription(llm: ILLM): ModelDescription {
     envSecretLocations: llm.envSecretLocations,
     sourceFile: llm.sourceFile,
     isFromAutoDetect: llm.isFromAutoDetect,
+    toolOverrides: llm.toolOverrides,
   };
 }
 

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1254,6 +1254,9 @@ export interface ModelDescription {
 
   sourceFile?: string;
   isFromAutoDetect?: boolean;
+
+  /** Tool overrides for this model */
+  toolOverrides?: ToolOverride[];
 }
 
 export interface JSONEmbedOptions {

--- a/core/tools/systemMessageTools/toolCodeblocks/index.ts
+++ b/core/tools/systemMessageTools/toolCodeblocks/index.ts
@@ -65,13 +65,20 @@ export class SystemMessageToolCodeblocksFramework
     return toolDefinition.trim();
   }
 
-  systemMessagePrefix = `You have access to several "tools" that you can use at any time to retrieve information and/or perform tasks for the User.
-To use a tool, respond with a tool code block (\`\`\`tool) using the syntax shown in the examples below:`;
+  systemMessagePrefix = `You have access to tools. To call a tool, you MUST respond with EXACTLY this format — a tool code block (\`\`\`tool) using the syntax shown below.
 
-  systemMessageSuffix = `If it seems like the User's request could be solved with one of the tools, choose the BEST one for the job based on the user's request and the tool descriptions
-Then send the \`\`\`tool codeblock (YOU call the tool, not the user). Always start the codeblock on a new line.
-Do not perform actions with/for hypothetical files. Ask the user or use tools to deduce which files are relevant.
-You can only call ONE tool at at time. The tool codeblock should be the last thing you say; stop your response after the tool codeblock.`;
+CRITICAL: Follow the exact syntax. Do not use XML tags, JSON objects, or any other format for tool calls.`;
+
+  systemMessageSuffix = `RULES FOR TOOL USE:
+1. To call a tool, output a \`\`\`tool code block using EXACTLY the format shown above.
+2. Always start the code block on a new line.
+3. You can only call ONE tool at a time.
+4. The \`\`\`tool code block MUST be the last thing in your response. Stop immediately after the closing \`\`\`.
+5. Do NOT wrap tool calls in XML tags like <tool_call> or <function=...>.
+6. Do NOT use JSON format for tool calls.
+7. Do NOT invent tools that are not listed above.
+8. If the user's request can be addressed with a listed tool, use it rather than guessing.
+9. Do not perform actions with hypothetical files. Use tools to find relevant files.`;
 
   exampleDynamicToolDefinition = `
 \`\`\`tool_definition


### PR DESCRIPTION
## Summary

- Strengthened system message tool instructions for models on the non-native tools path (used by local models via `capabilities: []` or `experimental.onlyUseSystemMessageTools`). The previous prose instructions were too vague — local models reverted to XML/JSON tool call formats from their training priors.
- Fixed `toolOverrides` being silently ignored on the system message path. `applyToolOverrides()` already existed and ran on the native tools path (in `BaseLLM.streamChat()`), but was never called when tools were injected via system message text. Config YAML `toolOverrides` for `disabled` and `description` now take effect on both paths.

## Changes

1. **`core/tools/systemMessageTools/toolCodeblocks/index.ts`** — Replaced prose `systemMessagePrefix`/`systemMessageSuffix` with explicit numbered rules that prohibit XML tags, JSON format, and tool invention
2. **`core/index.d.ts`** — Added `toolOverrides` to `ModelDescription` interface
3. **`core/config/load.ts`** — Serialized `toolOverrides` in `llmToSerializedModelDescription()`
4. **`gui/src/redux/thunks/streamNormalInput.ts`** — Imported `applyToolOverrides` and applied model-level overrides to `activeTools` before both the native and system message paths

## Test plan

- [x] `cd core && npm run vitest` — 1654 passed, 0 failures
- [x] Built vsix, tested with local models (nemotron-3-nano-30b, gpt-oss-20b, mirothinker-v1.5-30b) via LM Studio
- [x] Verified `view_diff` with `disabled: true` is absent from system message
- [x] Verified hardened numbered rules appear in system message prefix/suffix
- [x] Verified local models follow codeblock format through multi-step tool call chains
- [ ] Verify native tools path unaffected (cloud models)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves reliability of system-message tool calls for local models and applies model-level toolOverrides on that path. Local models now follow the codeblock format, and disabled/description overrides from config are respected.

- **Bug Fixes**
  - Hardened system message with clear, numbered rules: use only tool code blocks; no XML/JSON; one tool per response; code block last; no invented tools.
  - Applied applyToolOverrides before both native and system-message paths and added toolOverrides to ModelDescription serialization, so per-model disabled/description overrides take effect.

<sup>Written for commit 1a59f1ab56f78c041e00b7603a3f679f7861e678. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

