### PR TITLE
fix: use native http/https for agent creation (Azure 'call' undefined)

### DIFF
--- a/packages/fetch/src/fetch.ts
+++ b/packages/fetch/src/fetch.ts
@@ -1,13 +1,12 @@
 import { RequestOptions } from "@continuedev/config-types";
-import * as followRedirects from "follow-redirects";
+import * as http from "http";
 import { HttpProxyAgent } from "http-proxy-agent";
+import * as https from "https";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import { BodyInit, RequestInit, Response } from "node-fetch";
 import { getAgentOptions } from "./getAgentOptions.js";
 import patchedFetch from "./node-fetch-patch.js";
 import { getProxy, shouldBypassProxy } from "./util.js";
-
-const { http, https } = (followRedirects as any).default;
 
 function logRequest(
   method: string,


### PR DESCRIPTION
## Summary
- Replaced `follow-redirects` wrapped `http`/`https` imports with native Node.js `http`/`https` modules for HTTP agent creation
- The `follow-redirects` wrappers may not properly expose the `Agent` constructor in all bundling environments, causing `TypeError: Cannot read properties of undefined (reading 'call')` when the Agent constructor chain invokes its super constructor
- This only affected the agent creation path — `node-fetch-patch.js` already uses native modules for requests

## Test plan
- [ ] Verify Azure OpenAI GPT models work in chat (the primary failure scenario)
- [ ] Verify HTTP and HTTPS requests still work with and without proxy configuration
- [ ] Verify SSL certificate options (custom CA, client certs, verifySsl) still function
- [ ] Run existing e2e tests: `packages/fetch/src/fetch.e2e.test.ts`

Fixes #11828
Fixes #8700

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `follow-redirects` `http`/`https` with native Node.js `http`/`https` for agent creation to fix the "Cannot read properties of undefined (reading 'call')" crash on Azure OpenAI chat. Requests already use native modules via `node-fetch-patch.js`; proxy and SSL options remain supported. Fixes #11828. Fixes #8700.

<sup>Written for commit cf29ff304209e64cdb6d6746092b65dc8c9cab9e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

