### PR TITLE
fix: handle multiple zip files in JetBrains release artifact step

### DIFF
--- a/.github/workflows/jetbrains-release.yaml
+++ b/.github/workflows/jetbrains-release.yaml
@@ -286,7 +286,7 @@ jobs:
           echo "Contents of distributions folder:"
           ls
           echo "---"
-          FILENAME=`ls continue-intellij-extension-*.zip`
+          FILENAME=$(ls continue-intellij-extension-*.zip | head -1)
           echo "Filename=${FILENAME}"
           unzip "$FILENAME" -d content
 


### PR DESCRIPTION
## Summary
- The `Prepare Plugin Artifact` step in the JetBrains release workflow globs for `continue-intellij-extension-*.zip`, which matches multiple files (EAP signed/unsigned, stable signed/unsigned), causing `unzip` to fail with exit code 9
- Uses `head -1` to select only the first matching zip file

## Test plan
- [ ] Trigger a JetBrains release workflow run and verify the `Prepare Plugin Artifact` step succeeds