### PR TITLE
Avoid sending orphaned reasoning items to OpenAI Responses API

### DIFF
--- a/core/llm/openaiTypeConverters.test.ts
+++ b/core/llm/openaiTypeConverters.test.ts
@@ -22,6 +22,11 @@ type MessageItem = {
   content: unknown;
 };
 
+type ReasoningItem = {
+  type: "reasoning";
+  id: string;
+};
+
 // Helper functions for filtering results
 function getFunctionCalls(items: ResponseInputItem[]): FunctionCallItem[] {
   return items.filter(
@@ -45,6 +50,12 @@ function getMessagesByRole(
     const msg = item as { role?: string; type?: string };
     return msg.role === role && (!msg.type || msg.type === "message");
   }) as unknown as MessageItem[];
+}
+
+function getReasoningItems(items: ResponseInputItem[]): ReasoningItem[] {
+  return items.filter(
+    (item) => (item as { type?: string }).type === "reasoning",
+  ) as unknown as ReasoningItem[];
 }
 
 describe("openaiTypeConverters", () => {
@@ -494,6 +505,44 @@ describe("openaiTypeConverters", () => {
 
         const userMessages = getMessagesByRole(result, "user");
         expect(userMessages.length).toBe(2);
+      });
+
+      it("should skip trailing thinking messages without a following assistant item", () => {
+        const messages: ChatMessage[] = [
+          {
+            role: "thinking",
+            content: "",
+            reasoning_details: [{ type: "reasoning_id", id: "rs_trailing" }],
+          } as ChatMessage,
+        ];
+
+        const result = toResponsesInput(messages);
+
+        const reasoningItems = getReasoningItems(result);
+        expect(reasoningItems.length).toBe(0);
+      });
+
+      it("should preserve thinking messages when followed by assistant output", () => {
+        const messages: ChatMessage[] = [
+          {
+            role: "thinking",
+            content: "",
+            reasoning_details: [{ type: "reasoning_id", id: "rs_kept" }],
+          } as ChatMessage,
+          {
+            role: "assistant",
+            content: "Done.",
+          } as ChatMessage,
+        ];
+
+        const result = toResponsesInput(messages);
+
+        const reasoningItems = getReasoningItems(result);
+        const assistantMessages = getMessagesByRole(result, "assistant");
+
+        expect(reasoningItems.length).toBe(1);
+        expect(reasoningItems[0].id).toBe("rs_kept");
+        expect(assistantMessages.length).toBe(1);
       });
 
       it("should handle system message (converted to developer role)", () => {

--- a/core/llm/openaiTypeConverters.ts
+++ b/core/llm/openaiTypeConverters.ts
@@ -868,6 +868,18 @@ function convertThinkingMessageToReasoningItem(
   return reasoningItem;
 }
 
+function hasFollowingAssistantMessage(
+  messages: ChatMessage[],
+  startIndex: number,
+): boolean {
+  for (let i = startIndex + 1; i < messages.length; i++) {
+    const nextRole = messages[i]?.role;
+    if (nextRole === "thinking") continue;
+    return nextRole === "assistant";
+  }
+  return false;
+}
+
 export function toResponsesInput(messages: ChatMessage[]): ResponseInput {
   const input: ResponseInput = [];
 
@@ -967,6 +979,10 @@ export function toResponsesInput(messages: ChatMessage[]): ResponseInput {
         break;
       }
       case "thinking": {
+        if (!hasFollowingAssistantMessage(messages, i)) {
+          break;
+        }
+
         const reasoningItem = convertThinkingMessageToReasoningItem(
           msg as ThinkingChatMessage,
         );


### PR DESCRIPTION
## Summary\n- only include  messages in  when a later assistant message exists\n- skip trailing/orphaned reasoning items so we don't send invalid  entries without the required follow-up item\n- add regression tests that cover both skipped trailing reasoning and preserved reasoning before assistant output\n\n## Testing\n- undefined
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "vitest" not found *(fails in this environment: )*\n\nCloses #11138

---

<!-- continue-task-summary-start -->
**Continue Tasks:** 🔄 7 running — [View all](https://hub.continue.dev/inbox/pr/continuedev/continue/11140?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops sending orphaned reasoning items to the OpenAI Responses API by only including “thinking” entries when followed by an assistant message. Prevents invalid input and enforces correct item order. Fixes #11138.

- **Bug Fixes**
  - Skip trailing “thinking” messages without a following assistant.
  - Preserve reasoning when followed by assistant output.
  - Add unit tests covering both scenarios.

<sup>Written for commit d90c504ae3deaf4a020874fe1a86f5748f452be6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

