### PR TITLE
fix: allow multiple context providers of the same type in config.yaml

### DIFF
--- a/packages/config-yaml/src/load/blockDuplicationDetector.ts
+++ b/packages/config-yaml/src/load/blockDuplicationDetector.ts
@@ -19,7 +19,8 @@ export class BlockDuplicationDetector {
   }
 
   private isContextDuplicated(context: any): boolean {
-    return this.check(context.provider, "context");
+    const key = context.name ?? context.params?.title ?? context.provider;
+    return this.check(key, "context");
   }
 
   private isCommonBlockDuplicated(block: any, blockType: BlockType): boolean {

--- a/packages/config-yaml/src/load/mergeUnrolledAssistants.test.ts
+++ b/packages/config-yaml/src/load/mergeUnrolledAssistants.test.ts
@@ -205,15 +205,15 @@ describe("mergeUnrolledAssistants", () => {
     expect(result.models?.[0]?.model).toBe("gpt-4");
   });
 
-  it("should deduplicate context by provider", () => {
+  it("should deduplicate context by name when present", () => {
     const base = createBaseConfig();
     const incoming: AssistantUnrolled = {
       name: "Incoming Assistant",
       version: "1.1.0",
       context: [
         {
-          name: "file-context", // Different name but same provider
-          provider: "file", // Same provider as base
+          name: "file-context",
+          provider: "file",
         },
         {
           name: "terminal",
@@ -224,14 +224,60 @@ describe("mergeUnrolledAssistants", () => {
 
     const result = mergeUnrolledAssistants(base, incoming);
 
-    // Should only have 2 context providers (incoming file and incoming terminal)
-    expect(result.context).toHaveLength(2);
+    // Base has unnamed file provider, incoming has named "file-context" — different keys, both kept
+    expect(result.context).toHaveLength(3);
     expect(result.context?.map((c) => c?.provider)).toEqual([
       "file",
       "terminal",
+      "file",
     ]);
-    // Should keep the incoming version of file provider (base version filtered as duplicate)
-    expect(result.context?.[0]?.name).toBe("file-context");
+  });
+
+  it("should keep multiple context providers of the same type with different params.title", () => {
+    const base: AssistantUnrolled = {
+      name: "Base Assistant",
+      version: "1.0.0",
+    };
+    const incoming: AssistantUnrolled = {
+      name: "Incoming Assistant",
+      version: "1.1.0",
+      context: [
+        {
+          provider: "http",
+          params: {
+            url: "http://localhost:5000/context",
+            title: "http-provider-5000",
+            displayTitle: "HTTP Provider 5000",
+          },
+        },
+        {
+          provider: "http",
+          params: {
+            url: "http://localhost:5001/context",
+            title: "http-provider-5001",
+            displayTitle: "HTTP Provider 5001",
+          },
+        },
+        {
+          provider: "http",
+          params: {
+            url: "http://localhost:5002/context",
+            title: "http-provider-5002",
+            displayTitle: "HTTP Provider 5002",
+          },
+        },
+      ],
+    };
+
+    const result = mergeUnrolledAssistants(base, incoming);
+
+    // All three HTTP providers should be kept since they have different params.title
+    expect(result.context).toHaveLength(3);
+    expect(result.context?.map((c) => c?.params?.title)).toEqual([
+      "http-provider-5000",
+      "http-provider-5001",
+      "http-provider-5002",
+    ]);
   });
 
   it("should deduplicate rules by name", () => {


### PR DESCRIPTION
## Summary
- Fixes the `BlockDuplicationDetector` to use `name ?? params.title ?? provider` as the deduplication key for context entries, instead of just `provider`
- This allows multiple HTTP (or other) context providers with different `params.title` values to coexist in `config.yaml`, matching the behavior that already works in `config.json`

Fixes #9416

## Test plan
- [x] Updated existing deduplication test to reflect new key logic
- [x] Added test for multiple HTTP context providers with different `params.title` values
- [x] All 292 existing tests in config-yaml pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows multiple same-type context providers in `config.yaml` (e.g., several HTTP providers). We now dedupe by `name ?? params.title ?? provider`, matching `config.json` and preventing providers from being collapsed. Fixes #9416.

- **Bug Fixes**
  - Use `name ?? params.title ?? provider` as the context deduplication key.
  - Updated tests: adjusted deduplication test and added coverage for multiple HTTP providers with different `params.title`.

<sup>Written for commit 8e5d8ae4eb7fab20cfbf0d33453d71429a999fb9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

