### PR TITLE
feat: make create/read rule tools disabled by default

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -4,6 +4,7 @@ import {
   PromptTemplates,
   ToolOverrideConfig,
 } from "@continuedev/config-yaml";
+import { ToolPolicy } from "@continuedev/terminal-security";
 import { McpUiResourceMeta } from "@modelcontextprotocol/ext-apps";
 import { TextResourceContents } from "@modelcontextprotocol/sdk/types.js";
 import Parser from "web-tree-sitter";

--- a/core/tools/definitions/createRuleBlock.ts
+++ b/core/tools/definitions/createRuleBlock.ts
@@ -59,7 +59,7 @@ export const createRuleBlock: Tool = {
       },
     },
   },
-  defaultToolPolicy: "allowedWithPermission",
+  defaultToolPolicy: "disabled",
   systemMessageDescription: {
     prefix: `Sometimes the user will provide feedback or guidance on your output. If you were not aware of these "rules", consider using the ${BuiltInToolNames.CreateRuleBlock} tool to persist the rule for future interactions.
 This tool cannot be used to edit existing rules, but you can search in the ".continue/rules" folder and use the edit tool to manage rules.


### PR DESCRIPTION
## Description
Value of these has greatly reduced with skill support and we find both the error and hallucination rates are high and it's tricky to prompt non-super-smart models to understand these.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue-stage.tools/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F10543&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled the rule-creation tool (createRuleBlock) by default to reduce errors/hallucinations and lean on skills instead. The tool now requires explicit opt-in.

- **Migration**
  - To re-enable, add a tool override for createRuleBlock in your config and set defaultToolPolicy to allowedWithPermission (or allowed).

<sup>Written for commit e2217f91a9d529fe78d4fe65e020f05c9afb1b84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

