### PR TITLE
chore: jetbrains 65, vs code 36

### DIFF
--- a/extensions/intellij/gradle.properties
+++ b/extensions/intellij/gradle.properties
@@ -1,5 +1,5 @@
 pluginGroup=com.github.continuedev.continueintellijextension
-pluginVersion=1.0.64
+pluginVersion=1.0.65
 platformVersion=2024.1
 kotlin.stdlib.default.dependency=false
 org.gradle.configuration-cache=true


### PR DESCRIPTION
## Description
prerelease bumps

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare prerelease by bumping the IntelliJ plugin version from 1.0.64 to 1.0.65. No functional changes; updated `extensions/intellij/gradle.properties` only.

<sup>Written for commit 0244b0f9dc90e02b0f514033021df8e5f56f8866. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

