### PR TITLE
feat(bedrock): support Bedrock API key authentication

### DIFF
--- a/core/llm/llms/Bedrock.ts
+++ b/core/llm/llms/Bedrock.ts
@@ -70,6 +70,29 @@ class Bedrock extends BaseLLM {
     };
   }
 
+  private async _getClient(): Promise<BedrockRuntimeClient> {
+    if (this.apiKey) {
+      // Bedrock API key authentication (bearer token)
+      return new BedrockRuntimeClient({
+        region: this.region,
+        endpoint: this.apiBase,
+        token: async () => ({ token: this.apiKey! }),
+      });
+    }
+
+    // IAM credential authentication
+    const credentials = await this._getCredentials();
+    return new BedrockRuntimeClient({
+      region: this.region,
+      endpoint: this.apiBase,
+      credentials: {
+        accessKeyId: credentials.accessKeyId,
+        secretAccessKey: credentials.secretAccessKey,
+        sessionToken: credentials.sessionToken || "",
+      },
+    });
+  }
+
   protected async *_streamComplete(
     prompt: string,
     signal: AbortSignal,
@@ -86,16 +109,7 @@ class Bedrock extends BaseLLM {
     signal: AbortSignal,
     options: CompletionOptions,
   ): AsyncGenerator<ChatMessage> {
-    const credentials = await this._getCredentials();
-    const client = new BedrockRuntimeClient({
-      region: this.region,
-      endpoint: this.apiBase,
-      credentials: {
-        accessKeyId: credentials.accessKeyId,
-        secretAccessKey: credentials.secretAccessKey,
-        sessionToken: credentials.sessionToken || "",
-      },
-    });
+    const client = await this._getClient();
 
     let config_headers =
       this.requestOptions && this.requestOptions.headers
@@ -600,15 +614,7 @@ class Bedrock extends BaseLLM {
 
   // EMBED //
   async _embed(chunks: string[]): Promise<number[][]> {
-    const credentials = await this._getCredentials();
-    const client = new BedrockRuntimeClient({
-      region: this.region,
-      credentials: {
-        accessKeyId: credentials.accessKeyId,
-        secretAccessKey: credentials.secretAccessKey,
-        sessionToken: credentials.sessionToken || "",
-      },
-    });
+    const client = await this._getClient();
 
     return (
       await Promise.all(
@@ -683,15 +689,7 @@ class Bedrock extends BaseLLM {
     }
 
     try {
-      const credentials = await this._getCredentials();
-      const client = new BedrockRuntimeClient({
-        region: this.region,
-        credentials: {
-          accessKeyId: credentials.accessKeyId,
-          secretAccessKey: credentials.secretAccessKey,
-          sessionToken: credentials.sessionToken || "",
-        },
-      });
+      const client = await this._getClient();
 
       // Base payload for both models
       const payload: any = {

--- a/docs/customize/model-providers/top-level/bedrock.mdx
+++ b/docs/customize/model-providers/top-level/bedrock.mdx
@@ -77,6 +77,24 @@ Prompt caching is not supported in JSON configuration files, so use the YAML syn
 
 ## How to Set Up Authentication for Amazon Bedrock
 
+### Bedrock API Keys
+
+[Bedrock API keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html) let you authenticate without IAM credentials. Set your API key via the `apiKey` field:
+
+```yaml title="config.yaml"
+models:
+  - name: Claude Sonnet
+    provider: bedrock
+    model: us.anthropic.claude-sonnet-4-20250514-v1:0
+    apiKey: ${{ secrets.BEDROCK_API_KEY }}
+    env:
+      region: us-east-1
+    roles:
+      - chat
+```
+
+### AWS Credentials
+
 Authentication will be through temporary or long-term credentials in
 `~/.aws/credentials` under a configured profile (e.g. "bedrock").
 


### PR DESCRIPTION
## Summary
- Add [Bedrock API key](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html) authentication as an alternative to IAM credentials in the core LLM class (`Bedrock.ts`)
- When `apiKey` is set, uses bearer token auth via the AWS SDK's `token` provider; otherwise falls back to existing IAM credential flow
- Refactors client creation into a single `_getClient()` method used by `_streamChat`, `_embed`, and `rerank` (the OpenAI adapter already supported this)
- Adds docs section with YAML config example

Closes #6645

## Test plan
- [ ] Configure Bedrock with `apiKey` field and verify chat/completions work with bearer token auth
- [ ] Verify existing IAM credential flow (profile, accessKeyId/secretAccessKey) still works unchanged
- [ ] Verify embed and rerank operations work with API key auth

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Bedrock API key authentication as an alternative to IAM. Enables bearer token auth for chat, embed, and rerank, and unifies client creation.

- **New Features**
  - Support `apiKey` in `Bedrock.ts` using AWS SDK `token` bearer auth; IAM flow unchanged.
  - New `_getClient()` used by `_streamChat`, `_embed`, and `rerank`.
  - Docs updated with YAML example for API key setup.

<sup>Written for commit 443ced2898205e1f1a247ed9e91c8f11b613b86c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

