### PR TITLE
fix(gemini): retry transient fetch errors and improve error messages

### DIFF
--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -509,6 +509,18 @@ export abstract class BaseLLM implements ILLM {
               `${e.message}\n\nCode: ${e.code}\nError number: ${e.errno}\nSyscall: ${e.erroredSysCall}\nType: ${e.type}\n\n${e.stack}`,
             );
           }
+          // Surface the underlying cause of "TypeError: fetch failed" for better diagnostics
+          if (
+            e.name === "TypeError" &&
+            e.message === "fetch failed" &&
+            e.cause
+          ) {
+            const causeCode = e.cause.code ?? e.cause.name ?? "unknown";
+            const causeMsg = e.cause.message ?? "";
+            throw new Error(
+              `Network error (${causeCode}): ${causeMsg}. This may be caused by a timeout, proxy misconfiguration, or network connectivity issue. If you are using a proxy, verify it is working. For long-running requests, try a simpler prompt.`,
+            );
+          }
           if (
             e.code === "ECONNREFUSED" &&
             e.message.includes("http://127.0.0.1:11434")

--- a/core/util/withExponentialBackoff.ts
+++ b/core/util/withExponentialBackoff.ts
@@ -4,6 +4,27 @@ export interface APIError extends Error {
 
 export const RETRY_AFTER_HEADER = "Retry-After";
 
+/**
+ * Check if an error is a transient network error that should be retried.
+ * These are typically TypeError: fetch failed from Node.js undici,
+ * caused by timeouts, connection resets, or DNS failures.
+ */
+export function isTransientFetchError(error: any): boolean {
+  if (error?.name === "TypeError" && error?.message === "fetch failed") {
+    return true;
+  }
+  const code = error?.cause?.code ?? error?.code;
+  if (
+    code === "ETIMEDOUT" ||
+    code === "ECONNRESET" ||
+    code === "UND_ERR_CONNECT_TIMEOUT" ||
+    code === "UND_ERR_HEADERS_TIMEOUT"
+  ) {
+    return true;
+  }
+  return false;
+}
+
 const withExponentialBackoff = async <T>(
   apiCall: () => Promise<T>,
   maxTries = 5,
@@ -15,20 +36,23 @@ const withExponentialBackoff = async <T>(
       return result;
     } catch (error: any) {
       const lowerMessage = (error.message ?? "").toLowerCase();
-      if (
+      const isRateLimit =
         (error as APIError).response?.status === 429 ||
         /"code"\s*:\s*429/.test(error.message ?? "") ||
         lowerMessage.includes("overloaded") ||
-        lowerMessage.includes("malformed json")
-      ) {
+        lowerMessage.includes("malformed json");
+      const isTransient = isTransientFetchError(error);
+
+      if (isRateLimit || isTransient) {
         const retryAfter = (error as APIError).response?.headers.get(
           RETRY_AFTER_HEADER,
         );
         const delay = retryAfter
           ? parseInt(retryAfter, 10)
           : initialDelaySeconds * 2 ** attempt;
+        const reason = isTransient ? "network error" : "rate limit";
         console.log(
-          `Hit rate limit. Retrying in ${delay} seconds (attempt ${
+          `Hit ${reason}. Retrying in ${delay} seconds (attempt ${
             attempt + 1
           })`,
         );

--- a/gui/src/util/errorAnalysis.ts
+++ b/gui/src/util/errorAnalysis.ts
@@ -144,6 +144,19 @@ export function analyzeError(
     customErrorMessage = `Your ${providerLabel} account appears to be out of credits. Add more credits to your account to continue using this model.`;
   }
 
+  // Network / fetch errors (common with Gemini due to Node.js undici timeouts)
+  if (
+    errorText.includes("typeerror: fetch failed") ||
+    errorText.includes("network error") ||
+    errorText.includes("etimedout") ||
+    errorText.includes("econnreset") ||
+    errorText.includes("und_err_connect_timeout") ||
+    errorText.includes("und_err_headers_timeout")
+  ) {
+    customErrorMessage =
+      "A network error occurred while connecting to the API. This is often caused by a connection timeout or network instability. If you are using a proxy, verify it is working correctly. For large prompts, try a shorter message. You may also retry the request.";
+  }
+
   return {
     parsedError,
     statusCode,

--- a/packages/openai-adapters/src/apis/Gemini.ts
+++ b/packages/openai-adapters/src/apis/Gemini.ts
@@ -78,6 +78,12 @@ export class GeminiApi implements BaseLlmApi {
       () =>
         new GoogleGenAI({
           apiKey: this.config.apiKey,
+          httpOptions: {
+            // Default Node.js fetch (undici) has aggressive timeouts (~10s connect)
+            // that are too short for Gemini's longer-running requests.
+            // 5 minutes allows for complex prompts and reasoning models.
+            timeout: 5 * 60 * 1000,
+          },
         }),
     );
   }
@@ -394,25 +400,48 @@ export class GeminiApi implements BaseLlmApi {
     }
   }
 
-  /**generates stream from @google/genai sdk */
+  /**generates stream from @google/genai sdk, with retry for transient network errors */
   private async generateStream(
     genAI: GoogleGenAI,
     model: string,
     convertedBody: ReturnType<typeof this._convertBody>,
   ) {
-    // Use native fetch temporarily for stream operation to get proper ReadableStream
-    // The withNativeFetch wrapper restores native fetch, makes the call, then reverts
-    return withNativeFetch(() =>
-      genAI.models.generateContentStream({
-        model,
-        contents: convertedBody.contents,
-        config: {
-          systemInstruction: convertedBody.systemInstruction,
-          tools: convertedBody.tools,
-          ...convertedBody.generationConfig,
-        },
-      }),
-    );
+    const maxRetries = 3;
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      try {
+        // Use native fetch temporarily for stream operation to get proper ReadableStream
+        // The withNativeFetch wrapper restores native fetch, makes the call, then reverts
+        return await withNativeFetch(() =>
+          genAI.models.generateContentStream({
+            model,
+            contents: convertedBody.contents,
+            config: {
+              systemInstruction: convertedBody.systemInstruction,
+              tools: convertedBody.tools,
+              ...convertedBody.generationConfig,
+            },
+          }),
+        );
+      } catch (error: any) {
+        const isTransient =
+          (error?.name === "TypeError" && error?.message === "fetch failed") ||
+          error?.cause?.code === "ETIMEDOUT" ||
+          error?.cause?.code === "ECONNRESET" ||
+          error?.cause?.code === "UND_ERR_CONNECT_TIMEOUT" ||
+          error?.cause?.code === "UND_ERR_HEADERS_TIMEOUT";
+
+        if (isTransient && attempt < maxRetries - 1) {
+          const delay = Math.pow(2, attempt) * 1000;
+          console.log(
+            `Gemini fetch failed (${error?.cause?.code ?? error?.message}). Retrying in ${delay / 1000}s (attempt ${attempt + 1}/${maxRetries})`,
+          );
+          await new Promise((resolve) => setTimeout(resolve, delay));
+          continue;
+        }
+        throw error;
+      }
+    }
+    throw new Error("Unreachable");
   }
 
   async *chatCompletionStream(


### PR DESCRIPTION
## Summary

Fixes the `TypeError: fetch failed` error affecting all Gemini models (#11730 and 16 related issues).

**Root cause:** Gemini `streamChat` goes through the OpenAI adapter → `@google/genai` SDK → Node.js native fetch (undici), completely bypassing `BaseLLM.fetch()` and its retry logic. Undici has aggressive default timeouts (~10s connect) that are too short for Gemini's longer-running requests. The `@google/genai` SDK's built-in retry only handles HTTP status codes (429, 500, etc.), not network-level `TypeError: fetch failed`.

**Changes:**
- Add retry with exponential backoff (3 attempts) in `GeminiApi.generateStream()` for transient network errors (`TypeError: fetch failed`, `ETIMEDOUT`, `ECONNRESET`, `UND_ERR_CONNECT_TIMEOUT`)
- Set `httpOptions.timeout` on `GoogleGenAI` constructor (5 min) to override undici's aggressive defaults
- Extend `withExponentialBackoff` to also retry transient fetch errors (for code paths that do go through `BaseLLM.fetch()`)
- Surface `TypeError.cause` in `BaseLLM.fetch()` so users see actionable error messages instead of opaque "fetch failed"
- Detect network errors in GUI `errorAnalysis.ts` to show helpful guidance in the error dialog

Closes #11730

## Test plan
- [ ] Test Gemini streaming with a large prompt that previously triggered the timeout
- [ ] Test Gemini streaming with a proxy configuration
- [ ] Verify retry logging appears in console on transient failures
- [ ] Verify the error dialog shows the new helpful message instead of raw "TypeError: fetch failed"
- [ ] Verify non-Gemini providers are unaffected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Gemini streaming failures by retrying transient fetch errors and increasing timeouts, with clearer network error messages for users. Stabilizes long-running Gemini requests and reduces opaque “fetch failed” errors.

- **Bug Fixes**
  - Retries transient network errors in Gemini streaming with exponential backoff (3 attempts).
  - Sets 5-minute `httpOptions.timeout` on `@google/genai` to override `undici` defaults.
  - Extends `withExponentialBackoff` to also retry transient fetch errors.
  - Surfaces `TypeError.cause` in BaseLLM.fetch() for actionable messages.
  - Improves GUI errorAnalysis to detect network issues and show guidance.

<sup>Written for commit a9011d4a16500103ed1b20791ff2a22f6b4a182c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

