### PR TITLE
fix: detect embedded 429 errors from Gemini/VertexAI APIs

### DIFF
--- a/core/llm/utils/retry.test.ts
+++ b/core/llm/utils/retry.test.ts
@@ -98,6 +98,42 @@ describe("Retry Functionality", () => {
       expect(mockFn).toHaveBeenCalledTimes(2);
     });
 
+    it("should retry on embedded 429 in error message (Gemini/VertexAI)", async () => {
+      const error = new Error(
+        'Error from API: {"error":{"code":429,"message":"Resource exhausted"}}',
+      );
+      const mockFn = jest
+        .fn()
+        .mockRejectedValueOnce(error)
+        .mockResolvedValue("success");
+
+      const result = await retryAsync(mockFn, {
+        maxAttempts: 2,
+        baseDelay: 10,
+      });
+
+      expect(result).toBe("success");
+      expect(mockFn).toHaveBeenCalledTimes(2);
+    });
+
+    it("should retry on embedded 429 with space in error message", async () => {
+      const error = new Error(
+        'Error from API: {"error":{"code": 429,"message":"Rate limit exceeded"}}',
+      );
+      const mockFn = jest
+        .fn()
+        .mockRejectedValueOnce(error)
+        .mockResolvedValue("success");
+
+      const result = await retryAsync(mockFn, {
+        maxAttempts: 2,
+        baseDelay: 10,
+      });
+
+      expect(result).toBe("success");
+      expect(mockFn).toHaveBeenCalledTimes(2);
+    });
+
     it("should handle HTTP 5xx errors", async () => {
       const error = new Error("Internal Server Error");
       (error as any).status = 500;

--- a/core/llm/utils/retry.ts
+++ b/core/llm/utils/retry.ts
@@ -68,6 +68,11 @@ function defaultShouldRetry(error: any, attempt: number): boolean {
     return true;
   }
 
+  // Embedded rate limiting (e.g., Gemini/VertexAI return 429 in response body)
+  if (/"code"\s*:\s*429/.test(error.message ?? "")) {
+    return true;
+  }
+
   // HTTP status codes
   if (error.status || error.statusCode) {
     const status = error.status || error.statusCode;

--- a/core/util/withExponentialBackoff.ts
+++ b/core/util/withExponentialBackoff.ts
@@ -14,7 +14,10 @@ const withExponentialBackoff = async <T>(
       const result = await apiCall();
       return result;
     } catch (error: any) {
-      if ((error as APIError).response?.status === 429) {
+      if (
+        (error as APIError).response?.status === 429 ||
+        /"code"\s*:\s*429/.test(error.message ?? "")
+      ) {
         const retryAfter = (error as APIError).response?.headers.get(
           RETRY_AFTER_HEADER,
         );


### PR DESCRIPTION
## Summary
- Gemini and VertexAI APIs can return 429 rate-limit errors embedded in the response body JSON (`"code":429`) while the HTTP status code is not 429
- Added regex-based detection (`/"code"\s*:\s*429/`) in both `withExponentialBackoff` and `defaultShouldRetry` so these embedded errors trigger retry with backoff
- Added two tests covering `"code":429` (no space) and `"code": 429` (with space) variants

## Test plan
- [x] Existing retry tests pass
- [x] New test: error with `"code":429` in message is retried
- [x] New test: error with `"code": 429` (with space) in message is retried

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 7 failed — [View all](https://hub.continue.dev/inbox/pr/continuedev/continue/10674?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects embedded 429 rate-limit errors in Gemini/VertexAI responses so retries with exponential backoff trigger even when the HTTP status isn’t 429. This reduces failed calls and improves reliability with these APIs.

- **Bug Fixes**
  - Detect `"code": 429` in error messages in both withExponentialBackoff and defaultShouldRetry.
  - Add tests for no-space and spaced variants of the embedded code.

<sup>Written for commit 9759ad657dbed1aba6c19fa364917c2b0b486820. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

