### PR TITLE
Fix false-positive system tool parsing for quoted TOOL_NAME examples

### DIFF
--- a/core/tools/systemMessageTools/detectToolCallStart.ts
+++ b/core/tools/systemMessageTools/detectToolCallStart.ts
@@ -3,8 +3,22 @@ import { SystemMessageToolsFramework } from "./types";
 export function detectToolCallStart(
   buffer: string,
   toolCallFramework: SystemMessageToolsFramework,
+  options?: {
+    /**
+     * When false, only the canonical ```tool start is accepted.
+     */
+    allowNonCodeblockStarts?: boolean;
+  },
 ) {
-  const starts = toolCallFramework.acceptedToolCallStarts;
+  const allowNonCodeblockStarts = options?.allowNonCodeblockStarts ?? true;
+  const canonicalStart =
+    toolCallFramework.acceptedToolCallStarts.find(
+      ([start, replacement]) => start === replacement,
+    ) ?? toolCallFramework.acceptedToolCallStarts[0];
+
+  const starts = allowNonCodeblockStarts
+    ? toolCallFramework.acceptedToolCallStarts
+    : [canonicalStart];
   let modifiedBuffer = buffer;
   let isInToolCall = false;
   let isInPartialStart = false;

--- a/core/tools/systemMessageTools/interceptSystemToolCalls.ts
+++ b/core/tools/systemMessageTools/interceptSystemToolCalls.ts
@@ -28,6 +28,7 @@ export async function* interceptSystemToolCalls(
 ): AsyncGenerator<ChatMessage[], PromptLog | undefined> {
   let buffer = "";
   let parseState: ToolCallParseState | undefined;
+  let sawNonWhitespaceAssistantText = false;
 
   while (true) {
     const result = await messageGenerator.next();
@@ -71,7 +72,9 @@ export async function* interceptSystemToolCalls(
           buffer += chunk;
           if (!parseState) {
             const { isInPartialStart, isInToolCall, modifiedBuffer } =
-              detectToolCallStart(buffer, systemToolFramework);
+              detectToolCallStart(buffer, systemToolFramework, {
+                allowNonCodeblockStarts: !sawNonWhitespaceAssistantText,
+              });
 
             if (isInPartialStart) {
               continue;
@@ -100,6 +103,10 @@ export async function* interceptSystemToolCalls(
             // Prevent content after tool calls for now
             if (parseState) {
               continue;
+            }
+
+            if (buffer.trim().length > 0) {
+              sawNonWhitespaceAssistantText = true;
             }
 
             // Yield normal assistant message

--- a/core/tools/systemMessageTools/toolCodeblocks/interceptSystemToolCalls.vitest.ts
+++ b/core/tools/systemMessageTools/toolCodeblocks/interceptSystemToolCalls.vitest.ts
@@ -179,9 +179,8 @@ describe("interceptSystemToolCalls", () => {
     ).toBe("}");
   });
 
-  it("processes tool_name without codeblock format", async () => {
+  it("processes tool_name without codeblock format at response start", async () => {
     const messages: ChatMessage[][] = [
-      [{ role: "assistant", content: "I'll help you with that.\n" }],
       [{ role: "assistant", content: "TOOL_NAME: test_tool\n" }],
       [{ role: "assistant", content: "BEGIN_ARG: arg1\n" }],
       [{ role: "assistant", content: "value1\n" }],
@@ -194,30 +193,8 @@ describe("interceptSystemToolCalls", () => {
       framework,
     );
 
-    // First chunk should be normal text
-    let result = await generator.next();
-    expect(result.value).toEqual([
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "I'll help you with that." }],
-      },
-    ]);
-
-    result = await generator.next();
-    expect(result.value).toEqual([
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "text",
-            text: "\n",
-          },
-        ],
-      },
-    ]);
-
     // The system should detect the tool_name format and convert it
-    result = await generator.next();
+    let result = await generator.next();
     expect(
       (result.value as AssistantChatMessage[])[0].toolCalls?.[0].function?.name,
     ).toBe("test_tool");
@@ -240,6 +217,79 @@ describe("interceptSystemToolCalls", () => {
       (result.value as AssistantChatMessage[])[0].toolCalls?.[0].function
         ?.arguments,
     ).toBe("}");
+  });
+
+  it("still detects canonical ```tool blocks after assistant text", async () => {
+    const messages: ChatMessage[][] = [
+      [{ role: "assistant", content: "Let me check that for you.\n" }],
+      [{ role: "assistant", content: "```tool\n" }],
+      [{ role: "assistant", content: "TOOL_NAME: test_tool\n" }],
+    ];
+
+    const generator = interceptSystemToolCalls(
+      createAsyncGenerator(messages),
+      abortController,
+      framework,
+    );
+
+    await generator.next();
+    await generator.next();
+    const result = await generator.next();
+
+    expect(
+      (result.value as AssistantChatMessage[])[0].toolCalls?.[0].function?.name,
+    ).toBe("test_tool");
+  });
+
+  it("does not treat quoted TOOL_NAME lines as real tool calls", async () => {
+    const messages: ChatMessage[][] = [
+      [
+        {
+          role: "assistant",
+          content:
+            "Use this format when you call a tool:\nTOOL_NAME: read_file\nBEGIN_ARG: path\nREADME.md\nEND_ARG",
+        },
+      ],
+    ];
+
+    const generator = interceptSystemToolCalls(
+      createAsyncGenerator(messages),
+      abortController,
+      framework,
+    );
+
+    const chunks: ChatMessage[][] = [];
+    while (true) {
+      const result = await generator.next();
+      if (result.done) {
+        break;
+      }
+      if (result.value) {
+        chunks.push(result.value as ChatMessage[]);
+      }
+    }
+
+    expect(
+      chunks.flatMap((group) => group).every((message) => !message.toolCalls),
+    ).toBe(true);
+
+    const text = chunks
+      .flatMap((group) => group)
+      .flatMap((message) => {
+        if (typeof message.content === "string") {
+          return [message.content];
+        }
+        if (Array.isArray(message.content)) {
+          return message.content
+            .filter((part) => part.type === "text")
+            .map((part) => part.text);
+        }
+        return [];
+      })
+      .join("");
+
+    expect(text).toContain("TOOL_NAME: read_file");
+    expect(text).toContain("BEGIN_ARG: path");
   });
 
   it("ignores content after a tool call", async () => {


### PR DESCRIPTION
## Summary
- prevent fallback `TOOL_NAME:` parsing once the assistant has already emitted non-whitespace conversational text
- keep canonical ```tool block parsing unchanged, even when a response includes explanatory text first
- make canonical start detection explicit in `detectToolCallStart` instead of relying on tuple ordering
- add regression coverage so quoted syntax examples stay as plain assistant text

## Why
When a model explains tool syntax (for example, `TOOL_NAME: read_file` in a normal paragraph), the parser could misclassify that quoted text as a real tool invocation. This patch narrows the fallback path to reduce those false positives while preserving standard fenced tool-call behavior.

## Testing
- Added/updated unit tests in `core/tools/systemMessageTools/toolCodeblocks/interceptSystemToolCalls.vitest.ts`
- Local run in this environment is blocked because `vitest` is not installed (`ERR_MODULE_NOT_FOUND`)

Closes #11070

---

<!-- continue-task-summary-start -->
**Continue Tasks:** 🔄 7 running — [View all](https://hub.continue.dev/inbox/pr/continuedev/continue/11094?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents false-positive tool calls when the assistant shows quoted TOOL_NAME examples in normal text by limiting fallback parsing to the very start of a response. Canonical ```tool code blocks still parse normally.

- **Bug Fixes**
  - Allow non-codeblock TOOL_NAME starts only at response start; disable once any non-whitespace assistant text appears.
  - Continue to parse canonical ```tool blocks even after conversational text.
  - Add explicit canonical-start detection with an allowNonCodeblockStarts option and regression tests to keep quoted examples as plain text.

<sup>Written for commit 059a085ce9af91ec1ad93a60b70c7c162f9ac95a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

