### PR TITLE
fix(openai-adapter): map max_tokens to max_completion_tokens for DeepSeek reasoner

### DIFF
--- a/packages/openai-adapters/src/apis/OpenAI.ts
+++ b/packages/openai-adapters/src/apis/OpenAI.ts
@@ -54,6 +54,16 @@ export class OpenAIApi implements BaseLlmApi {
       (body as any).stream_options = { include_usage: true };
     }
 
+    // DeepSeek reasoner models use max_completion_tokens instead of max_tokens
+    if (
+      body.max_tokens &&
+      (this.apiBase?.includes("api.deepseek.com") ||
+        body.model.includes("deepseek-reasoner"))
+    ) {
+      body.max_completion_tokens = body.max_tokens;
+      body.max_tokens = undefined;
+    }
+
     // o-series models - only apply for official OpenAI API
     const isOfficialOpenAIAPI = this.apiBase === "https://api.openai.com/v1/";
     if (isOfficialOpenAIAPI) {


### PR DESCRIPTION
Based on the work by @BurakBebek1 in #10478 — extracting just the `max_completion_tokens` fix as requested in review comments.

## Summary

- DeepSeek Reasoner models require `max_completion_tokens` instead of `max_tokens` (similar to OpenAI's o-series models)
- Automatically maps the parameter when the API base includes `api.deepseek.com` or the model name includes `deepseek-reasoner`

## Test plan

- [ ] Verify DeepSeek Reasoner models no longer fail due to `max_tokens` being sent
- [ ] Verify no regression for standard OpenAI or other provider logic
- [ ] Verify o-series handling still works as expected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Map `max_tokens` to `max_completion_tokens` for DeepSeek Reasoner models in the OpenAI adapter to prevent request failures. Applies when the API base includes `api.deepseek.com` or the model name includes `deepseek-reasoner`; standard OpenAI and o-series handling remain unchanged.

<sup>Written for commit 4f1374015bba33a55988c575e203d9febf2ade56. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

