### PR TITLE
jb 1.0.62, vscode 1.3.33

### DIFF
--- a/extensions/intellij/gradle.properties
+++ b/extensions/intellij/gradle.properties
@@ -1,5 +1,5 @@
 pluginGroup=com.github.continuedev.continueintellijextension
-pluginVersion=1.0.61
+pluginVersion=1.0.62
 platformVersion=2024.1
 kotlin.stdlib.default.dependency=false
 org.gradle.configuration-cache=true

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "1.3.32",
+  "version": "1.3.33",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION
prerelease bumps

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped the IntelliJ plugin to 1.0.62 and the VS Code extension to 1.3.33 to prepare the next prerelease build.

<sup>Written for commit ad9dd4fdc1a74053e0fc71a8cdcd4fb8af03d393. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

