### PR TITLE
Fix npm OIDC: Node 24 for publish, unset bogus token

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -30,11 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Update npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+          node-version: 20
 
       - name: Setup packages
         uses: ./.github/actions/setup-packages
@@ -66,11 +62,16 @@ jobs:
         working-directory: extensions/cli
         run: npm test
 
+      - name: Setup Node.js for OIDC publish
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+
       - name: Publish to npm
         working-directory: extensions/cli
-        env:
-          NODE_AUTH_TOKEN: ""
         run: |
+          unset NODE_AUTH_TOKEN
           npm publish --tag latest --provenance
           echo "Published version: ${{ inputs.stable_version }}"
 


### PR DESCRIPTION
## Summary
- Switch to Node 24 (npm 11.5.1+ with OIDC) right before the publish step
- `unset NODE_AUTH_TOKEN` before `npm publish` — `setup-node` creates a bogus token that blocks OIDC
- Keep Node 20 for build/test steps (matches `.nvmrc`)

## Root cause
`setup-packages` composite action runs `setup-node@v4` with `.nvmrc` (Node 20), which overwrites the npm version back to 10.x. npm 10.x has no OIDC support, causing `ENEEDAUTH`. Previous attempts to fix (`npm install -g npm@latest`) ran before `setup-packages` and got wiped out.

## Test plan
- [ ] Re-run stable release workflow and confirm publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 7 no changes — [View all](https://hub.continue.dev/inbox/pr/continuedev/continue/10964?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes npm OIDC trusted publishing in the stable-release workflow by using Node 24 (npm 11.5+) for the publish step and clearing NODE_AUTH_TOKEN so npm falls back to OIDC. Build and tests stay on Node 20.

- **Bug Fixes**
  - Setup Node 24 with registry-url right before publish to enable OIDC.
  - Unset NODE_AUTH_TOKEN before npm publish to avoid token-based auth.
  - Keep Node 20 for build/test to match .nvmrc.

<sup>Written for commit 57e9adb69be08add402052b299abdb9f0163f69c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

