### PR TITLE
fix: prevent responseListeners memory leak in CoreMessenger

### DIFF
--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessenger.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessenger.kt
@@ -65,9 +65,10 @@ class CoreMessenger(
         responseListeners[messageId]?.let { listener ->
             listener(data)
             @Suppress("UNCHECKED_CAST")
-            val done = (data as? Map<String, Boolean>)?.get("done")
+            val done = (data as? Map<String, Any>)?.get("done") as? Boolean
 
-            if (done == true) {
+            // Remove unless explicitly streaming (done == false)
+            if (done != false) {
                 responseListeners.remove(messageId)
             }
         }


### PR DESCRIPTION
## Summary
- Fixes a memory leak in `CoreMessenger.responseListeners` where callback entries were never removed for non-streaming messages
- Response listeners were only cleaned up when `data` contained `"done": true`, but most message types (`files/changed`, `files/opened`, autocomplete, `nextEdit/*`, etc.) return responses without a `done` field — leaking every callback permanently
- Over a long session with heavy autocomplete and file navigation, this can accumulate hundreds of thousands of entries (estimated 40-100+ MB)
- Fix: invert the removal logic — remove the listener by default, only retain it when `done == false` (streaming still in progress). This is safe for all message types:
  - **Streaming responses** (`done: false` → `done: true`): listener kept during streaming, removed on completion — same as before
  - **Non-streaming responses** (no `done` field): listener removed immediately after callback — **this is the fix**
  - **Fire-and-forget** (`{ _ -> }` / `{}`): listener removed on first response — **this is the fix**

Related: #8085 (sidebar freezes), which identified memory pressure as a contributing factor

## Test plan
- [ ] Stream a long LLM response in the sidebar — verify it streams correctly and completes
- [ ] Navigate between files, open/close tabs — verify no regressions
- [ ] Use autocomplete heavily — verify suggestions still work
- [ ] Monitor JVM heap over a long session — confirm `responseListeners` map stays small

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a memory leak in `CoreMessenger` by removing response listeners by default and only keeping them during streaming (`done == false`). This prevents `responseListeners` from growing unbounded during autocomplete and file events.

- **Bug Fixes**
  - Invert cleanup: remove listener when `done != false`; keep only while streaming.
  - Non-streaming responses (no `done`) and fire-and-forget calls now clean up after the first callback; streaming completion still removes on `done: true`.

<sup>Written for commit cf67e4dabccf0007d7e23365577691ecb4f5a661. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

