### PR TITLE
Add conversation message caching to AnthropicApi

### DIFF
--- a/packages/openai-adapters/src/apis/Anthropic.test.ts
+++ b/packages/openai-adapters/src/apis/Anthropic.test.ts
@@ -83,12 +83,14 @@ describe("AnthropicApi", () => {
       }
     });
 
-    it("still caches user messages even when caching strategy is none", () => {
-      const body = new AnthropicApi({
+    it("does not cache user messages when caching strategy is none", () => {
+      const api = new AnthropicApi({
         provider: "anthropic",
         apiKey: "test-key",
         cachingStrategy: "none",
-      })._convertToCleanAnthropicBody({
+      });
+
+      const result = (api as any)._convertBody({
         model: "claude-sonnet-4-20250514",
         messages: [
           { role: "user", content: "Hello" },
@@ -97,17 +99,14 @@ describe("AnthropicApi", () => {
         ],
       });
 
-      const result = CACHING_STRATEGIES["none"](body);
-      addCacheControlToLastTwoUserMessages(result.messages);
-
-      // User message caching is applied regardless of strategy
+      // No cache_control should be added when strategy is "none"
       const lastUserMsg = result.messages[2];
       expect(lastUserMsg.role).toBe("user");
       if (Array.isArray(lastUserMsg.content)) {
         const textPart = lastUserMsg.content.find(
           (p: any) => p.type === "text",
         );
-        expect((textPart as any)?.cache_control).toEqual({ type: "ephemeral" });
+        expect((textPart as any)?.cache_control).toBeUndefined();
       }
     });
   });

--- a/packages/openai-adapters/src/apis/Anthropic.ts
+++ b/packages/openai-adapters/src/apis/Anthropic.ts
@@ -77,7 +77,10 @@ export class AnthropicApi implements BaseLlmApi {
     const result = cachingStrategy(cleanBody);
 
     // Step 3: Cache last two user messages for conversation turn caching
-    addCacheControlToLastTwoUserMessages(result.messages);
+    // Skip when caching is disabled
+    if ((this.config.cachingStrategy ?? "systemAndTools") !== "none") {
+      addCacheControlToLastTwoUserMessages(result.messages);
+    }
 
     return result;
   }


### PR DESCRIPTION
## Summary
- Add `addCacheControlToLastTwoUserMessages()` call to `AnthropicApi._convertBody()`, caching the last two user messages with ephemeral `cache_control` markers
- This brings the direct Anthropic API path to parity with the OpenRouter path (`OpenRouterCaching.ts`), which already applies this optimization
- Adds vitest tests covering multi-turn conversations, single-message conversations, and interaction with the `none` caching strategy

## Cost Impact
Anthropic's prompt caching charges 1/10th the normal input token price for cache reads. By marking the last two user messages as cacheable, subsequent requests in a multi-turn conversation can serve ~90% of those tokens from cache, significantly reducing per-request costs. This is the same approach used by Claude Code (last user message) and Open Code (last two user messages).

## Test plan
- [x] `npx vitest run src/apis/Anthropic.test.ts` -- 3 tests pass
- [ ] Verify cache hit rates increase in production telemetry after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 7 failed — [View all](https://hub.continue.dev/inbox/pr/continuedev/continue/10935?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache the last two user messages in AnthropicApi by adding ephemeral cache_control markers after the caching strategy runs. Skip this when the caching strategy is "none" to ensure no markers are applied; matches the OpenRouter path and lowers input token costs in multi-turn chats.

- **Bug Fixes**
  - Fix TypeScript errors in caching tests by adding provider: "anthropic" to constructors and using (textPart as any) for cache_control access.

<sup>Written for commit f5f9ccbb167ef7b0351ae4b6073a826f12bd13f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

