### PR TITLE
fix: hide thinking indicator for empty thinking content

### DIFF
--- a/gui/src/components/StepContainer/StepContainer.tsx
+++ b/gui/src/components/StepContainer/StepContainer.tsx
@@ -85,7 +85,7 @@ export default function StepContainer(props: StepContainerProps) {
           </pre>
         ) : (
           <>
-            {props.item.reasoning?.text && (
+            {props.item.reasoning?.text?.trim() && (
               <ThinkingBlockPeek
                 content={props.item.reasoning.text}
                 index={props.index}

--- a/gui/src/pages/gui/Chat.tsx
+++ b/gui/src/pages/gui/Chat.tsx
@@ -393,10 +393,14 @@ export function Chat() {
       }
 
       if (message.role === "thinking") {
+        const thinkingContent = renderChatMessage(message);
+        if (!thinkingContent?.trim()) {
+          return null;
+        }
         return (
           <div className={isBeforeLatestSummary ? "opacity-50" : ""}>
             <ThinkingBlockPeek
-              content={renderChatMessage(message)}
+              content={thinkingContent}
               redactedThinking={message.redactedThinking}
               index={index}
               prevItem={index > 0 ? history[index - 1] : null}


### PR DESCRIPTION
## Summary
- Skip rendering the `ThinkingBlockPeek` component when thinking content is empty or whitespace-only
- Adds `.trim()` check in `StepContainer.tsx` for inline reasoning text
- Adds content check in `Chat.tsx` before rendering thinking role messages

## Test plan
- [ ] Send a message to a model that returns empty thinking blocks — no thinking indicator should appear
- [ ] Send a message to a model with real thinking content — thinking indicator should still display normally
- [ ] Verify whitespace-only thinking content is also hidden