### PR TITLE
fix: move contextLength to model level in YAML config

### DIFF
--- a/core/config/yaml/models.ts
+++ b/core/config/yaml/models.ts
@@ -51,7 +51,6 @@ async function modelConfigToBaseLLM({
 
   let options: LLMOptions = {
     ...rest,
-    contextLength: model.defaultCompletionOptions?.contextLength,
     completionOptions: {
       ...(model.defaultCompletionOptions ?? {}),
       model: model.model,

--- a/docs/customize/model-providers/more/watsonx.mdx
+++ b/docs/customize/model-providers/more/watsonx.mdx
@@ -140,8 +140,8 @@ You can also configure generation parameters, such as temperature, topP, topK, f
       apiBase: watsonx endpoint e.g. https://us-south.ml.cloud.ibm.com
       apiKey: API_KEY/ZENAPI_KEY/USERNAME:PASSWORD
       template: granite
+      contextLength: 8000
       defaultCompletionOptions:
-        contextLength: 8000
         temperature: 0.1
         topP: 0.3
         topK: 20

--- a/docs/guides/ollama-guide.mdx
+++ b/docs/guides/ollama-guide.mdx
@@ -209,7 +209,7 @@ models:
     provider: ollama
     model: deepseek-r1:32b
     contextLength: 8192 # Adjust context window (default varies by model)
-    completionOptions:
+    defaultCompletionOptions:
       temperature: 0.7 # Controls randomness (0.0-1.0)
       top_p: 0.9 # Nucleus sampling threshold
       top_k: 40 # Top-k sampling

--- a/docs/reference.mdx
+++ b/docs/reference.mdx
@@ -85,6 +85,8 @@ The `models` section defines the language models used in your configuration. Mod
 
   Continue automatically detects these capabilities for most models, but you can override this when using custom deployments or if autodetection isn't working correctly.
 
+- `contextLength`: Maximum context length of the model, typically in tokens.
+
 - `maxStopWords`: Maximum number of stop words allowed, to avoid API errors with extensive lists.
 
 - `promptTemplates`: Can be used to override the default prompt templates for different model roles. Valid values are [`chat`](), [`edit`](/customize/model-roles/edit#prompt-templating), [`apply`](/customize/model-roles/apply#prompt-templating) and [`autocomplete`](/customize/model-roles/autocomplete#prompt-templating). The `chat` property must be a valid template name, such as `llama3` or `anthropic`.
@@ -102,7 +104,6 @@ The `models` section defines the language models used in your configuration. Mod
 
 - `defaultCompletionOptions`: Default completion options for model settings.
 
-  - `contextLength`: Maximum context length of the model, typically in tokens.
   - `maxTokens`: Maximum number of tokens to generate in a completion.
   - `temperature`: Controls the randomness of the completion. Values range from `0.0` (deterministic) to `1.0` (random).
   - `topP`: The cumulative probability for nucleus sampling.

--- a/extensions/cli/src/util/tokenizer.test.ts
+++ b/extensions/cli/src/util/tokenizer.test.ts
@@ -44,9 +44,7 @@ describe("tokenizer", () => {
         name: "test-model",
         model: "test",
         provider: "openai",
-        defaultCompletionOptions: {
-          contextLength: 8192,
-        },
+        contextLength: 8192,
       };
 
       expect(getModelContextLimit(model)).toBe(8192);
@@ -216,9 +214,7 @@ describe("tokenizer", () => {
         name: "test-model",
         model: "test",
         provider: "openai",
-        defaultCompletionOptions: {
-          contextLength: 1000,
-        },
+        contextLength: 1000,
       };
 
       expect(calculateContextUsagePercentage(800, model)).toBe(80);
@@ -235,8 +231,8 @@ describe("tokenizer", () => {
       name: "test-model",
       model: "test",
       provider: "openai",
+      contextLength,
       defaultCompletionOptions: {
-        contextLength,
         maxTokens,
       },
     });

--- a/extensions/cli/src/util/tokenizer.ts
+++ b/extensions/cli/src/util/tokenizer.ts
@@ -17,9 +17,7 @@ export const DEFAULT_CONTEXT_LENGTH = 200_000;
  * @returns The context length limit in tokens
  */
 export function getModelContextLimit(model: ModelConfig): number {
-  return (
-    model.defaultCompletionOptions?.contextLength ?? DEFAULT_CONTEXT_LENGTH
-  );
+  return model.contextLength ?? DEFAULT_CONTEXT_LENGTH;
 }
 
 export function getModelMaxTokens(model: ModelConfig): number {

--- a/gui/src/redux/slices/configSlice.ts
+++ b/gui/src/redux/slices/configSlice.ts
@@ -1,7 +1,7 @@
 import { ConfigResult, ConfigValidationError } from "@continuedev/config-yaml";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { BrowserSerializedContinueConfig } from "core";
-import { DEFAULT_MAX_TOKENS } from "core/llm/constants";
+import { DEFAULT_CONTEXT_LENGTH } from "core/llm/constants";
 
 export type ConfigState = {
   configError: ConfigValidationError[] | undefined;
@@ -86,7 +86,7 @@ export const configSlice = createSlice({
     selectSelectedChatModelContextLength: (state): number => {
       return (
         state.config.selectedModelByRole.chat?.contextLength ||
-        DEFAULT_MAX_TOKENS
+        DEFAULT_CONTEXT_LENGTH
       );
     },
     selectSelectedChatModel: (state) => {

--- a/packages/config-yaml/src/schemas/models.ts
+++ b/packages/config-yaml/src/schemas/models.ts
@@ -45,7 +45,6 @@ export const modelCapabilitySchema = z.union([
 export type ModelCapability = "tool_use" | "image_input" | "next_edit";
 
 export const completionOptionsSchema = z.object({
-  contextLength: z.number().optional(),
   maxTokens: z.number().optional(),
   temperature: z.number().optional(),
   topP: z.number().optional(),
@@ -179,6 +178,7 @@ const baseModelFields = {
   model: z.string(),
   apiKey: z.string().optional(),
   apiBase: z.string().optional(),
+  contextLength: z.number().optional(),
   maxStopWords: z.number().optional(),
   roles: modelRolesSchema.array().optional(),
   capabilities: modelCapabilitySchema.array().optional(),

--- a/packages/config-yaml/src/validation.ts
+++ b/packages/config-yaml/src/validation.ts
@@ -58,18 +58,14 @@ export function validateConfigYaml(
       }
     }
     // Max tokens not too close to context length
-    if (
-      model.defaultCompletionOptions?.contextLength &&
-      model.defaultCompletionOptions?.maxTokens
-    ) {
+    if (model.contextLength && model.defaultCompletionOptions?.maxTokens) {
       const difference =
-        model.defaultCompletionOptions?.contextLength -
-        model.defaultCompletionOptions?.maxTokens;
+        model.contextLength - model.defaultCompletionOptions.maxTokens;
 
       if (difference < 1000) {
         errors.push({
           fatal: false,
-          message: `Model "${model.name}" has a contextLength of ${model.defaultCompletionOptions?.contextLength} and a maxTokens of ${model.defaultCompletionOptions?.maxTokens}. This leaves only ${difference} tokens for input context and will likely result in your inputs being truncated.`,
+          message: `Model "${model.name}" has a contextLength of ${model.contextLength} and a maxTokens of ${model.defaultCompletionOptions.maxTokens}. This leaves only ${difference} tokens for input context and will likely result in your inputs being truncated.`,
         });
       }
     }


### PR DESCRIPTION
## Summary

- **Move `contextLength` from `defaultCompletionOptions` to model level** in the YAML schema — matching JSON config and eliminating the silent stripping by zod that caused the setting to be ignored
- **Remove `contextLength` from `completionOptionsSchema`** so there's only one place to set it
- **Fix GUI selector fallback** using `DEFAULT_MAX_TOKENS` (4096) instead of `DEFAULT_CONTEXT_LENGTH` (32768)
- **Update CLI tokenizer** to read `model.contextLength` instead of `model.defaultCompletionOptions.contextLength`
- **Update all docs** to consistently show `contextLength` at model level

```yaml
models:
  - name: my-model
    provider: openai
    model: my-model
    contextLength: 65536
    defaultCompletionOptions:
      maxTokens: 32000
```

Closes #4638
Closes #4304

## Test plan
- [ ] Set `contextLength` at model level in YAML config — verify it's respected
- [ ] Verify validation warning fires when `maxTokens` is too close to `contextLength`
- [ ] Run CLI tokenizer tests (`extensions/cli/src/util/tokenizer.test.ts`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move `contextLength` to the model level in YAML config so the value is respected and matches JSON config. Also fixes GUI fallback and updates CLI/tokenizer, validation, and docs.

- **Bug Fixes**
  - Schema: remove `contextLength` from `completionOptionsSchema`; add `contextLength` to model fields in `packages/config-yaml`.
  - Runtime: `extensions/cli` tokenizer and config validation read `model.contextLength`; stop passing stripped `defaultCompletionOptions.contextLength` from `core/config/yaml/models.ts`.
  - GUI: selector fallback now uses `DEFAULT_CONTEXT_LENGTH` instead of `DEFAULT_MAX_TOKENS`.
  - Docs: examples updated to show model-level `contextLength`.

- **Migration**
  - In YAML, move `defaultCompletionOptions.contextLength` to the model root as `contextLength`.
  - JSON configs are unchanged.

<sup>Written for commit 2a84eb3d74c1ef3ee818a4e25c69be5a8a2b05a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

