### PR TITLE
fix: Fix install dependencies Console Ouput

### DIFF
--- a/scripts/install-dependencies.ps1
+++ b/scripts/install-dependencies.ps1
@@ -85,7 +85,7 @@ npm install
 npm link
 Pop-Location
 
-Write-Output "`nInstalling GUI extension dependencies..." -ForegroundColor White
+Write-Host "`nInstalling GUI extension dependencies..." -ForegroundColor White
 Push-Location gui
 npm install
 npm link @continuedev/core
@@ -93,7 +93,7 @@ npm run build
 Pop-Location
 
 # VSCode Extension (will also package GUI)
-Write-Output "`nInstalling VSCode extension dependencies..." -ForegroundColor White
+Write-Host "`nInstalling VSCode extension dependencies..." -ForegroundColor White
 Push-Location extensions/vscode
 
 # This does way too many things inline but is the common denominator between many of the scripts
@@ -105,7 +105,7 @@ npm run package
 Pop-Location
 
 
-Write-Output "`nInstalling binary dependencies..." -ForegroundColor White
+Write-Host "`nInstalling binary dependencies..." -ForegroundColor White
 Push-Location binary
 
 npm install
@@ -113,7 +113,7 @@ npm run build
 
 Pop-Location
 
-Write-Output "`nInstalling docs dependencies..." -ForegroundColor White
+Write-Host "`nInstalling docs dependencies..." -ForegroundColor White
 Push-Location docs
 
 npm install


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

Write-Output does not support the ForegroundColor parameter, causing errors or unexpected behavior when running the install dependencies task on Windows via PowerShell Script. Replaced all occurrences with Write-Host, which correctly supports ForegroundColor.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

### Before Change 
<img width="755" height="175" alt="image" src="https://github.com/user-attachments/assets/b80b2ffd-6aff-40fd-bb9c-f7bafd33a0d0" />

### After Change
<img width="672" height="145" alt="image" src="https://github.com/user-attachments/assets/f06e5edc-69ee-49d8-b411-56eac9f91760" />





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use Write-Host instead of Write-Output when setting ForegroundColor in scripts/install-dependencies.ps1. This prevents PowerShell errors on Windows and restores colored install logs for GUI, VSCode extension, binary, and docs steps.

<sup>Written for commit 1f9b2d6efc126d039344844226ba0dfd27cc018b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

