### PR TITLE
fix: guard BASH_SOURCE[0] in CLI install script (#11268)

### DIFF
--- a/extensions/cli/scripts/install.sh
+++ b/extensions/cli/scripts/install.sh
@@ -324,6 +324,6 @@ main() {
 }
 
 # Allow sourcing without running
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]] || [ -z "${BASH_SOURCE[0]:-}" ]; then
+if [[ "${BASH_SOURCE[0]:-}" == "${0}" ]] || [ -z "${BASH_SOURCE[0]:-}" ]; then
     main "$@"
 fi


### PR DESCRIPTION
## Summary

Fixes #11268

The CLI install script fails when piped via `curl -fsSL ... | bash` because `BASH_SOURCE[0]` is referenced without a `:-` default value guard under `set -u`.

## Root Cause

Line 327 has two references to `BASH_SOURCE[0]`:
- First: `${BASH_SOURCE[0]}` - missing guard (crashes)
- Second: `${BASH_SOURCE[0]:-}` - has guard (correct)

When bash reads from a pipe, `BASH_SOURCE` is empty. Under `set -u` (enabled on line 2), accessing index 0 of an empty array triggers "unbound variable".

## Fix

Added `:-` to the first reference: `${BASH_SOURCE[0]:-}`, matching the pattern already used in the second reference on the same line.

## Test Plan

- `bash -euo pipefail -c 'echo ${BASH_SOURCE[0]}'` fails (before)
- `bash -euo pipefail -c 'echo ${BASH_SOURCE[0]:-}'` succeeds (after)

This contribution was developed with AI assistance (Claude Code).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent "unbound variable" errors in the CLI install script when run via `curl -fsSL ... | bash` with `set -u`. Adds a `:-` default guard to the first `BASH_SOURCE[0]` check so the script runs when `BASH_SOURCE` is empty.

<sup>Written for commit ccd8a7ce9687123607b6de63e27024653fd55f6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

