### PR TITLE
fix: refresh all configs when creating a new assistant file

### DIFF
--- a/core/core.ts
+++ b/core/core.ts
@@ -403,7 +403,7 @@ export class Core {
 
     on("config/newAssistantFile", async (msg) => {
       await createNewAssistantFile(this.ide, undefined);
-      await this.configHandler.reloadConfig(
+      await this.configHandler.refreshAll(
         "Assistant file created (config/newAssistantFile message)",
       );
     });


### PR DESCRIPTION
## Summary
- switch `config/newAssistantFile` handling from `reloadConfig()` to `refreshAll()`
- ensure newly created local agent config files appear immediately without waiting for file watcher events
- align behavior with the existing local config file creation watcher path

Fixes #11062


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh all configs after creating a new assistant file so the new local config appears immediately without waiting for file watcher events. Replaces reloadConfig with refreshAll to match the existing local config creation behavior.

<sup>Written for commit 28d3972e87c06af5a503708974feb74674ef79e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

