### PR TITLE
fix: surface Ollama model-not-found errors in stream error dialog

### DIFF
--- a/core/llm/llms/Ollama.ts
+++ b/core/llm/llms/Ollama.ts
@@ -457,8 +457,11 @@ class Ollama extends BaseLLM implements ModelInstaller {
             }
             j.response ??= "";
             yield j.response;
-          } catch (e) {
-            throw new Error(`Error parsing Ollama response: ${e} ${chunk}`);
+          } catch (e: any) {
+            if (e instanceof SyntaxError) {
+              throw new Error(`Error parsing Ollama response: ${e} ${chunk}`);
+            }
+            throw e;
           }
         }
       }
@@ -651,8 +654,11 @@ class Ollama extends BaseLLM implements ModelInstaller {
               for (const msg of convertChatMessage(j)) {
                 yield msg;
               }
-            } catch (e) {
-              throw new Error(`Error parsing Ollama response: ${e} ${chunk}`);
+            } catch (e: any) {
+              if (e instanceof SyntaxError) {
+                throw new Error(`Error parsing Ollama response: ${e} ${chunk}`);
+              }
+              throw e;
             }
           }
         }
@@ -703,8 +709,11 @@ class Ollama extends BaseLLM implements ModelInstaller {
             } else if ("error" in j) {
               throw new Error(j.error);
             }
-          } catch (e) {
-            throw new Error(`Error parsing Ollama response: ${e} ${chunk}`);
+          } catch (e: any) {
+            if (e instanceof SyntaxError) {
+              throw new Error(`Error parsing Ollama response: ${e} ${chunk}`);
+            }
+            throw e;
           }
         }
       }

--- a/packages/fetch/src/stream.ts
+++ b/packages/fetch/src/stream.ts
@@ -15,7 +15,7 @@ export async function* streamResponse(
   }
 
   if (response.status !== 200) {
-    throw new Error(await response.text());
+    throw new Error(`${response.status} ${await response.text()}`);
   }
 
   if (!response.body) {


### PR DESCRIPTION
## Summary
- Include HTTP status code in `streamResponse` error messages so the existing `analyzeError` / `StreamErrorDialog` UI can extract it and show status-specific help (e.g. 404 → "Model/deployment not found")
- Fix Ollama stream catch blocks that were wrapping all errors (including legitimate Ollama API errors like "model not found") as "Error parsing Ollama response" — now only actual JSON `SyntaxError`s get that treatment

## Test plan
- [ ] Configure an Ollama model that isn't pulled locally, send a message, and verify the stream error dialog shows "Model/deployment not found" instead of a generic error
- [ ] Verify that other non-200 errors (401, 429, etc.) from any provider still surface correctly with their status codes
- [ ] Verify that actual JSON parse errors in Ollama streaming still show the "Error parsing Ollama response" message

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show precise stream errors by adding HTTP status codes and surfacing real Ollama API errors, so 404s display “model/deployment not found” instead of a generic parse error.

- **Bug Fixes**
  - `streamResponse` now includes the HTTP status code in thrown errors, enabling `analyzeError` and `StreamErrorDialog` to show status-specific guidance.
  - Ollama streaming only wraps JSON `SyntaxError`s as “Error parsing Ollama response” and rethrows other errors, preserving provider messages like “model not found.”

<sup>Written for commit f9583915b61079c2f21ba758927c0ecc0e6aa363. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

