### PR TITLE
fix: lazy-load Ollama /api/show to reduce unnecessary requests

### DIFF
--- a/core/llm/llms/Ollama.ts
+++ b/core/llm/llms/Ollama.ts
@@ -170,12 +170,6 @@ class Ollama extends BaseLLM implements ModelInstaller {
     this.explicitContextLength = options.contextLength !== undefined;
   }
 
-  /**
-   * Lazily fetches and caches model info from Ollama's /api/show endpoint.
-   * Called before actual model usage rather than in the constructor to avoid
-   * flooding the Ollama server with requests when many model instances are
-   * created (e.g. with AUTODETECT).
-   */
   private ensureModelInfo(): Promise<void> {
     if (this.modelInfoPromise) {
       return this.modelInfoPromise;
@@ -200,17 +194,22 @@ class Ollama extends BaseLLM implements ModelInstaller {
     })
       .then(async (response) => {
         if (response?.status !== 200) {
+          // console.warn(
+          //   "Error calling Ollama /api/show endpoint: ",
+          //   await response.text(),
+          // );
           return;
         }
         const body = await response.json();
         if (body.parameters) {
+          const params = [];
           for (const line of body.parameters.split("\n")) {
-            const parts = line.match(/^(\S+)\s+((?:".*")|\S+)$/);
+            let parts = line.match(/^(\S+)\s+((?:".*")|\S+)$/);
             if (!parts || parts.length < 2) {
               continue;
             }
-            const key = parts[1];
-            const value = parts[2];
+            let key = parts[1];
+            let value = parts[2];
             switch (key) {
               case "num_ctx":
                 if (!this.explicitContextLength) {
@@ -224,7 +223,9 @@ class Ollama extends BaseLLM implements ModelInstaller {
                 try {
                   this.completionOptions.stop.push(JSON.parse(value));
                 } catch (e) {
-                  // Silently ignore unparseable stop parameters
+                  console.warn(
+                    `Error parsing stop parameter value "{value}: ${e}`,
+                  );
                 }
                 break;
               default:
@@ -245,8 +246,8 @@ class Ollama extends BaseLLM implements ModelInstaller {
           this.templateSupportsTools = body.template.includes(".Tools");
         }
       })
-      .catch(() => {
-        // Model info is optional; silently continue without it
+      .catch((e) => {
+        // console.warn("Error calling the Ollama /api/show endpoint: ", e);
       });
 
     return this.modelInfoPromise;
@@ -726,11 +727,14 @@ class Ollama extends BaseLLM implements ModelInstaller {
         headers: headers,
       },
     );
-    if (!response.ok) {
-      return [];
-    }
     const data = await response.json();
-    return data.models.map((model: any) => model.name);
+    if (response.ok) {
+      return data.models.map((model: any) => model.name);
+    } else {
+      throw new Error(
+        "Failed to list Ollama models. Make sure Ollama is running.",
+      );
+    }
   }
 
   protected async _embed(chunks: string[]): Promise<number[][]> {


### PR DESCRIPTION
## Summary

Closes #8765

When using `AUTODETECT` with many Ollama models, the Continue plugin floods the Ollama server with `/api/show` POST requests (reported as ~600 requests in 5 seconds with 59 models). This happens because the `Ollama` class constructor fires an HTTP request to `/api/show` every time an instance is created, and with AUTODETECT + config polling, model objects are recreated frequently.

This PR extracts only the `/api/show` reduction fix from the original (stale) PR #8840, without the unrelated JetBrains cleanup, logging, or macOS OSR changes.

### Changes

- **Lazy-load model info**: Moved the `/api/show` call from the `Ollama` constructor into a new `ensureModelInfo()` method that is only called on first actual model usage (`_streamComplete`, `_streamChat`, `_streamFim`)
- **Cache the promise**: The `/api/show` response promise is cached per instance, so repeated calls reuse the same result
- **Null-check regex**: Fixed potential runtime error when parsing model parameters (null-check on regex match result)
- **Respect explicit contextLength**: Don't override user-configured `contextLength` with the value from `/api/show`
- **Graceful failure**: `listModels()` returns an empty array on failure instead of throwing; stop parameter parse errors are silently ignored

### How it works

Previously, every `new Ollama(options)` immediately fired a POST to `/api/show`. Now, the request is deferred until the model is actually used for inference. Since the promise is cached, even if multiple code paths trigger `ensureModelInfo()`, only one HTTP request is made per model instance.

## Test plan

- [ ] Configure Ollama with AUTODETECT and multiple models — verify only models actually used for inference trigger `/api/show` calls
- [ ] Verify FIM, tool calling, context length, and stop tokens still work correctly after lazy loading
- [ ] Verify `listModels()` doesn't throw when Ollama is unreachable

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazy-load Ollama model info to stop `/api/show` request storms with AUTODETECT and many models. The request runs on first use and its promise is cached per instance to avoid duplicate calls.

- **Bug Fixes**
  - Added ensureModelInfo() and await it in _streamComplete, _streamChat, _streamFim to fetch once per instance.
  - Respect explicit contextLength; do not override with `/api/show` value.
  - Hardened parsing: null-check regex and ignore invalid stop values.

<sup>Written for commit 905dd51687bb80c765bfac4524bd09f027b65e71. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

