### PR TITLE
Remove Gemini 2.0 Flash from defaults and update Claude defaults to 4.6

### DIFF
--- a/core/config/onboarding.ts
+++ b/core/config/onboarding.ts
@@ -9,7 +9,7 @@ export const LOCAL_ONBOARDING_EMBEDDINGS_MODEL = "nomic-embed-text:latest";
 export const LOCAL_ONBOARDING_EMBEDDINGS_TITLE = "Nomic Embed";
 
 const ANTHROPIC_MODEL_CONFIG = {
-  slugs: ["anthropic/claude-3-7-sonnet", "anthropic/claude-4-sonnet"],
+  slugs: ["anthropic/claude-sonnet-4-6", "anthropic/claude-opus-4-6"],
   apiKeyInputName: "ANTHROPIC_API_KEY",
 };
 const OPENAI_MODEL_CONFIG = {
@@ -19,7 +19,7 @@ const OPENAI_MODEL_CONFIG = {
 
 // TODO: These need updating on the hub
 const GEMINI_MODEL_CONFIG = {
-  slugs: ["google/gemini-2.5-pro", "google/gemini-2.0-flash"],
+  slugs: ["google/gemini-2.5-pro", "google/gemini-2.5-flash"],
   apiKeyInputName: "GEMINI_API_KEY",
 };
 

--- a/core/config/workspace/workspaceBlocks.ts
+++ b/core/config/workspace/workspaceBlocks.ts
@@ -42,9 +42,9 @@ function getContentsForNewBlock(blockType: BlockType): ConfigYaml {
       configYaml.models = [
         {
           provider: "anthropic",
-          model: "claude-sonnet-4-5",
+          model: "claude-sonnet-4-6",
           apiKey: "${{ secrets.ANTHROPIC_API_KEY }}",
-          name: "Claude Sonnet 4.5",
+          name: "Claude Sonnet 4.6",
           roles: ["chat", "edit"],
         },
       ];

--- a/core/llm/llms/CometAPI.ts
+++ b/core/llm/llms/CometAPI.ts
@@ -211,7 +211,6 @@ class CometAPI extends OpenAI {
     "gemini-2.5-pro",
     "gemini-2.5-flash",
     "gemini-2.5-flash-lite",
-    "gemini-2.0-flash",
 
     // Grok series
     "grok-4-0709",

--- a/docs/customize/deep-dives/model-capabilities.mdx
+++ b/docs/customize/deep-dives/model-capabilities.mdx
@@ -202,7 +202,7 @@ This matrix shows which models support tool use and image input capabilities. Co
 | Model            | Tool Use | Image Input | Context Window |
 | :--------------- | -------- | ----------- | -------------- |
 | Gemini 2.5 Pro   | Yes      | Yes         | 2M             |
-| Gemini 2.0 Flash | Yes      | Yes         | 1M             |
+| Gemini 2.5 Flash | Yes      | Yes         | 1M             |
 
 ### Mistral
 

--- a/docs/customize/model-roles/apply.mdx
+++ b/docs/customize/model-roles/apply.mdx
@@ -37,7 +37,7 @@ Example:
 models:
   - name: My Custom Apply Template
     provider: anthropic
-    model: claude-3-5-sonnet-latest
+    model: claude-sonnet-4-6
     promptTemplates:
       apply: |
         Original: {{{original_code}}}

--- a/docs/customize/model-roles/edit.mdx
+++ b/docs/customize/model-roles/edit.mdx
@@ -16,9 +16,9 @@ version: 0.0.1
 schema: v1
 
 models:
-  - name: Claude 4 Sonnet
+  - name: Claude Sonnet 4.6
     provider: anthropic
-    model: claude-3-5-sonnet-latest
+    model: claude-sonnet-4-6
     apiKey: <YOUR_ANTHROPIC_API_KEY>
     roles:
       - edit

--- a/docs/faqs.mdx
+++ b/docs/faqs.mdx
@@ -343,7 +343,7 @@ version: 0.0.1
 schema: v1
 models:
   - uses: ollama/llama3.1-8b
-  - uses: anthropic/claude-3.5-sonnet
+  - uses: anthropic/claude-sonnet-4-6
   - uses: openai/gpt-4
 ```
 
@@ -357,7 +357,7 @@ version: 0.0.1
 schema: v1
 models:
   # Hub model addon
-  - uses: anthropic/claude-3.5-sonnet
+  - uses: anthropic/claude-sonnet-4-6
   
   # Local model configuration
   - name: Local Ollama

--- a/docs/reference.mdx
+++ b/docs/reference.mdx
@@ -382,7 +382,7 @@ name: My Config
 version: 1.0.0
 schema: v1
 models:
-  - uses: anthropic/claude-3.5-sonnet
+  - uses: anthropic/claude-sonnet-4-6
     with:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     override:

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -969,16 +969,12 @@
               },
               "model": {
                 "enum": [
-                  "chat-bison-001",
-                  "gemini-pro",
-                  "gemini-2.0-flash-exp",
-                  "gemini-2.0-flash",
-                  "gemini-2.0-flash-thinking-exp-01-21",
-                  "gemini-2.0-pro-exp-02-05",
-                  "gemini-2.0-flash-lite-preview-02-05",
-                  "gemini-2.0-flash-lite",
-                  "gemini-2.0-flash-exp-image-generation",
-                  "gemini-2.5-pro-latest"
+                  "gemini-3-pro-preview",
+                  "gemini-3-flash-preview",
+                  "gemini-2.5-pro",
+                  "gemini-2.5-flash",
+                  "gemini-2.5-flash-lite",
+                  "gemini-pro"
                 ]
               }
             }

--- a/gui/src/pages/AddNewModel/configs/models.ts
+++ b/gui/src/pages/AddNewModel/configs/models.ts
@@ -1027,49 +1027,6 @@ export const models: { [key: string]: ModelPackage } = {
     icon: "mistral.png",
     isOpenSource: true,
   },
-  gemini20Flash: {
-    title: "Gemini 2.0 Flash",
-    description:
-      "Google's powerful workhorse model with low latency and enhanced performance.",
-    params: {
-      title: "Gemini 2.0 Flash",
-      model: "gemini-2.0-flash",
-      contextLength: 1_000_000,
-      apiKey: "<API_KEY>",
-    },
-    icon: "gemini.png",
-    providerOptions: ["gemini"],
-    isOpenSource: false,
-  },
-  gemini20FlashLite: {
-    title: "Gemini 2.0 Flash Lite",
-    description:
-      "A more efficient version of Gemini 2.0 Flash optimized for faster responses and lower resource usage.",
-    params: {
-      title: "Gemini 2.0 Flash Lite",
-      model: "gemini-2.0-flash-lite",
-      contextLength: 1_048_576,
-      apiKey: "<API_KEY>",
-    },
-    icon: "gemini.png",
-    providerOptions: ["gemini"],
-    isOpenSource: false,
-  },
-  gemini20FlashImageGeneration: {
-    title: "Gemini 2.0 Flash Image Generation",
-    description:
-      "A version of Gemini 2.0 Flash optimized for image generation capabilities.",
-    params: {
-      title: "Gemini 2.0 Flash Image Generation",
-      model: "gemini-2.0-flash-exp-image-generation",
-      contextLength: 32_768,
-      apiKey: "<API_KEY>",
-    },
-    icon: "gemini.png",
-    providerOptions: ["gemini"],
-    isOpenSource: false,
-  },
-
   gemini25Pro: {
     title: "Gemini 2.5 Pro",
     description:
@@ -2002,20 +1959,6 @@ export const models: { [key: string]: ModelPackage } = {
     providerOptions: ["askSage"],
     icon: "groq.png",
     isOpenSource: true,
-  },
-  asksagegemini20Flash: {
-    title: "Gemini 2.0 Flash*",
-    description:
-      "Google's powerful workhorse model with low latency and enhanced performance.",
-    params: {
-      title: "Gemini 2.0 Flash*",
-      model: "google-gemini-20-flash",
-      contextLength: 1_000_000,
-      apiKey: "",
-    },
-    icon: "gemini.png",
-    providerOptions: ["askSage"],
-    isOpenSource: false,
   },
   asksagegemini25Pro: {
     title: "Gemini 2.5 Pro*",
@@ -3107,20 +3050,6 @@ export const models: { [key: string]: ModelPackage } = {
       model: "gemini-2.5-flash-lite",
       contextLength: 8_000,
       title: "Gemini 2.5 Flash Lite",
-      apiKey: "",
-    },
-    providerOptions: ["cometapi"],
-    icon: "cometapi.png",
-    isOpenSource: false,
-  },
-  cometapiGemini20Flash: {
-    title: "Gemini 2.0 Flash",
-    description:
-      "Gemini 2.0 Flash via CometAPI - Google's powerful workhorse model with low latency.",
-    params: {
-      model: "gemini-2.0-flash",
-      contextLength: 32_000,
-      title: "Gemini 2.0 Flash",
       apiKey: "",
     },
     providerOptions: ["cometapi"],

--- a/gui/src/pages/AddNewModel/configs/providers.ts
+++ b/gui/src/pages/AddNewModel/configs/providers.ts
@@ -122,7 +122,6 @@ export const providers: Partial<Record<string, ProviderInfo>> = {
       models.cometapiGemini25Pro,
       models.cometapiGemini25Flash,
       models.cometapiGemini25FlashLite,
-      models.cometapiGemini20Flash,
       // xAI Grok family
       models.cometapiGrok40709,
       models.cometapiGrok3,
@@ -1151,7 +1150,6 @@ To get started, [register](https://dataplatform.cloud.ibm.com/registration/stepo
       models.asksageclaude45sonnetgov,
       models.asksageclaude45opus,
       models.asksageclaude45haiku,
-      models.asksagegemini20Flash,
       models.asksagegemini25Pro,
       models.asksagegemini25flash,
       models.asksagegpt5,

--- a/packages/config-yaml/src/schemas/commonSlugs.ts
+++ b/packages/config-yaml/src/schemas/commonSlugs.ts
@@ -12,7 +12,7 @@ export const commonModelSlugs = [
   "openai/gpt-4o",
   "togetherai/llama-4-scout-instruct-17bx16e",
   "anthropic/claude-haiku-4-5",
-  "google/gemini-2.0-flash",
+  "google/gemini-2.5-flash",
   "voyageai/rerank-2",
   "anthropic/claude-opus-4-1",
   "ollama/deepseek-r1",


### PR DESCRIPTION
## Summary
- **Remove Gemini 2.0 Flash** from add model form (Gemini, CometAPI, AskSage providers), onboarding defaults, config schema, docs, and CometAPI supported models list. Replaced with Gemini 2.5 Flash in onboarding/common slugs. Gemini 2.0 Flash remains in llm-info for existing users.
- **Update Claude defaults to 4.6** — onboarding now defaults to `claude-sonnet-4-6` and `claude-opus-4-6` instead of older models. Workspace block template and doc examples updated to Claude Sonnet 4.6.
- **Update config schema** for Gemini provider to list Gemini 3 Pro/Flash Preview, 2.5 Pro/Flash/Flash Lite instead of old 2.0 entries.

## Files changed
- `core/config/onboarding.ts` — Anthropic slugs → 4.6, Gemini slug → 2.5-flash
- `core/config/workspace/workspaceBlocks.ts` — Default model → claude-sonnet-4-6
- `core/llm/llms/CometAPI.ts` — Remove gemini-2.0-flash from supported models
- `extensions/vscode/config_schema.json` — Update Gemini provider model enum
- `gui/src/pages/AddNewModel/configs/models.ts` — Remove 3 Gemini 2.0 Flash model entries + CometAPI/AskSage variants
- `gui/src/pages/AddNewModel/configs/providers.ts` — Remove references to deleted models
- `packages/config-yaml/src/schemas/commonSlugs.ts` — Replace gemini-2.0-flash → gemini-2.5-flash
- Docs: Update model examples to claude-sonnet-4-6, replace Gemini 2.0 Flash → 2.5 Flash in capabilities table

## Test plan
- [ ] Verify add model form no longer shows Gemini 2.0 Flash for Gemini, CometAPI, and AskSage providers
- [ ] Verify Gemini 2.5 Flash and Claude Sonnet 4.6 appear as expected defaults
- [ ] Verify onboarding flow uses updated model slugs
- [ ] Verify docs render correctly with updated model names

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed Gemini 2.0 Flash from defaults and UI, replacing it with Gemini 2.5 Flash. Updated Anthropic defaults to Claude Sonnet 4.6 and Opus 4.6; schemas, onboarding slugs, workspace templates, CometAPI supported models, and docs were updated accordingly.

- **Migration**
  - Existing configs using `google/gemini-2.0-flash` continue to work; no action required.
  - New defaults use `google/gemini-2.5-flash`, `anthropic/claude-sonnet-4-6`, and `anthropic/claude-opus-4-6`. Update your config if you want these.
  - VS Code config schema now enumerates Gemini 3 Preview and 2.5 models; remove references to Gemini 2.0 Flash in new configs.

<sup>Written for commit cf880b80f8eee6b3572ef71c6406f8151806c211. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

