### PR TITLE
fix: load config in project with no dirs

### DIFF
--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -592,6 +592,7 @@ export class ConfigHandler {
   async getSerializedConfig(): Promise<
     ConfigResult<BrowserSerializedContinueConfig>
   > {
+    await this.isInitialized;
     if (!this.currentProfile) {
       return {
         config: undefined,

--- a/gui/src/hooks/ParallelListeners.tsx
+++ b/gui/src/hooks/ParallelListeners.tsx
@@ -64,6 +64,9 @@ function ParallelListeners() {
       if (isInitial && hasDoneInitialConfigLoad.current) {
         return;
       }
+      if (configResult.configLoadInterrupted) {
+        return;
+      }
       hasDoneInitialConfigLoad.current = true;
       dispatch(setOrganizations(organizations));
       dispatch(setSelectedOrgId(selectedOrgId));


### PR DESCRIPTION
## Description

Wait for cascadeInit to finish before getting the serialized config. This previously created a race condition where the current profile and config were still null and not loaded.

Also in ParallelListeners, do not update config till configLoadInterrupted returns true.

resolves CON-5299
closes https://github.com/continuedev/continue/issues/9587

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 7 failed — [View all](https://hub.continue.dev/inbox/pr/continuedev/continue/10737?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix a config loading race in projects without directories by waiting for initialization before reading the serialized config and skipping updates when the load is interrupted (CON-5299).

- **Bug Fixes**
  - ConfigHandler: await initialization before returning serialized config to avoid null profile/config.
  - ParallelListeners: do not update config when configLoadInterrupted is true.

<sup>Written for commit 409a9454e230189e841c9f0879227e1825ef8d08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

