### PR TITLE
Fix stable release npm publish with OIDC trusted publishing

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -187,7 +187,7 @@ jobs:
       - name: Publish stable to npm
         working-directory: extensions/cli
         run: |
-          npm publish --tag latest
+          npm publish --tag latest --provenance
           echo "Published stable version: ${{ steps.final_version.outputs.stable_version }}"
 
       - name: Create stable release on GitHub


### PR DESCRIPTION
## Summary
- Add `--provenance` flag to `npm publish` in the stable release workflow so it uses GitHub OIDC token exchange for authentication instead of the expired `NODE_AUTH_TOKEN`
- Trusted publishing was already configured on npm's side (`stable-release.yml`) and `id-token: write` was set in the workflow, but without `--provenance` npm never triggered the OIDC flow

## Test plan
- [ ] Re-run the stable release workflow and verify `npm publish --tag latest --provenance` succeeds
- [ ] Verify the published package has provenance attestation on npmjs.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 7 failed — [View all](https://hub.continue.dev/inbox/pr/continuedev/continue/10951?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the stable release publish by enabling npm's OIDC trusted publishing. Adds --provenance to npm publish in the stable-release workflow so it uses OIDC instead of the expired NODE_AUTH_TOKEN, and publishes with provenance attestation.

<sup>Written for commit 9fe15eeea84216f7e38f022536fa6165a79b597c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

