### PR TITLE
Fix duplicate predefined tools in dynamic tools system message

### DIFF
--- a/core/tools/systemMessageTools/buildToolsSystemMessage.ts
+++ b/core/tools/systemMessageTools/buildToolsSystemMessage.ts
@@ -40,7 +40,7 @@ export const generateToolsSystemMessage = (
       `\nAlso, these additional tool definitions show other tools you can call with the same syntax:`,
     );
 
-    for (const tool of tools) {
+    for (const tool of withDynamicMessage) {
       try {
         const definition = framework.toolToSystemToolDefinition(tool);
         instructions.push(`\n${definition}`);

--- a/core/tools/systemMessageTools/toolCodeblocks/buildSystemMessage.vitest.ts
+++ b/core/tools/systemMessageTools/toolCodeblocks/buildSystemMessage.vitest.ts
@@ -191,6 +191,11 @@ describe("generateToolsSystemMessage", () => {
 
     const hasDynamicToolsSection = /additional tool definitions/i.test(result);
     expect(hasDynamicToolsSection).toBe(true);
+
+    // Dynamic definitions should not duplicate tools that already have predefined messages.
+    expect(result.match(/TOOL_NAME: tool_with_description/g)?.length ?? 0).toBe(
+      1,
+    );
   });
 
   it("includes example tool definition and call", () => {


### PR DESCRIPTION
## Summary
- iterate only over tools without predefined system-message descriptions when building the dynamic tool definitions section
- prevent built-in/predefined tools from being duplicated when MCP/dynamic tools are present
- add a regression assertion verifying predefined tools appear only once in mixed tool lists

Fixes #11064.

## Testing
- Unable to run local vitest in this workspace because project dependencies are not installed (`node_modules` missing).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate predefined tools in the dynamic tools section of the system message. Only tools without a predefined description are included, and a test guards against regressions.

- **Bug Fixes**
  - Generate dynamic definitions from tools with dynamic messages only.
  - Avoid duplicating built-in/predefined tools when dynamic tools are present.
  - Add regression assertion to ensure predefined tools appear once in mixed lists.

<sup>Written for commit 8a16aa7b4bdea7647a7df2c06b5e55e1933fef2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

