### PR TITLE
fix: harden JetBrains remote config sync to prevent IDE freezes

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/services/ContinueExtensionSettingsService.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/services/ContinueExtensionSettingsService.kt
@@ -2,13 +2,13 @@ package com.github.continuedev.continueintellijextension.services
 
 import com.github.continuedev.continueintellijextension.constants.getConfigJsonPath
 import com.github.continuedev.continueintellijextension.constants.getConfigJsPath
-import com.github.continuedev.continueintellijextension.error.ContinueSentryService
 import com.google.gson.Gson
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.project.DumbAware
 import com.intellij.util.concurrency.AppExecutorUtil
@@ -17,7 +17,6 @@ import com.intellij.util.messages.Topic
 import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
 import java.io.File
-import java.io.IOException
 import java.net.URL
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
@@ -104,62 +103,56 @@ open class ContinueExtensionSettings : PersistentStateComponent<ContinueExtensio
     }
 
     companion object {
+        private val log = Logger.getInstance(ContinueExtensionSettings::class.java)
+
         val instance: ContinueExtensionSettings
             get() = service<ContinueExtensionSettings>()
     }
 
-
-    // Sync remote config from server
     private fun syncRemoteConfig() {
         val remoteServerUrl = state.remoteConfigServerUrl
+        if (remoteServerUrl.isNullOrEmpty()) return
+
         val token = state.userToken
-        if (remoteServerUrl != null && remoteServerUrl.isNotEmpty()) {
-            val baseUrl = remoteServerUrl.removeSuffix("/")
-            try {
-                val url = "$baseUrl/sync"
-                val responseBody = HttpRequests.request(url)
-                    .tuner { connection ->
-                        if (token != null)
-                            connection.addRequestProperty("Authorization", "Bearer $token")
-                    }.readString()
-                val response = Gson().fromJson(responseBody, ContinueRemoteConfigSyncResponse::class.java)
-                val hostname = URL(url).host
-                
-                // Write configJson to config.json if present
-                if (!response.configJson.isNullOrEmpty()) {
-                    File(getConfigJsonPath(hostname)).writeText(response.configJson!!)
-                }
-                
-                // Write configJs to config.js if present
-                if (!response.configJs.isNullOrEmpty()) {
-                    File(getConfigJsPath(hostname)).writeText(response.configJs!!)
-                }
-            } catch (e: Exception) {
-                // Catch all exceptions including JsonSyntaxException
-                service<ContinueSentryService>().report(e, "Unexpected exception during remote config sync")
+        val baseUrl = remoteServerUrl.removeSuffix("/")
+        try {
+            val url = "$baseUrl/sync"
+            val responseBody = HttpRequests.request(url)
+                .connectTimeout(5000)
+                .readTimeout(5000)
+                .tuner { connection ->
+                    if (token != null)
+                        connection.addRequestProperty("Authorization", "Bearer $token")
+                }.readString()
+            val response = Gson().fromJson(responseBody, ContinueRemoteConfigSyncResponse::class.java)
+            val hostname = URL(url).host
+
+            if (!response.configJson.isNullOrEmpty()) {
+                File(getConfigJsonPath(hostname)).writeText(response.configJson!!)
             }
+
+            if (!response.configJs.isNullOrEmpty()) {
+                File(getConfigJsPath(hostname)).writeText(response.configJs!!)
+            }
+        } catch (e: Exception) {
+            log.warn("Failed to sync remote config from $baseUrl", e)
         }
     }
 
-    // Create a scheduled task to sync remote config every `remoteConfigSyncPeriod` minutes
     fun addRemoteSyncJob() {
-        // Cancel existing job if present
-        if (remoteSyncFuture != null) {
-            remoteSyncFuture?.cancel(false)
-            remoteSyncFuture = null
-        }
+        remoteSyncFuture?.cancel(false)
+        remoteSyncFuture = null
 
-        // Only schedule sync job if remote config server URL is configured
         val remoteServerUrl = continueState.remoteConfigServerUrl
-        if (remoteServerUrl != null && remoteServerUrl.isNotEmpty()) {
-            instance.remoteSyncFuture = AppExecutorUtil.getAppScheduledExecutorService()
-                .scheduleWithFixedDelay(
-                    ::syncRemoteConfig,
-                    0,
-                    continueState.remoteConfigSyncPeriod.toLong(),
-                    TimeUnit.MINUTES
-                )
-        }
+        if (remoteServerUrl.isNullOrEmpty()) return
+
+        remoteSyncFuture = AppExecutorUtil.getAppScheduledExecutorService()
+            .scheduleWithFixedDelay(
+                ::syncRemoteConfig,
+                0,
+                continueState.remoteConfigSyncPeriod.toLong(),
+                TimeUnit.MINUTES
+            )
     }
 }
 
@@ -215,8 +208,6 @@ class ContinueExtensionConfigurable : Configurable {
         mySettingsComponent?.displayEditorTooltip?.isSelected = settings.continueState.displayEditorTooltip
         mySettingsComponent?.showIDECompletionSideBySide?.isSelected =
             settings.continueState.showIDECompletionSideBySide
-
-        ContinueExtensionSettings.instance.addRemoteSyncJob()
     }
 
     override fun disposeUIResources() {


### PR DESCRIPTION
## Summary
- Remove `service<ContinueSentryService>().report(...)` from the remote config sync catch block — this call could itself throw from the background executor thread, letting the original exception escape and **silently killing all future scheduled sync runs** (a `ScheduledFuture` stops rescheduling when the runnable throws)
- Replace with `Logger.warn()` so sync failures are visible in the IDEA log
- Add explicit `connectTimeout(5000)` / `readTimeout(5000)` to prevent a hung remote server from blocking the shared `AppScheduledExecutorService` indefinitely
- Early-return in both `syncRemoteConfig()` and `addRemoteSyncJob()` when `remoteConfigServerUrl` is not configured, so no work is done at all for users who don't use this deprecated setting
- Remove redundant `addRemoteSyncJob()` call from `reset()`, which only restores UI fields from saved state

Ref: https://github.com/continuedev/continue/discussions/8606#discussioncomment-15003299

## Test plan
- [ ] Verify IDE starts without freezing when `remoteConfigServerUrl` is not set (default)
- [ ] Verify remote config sync still works when a valid URL is configured
- [ ] Verify sync failure with an invalid/unreachable URL logs a warning and doesn't freeze the IDE
- [ ] Verify sync failure doesn't prevent future sync attempts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents IDE freezes by hardening the JetBrains remote config sync. Failures now log without killing future runs, and hung servers no longer block the shared executor.

- **Bug Fixes**
  - Replaced `service<ContinueSentryService>().report(...)` with `Logger.warn()` so exceptions don’t escape the scheduler thread.
  - Added `connectTimeout(5000)` and `readTimeout(5000)` to `HttpRequests` to avoid blocking `AppScheduledExecutorService`.
  - Early-return when `remoteConfigServerUrl` is empty in both `syncRemoteConfig()` and `addRemoteSyncJob()`.
  - Always cancel any existing `remoteSyncFuture` before scheduling; removed redundant `addRemoteSyncJob()` from `reset()`.

<sup>Written for commit 4a85441447925e2692a9d3b2b0f6b1307bde91c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

