### PR TITLE
chore: prerelease bumps jb 64, vs code 35

### DIFF
--- a/extensions/intellij/gradle.properties
+++ b/extensions/intellij/gradle.properties
@@ -1,5 +1,5 @@
 pluginGroup=com.github.continuedev.continueintellijextension
-pluginVersion=1.0.63
+pluginVersion=1.0.64
 platformVersion=2024.1
 kotlin.stdlib.default.dependency=false
 org.gradle.configuration-cache=true

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "1.3.34",
+  "version": "1.3.35",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION
## Description
Prerelease version bumps

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prep prerelease by bumping extension versions to prepare the next publish. IntelliJ plugin `pluginVersion` is now 1.0.64; VS Code extension `version` is now 1.3.35.

<sup>Written for commit 254c64efbd0469e7931007a21f2152c38be6fc8f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

