### PR TITLE
fix: retry premature close and connection errors in core

### DIFF
--- a/core/llm/utils/retry.test.ts
+++ b/core/llm/utils/retry.test.ts
@@ -205,6 +205,70 @@ describe("Retry Functionality", () => {
       expect(mockFn).toHaveBeenCalledTimes(2);
     });
 
+    it("should retry on premature close error", async () => {
+      const error = new Error("Premature close");
+      const mockFn = jest
+        .fn()
+        .mockRejectedValueOnce(error)
+        .mockResolvedValue("success");
+
+      const result = await retryAsync(mockFn, {
+        maxAttempts: 2,
+        baseDelay: 10,
+      });
+
+      expect(result).toBe("success");
+      expect(mockFn).toHaveBeenCalledTimes(2);
+    });
+
+    it("should retry on socket hang up error", async () => {
+      const error = new Error("socket hang up");
+      const mockFn = jest
+        .fn()
+        .mockRejectedValueOnce(error)
+        .mockResolvedValue("success");
+
+      const result = await retryAsync(mockFn, {
+        maxAttempts: 2,
+        baseDelay: 10,
+      });
+
+      expect(result).toBe("success");
+      expect(mockFn).toHaveBeenCalledTimes(2);
+    });
+
+    it("should retry on premature end error", async () => {
+      const error = new Error("premature end of stream");
+      const mockFn = jest
+        .fn()
+        .mockRejectedValueOnce(error)
+        .mockResolvedValue("success");
+
+      const result = await retryAsync(mockFn, {
+        maxAttempts: 2,
+        baseDelay: 10,
+      });
+
+      expect(result).toBe("success");
+      expect(mockFn).toHaveBeenCalledTimes(2);
+    });
+
+    it("should retry on connection reset message error", async () => {
+      const error = new Error("connection reset by peer");
+      const mockFn = jest
+        .fn()
+        .mockRejectedValueOnce(error)
+        .mockResolvedValue("success");
+
+      const result = await retryAsync(mockFn, {
+        maxAttempts: 2,
+        baseDelay: 10,
+      });
+
+      expect(result).toBe("success");
+      expect(mockFn).toHaveBeenCalledTimes(2);
+    });
+
     it("should not retry AbortError", async () => {
       const error = new Error("Aborted");
       error.name = "AbortError";

--- a/core/llm/utils/retry.ts
+++ b/core/llm/utils/retry.ts
@@ -113,6 +113,17 @@ function defaultShouldRetry(error: any, attempt: number): boolean {
     return true;
   }
 
+  // Connection/stream errors (e.g. provider drops connection mid-stream)
+  const connectionPatterns = [
+    "premature close",
+    "premature end",
+    "connection reset",
+    "socket hang up",
+  ];
+  if (connectionPatterns.some((p) => lowerMessage.includes(p))) {
+    return true;
+  }
+
   // Abort signal errors should not be retried
   if (isAbortError(error)) {
     return false;

--- a/core/util/withExponentialBackoff.ts
+++ b/core/util/withExponentialBackoff.ts
@@ -19,7 +19,11 @@ const withExponentialBackoff = async <T>(
         (error as APIError).response?.status === 429 ||
         /"code"\s*:\s*429/.test(error.message ?? "") ||
         lowerMessage.includes("overloaded") ||
-        lowerMessage.includes("malformed json")
+        lowerMessage.includes("malformed json") ||
+        lowerMessage.includes("premature close") ||
+        lowerMessage.includes("premature end") ||
+        lowerMessage.includes("connection reset") ||
+        lowerMessage.includes("socket hang up")
       ) {
         const retryAfter = (error as APIError).response?.headers.get(
           RETRY_AFTER_HEADER,


### PR DESCRIPTION
## Summary
- Add "premature close", "premature end", "connection reset", and "socket hang up" as retryable error patterns in `core/util/withExponentialBackoff.ts` and `core/llm/utils/retry.ts`
- These patterns were already handled in the CLI (`extensions/cli/src/util/exponentialBackoff.ts`) but missing from core, which is used by the VS Code extension
- Add 4 new test cases covering the new connection error patterns

## Context
Five open issues report "premature close" errors across different providers (Ollama, OpenAI-compatible, xAI). All are from VS Code users. The CLI already retries these transient errors, but the core retry logic did not — so users saw unrecoverable "Unknown error" messages instead of automatic recovery.

Fixes #11108, #11102, #10948, #9667, #9999

## Test plan
- [x] All 29 retry tests pass (including 4 new ones for premature close, premature end, socket hang up, connection reset)
- [ ] Manual: trigger a premature close with a local Ollama instance and verify retry behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Core now retries transient connection/stream errors (“premature close”, “premature end”, “connection reset”, “socket hang up”) to match the CLI. This prevents unrecoverable “Unknown error” in the VS Code extension.

- **Bug Fixes**
  - Added retry patterns to `core/util/withExponentialBackoff.ts` and `core/llm/utils/retry.ts`.
  - Added 4 tests covering the new connection error cases. Fixes #11108, #11102, #10948, #9667, #9999.

<sup>Written for commit e9fccbc99be7b441d7dd092d97a7eae8c6b2c50b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

