### PR TITLE
Fix displaying diff line when instant applying in jetbrains extensions

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/DiffStreamHandler.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/DiffStreamHandler.kt
@@ -247,7 +247,7 @@ class DiffStreamHandler(
                         currentBlock = createDiffBlock()
                         currentBlock!!.startLine = currentLine
                     }
-                    currentBlock!!.addedLines.add(text)
+                    currentBlock.addNewLineForHighlightOnly(text, currentLine);
                     currentLine++
                 }
                 DiffLineType.SAME -> {

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/VerticalDiffBlock.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/VerticalDiffBlock.kt
@@ -91,6 +91,13 @@ class VerticalDiffBlock(
         addedLines.add(text)
     }
 
+    fun addNewLineForHighlightOnly(text: String, line: Int) {
+        val greenKey = EditorUtils(editor).createTextAttributesKey("CONTINUE_DIFF_NEW_LINE", 0x3000FF00)
+        editor.markupModel.addLineHighlighter(greenKey, line, HighlighterLayer.LAST)
+
+        addedLines.add(text)
+    }
+
     fun onLastDiffLine() {
         // Handles the case where we are invoking one last time on last line of diff stream, but the block has
         // already been rendered


### PR DESCRIPTION
Before:
<img width="1169" height="765" alt="Снимок экрана 2026-02-18 в 22 12 59" src="https://github.com/user-attachments/assets/1197a0d8-ffba-466f-b273-d55ab854b05a" />

After:
<img width="1178" height="802" alt="Снимок экрана 2026-02-18 в 22 15 29" src="https://github.com/user-attachments/assets/8e500b7c-57ba-48c3-802d-d44adf51420c" />

Should also resolve same issue for multi-edit tool, since they use the same path. Should not affect edit_existing_file in any way.
No the cleanest solution, but it works.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Tests
no testing, trust me (c)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued · ▶️ 7 not started · ✅ 27 no changes — [View all](https://hub.continue-stage.tools/inbox/pr/continuedev/continue/10627?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing added-line highlights when instant-applying diffs in the JetBrains extension. Also fixes the same issue in the multi-edit tool; no impact to edit_existing_file.

- **Bug Fixes**
  - Send ADD lines to addNewLineForHighlightOnly with the current line to render the highlight during streaming.
  - Add addNewLineForHighlightOnly in VerticalDiffBlock to apply the green CONTINUE_DIFF_NEW_LINE highlighter and record the text.

<sup>Written for commit cc0b12e065d1787b856ec211f36abe7205853f5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

