### PR TITLE
fix: include reasoning_content field for DeepSeek Reasoner models

### DIFF
--- a/core/llm/openaiTypeConverters.ts
+++ b/core/llm/openaiTypeConverters.ts
@@ -36,6 +36,7 @@ import {
   ThinkingChatMessage,
   ToolCallDelta,
 } from "..";
+import { stripImages } from "../util/messageContent";
 
 function appendReasoningFieldsIfSupported(
   msg: ChatCompletionAssistantMessageParam & {
@@ -64,7 +65,7 @@ function appendReasoningFieldsIfSupported(
   // Default to empty string to avoid 400 "Missing reasoning_content field".
   if (includeReasoningContent) {
     msg.reasoning_content = hasThinkingContent
-      ? (prevMessage.content as string)
+      ? stripImages(prevMessage.content)
       : "";
   }
 
@@ -97,7 +98,7 @@ function appendReasoningFieldsIfSupported(
     msg.reasoning_details = reasoningDetailsValue || [];
   }
   if (includeReasoning) {
-    msg.reasoning = prevMessage.content as string;
+    msg.reasoning = stripImages(prevMessage.content);
   }
 }
 


### PR DESCRIPTION
## Summary
- DeepSeek Reasoner API requires `reasoning_content` on every assistant message, but `appendReasoningFieldsIfSupported` returned early when no thinking message preceded the assistant message (e.g. in resumed sessions)
- Now `reasoning_content` defaults to an empty string when `includeReasoningContentField` is true but no thinking content is available, preventing 400 "Missing reasoning_content field" errors

## How it works
- Moved the `includeReasoningContent` check before the early return guard so it always runs for providers that need it
- When a thinking message precedes the assistant message, the actual reasoning content is used
- When no thinking message is present, an empty string is used as the default
- Other reasoning fields (`reasoning`, `reasoning_details`) still require a preceding thinking message

## Test plan
- [ ] Verify DeepSeek Reasoner no longer returns 400 errors in resumed sessions
- [ ] Verify DeepSeek Reasoner still includes actual reasoning_content when thinking messages are present
- [ ] Verify Claude and other providers are unaffected (they use `reasoning_details`, not `reasoning_content`)

Fixes #11285

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always include `reasoning_content` for DeepSeek Reasoner models, defaulting to an empty string when no prior `thinking` message exists. Prevents 400 errors in resumed sessions and safely handles mixed message content.

- **Bug Fixes**
  - Run `includeReasoningContentField` before the early return and set `msg.reasoning_content` to the previous `thinking` content or "" if missing.
  - Use `stripImages` to populate `reasoning_content` and `reasoning`, handling string or `MessagePart[]` content; keep `reasoning_details` unchanged and only set when a `thinking` message is present.

<sup>Written for commit 8cd24cbf14c13607f708b66eee9f7e5c58e3913b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

