### PR TITLE
fix: remove automated version bump from prerelease workflow

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -125,21 +125,9 @@ jobs:
     needs:
       - build
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.publish_build == 'true'
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
-      # 0. Setup git
       - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Set up Git
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-
-      - name: Pull latest changes from release
-        run: git fetch origin ${{ github.ref }} && git checkout ${{ github.ref }}
 
       # 1. Download the artifacts
       - uses: actions/download-artifact@v8
@@ -163,52 +151,3 @@ jobs:
           cd extensions/vscode
           npx ovsx publish --pre-release -p ${{ secrets.VSX_REGISTRY_TOKEN }} --packagePath ../../vsix-artifacts/*.vsix
 
-      # 4. Create PR with version bump
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: ".nvmrc"
-
-      - name: Create PR branch
-        run: |
-          BRANCH_NAME="chore/bump-vscode-version-$(date +%Y%m%d-%H%M%S)"
-          git checkout -b $BRANCH_NAME
-          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
-
-      - name: Bump version in package.json
-        run: |
-          cd extensions/vscode
-          npm version patch --no-git-tag-version
-          VERSION=$(node -p "require('./package.json').version")
-          echo "NEW_VERSION=$VERSION" >> $GITHUB_ENV
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
-        with:
-          token: ${{ secrets.CI_GITHUB_TOKEN }}
-          commit-message: "chore: bump vscode extension version to ${{ env.NEW_VERSION }}"
-          title: "chore: bump vscode extension version to ${{ env.NEW_VERSION }}"
-          body: |
-            Automated PR to bump the VS Code extension version after successful pre-release publication.
-
-            - Bumped version in extensions/vscode/package.json to ${{ env.NEW_VERSION }}
-          branch: ${{ env.BRANCH_NAME }}
-          base: main
-          delete-branch: true
-
-      # 5. Update version in package.json
-      # - name: Update version in package.json
-      #   run: |
-      #     cd extensions/vscode
-      #     npm version patch
-      # - name: Commit changes
-      #   run: |
-      #     git config --local user.email "action@github.com"
-      #     git config --local user.name "GitHub Action"
-      #     git commit -am "💚 Update package.json version [skip ci]"
-
-      # - name: Push changes
-      #   uses: ad-m/github-push-action@master
-      #   with:
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}
-      #     branch: ${{ github.ref }}


### PR DESCRIPTION
## Summary
- Removes the version bump + PR creation step from the `publish` job in the prerelease workflow (`preview.yaml`)
- Also removes the now-unnecessary git setup steps and `contents: write` / `pull-requests: write` permissions from the `publish` job

The version is bumped manually prior to release, making this automation unnecessary. It was also causing the workflow to report as "failed" (e.g. [this run](https://github.com/continuedev/continue/actions/runs/23668108972/job/68956212429)) even though the extension was successfully published to both marketplaces.

## Test plan
- [ ] Trigger a prerelease and confirm the publish job succeeds without the version bump step

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the automated version bump and PR creation from the prerelease `publish` job in `.github/workflows/preview.yaml` to stop false “failed” runs after successful marketplace publishes. Also drops git/node setup steps and the `contents: write` and `pull-requests: write` permissions that were only needed for that automation.

<sup>Written for commit c9123dbecd7da5979c14008d88eeae049b4dd513. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

