### PR TITLE
feat: add allowedUnrestricted mode for tool calling

### DIFF
--- a/core/tools/policies/fileAccess.ts
+++ b/core/tools/policies/fileAccess.ts
@@ -16,6 +16,11 @@ export function evaluateFileAccessPolicy(
     return "disabled";
   }
 
+  // If tool is in unrestricted mode, skip workspace boundary check
+  if (basePolicy === "allowedUnrestricted") {
+    return "allowedUnrestricted";
+  }
+
   // Files within workspace use the base policy (typically "allowedWithoutPermission")
   if (isWithinWorkspace) {
     return basePolicy;

--- a/gui/src/pages/config/components/ToolPolicyItem.tsx
+++ b/gui/src/pages/config/components/ToolPolicyItem.tsx
@@ -141,14 +141,19 @@ export function ToolPolicyItem(props: ToolPolicyItemProps) {
                   <span className="text-xs">
                     {disabled || policy === "disabled"
                       ? "Excluded"
-                      : policy === "allowedWithoutPermission"
-                        ? "Automatic"
-                        : "Ask First"}
+                      : policy === "allowedUnrestricted"
+                        ? "Unrestricted"
+                        : policy === "allowedWithoutPermission"
+                          ? "Automatic"
+                          : "Ask First"}
                   </span>
                   <ChevronDownIcon className="h-3 w-3" />
                 </ListboxButton>
                 {!disabled && (
                   <ListboxOptions className="min-w-0">
+                    <ListboxOption value="allowedUnrestricted">
+                      Unrestricted
+                    </ListboxOption>
                     <ListboxOption value="allowedWithoutPermission">
                       Automatic
                     </ListboxOption>

--- a/gui/src/redux/slices/uiSlice.ts
+++ b/gui/src/redux/slices/uiSlice.ts
@@ -97,14 +97,17 @@ export const uiSlice = createSlice({
       const setting = state.toolSettings[action.payload];
 
       switch (setting) {
-        case "allowedWithPermission":
+        case "allowedUnrestricted":
           state.toolSettings[action.payload] = "allowedWithoutPermission";
           break;
         case "allowedWithoutPermission":
+          state.toolSettings[action.payload] = "allowedWithPermission";
+          break;
+        case "allowedWithPermission":
           state.toolSettings[action.payload] = "disabled";
           break;
         case "disabled":
-          state.toolSettings[action.payload] = "allowedWithPermission";
+          state.toolSettings[action.payload] = "allowedUnrestricted";
           break;
         default:
           state.toolSettings[action.payload] = DEFAULT_TOOL_SETTING;

--- a/packages/terminal-security/src/types.ts
+++ b/packages/terminal-security/src/types.ts
@@ -4,4 +4,5 @@
 export type ToolPolicy =
   | "allowedWithPermission"
   | "allowedWithoutPermission"
-  | "disabled";
+  | "disabled"
+  | "allowedUnrestricted";

--- a/packages/terminal-security/test/terminalCommandSecurity.test.ts
+++ b/packages/terminal-security/test/terminalCommandSecurity.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { evaluateTerminalCommandSecurity, ToolPolicy } from "../src/index.js";
+import { describe, expect, it } from "vitest";
+import { evaluateTerminalCommandSecurity } from "../src/index.js";
 
 describe("evaluateTerminalCommandSecurity", () => {
   describe("Critical Risk - Always Disabled", () => {
@@ -1862,6 +1862,53 @@ describe("evaluateTerminalCommandSecurity", () => {
         );
         expect(result).toBe("allowedWithoutPermission");
       });
+    });
+  });
+
+  describe("Unrestricted Mode", () => {
+    it("should always return allowedUnrestricted when base policy is allowedUnrestricted", () => {
+      const result = evaluateTerminalCommandSecurity(
+        "allowedUnrestricted",
+        "rm -rf /",
+      );
+      expect(result).toBe("allowedUnrestricted");
+    });
+
+    it("should return allowedUnrestricted for dangerous commands in unrestricted mode", () => {
+      const result = evaluateTerminalCommandSecurity(
+        "allowedUnrestricted",
+        "sudo apt-get update",
+      );
+      expect(result).toBe("allowedUnrestricted");
+    });
+
+    it("should return allowedUnrestricted for command substitution in unrestricted mode", () => {
+      const result = evaluateTerminalCommandSecurity(
+        "allowedUnrestricted",
+        "echo $(rm -rf /)",
+      );
+      expect(result).toBe("allowedUnrestricted");
+    });
+
+    it("should return allowedUnrestricted for obfuscated commands in unrestricted mode", () => {
+      const result = evaluateTerminalCommandSecurity(
+        "allowedUnrestricted",
+        "echo 'cm0gLXJmIC8=' | base64 -d | sh",
+      );
+      expect(result).toBe("allowedUnrestricted");
+    });
+
+    it("should return allowedUnrestricted for multi-line commands in unrestricted mode", () => {
+      const result = evaluateTerminalCommandSecurity(
+        "allowedUnrestricted",
+        "ls\nrm -rf /",
+      );
+      expect(result).toBe("allowedUnrestricted");
+    });
+
+    it("should handle empty command in unrestricted mode", () => {
+      const result = evaluateTerminalCommandSecurity("allowedUnrestricted", "");
+      expect(result).toBe("allowedUnrestricted");
     });
   });
 });


### PR DESCRIPTION
## Description

Add a new unrestricted mode for agent tool calling

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an “Unrestricted” tool policy that lets agents run terminal commands and access files without prompts or workspace checks. Exposes this option in the config UI and updates policy evaluation and tests.

- **New Features**
  - Added ToolPolicy value: allowedUnrestricted.
  - Terminal security: returns allowedUnrestricted and skips all checks when enabled.
  - File access: bypasses workspace boundary check when allowedUnrestricted.
  - Config UI: “Unrestricted” option added with label; cycle now goes Disabled → Unrestricted → Automatic → Ask First → Disabled.
  - Tests: coverage for unrestricted mode, including dangerous, obfuscated, multi-line, and empty commands.

<sup>Written for commit b1c903b847d91cbc0f0498e4c4c38694e389ad38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

