### PR TITLE
fix: update JetBrains binary test expected files

### DIFF
--- a/binary/test/binary.test.ts
+++ b/binary/test/binary.test.ts
@@ -67,7 +67,7 @@ describe("Test Suite", () => {
     const binaryPath = path.join(binaryDir, `continue-binary${exe}`);
     const expectedItems = [
       `continue-binary${exe}`,
-      `esbuild${exe}`,
+      `rg${exe}`,
       "index.node",
       "package.json",
       "build/Release/node_sqlite3.node",
@@ -144,7 +144,7 @@ describe("Test Suite", () => {
       (
         messenger as CoreBinaryTcpMessenger<ToIdeProtocol, FromIdeProtocol>
       ).close();
-    } else {
+    } else if (subprocess) {
       subprocess.kill();
       await new Promise((resolve) => subprocess.on("close", resolve));
       await new Promise((resolve) => setTimeout(resolve, 1000));


### PR DESCRIPTION
## Summary
- Fix binary test expecting `esbuild` when the build actually produces `rg` (ripgrep)
- Guard `afterAll` against `subprocess` being undefined when `beforeAll` fails

## Test plan
- [ ] Verify JetBrains binary tests pass in CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix JetBrains binary tests by expecting `rg` (ripgrep) instead of `esbuild`, matching the build output. Also guard afterAll to only kill the subprocess when it exists, preventing failures if beforeAll fails.

<sup>Written for commit 9205a0dc3ba158d7f7256586cbf39243cf53d08b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

