### PR TITLE
feat: Claude Sonnet and Opus 4.6 updates

### DIFF
--- a/core/llm/llms/Anthropic.ts
+++ b/core/llm/llms/Anthropic.ts
@@ -35,9 +35,9 @@ import { BaseLLM } from "../index.js";
 class Anthropic extends BaseLLM {
   static providerName = "anthropic";
   static defaultOptions: Partial<LLMOptions> = {
-    model: "claude-3-5-sonnet-latest",
+    model: "claude-sonnet-4-6",
     completionOptions: {
-      model: "claude-3-5-sonnet-latest",
+      model: "claude-sonnet-4-6",
       maxTokens: 8192,
     },
     apiBase: "https://api.anthropic.com/v1/",

--- a/core/llm/llms/CometAPI.ts
+++ b/core/llm/llms/CometAPI.ts
@@ -197,6 +197,8 @@ class CometAPI extends OpenAI {
     "o3-pro-2025-06-10",
 
     // Claude series
+    "claude-sonnet-4-6",
+    "claude-opus-4-6",
     "claude-opus-4-1-20250805",
     "claude-opus-4-1-20250805-thinking",
     "claude-sonnet-4-20250514",

--- a/core/llm/utils/calculateRequestCost.ts
+++ b/core/llm/utils/calculateRequestCost.ts
@@ -17,6 +17,22 @@ function calculateAnthropicCost(
     string,
     { input: number; output: number; cacheWrite: number; cacheRead: number }
   > = {
+    // Claude Sonnet 4.6
+    "claude-sonnet-4-6": {
+      input: 3,
+      output: 15,
+      cacheWrite: 3.75,
+      cacheRead: 0.3,
+    },
+
+    // Claude Opus 4.6
+    "claude-opus-4-6": {
+      input: 5,
+      output: 25,
+      cacheWrite: 6.25,
+      cacheRead: 0.5,
+    },
+
     // Claude Opus 4.5 (most intelligent model)
     "claude-opus-4-5": {
       input: 5,

--- a/extensions/cli/src/e2e/headless-anthropic-api-key.test.ts
+++ b/extensions/cli/src/e2e/headless-anthropic-api-key.test.ts
@@ -115,7 +115,7 @@ models:
 
     if (configExists) {
       const configContent = await fs.readFile(configPath, "utf-8");
-      expect(configContent).toContain("anthropic/claude-sonnet-4-5");
+      expect(configContent).toContain("anthropic/claude-sonnet-4-6");
       expect(configContent).toContain(
         "ANTHROPIC_API_KEY: TEST-test-invalid-key-format",
       );

--- a/extensions/cli/src/services/ConfigService.test.ts
+++ b/extensions/cli/src/services/ConfigService.test.ts
@@ -537,7 +537,7 @@ describe("ConfigService", () => {
             uriType: "slug",
             fullSlug: {
               ownerSlug: "anthropic",
-              packageSlug: "claude-sonnet-4-5",
+              packageSlug: "claude-sonnet-4-6",
               versionSlug: "1.0.0",
             },
           },

--- a/extensions/cli/src/services/ConfigService.ts
+++ b/extensions/cli/src/services/ConfigService.ts
@@ -31,7 +31,7 @@ const DEFAULT_MODEL_IDENTIFIER: PackageIdentifier = {
   uriType: "slug",
   fullSlug: {
     ownerSlug: "anthropic",
-    packageSlug: "claude-sonnet-4-5",
+    packageSlug: "claude-sonnet-4-6",
     versionSlug: "1.0.0",
   },
 };

--- a/extensions/cli/src/util/yamlConfigUpdater.test.ts
+++ b/extensions/cli/src/util/yamlConfigUpdater.test.ts
@@ -12,7 +12,7 @@ describe("updateAnthropicModelInYaml", () => {
       expect(result).toContain("name: Local Config");
       expect(result).toContain("version: 1.0.0");
       expect(result).toContain("schema: v1");
-      expect(result).toContain("uses: anthropic/claude-sonnet-4-5");
+      expect(result).toContain("uses: anthropic/claude-sonnet-4-6");
       expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
     });
 
@@ -21,7 +21,7 @@ describe("updateAnthropicModelInYaml", () => {
       const result = updateAnthropicModelInYaml(invalidYaml, testApiKey);
 
       expect(result).toContain("name: Local Config");
-      expect(result).toContain("uses: anthropic/claude-sonnet-4-5");
+      expect(result).toContain("uses: anthropic/claude-sonnet-4-6");
       expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
     });
   });
@@ -44,7 +44,7 @@ models:
       expect(result).toContain("# My Continue config");
       expect(result).toContain("# List of available models");
       expect(result).toContain("uses: openai/gpt-4");
-      expect(result).toContain("uses: anthropic/claude-sonnet-4-5");
+      expect(result).toContain("uses: anthropic/claude-sonnet-4-6");
       expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
     });
 
@@ -55,7 +55,7 @@ version: 1.0.0
 schema: v1
 # List of available models
 models:
-  - uses: anthropic/claude-sonnet-4-5
+  - uses: anthropic/claude-sonnet-4-6
     with:
       ANTHROPIC_API_KEY: old-key
 `;
@@ -64,7 +64,7 @@ models:
 
       expect(result).toContain("# My Continue config");
       expect(result).toContain("# List of available models");
-      expect(result).toContain("uses: anthropic/claude-sonnet-4-5");
+      expect(result).toContain("uses: anthropic/claude-sonnet-4-6");
       expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
       expect(result).not.toContain("old-key");
     });
@@ -84,7 +84,7 @@ models:
       const result = updateAnthropicModelInYaml(existingConfig, testApiKey);
 
       expect(result).toContain("uses: openai/gpt-4");
-      expect(result).toContain("uses: anthropic/claude-sonnet-4-5");
+      expect(result).toContain("uses: anthropic/claude-sonnet-4-6");
       expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
       expect(result).toContain("OPENAI_API_KEY: TEST-openai-test");
     });
@@ -94,7 +94,7 @@ models:
 version: 1.0.0
 schema: v1
 models:
-  - uses: anthropic/claude-sonnet-4-5
+  - uses: anthropic/claude-sonnet-4-6
     with:
       ANTHROPIC_API_KEY: old-anthropic-key
   - uses: openai/gpt-4
@@ -104,7 +104,7 @@ models:
 
       const result = updateAnthropicModelInYaml(existingConfig, testApiKey);
 
-      expect(result).toContain("uses: anthropic/claude-sonnet-4-5");
+      expect(result).toContain("uses: anthropic/claude-sonnet-4-6");
       expect(result).toContain("uses: openai/gpt-4");
       expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
       expect(result).toContain("OPENAI_API_KEY: TEST-openai-test");
@@ -130,7 +130,7 @@ schema: v1
 
       expect(result).toContain("name: Local Config");
       expect(result).toContain("models:");
-      expect(result).toContain("uses: anthropic/claude-sonnet-4-5");
+      expect(result).toContain("uses: anthropic/claude-sonnet-4-6");
       expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
     });
 
@@ -147,7 +147,7 @@ models: []
       );
 
       expect(result).toContain("name: Local Config");
-      expect(result).toContain("uses: anthropic/claude-sonnet-4-5");
+      expect(result).toContain("uses: anthropic/claude-sonnet-4-6");
       expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
     });
   });
@@ -189,7 +189,7 @@ models: "not an array"
 
       const result = updateAnthropicModelInYaml(malformedConfig, testApiKey);
 
-      expect(result).toContain("uses: anthropic/claude-sonnet-4-5");
+      expect(result).toContain("uses: anthropic/claude-sonnet-4-6");
       expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
     });
 

--- a/extensions/cli/src/util/yamlConfigUpdater.ts
+++ b/extensions/cli/src/util/yamlConfigUpdater.ts
@@ -27,7 +27,7 @@ export function updateAnthropicModelInYaml(
   apiKey: string,
 ): string {
   const newModel: ModelConfig = {
-    uses: "anthropic/claude-sonnet-4-5",
+    uses: "anthropic/claude-sonnet-4-6",
     with: {
       ANTHROPIC_API_KEY: apiKey,
     },
@@ -62,7 +62,7 @@ export function updateAnthropicModelInYaml(
 
     // Filter out existing anthropic models
     config.models = config.models.filter(
-      (model: any) => !model || model.uses !== "anthropic/claude-sonnet-4-5",
+      (model: any) => !model || model.uses !== "anthropic/claude-sonnet-4-6",
     );
 
     // Add the new anthropic model

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -850,6 +850,8 @@
                 "anyOf": [
                   {
                     "enum": [
+                      "claude-sonnet-4-6",
+                      "claude-opus-4-6",
                       "claude-sonnet-4",
                       "claude-sonnet-4-5",
                       "claude-opus-4-1",
@@ -1612,6 +1614,8 @@
                       "codeup-13b",
                       "deepseek-7b",
                       "deepseek-33b",
+                      "claude-sonnet-4-6",
+                      "claude-opus-4-6",
                       "claude-sonnet-4",
                       "claude-sonnet-4-5",
                       "claude-opus-4-1",

--- a/gui/src/pages/AddNewModel/configs/models.ts
+++ b/gui/src/pages/AddNewModel/configs/models.ts
@@ -1317,14 +1317,42 @@ export const models: { [key: string]: ModelPackage } = {
     icon: "openai.png",
     isOpenSource: false,
   },
+  claude46Sonnet: {
+    title: "Claude Sonnet 4.6",
+    description:
+      "Anthropic's latest and most capable Sonnet model with exceptional coding, reasoning, and multilingual performance.",
+    params: {
+      model: "claude-sonnet-4-6",
+      contextLength: 200_000,
+      title: "Claude Sonnet 4.6",
+      apiKey: "",
+    },
+    providerOptions: ["anthropic", "replicate"],
+    icon: "anthropic.png",
+    isOpenSource: false,
+  },
+  claude46Opus: {
+    title: "Claude Opus 4.6",
+    description:
+      "Anthropic's most intelligent model with the highest level of capability for complex reasoning and agentic tasks.",
+    params: {
+      model: "claude-opus-4-6",
+      contextLength: 200_000,
+      title: "Claude Opus 4.6",
+      apiKey: "",
+    },
+    providerOptions: ["anthropic"],
+    icon: "anthropic.png",
+    isOpenSource: false,
+  },
   claude45Sonnet: {
     title: "Claude Sonnet 4.5",
     description:
-      "Anthropic's smartest model for complex agents and coding with exceptional performance in reasoning and multilingual tasks.",
+      "Previous generation Sonnet model with strong performance in reasoning and multilingual tasks.",
     params: {
       model: "claude-sonnet-4-5-20250929",
       contextLength: 200_000,
-      title: "Claude 4.5 Sonnet",
+      title: "Claude Sonnet 4.5",
       apiKey: "",
     },
     providerOptions: ["anthropic", "replicate"],
@@ -1360,12 +1388,12 @@ export const models: { [key: string]: ModelPackage } = {
     isOpenSource: false,
   },
   claude4_5Opus: {
-    title: "Claude 4.5 Opus",
+    title: "Claude Opus 4.5",
     description: "The most capable model in the Claude 4.5 series",
     params: {
       model: "claude-opus-4-5",
       contextLength: 200_000,
-      title: "Claude 4.5 Opus",
+      title: "Claude Opus 4.5",
       apiKey: "",
     },
     providerOptions: ["anthropic"],
@@ -1843,13 +1871,13 @@ export const models: { [key: string]: ModelPackage } = {
     isOpenSource: false,
   },
   asksageclaude45sonnet: {
-    title: "Claude 4.5 Sonnet*",
+    title: "Claude Sonnet 4.5*",
     description:
       "Anthropic's most powerful model, designed for complex, reasoning-heavy tasks like agentic search, coding, and writing.",
     params: {
       model: "google-claude-45-sonnet",
       contextLength: 200_000,
-      title: "Claude 4.5 Sonnet*",
+      title: "Claude Sonnet 4.5*",
       apiKey: "",
     },
     providerOptions: ["askSage"],
@@ -2566,13 +2594,13 @@ export const models: { [key: string]: ModelPackage } = {
     isOpenSource: false,
   },
   cometapiClaude45Sonnet: {
-    title: "Claude 4.5 Sonnet Latest",
+    title: "Claude Sonnet 4.5 Latest",
     description:
-      "Claude 4.5 Sonnet Latest via CometAPI - Anthropic's smartest model for complex agents and coding.",
+      "Claude Sonnet 4.5 Latest via CometAPI - Anthropic's smartest model for complex agents and coding.",
     params: {
       model: "claude-sonnet-4-5-20250929",
       contextLength: 200_000,
-      title: "Claude 4.5 Sonnet Latest",
+      title: "Claude Sonnet 4.5 Latest",
       apiKey: "",
     },
     providerOptions: ["cometapi"],
@@ -2580,13 +2608,13 @@ export const models: { [key: string]: ModelPackage } = {
     isOpenSource: false,
   },
   cometapiClaude45Haiku: {
-    title: "Claude 4.5 Haiku Latest",
+    title: "Claude Haiku 4.5 Latest",
     description:
-      "Claude 4.5 Haiku Latest via CometAPI - Anthropic's fastest model with near-frontier intelligence.",
+      "Claude Haiku 4.5 Latest via CometAPI - Anthropic's fastest model with near-frontier intelligence.",
     params: {
       model: "claude-haiku-4-5-20251001",
       contextLength: 200_000,
-      title: "Claude 4.5 Haiku Latest",
+      title: "Claude Haiku 4.5 Latest",
       apiKey: "",
     },
     providerOptions: ["cometapi"],
@@ -2621,12 +2649,12 @@ export const models: { [key: string]: ModelPackage } = {
     isOpenSource: false,
   },
   asksageclaude45sonnetgov: {
-    title: "Claude 4.5 Sonnet gov*",
+    title: "Claude Sonnet 4.5 gov*",
     description: "Anthropic's 4.5 Sonnet model.",
     params: {
       model: "aws-bedrock-claude-45-sonnet-gov",
       contextLength: 200_000,
-      title: "Claude 4.5 Sonnet gov*",
+      title: "Claude Sonnet 4.5 gov*",
       apiKey: "",
     },
     providerOptions: ["askSage"],
@@ -2634,12 +2662,12 @@ export const models: { [key: string]: ModelPackage } = {
     isOpenSource: false,
   },
   asksageclaude45opus: {
-    title: "Claude 4.5 Opus*",
-    description: "Claude 4.5 Opus",
+    title: "Claude Opus 4.5*",
+    description: "Claude Opus 4.5",
     params: {
       model: "google-claude-45-opus",
       contextLength: 200_000,
-      title: "Claude 4.5 Opus*",
+      title: "Claude Opus 4.5*",
       apiKey: "",
     },
     providerOptions: ["askSage"],
@@ -2647,12 +2675,12 @@ export const models: { [key: string]: ModelPackage } = {
     isOpenSource: false,
   },
   asksageclaude45haiku: {
-    title: "Claude 4.5 Haiku*",
-    description: "Claude 4.5 Haiku",
+    title: "Claude Haiku 4.5*",
+    description: "Claude Haiku 4.5",
     params: {
       model: "google-claude-45-haiku",
       contextLength: 200_000,
-      title: "Claude 4.5 Haiku*",
+      title: "Claude Haiku 4.5*",
       apiKey: "",
     },
     providerOptions: ["askSage"],

--- a/gui/src/pages/AddNewModel/configs/providers.ts
+++ b/gui/src/pages/AddNewModel/configs/providers.ts
@@ -204,6 +204,8 @@ export const providers: Partial<Record<string, ProviderInfo>> = {
       },
     ],
     packages: [
+      models.claude46Opus,
+      models.claude46Sonnet,
       models.claude4_5Opus,
       models.claude45Sonnet,
       models.claude45Haiku,

--- a/packages/config-yaml/src/schemas/commonSlugs.ts
+++ b/packages/config-yaml/src/schemas/commonSlugs.ts
@@ -1,4 +1,6 @@
 export const commonModelSlugs = [
+  "anthropic/claude-sonnet-4-6",
+  "anthropic/claude-opus-4-6",
   "anthropic/claude-sonnet-4",
   "togetherai/llama-4-maverick-instruct-17bx128e",
   "google/gemini-2.5-pro",

--- a/packages/llm-info/src/providers/anthropic.ts
+++ b/packages/llm-info/src/providers/anthropic.ts
@@ -5,18 +5,38 @@ export const Anthropic: ModelProvider = {
   displayName: "Anthropic",
   models: [
     {
-      model: "claude-sonnet-4-5-20250929",
-      displayName: "Claude 4.5 Sonnet",
+      model: "claude-sonnet-4-6",
+      displayName: "Claude Sonnet 4.6",
       contextLength: 200000,
       maxCompletionTokens: 64000,
       description:
-        "Anthropic's smartest model for complex agents and coding with exceptional performance in reasoning and multilingual tasks.",
+        "Anthropic's latest and most capable Sonnet model with exceptional coding, reasoning, and multilingual performance.",
+      regex: /claude-(?:4[.-]6-sonnet|sonnet-4[.-]6).*/i,
+      recommendedFor: ["chat"],
+    },
+    {
+      model: "claude-opus-4-6",
+      displayName: "Claude Opus 4.6",
+      contextLength: 200000,
+      maxCompletionTokens: 64000,
+      description:
+        "Anthropic's most intelligent model with the highest level of capability for complex reasoning and agentic tasks.",
+      regex: /claude-(?:4[.-]6-opus|opus-4[.-]6).*/i,
+      recommendedFor: ["chat"],
+    },
+    {
+      model: "claude-sonnet-4-5-20250929",
+      displayName: "Claude Sonnet 4.5",
+      contextLength: 200000,
+      maxCompletionTokens: 64000,
+      description:
+        "Previous generation Sonnet model with strong performance in reasoning and multilingual tasks.",
       regex: /claude-(?:4[.-]5-sonnet|sonnet-4[.-]5).*/i,
       recommendedFor: ["chat"],
     },
     {
       model: "claude-haiku-4-5-20251001",
-      displayName: "Claude 4.5 Haiku",
+      displayName: "Claude Haiku 4.5",
       contextLength: 200000,
       maxCompletionTokens: 64000,
       description:
@@ -30,7 +50,7 @@ export const Anthropic: ModelProvider = {
       contextLength: 200000,
       maxCompletionTokens: 32000,
       description:
-        "Exceptional model for specialized reasoning tasks with advanced agentic capabilities and superior coding performance.",
+        "Previous generation Opus model with advanced agentic capabilities and coding performance.",
       regex: /claude-opus-4[.-]1.*/i,
       recommendedFor: ["chat"],
     },
@@ -40,7 +60,7 @@ export const Anthropic: ModelProvider = {
       contextLength: 200000,
       maxCompletionTokens: 8192,
       description:
-        "Previous generation model with strong coding and reasoning capabilities, now superseded by Claude 4.5 Sonnet.",
+        "Previous generation model with strong coding and reasoning capabilities.",
       // Sometimes written as claude-4-sonnet, other times as claude-sonnet-4
       regex: /claude-(?:4-sonnet|sonnet-4).*/i,
       recommendedFor: ["chat"],
@@ -51,7 +71,7 @@ export const Anthropic: ModelProvider = {
       contextLength: 200000,
       maxCompletionTokens: 64000,
       description:
-        "Most intelligent model with the highest level of intelligence and capability.",
+        "Previous generation Opus with high intelligence and capability.",
       regex: /claude-(?:4-5-opus|opus-4-5).*/i,
       recommendedFor: ["chat"],
     },

--- a/packages/llm-info/src/providers/cometapi.ts
+++ b/packages/llm-info/src/providers/cometapi.ts
@@ -80,12 +80,30 @@ export const CometAPI: ModelProvider = {
 
     // Claude Series
     {
-      model: "claude-sonnet-4-5",
-      displayName: "Claude 4.5 Sonnet",
+      model: "claude-sonnet-4-6",
+      displayName: "Claude Sonnet 4.6",
       contextLength: 200000,
       maxCompletionTokens: 64000,
       description:
-        "Anthropic's smartest model for complex agents and coding with exceptional performance in reasoning and multilingual tasks.",
+        "Anthropic's latest and most capable Sonnet model with exceptional coding, reasoning, and multilingual performance.",
+      recommendedFor: ["chat"],
+    },
+    {
+      model: "claude-opus-4-6",
+      displayName: "Claude Opus 4.6",
+      contextLength: 200000,
+      maxCompletionTokens: 64000,
+      description:
+        "Anthropic's most intelligent model with the highest level of capability for complex reasoning and agentic tasks.",
+      recommendedFor: ["chat"],
+    },
+    {
+      model: "claude-sonnet-4-5",
+      displayName: "Claude Sonnet 4.5",
+      contextLength: 200000,
+      maxCompletionTokens: 64000,
+      description:
+        "Previous generation Sonnet model with strong performance in reasoning and multilingual tasks.",
       recommendedFor: ["chat"],
     },
     {


### PR DESCRIPTION
Add claude-sonnet-4-6 and claude-opus-4-6 as the new default Sonnet and Opus models across providers, GUI configs, schemas, cost calculation, and CLI defaults. Update display names for all >= 4.5 models to use name-first format (e.g. "Claude Sonnet 4.5" not "Claude 4.5 Sonnet").

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 7 not started · ✅ 20 no changes · ✅ 1 merged — [View all](https://hub.continue-stage.tools/inbox/pr/continuedev/continue/10600?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Claude Sonnet 4.6 and Claude Opus 4.6 and set them as the new defaults across core, CLI, GUI, schemas, and cost calculator. Standardize display names to “Claude <Name> <Version>” for all 4.5+ models.

- **New Features**
  - Default Anthropic model changed to claude-sonnet-4-6 (core and CLI).
  - 4.6 models added to providers (Anthropic, CometAPI), GUI catalog, VS Code schema, and YAML slugs.
  - Pricing added for 4.6 models in the request cost calculator.
  - Tests and YAML updater updated to target 4.6.
  - Display names updated to name-first format (e.g., “Claude Sonnet 4.5”, “Claude Haiku 4.5”, “Claude Opus 4.5”).

- **Migration**
  - New configs will default to Sonnet 4.6. Pin a specific model in your config if you want to keep 4.5 or another version.

<sup>Written for commit c006d4b231dac2b02b05b51645dc462b38fa5531. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

