### PR TITLE
chore: vs code 1.3.39, jetbrains 1.0.68

### DIFF
--- a/extensions/intellij/gradle.properties
+++ b/extensions/intellij/gradle.properties
@@ -1,5 +1,5 @@
 pluginGroup=com.github.continuedev.continueintellijextension
-pluginVersion=1.0.67
+pluginVersion=1.0.68
 platformVersion=2024.1
 kotlin.stdlib.default.dependency=false
 org.gradle.configuration-cache=true

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "continue",
   "icon": "media/icon.png",
   "author": "Continue Dev, Inc",
-  "version": "1.3.38",
+  "version": "1.3.39",
   "repository": {
     "type": "git",
     "url": "https://github.com/continuedev/continue"


### PR DESCRIPTION
## Description
release bumps


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare new extension releases by bumping versions: VS Code extension `continue` to 1.3.39 and IntelliJ plugin to 1.0.68. No functional changes; metadata only for publishing.

<sup>Written for commit b92656f40fd94bd323c1ddd333ad494bb430187e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

