### PR TITLE
feat: alias /rename for /title

### DIFF
--- a/extensions/cli/src/commands/commands.ts
+++ b/extensions/cli/src/commands/commands.ts
@@ -97,6 +97,11 @@ export const SYSTEM_SLASH_COMMANDS: SystemCommand[] = [
     category: "system",
   },
   {
+    name: "rename",
+    description: "Rename the current session",
+    category: "system",
+  },
+  {
     name: "exit",
     description: "Exit the chat",
     category: "system",

--- a/extensions/cli/src/slashCommands.test.ts
+++ b/extensions/cli/src/slashCommands.test.ts
@@ -337,6 +337,23 @@ describe("slashCommands", () => {
       expect(result?.exit).toBe(false);
     });
 
+    it("should handle /rename as an alias for /title", async () => {
+      const { updateSessionTitle } = await import("./session.js");
+      (updateSessionTitle as any).mockReset();
+
+      const result = await handleSlashCommands(
+        "/rename My Renamed Session",
+        mockAssistant,
+      );
+
+      expect(updateSessionTitle).toHaveBeenCalledWith("My Renamed Session");
+      expect(result).toBeDefined();
+      expect(result?.output).toContain(
+        'Session title updated to: "My Renamed Session"',
+      );
+      expect(result?.exit).toBe(false);
+    });
+
     it("should handle custom assistant prompts", async () => {
       const assistantWithPrompts: AssistantUnrolled = {
         ...mockAssistant,

--- a/extensions/cli/src/slashCommands.ts
+++ b/extensions/cli/src/slashCommands.ts
@@ -200,6 +200,7 @@ const commandHandlers: Record<string, CommandHandler> = {
   },
   fork: handleFork,
   title: handleTitle,
+  rename: handleTitle,
   init: (args, assistant) => {
     posthogService.capture("useSlashCommand", { name: "init" });
     return handleInit(args, assistant);


### PR DESCRIPTION
## Description

Alias `/title` with `/rename`

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add /rename as an alias for /title in the CLI, so users can rename the current session with either command. Updated the system command list and mapped /rename to the existing title handler; added a test to cover the alias.

<sup>Written for commit c13b1f9e75eb3b5cd7dfe4091e38573a2058c908. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

