### PR TITLE
feat: pre-install suggestions CLI in devbox blueprints

### DIFF
--- a/.github/workflows/runloop-blueprint-staging-template.json
+++ b/.github/workflows/runloop-blueprint-staging-template.json
@@ -16,6 +16,7 @@
     "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main' | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null",
     "sudo apt update",
     "sudo apt install -y gh",
+    "curl -fsSL -o /usr/local/bin/suggestions https://github.com/continuedev/suggestions-cli/releases/latest/download/suggestions-linux-amd64 && chmod +x /usr/local/bin/suggestions",
     "npm cache clean --force"
   ],
   "launch_parameters": {

--- a/.github/workflows/runloop-blueprint-template.json
+++ b/.github/workflows/runloop-blueprint-template.json
@@ -16,6 +16,7 @@
     "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main' | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null",
     "sudo apt update",
     "sudo apt install -y gh",
+    "curl -fsSL -o /usr/local/bin/suggestions https://github.com/continuedev/suggestions-cli/releases/latest/download/suggestions-linux-amd64 && chmod +x /usr/local/bin/suggestions",
     "npm cache clean --force"
   ],
   "launch_parameters": {


### PR DESCRIPTION
## Summary

- Add suggestions CLI binary download to both prod and staging devbox blueprint templates
- Downloads from `github.com/continuedev/suggestions-cli/releases/latest` during blueprint build
- Installs to `/usr/local/bin/suggestions` so it's on PATH without runtime downloads

Companion to continuedev/remote-config-server#3426 which adds the GoReleaser config and release workflow.

## Test plan

- [ ] After `suggestions-cli/v0.1.0` is released, verify blueprint build succeeds
- [ ] Create a new devbox and verify `suggestions --version` works
- [ ] Verify `which suggestions` returns `/usr/local/bin/suggestions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 7 failed — [View all](https://hub.continue.dev/inbox/pr/continuedev/continue/10734?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-install the suggestions CLI in both prod and staging Devbox blueprints. The build fetches the latest linux-amd64 release from GitHub and installs it to /usr/local/bin/suggestions so it’s on PATH without runtime downloads.

<sup>Written for commit 55b256cd14add16e0c590df8ef39a315fb11acbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

