### PR TITLE
fix: filter empty/whitespace text content blocks at provider boundaries

### DIFF
--- a/core/llm/llms/Anthropic.ts
+++ b/core/llm/llms/Anthropic.ts
@@ -90,7 +90,7 @@ class Anthropic extends BaseLLM {
   ): ContentBlockParam[] {
     const parts: ContentBlockParam[] = [];
     if (typeof content === "string") {
-      if (content) {
+      if (content.trim()) {
         parts.push({
           type: "text",
           text: content,
@@ -99,7 +99,7 @@ class Anthropic extends BaseLLM {
     } else {
       for (const part of content) {
         if (part.type === "text") {
-          if (part.text) {
+          if (part.text?.trim()) {
             parts.push({
               type: "text",
               text: part.text,

--- a/core/llm/llms/Bedrock.ts
+++ b/core/llm/llms/Bedrock.ts
@@ -538,11 +538,15 @@ class Bedrock extends BaseLLM {
   ): ContentBlock[] {
     const blocks: ContentBlock[] = [];
     if (typeof content === "string") {
-      blocks.push({ text: content });
+      if (content.trim()) {
+        blocks.push({ text: content });
+      }
     } else {
       for (const part of content) {
         if (part.type === "text") {
-          blocks.push({ text: part.text });
+          if (part.text?.trim()) {
+            blocks.push({ text: part.text });
+          }
         } else if (part.type === "imageUrl" && part.imageUrl) {
           const parsed = parseDataUrl(part.imageUrl.url);
           if (parsed) {

--- a/packages/openai-adapters/src/apis/Bedrock.ts
+++ b/packages/openai-adapters/src/apis/Bedrock.ts
@@ -203,9 +203,14 @@ export class BedrockApi implements BaseLlmApi {
           const content = message.content;
           if (content) {
             if (typeof content === "string") {
-              currentBlocks.push({ text: content });
+              if (content.trim()) {
+                currentBlocks.push({ text: content });
+              }
             } else {
               content.forEach((part) => {
+                if (part.type === "text" && !part.text?.trim()) {
+                  return;
+                }
                 currentBlocks.push(this._oaiPartToBedrockPart(part));
               });
             }


### PR DESCRIPTION
## Summary

Skip empty and whitespace-only text content blocks at each provider's message conversion layer, preventing 400 errors from Anthropic and Bedrock.

**3 targeted changes, +14/-5 lines, zero upstream behavioral changes.**

### Changes

| File | Change | Issues fixed |
|------|--------|-------------|
| `core/llm/llms/Anthropic.ts` | `.trim()` check in `convertMessageContentToBlocks` | #11446 |
| `core/llm/llms/Bedrock.ts` | Skip empty text in `_convertMessageContentToBlocks` | #9765, #9767, #11264, #11497 |
| `packages/openai-adapters/src/apis/Bedrock.ts` | Skip empty text in user message conversion | #10148, #10804, #11045 |

### What this does NOT change

- No upstream message filtering or compilation logic
- No changes to `messages.ts`, `countTokens.ts`, or `toResponsesInput`
- Existing `" "` fallbacks for string content are untouched
- No changes to the OpenAI adapter's `toChatMessage` conversion

## Issues fixed

Fixes #9765, fixes #9767, fixes #10148, fixes #10804, fixes #11045, fixes #11264, fixes #11446, fixes #11497

## Test plan

- [x] `openaiTypeConverters.test.ts` — 24/24 pass
- [x] Prettier clean
- [ ] Manual: Bedrock ConverseStream
- [ ] Manual: Bedrock InvokeModelWithResponseStream
- [ ] Manual: Anthropic direct