### PR TITLE
fix(ci): remove failing create-PR steps from vscode release workflows

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -127,7 +127,6 @@ jobs:
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.publish_build == 'true'
     permissions:
       contents: write
-      pull-requests: write
     steps:
       # 0. Setup git
       - name: Checkout
@@ -163,40 +162,7 @@ jobs:
           cd extensions/vscode
           npx ovsx publish --pre-release -p ${{ secrets.VSX_REGISTRY_TOKEN }} --packagePath ../../vsix-artifacts/*.vsix
 
-      # 4. Create PR with version bump
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: ".nvmrc"
-
-      - name: Create PR branch
-        run: |
-          BRANCH_NAME="chore/bump-vscode-version-$(date +%Y%m%d-%H%M%S)"
-          git checkout -b $BRANCH_NAME
-          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
-
-      - name: Bump version in package.json
-        run: |
-          cd extensions/vscode
-          npm version patch --no-git-tag-version
-          VERSION=$(node -p "require('./package.json').version")
-          echo "NEW_VERSION=$VERSION" >> $GITHUB_ENV
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
-        with:
-          token: ${{ secrets.CI_GITHUB_TOKEN }}
-          commit-message: "chore: bump vscode extension version to ${{ env.NEW_VERSION }}"
-          title: "chore: bump vscode extension version to ${{ env.NEW_VERSION }}"
-          body: |
-            Automated PR to bump the VS Code extension version after successful pre-release publication.
-
-            - Bumped version in extensions/vscode/package.json to ${{ env.NEW_VERSION }}
-          branch: ${{ env.BRANCH_NAME }}
-          base: main
-          delete-branch: true
-
-      # 5. Update version in package.json
+      # 4. Update version in package.json
       # - name: Update version in package.json
       #   run: |
       #     cd extensions/vscode

--- a/.github/workflows/vscode-prerelease.yml
+++ b/.github/workflows/vscode-prerelease.yml
@@ -7,10 +7,6 @@ on:
         description: "Main branch commit SHA to create pre-release from - leave empty to use HEAD of main"
         required: false
         type: string
-      prerelease_version:
-        description: "New pre-release version (e.g., 1.3.15) - leave empty to auto-increment"
-        required: false
-        type: string
 
 permissions:
   contents: write
@@ -32,55 +28,19 @@ jobs:
         with:
           node-version: 20
 
-      - name: Determine version numbers
+      - name: Determine version
         id: version
         working-directory: extensions/vscode
         run: |
-          # Get current version from package.json
-          CURRENT_VERSION=$(node -p "require('./package.json').version")
-          echo "Current version in package.json: $CURRENT_VERSION"
+          # Read the version that was manually bumped in package.json
+          VERSION=$(node -p "require('./package.json').version")
+          TAG_NAME="v${VERSION}-vscode"
 
-          # Determine new pre-release version
-          if [[ -n "${{ inputs.prerelease_version }}" ]]; then
-            NEW_VERSION="${{ inputs.prerelease_version }}"
-            echo "Using manually specified new version: $NEW_VERSION"
-          else
-            # Auto-increment patch version
-            IFS='.' read -r major minor patch <<< "$CURRENT_VERSION"
-            NEW_PATCH=$((patch + 1))
-            NEW_VERSION="${major}.${minor}.${NEW_PATCH}"
-            echo "Auto-incremented version: $NEW_VERSION"
-          fi
-
-          TAG_NAME="v${NEW_VERSION}-vscode"
-
-          echo "previous_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
-          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
 
-          echo "Summary:"
-          echo "  Previous version: $CURRENT_VERSION"
-          echo "  New version: $NEW_VERSION"
-          echo "  Tag name: $TAG_NAME"
-
-      - name: Update package.json version
-        working-directory: extensions/vscode
-        run: |
-          # Update version in package.json
-          npm version ${{ steps.version.outputs.new_version }} --no-git-tag-version
-
-          echo "Updated package.json to version ${{ steps.version.outputs.new_version }}"
-
-      - name: Commit and push version bump to main
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-
-          git add extensions/vscode/package.json
-          git commit -m "chore: bump VSCode extension version to ${{ steps.version.outputs.new_version }}"
-          git push origin main
-
-          echo "Pushed version bump directly to main"
+          echo "Version: $VERSION"
+          echo "Tag name: $TAG_NAME"
 
       - name: Create and push tag
         run: |
@@ -122,7 +82,7 @@ jobs:
 
           # Create the pre-release
           gh release create "${{ steps.version.outputs.tag_name }}" \
-            --title "VSCode Pre-release ${{ steps.version.outputs.new_version }}" \
+            --title "VSCode Pre-release ${{ steps.version.outputs.version }}" \
             --notes "$RELEASE_NOTES" \
             --prerelease \
             --target main
@@ -134,8 +94,7 @@ jobs:
           echo "## VSCode Pre-release Created Successfully! 🚀" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Version Information" >> $GITHUB_STEP_SUMMARY
-          echo "- **Previous Version:** ${{ steps.version.outputs.previous_version }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **New Version:** ${{ steps.version.outputs.new_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version:** ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Tag:** \`${{ steps.version.outputs.tag_name }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Links" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/vscode-prerelease.yml
+++ b/.github/workflows/vscode-prerelease.yml
@@ -14,7 +14,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   create-prerelease:
@@ -64,18 +63,6 @@ jobs:
           echo "  New version: $NEW_VERSION"
           echo "  Tag name: $TAG_NAME"
 
-      - name: Create pre-release branch
-        id: branch
-        run: |
-          BRANCH_NAME="prerelease/vscode-${{ steps.version.outputs.new_version }}"
-          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
-
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-
-          git checkout -b "$BRANCH_NAME"
-          echo "Created branch: $BRANCH_NAME"
-
       - name: Update package.json version
         working-directory: extensions/vscode
         run: |
@@ -84,88 +71,16 @@ jobs:
 
           echo "Updated package.json to version ${{ steps.version.outputs.new_version }}"
 
-      - name: Commit version bump
+      - name: Commit and push version bump to main
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
 
           git add extensions/vscode/package.json
           git commit -m "chore: bump VSCode extension version to ${{ steps.version.outputs.new_version }}"
+          git push origin main
 
-          echo "Committed version bump"
-
-      - name: Push branch and create PR
-        id: pr
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git push origin "${{ steps.branch.outputs.branch_name }}"
-          echo "Pushed branch: ${{ steps.branch.outputs.branch_name }}"
-
-          # Create pull request
-          PR_URL=$(gh pr create \
-            --base main \
-            --head "${{ steps.branch.outputs.branch_name }}" \
-            --title "chore: VSCode pre-release ${{ steps.version.outputs.new_version }}" \
-            --body "$(cat <<'EOF'
-          ## VSCode Pre-release ${{ steps.version.outputs.new_version }}
-
-          This PR bumps the VSCode extension version for pre-release.
-
-          ### Changes
-          - Version bumped from ${{ steps.version.outputs.previous_version }} to ${{ steps.version.outputs.new_version }}
-          - Based on commit: ${{ inputs.main_commit_sha }}
-
-          ### Release Process
-          After merging this PR:
-          1. The tag \`${{ steps.version.outputs.tag_name }}\` will be created automatically
-          2. A GitHub pre-release will be created with auto-generated release notes
-
-          🤖 This PR was created automatically by the VSCode Pre-release workflow.
-          EOF
-          )")
-
-          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
-          echo "Created PR: $PR_URL"
-
-      - name: Auto-merge PR
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Get PR number from URL
-          PR_NUMBER=$(echo "${{ steps.pr.outputs.pr_url }}" | grep -oE '[0-9]+$')
-
-          # Merge the PR
-          gh pr merge "$PR_NUMBER" --squash --auto
-
-          echo "PR #$PR_NUMBER set to auto-merge"
-
-          # Wait for merge to complete (with timeout)
-          echo "Waiting for PR to be merged..."
-          TIMEOUT=300  # 5 minutes
-          ELAPSED=0
-          INTERVAL=10
-
-          while [ $ELAPSED -lt $TIMEOUT ]; do
-            PR_STATE=$(gh pr view "$PR_NUMBER" --json state --jq '.state')
-            if [ "$PR_STATE" = "MERGED" ]; then
-              echo "PR successfully merged!"
-              break
-            fi
-            sleep $INTERVAL
-            ELAPSED=$((ELAPSED + INTERVAL))
-            echo "Still waiting... ($ELAPSED seconds elapsed)"
-          done
-
-          if [ $ELAPSED -ge $TIMEOUT ]; then
-            echo "Warning: Timed out waiting for PR merge. Please check manually." && exit 1
-          fi
-
-      - name: Checkout main branch
-        run: |
-          git fetch origin main
-          git checkout main
-          git pull origin main
+          echo "Pushed version bump directly to main"
 
       - name: Create and push tag
         run: |
@@ -224,7 +139,6 @@ jobs:
           echo "- **Tag:** \`${{ steps.version.outputs.tag_name }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Links" >> $GITHUB_STEP_SUMMARY
-          echo "- **PR:** ${{ steps.pr.outputs.pr_url }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Release:** https://github.com/${{ github.repository }}/releases/tag/${{ steps.version.outputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Commit" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Remove the create-PR and auto-merge steps from `vscode-prerelease.yml` — version bumps are now pushed directly to main
- Remove the create-PR step (version bump after publish) from `preview.yaml`
- Remove unused `pull-requests: write` permissions from both workflows

## Test plan
- [ ] Trigger `vscode-prerelease` workflow and verify it pushes the version bump directly to main, tags, and creates the release without failing on PR creation
- [ ] Trigger `preview.yaml` (publish pre-release) and verify it publishes successfully without the PR step

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove PR creation and auto-bump logic from VS Code release workflows. `vscode-prerelease.yml` now reads a manually bumped version and creates the tag/release; `preview.yaml` publishes without opening PRs.

- **Bug Fixes**
  - `vscode-prerelease.yml`: remove branch/PR/auto-merge and auto-increment/version commit steps; read version from `extensions/vscode/package.json` for tag/title; drop `pull-requests: write`.
  - `preview.yaml`: remove post-publish PR step; drop `pull-requests: write`.

<sup>Written for commit 1bb1fdad5a95131f053e455edebac4af987f481b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

