### PR TITLE
docs: cover AI SDK flag and background job polling in CLI

### DIFF
--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -75,3 +75,16 @@ Store sensitive values (API keys, tokens) in [Continue → Settings → Secrets]
 ```yaml
 ${{ secrets.MY_API_KEY }}
 ```
+
+## Advanced environment flags
+
+### `CONTINUE_USE_AI_SDK`
+
+Set `CONTINUE_USE_AI_SDK=1` to route `openai` and `anthropic` provider requests through Continue's Vercel AI SDK adapter instead of the default provider clients:
+
+```bash
+export CONTINUE_USE_AI_SDK=1
+cn
+```
+
+This is useful when you want to test the AI SDK-backed request path without changing your `config.yaml`. The flag only changes `openai` and `anthropic` providers; all other providers continue using their standard adapters.

--- a/docs/cli/headless-mode.mdx
+++ b/docs/cli/headless-mode.mdx
@@ -48,6 +48,12 @@ cn -p "Set up the project" --allow "*"
 
 See [tool permissions](/cli/tool-permissions) for the full policy system.
 
+Read-only helpers such as `CheckBackgroundJob` remain allowed by default, so the agent can safely inspect long-running work without additional approval.
+
+## Background jobs
+
+If a shell command is moved to the background, Continue returns a job id and the output collected so far. The agent can then call `CheckBackgroundJob("<job-id>")` to fetch the current status, exit code, and accumulated output while the job continues running.
+
 ## Authentication in CI
 
 Set `CONTINUE_API_KEY` instead of running `cn login`:


### PR DESCRIPTION
## Description
Partially addresses #10997.

This documents the remaining CLI docs gaps around the `CONTINUE_USE_AI_SDK` environment variable and the default `CheckBackgroundJob` flow for backgrounded shell work. It adds an advanced configuration note explaining that the flag routes `openai` and `anthropic` providers through Continue's AI SDK adapter, and it adds headless-mode guidance that `CheckBackgroundJob` stays allow-by-default and can be used to poll background jobs. The change is intentionally small and safe because it only updates two existing docs pages and does not alter runtime behavior.

## Checklist
- [x] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created

## Tests
- `npx --yes prettier --check --no-config --tab-width 2 --use-tabs false --trailing-comma all --semi true --single-quote false --bracket-spacing true docs/cli/configuration.mdx docs/cli/headless-mode.mdx`
- `printf 'continue\\n' | npx mintlify broken-links` *(currently fails in the repo on a pre-existing parse error in `extensions/cli/BUILD.md`, not on these updated pages)*

## Why this is small and safe
- This PR only adds documentation for existing CLI behavior.
- No code paths, configs, or shipped behavior are modified.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CLI docs for `CONTINUE_USE_AI_SDK` and for polling backgrounded shell jobs, addressing gaps from #10997. Setting `CONTINUE_USE_AI_SDK=1` routes `openai` and `anthropic` via Continue’s Vercel AI SDK adapter; headless mode docs now note that backgrounded commands return a job id and can be polled with `CheckBackgroundJob`, with read-only helpers allowed by default.

<sup>Written for commit ca7b97c6c92877e12d4c4e03ce253b785db2d20f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

