### PR TITLE
fix: remove hardcoded Unix $ prompt prefix from terminal UI

### DIFF
--- a/gui/src/components/UnifiedTerminal/UnifiedTerminal.test.tsx
+++ b/gui/src/components/UnifiedTerminal/UnifiedTerminal.test.tsx
@@ -48,7 +48,7 @@ describe("UnifiedTerminalCommand", () => {
     );
 
     // Should show the command
-    expect(screen.getByText(`$ ${MOCK_COMMAND}`)).toBeInTheDocument();
+    expect(screen.getByText(MOCK_COMMAND)).toBeInTheDocument();
 
     // Should show terminal header
     expect(screen.getByText("Terminal")).toBeInTheDocument();
@@ -68,7 +68,7 @@ describe("UnifiedTerminalCommand", () => {
     );
 
     // Should show the command and output
-    expect(screen.getByText(`$ ${MOCK_COMMAND}`)).toBeInTheDocument();
+    expect(screen.getByText(MOCK_COMMAND)).toBeInTheDocument();
 
     // Check that the output content exists in the container
     expect(container.textContent).toMatch(/Test 1 passed/);
@@ -303,7 +303,7 @@ describe("UnifiedTerminalCommand", () => {
     );
 
     // Should show command but no output section
-    expect(screen.getByText(`$ ${MOCK_COMMAND}`)).toBeInTheDocument();
+    expect(screen.getByText(MOCK_COMMAND)).toBeInTheDocument();
 
     // Should not show any output content
     const outputElements = container.querySelectorAll(

--- a/gui/src/components/UnifiedTerminal/UnifiedTerminal.tsx
+++ b/gui/src/components/UnifiedTerminal/UnifiedTerminal.tsx
@@ -410,7 +410,7 @@ export function UnifiedTerminalCommand({
 
   // Create combined content for copying (command + output)
   const copyContent = useMemo(() => {
-    let content = `$ ${command}`;
+    let content = command;
     if (hasOutput) {
       content += `\n\n${output}`;
     }
@@ -459,7 +459,7 @@ export function UnifiedTerminalCommand({
             <pre className="bg-editor">
               <code>
                 {/* Command is always visible */}
-                <div className="text-terminal pb-2">$ {command}</div>
+                <div className="text-terminal pb-2">{command}</div>
 
                 {/* Running state with cursor */}
                 {isRunning && !hasOutput && (


### PR DESCRIPTION
## Summary

- Removes the hardcoded `$ ` prefix from terminal command display in the GUI
- The `$ ` is a Unix bash convention that has no meaning for Windows users (PowerShell uses `PS>`, cmd uses `>`)
- It doesn't reflect the user's actual shell — Continue doesn't know which shell runs the command
- The command is already visually distinct (styled text inside a labeled "Terminal" block), so the prefix adds no information and is misleading cross-platform

## Test plan

- [ ] Verify terminal commands render without `$ ` prefix
- [ ] Verify copy button copies command text without `$ ` prefix
- [ ] Run `cd gui && npx vitest run UnifiedTerminal`

Closes #11428

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the hardcoded `$ ` prefix from terminal command display and copy-to-clipboard so commands are shell-agnostic and accurate across OSes. Closes #11428.

<sup>Written for commit 87de81590c9902a3157311c187cea5dc4b3f6ebe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

