### PR TITLE
fix: resolve SideEffectNotAllowedException in intention previews

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/listeners/ActiveHandlerManager.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/listeners/ActiveHandlerManager.kt
@@ -56,7 +56,7 @@ interface CursorMovementHandler {
 @Service(Service.Level.PROJECT)
 class ActiveHandlerManager(private val project: Project) : SelectionListener, CaretListener, DumbAware {
 
-    private val coroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+    private val coroutineScope = CoroutineScope(Dispatchers.Default.limitedParallelism(1) + SupervisorJob())
     private var activeHandler: CursorMovementHandler? = null
     private var isHandlingEvent = false
 

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/listeners/DocumentChangeTracker.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/listeners/DocumentChangeTracker.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.*
 @Service(Service.Level.PROJECT)
 class DocumentChangeTracker(private val project: Project) : DocumentListener {
 
-    private val coroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+    private val coroutineScope = CoroutineScope(Dispatchers.Default.limitedParallelism(1) + SupervisorJob())
     private var typingHandler: TypingSessionHandler? = null
     private var typingSessionTimer: Job? = null
 


### PR DESCRIPTION
## Summary
- Fixes `SideEffectNotAllowedException` thrown during JetBrains intention preview computation (autocomplete, inspections)
- Changes `Dispatchers.Main` to `Dispatchers.Default` in `DocumentChangeTracker` and `ActiveHandlerManager` coroutine scopes
- `Dispatchers.Main` schedules work via `INVOKE_LATER`, which JetBrains forbids during preview computation; neither class requires EDT for its coroutine work

Fixes #9463, #8035

## Test plan
- [ ] Verify autocomplete/intention previews no longer throw `SideEffectNotAllowedException`
- [ ] Verify typing session detection still works correctly
- [ ] Verify cursor movement handling and next-edit chain deletion still function as expected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent SideEffectNotAllowedException in JetBrains intention previews by moving coroutine work off the EDT while keeping handlers single-threaded. Switched `Dispatchers.Main` to `Dispatchers.Default.limitedParallelism(1)` to keep autocomplete and inspections stable and avoid race conditions.

- **Bug Fixes**
  - Use `Dispatchers.Default.limitedParallelism(1)` in `DocumentChangeTracker` and `ActiveHandlerManager` to avoid INVOKE_LATER during previews and preserve serialized access to shared state.
  - Fixes #9463, #8035.

<sup>Written for commit 911240a6b9ecfbbb104fcbdedc285bce2e31d0ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

