### PR TITLE
fix: remove Ollama template-based tool support gate

### DIFF
--- a/core/llm/llms/Ollama.ts
+++ b/core/llm/llms/Ollama.ts
@@ -240,7 +240,6 @@ class Ollama extends BaseLLM implements ModelInstaller {
          * it's a good indication the model supports FIM.
          */
         this.fimSupported = !!body?.template?.includes(".Suffix");
-
       })
       .catch((e) => {
         // console.warn("Error calling the Ollama /api/show endpoint: ", e);


### PR DESCRIPTION
## Summary
- The Ollama provider was checking the model template (via `/api/show`) for a `.Tools` placeholder to decide whether to pass tools to the API
- This silently stripped tools for newer models (e.g. `qwen3.5:9b`) whose templates don't yet include `.Tools`, even when `toolSupport.ts` or explicit config said the model supports tools
- Removed the `templateSupportsTools` check entirely — if `options.tools` is non-empty, the upstream (`capabilities.tools` from config or `toolSupport.ts` heuristic) already decided the model supports tools

## Test plan
- [ ] Configure an Ollama model (e.g. `qwen3.5:9b`) and verify tools are passed to the API
- [ ] Verify models that don't match `toolSupport.ts` heuristics still don't receive tools