### PR TITLE
fix: handle spaces in filepaths for JetBrains autocomplete

### DIFF
--- a/demo-pr.sh
+++ b/demo-pr.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Usage: ./demo-pr.sh [optional-suffix]
+# Creates a PR from a saved patch for demo purposes.
+# Run `git format-patch HEAD~1 -o /tmp/demo-patch/` first to save the patch.
+SUFFIX="${1:-$(date +%s)}"
+BRANCH="fix/spaces-in-filepath-${SUFFIX}"
+BASE="main"
+
+git checkout "$BASE"
+git checkout -b "$BRANCH"
+git am /tmp/demo-patch/*.patch
+git push -u origin "$BRANCH"
+gh pr create --title "fix: handle spaces in filepaths for JetBrains autocomplete" \
+  --body "Fixes #10613" --base "$BASE"

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/UriUtils.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/UriUtils.kt
@@ -4,36 +4,54 @@ import java.io.File
 import java.net.URI
 
 /**
- * Utility class for URI operations
+ * Utility class for URI operations.
+ *
+ * Provides methods for parsing URI strings and converting them to File objects,
+ * with special handling for Windows file paths, WSL paths, and unencoded URIs
+ * that may contain spaces or other special characters in the path component.
  */
 object UriUtils {
     /**
-     * Parses a URI string into a URI object, handling special cases for Windows file paths
+     * Parses a URI string into a URI object, handling special cases for Windows
+     * file paths and unencoded URIs (e.g. paths containing spaces).
+     *
+     * @param uri The URI string to parse
+     * @return A properly parsed URI object
+     * @throws Exception if the URI cannot be parsed
      */
     fun parseUri(uri: String): URI {
-        try {
-            // Remove query parameters if present
-            val uriStr = uri.substringBefore("?")
+        // Remove query parameters if present
+        val uriStr = uri.substringBefore("?")
 
-            // Handle Windows file paths with authority component
-            if (uriStr.startsWith("file://") && !uriStr.startsWith("file:///")) {
-                val path = uriStr.substringAfter("file://")
-                return URI("file:///$path")
-            }
+        // Handle Windows file paths with authority component
+        if (uriStr.startsWith("file://") && !uriStr.startsWith("file:///")) {
+            val path = uriStr.substringAfter("file://")
+            return URI("file:///$path")
+        }
 
-            // Standard URI handling for other cases
-            val uriWithoutQuery = URI(uriStr)
-            return uriWithoutQuery
+        return try {
+            URI(uriStr)
         } catch (e: Exception) {
-            println("Error parsing URI: $uri ${e.message}")
-            throw Exception("Invalid URI: $uri ${e.message}")
+            // Handle unencoded file URIs (e.g. spaces in path from VirtualFile.toUriOrNull())
+            if (uriStr.startsWith("file:///")) {
+                val path = uriStr.removePrefix("file://")
+                val file = File(path)
+                file.toURI()
+            } else {
+                throw Exception("Invalid URI: $uri ${e.message}")
+            }
         }
     }
 
     /**
-     * Converts a URI string to a File object
+     * Converts a URI string to a File object by first parsing the URI
+     * and then constructing a File from the parsed result.
+     *
+     * @param uri The URI string to convert to a file path
+     * @return A File object representing the path from the URI
      */
     fun uriToFile(uri: String): File {
-        return File(parseUri(uri))
+        val parsedUri = parseUri(uri)
+        return File(parsedUri)
     }
 }

--- a/extensions/intellij/src/test/kotlin/com/github/continuedev/continueintellijextension/unit/UriUtilsTest.kt
+++ b/extensions/intellij/src/test/kotlin/com/github/continuedev/continueintellijextension/unit/UriUtilsTest.kt
@@ -47,4 +47,17 @@ class UriUtilsTest : TestCase() {
         val file = UriUtils.uriToFile(uri)
         assertEquals(File("/wsl.localhost/Ubuntu/home/user/file.txt"), file)
     }
+
+    /**
+     * Validates that unencoded space characters in file URIs are handled
+     * correctly by the URI parser, ensuring proper conversion to File objects.
+     * This is a regression test for GitHub issue #10613.
+     */
+    fun `test unencoded spaces`() {
+        // Verify that a URI string containing literal spaces can be parsed
+        val uri = "file:///path/to/file with spaces"
+        val result = UriUtils.uriToFile(uri)
+        val expectedFile = File("/path/to/file with spaces")
+        assertEquals(expectedFile, result)
+    }
 }


### PR DESCRIPTION
## Summary
- Fix `parseUri()` to handle unencoded file URIs (e.g. `file:///C:/src/test1 project/file.py`) by falling back to `File(path).toURI()` when `URI()` throws on illegal characters
- Add regression test for unencoded spaces in file paths

## Test plan
- [ ] Existing `UriUtilsTest` tests continue to pass
- [ ] New `test unencoded spaces` test passes
- [ ] Verify JetBrains autocomplete no longer crashes on file paths with spaces

Fixes #10613

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued · ▶️ 42 not started · ✅ 6 no changes — [View all](https://hub.continue-stage.tools/inbox/pr/continuedev/continue/10629?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix URI parsing for unencoded file paths with spaces so JetBrains autocomplete no longer crashes. Falls back to File(path).toURI() when URI() throws. Fixes #10613.

- **Bug Fixes**
  - Handle unencoded file URIs (e.g., file:///C:/src/test1 project/file.py) by falling back to File(path).toURI() when parsing fails.
  - Add a regression test for paths with spaces.

<sup>Written for commit c5ebf13b47082a12c7417dedf1de454c9b642066. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

