### PR TITLE
fix: expand tool support to reduce 'Invalid tool name' errors

### DIFF
--- a/core/llm/toolSupport.ts
+++ b/core/llm/toolSupport.ts
@@ -28,9 +28,14 @@ export const PROVIDER_TOOL_SUPPORT: Record<string, (model: string) => boolean> =
       return false;
     },
     azure: (model) => {
+      const lower = model.toLowerCase();
       if (
-        model.toLowerCase().startsWith("gpt-4") ||
-        model.toLowerCase().startsWith("o3")
+        lower.startsWith("gpt-4") ||
+        lower.startsWith("gpt-5") ||
+        lower.startsWith("gpt-4.1") ||
+        lower.startsWith("o1") ||
+        lower.startsWith("o3") ||
+        lower.startsWith("o4")
       )
         return true;
       return false;
@@ -210,6 +215,10 @@ export const PROVIDER_TOOL_SUPPORT: Record<string, (model: string) => boolean> =
           "devstral",
           "exaone",
           "gpt-oss",
+          "glm-4",
+          "glm-5",
+          "deepseek",
+          "dolphin",
         ].some((part) => modelName.toLowerCase().includes(part))
       ) {
         return true;
@@ -270,7 +279,12 @@ export const PROVIDER_TOOL_SUPPORT: Record<string, (model: string) => boolean> =
     deepseek: (model) => {
       // https://api-docs.deepseek.com/quick_start/pricing
       // https://api-docs.deepseek.com/guides/function_calling
-      if (model === "deepseek-reasoner" || model === "deepseek-chat") {
+      const lower = model.toLowerCase();
+      if (
+        lower === "deepseek-reasoner" ||
+        lower === "deepseek-chat" ||
+        lower.startsWith("deepseek-coder")
+      ) {
         return true;
       }
 
@@ -343,6 +357,8 @@ export const PROVIDER_TOOL_SUPPORT: Record<string, (model: string) => boolean> =
         "amazon/nova",
         "deepseek/deepseek-r1",
         "deepseek/deepseek-chat",
+        "deepseek/deepseek-v3",
+        "deepseek/deepseek-coder",
         "meta-llama/llama-4",
         "all-hands/openhands-lm-32b",
         "lgai-exaone/exaone",


### PR DESCRIPTION
## Summary

- **Azure**: Add `gpt-5`, `gpt-4.1`, `o1`, `o4` model prefixes (was only `gpt-4`, `o3`)
- **Ollama**: Add `glm-4`/`glm-5`, `deepseek`, and `dolphin` model families
- **DeepSeek provider**: Add `deepseek-coder` (was only `deepseek-chat`/`deepseek-reasoner`)
- **OpenRouter**: Add `deepseek/deepseek-v3` and `deepseek/deepseek-coder` prefixes

## Root cause

When a model is not recognized in `PROVIDER_TOOL_SUPPORT` (`core/llm/toolSupport.ts`), Continue falls back to a text-based tool calling format injected into the system message. The model is expected to output tool calls in a specific structured format (` ```tool` / `tool_name:` / `begin_arg:` / `end_arg` blocks). When models don't follow this format exactly, the parser at `core/tools/systemMessageTools/toolCodeblocks/parseSystemToolCall.ts:47` throws `"Invalid tool name"`.

All 11 reported issues are models that **do** support native tool calling but were missing from the allowlist, causing them to fall through to the fragile text-based path.

## Fixes

Fixes #10678, #11594, #11431, #11218, #10900, #10272, #10156, #10143, #10050, #9891, #9839

## Test plan

- [ ] Verify existing `core/llm/toolSupport.test.ts` tests pass
- [ ] Test with an Ollama `glm-4` or `deepseek` model — should use native tool calling instead of system message fallback
- [ ] Test with Azure `gpt-5-mini` — should use native tool calling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands tool support so native tool calling is used for more Azure, Ollama, DeepSeek, and OpenRouter models, eliminating "Invalid tool name" errors. Prevents fallback to the fragile system-message tool format for these families.

- **Bug Fixes**
  - Azure: recognize `gpt-5`, `gpt-4.1`, `o1`, `o4` prefixes.
  - Ollama: recognize `glm-4`, `glm-5`, `deepseek`, `dolphin`.
  - DeepSeek: recognize `deepseek-coder*` in the provider.
  - OpenRouter: recognize `deepseek/deepseek-v3` and `deepseek/deepseek-coder*`.

<sup>Written for commit 7335493d01cbaaaea751ab6d97ba064910e84ada. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

