### PR TITLE
docs: simplify quickstart to continue.dev/check

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -8,13 +8,7 @@ Continue runs AI checks on every pull request. Each check is a markdown file in 
 
 ## Quickstart
 
-Paste this into Claude Code (or any coding agent):
-
-```
-Help me write checks for this codebase: https://continue.dev/walkthrough
-```
-
-This walks you through creating your first checks, connecting GitHub, and seeing them run on a PR. See [Write Your First Check](/checks/quickstart) for the full guide.
+1. Go to [continue.dev/check](https://continue.dev/check) to run checks on a pull request.
 
 ## How it works
 


### PR DESCRIPTION
Updates the docs homepage quickstart to a single action: go to https://continue.dev/check. Removes the walkthrough prompt flow from this page.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the docs homepage quickstart to a single step: go to continue.dev/check to run checks on a pull request. Removed the Claude Code prompt walkthrough to make onboarding faster and clearer.

<sup>Written for commit 342d1aa96e7b10577856c25f55508c7c4fedd05f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

