### PR TITLE
fix(cli): show create new assistant option when logged in

### DIFF
--- a/extensions/cli/src/ui/ConfigSelector.tsx
+++ b/extensions/cli/src/ui/ConfigSelector.tsx
@@ -111,13 +111,15 @@ const ConfigSelector: React.FC<ConfigSelectorProps> = ({
           }
         }
 
-        // Add "Create new assistant" option
-        options.push({
-          id: "create",
-          name: "Create new assistant",
-          type: "create",
-          displaySuffix: " (opens web)",
-        });
+        // Add "Create new assistant" option only when logged in
+        if (accessToken) {
+          options.push({
+            id: "create",
+            name: "Create new assistant",
+            type: "create",
+            displaySuffix: " (opens web)",
+          });
+        }
 
         // Determine current config by checking both auth config and service state
         const assistantSlug = getAssistantSlug(authConfig);


### PR DESCRIPTION
## Description

"Create new assistant option (opens web)" should be only shown when the user is logged in.

Eventually, another option should be added to create a config locally (and shown in the config list).

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Only show "Create new assistant (opens web)" in the CLI config selector when the user is logged in. The option is now gated on accessToken presence to avoid showing unusable actions to unauthenticated users.

<sup>Written for commit ec638b020d884f84ebd8007a8f5e8d8134fdd8f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

---

<!-- continue-task-summary-start -->
**Continue Tasks:** 🔄 7 running — [View all](https://hub.continue.dev/inbox/pr/continuedev/continue/11004?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->