### PR TITLE
fix: update broken Mission Control workflows links

### DIFF
--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -15,7 +15,7 @@ Both run on Continue's cloud infrastructure.
 
 ## Triggers
 
-Triggers determine when an agent runs. They are configured in [Mission Control](/mission-control/workflows).
+Triggers determine when an agent runs. They are configured in [Mission Control](/mission-control/beyond-checks).
 
 Supported trigger types:
 
@@ -58,7 +58,7 @@ Version-controlled trigger configuration (defined in the agent file itself) is o
 | | Checks | Agents |
 |---|---|---|
 | File location | `.continue/checks/` | `.continue/agents/` or continue.dev |
-| Trigger | Always on PR open | Configurable in [Mission Control](/mission-control/workflows) |
+| Trigger | Always on PR open | Configurable in [Mission Control](/mission-control/beyond-checks) |
 | Purpose | Pass/fail review of PRs | Any automated task |
 
 ## Cloud agent gallery

--- a/docs/mission-control/tasks.mdx
+++ b/docs/mission-control/tasks.mdx
@@ -128,7 +128,7 @@ description: "A Task is a unit of work shared between you and an agent. You trig
 ## Next Steps
 
 
-  <Card title="Create a Workflow" icon="workflow" href="/mission-control/workflows">
+  <Card title="Create a Workflow" icon="workflow" href="/mission-control/beyond-checks">
 
     Automate tasks with event-based triggers
 

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -19,7 +19,7 @@ description: "Source-controlled AI checks, enforceable in CI"
     <sub>• Run a one-time task or test for automation</sub><br />
     <sub>• Monitor progress in the tasks tab</sub>
   </Card>
-  <Card title="Create an Agent Workflow" icon="clock" href="/mission-control/workflows">
+  <Card title="Create an Agent Workflow" icon="clock" href="/mission-control/beyond-checks">
     Schedule or trigger your agents automatically.
 
     <sub>• Cron, Webhook, or GitHub-based triggers</sub><br />


### PR DESCRIPTION
## Summary
- Updated 4 broken `/mission-control/workflows` links to `/mission-control/beyond-checks` across docs
- The `/mission-control/workflows` path has a redirect in `docs.json` and is not a navigable page in the docs sidebar, so links to it were effectively broken
- `/mission-control/beyond-checks` is the actual page in the docs navigation covering agents, triggers, and workflow automation

### Files changed
- `docs/agents/overview.mdx` — 2 links
- `docs/overview.mdx` — 1 card href
- `docs/mission-control/tasks.mdx` — 1 card href

Closes #10641

## Test plan
- [ ] Verify `/mission-control/beyond-checks` resolves correctly on the docs site
- [ ] Confirm all updated links navigate to the expected page

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated four broken links from /mission-control/workflows to /mission-control/beyond-checks so users land on the correct Mission Control page for agents, triggers, and workflows. This fixes dead links caused by the non-navigable workflows path.

<sup>Written for commit 6917ff8d42372200bb2d013980a405a927ac5067. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

