### PR TITLE
fix: preserve leading dot in ls tool path resolution

### DIFF
--- a/core/tools/implementations/lsTool.ts
+++ b/core/tools/implementations/lsTool.ts
@@ -9,10 +9,6 @@ export function resolveLsToolDirPath(dirPath: string | undefined) {
   if (!dirPath || dirPath === ".") {
     return ".";
   }
-  // Don't strip leading slash from absolute paths - let the resolver handle it
-  if (dirPath.startsWith(".") && !dirPath.startsWith("./")) {
-    return dirPath.slice(1);
-  }
   return dirPath.replace(/\\/g, "/");
 }
 

--- a/core/tools/implementations/lsTool.vitest.ts
+++ b/core/tools/implementations/lsTool.vitest.ts
@@ -36,6 +36,19 @@ test("resolveLsToolDirPath preserves forward slashes", () => {
   expect(resolveLsToolDirPath("path/to/dir")).toBe("path/to/dir");
 });
 
+test("resolveLsToolDirPath preserves hidden directory paths", () => {
+  expect(resolveLsToolDirPath(".continue/rules")).toBe(".continue/rules");
+});
+
+test("resolveLsToolDirPath preserves hidden directory name only", () => {
+  expect(resolveLsToolDirPath(".git")).toBe(".git");
+});
+
+test("resolveLsToolDirPath preserves parent directory references", () => {
+  expect(resolveLsToolDirPath("..")).toBe("..");
+  expect(resolveLsToolDirPath("../foo")).toBe("../foo");
+});
+
 test("lsToolImpl truncates output when entries exceed MAX_LS_TOOL_LINES", async () => {
   // Generate more than MAX_LS_TOOL_LINES entries (which is 200)
   const mockEntries = Array.from({ length: 250 }, (_, i) => `file${i}.txt`);


### PR DESCRIPTION
## Description

Fixes the `ls` tool failing when called with hidden directory paths like `.continue/rules`.

The `resolveLsToolDirPath` function had a condition that matched paths starting with `.` (but not `./`) and stripped the leading character via `slice(1)`. This converted `.continue/rules` to `continue/rules`, which doesn't exist, causing the tool to error with "Directory not found."

The fix removes this faulty condition. The downstream `resolveInputPath` and `resolveRelativePathInDir` functions handle dot-prefixed paths correctly without any preprocessing.

Fixes #10466

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Tests

- Added test: hidden directory paths (`.continue/rules`) are preserved
- Added test: hidden directory names (`.git`) are preserved
- Added test: parent directory references (`..`, `../foo`) are preserved
- All 12 existing + new `lsTool` tests pass

---
🤖 Generated with Claude Code (issue-hunter-pro)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue-stage.tools/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F10515&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves leading dots in ls tool path resolution so hidden directories (.continue/rules, .git) and parent refs (.., ../foo) work without errors. Removed the stripping logic and added tests to cover these cases.

<sup>Written for commit deac90f18e5eed55a21be064500958e06d8bd9d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

