### PR TITLE
fix: add ModelDescription type to binary test callbacks

### DIFF
--- a/binary/test/binary.test.ts
+++ b/binary/test/binary.test.ts
@@ -1,4 +1,4 @@
-import { SerializedContinueConfig } from "core";
+import { ModelDescription, SerializedContinueConfig } from "core";
 // import Mock from "core/llm/llms/Mock.js";
 import { FromIdeProtocol, ToIdeProtocol } from "core/protocol/index.js";
 import { IMessenger } from "core/protocol/messenger";
@@ -235,16 +235,20 @@ describe("Test Suite", () => {
       result: { config },
     } = await messenger.request("config/getSerializedProfileInfo", undefined);
 
-    expect(config!.modelsByRole.chat.some((m) => m.title === model.title)).toBe(
-      true,
-    );
+    expect(
+      config!.modelsByRole.chat.some(
+        (m: ModelDescription) => m.title === model.title,
+      ),
+    ).toBe(true);
 
     await messenger.request("config/deleteModel", { title: model.title });
     const {
       result: { config: configAfterDelete },
     } = await messenger.request("config/getSerializedProfileInfo", undefined);
     expect(
-      configAfterDelete!.modelsByRole.chat.some((m) => m.title === model.title),
+      configAfterDelete!.modelsByRole.chat.some(
+        (m: ModelDescription) => m.title === model.title,
+      ),
     ).toBe(false);
   });
 


### PR DESCRIPTION
## Summary
- Fixes TS7006 implicit `any` type errors in `binary/test/binary.test.ts` that broke the JetBrains 1.0.64 release CI
- Adds explicit `ModelDescription` type annotation to `.some()` callback parameters on lines 238 and 247

## Test plan
- [ ] Re-run JetBrains release after merging (re-tag `v1.0.64-jetbrains`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TS7006 implicit any errors in `binary/test/binary.test.ts` by adding `ModelDescription` types to `.some()` callbacks when checking chat model titles. This restores type safety and unblocks the JetBrains 1.0.64 release CI.

<sup>Written for commit 96754dc7a0ed30e0d67263746830f033756346da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

