### PR TITLE
Fix npm OIDC publish: restore registry-url, clear token, use Node 22

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -30,7 +30,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
+          registry-url: "https://registry.npmjs.org"
 
       - name: Update npm for OIDC trusted publishing
         run: npm install -g npm@latest
@@ -67,6 +68,8 @@ jobs:
 
       - name: Publish to npm
         working-directory: extensions/cli
+        env:
+          NODE_AUTH_TOKEN: ""
         run: |
           npm publish --tag latest --provenance
           echo "Published version: ${{ inputs.stable_version }}"


### PR DESCRIPTION
## Summary
- Restore `registry-url` in `setup-node` so npm knows the registry endpoint (removing it caused `ENEEDAUTH`)
- Set `NODE_AUTH_TOKEN: ""` on the publish step to clear the GitHub token that `setup-node` injects, forcing npm to fall back to OIDC
- Bump to Node 22 for native npm OIDC support

## Context
The previous fix (#10958) removed `registry-url` which stopped npm from receiving any auth at all. The correct approach is to keep the registry config but explicitly clear the conflicting token at publish time.

## Test plan
- [ ] Re-run stable release workflow and confirm publish succeeds via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 7 no changes — [View all](https://hub.continue.dev/inbox/pr/continuedev/continue/10961?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores OIDC-based npm publishing in the stable-release workflow to resolve ENEEDAUTH and ensure publishes succeed with provenance.

- **Bug Fixes**
  - Add registry-url to setup-node so npm targets npmjs.
  - Clear NODE_AUTH_TOKEN during publish to force OIDC.
  - Run on Node 22 for native npm OIDC support.

<sup>Written for commit 6c9b9aa943d6992c38b02de3b0450c4640f67d12. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

