### PR TITLE
fix: strengthen default Apply prompt for local models

### DIFF
--- a/core/llm/templates/edit/gpt.ts
+++ b/core/llm/templates/edit/gpt.ts
@@ -73,8 +73,31 @@ export const gptEditPrompt: PromptTemplateFunction = (history, otherData) => {
 };
 
 export const defaultApplyPrompt: PromptTemplateFunction = (
-  history,
+  _history,
   otherData,
 ) => {
-  return `${otherData.original_code}\n\nThe following code was suggested as an edit:\n\`\`\`\n${otherData.new_code}\n\`\`\`\nPlease apply it to the previous code. Leave existing comments in place unless changes require modifying them.`;
+  return [
+    {
+      role: "user",
+      content: dedent`
+        ORIGINAL CODE:
+        \`\`\`
+        ${otherData.original_code}
+        \`\`\`
+
+        SUGGESTED EDIT:
+        \`\`\`
+        ${otherData.new_code}
+        \`\`\`
+
+        Apply the SUGGESTED EDIT to the ORIGINAL CODE. Output the complete modified file.
+        - Output ONLY code. Do NOT explain, summarize, or describe changes.
+        - Leave existing comments in place unless changes require modifying them.
+        - Preserve all unchanged code exactly as-is.`,
+    },
+    {
+      role: "assistant",
+      content: `\`\`\`\n`,
+    },
+  ];
 };


### PR DESCRIPTION
## Summary

- Local/open-weight models respond to the default Apply prompt with prose summaries of changes instead of actual code, because `defaultApplyPrompt` returns a single-sentence plain string with no code-only constraint
- Change `defaultApplyPrompt` to return `ChatMessage[]` with labeled ORIGINAL CODE / SUGGESTED EDIT sections, explicit "Output ONLY code" instructions, and an assistant prefill opening a code block
- This routes through `streamChat` (instead of `streamComplete`), and the assistant prefill forces the model to continue with code rather than prose
- The existing `filterCodeBlockLines` filter strips the closing fence from the output

## Context

`defaultApplyPrompt` is the fallback Apply prompt used when no model-specific `promptTemplates.apply` is configured. It applies when a model calls `edit_existing_file` and the Apply step merges the suggested code into the original file.

The previous prompt was:
```
{original_code}\n\nThe following code was suggested as an edit:\n```\n{new_code}\n```\nPlease apply it to the previous code.
```

Local models (tested with gpt-oss-20b via LM Studio) interpreted this as a request to *describe* changes rather than output code. The new prompt with explicit rules and assistant prefill produces clean code diffs.

## What this doesn't change

- Claude Sonnet lazy-apply path (separate code path in `core/edit/lazy/`)
- GPT/Claude edit prompts (`gptEditPrompt`, not `defaultApplyPrompt`)
- Users with custom `promptTemplates.apply` in config (custom overrides `defaultApplyPrompt`)

## Test plan

- [x] `cd core && npm run vitest` — 1654 tests pass, 0 failures
- [x] Tested with gpt-oss-20b (local model via LM Studio) — Apply produces code diffs instead of prose summaries
- [ ] Verify cloud model Apply still works (they typically use model-specific prompts, not `defaultApplyPrompt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the default Apply prompt produce code (not prose) for local/open‑weight models by switching to a chat-based prompt with code-only instructions and an assistant prefill. Apply now routes through streamChat and returns the full modified file.

- **Bug Fixes**
  - defaultApplyPrompt now returns ChatMessage[] with ORIGINAL CODE / SUGGESTED EDIT blocks and “output ONLY code” instructions.
  - Assistant prefill opens a code block to force code continuation; existing filter removes the closing fence.
  - No changes to model-specific prompts, lazy-apply path, or user overrides.

<sup>Written for commit 25026d72e36e3e58deb87c9ee1a78f24d0a99e40. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

