### PR TITLE
fix: preserve region and profile from YAML model config

### DIFF
--- a/packages/config-yaml/src/schemas/models.ts
+++ b/packages/config-yaml/src/schemas/models.ts
@@ -180,6 +180,8 @@ const baseModelFields = {
   apiKey: z.string().optional(),
   apiBase: z.string().optional(),
   maxStopWords: z.number().optional(),
+  region: z.string().optional(),
+  profile: z.string().optional(),
   roles: modelRolesSchema.array().optional(),
   capabilities: modelCapabilitySchema.array().optional(),
   defaultCompletionOptions: completionOptionsSchema.optional(),


### PR DESCRIPTION
## Summary

- Add `region` and `profile` to the Zod `baseModelFields` in the config-yaml model schema so they survive YAML parsing instead of being stripped as unknown keys

## Problem

The [SageMaker docs](https://docs.continue.dev/customize/model-providers/more/sagemaker) show `region` at the model level:

```yaml
models:
  - name: deepseek-6.7b-instruct
    provider: sagemaker
    model: lmi-model-deepseek-coder-xxxxxxx
    region: eu-central-1
```

But the Zod schema for `ModelConfig` didn't include `region` or `profile` in `baseModelFields`, so `z.object().parse()` silently stripped them. The only way to set these fields was through the nested `env` object, which the SageMaker docs don't mention.

This caused SageMaker to always default to `us-west-2` and Bedrock to `us-east-1`, regardless of the user's configured region.

## Fix

Add `region: z.string().optional()` and `profile: z.string().optional()` to `baseModelFields`. These fields are already in `LLMOptions` and are spread via `...rest` in `modelConfigToBaseLLM()`, so no other code changes are needed.

The `env` nested object path continues to work and takes precedence when both are set (the `env` handler runs after the initial spread), maintaining backward compatibility.

Fixes #10879

## Disclosure

This PR was authored by Claude Opus 4.6 (an AI), operating transparently. See https://github.com/anthropics/claude-code for details.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves `region` and `profile` from YAML model configs so SageMaker and Bedrock use the user’s region instead of defaulting to `us-west-2`/`us-east-1`. Adds these fields to the `baseModelFields` Zod schema in `packages/config-yaml`.

- **Bug Fixes**
  - Added `region` and `profile` as optional fields to `baseModelFields` so they aren’t stripped during parse.
  - Top-level `region`/`profile` are now respected; `env` still works and takes precedence when both are set.

<sup>Written for commit 9f70054456c3469357bc32f84622e50898d38aed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

