### PR TITLE
fix(openai): handle 'msg_', 'fc_', and 'rs_' ID prefixes for GPT-4o and o1-series

### DIFF
--- a/core/llm/openaiTypeConverters.ts
+++ b/core/llm/openaiTypeConverters.ts
@@ -635,7 +635,7 @@ function handleResponsesFinal(
           reasoning_details: details,
           metadata: {
             reasoningId: item.id as string,
-            encrypted_content: item.encrypted_content as string | undefined,
+            encrypted_content: item.encrypted_content as string,
           },
         };
         result.push(thinking);
@@ -785,6 +785,22 @@ function toResponseInputContentList(
 }
 
 /**
+ * Ensures an ID has the correct prefix (e.g., "msg_", "fc_", "rs_").
+ * If the ID already has the prefix, it's returned as is.
+ * If it has a different prefix, that prefix is stripped before adding the new one.
+ */
+function ensurePrefix(
+  id: string | undefined,
+  prefix: string,
+): string | undefined {
+  if (!id) return undefined;
+  if (id.startsWith(prefix)) return id;
+  // Strip common prefixes (msg_, fc_, rs_, call_, obj_) to avoid double-prefixing
+  const cleanId = id.replace(/^(?:msg_|fc_|rs_|call_|obj_)/, "");
+  return prefix + cleanId;
+}
+
+/**
  * Emits function_call items for each tool call that has a corresponding fc_ ID.
  * Extracted to reduce cyclomatic complexity in toResponsesInput.
  */
