### PR TITLE
fix: add guard for disposed JCEF browser in sendToWebview

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/browser/ContinueBrowser.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/browser/ContinueBrowser.kt
@@ -85,7 +85,10 @@ class ContinueBrowser(
     }
 
     fun sendToWebview(messageType: String, data: Any? = null, messageId: String = uuid()) {
-        if (browser.cefBrowser.isClosed) return
+        if (browser.cefBrowser.isClosed) {
+            log.warn("Attempted to send message to disposed browser: $messageType")
+            return
+        }
         val json = gsonService.gson.toJson(BrowserMessage(messageType, messageId, data))
         val jsCode = """window.postMessage($json, "*");"""
         try {


### PR DESCRIPTION
## Summary
- Adds an `isClosed` guard before calling `executeJavaScript` in `sendToWebview` to prevent NPE when the JCEF browser is already disposed
- Broadens the catch clause from `IllegalStateException` to `Exception` to handle NPE and other errors that propagate from deeper in JCEF

Fixes #8085, #9159

## Test plan
- [ ] Open a Continue sidebar panel in IntelliJ, close the project, and verify no NPE is logged
- [ ] Verify normal webview messaging still works when the browser is active

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent NPEs when the JCEF browser is disposed by guarding `sendToWebview`, broadening error handling, and logging a warning when messages are dropped. This avoids errors on project close and keeps webview messaging stable and debuggable.

- **Bug Fixes**
  - Return early if `browser.cefBrowser.isClosed` and log the message type before skipping `executeJavaScript`.
  - Catch `Exception` instead of `IllegalStateException` to handle NPEs and other JCEF errors.

<sup>Written for commit 01d876b899a9a55cb951b7591c0124c9117a0683. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

