### PR TITLE
docs: fix grammar - add missing 'to' in model setup instructions

### DIFF
--- a/docs/customize/models.mdx
+++ b/docs/customize/models.mdx
@@ -48,49 +48,49 @@ Read more about [model roles](/customize/model-roles), [model capabilities](/cus
 [Qwen Coder 3 480B](https://continue.dev/openrouter/qwen3-coder) from Qwen
 
 1. Get your API key from [OpenRouter](https://openrouter.ai/settings/keys)
-2. Add [Qwen Coder 3 480B](https://continue.dev/openrouter/qwen3-coder)  a config on Continue Mission Control
+2. Add [Qwen Coder 3 480B](https://continue.dev/openrouter/qwen3-coder) to a config on Continue Mission Control
 3. Add `OPENROUTER_API_KEY` as a [User Secret](https://docs.continue.dev/mission-control/secrets/secret-types#user-secrets) on Continue Mission Control [here](https://continue.dev/settings/secrets)
 4. Click `Reload config` in the config selector in the Continue IDE extension
 
 [GPT-5](https://continue.dev/openai/gpt-5) from OpenAI
 
 1. Get your API key from [OpenAI](https://platform.openai.com)
-2. Add [GPT-5](https://continue.dev/openai/gpt-5)  a config on Continue Mission Control
+2. Add [GPT-5](https://continue.dev/openai/gpt-5) to a config on Continue Mission Control
 3. Add `OPENAI_API_KEY` as a [User Secret](https://docs.continue.dev/mission-control/secrets/secret-types#user-secrets) on Continue Mission Control [here](https://continue.dev/settings/secrets)
 4. Click `Reload config` in the config selector in the Continue IDE extension
 
 [Kimi K2](https://continue.dev/openrouter/kimi-k2) from Moonshot AI
 
 1. Get your API key from [OpenRouter](https://openrouter.ai/settings/keys)
-2. Add [Kimi K2](https://continue.dev/openrouter/kimi-k2)  a config on Continue Mission Control
+2. Add [Kimi K2](https://continue.dev/openrouter/kimi-k2) to a config on Continue Mission Control
 3. Add `OPENROUTER_API_KEY` as a [User Secret](https://docs.continue.dev/mission-control/secrets/secret-types#user-secrets) on Continue Mission Control [here](https://continue.dev/settings/secrets)
 4. Click `Reload config` in the config selector in the Continue IDE extension
 
 [Gemini 2.5 Pro](https://continue.dev/google/gemini-2.5-pro) from Google
 
 1. Get your API key from [Google AI Studio](https://aistudio.google.com)
-2. Add [Gemini 2.5 Pro](https://continue.dev/google/gemini-2.5-pro)  a config on Continue Mission Control
+2. Add [Gemini 2.5 Pro](https://continue.dev/google/gemini-2.5-pro) to a config on Continue Mission Control
 3. Add `GEMINI_API_KEY` as a [User Secret](https://docs.continue.dev/mission-control/secrets/secret-types#user-secrets) on Continue Mission Control [here](https://continue.dev/settings/secrets)
 4. Click `Reload config` in the config selector in the Continue IDE extension
 
 [Grok Code Fast 1](https://continue.dev/xai/grok-code-fast-1) from xAI
 
 1. Get your API key from [xAI](https://console.x.ai/)
-2. Add [Grok Code Fast 1](https://continue.dev/xai/grok-code-fast-1)  a config on Continue Mission Control
+2. Add [Grok Code Fast 1](https://continue.dev/xai/grok-code-fast-1) to a config on Continue Mission Control
 3. Add `XAI_API_KEY` as a [User Secret](https://docs.continue.dev/mission-control/secrets/secret-types#user-secrets) on Continue Mission Control [here](https://continue.dev/settings/secrets)
 4. Click `Reload config` in the config selector in the Continue IDE extension
 
 [Devstral Medium](https://continue.dev/mistral/devstral-medium) from Mistral AI
 
 1. Get your API key from [Mistral AI](https://console.mistral.ai/)
-2. Add [Devstral Medium](https://continue.dev/mistral/devstral-medium)  a config on Continue Mission Control
+2. Add [Devstral Medium](https://continue.dev/mistral/devstral-medium) to a config on Continue Mission Control
 3. Add `MISTRAL_API_KEY` as a [User Secret](https://docs.continue.dev/mission-control/secrets/secret-types#user-secrets) on Continue Mission Control [here](https://continue.dev/settings/secrets)
 4. Click `Reload config` in the config selector in the Continue IDE extension
 
 [gpt-oss-120b](https://continue.dev/openrouter/gpt-oss-120b) from OpenAI
 
 1. Get your API key from [OpenRouter](https://openrouter.ai/settings/keys)
-2. Add [gpt-oss-120b](https://continue.dev/openrouter/gpt-oss-120b)  a config on Continue Mission Control
+2. Add [gpt-oss-120b](https://continue.dev/openrouter/gpt-oss-120b) to a config on Continue Mission Control
 3. Add `OPENROUTER_API_KEY` as a [User Secret](https://docs.continue.dev/mission-control/secrets/secret-types#user-secrets) on Continue Mission Control [here](https://continue.dev/settings/secrets)
 4. Click `Reload config` in the config selector in the Continue IDE extension
 
@@ -106,36 +106,36 @@ Their limited tool calling and reasoning capabilities will make it challenging t
 
 [Qwen3 Coder 30B](https://continue.dev/ollama/qwen3-coder-30b)
 
-1. Add [Qwen3 Coder 30B](https://continue.dev/ollama/qwen3-coder-30b)  a config on Continue Mission Control
+1. Add [Qwen3 Coder 30B](https://continue.dev/ollama/qwen3-coder-30b) to a config on Continue Mission Control
 2. Run the model with [Ollama](https://docs.continue.dev/guides/ollama-guide#using-ollama-with-continue-a-developers-guide)
 3. Click `Reload config` in the config selector in the Continue IDE extension
 
 [gpt-oss-20b](https://continue.dev/ollama/gpt-oss-20b)
 
-1. Add [gpt-oss-20b](https://continue.dev/ollama/gpt-oss-20b)  a config on Continue Mission Control
+1. Add [gpt-oss-20b](https://continue.dev/ollama/gpt-oss-20b) to a config on Continue Mission Control
 2. Run the model with [Ollama](https://docs.continue.dev/guides/ollama-guide#using-ollama-with-continue-a-developers-guide)
 3. Click `Reload config` in the config selector in the Continue IDE extension
 
 [Devstral Small 27B](https://continue.dev/ollama/devstral)
 
-1. Add [Devstral Small](https://continue.dev/ollama/devstral)  a config on Continue Mission Control
+1. Add [Devstral Small](https://continue.dev/ollama/devstral) to a config on Continue Mission Control
 2. Run the model with [Ollama](https://docs.continue.dev/guides/ollama-guide#using-ollama-with-continue-a-developers-guide)
 3. Click `Reload config` in the config selector in the Continue IDE extension
 
 [Qwen2.5-Coder 7B](https://continue.dev/ollama/qwen2.5-coder-7b) from Qwen
 
-1. Add [Qwen2.5-Coder 7B](https://continue.dev/ollama/qwen2.5-coder-7b)  a config on Continue Mission Control
+1. Add [Qwen2.5-Coder 7B](https://continue.dev/ollama/qwen2.5-coder-7b) to a config on Continue Mission Control
 2. Run the model with [Ollama](https://docs.continue.dev/guides/ollama-guide#using-ollama-with-continue-a-developers-guide)
 3. Click `Reload config` in the config selector in the Continue IDE extension
 
 [Gemma 3 4B](https://continue.dev/ollama/gemma3-4b) from Google
 
-1. Add [Gemma 3 4B](https://continue.dev/ollama/gemma3-4b)  a config on Continue Mission Control
+1. Add [Gemma 3 4B](https://continue.dev/ollama/gemma3-4b) to a config on Continue Mission Control
 2. Run the model with [Ollama](https://docs.continue.dev/guides/ollama-guide#using-ollama-with-continue-a-developers-guide)
 3. Click `Reload config` in the config selector in the Continue IDE extension
 
 [Qwen2.5-Coder 1.5B](https://continue.dev/ollama/qwen2.5-coder-1.5b) from Qwen
 
-1. Add [Qwen2.5-Coder 1.5B](https://continue.dev/ollama/qwen2.5-coder-1.5b)  a config on Continue Mission Control
+1. Add [Qwen2.5-Coder 1.5B](https://continue.dev/ollama/qwen2.5-coder-1.5b) to a config on Continue Mission Control
 2. Run the model with [Ollama](https://docs.continue.dev/guides/ollama-guide#using-ollama-with-continue-a-developers-guide)
 3. Click `Reload config` in the config selector in the Continue IDE extension


### PR DESCRIPTION
Fixes a grammar issue in the models documentation where the word 'to' was missing from the setup instructions.

Changed 'Add [Model]  a config' to 'Add [Model] to a config' for all model entries in the documentation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing "to" in model setup instructions by changing "Add [Model]  a config" to "Add [Model] to a config". Applies to all model entries in docs/customize/models.mdx to improve clarity.

<sup>Written for commit 458e04a3e0600a2b115c9faae3632063d02d2f1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

