### PR TITLE
fix: map reasoning-delta to reasoning_content instead of content

### DIFF
--- a/packages/openai-adapters/src/test/vercelStreamConverter.test.ts
+++ b/packages/openai-adapters/src/test/vercelStreamConverter.test.ts
@@ -34,7 +34,10 @@ describe("convertVercelStreamPart", () => {
     const result = convertVercelStreamPart(part, options);
 
     expect(result).not.toBeNull();
-    expect(result?.choices[0].delta.content).toBe("Let me think...");
+    expect((result?.choices[0].delta as any).reasoning_content).toBe(
+      "Let me think...",
+    );
+    expect(result?.choices[0].delta.content).toBeUndefined();
   });
 
   test("returns null for tool-call without thoughtSignature", () => {

--- a/packages/openai-adapters/src/vercelStreamConverter.ts
+++ b/packages/openai-adapters/src/vercelStreamConverter.ts
@@ -94,8 +94,13 @@ export function convertVercelStreamPart(
       });
 
     case "reasoning-delta":
-      return chatChunk({
-        content: part.text,
+      return chatChunkFromDelta({
+        delta: {
+          role: "assistant",
+          reasoning_content: part.text,
+        } as ChatCompletionChunk.Choice["delta"] & {
+          reasoning_content?: string;
+        },
         model,
       });
 


### PR DESCRIPTION
> Credit to @MumuTW who identified this fix in #11089.

## Summary
- Fixes the Vercel stream converter to map `reasoning-delta` events to `delta.reasoning_content` instead of `delta.content`
- Previously, reasoning/thinking content from models like DeepSeek was incorrectly treated as regular assistant output, breaking thinking display in the UI
- Updates the corresponding test to assert the correct field

Closes #11069
Related: #11089

## Test plan
- [ ] Verify `reasoning-delta` stream events produce chunks with `delta.reasoning_content` set (not `delta.content`)
- [ ] Verify `text-delta` events still produce chunks with `delta.content` as before
- [ ] Test with a reasoning model (e.g. DeepSeek) through a Vercel AI SDK provider to confirm thinking content displays correctly