### PR TITLE
feat(openrouter): send HTTP-Referer and X-Title headers to identify app

### DIFF
--- a/packages/openai-adapters/src/apis/OpenRouter.ts
+++ b/packages/openai-adapters/src/apis/OpenRouter.ts
@@ -28,13 +28,6 @@ export class OpenRouterApi extends OpenAIApi {
     });
   }
 
-  protected override getHeaders(): Record<string, string> {
-    return {
-      ...super.getHeaders(),
-      ...OPENROUTER_HEADERS,
-    };
-  }
-
   private isAnthropicModel(model?: string): boolean {
     if (!model) {
       return false;


### PR DESCRIPTION
## Summary

- Adds `HTTP-Referer: https://www.continue.dev/` and `X-Title: Continue` headers to all OpenRouter API requests, per the [OpenRouter docs](https://openrouter.ai/docs/api-reference/overview#headers)
- This identifies Continue in OpenRouter's activity dashboard and App Showcase
- User-configured headers in `requestOptions.headers` take precedence over the defaults

Closes #4049

## Test plan

- [ ] Verify OpenRouter requests include `HTTP-Referer` and `X-Title` headers
- [ ] Verify user-configured `requestOptions.headers` can still override these defaults
- [ ] Confirm the OpenRouter activity dashboard shows "Continue" in the App column

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send `HTTP-Referer: https://www.continue.dev/` and `X-Title: Continue` with all OpenRouter API requests to identify the app in OpenRouter’s dashboard and App Showcase. Headers are injected via `requestOptions.headers` so they apply to all requests; user-provided headers still override, and the redundant `getHeaders()` override was removed.

<sup>Written for commit 294515901d16e7e4842854e308b1b486fa41bbce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

