### PR TITLE
fix(moonshot): add reasoning_content field support for Kimi models

### DIFF
--- a/core/llm/llms/Moonshot.ts
+++ b/core/llm/llms/Moonshot.ts
@@ -6,6 +6,13 @@ import OpenAI from "./OpenAI.js";
 
 class Moonshot extends OpenAI {
   static providerName = "moonshot";
+
+  constructor(options: LLMOptions) {
+    super(options);
+    this.supportsReasoningContentField =
+      this.model?.startsWith("kimi") ?? false;
+  }
+
   static defaultOptions: Partial<LLMOptions> = {
     apiBase: "https://api.moonshot.cn/v1/",
     model: "moonshot-v1-8k",


### PR DESCRIPTION
## Summary
- Adds `supportsReasoningContentField = true` to the Moonshot provider, matching the existing DeepSeek fix
- This ensures `reasoning_content` is included in assistant messages, preventing 400 errors from the Kimi API when thinking/reasoning is enabled

## Context
Kimi-K2.5 requires a `reasoning_content` field in assistant tool call messages when thinking is enabled. Without it, the API returns:
> `400 thinking is enabled but reasoning_content is missing in assistant tool call message`

This was already fixed for DeepSeek in #11290 / #10027. The same one-line fix applies to Moonshot/Kimi models.

Fixes #11600
Fixes #11711

## Test plan
- [ ] Configure a Moonshot provider with Kimi-K2.5 model
- [ ] Enable thinking/reasoning and use tool calls
- [ ] Verify no 400 errors about missing reasoning_content

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `reasoning_content` support for `kimi-*` models in the `Moonshot` provider when thinking is on, preventing 400s on assistant tool-call messages. Gated by model prefix via `supportsReasoningContentField`, so `moonshot-v1-*` are unaffected. Fixes #11600 and #11711.

<sup>Written for commit e854d69ffcc17b6518bf6f7fbc179eaae85006f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

