### PR TITLE
fix: resolve crashes in DiffStreamHandler — unsafe cast and negative line numbers

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/DiffStreamHandler.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/DiffStreamHandler.kt
@@ -271,9 +271,8 @@ class DiffStreamHandler(
         val unfinishedKey = editorUtils.createTextAttributesKey("CONTINUE_DIFF_UNFINISHED_LINE", 0x20888888)
 
         for (i in startLine..endLine) {
-            val lineNum = min(i, editor.document.lineCount - 1).coerceAtLeast(0)
             val highlighter = editor.markupModel.addLineHighlighter(
-                unfinishedKey, lineNum, HighlighterLayer.LAST
+                unfinishedKey, min(i, editor.document.lineCount - 1).coerceAtLeast(0), HighlighterLayer.LAST
             )
             unfinishedHighlighters.add(highlighter)
         }


### PR DESCRIPTION
## Summary
- **Fix A**: Use safe cast (`as?`) for `TextEditor` in `undoChanges()` to prevent `ClassCastException`/`NullPointerException` when the selected editor is not a `TextEditor`
- **Fix B**: Add early return for empty documents and clamp line numbers with `coerceAtLeast(0)` in `initUnfinishedRangeHighlights()` to prevent `IndexOutOfBoundsException`
- **Fix C**: Remove redundant `.toList()` call in `rejectAll()` — the list was already copied on the previous line

Fixes #4267

## Test plan
- [ ] Open a diff stream on an empty file — verify no crash in `initUnfinishedRangeHighlights()`
- [ ] Trigger `undoChanges()` when the active editor is not a `TextEditor` (e.g., image viewer) — verify graceful no-op instead of crash
- [ ] Reject all diff blocks after accepting/rejecting one — verify behavior unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two crashes in `DiffStreamHandler` by safely handling non-`TextEditor` cases and clamping line numbers for empty or short documents. Prevents crashes when opening diffs on empty files and when undo is triggered in non-text editors. Fixes #4267.

- **Bug Fixes**
  - Use safe cast in `undoChanges()` and no-op if not a `TextEditor` to avoid `ClassCastException`/`NullPointerException`.
  - Early return for empty documents and clamp line numbers in `initUnfinishedRangeHighlights()` to avoid `IndexOutOfBoundsException`.

- **Refactors**
  - Remove redundant `.toList()` in `rejectAll()` to avoid an extra allocation.
  - Inline `lineNum` in `initUnfinishedRangeHighlights()` for clarity.

<sup>Written for commit 324f1a1f7d6d310103265910683af149475694b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

