### PR TITLE
fix(core): normalize workspace dir paths to file:// URIs

### DIFF
--- a/core/util/ideUtils.ts
+++ b/core/util/ideUtils.ts
@@ -7,6 +7,36 @@ import {
 } from "./uri";
 
 /*
+  Helper function to normalize workspace directory paths to proper file:// URIs.
+  This handles cases where workspace directories might be returned as plain file paths
+  instead of URIs, which can occur on some IDE extensions like IntelliJ on Linux.
+
+  Examples:
+  - Input: "/home/user/project" -> Output: "file:///home/user/project"
+  - Input: "file:///home/user/project" -> Output: "file:///home/user/project"
+*/
+export function normalizeDirUri(dirPath: string): string {
+  // If it's already a URI with a scheme, return as-is
+  if (dirPath.includes("://")) {
+    return dirPath;
+  }
+
+  // Convert likely absolute filesystem paths to file:// URIs.
+  // Workspace dirs should already be URIs, but this guards against malformed IDE inputs.
+  if (dirPath.startsWith("/")) {
+    return `file:///${pathToUriPathSegment(dirPath)}`;
+  }
+
+  // For Windows paths (C:\ or drive letters)
+  if (/^[a-zA-Z]:/.test(dirPath)) {
+    const normalized = dirPath.replaceAll("\\", "/");
+    return `file:///${pathToUriPathSegment(normalized)}`;
+  }
+
+  return dirPath;
+}
+
+/*
   This function takes a relative (to workspace) filepath
   And checks each workspace for if it exists or not
   Only returns fully resolved URI if it exists
@@ -18,7 +48,10 @@ export async function resolveRelativePathInDir(
 ): Promise<string | undefined> {
   const dirs = dirUriCandidates ?? (await ide.getWorkspaceDirs());
   for (const dirUri of dirs) {
-    const fullUri = joinPathsToUri(dirUri, path);
+    // Normalize the directory URI to ensure it's a proper file:// URI
+    // This handles cases where workspace directories might be plain file paths
+    const normalizedDirUri = normalizeDirUri(dirUri);
+    const fullUri = joinPathsToUri(normalizedDirUri, path);
     if (await ide.fileExists(fullUri)) {
       return fullUri;
     }
@@ -39,7 +72,10 @@ export async function inferResolvedUriFromRelativePath(
   dirCandidates?: string[],
 ): Promise<string> {
   const relativePath = _relativePath.trim().replaceAll("\\", "/");
-  const dirs = dirCandidates ?? (await ide.getWorkspaceDirs());
+  const rawDirs = dirCandidates ?? (await ide.getWorkspaceDirs());
+
+  // Normalize all directories to proper file:// URIs
+  const dirs = rawDirs.map(normalizeDirUri);
 
   if (dirs.length === 0) {
     throw new Error("inferResolvedUriFromRelativePath: no dirs provided");

--- a/core/util/ideUtils.vitest.ts
+++ b/core/util/ideUtils.vitest.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import { IDE } from "..";
+import {
+  inferResolvedUriFromRelativePath,
+  normalizeDirUri,
+  resolveRelativePathInDir,
+} from "./ideUtils";
+
+describe("normalizeDirUri", () => {
+  it("should pass through file:// URIs unchanged", () => {
+    expect(normalizeDirUri("file:///home/user/project")).toBe(
+      "file:///home/user/project",
+    );
+  });
+
+  it("should convert Linux absolute path to file:// URI", () => {
+    expect(normalizeDirUri("/home/user/project")).toBe("file:///home/user/project");
+  });
+
+  it("should encode special characters in Linux paths", () => {
+    expect(normalizeDirUri("/home/user/my project")).toBe("file:///home/user/my%20project");
+  });
+
+  it("should convert Windows drive path to file:// URI", () => {
+    expect(normalizeDirUri("C:\\Users\\user\\project")).toBe("file:///C%3A/Users/user/project");
+  });
+});
+
+function createMockIde(opts: {
+  workspaceDirs: string[];
+  existingFiles?: Set<string>;
+}): IDE {
+  const existingFiles = opts.existingFiles ?? new Set<string>();
+  return {
+    getWorkspaceDirs: vi.fn(async () => opts.workspaceDirs),
+    fileExists: vi.fn(async (uri: string) => existingFiles.has(uri)),
+  } as unknown as IDE;
+}
+
+describe("resolveRelativePathInDir", () => {
+  it("should resolve a relative path against a proper file:// workspace dir", async () => {
+    const ide = createMockIde({
+      workspaceDirs: ["file:///home/user/project"],
+      existingFiles: new Set(["file:///home/user/project/src/file.ts"]),
+    });
+    const result = await resolveRelativePathInDir("src/file.ts", ide);
+    expect(result).toBe("file:///home/user/project/src/file.ts");
+  });
+
+  it("should resolve when workspace dir is a plain Linux path (bug #11559)", async () => {
+    const ide = createMockIde({
+      workspaceDirs: ["/home/user/project"],
+      existingFiles: new Set(["file:///home/user/project/src/file.ts"]),
+    });
+    const result = await resolveRelativePathInDir("src/file.ts", ide);
+    expect(result).toBe("file:///home/user/project/src/file.ts");
+  });
+
+  it("should NOT produce a double-prefixed path (regression guard)", async () => {
+    const ide = createMockIde({
+      workspaceDirs: ["/home/user/project"],
+      existingFiles: new Set(["file:///home/user/project/src/file.ts"]),
+    });
+    const result = await resolveRelativePathInDir("src/file.ts", ide);
+    expect(result).not.toContain("/home/user/home/");
+  });
+});
+
+describe("inferResolvedUriFromRelativePath", () => {
+  it("should join relative path to normalized workspace dir", async () => {
+    const ide = createMockIde({
+      workspaceDirs: ["file:///home/user/project"],
+    });
+    const result = await inferResolvedUriFromRelativePath("src/file.ts", ide);
+    expect(result).toBe("file:///home/user/project/src/file.ts");
+  });
+
+  it("should produce correct URI when workspace dir is plain path (bug #11559)", async () => {
+    const ide = createMockIde({
+      workspaceDirs: ["/home/user/project"],
+    });
+    const result = await inferResolvedUriFromRelativePath("src/file.ts", ide);
+    expect(result).toBe("file:///home/user/project/src/file.ts");
+  });
+
+  it("should NOT produce double-prefixed path (regression guard)", async () => {
+    const ide = createMockIde({
+      workspaceDirs: ["/home/user/project"],
+    });
+    const result = await inferResolvedUriFromRelativePath("src/file.ts", ide);
+    expect(result).not.toContain("/home/user/home/");
+  });
+});


### PR DESCRIPTION
## Description

Fixes #11559 - File Path Resolution Failure in Tools

When IDE extensions (e.g., IntelliJ on Linux) return workspace directories as plain file paths like `/home/user/project` instead of proper file:// URIs, the path resolution logic would produce incorrect double-prefixed paths like `/home/user/home/user/project`.

## Root Cause

The `resolveRelativePathInDir()` and `inferResolvedUriFromRelativePath()` functions in `core/util/ideUtils.ts` expected workspace directories to always be in URI format (`file:///home/user/project`), but some IDE extensions return plain filesystem paths.

## Fix

Added `normalizeDirUri()` helper that converts plain file paths to proper file:// URIs before joining with relative paths:
- Handles Linux absolute paths (`/home/user/project`)
- Handles Windows paths (`C:\\Users\\project`)
- Passes through already-valid URIs unchanged
- Handles vscode-remote:// and other schemes

## Tests

Added `core/util/ideUtils.vitest.ts` with tests for:
- `normalizeDirUri()` - URI passthrough, Linux paths, Windows paths, encoding
- `resolveRelativePathInDir()` - normal case, bug case, regression guard
- `inferResolvedUriFromRelativePath()` - normal case, bug case, regression guard

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant tests have been created

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize workspace directory paths to file:// URIs to fix path resolution when IDEs return plain paths (e.g., IntelliJ on Linux). Prevents double-prefixed paths and ensures correct URI joining.

- **Bug Fixes**
  - Added normalizeDirUri to convert Linux/Windows paths; passthrough for existing URIs and other schemes.
  - Updated resolveRelativePathInDir and inferResolvedUriFromRelativePath to normalize dir inputs.
  - Added tests for normalization and both resolution functions, including regression guards.

<sup>Written for commit da335b80877721ed9e846aa75643fce9cb50eb6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

