### PR TITLE
Fix npm OIDC publish by removing setup-node registry config

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -11,6 +11,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write  # Required for npm OIDC trusted publishing
 
 jobs:
   beta-release:
@@ -29,8 +30,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 20
-          registry-url: "https://registry.npmjs.org"
-          always-auth: true
 
       - name: Setup packages
         uses: ./.github/actions/setup-packages
@@ -46,11 +45,12 @@ jobs:
           cd core
           npm run build
 
+      - name: Update npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: Install CLI dependencies
         working-directory: extensions/cli
         run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Get current version
         id: get_version
@@ -94,10 +94,8 @@ jobs:
 
       - name: Publish beta to npm
         working-directory: extensions/cli
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          npm publish --tag beta
+          npm publish --tag beta --provenance
           echo "Published beta version: ${{ steps.get_version.outputs.beta_version }}"
 
       - name: Create beta release on GitHub

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -43,8 +43,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 20
-          registry-url: "https://registry.npmjs.org"
-          always-auth: true
 
       - name: Update npm for OIDC trusted publishing
         run: npm install -g npm@latest


### PR DESCRIPTION
## Summary
- Remove `registry-url` and `always-auth` from `setup-node` in both release workflows — these cause `setup-node` to set `NODE_AUTH_TOKEN` to the GitHub token, which npm uses instead of its native OIDC flow, resulting in `Access token expired` / `404` errors on publish
- Switch beta workflow to OIDC trusted publishing (add `id-token: write`, `--provenance`, `npm@latest`, remove `NPM_TOKEN` usage)

## Test plan
- [ ] Re-run the stable release workflow and confirm `npm publish --provenance` succeeds via OIDC
- [ ] Add `beta-release.yml` as a trusted publisher on npmjs.com for `@continuedev/cli`
- [ ] Verify next beta release publishes successfully with OIDC
- [ ] Remove `NPM_TOKEN` secret from repo after confirming both workflows work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 7 no changes — [View all](https://hub.continue.dev/inbox/pr/continuedev/continue/10958?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch beta and stable release workflows to npm OIDC trusted publishing to fix auth failures during npm publish. Remove setup-node registry settings that injected a GitHub token, add id-token permissions, upgrade to npm@latest, and publish with provenance.

- **Bug Fixes**
  - Removed setup-node registry-url and always-auth so npm uses OIDC instead of NODE_AUTH_TOKEN.
  - Dropped NPM_TOKEN usage; added permissions: id-token: write.
  - Installed npm@latest and used npm publish --provenance for beta.

- **Migration**
  - Add beta-release.yml as a trusted publisher for @continuedev/cli on npm.
  - Re-run stable release and confirm OIDC publish works.
  - Remove the NPM_TOKEN secret after both workflows succeed.

<sup>Written for commit 36d82f7ceb36a30dce4cd99450df3ecf41ee334f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

