### PR TITLE
chore: jb-66-vs-37

### DIFF
--- a/extensions/intellij/gradle.properties
+++ b/extensions/intellij/gradle.properties
@@ -1,5 +1,5 @@
 pluginGroup=com.github.continuedev.continueintellijextension
-pluginVersion=1.0.65
+pluginVersion=1.0.66
 platformVersion=2024.1
 kotlin.stdlib.default.dependency=false
 org.gradle.configuration-cache=true

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "1.3.36",
+  "version": "1.3.37",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION
## Description
Prerelease version bumps

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump prerelease versions for both IDE extensions to prepare the next publish. IntelliJ plugin to 1.0.66 and VS Code extension to 1.3.37.

<sup>Written for commit 36b23faf1e329a4c3a39622276d11f3bff04ea6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

