### PR TITLE
fix: guard against non-string NO_PROXY env value

### DIFF
--- a/packages/fetch/src/util.test.ts
+++ b/packages/fetch/src/util.test.ts
@@ -212,3 +212,9 @@ test("shouldBypassProxy handles undefined options", () => {
   process.env.NO_PROXY = "example.org";
   expect(shouldBypassProxy("example.org", undefined)).toBe(true);
 });
+
+test("shouldBypassProxy handles non-string NO_PROXY value", () => {
+  // In some environments, env values may not be strings
+  (process.env as any).NO_PROXY = 1234;
+  expect(shouldBypassProxy("example.com", undefined)).toBe(false);
+});

--- a/packages/fetch/src/util.ts
+++ b/packages/fetch/src/util.ts
@@ -31,7 +31,7 @@ export function getProxy(
 
 export function getEnvNoProxyPatterns(): string[] {
   const envValue = process.env.NO_PROXY || process.env.no_proxy;
-  if (envValue) {
+  if (envValue && typeof envValue === "string") {
     return envValue
       .split(",")
       .map((item) => item.trim().toLowerCase())


### PR DESCRIPTION
## Summary

- Adds a `typeof envValue === "string"` check in `getEnvNoProxyPatterns()` before calling `.split()` to prevent `envValue.split is not a function` runtime errors
- Adds a test case covering non-string `NO_PROXY` values

## Related Issues

Fixes #11631
Fixes #9334

## Test plan

- [x] Existing proxy bypass tests pass (31/31)
- [x] New test verifies non-string `NO_PROXY` values are handled gracefully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent runtime errors when `NO_PROXY` is not a string by checking the type in `getEnvNoProxyPatterns()` before calling `.split()`. Adds test coverage for non-string env values and fixes #11631, #9334.

<sup>Written for commit 11ef40ec4adbb02a49990bbead61bd5006f69020. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

