### PR TITLE
fix: preserve indentation when applying code edits to Python files

### DIFF
--- a/core/edit/searchAndReplace/executeFindAndReplace.vitest.ts
+++ b/core/edit/searchAndReplace/executeFindAndReplace.vitest.ts
@@ -207,6 +207,84 @@ describe("executeFindAndReplace", () => {
     });
   });
 
+  describe("indentation adjustment", () => {
+    it("should adjust indentation when trimmedMatch finds unindented old_string in indented file", () => {
+      const fileContent =
+        "def foo():\n    x = 1\n    y = 2\n    return x + y\n";
+      // LLM sends unindented old_string that matches via trimmedMatch
+      const oldString = "x = 1\ny = 2";
+      const newString = "x = 10\ny = 20";
+      const result = executeFindAndReplace(
+        fileContent,
+        oldString,
+        newString,
+        false,
+      );
+      expect(result).toBe(
+        "def foo():\n    x = 10\n    y = 20\n    return x + y\n",
+      );
+    });
+
+    it("should preserve relative inner indentation in multi-line replacement", () => {
+      const fileContent =
+        "class Foo:\n    def bar(self):\n        if True:\n            x = 1\n";
+      const oldString = "if True:\n    x = 1";
+      const newString = "if True:\n    x = 1\n    y = 2";
+      const result = executeFindAndReplace(
+        fileContent,
+        oldString,
+        newString,
+        false,
+      );
+      expect(result).toBe(
+        "class Foo:\n    def bar(self):\n        if True:\n            x = 1\n            y = 2\n",
+      );
+    });
+
+    it("should handle tab vs space mismatch", () => {
+      const fileContent = "function foo() {\n\tconst x = 1;\n}\n";
+      // LLM sends with leading spaces (not tabs), triggering trimmedMatch
+      const oldString = "  const x = 1;";
+      const newString = "  const x = 2;\n  const y = 3;";
+      const result = executeFindAndReplace(
+        fileContent,
+        oldString,
+        newString,
+        false,
+      );
+      expect(result).toBe(
+        "function foo() {\n\tconst x = 2;\n\tconst y = 3;\n}\n",
+      );
+    });
+
+    it("should not adjust indentation for exactMatch", () => {
+      const fileContent = "    x = 1\n";
+      const oldString = "    x = 1";
+      const newString = "    x = 2";
+      const result = executeFindAndReplace(
+        fileContent,
+        oldString,
+        newString,
+        false,
+      );
+      expect(result).toBe("    x = 2\n");
+    });
+
+    it("should handle whitespaceIgnoredMatch with different internal whitespace", () => {
+      const fileContent = "def outer():\n    if  True:\n        return  42\n";
+      // Different internal whitespace triggers whitespaceIgnoredMatch
+      const oldString = "if True:\n    return 42";
+      const newString = "if True:\n    return 99";
+      const result = executeFindAndReplace(
+        fileContent,
+        oldString,
+        newString,
+        false,
+      );
+      expect(result).toBe("def outer():\n    if True:\n        return 99\n");
+    });
+  });
+
   describe("edge cases", () => {
     it("should handle single character replacement", () => {
       const content = "a b c";

--- a/core/edit/searchAndReplace/performReplace.ts
+++ b/core/edit/searchAndReplace/performReplace.ts
@@ -17,6 +17,23 @@ function getLeadingIndent(text: string): string {
 }
 
 /**
+ * Get the indentation of the file line containing a given character position.
+ */
+function getLineIndentAtPosition(
+  fileContent: string,
+  position: number,
+): string {
+  const lineStart = fileContent.lastIndexOf("\n", position - 1) + 1;
+  const lineEnd = fileContent.indexOf("\n", lineStart);
+  const line = fileContent.substring(
+    lineStart,
+    lineEnd === -1 ? fileContent.length : lineEnd,
+  );
+  const match = line.match(/^(\s*)/);
+  return match ? match[1] : "";
+}
+
+/**
  * When a fuzzy match strategy (trimmedMatch, whitespaceIgnoredMatch, etc.)
  * finds a match, the indentation of the matched region in the file may
  * differ from the indentation in the search string provided by the LLM.
@@ -36,8 +53,7 @@ function adjustReplacementIndentation(
     return newString;
   }
 
-  const matchedText = fileContent.substring(match.startIndex, match.endIndex);
-  const matchedIndent = getLeadingIndent(matchedText);
+  const matchedIndent = getLineIndentAtPosition(fileContent, match.startIndex);
   const oldIndent = getLeadingIndent(oldString);
 
   if (matchedIndent === oldIndent) {
@@ -49,14 +65,17 @@ function adjustReplacementIndentation(
     if (line.trim().length === 0) {
       return line;
     }
+    if (index === 0) {
+      // First line: the file content before startIndex already provides
+      // indentation, so strip the old indent rather than adding new
+      if (oldIndent && line.startsWith(oldIndent)) {
+        return line.slice(oldIndent.length);
+      }
+      return line;
+    }
+    // Subsequent lines: replace oldIndent prefix with matchedIndent
     if (line.startsWith(oldIndent)) {
       return matchedIndent + line.slice(oldIndent.length);
-    }
-    // For lines that don't start with the old indent (e.g. first line
-    // might have no indent if old_string was trimmed), apply the
-    // matched indent directly
-    if (index === 0 && oldIndent === "" && matchedIndent !== "") {
-      return matchedIndent + line;
     }
     return line;
   });


### PR DESCRIPTION
## Summary
- Fixes indentation corruption when the code edit tool uses fallback match strategies (`trimmedMatch`, `whitespaceIgnoredMatch`, etc.) to apply edits
- When an LLM provides search/replace strings with different indentation than the target code (common with Python), the replacement text is now re-indented to match the file's actual indentation level

## How it works

`adjustReplacementIndentation()` compares the indentation of the file line at the match position against the leading indent of the LLM-provided `old_string`. If they differ:

- **First line**: strips the old indent prefix (the file content before the splice point already provides correct indentation)
- **Subsequent lines**: replaces the old indent prefix with the matched indent, preserving relative inner indentation
- **Exact matches**: passed through unchanged - no indentation adjustment needed

This handles tab/space mismatches, completely unindented LLM output, and deeply nested code blocks.

## Test plan
- [x] Unindented `old_string` matching indented file content gets correct indentation
- [x] Multi-level nesting preserves relative inner indentation
- [x] Tab vs space mismatch resolved correctly
- [x] Exact matches unchanged (no regression)
- [x] `whitespaceIgnoredMatch` with differing internal whitespace works correctly
- [x] `replaceAll` mode applies indentation adjustment per-match

Fixes #11282

🤖 Generated with [Claude Code](https://claude.com/claude-code)