### PR TITLE
fix: don't duplicate built-in tools in system prompt when MCP tools present

### DIFF
--- a/core/tools/systemMessageTools/buildToolsSystemMessage.ts
+++ b/core/tools/systemMessageTools/buildToolsSystemMessage.ts
@@ -40,7 +40,7 @@ export const generateToolsSystemMessage = (
       `\nAlso, these additional tool definitions show other tools you can call with the same syntax:`,
     );
 
-    for (const tool of tools) {
+    for (const tool of withDynamicMessage) {
       try {
         const definition = framework.toolToSystemToolDefinition(tool);
         instructions.push(`\n${definition}`);

--- a/core/tools/systemMessageTools/toolCodeblocks/buildSystemMessage.vitest.ts
+++ b/core/tools/systemMessageTools/toolCodeblocks/buildSystemMessage.vitest.ts
@@ -193,6 +193,54 @@ describe("generateToolsSystemMessage", () => {
     expect(hasDynamicToolsSection).toBe(true);
   });
 
+  it("should not duplicate predefined tools in dynamic section when both types present", () => {
+    const tools: Tool[] = [
+      {
+        function: {
+          name: "builtin_tool",
+          description: "A built-in tool",
+          parameters: {
+            type: "object",
+            properties: {},
+            required: [],
+          },
+        },
+        systemMessageDescription: {
+          prefix: "Use this built-in tool",
+        },
+        ...SHARED_TOOL_FIELDS,
+      },
+      {
+        function: {
+          name: "mcp_tool",
+          description: "An MCP tool",
+          parameters: {
+            type: "object",
+            properties: {
+              query: {
+                type: "string",
+                description: "Search query",
+              },
+            },
+            required: ["query"],
+          },
+        },
+        ...SHARED_TOOL_FIELDS,
+      },
+    ];
+
+    const result = generateToolsSystemMessage(tools, framework);
+
+    // builtin_tool should appear once via predefined section (systemMessageDescription)
+    // mcp_tool should appear once via dynamic section (toolToSystemToolDefinition)
+    // Bug: without fix, builtin_tool appears TWICE — once in each section
+    const builtinOccurrences = result.split("TOOL_NAME: builtin_tool").length - 1;
+    const mcpOccurrences = result.split("TOOL_NAME: mcp_tool").length - 1;
+
+    expect(builtinOccurrences).toBe(1);
+    expect(mcpOccurrences).toBe(1);
+  });
+
   it("includes example tool definition and call", () => {
     const tools: Tool[] = [
       {


### PR DESCRIPTION
## Summary

- **Fix #11064**: `generateToolsSystemMessage()` duplicates all built-in tools in the system prompt when any MCP/dynamic tool is registered alongside them

## The bug

`buildToolsSystemMessage.ts` line 43 iterates `tools` (all tools) instead of `withDynamicMessage` (only tools without `systemMessageDescription`). When the `withDynamicMessage.length > 0` branch fires, every built-in tool gets listed twice:

1. In the **predefined section** via `createSystemMessageExampleCall()` (using `systemMessageDescription.prefix` + example args)
2. In the **dynamic section** via `toolToSystemToolDefinition()` (using `tool_definition` codeblock format)

The `withDynamicMessage` variable is computed on lines 18-20 for exactly this purpose — it just wasn't used.

## Context

Found while auditing the system message tools framework for local model compatibility. Duplicate definitions waste context tokens and send contradictory format information (predefined uses example calls, dynamic uses `tool_definition` blocks). Frontier models silently handle the redundancy; local models with smaller context windows are disproportionately affected.

## Changes

| File | Change |
|------|--------|
| `core/tools/systemMessageTools/buildToolsSystemMessage.ts` | `tools` → `withDynamicMessage` on line 43 |
| `core/tools/systemMessageTools/toolCodeblocks/buildSystemMessage.vitest.ts` | New test asserting no duplicate tool definitions when mixed predefined + dynamic tools |

## Test plan

- [x] 11 tests passing (10 existing + 1 new dedup assertion)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** 🔄 7 running — [View all](https://hub.continue.dev/inbox/pr/continuedev/continue/11068?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix duplicated built-in tool definitions in the system prompt when MCP/dynamic tools are present, reducing token waste and conflicting instructions. Fixes #11064 by listing only dynamic tools in the additional definitions section and adds a test to ensure no duplicates.

<sup>Written for commit 9702f31b1b7175224af284b831561fe2a4c6f0e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

