### PR TITLE
docs: fix checks best practices examples and add skill links

### DIFF
--- a/docs/checks/best-practices.mdx
+++ b/docs/checks/best-practices.mdx
@@ -40,7 +40,7 @@ Check that the code is secure.
 Structure criteria as a concrete list:
 
 ```markdown
-Look for these issues in the changed code and fix them:
+Look for these issues and fix them:
 
 - New REST endpoints missing request body validation
 - Database queries using string interpolation instead of parameterized queries
@@ -101,7 +101,7 @@ name: Security Review
 description: Catch hardcoded secrets, injection vectors, and missing input validation
 ---
 
-Look for these security issues in the changed code and fix them:
+Look for these security issues and fix them:
 
 - Hardcoded API keys, tokens, passwords, or connection strings — move them to environment variables
 - New API endpoints or request handlers without input validation — add appropriate validation
@@ -147,23 +147,6 @@ Look for changes to public-facing APIs or configuration where the documentation 
 - API route paths or request/response shapes changed — update the API documentation
 
 No changes needed if the PR doesn't touch public APIs or configuration, or if docs were already updated.
-````
-
-### Conventional commits
-
-````markdown conventional-commits.md
----
-name: Conventional Commits
-description: Ensure the PR title follows conventional commit format
----
-
-Check that the pull request title follows the Conventional Commits specification.
-
-The title must match this format: `type(optional scope): description`
-
-Valid types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
-
-If the PR title doesn't match the format, suggest a corrected title based on the content of the changes.
 ````
 
 ### Dependency audit

--- a/docs/checks/generating-checks.mdx
+++ b/docs/checks/generating-checks.mdx
@@ -2,7 +2,7 @@
 title: "Generating Checks"
 ---
 
-The best way to create checks is to have your coding agent write them. Install the writing-checks skill to teach your agent the check file format and best practices:
+The best way to create checks is to have your coding agent write them. Install the [`writing-checks`](https://github.com/continuedev/skills?tab=readme-ov-file#writing-checks) skill to teach your agent the check file format and best practices:
 
 ```bash
 npx skills add continuedev/skills --skill writing-checks

--- a/docs/checks/running-locally.mdx
+++ b/docs/checks/running-locally.mdx
@@ -6,6 +6,8 @@ Run your checks locally before pushing to CI using the `/check` command in your 
 
 ## Install
 
+Install the [`check`](https://github.com/continuedev/skills?tab=readme-ov-file#check) skill:
+
 ```bash
 npx skills add continuedev/skills --skill check
 ```


### PR DESCRIPTION
## Summary

- Remove diff-scoping language ("in the changed code") from two examples on the best practices page that contradicted the page's own advice about not including scoping instructions
- Delete the Conventional Commits example since PR title format validation is a pattern-match task better suited for a linter — contradicts the "Checks vs. tests vs. linting" guidance on the same page
- Add links to the `writing-checks` and `check` skills on their respective pages

## Test plan

- [ ] Verify the best practices page renders correctly
- [ ] Confirm no remaining examples contain diff-scoping language
- [ ] Confirm skill links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 7 not started · ✅ 13 no changes · 🔴 1 closed — [View all](https://hub.continue-stage.tools/inbox/pr/continuedev/continue/10591?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align checks docs with best practices and make skill installation clearer. Removed diff-scoping language from two examples, deleted the Conventional Commits example (title format should be linted), and added links to the writing-checks and check skills.

<sup>Written for commit d81d5936480d0b27100c9aed361c680595618c64. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

