### PR TITLE
fix: fix listener leaks and redundant file read in autocomplete

### DIFF
--- a/core/autocomplete/templating/constructPrefixSuffix.ts
+++ b/core/autocomplete/templating/constructPrefixSuffix.ts
@@ -1,23 +1,23 @@
-import { IDE } from "../..";
 import { getRangeInString } from "../../util/ranges";
 import { languageForFilepath } from "../constants/AutocompleteLanguageInfo";
 import { AutocompleteInput } from "../util/types";
 
 /**
  * We have to handle a few edge cases in getting the entire prefix/suffix for the current file.
- * This is entirely prior to finding snippets from other files
+ * This is entirely prior to finding snippets from other files.
+ *
+ * Accepts pre-loaded file contents to avoid a redundant file read
+ * (the caller already has the contents loaded).
  */
-export async function constructInitialPrefixSuffix(
+export function constructInitialPrefixSuffix(
   input: AutocompleteInput,
-  ide: IDE,
-): Promise<{
+  fileContents: string,
+): {
   prefix: string;
   suffix: string;
-}> {
+} {
   const lang = languageForFilepath(input.filepath);
 
-  const fileContents =
-    input.manuallyPassFileContents ?? (await ide.readFile(input.filepath));
   const fileLines = fileContents.split("\n");
   let prefix =
     getRangeInString(fileContents, {

--- a/core/autocomplete/util/HelperVars.ts
+++ b/core/autocomplete/util/HelperVars.ts
@@ -53,7 +53,7 @@ export class HelperVars {
 
     // Construct full prefix/suffix (a few edge cases handled in here)
     const { prefix: fullPrefix, suffix: fullSuffix } =
-      await constructInitialPrefixSuffix(this.input, this.ide);
+      constructInitialPrefixSuffix(this.input, this._fileContents);
     this._fullPrefix = fullPrefix;
     this._fullSuffix = fullSuffix;
 

--- a/extensions/vscode/src/activation/NextEditWindowManager.ts
+++ b/extensions/vscode/src/activation/NextEditWindowManager.ts
@@ -602,69 +602,80 @@ export class NextEditWindowManager {
    */
   private setupListeners() {
     // Theme change listener.
-    vscode.workspace.onDidChangeConfiguration(async (e) => {
-      if (
-        e.affectsConfiguration("workbench.colorTheme") ||
-        e.affectsConfiguration("editor.fontSize") ||
-        e.affectsConfiguration("editor.fontFamily") ||
-        e.affectsConfiguration("window.autoDetectColorScheme") ||
-        e.affectsConfiguration("window.autoDetectHighContrast") ||
-        e.affectsConfiguration("workbench.preferredDarkColorTheme") ||
-        e.affectsConfiguration("workbench.preferredLightColorTheme") ||
-        e.affectsConfiguration("workbench.preferredHighContrastColorTheme") ||
-        e.affectsConfiguration("workbench.preferredHighContrastLightColorTheme")
-      ) {
+    this.disposables.push(
+      vscode.workspace.onDidChangeConfiguration(async (e) => {
+        if (
+          e.affectsConfiguration("workbench.colorTheme") ||
+          e.affectsConfiguration("editor.fontSize") ||
+          e.affectsConfiguration("editor.fontFamily") ||
+          e.affectsConfiguration("window.autoDetectColorScheme") ||
+          e.affectsConfiguration("window.autoDetectHighContrast") ||
+          e.affectsConfiguration("workbench.preferredDarkColorTheme") ||
+          e.affectsConfiguration("workbench.preferredLightColorTheme") ||
+          e.affectsConfiguration("workbench.preferredHighContrastColorTheme") ||
+          e.affectsConfiguration(
+            "workbench.preferredHighContrastLightColorTheme",
+          )
+        ) {
+          this.theme = getThemeString();
+          await this.codeRenderer.setTheme(this.theme);
+          console.debug(
+            "Theme updated:",
+            this.theme ? "Theme exists" : "Theme is undefined",
+          );
+          const editorConfig = vscode.workspace.getConfiguration("editor");
+          this.fontSize = editorConfig.get<number>("fontSize") ?? 14;
+          this.fontFamily =
+            editorConfig.get<string>("fontFamily") ?? "monospace";
+        }
+      }),
+    );
+
+    // Listen for active color theme changes.
+    this.disposables.push(
+      vscode.window.onDidChangeActiveColorTheme(async () => {
         this.theme = getThemeString();
         await this.codeRenderer.setTheme(this.theme);
         console.debug(
-          "Theme updated:",
+          "Active theme changed:",
           this.theme ? "Theme exists" : "Theme is undefined",
         );
-        const editorConfig = vscode.workspace.getConfiguration("editor");
-        this.fontSize = editorConfig.get<number>("fontSize") ?? 14;
-        this.fontFamily = editorConfig.get<string>("fontFamily") ?? "monospace";
-      }
-    });
-
-    // Listen for active color theme changes.
-    vscode.window.onDidChangeActiveColorTheme(async () => {
-      this.theme = getThemeString();
-      await this.codeRenderer.setTheme(this.theme);
-      console.debug(
-        "Active theme changed:",
-        this.theme ? "Theme exists" : "Theme is undefined",
-      );
-    });
+      }),
+    );
 
     // Listen for editor changes to clean up decorations when editor closes.
-    vscode.window.onDidChangeVisibleTextEditors(async () => {
-      // If our active editor is no longer visible, clear decorations.
-      if (
-        this.activeEditor &&
-        !vscode.window.visibleTextEditors.includes(this.activeEditor)
-      ) {
-        if (this.mostRecentCompletionId) {
-          this.loggingService.cancelRejectionTimeout(
-            this.mostRecentCompletionId,
-          );
+    this.disposables.push(
+      vscode.window.onDidChangeVisibleTextEditors(async () => {
+        // If our active editor is no longer visible, clear decorations.
+        if (
+          this.activeEditor &&
+          !vscode.window.visibleTextEditors.includes(this.activeEditor)
+        ) {
+          if (this.mostRecentCompletionId) {
+            this.loggingService.cancelRejectionTimeout(
+              this.mostRecentCompletionId,
+            );
+          }
+          await this.hideAllNextEditWindows();
         }
-        await this.hideAllNextEditWindows();
-      }
-    });
+      }),
+    );
 
     // Listen for selection changes to hide tooltip when cursor moves.
-    vscode.window.onDidChangeTextEditorSelection(async (e) => {
-      // If the selection changed in our active editor, hide the tooltip.
-      if (this.activeEditor && e.textEditor === this.activeEditor) {
-        // If the cursor moved because of something other than accepting next edit, stop logging it.
-        if (!this.accepted && this.mostRecentCompletionId) {
-          this.loggingService.cancelRejectionTimeout(
-            this.mostRecentCompletionId,
-          );
+    this.disposables.push(
+      vscode.window.onDidChangeTextEditorSelection(async (e) => {
+        // If the selection changed in our active editor, hide the tooltip.
+        if (this.activeEditor && e.textEditor === this.activeEditor) {
+          // If the cursor moved because of something other than accepting next edit, stop logging it.
+          if (!this.accepted && this.mostRecentCompletionId) {
+            this.loggingService.cancelRejectionTimeout(
+              this.mostRecentCompletionId,
+            );
+          }
+          await this.hideAllNextEditWindows();
         }
-        await this.hideAllNextEditWindows();
-      }
-    });
+      }),
+    );
   }
 
   private shouldRenderTip(uri: vscode.Uri): boolean {

--- a/extensions/vscode/src/autocomplete/statusBar.ts
+++ b/extensions/vscode/src/autocomplete/statusBar.ts
@@ -103,6 +103,7 @@ let statusBarStatus: StatusBarStatus | undefined = undefined;
 let statusBarItem: vscode.StatusBarItem | undefined = undefined;
 let statusBarFalseTimeout: NodeJS.Timeout | undefined = undefined;
 let statusBarError: boolean = false;
+let configListenerRegistered = false;
 
 export function stopStatusBarLoading() {
   statusBarFalseTimeout = setTimeout(() => {
@@ -153,19 +154,24 @@ export function setupStatusBar(
     statusBarStatus = status;
   }
 
-  vscode.workspace.onDidChangeConfiguration((event) => {
-    if (event.affectsConfiguration(CONTINUE_WORKSPACE_KEY)) {
-      const enabled = getContinueWorkspaceConfig().get<boolean>(
-        "enableTabAutocomplete",
-      );
-      if (enabled && statusBarStatus === StatusBarStatus.Paused) {
-        return;
+  // Guard: only register this listener once. Previously it was registered on
+  // every setupStatusBar() call, causing unbounded listener accumulation.
+  if (!configListenerRegistered) {
+    configListenerRegistered = true;
+    vscode.workspace.onDidChangeConfiguration((event) => {
+      if (event.affectsConfiguration(CONTINUE_WORKSPACE_KEY)) {
+        const enabled = getContinueWorkspaceConfig().get<boolean>(
+          "enableTabAutocomplete",
+        );
+        if (enabled && statusBarStatus === StatusBarStatus.Paused) {
+          return;
+        }
+        setupStatusBar(
+          enabled ? StatusBarStatus.Enabled : StatusBarStatus.Disabled,
+        );
       }
-      setupStatusBar(
-        enabled ? StatusBarStatus.Enabled : StatusBarStatus.Disabled,
-      );
-    }
-  });
+    });
+  }
 }
 
 export function getStatusBarStatus(): StatusBarStatus | undefined {


### PR DESCRIPTION
## Summary

Three focused fixes for autocomplete performance — the highest impact-per-line changes from the analysis of stale PR #8364 and related issues.

- **statusBar.ts**: `onDidChangeConfiguration` was registered on every `setupStatusBar()` call. Since `setupStatusBar` is called on every config change (including autocomplete toggle), listeners accumulated exponentially — each one re-triggering `setupStatusBar`, which added another listener. Guard with a `configListenerRegistered` flag.

- **NextEditWindowManager.setupListeners()**: 4 VS Code event listeners were created without being added to `this.disposables`. The `dispose()` method iterates `this.disposables` to clean up, but these listeners weren't in it — so they survived across `clearInstance()`/re-creation cycles when toggling Next Edit.

- **constructPrefixSuffix**: Was calling `ide.readFile()` internally, but its only caller (`HelperVars.init()`) already has the file contents loaded 3 lines above. Changed the signature to accept `fileContents: string` directly, eliminating one redundant file read per completion request.

## Related issues

Fixes #3616
Refs #5055
Refs #8364

## Test plan

- [ ] Autocomplete still works end-to-end
- [ ] Toggle tab autocomplete on/off 20+ times — CPU should stay stable
- [ ] Toggle Next Edit on/off repeatedly — no performance degradation
- [ ] Existing vitest suite passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents listener leaks when toggling autocomplete and Next Edit, and removes a redundant file read per completion to improve stability and CPU. Fixes #3616 (refs #5055, #8364).

- **Bug Fixes**
  - Status bar: register `onDidChangeConfiguration` once with a guard to stop exponential listener growth.
  - Next Edit: add four VS Code event listeners to `this.disposables` so `dispose()` cleans them up between toggle cycles.
  - Autocomplete: make `constructInitialPrefixSuffix` accept preloaded `fileContents` (updated `HelperVars`) to remove an extra `readFile` per completion.

<sup>Written for commit 4794082974896f71670f861f3d4b98e7b43418cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

