### PR TITLE
fix: ensure config.yaml exists and is populated when accessed

### DIFF
--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -638,7 +638,6 @@ export class ConfigHandler {
     }
 
     if (profile.profileDescription.profileType === "local") {
-      // Ensure the config file exists (creates with defaults if missing)
       getConfigYamlPath();
       const configFile = element?.sourceFile ?? profile.profileDescription.uri;
       await this.ide.openFile(configFile);

--- a/core/util/paths.ts
+++ b/core/util/paths.ts
@@ -118,10 +118,11 @@ export function getConfigJsonPath(): string {
 
 export function getConfigYamlPath(ideType?: IdeType): string {
   const p = path.join(getContinueGlobalPath(), "config.yaml");
-  if (
-    (!fs.existsSync(p) && !fs.existsSync(getConfigJsonPath())) ||
-    (fs.existsSync(p) && fs.readFileSync(p, "utf8").trim() === "")
-  ) {
+  const exists = fs.existsSync(p);
+  const isEmpty = exists && fs.readFileSync(p, "utf8").trim() === "";
+  const needsCreation = !exists && !fs.existsSync(getConfigJsonPath());
+
+  if (needsCreation || isEmpty) {
     fs.writeFileSync(p, YAML.stringify(defaultConfig));
     setConfigFilePermissions(p);
   }


### PR DESCRIPTION
## Summary
- **Gear icon (open config profile)** now creates `config.yaml` with defaults if the file is missing, matching the behavior on startup
- **Empty `config.yaml`** is detected and populated with the default config instead of causing a parse error

## Test plan
- [ ] Delete `~/.continue/config.yaml`, click the gear icon in the GUI — file should be created with defaults and opened
- [ ] Create an empty `~/.continue/config.yaml`, reload — should be populated with default config
- [ ] Normal startup with existing config.yaml — no behavior change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Create and populate `config.yaml` with defaults when opening the config profile and when the file exists but is empty. This prevents parse errors and aligns behavior with startup.

- **Bug Fixes**
  - `getConfigYamlPath()` now writes defaults if `config.yaml` is missing or empty, with a simplified existence check for readability.
  - Opening a local config profile (gear icon) calls `getConfigYamlPath()` first to ensure the file exists with defaults.

<sup>Written for commit 20088945a8f21b5e78c992bbf47074f866618ee0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

