### PR TITLE
docs: document all CLI slash commands in TUI mode

### DIFF
--- a/docs/cli/tui-mode.mdx
+++ b/docs/cli/tui-mode.mdx
@@ -26,14 +26,26 @@ Type `/` to see available commands. Run `/help` for the full list.
 
 | Command | What it does |
 |---------|-------------|
+| `/help` | Show the help message and keyboard shortcuts |
+| `/clear` | Clear the chat history |
+| `/login` | Authenticate with your account |
+| `/logout` | Sign out of your current session |
+| `/update` | Update the Continue CLI |
+| `/whoami` | Check who you're currently logged in as |
+| `/info` | Show session information, including token usage and cost |
 | `/model` | Switch between configured chat models |
 | `/config` | Switch configuration or organization |
-| `/compact` | Summarize chat history to free up context |
-| `/fork` | Branch the conversation from the current point |
-| `/resume` | Pick up a previous session |
-| `/info` | Show token usage and cost for this session |
-| `/init` | Create an `AGENTS.md` file for the current project |
 | `/mcp` | Manage MCP server connections |
+| `/init` | Create an `AGENTS.md` file for the current project |
+| `/compact` | Summarize chat history into a compact form |
+| `/resume` | Resume a previous chat session |
+| `/fork` | Start a forked chat session from the current history |
+| `/title` | Set the title for the current session |
+| `/rename` | Rename the current session (alias for `/title`) |
+| `/exit` | Exit the chat |
+| `/jobs` | List background jobs |
+
+When you're connected to a remote environment, Continue also adds remote-only slash commands such as `/diff` and `/apply`.
 
 ## Resume previous sessions
 


### PR DESCRIPTION
## Description
Closes #11316.

This updates the TUI slash command table so it matches the commands currently exposed by the CLI. It adds the missing slash commands, refreshes a few outdated descriptions, and notes that `/diff` and `/apply` are only available in remote environments. The change is intentionally small and safe because it only updates user-facing documentation in a single file and does not affect runtime behavior.

## Checklist
- [x] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created

## Tests
- `npx --yes prettier --check docs/cli/tui-mode.mdx`

## Why this is small and safe
- This PR only changes documentation for existing commands.
- No code paths, configs, or shipped behavior are modified.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update TUI mode docs to list all current CLI slash commands and refresh outdated descriptions so the table matches the CLI. Also note that `/diff` and `/apply` are only available in remote environments.

<sup>Written for commit a7eb2dde7611512eac962e3e1e0a5ace98b98e86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

