### PR TITLE
Remove NODE_AUTH_TOKEN from stable-release workflow

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -24,6 +24,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write  # Required for OIDC
 
 jobs:
   stable-release:
@@ -67,8 +68,6 @@ jobs:
         if: ${{ (inputs.release_type || 'promote-beta') == 'promote-beta' }}
         id: find_beta
         working-directory: extensions/cli
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           if [[ -n "${{ inputs.beta_version }}" ]]; then
             # Manual input provided
@@ -117,8 +116,6 @@ jobs:
       - name: Download and verify beta package
         if: ${{ (inputs.release_type || 'promote-beta') == 'promote-beta' }}
         working-directory: extensions/cli
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           # Download the specific beta version
           npm pack @continuedev/cli@${{ steps.find_beta.outputs.beta_version }}
@@ -189,8 +186,6 @@ jobs:
 
       - name: Publish stable to npm
         working-directory: extensions/cli
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           npm publish --tag latest
           echo "Published stable version: ${{ steps.final_version.outputs.stable_version }}"


### PR DESCRIPTION
Removed NODE_AUTH_TOKEN environment variable from various steps in the stable release workflow.

## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 7 failed — [View all](https://hub.continue.dev/inbox/pr/continuedev/continue/10950?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the stable-release workflow to OIDC-based npm auth and remove step-level NODE_AUTH_TOKEN usage. This reduces secret exposure and supports provenance-enabled publishing.

- **Refactors**
  - Added id-token: write permission to the workflow.
  - Removed NODE_AUTH_TOKEN from find_beta, download/verify beta, and publish steps.

<sup>Written for commit 966ffe9883de07796c240e0fdbc34a6c7f740434. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

