### PR TITLE
Add block-no-verify PreToolUse hook to .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{ "type": "command", "command": "npx block-no-verify@1.1.2" }]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Creates `.claude/settings.json` with `block-no-verify@1.1.2` as a `PreToolUse` Bash hook to prevent Claude Code agents from bypassing git hooks via the hook-skip flag.

## Details

When an agent runs `git commit` or `git push` with the hook-bypass flag, it silently disables pre-commit, commit-msg, and pre-push hooks. `block-no-verify` reads `tool_input.command` from the Claude Code hook stdin payload, detects the hook-bypass flag across all git subcommands, and exits 2 to block. No custom scripts needed. The existing `.claude/skills` directory is unchanged.

Closes #11628

---

_Disclosure: I am the author and maintainer of `block-no-verify`._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PreToolUse Bash hook in .claude/settings.json that runs `block-no-verify@1.1.2` via npx to block `--no-verify` and ensure git hooks always run on agent commits and pushes. Aligns with #11628.

- **New Features**
  - Runs `block-no-verify@1.1.2` before tool use to detect hook-bypass flags and exit with a block.
  - No changes to `.claude/skills` or other scripts.

<sup>Written for commit d561c9f2fc314640e47f2763e2b9059bcaf5dcfd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

