### PR TITLE
fix: show actionable error when Ollama fails to parse tool calls

### DIFF
--- a/gui/src/util/errorAnalysis.ts
+++ b/gui/src/util/errorAnalysis.ts
@@ -150,7 +150,7 @@ export function analyzeError(
   }
 
   // Ollama tool call parsing failure (transient model output issue)
-  if (errorText.includes("error parsing ollama response: error: error parsing tool call")) {
+  if (errorText.includes("error parsing tool call")) {
     customErrorMessage =
       "This model produced an invalid tool call that Ollama could not parse. " +
       "This is a known transient issue — you can resubmit your message to try again. " +


### PR DESCRIPTION
## Summary

When Ollama models (e.g. `gpt-oss:20b`) produce malformed tool call output, Ollama's server-side parser returns `"error parsing tool call"` which was surfacing as an opaque "Unknown error" in the stream error dialog.

This PR adds pattern matching in `analyzeError()` to detect this specific error and show a `customErrorMessage` explaining:
- The issue is transient and they can resubmit to try again
- They can enable "Only use system message tools" in Settings > Experimental to bypass Ollama's native tool call parser

Fixes #11783, #11063, #10954, #10897, #10711, #10221, #9433

## Test plan
- [ ] Use `gpt-oss:20b` on Ollama with tool calling — when a tool call parse failure occurs, verify the stream error dialog shows the actionable message instead of "Unknown error"
- [ ] Verify other Ollama errors (e.g. "model not found") still show their normal error messages