### PR TITLE
fix: ls tool no longer hides gitignored directories from agent

### DIFF
--- a/core/indexing/walkDir.ts
+++ b/core/indexing/walkDir.ts
@@ -11,6 +11,7 @@ export interface WalkerOptions {
   returnRelativeUrisPaths?: boolean;
   source?: string;
   overrideDefaultIgnores?: Ignore;
+  skipGitIgnore?: boolean;
   recursive?: boolean;
 }
 
@@ -157,6 +158,7 @@ class DFSWalker {
           entries,
           this.ide,
           defaultAndGlobalIgnores,
+          this.options.skipGitIgnore,
         );
         walkDirCache.dirIgnoreCache.set(cur.walkableEntry.uri, {
           time: Date.now(),
@@ -301,6 +303,7 @@ export async function getIgnoreContext(
   currentDirEntries: Entry[],
   ide: IDE,
   defaultAndGlobalIgnores: Ignore,
+  skipGitIgnore?: boolean,
 ) {
   const dirFiles = currentDirEntries
     .filter(([_, entryType]) => entryType === (1 as FileType.File))
@@ -308,7 +311,9 @@ export async function getIgnoreContext(
 
   // Find ignore files and get ignore arrays from their contexts
   // These are done separately so that .continueignore can override .gitignore
-  const gitIgnoreFile = dirFiles.find((name) => name === ".gitignore");
+  const gitIgnoreFile = skipGitIgnore
+    ? undefined
+    : dirFiles.find((name) => name === ".gitignore");
   const continueIgnoreFile = dirFiles.find(
     (name) => name === ".continueignore",
   );

--- a/core/tools/implementations/lsTool.ts
+++ b/core/tools/implementations/lsTool.ts
@@ -29,6 +29,7 @@ export const lsToolImpl: ToolImpl = async (args, extras) => {
     include: "both",
     recursive: args?.recursive ?? false,
     overrideDefaultIgnores: ignore(), // Show all directories including dist/, build/, etc.
+    skipGitIgnore: true, // Show gitignored directories like .venv so agent can discover them
   });
 
   const lines = entries.slice(0, MAX_LS_TOOL_LINES);


### PR DESCRIPTION
## Summary
- The built-in `ls` tool was respecting `.gitignore` rules, hiding directories like `.venv` from the agent's view
- Added a `skipGitIgnore` option to `walkDir` and enabled it in the ls tool so the agent can discover and interact with all directories

Fixes #11303

## Test plan
- [ ] Create a `.venv` directory (or any gitignored directory) in a workspace
- [ ] Ask the agent to list folders — it should now show `.venv` and other gitignored directories
- [ ] Verify that indexing/other features still respect `.gitignore` (only the ls tool behavior changed)