### PR TITLE
fix(intellij): handle square brackets in file paths for autocomplete

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/UriUtils.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/UriUtils.kt
@@ -23,11 +23,9 @@ object UriUtils {
         // Remove query parameters if present
         val uriStr = uri.substringBefore("?")
 
-        // Handle Windows file paths with authority component (e.g. file://C:/path/to/file)
+        // Handle Windows file paths with authority component
         if (uriStr.startsWith("file://") && !uriStr.startsWith("file:///")) {
             val path = uriStr.substringAfter("file://")
-            // Use multi-arg URI constructor to properly percent-encode special characters like [ ]
-            // This is cross-platform unlike File.toURI() which depends on the host OS
             return URI("file", "", "/$path", null)
         }
 

--- a/extensions/intellij/src/test/kotlin/com/github/continuedev/continueintellijextension/unit/UriUtilsTest.kt
+++ b/extensions/intellij/src/test/kotlin/com/github/continuedev/continueintellijextension/unit/UriUtilsTest.kt
@@ -61,30 +61,18 @@ class UriUtilsTest : TestCase() {
         assertEquals(expectedFile, result)
     }
 
-    /**
-     * Validates that square brackets in file paths are handled correctly.
-     * This is a regression test for GitHub issue #10978.
-     * Frameworks like Next.js and FiveM use bracket-named directories
-     * (e.g. [gamemode]) which caused URI parsing to crash.
-     */
+    // Regression test for #10978 — bracket directories like [gamemode]
     fun `test square brackets in path`() {
         val uri = "file:///path/to/[gamemode]/file.lua"
         val result = UriUtils.uriToFile(uri)
         assertEquals(File("/path/to/[gamemode]/file.lua"), result)
     }
 
-    /**
-     * Validates that Windows-style file URIs with square brackets are handled.
-     * Regression test for GitHub issue #10978 — the original crash occurred
-     * specifically with Windows two-slash file:// URIs.
-     */
     fun `test Windows path with square brackets`() {
         val uri = "file://C:/Users/user/projects/[gamemode]/file.lua"
         val parsed = UriUtils.parseUri(uri)
         assertEquals("file", parsed.scheme)
-        // URI.path returns the decoded path — brackets should be literal here
         assertEquals("/C:/Users/user/projects/[gamemode]/file.lua", parsed.path)
-        // The raw URI string should have them percent-encoded
         assertEquals("file:///C:/Users/user/projects/%5Bgamemode%5D/file.lua", parsed.toString())
     }
 }


### PR DESCRIPTION
Use File.toURI() instead of URI constructor for Windows two-slash
file:// URIs to properly percent-encode special characters like [ ].
Fixes #10978.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes URI parsing for file paths with square brackets to prevent IntelliJ autocomplete crashes on Windows two‑slash file URIs. Builds Windows `file://C:/...` URIs with the cross‑platform multi‑arg `URI(...)` constructor so `[` and `]` are percent‑encoded.

- **Bug Fixes**
  - Update `UriUtils` to handle Windows two‑slash `file://` URIs using `URI("file", "", "/$path", null)` instead of `File.toURI()` to avoid host‑dependent behavior.
  - Add regression tests for Unix and Windows; strengthen Windows checks for scheme, decoded path (with literal brackets), and encoded URI string.

<sup>Written for commit 2d6a66d713e3100f23ef831b3f3beaf25b1af197. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

