### PR TITLE
fix: increase JCEF JS query pool size from 200 to 1000

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/browser/ContinueBrowser.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/browser/ContinueBrowser.kt
@@ -26,7 +26,7 @@ class ContinueBrowser(
 
     init {
         CefApp.getInstance().registerSchemeHandlerFactory("http", "continue", CustomSchemeHandlerFactory())
-        browser.jbCefClient.setProperty(JBCefClient.Properties.JS_QUERY_POOL_SIZE, 200)
+        browser.jbCefClient.setProperty(JBCefClient.Properties.JS_QUERY_POOL_SIZE, 1000)
         myJSQueryOpenInBrowser.addHandler { msg: String? ->
             val json = gsonService.gson.fromJson(msg, BrowserMessage::class.java)
             val messageType = json.messageType


### PR DESCRIPTION
## Summary
- Increases the JCEF JS query pool size from 200 to 1000 in `ContinueBrowser.kt` to prevent pool exhaustion during streaming responses
- When the IDE sends many messages to the webview (e.g. streaming LLM responses), the 200-entry pool gets exhausted, causing `JavaScript query pool is over [size: 200]` errors and eventual browser freeze
- Multiple issue reporters have confirmed this change resolves the freeze

The true root cause is JCEF's out-of-process server crashing (a JetBrains bug), but this mitigates the most commonly reported symptom significantly.

Fixes #8085, #8587, #7285, #9159, #10069

## Test plan
- [ ] Open Continue in IntelliJ and stream a long response — verify no "JS query pool is over" errors appear
- [ ] Confirm the webview does not freeze during extended streaming sessions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the `JCEF` JS query pool size from 200 to 1000 to prevent pool exhaustion during streaming. This removes "JavaScript query pool is over" errors and stops webview freezes in IntelliJ.

- **Bug Fixes**
  - Fixes #8085, #8587, #7285, #9159, #10069.

<sup>Written for commit 409f86396ae3d7e22904ef6e1bd971fd87babe7e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

