### PR TITLE
fix(llama.cpp): include model name in completion request body

### DIFF
--- a/core/llm/llms/LlamaCpp.ts
+++ b/core/llm/llms/LlamaCpp.ts
@@ -39,6 +39,7 @@ class LlamaCpp extends BaseLLM {
       method: "POST",
       headers,
       body: JSON.stringify({
+        model: this.model,
         prompt,
         stream: true,
         ...this._convertArgs(options, prompt),


### PR DESCRIPTION
## Summary
- The llama.cpp provider was not including the `model` field in the request body sent to llama-server
- This caused `400: model name is missing from the request` errors when using llama-server's model router feature (e.g. `--model-presets`)
- Fix adds `model: this.model` to the completion request body

Fixes #11244
Fixes #10846

## Backwards compatibility
No breaking changes. llama-server accepts and ignores the `model` field when no model router is configured (single-model mode), so existing setups are unaffected.

## Test plan
- [ ] Configure a llama.cpp provider with a model name and llama-server running with `--model-presets`
- [ ] Verify completions succeed without 400 errors
- [ ] Verify single-model llama-server setups still work (model field is accepted but not required when no router is configured)