### PR TITLE
Upgrade npm for OIDC trusted publishing in stable release

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -46,6 +46,9 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           always-auth: true
 
+      - name: Update npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: Validate inputs
         run: |
           RELEASE_TYPE="${{ inputs.release_type || 'promote-beta' }}"


### PR DESCRIPTION
## Summary
- Adds `npm install -g npm@latest` before publish in the stable release workflow
- Node 20 ships with npm 10.x, which doesn't support OIDC-based publish authentication
- Trusted publishing requires npm >= 11.5.1; without it, the publish request goes out unauthenticated and the registry returns E404

## Test plan
- [ ] Re-run the stable release workflow and confirm `npm publish --provenance` succeeds with OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 6 failed · 🔄 1 running — [View all](https://hub.continue.dev/inbox/pr/continuedev/continue/10952?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades npm to the latest in the stable release workflow to enable OIDC trusted publishing with npm publish --provenance. Prevents unauthenticated publishes from Node 20’s npm 10.x that resulted in E404 errors.

- **Dependencies**
  - Install npm@latest before publish so version >=11.5.1 is used (Node 20 ships npm 10.x without OIDC support).

<sup>Written for commit d21a0089f40afb906148023e6e58eee192b7b9ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

