### PR TITLE
docs: fix typo 'contibuting' -> 'contributing' in CONTRIBUTING.mdx

### DIFF
--- a/docs/CONTRIBUTING.mdx
+++ b/docs/CONTRIBUTING.mdx
@@ -344,4 +344,4 @@ Learn more about linking PRs to issues in the [GitHub documentation](https://doc
 - **Existing docs**: Review similar pages for formatting examples
 ---
 
-Thank you for contributing to Continue! Your efforts help make our documentation better for everyone. To learn more about contibuting to other parts of the project, check out our [main CONTRIBUTING guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md) 🎉
+Thank you for contributing to Continue! Your efforts help make our documentation better for everyone. To learn more about contributing to other parts of the project, check out our [main CONTRIBUTING guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md) 🎉


### PR DESCRIPTION
Fixes a small typo in the documentation where 'contributing' was misspelled as 'contibuting'.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects a typo in docs/CONTRIBUTING.mdx. Replaces "contibuting" with "contributing" to improve clarity.

<sup>Written for commit 641c3fc1dbc64416ad3c9fa1ad71fe0e70fcbfc1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

