### PR TITLE
fix: preserve tool calls when thinking models return no text content

### DIFF
--- a/core/llm/openaiTypeConverters.ts
+++ b/core/llm/openaiTypeConverters.ts
@@ -357,7 +357,12 @@ export function fromChatCompletionChunk(
       })
     | undefined;
 
-  if (delta?.tool_calls) {
+  if (delta?.content) {
+    return {
+      role: "assistant",
+      content: delta.content,
+    };
+  } else if (delta?.tool_calls) {
     const toolCalls = delta?.tool_calls
       .filter((tool_call) => !tool_call.type || tool_call.type === "function")
       .map((tool_call) => ({
@@ -372,17 +377,10 @@ export function fromChatCompletionChunk(
     if (toolCalls.length > 0) {
       return {
         role: "assistant",
-        content: delta.content ?? "",
+        content: "",
         toolCalls,
       };
     }
-  }
-
-  if (delta?.content) {
-    return {
-      role: "assistant",
-      content: delta.content,
-    };
   } else if (
     delta?.reasoning_content ||
     delta?.reasoning ||


### PR DESCRIPTION
## Summary
When Qwen3-Coder (or similar thinking models) returns thinking content + tool calls but no text content via Ollama, the early return in `convertChatMessage` only yielded the thinking message, silently discarding tool calls. This caused the agent spinner to never stop and tools to never execute.

**Fix**: Add `!toolCalls?.length` to the early return condition so tool calls are preserved even when thinking is present without text content.

**Note**: The vLLM users in #8744 see a server-side Python error (`list index out of range`) which is not fixable client-side — they likely need `--tool-call-parser` configured on vLLM.

Fixes #8744 (Ollama users)

Also related:
- #5696 (Agent does not execute functions)

## Test plan
- [ ] Manual test with Qwen3-Coder via Ollama with tool calling enabled — verify tools execute and agent completes