### PR TITLE
feat: Add ModelsLab provider

### DIFF
--- a/core/llm/llms/ModelsLab.ts
+++ b/core/llm/llms/ModelsLab.ts
@@ -1,0 +1,54 @@
+import { CompletionOptions } from "../../..";
+
+import OpenAI from "./OpenAI";
+
+import type { ChatMessage } from "../chatTransformers.js";
+import type { LLMOptions } from "../../index.js";
+
+class ModelsLab extends OpenAI {
+  static providerName = "modelslab";
+  static defaultOptions: Partial<LLMOptions> = {
+    apiBase: "https://modelslab.com/api/uncensored-chat/v1/",
+    useLegacyCompletionsEndpoint: false,
+  };
+
+  private static MODEL_IDS: { [name: string]: string } = {
+    "llama3.1-8b": "meta-llama/Meta-Llama-3.1-8B-Instruct",
+    "llama3.1-70b": "meta-llama/Meta-Llama-3.1-70B-Instruct",
+    "llama3.1-405b": "meta-llama/Meta-Llama-3.1-405B-Instruct",
+    "llama3-8b": "meta-llama/Meta-Llama-3-8B-Instruct",
+    "llama3-70b": "meta-llama/Meta-Llama-3-70B-Instruct",
+    "llama2-70b": "meta-llama/Llama-2-70b-chat-hf",
+    "mistral-7b": "mistralai/Mistral-7B-Instruct-v0.2",
+    "mixtral-8x7b": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+    "mixtral-8x22b": "mistralai/Mixtral-8x22B-Instruct-v0.1",
+    "qwen-2.5-7b": "Qwen/Qwen2.5-7B-Instruct",
+    "qwen-2.5-14b": "Qwen/Qwen2.5-14B-Instruct",
+    "qwen-2.5-32b": "Qwen/Qwen2.5-32B-Instruct",
+    "qwen-2.5-72b": "Qwen/Qwen2.5-72B-Instruct",
+    "phi-3-mini-4k": "microsoft/Phi-3-mini-4k-instruct",
+    "phi-3-medium-4k": "microsoft/Phi-3-medium-4k-instruct",
+    "gemma-2-9b": "google/gemma-2-9b-it",
+    "gemma-2-27b": "google/gemma-2-27b-it",
+    "falcon-180b": "tiiuae/falcon-180B-chat",
+    "yi-34b": "01-ai/Yi-34B-Chat",
+  };
+
+  protected _convertModelName(model: string): string {
+    return ModelsLab.MODEL_IDS[model] || model;
+  }
+
+  protected _convertArgs(
+    options: CompletionOptions,
+    messages: ChatMessage[],
+  ): any {
+    // Apply model name conversion before creating the request body
+    const convertedOptions = {
+      ...options,
+      model: this._convertModelName(options.model),
+    };
+    return super._convertArgs(convertedOptions, messages);
+  }
+}
+
+export default ModelsLab;


### PR DESCRIPTION
# feat: Add ModelsLab provider

## Summary

Adds [ModelsLab](https://modelslab.com) as a provider in Continue, giving users access to uncensored Llama 3.1 8B and 70B models with 128K context windows.

## What is ModelsLab?

ModelsLab is an AI API platform providing uncensored language models via an OpenAI-compatible endpoint — ideal for code assistance, creative writing, and use cases where standard content filters are too restrictive.

- Website: https://modelslab.com
- Docs: https://docs.modelslab.com/uncensored-chat
- API key: https://modelslab.com/dashboard

## Files

### New files
- `core/llm/llms/ModelsLab.ts` — provider implementation
- `docs/docs/reference/model-providers/modelslab.md` — user documentation

### Modified files (one-line patches)

**`core/llm/llms/index.ts`** — add import and export:
```diff
+import ModelsLab from "./ModelsLab";

 export const ALL_PROVIDERS = {
   ...
+  modelslab: ModelsLab,
   ...
 };
```

## Implementation

Follows the exact same pattern as `Together`, `Groq`, `Fireworks`, and other OpenAI-compatible providers — extends `OpenAI` base class, sets `providerName` and `defaultOptions.apiBase`:

```typescript
class ModelsLab extends OpenAI {
  static providerName = "modelslab";
  static defaultOptions: Partial<LLMOptions> = {
    apiBase: "https://modelslab.com/uncensored-chat/v1/",
    model: "llama-3.1-8b-uncensored",
  };
}
```

No new dependencies. No behavior overrides. All streaming, tool calling, and completion logic is inherited from the OpenAI base class.

## Usage

```json
{
  "models": [{
    "title": "ModelsLab Llama 3.1 8B",
    "provider": "modelslab",
    "model": "llama-3.1-8b-uncensored",
    "apiKey": "YOUR_MODELSLAB_API_KEY"
  }]
}
```

## Models

| Model | Context | Notes |
|---|---|---|
| `llama-3.1-8b-uncensored` (default) | 128K | Fast, efficient |
| `llama-3.1-70b-uncensored` | 128K | Higher quality |

## Checklist

- [x] Extends `OpenAI` base class (same pattern as Together, Groq, Fireworks, Novita, etc.)
- [x] `static providerName` set to `"modelslab"`
- [x] `static defaultOptions` with `apiBase` and `model`
- [x] Model name alias map (`_convertModelName`)
- [x] No new dependencies
- [x] Documentation page with usage examples
- [x] Registered in `index.ts` (see patch above)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued · ▶️ 7 not started · ✅ 13 no changes — [View all](https://hub.continue-stage.tools/inbox/pr/continuedev/continue/10620?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ModelsLab as an OpenAI-compatible provider and fixes model alias resolution so short names map correctly to provider IDs.

- **New Features**
  - New provider: `modelslab`, extends `OpenAI` with apiBase https://modelslab.com/api/uncensored-chat/v1/.
  - Registered in the LLM provider list.
  - Docs added at customize/model-providers/more/modelslab with config examples.
  - GUI: provider card with API key input and presets for Llama 3.1 8B and 70B.

- **Bug Fixes**
  - Convert short model aliases (e.g., `llama3.1-8b`) to ModelsLab IDs in the request body so configs resolve to the correct models.

<sup>Written for commit 2023501812fb8d2a4b2b5afcae93686f93b4c784. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

