### PR TITLE
docs: reference dedicated /checks page in Mission Control

### DIFF
--- a/docs/agents/create-and-edit.mdx
+++ b/docs/agents/create-and-edit.mdx
@@ -12,7 +12,7 @@ sidebarTitle: "Create & Edit"
 
 <Steps>
   <Step title="🧭 Navigate to Create Agent">
-    Navigate to the [New Agent page](https://continue.dev/agents/new).
+    Navigate to the [New Agent page](https://continue.dev/agents/new), or the [New Check page](https://continue.dev/checks/new) if you're creating a PR-triggered review.
     
 
   </Step>
@@ -53,7 +53,7 @@ sidebarTitle: "Create & Edit"
 
 You can edit any AI Agent you own or that has Organization-level access.
 
-From the **[Agents](https://continue.dev/agents)** page, click your agent's name. Change any of the fields in the edit form, then click **"Save Changes"**.
+From the **[Agents](https://continue.dev/agents)** page (or the **[Checks](https://continue.dev/checks)** page for PR-triggered reviews), click the name of the agent or check you want to edit. Change any of the fields in the edit form, then click **"Save Changes"**.
   
 ## Example Agent Configurations
 

--- a/docs/agents/intro.mdx
+++ b/docs/agents/intro.mdx
@@ -26,7 +26,7 @@ Use Mission Control to kick off Cloud Agents for:
 
 <Steps>
   <Step title="Navigate to Your Agents Page">
-    Go to [Mission Control Agents page](https://continue.dev/agents) and select an existing workflow with a pre-configured Cloud Agent.
+    Go to the [Agents page](https://continue.dev/agents) or the [Checks page](https://continue.dev/checks) in Mission Control and select an existing workflow.
   </Step>
   
   <Step title="Run Your First Cloud Agent">

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -9,7 +9,7 @@ Agents use the same markdown file format as checks. The difference: agents can b
 There are two ways to define agents:
 
 - **Local**: Place agent files in `.continue/agents/` in your repository. Version-controlled and shared with your team.
-- **Cloud**: Created and managed on [continue.dev/agents](https://continue.dev/agents). Web UI for configuration, no file to commit.
+- **Cloud**: Created and managed in Mission Control. Agents are at [continue.dev/agents](https://continue.dev/agents), checks (PR-triggered reviews) are at [continue.dev/checks](https://continue.dev/checks). Web UI for configuration, no file to commit.
 
 Both run on Continue's cloud infrastructure.
 
@@ -60,6 +60,7 @@ Version-controlled trigger configuration (defined in the agent file itself) is o
 | File location | `.continue/checks/` | `.continue/agents/` or continue.dev |
 | Trigger | Always on PR open | Configurable in [Mission Control](/mission-control/workflows) |
 | Purpose | Pass/fail review of PRs | Any automated task |
+| Mission Control page | [continue.dev/checks](https://continue.dev/checks) | [continue.dev/agents](https://continue.dev/agents) |
 
 ## Cloud agent gallery
 

--- a/docs/mission-control/beyond-checks.mdx
+++ b/docs/mission-control/beyond-checks.mdx
@@ -15,6 +15,7 @@ Agents use the same markdown file format as checks. The difference: agents can b
 | File location | `.continue/checks/` | `.continue/agents/` or continue.dev |
 | Trigger | Always on PR open | Configurable in Mission Control |
 | Purpose | Pass/fail review of PRs | Any automated task |
+| Mission Control page | [continue.dev/checks](https://continue.dev/checks) | [continue.dev/agents](https://continue.dev/agents) |
 
 ### Cloud agent gallery
 

--- a/docs/mission-control/index.mdx
+++ b/docs/mission-control/index.mdx
@@ -147,8 +147,12 @@ For personal or single-use configurations, you can skip the inputs layer and ref
     Start with a prompt and run an Agent on demand.
   </Card>
 
-  <Card title="Build Workflows for Cloud Agents" icon="clock" href="https://continue.dev/agents/new">
-    Automate work using GitHub triggers, cron schedules, or webhooks.
+  <Card title="Build Agent Workflows" icon="clock" href="https://continue.dev/agents/new">
+    Automate work using cron schedules, webhooks, or GitHub events.
+  </Card>
+
+  <Card title="Manage Checks" icon="shield-check" href="https://continue.dev/checks">
+    View and create PR-triggered review checks.
   </Card>
 
   <Card title="Add Integrations" icon="workflow" href="https://continue.dev/integrations">

--- a/docs/mission-control/workflows.mdx
+++ b/docs/mission-control/workflows.mdx
@@ -27,7 +27,7 @@ description: "Cloud agents that are triggered on a schedule or when events occur
 
   <Step title="Start from scratch or a template">
 
-    In Mission Control, create a [new agent](https://continue.dev/agents/new).
+    In Mission Control, create a [new agent](https://continue.dev/agents/new) or a [new check](https://continue.dev/checks/new) (for PR-triggered reviews).
 <AccordionGroup>
 
   <Accordion title="Start with a Blank Agent">
@@ -80,7 +80,7 @@ description: "Cloud agents that are triggered on a schedule or when events occur
 
   <Step title="Create the Agent Workflow">
 
-    Click Create Agent and now you'll be able to see, edit, and montitor it in your [Agents tab in Mission Control](https://continue.dev/agents).
+    Click Create Agent (or Create Check) and now you'll be able to see, edit, and monitor it in Mission Control — on the [Agents page](https://continue.dev/agents) or the [Checks page](https://continue.dev/checks) depending on the trigger type.
 
   </Step>
 


### PR DESCRIPTION
## Summary
- Updates 6 docs files to reference the new dedicated `/checks` page on the hub
- Adds `/checks` and `/checks/new` links alongside existing `/agents` links
- Adds "Mission Control page" row to both "Checks vs. agents" comparison tables
- Adds a "Manage Checks" card to the Mission Control overview page

Context: The hub now has a separate top-level `/checks` page for PR-triggered review checks, distinct from the `/agents` page.

## Test plan
- [ ] Verify all links resolve correctly on the docs site
- [ ] Check that the comparison tables render properly with the new row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 7 no changes — [View all](https://hub.continue.dev/inbox/pr/continuedev/continue/11087?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Mission Control docs to point PR-triggered reviews to the new dedicated /checks page, separate from /agents, for clearer navigation. Adds /checks and /checks/new links across six pages, a “Mission Control page” row to both “Checks vs. agents” tables, and a “Manage Checks” card on the Mission Control overview.

<sup>Written for commit 0f03313a0351db8b00a84c1add201f6930bec36b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

