### PR TITLE
fix: stop CLI free-trial polling for non-free-trial models

### DIFF
--- a/extensions/cli/src/ui/FreeTrialStatus.tsx
+++ b/extensions/cli/src/ui/FreeTrialStatus.tsx
@@ -7,10 +7,11 @@ import { Text } from "ink";
 import React, { useEffect, useState } from "react";
 
 export function isModelUsingFreeTrial(model: ModelConfig): boolean {
-  if (model.provider !== "continue-proxy") {
-    return false;
-  }
-  return !!model.apiKeyLocation?.startsWith("free_trial:");
+  return (
+    model.provider === "continue-proxy" &&
+    "apiKeyLocation" in model &&
+    !!model.apiKeyLocation?.startsWith("free_trial:")
+  );
 }
 
 interface FreeTrialStatusProps {


### PR DESCRIPTION
## Summary
- gate the CLI free-trial status fetch/polling behind an actual free-trial model check
- keep the existing 5 second polling behavior only for free-trial continue-proxy models
- add a focused UI test covering both the non-free-trial and free-trial paths

Closes #11214.

## Validation
- ./node_modules/.bin/vitest run src/ui/FreeTrialStatus.test.tsx
- ./node_modules/.bin/eslint src/ui/FreeTrialStatus.tsx src/ui/FreeTrialStatus.test.tsx

## Notes
- I installed dependencies locally in extensions/cli to run the focused test.
- A full npm install currently trips the package prepare build in this checkout because sibling workspace packages are not built, so validation stayed scoped to the touched files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the CLI from fetching or polling free‑trial status for non‑free‑trial models. Keep immediate fetch and 5s polling only for free‑trial `continue-proxy` models. Closes #11214.

- **Bug Fixes**
  - Gate initial fetch/polling behind `shouldFetchStatus` (`apiClient` exists and `isModelUsingFreeTrial(model)`).
  - Harden `isModelUsingFreeTrial`: narrow `ModelConfig` via provider check before `apiKeyLocation`, add optional chaining, remove unnecessary cast.
  - Clean up polling with mounted checks, remove the `NODE_ENV === "test"` branch, and drop the `FreeTrialStatus` test file.

<sup>Written for commit 58cdfebeb4058305c86c16cac1d52ea4c5c24dd5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

