### PR TITLE
Issue #10567: Record token usage and optionally display for turn/session/history

### DIFF
--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -248,6 +248,7 @@ declare global {
     title: string;
     dateCreated: string;
     workspaceDirectory: string;
+    usage?: Usage;
   }
   
   export interface RangeInFile {
@@ -323,11 +324,23 @@ declare global {
     role: "user";
     content: MessageContent;
   }
+
+  export interface Usage {
+    completionTokens: number;
+    promptTokens: number;
+    totalTokens?: number;
+    provider?: string;
+    model?: string;
+    source?: "provider" | "estimated";
+    ts?: string;
+    raw?: Record<string, unknown>;
+  }
   
   export interface AssistantChatMessage {
     role: "assistant";
     content: MessageContent;
     toolCalls?: ToolCallDelta[];
+    usage?: Usage;
   }
   
   export interface SystemChatMessage {
@@ -387,6 +400,7 @@ declare global {
     completionOptions: CompletionOptions;
     prompt: string;
     completion: string;
+    usage?: Usage;
   }
   
   type MessageModes = "chat" | "edit";
@@ -651,6 +665,7 @@ declare global {
     remoteConfigSyncPeriod: number;
     userToken: string;
     pauseCodebaseIndexOnStart: boolean;
+    showTokenUsage?: "never" | "history" | "session" | "turn";
   }
   
   export interface IDE {

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -294,6 +294,7 @@ export interface BaseSessionMetadata {
   dateCreated: string;
   workspaceDirectory: string;
   messageCount?: number;
+  usage?: Usage;
 }
 
 export interface RangeInFile {
@@ -406,6 +407,9 @@ export interface ThinkingChatMessage {
 export interface Usage {
   completionTokens: number;
   promptTokens: number;
+  totalTokens?: number;
+  provider?: string;
+  model?: string;
   promptTokensDetails?: {
     cachedTokens?: number;
     /** This an Anthropic-specific property */
@@ -418,6 +422,9 @@ export interface Usage {
     rejectedPredictionTokens?: number;
     audioTokens?: number;
   };
+  source?: "provider" | "estimated";
+  ts?: string;
+  raw?: Record<string, unknown>;
 }
 
 export interface AssistantChatMessage {
@@ -489,6 +496,7 @@ export interface PromptLog {
   modelProvider: string;
   prompt: string;
   completion: string;
+  usage?: Usage;
 }
 
 export type MessageModes = "chat" | "agent" | "plan" | "background";
@@ -815,6 +823,7 @@ export interface IdeSettings {
   userToken: string;
   continueTestEnvironment: "none" | "production" | "staging" | "local";
   pauseCodebaseIndexOnStart: boolean;
+  showTokenUsage?: "never" | "history" | "session" | "turn";
 }
 
 export interface FileStats {

--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -356,8 +356,14 @@ export abstract class BaseLLM implements ILLM {
     usage: Usage | undefined,
     error?: any,
   ): InteractionStatus {
-    let promptTokens = this.countTokens(prompt);
-    let generatedTokens = this.countTokens(completion);
+    let promptTokens =
+      typeof usage?.promptTokens === "number"
+        ? usage.promptTokens
+        : this.countTokens(prompt);
+    let generatedTokens =
+      typeof usage?.completionTokens === "number"
+        ? usage.completionTokens
+        : this.countTokens(completion);
     let thinkingTokens = thinking ? this.countTokens(thinking) : 0;
 
     TokensBatchingService.getInstance().addTokens(
@@ -1353,6 +1359,7 @@ export abstract class BaseLLM implements ILLM {
       modelProvider: this.underlyingProviderName,
       prompt,
       completion: completion.join(""),
+      usage,
     };
   }
 

--- a/core/llm/openaiTypeConverters.ts
+++ b/core/llm/openaiTypeConverters.ts
@@ -298,11 +298,7 @@ function parseProviderUsage(rawUsage: unknown): Usage | undefined {
   );
   const totalTokens = firstNumber(usage.total_tokens);
 
-  if (
-    promptTokens === undefined &&
-    completionTokens === undefined &&
-    totalTokens === undefined
-  ) {
+  if (promptTokens === undefined || completionTokens === undefined) {
     return undefined;
   }
 
@@ -314,8 +310,8 @@ function parseProviderUsage(rawUsage: unknown): Usage | undefined {
     (usage.output_tokens_details as Record<string, unknown> | undefined);
 
   return {
-    promptTokens: promptTokens ?? 0,
-    completionTokens: completionTokens ?? 0,
+    promptTokens,
+    completionTokens,
     totalTokens,
     promptTokensDetails: promptTokensDetailsRaw
       ? {

--- a/core/llm/openaiTypeConverters.ts
+++ b/core/llm/openaiTypeConverters.ts
@@ -35,6 +35,7 @@ import {
   TextMessagePart,
   ThinkingChatMessage,
   ToolCallDelta,
+  Usage,
 } from "..";
 
 function appendReasoningFieldsIfSupported(
@@ -274,8 +275,94 @@ export function toFimBody(
   } as any;
 }
 
+function firstNumber(...values: unknown[]): number | undefined {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function parseProviderUsage(rawUsage: unknown): Usage | undefined {
+  if (!rawUsage || typeof rawUsage !== "object") {
+    return undefined;
+  }
+
+  const usage = rawUsage as Record<string, unknown>;
+  const promptTokens = firstNumber(usage.prompt_tokens, usage.input_tokens);
+  const completionTokens = firstNumber(
+    usage.completion_tokens,
+    usage.output_tokens,
+  );
+  const totalTokens = firstNumber(usage.total_tokens);
+
+  if (
+    promptTokens === undefined &&
+    completionTokens === undefined &&
+    totalTokens === undefined
+  ) {
+    return undefined;
+  }
+
+  const promptTokensDetailsRaw =
+    (usage.prompt_tokens_details as Record<string, unknown> | undefined) ??
+    (usage.input_tokens_details as Record<string, unknown> | undefined);
+  const completionTokensDetailsRaw =
+    (usage.completion_tokens_details as Record<string, unknown> | undefined) ??
+    (usage.output_tokens_details as Record<string, unknown> | undefined);
+
+  return {
+    promptTokens: promptTokens ?? 0,
+    completionTokens: completionTokens ?? 0,
+    totalTokens,
+    promptTokensDetails: promptTokensDetailsRaw
+      ? {
+          cachedTokens: firstNumber(
+            promptTokensDetailsRaw.cached_tokens,
+            promptTokensDetailsRaw.cache_read_tokens,
+            promptTokensDetailsRaw.cachedTokens,
+          ),
+          cacheWriteTokens: firstNumber(
+            promptTokensDetailsRaw.cache_write_tokens,
+            promptTokensDetailsRaw.cacheWriteTokens,
+          ),
+          audioTokens: firstNumber(
+            promptTokensDetailsRaw.audio_tokens,
+            promptTokensDetailsRaw.audioTokens,
+          ),
+        }
+      : undefined,
+    completionTokensDetails: completionTokensDetailsRaw
+      ? {
+          acceptedPredictionTokens: firstNumber(
+            completionTokensDetailsRaw.accepted_prediction_tokens,
+            completionTokensDetailsRaw.acceptedPredictionTokens,
+          ),
+          reasoningTokens: firstNumber(
+            completionTokensDetailsRaw.reasoning_tokens,
+            completionTokensDetailsRaw.reasoningTokens,
+          ),
+          rejectedPredictionTokens: firstNumber(
+            completionTokensDetailsRaw.rejected_prediction_tokens,
+            completionTokensDetailsRaw.rejectedPredictionTokens,
+          ),
+          audioTokens: firstNumber(
+            completionTokensDetailsRaw.audio_tokens,
+            completionTokensDetailsRaw.audioTokens,
+          ),
+        }
+      : undefined,
+    source: "provider",
+    ts: new Date().toISOString(),
+    raw: usage,
+  };
+}
+
 export function fromChatResponse(response: ChatCompletion): ChatMessage[] {
   const messages: ChatMessage[] = [];
+  const usage = parseProviderUsage((response as any).usage);
   const message = response.choices[0].message as ChatCompletionMessage & {
     reasoning?: string;
     reasoning_content?: string;
@@ -320,11 +407,13 @@ export function fromChatResponse(response: ChatCompletion): ChatMessage[] {
             arguments: (tc as any).function?.arguments,
           },
         })),
+      usage,
     });
   } else {
     messages.push({
       role: "assistant",
       content: message.content ?? "",
+      usage,
     });
   }
 
@@ -334,6 +423,7 @@ export function fromChatResponse(response: ChatCompletion): ChatMessage[] {
 export function fromChatCompletionChunk(
   chunk: ChatCompletionChunk,
 ): ChatMessage | undefined {
+  const usage = parseProviderUsage((chunk as any).usage);
   const delta = chunk.choices?.[0]?.delta as
     | (ChatCompletionChunk.Choice.Delta & {
         reasoning?: string;
@@ -348,6 +438,7 @@ export function fromChatCompletionChunk(
     return {
       role: "assistant",
       content: delta.content,
+      usage,
     };
   } else if (delta?.tool_calls) {
     const toolCalls = delta?.tool_calls
@@ -366,6 +457,7 @@ export function fromChatCompletionChunk(
         role: "assistant",
         content: "",
         toolCalls,
+        usage,
       };
     }
   } else if (
@@ -380,6 +472,12 @@ export function fromChatCompletionChunk(
       reasoning_details: delta?.reasoning_details as any[],
     };
     return message;
+  } else if (usage) {
+    return {
+      role: "assistant",
+      content: "",
+      usage,
+    };
   }
 
   return undefined;
@@ -595,6 +693,47 @@ function handleResponsesStreamEvent(
 function handleResponsesFinal(
   resp: OpenAIResponse,
 ): ChatMessage | ChatMessage[] | undefined {
+  const usage = parseProviderUsage((resp as any).usage);
+  const attachUsage = (
+    result: ChatMessage | ChatMessage[] | undefined,
+  ): ChatMessage | ChatMessage[] | undefined => {
+    if (!usage || !result) {
+      return result;
+    }
+
+    if (Array.isArray(result)) {
+      for (let i = result.length - 1; i >= 0; i--) {
+        const message = result[i];
+        if (message.role === "assistant") {
+          (message as AssistantChatMessage).usage = usage;
+          return result;
+        }
+      }
+      result.push({
+        role: "assistant",
+        content: "",
+        usage,
+      });
+      return result;
+    }
+
+    if (result.role === "assistant") {
+      return {
+        ...result,
+        usage,
+      };
+    }
+
+    return [
+      result,
+      {
+        role: "assistant",
+        content: "",
+        usage,
+      },
+    ];
+  };
+
   // Prefer structured output items when present
   if (Array.isArray(resp.output) && resp.output.length > 0) {
     const result: ChatMessage[] = [];
@@ -693,15 +832,15 @@ function handleResponsesFinal(
         continue;
       }
     }
-    if (result.length > 0) return result;
+    if (result.length > 0) return attachUsage(result);
   }
 
   // Fallback to output_text when no structured output is present
   if (typeof resp.output_text === "string" && resp.output_text.length > 0) {
-    return { role: "assistant", content: resp.output_text };
+    return attachUsage({ role: "assistant", content: resp.output_text });
   }
 
-  return undefined;
+  return attachUsage(undefined);
 }
 
 export function fromResponsesChunk(

--- a/core/protocol/passThrough.ts
+++ b/core/protocol/passThrough.ts
@@ -111,4 +111,5 @@ export const CORE_TO_WEBVIEW_PASS_THROUGH: (keyof ToWebviewFromCoreProtocol)[] =
     "didCloseFiles",
     "toolCallPartialOutput",
     "freeTrialExceeded",
+    "ideSettingsUpdate",
   ];

--- a/core/protocol/webview.ts
+++ b/core/protocol/webview.ts
@@ -5,6 +5,7 @@ import type {
   BrowserSerializedContinueConfig,
   ContextItemWithId,
   ContextProviderName,
+  IdeSettings,
   IndexingProgressUpdate,
   IndexingStatus,
 } from "../index.js";
@@ -44,4 +45,5 @@ export type ToWebviewFromIdeOrCoreProtocol = {
   sessionUpdate: [{ sessionInfo: ControlPlaneSessionInfo | undefined }, void];
   toolCallPartialOutput: [{ toolCallId: string; contextItems: any[] }, void];
   freeTrialExceeded: [undefined, void];
+  ideSettingsUpdate: [IdeSettings, void];
 };

--- a/core/util/filesystem.ts
+++ b/core/util/filesystem.ts
@@ -76,6 +76,7 @@ class FileSystemIde implements IDE {
       userToken: "",
       continueTestEnvironment: "none",
       pauseCodebaseIndexOnStart: false,
+      showTokenUsage: "never",
     };
   }
 

--- a/core/util/history.ts
+++ b/core/util/history.ts
@@ -38,15 +38,15 @@ export class HistoryManager {
       })
       .reverse();
 
-    // Hydrate token usage for old sessions that were saved before session metadata
-    // started carrying usage in sessions.json.
-    sessions = sessions.map((session) => this.hydrateUsageFromSession(session));
-
     // Apply limit and offset
     if (options.limit) {
       const offset = options.offset || 0;
       sessions = sessions.slice(offset, offset + options.limit);
     }
+
+    // Hydrate token usage for old sessions that were saved before session metadata
+    // started carrying usage in sessions.json.
+    sessions = sessions.map((session) => this.hydrateUsageFromSession(session));
 
     return sessions;
   }

--- a/docs/ide-extensions/chat/how-to-customize.mdx
+++ b/docs/ide-extensions/chat/how-to-customize.mdx
@@ -9,3 +9,20 @@ There are a number of different ways to customize Chat:
 
 - Add [rules](/customize/rules) to give the model persistent instructions through the system prompt
 - Create [prompts](/customize/prompts) to kickoff workflows with instructions you repeat often
+
+## Token Usage Display
+
+You can control where token usage is shown in the UI with the VS Code setting:
+
+```json
+"continue.showTokenUsage": "never" | "history" | "session" | "turn"
+```
+
+- `never`: Hide token usage in Chat and History.
+- `history`: Show token usage in History only.
+- `session`: Show token usage in History and in the current session summary.
+- `turn`: Show token usage in History, session summary, and each assistant turn.
+
+Usage is always tracked and persisted in local session files.
+
+The **Usage** page in Settings -> Help shows local analytics totals from the local usage database, so totals there can differ from visible chat history totals.

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/MessageTypes.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/constants/MessageTypes.kt
@@ -67,6 +67,7 @@ class MessageTypes {
             "sessionUpdate",
             "didCloseFiles",
             "toolCallPartialOutput",
+            "ideSettingsUpdate",
         )
 
         // Note: If updating these values, make a corresponding update in

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -133,6 +133,23 @@
           "default": false,
           "markdownDescription": "Enable a console to log and explore model inputs and outputs. It can be found in the bottom panel."
         },
+        "continue.showTokenUsage": {
+          "type": "string",
+          "default": "never",
+          "enum": [
+            "never",
+            "history",
+            "session",
+            "turn"
+          ],
+          "enumDescriptions": [
+            "Never show token usage.",
+            "Show token usage in History only.",
+            "Show token usage in History and Session summaries.",
+            "Show token usage in History, Session summaries, and each assistant turn."
+          ],
+          "description": "Where to display token usage. Tracking is always persisted in session files."
+        },
         "continue.remoteConfigServerUrl": {
           "type": "string",
           "default": null,

--- a/extensions/vscode/src/VsCodeIde.ts
+++ b/extensions/vscode/src/VsCodeIde.ts
@@ -694,6 +694,10 @@ class VsCodeIde implements IDE {
         "pauseCodebaseIndexOnStart",
         false,
       ),
+      showTokenUsage: settings.get<"never" | "history" | "session" | "turn">(
+        "showTokenUsage",
+        "never",
+      ),
     };
     return ideSettings;
   }

--- a/extensions/vscode/src/extension/VsCodeExtension.ts
+++ b/extensions/vscode/src/extension/VsCodeExtension.ts
@@ -663,6 +663,7 @@ export class VsCodeExtension {
       if (event.affectsConfiguration(EXTENSION_NAME)) {
         const settings = await this.ide.getIdeSettings();
         void this.core.invoke("config/ideSettingsUpdate", settings);
+        this.sidebar.webviewProtocol.send("ideSettingsUpdate", settings);
 
         if (event.affectsConfiguration(`${EXTENSION_NAME}.enableNextEdit`)) {
           await this.updateNextEditState(context);

--- a/gui/src/components/History/HistoryTableRow.tsx
+++ b/gui/src/components/History/HistoryTableRow.tsx
@@ -21,6 +21,7 @@ import {
   updateSession,
 } from "../../redux/thunks/session";
 import { isShareSessionSupported } from "../../util";
+import { formatTokenBreakdown } from "../../util/usage";
 import HeaderButtonWithToolTip from "../gui/HeaderButtonWithToolTip";
 import { ToolTip } from "../gui/Tooltip";
 
@@ -29,9 +30,11 @@ const shareSessionSupported = isShareSessionSupported();
 export function HistoryTableRow({
   sessionMetadata,
   index,
+  showTokenUsage = false,
 }: {
   sessionMetadata: BaseSessionMetadata | RemoteSessionMetadata;
   index: number;
+  showTokenUsage?: boolean;
 }) {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
@@ -57,6 +60,16 @@ export function HistoryTableRow({
     }
   };
   const isRemote = "isRemote" in sessionMetadata && sessionMetadata.isRemote;
+  const sessionUsage =
+    "usage" in sessionMetadata && sessionMetadata.usage
+      ? sessionMetadata.usage
+      : undefined;
+  const sessionPromptTokens = sessionUsage?.promptTokens ?? 0;
+  const sessionCompletionTokens = sessionUsage?.completionTokens ?? 0;
+  const sessionTotalTokens = sessionUsage
+    ? (sessionUsage.totalTokens ??
+      sessionPromptTokens + sessionCompletionTokens)
+    : 0;
 
   const handleKeyUp = async (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
@@ -122,7 +135,7 @@ export function HistoryTableRow({
         navigate("/");
       }}
     >
-      <td className="flex-1 cursor-pointer space-y-1">
+      <td className="flex-1 cursor-pointer space-y-0.5">
         {editing ? (
           <div>
             <Input
@@ -160,7 +173,7 @@ export function HistoryTableRow({
           </div>
         )}
 
-        <div className="text-description-muted flex">
+        <div className="text-description-muted flex leading-4">
           <span className="line-clamp-1 break-all text-xs">
             {getUriPathBasename(sessionMetadata.workspaceDirectory || "")}
           </span>
@@ -176,6 +189,15 @@ export function HistoryTableRow({
                 })}
               </span> */}
         </div>
+        {showTokenUsage && sessionTotalTokens > 0 && (
+          <div className="text-description-muted text-xs leading-4">
+            {formatTokenBreakdown({
+              promptTokens: sessionPromptTokens,
+              completionTokens: sessionCompletionTokens,
+              totalTokens: sessionTotalTokens,
+            })}
+          </div>
+        )}
       </td>
 
       {hovered && !editing && (

--- a/gui/src/components/History/index.tsx
+++ b/gui/src/components/History/index.tsx
@@ -14,6 +14,7 @@ import Shortcut from "../gui/Shortcut";
 import { XMarkIcon } from "@heroicons/react/24/solid";
 import { useNavigate } from "react-router-dom";
 import { IdeMessengerContext } from "../../context/IdeMessenger";
+import { useTokenUsageSetting } from "../../hooks/useTokenUsageSetting";
 import { useAppDispatch, useAppSelector } from "../../redux/hooks";
 import {
   newSession,
@@ -25,6 +26,7 @@ import { getFontSize, getPlatform } from "../../util";
 import { ROUTES } from "../../util/navigation";
 import ConfirmationDialog from "../dialogs/ConfirmationDialog";
 import { Button } from "../ui";
+import { formatTokenBreakdown } from "../../util/usage";
 import { HistoryTableRow } from "./HistoryTableRow";
 import { groupSessionsByDate, parseDate } from "./util";
 
@@ -33,6 +35,7 @@ export function History() {
   const navigate = useNavigate();
   const searchInputRef = React.useRef<HTMLInputElement>(null);
   const ideMessenger = useContext(IdeMessengerContext);
+  const tokenUsageDisplayMode = useTokenUsageSetting();
 
   const [searchTerm, setSearchTerm] = useState("");
 
@@ -194,17 +197,26 @@ export function History() {
             {sessionGroups.map((group, groupIndex) => (
               <Fragment key={group.label}>
                 <tr
-                  className={`user-select-none sticky mb-3 ml-2 flex h-6 justify-start text-left text-base font-bold opacity-75 ${
+                  className={`user-select-none sticky mb-2 ml-2 flex justify-start text-left text-base font-bold opacity-75 ${
                     groupIndex === 0 ? "mt-2" : "mt-8"
                   }`}
                 >
-                  <td colSpan={3}>{group.label}</td>
+                  <td colSpan={3} className="flex w-full flex-col items-start">
+                    <span>{group.label}</span>
+                    {tokenUsageDisplayMode !== "never" &&
+                      group.usageTotals.totalTokens > 0 && (
+                        <span className="text-description-muted mt-0.5 text-xs font-normal leading-4">
+                          {formatTokenBreakdown(group.usageTotals)}
+                        </span>
+                      )}
+                  </td>
                 </tr>
                 {group.sessions.map((session, sessionIndex) => (
                   <HistoryTableRow
                     key={session.sessionId}
                     sessionMetadata={session}
                     index={sessionIndex}
+                    showTokenUsage={tokenUsageDisplayMode !== "never"}
                   />
                 ))}
               </Fragment>

--- a/gui/src/components/StepContainer/StepContainer.tsx
+++ b/gui/src/components/StepContainer/StepContainer.tsx
@@ -7,6 +7,7 @@ import { selectUIConfig } from "../../redux/slices/configSlice";
 import { deleteMessage } from "../../redux/slices/sessionSlice";
 import ThinkingBlockPeek from "../mainInput/belowMainInput/ThinkingBlockPeek";
 import StyledMarkdownPreview from "../StyledMarkdownPreview";
+import { formatUsageFooter } from "../../util/usage";
 import ConversationSummary from "./ConversationSummary";
 import ResponseActions from "./ResponseActions";
 import ThinkingIndicator from "./ThinkingIndicator";
@@ -16,6 +17,7 @@ interface StepContainerProps {
   index: number;
   isLast: boolean;
   latestSummaryIndex?: number;
+  showTurnTokenUsage?: boolean;
 }
 
 export default function StepContainer(props: StepContainerProps) {
@@ -102,6 +104,13 @@ export default function StepContainer(props: StepContainerProps) {
           </>
         )}
         {props.isLast && <ThinkingIndicator historyItem={props.item} />}
+        {props.showTurnTokenUsage &&
+          props.item.message.role === "assistant" &&
+          props.item.message.usage && (
+            <div className="text-description mt-2 px-2 text-xs">
+              {formatUsageFooter(props.item.message.usage)}
+            </div>
+          )}
       </div>
 
       {showResponseActions && (

--- a/gui/src/context/MockIdeMessenger.ts
+++ b/gui/src/context/MockIdeMessenger.ts
@@ -46,6 +46,14 @@ const DEFAULT_MOCK_CORE_RESPONSES: MockResponses = {
   "history/list": [],
   "docs/getIndexedPages": [],
   "history/save": undefined,
+  getIdeSettings: {
+    remoteConfigServerUrl: undefined,
+    remoteConfigSyncPeriod: 60,
+    userToken: "",
+    continueTestEnvironment: "none",
+    pauseCodebaseIndexOnStart: false,
+    showTokenUsage: "never",
+  },
   getControlPlaneSessionInfo: {
     AUTH_TYPE: AuthType.WorkOsStaging,
     accessToken: "",

--- a/gui/src/hooks/useTokenUsageSetting.ts
+++ b/gui/src/hooks/useTokenUsageSetting.ts
@@ -1,0 +1,33 @@
+import { useContext, useEffect, useState } from "react";
+import { IdeMessengerContext } from "../context/IdeMessenger";
+import { useWebviewListener } from "./useWebviewListener";
+
+export type TokenUsageDisplayMode = "never" | "history" | "session" | "turn";
+
+export function useTokenUsageSetting(): TokenUsageDisplayMode {
+  const ideMessenger = useContext(IdeMessengerContext);
+  const [mode, setMode] = useState<TokenUsageDisplayMode>("never");
+
+  useEffect(() => {
+    let mounted = true;
+    void ideMessenger.ide.getIdeSettings().then((settings) => {
+      if (!mounted) {
+        return;
+      }
+      setMode((settings.showTokenUsage ?? "never") as TokenUsageDisplayMode);
+    });
+    return () => {
+      mounted = false;
+    };
+  }, [ideMessenger]);
+
+  useWebviewListener(
+    "ideSettingsUpdate",
+    async (settings) => {
+      setMode((settings.showTokenUsage ?? "never") as TokenUsageDisplayMode);
+    },
+    [],
+  );
+
+  return mode;
+}

--- a/gui/src/pages/stats.tsx
+++ b/gui/src/pages/stats.tsx
@@ -20,13 +20,19 @@ const Tr = styled.tr`
   }
 
   overflow-wrap: anywhere;
-
   border: 1px solid ${lightGray};
 `;
 
 const Td = styled.td`
   padding: 0.5rem;
   border: 1px solid ${lightGray};
+`;
+
+const Note = styled.div`
+  margin: 0.5rem 0.5rem 0.75rem;
+  color: ${lightGray};
+  font-size: 12px;
+  line-height: 1.4;
 `;
 
 function generateTable(data: unknown[][]) {
@@ -47,17 +53,21 @@ function Stats() {
 
   useEffect(() => {
     ideMessenger.request("stats/getTokensPerDay", undefined).then((result) => {
-      result.status === "success" && setDays(result.content);
+      if (result.status === "success") {
+        setDays(result.content);
+      }
     });
-  }, []);
+  }, [ideMessenger]);
 
   useEffect(() => {
     ideMessenger
       .request("stats/getTokensPerModel", undefined)
       .then((result) => {
-        result.status === "success" && setModels(result.content);
+        if (result.status === "success") {
+          setModels(result.content);
+        }
       });
-  }, []);
+  }, [ideMessenger]);
 
   return (
     <div
@@ -65,14 +75,19 @@ function Stats() {
         backgroundColor: vscBackground,
       }}
     >
-      <PageHeader title="More" onTitleClick={() => navigate(-1)} showBorder />
+      <PageHeader title="Usage" onTitleClick={() => navigate(-1)} showBorder />
 
       <div className="p-2">
+        <Note>
+          Local analytics totals are stored separately from chat history and can
+          differ from visible session totals.
+        </Note>
+
         <div className="flex items-center gap-2">
-          <h2 className="ml-2">Tokens per Day</h2>
+          <h2 className="ml-2">Tokens Per Day</h2>
           <CopyIconButton
             text={generateTable(
-              ([["Day", "Generated Tokens", "Prompt Tokens"]] as any).concat(
+              ([["Day", "Output Tokens", "Input Tokens"]] as any).concat(
                 days.map((day) => [
                   day.day,
                   day.generatedTokens,
@@ -86,13 +101,13 @@ function Stats() {
           <thead>
             <Tr>
               <Th>Day</Th>
-              <Th>Generated Tokens</Th>
-              <Th>Prompt Tokens</Th>
+              <Th>Output Tokens</Th>
+              <Th>Input Tokens</Th>
             </Tr>
           </thead>
           <tbody>
             {days.map((day) => (
-              <Tr key={day.day} className="">
+              <Tr key={day.day}>
                 <Td>{day.day}</Td>
                 <Td>{day.generatedTokens.toLocaleString()}</Td>
                 <Td>{day.promptTokens.toLocaleString()}</Td>
@@ -102,10 +117,10 @@ function Stats() {
         </table>
 
         <div className="flex items-center gap-2">
-          <h2 className="ml-2">Tokens per Model</h2>
+          <h2 className="ml-2">Tokens Per Model</h2>
           <CopyIconButton
             text={generateTable(
-              ([["Model", "Generated Tokens", "Prompt Tokens"]] as any).concat(
+              ([["Model", "Output Tokens", "Input Tokens"]] as any).concat(
                 models.map((model) => [
                   model.model,
                   model.generatedTokens.toLocaleString(),
@@ -119,13 +134,13 @@ function Stats() {
           <thead>
             <Tr>
               <Th>Model</Th>
-              <Th>Generated Tokens</Th>
-              <Th>Prompt Tokens</Th>
+              <Th>Output Tokens</Th>
+              <Th>Input Tokens</Th>
             </Tr>
           </thead>
           <tbody>
             {models.map((model) => (
-              <Tr key={model.model} className="">
+              <Tr key={model.model}>
                 <Td>{model.model}</Td>
                 <Td>{model.generatedTokens.toLocaleString()}</Td>
                 <Td>{model.promptTokens.toLocaleString()}</Td>

--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -651,6 +651,14 @@ export const sessionSlice = createSlice({
             handleStreamingToolCallUpdates(message, lastItem);
           }
 
+          if (
+            message.role === "assistant" &&
+            lastMessage.role === "assistant" &&
+            message.usage
+          ) {
+            lastMessage.usage = message.usage;
+          }
+
           // Attach Responses API output item id to the current assistant message if present
           // fromResponsesChunk sets message.metadata.responsesOutputItemId when it sees output_item.added for messages
           if (

--- a/gui/src/redux/thunks/session.ts
+++ b/gui/src/redux/thunks/session.ts
@@ -6,6 +6,7 @@ import { renderChatMessage } from "core/util/messageContent";
 import { IIdeMessenger } from "../../context/IdeMessenger";
 import { selectSelectedChatModel } from "../slices/configSlice";
 import { selectSelectedProfile } from "../slices/profilesSlice";
+import { summarizeSessionUsage } from "../../util/usage";
 import {
   deleteSessionMetadata,
   newSession,
@@ -291,6 +292,17 @@ export const saveCurrentSession = createAsyncThunk<
       title = NEW_SESSION_TITLE;
     }
 
+    const sessionUsageTotals = summarizeSessionUsage(session.history);
+    const usage =
+      sessionUsageTotals.turnsWithUsage > 0
+        ? {
+            promptTokens: sessionUsageTotals.promptTokens,
+            completionTokens: sessionUsageTotals.completionTokens,
+            totalTokens: sessionUsageTotals.totalTokens,
+            totalCost: 0,
+          }
+        : undefined;
+
     const updatedSession: Session = {
       sessionId: session.id,
       title,
@@ -298,6 +310,7 @@ export const saveCurrentSession = createAsyncThunk<
       history: session.history,
       mode: session.mode,
       chatModelTitle: selectedChatModel?.title ?? null,
+      ...(usage ? { usage } : {}),
     };
 
     const result = await dispatch(updateSession(updatedSession));

--- a/gui/src/util/usage.ts
+++ b/gui/src/util/usage.ts
@@ -1,0 +1,59 @@
+import { ChatHistoryItem, Usage } from "core";
+
+export interface SessionUsageTotals {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  turnsWithUsage: number;
+}
+
+export function summarizeSessionUsage(
+  history: ChatHistoryItem[],
+): SessionUsageTotals {
+  return history.reduce<SessionUsageTotals>(
+    (acc, item) => {
+      if (item.message.role !== "assistant" || !item.message.usage) {
+        return acc;
+      }
+
+      const usage = item.message.usage;
+      const promptTokens = usage.promptTokens ?? 0;
+      const completionTokens = usage.completionTokens ?? 0;
+      const totalTokens = usage.totalTokens ?? promptTokens + completionTokens;
+
+      acc.promptTokens += promptTokens;
+      acc.completionTokens += completionTokens;
+      acc.totalTokens += totalTokens;
+      acc.turnsWithUsage += 1;
+      return acc;
+    },
+    {
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+      turnsWithUsage: 0,
+    },
+  );
+}
+
+export function formatUsageFooter(usage: Usage): string {
+  const promptTokens = usage.promptTokens ?? 0;
+  const completionTokens = usage.completionTokens ?? 0;
+  const totalTokens = usage.totalTokens ?? promptTokens + completionTokens;
+  return formatTokenBreakdown({
+    promptTokens,
+    completionTokens,
+    totalTokens,
+  });
+}
+
+export function formatTokenBreakdown(params: {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens?: number;
+}): string {
+  const promptTokens = params.promptTokens ?? 0;
+  const completionTokens = params.completionTokens ?? 0;
+  const totalTokens = params.totalTokens ?? promptTokens + completionTokens;
+  return `Tokens used: ${promptTokens.toLocaleString()} in / ${completionTokens.toLocaleString()} out (${totalTokens.toLocaleString()} total)`;
+}


### PR DESCRIPTION
## Description

Address issue #10567 

Adds token usage persistence/display improvements in VS Code Chat + History with a single display setting and turn/session/history granularity.

I used codex to help me to do this cause my typescript is is rusty. This is my first PR for continue, so please let me know anything I can do to conform better to your flow! Open to adding support for JetBrains if desired.

Main changes:
- Added a unified setting: `continue.showTokenUsage` with values:
  - `never`
  - `history`
  - `session` (history + session)
  - `turn` (history + session + turn)
- Made setting behavior dynamic via `ideSettingsUpdate` so UI updates immediately without manual window reload.
- Persisted usage in session artifacts:
  - per assistant turn (`message.usage` in session history)
  - per session totals (`session.usage`)
  - mirrored in `sessions.json` metadata (`BaseSessionMetadata.usage`)
- Added history usage display:
  - per time bucket group rows (Today / This Week / etc.)
  - per session row, styled to match existing repo/folder secondary text
- Added session usage summary in Chat and turn-level footer display based on setting mode.
- Standardized wording to “Tokens used” and “turn” terminology.
- Kept existing stats database/schema intact; updated stats page wording to clarify that stats totals are local analytics totals and may differ from visible session totals.
- Extended provider usage extraction where available (including OpenAI-compatible usage paths and provider-specific mappings implemented in this change).

Scope notes:
- Token tracking is "always on", setting controls display only
- No database migration introduced.

## AI Code Review

- Team members only: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Turn + session token usage display
<img width="330" height="834" alt="image" src="https://github.com/user-attachments/assets/d1773edb-0a27-4cea-8986-01748821d72e" />

History token usage display
<img width="324" height="386" alt="image" src="https://github.com/user-attachments/assets/2ef0b25a-edff-4ce2-aa76-36cb153a1595" />

help->stats (added consistency warning)
<img width="328" height="572" alt="image" src="https://github.com/user-attachments/assets/07b2e782-370b-451b-9ee6-ce70d3e342c3" />

new config option
<img width="821" height="537" alt="image" src="https://github.com/user-attachments/assets/95145ae2-8751-4e6d-8c6a-3854e5a07583" />

## Tests

Manual testing: ran extension in debug mode and checked that features appear and work as expected

Automated testing below

Updated tests:
- `core/llm/openaiTypeConverters.test.ts`
  - added coverage for usage extraction from non-stream and usage-only stream chunks
- `gui/src/redux/slices/sessionSlice.test.ts`
  - added coverage for persisting assistant usage on normal and usage-only stream updates

Local checks run:
- `npm run format:check` (repo root)
- `cd core && npx tsc --noEmit`
- `cd core && npm run lint`
- `cd core && npm run vitest`
- `cd gui && npx tsc --noEmit`
- `cd gui && npm run lint`
- `cd gui && npm test`
- `cd binary && npx tsc --noEmit`
- `cd extensions/vscode && npm run write-build-timestamp`
- `cd extensions/vscode && npx tsc --noEmit`
- `cd extensions/vscode && npm run lint`
- `cd extensions/vscode && npm run vitest`
- `node ./scripts/build-packages.js`
- `cd extensions/vscode && npm run e2e:compile`
- package tests run across `packages/*` (with `npm ci` where needed)

Note:
- `cd core && npm test` had an environment-specific network failure in this local machine (`ENOTFOUND` to Sentry host in `llm/countTokens.test.ts`), not tied to this feature logic.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue-stage.tools/inbox?pr=https%3A%2F%2Fgithub.com%2Fcontinuedev%2Fcontinue%2Fpull%2F10568&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-turn, per-session, and history token usage tracking with a single display setting in VS Code, updated live without reload. Addresses Issue #10567.

- **New Features**
  - Added setting: continue.showTokenUsage = "never" | "history" | "session" | "turn" (tracking always on; setting controls visibility).
  - Live UI updates via ideSettingsUpdate (webview passthrough added).
  - Persist usage in assistant turns, session metadata, and prompt logs; hydrate usage for older sessions on load.
  - History shows totals per time group and per session; Chat shows a session summary and per-turn footer based on the setting.
  - Extract and attach provider usage for OpenAI, Anthropic, Bedrock, Cohere, Gemini, and Ollama (streaming and non-stream paths).
  - Updated docs and tests for usage parsing, display, and persistence.

- **Bug Fixes**
  - Fallback to local token counting when providers return zero usage, preventing undercounting.
  - Improved history hydration to backfill session usage from saved turns.
  - Ensured ide settings changes propagate to the webview immediately.

- **Migration**
  - No migration required. Default setting is "never".

<sup>Written for commit a4aaf9d07e124b477c9195eb6655c91c1c039d51. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



