### PR TITLE
chore: jb-67-vs-38

### DIFF
--- a/extensions/intellij/gradle.properties
+++ b/extensions/intellij/gradle.properties
@@ -1,5 +1,5 @@
 pluginGroup=com.github.continuedev.continueintellijextension
-pluginVersion=1.0.66
+pluginVersion=1.0.67
 platformVersion=2024.1
 kotlin.stdlib.default.dependency=false
 org.gradle.configuration-cache=true

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "1.3.37",
+  "version": "1.3.38",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION
## Summary
- Bump JetBrains plugin version from 1.0.66 to 1.0.67
- Bump VS Code extension version from 1.3.37 to 1.3.38

## Test plan
- [ ] Verify JetBrains plugin builds with new version
- [ ] Verify VS Code extension builds with new version

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump extension versions for release: JetBrains plugin to 1.0.67 and VS Code extension to 1.3.38. No functional changes; version-only updates to publish new builds.

<sup>Written for commit b27b1007f0e0bf00aaf99e50380d64300ebb5d0d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