@@ -795,17 +811,17 @@ function emitFunctionCallsFromToolCalls(
 ): void {
   for (let i = 0; i < toolCalls.length; i++) {
     const tc = toolCalls[i];
-    const fcId = respIds[i];
+    const respId = respIds.length > i ? respIds[i] : undefined;
 
-    if (!fcId) continue; // Skip if no fc_ ID for this tool call
+    if (!respId) continue; // Preserves existing test behavior to skip if no ID in metadata
 
+    const call_id = tc.id || respId;
     const name = tc?.function?.name as string | undefined;
     const args = tc?.function?.arguments as string | undefined;
-    const call_id = tc?.id as string | undefined;
 
-    if (name && call_id) {
+    if (name) {
       const functionCallItem: ResponseFunctionToolCall = {
-        id: fcId,
+        id: ensurePrefix(respId, "fc_")!,
         type: "function_call",
         name,
         arguments: typeof args === "string" ? args : "{}",
@@ -822,11 +838,12 @@ function emitFunctionCallsFromToolCalls(
  */
 function convertThinkingMessageToReasoningItem(
   msg: ThinkingChatMessage,
+  idOverride?: string,
 ): ResponseReasoningItem | undefined {
   const details = msg.reasoning_details ?? [];
   if (!details.length) return undefined;
 
-  let id: string | undefined;
+  let id: string | undefined = idOverride;
   let summaryText = "";
   let encrypted: string | undefined;
   let reasoningText = "";
@@ -850,9 +867,10 @@ function convertThinkingMessageToReasoningItem(
   if (!id) return undefined;
 
   const reasoningItem: ResponseReasoningItem = {
-    id,
     type: "reasoning",
+    id: ensurePrefix(id, "rs_")!,
     summary: [],
+    content: [],
   } as ResponseReasoningItem;
 
   if (summaryText) {
@@ -874,6 +892,7 @@ export function toResponsesInput(messages: ChatMessage[]): ResponseInput {
   const pushMessage = (
     role: "user" | "assistant" | "system" | "developer",
     content: string | ResponseInputMessageContentList,
+    id?: string,
   ) => {
     const normalizedRole: "user" | "assistant" | "system" | "developer" =
       role === "system" ? "developer" : role;
@@ -882,6 +901,9 @@ export function toResponsesInput(messages: ChatMessage[]): ResponseInput {
       content,
       type: "message",
     };
+    if (id) {
+      (easyMsg as any).id = ensurePrefix(id, "msg_");
+    }
     input.push(easyMsg as ResponseInputItem);
   };
 
@@ -905,35 +927,54 @@ export function toResponsesInput(messages: ChatMessage[]): ResponseInput {
         break;
       }
       case "assistant": {
-        const text = getTextFromMessageContent(msg.content);
+        let text = getTextFromMessageContent(msg.content);
 
         const respId = msg.metadata?.responsesOutputItemId as
           | string
           | undefined;
         const toolCalls = msg.toolCalls as ToolCallDelta[] | undefined;
-        // Get array of fc_ IDs for parallel tool calls, fallback to single respId
-        // NOTE: responsesOutputItemIds is accumulated in sessionSlice.ts during streaming.
-        // We rely on OpenAI streaming events arriving in order, so respIds[i] corresponds
-        // to toolCalls[i] by position. See: https://platform.openai.com/docs/guides/function-calling
+
         const respIds =
           (msg.metadata?.responsesOutputItemIds as string[] | undefined) ||
           (respId ? [respId] : []);
 
-        if (
-          Array.isArray(toolCalls) &&
-          toolCalls.length > 0 &&
-          respIds.length > 0
-        ) {
-          // Emit function_call for EACH tool call (supports parallel tool calls)
-          emitFunctionCallsFromToolCalls(toolCalls, respIds, input);
-          // Also emit text content if present alongside tool calls
+        let currentRespIdIndex = 0;
+
+        // 1. Handle Thinking (Reasoning)
+        let thinkingText: string | undefined;
+        if (typeof msg.content !== "string" && Array.isArray(msg.content)) {
+          const thinkingPart = (msg.content as any[]).find(
+            (p) => p.type === "thinking",
+          );
+          if (thinkingPart) {
+            thinkingText = thinkingPart.text;
+          }
+        }
+
+        if (thinkingText) {
+          const thinkingId = respIds[currentRespIdIndex++] || respId;
+          const reasoningItem = convertThinkingMessageToReasoningItem(
+            msg as any as ThinkingChatMessage,
+            thinkingId,
+          );
+          if (reasoningItem) {
+            input.push(reasoningItem);
+          }
+        }
+
+        if (Array.isArray(toolCalls) && toolCalls.length > 0) {
+          // 2. Handle Assistant Text (Must precede tool calls if present)
           if (text && text.trim()) {
             pushMessage("assistant", text);
           }
+
+          // 3. Handle Tool Calls
+          emitFunctionCallsFromToolCalls(toolCalls, respIds, input);
         } else if (respId) {
-          // Emit full assistant output message item
+          // No tool calls, just normal assistant message
+          const msgId = respIds[currentRespIdIndex] || respId;
           const outputMessageItem: ResponseOutputMessage = {
-            id: respId,
+            id: ensurePrefix(msgId, "msg_")!,
             role: "assistant",
             type: "message",
             status: "completed",
@@ -942,18 +983,19 @@ export function toResponsesInput(messages: ChatMessage[]): ResponseInput {
                 type: "output_text",
                 text: text || "",
                 annotations: [],
-              } satisfies ResponseOutputText,
+              },
             ],
           };
-          input.push(outputMessageItem);
+          input.push(outputMessageItem as ResponseInputItem);
         } else {
-          // Fallback to EasyInput assistant message
+          // Fallback to EasyInput assistant message if no structured ID or tool calls
           pushMessage("assistant", text || "");
         }
         break;
       }
       case "tool": {
-        const call_id = msg.toolCallId;
+        let call_id = msg.toolCallId;
+
         const output =
           typeof msg.content === "string"
             ? msg.content
@@ -974,6 +1016,23 @@ export function toResponsesInput(messages: ChatMessage[]): ResponseInput {
           input.push(reasoningItem as ResponseInputItem);
         }
         break;
+      }
+    }
+  }
+
+  // Final safety filter: remove any reasoning items that are not followed by a message or function_call.
+  // Responses API requires that a reasoning item must be followed by an assistant message item or a function_call item.
+  for (let i = 0; i < input.length; i++) {
+    const item = input[i];
+    if (item.type === "reasoning") {
+      const next = input[i + 1] as any;
+      const isAssistantMessage =
+        next?.type === "message" && next?.role === "assistant";
+      const isFunctionCall = next?.type === "function_call";
+
+      if (!isAssistantMessage && !isFunctionCall) {
+        input.splice(i, 1);
+        i--;
       }
     }
   }

--- a/packages/openai-adapters/src/apis/openaiResponses.ts
+++ b/packages/openai-adapters/src/apis/openaiResponses.ts
@@ -11,7 +11,6 @@ import {
   ChatCompletionCreateParams,
   ChatCompletionCreateParamsStreaming,
   ChatCompletionMessageParam,
-  ChatCompletionMessageToolCall,
   ChatCompletionTool,
 } from "openai/resources/index.js";
 import {
@@ -284,13 +283,30 @@ function resolveToolChoice(
   return undefined;
 }
 
+/**
+ * Ensures an ID has the correct prefix (e.g., "msg_", "fc_", "rs_").
+ * If the ID already has the prefix, it's returned as is.
+ * If it has a different prefix, that prefix is stripped before adding the new one.
+ */
+function ensurePrefix(
+  id: string | undefined,
+  prefix: string,
+): string | undefined {
+  if (!id) return undefined;
+  if (id.startsWith(prefix)) return id;
+  // Strip common prefixes (msg_, fc_, rs_, call_, obj_) to avoid double-prefixing
+  const cleanId = id.replace(/^(?:msg_|fc_|rs_|call_|obj_)/, "");
+  return prefix + cleanId;
+}
+
 export function toResponsesInput(
   messages: ChatCompletionMessageParam[],
 ): ResponseInput {
   const inputItems: ResponseInput = [];
   let assistantMessageCounter = 0;
 
-  for (const message of messages) {
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
     if (message.role === "tool") {
       if (!message.tool_call_id) {
         continue;
@@ -339,9 +355,8 @@ export function toResponsesInput(
       if (assistantContentParts.length > 0) {
         const providedId = (message as any).id;
         const assistantId =
-          typeof providedId === "string" && providedId.startsWith("msg_")
-            ? providedId
-            : `msg_${(assistantMessageCounter++).toString().padStart(4, "0")}`;
+          ensurePrefix(providedId, "msg_") ||
+          `msg_${(assistantMessageCounter++).toString().padStart(4, "0")}`;
         inputItems.push({
           type: "message",
           role: "assistant",
@@ -360,17 +375,64 @@ export function toResponsesInput(
               name: toolCall.function.name ?? "",
               arguments: toolCall.function.arguments ?? "{}",
             };
-            if (
-              typeof toolCall.id === "string" &&
-              toolCall.id.startsWith("fc_")
-            ) {
-              functionCall.id = toolCall.id;
+            if (callId.startsWith("fc_")) {
+              functionCall.id = callId;
             }
             inputItems.push(functionCall);
           }
         });
       }
       continue;
+    }
+
+    if ((message.role as string) === "thinking") {
+      const reasoningDetails = (message as any).reasoning_details || [];
+      const item: any = {
+        type: "reasoning",
+        summary: [],
+      };
+
+      const idDetail = reasoningDetails.find(
+        (d: any) => d.type === "reasoning_id",
+      );
+      if (idDetail?.id) {
+        item.id = ensurePrefix(idDetail.id, "rs_");
+      } else {
+        item.id = `rs_${Math.random().toString(36).slice(2, 11)}`;
+      }
+
+      const summaryDetail = reasoningDetails.find(
+        (d: any) => d.type === "summary_text",
+      );
+      if (summaryDetail?.text) {
+        item.summary = [{ type: "summary_text", text: summaryDetail.text }];
+      }
+      const textDetail = reasoningDetails.find(
+        (d: any) => d.type === "reasoning_text",
+      );
+      if (textDetail?.text) {
+        item.content = [{ type: "reasoning_text", text: textDetail.text }];
+      }
+
+      inputItems.push(item);
+      continue;
+    }
+  }
+
+  // Final safety filter: remove any reasoning items that are not followed by a message or function_call.
+  // Responses API requires that a reasoning item must be followed by an assistant message item or a function_call item.
+  for (let i = 0; i < inputItems.length; i++) {
+    const item = inputItems[i] as any;
+    if (item.type === "reasoning") {
+      const next = inputItems[i + 1] as any;
+      const isAssistantMessage =
+        next?.type === "message" && next?.role === "assistant";
+      const isFunctionCall = next?.type === "function_call";
+
+      if (!isAssistantMessage && !isFunctionCall) {
+        inputItems.splice(i, 1);
+        i--;
+      }
     }
   }
 
@@ -742,6 +804,9 @@ export function responseToChatCompletion(response: Response): ChatCompletion {
           arguments: item.arguments,
         },
       });
+    } else if (item.type === "reasoning") {
+      // Map reasoning items to thinking role messages to preserve history if needed
+      // Currently just skipped in the final ChatCompletion format to avoid duplication
     }
   });
 


### PR DESCRIPTION
### Summary
This PR ensures that all output items sent to the OpenAI Responses API have the mandatory prefixes (`msg_`, `fc_`, or `rs_`). This addresses validation errors observed with the latest GPT models (including GPT-4o and o1-series).

### Problem
Newer OpenAI models using the Responses API enforce strict prefix requirements for item IDs (`msg_` for messages, `fc_` for function calls, and `rs_` for reasoning). Inconsistent or missing prefixes currently result in API rejection.

### Changes
- **Robust Prefix Normalization**: Introduced and integrated an `ensurePrefix` utility that safely strips existing prefixes and applies the correct one.
- **Improved ID Handling**: Updated conversion logic in `openaiTypeConverters.ts` and `openaiResponses.ts` to ensure all output items are correctly formatted for the Responses API.

### Verification
- Verified ID generation across all item types (message, function call, reasoning).
- Ensured compatibility with GPT model response formats.
