### PR TITLE
fix: remove unsupported anthropic_beta flag from Bedrock Converse API

### DIFF
--- a/core/llm/llms/Bedrock.ts
+++ b/core/llm/llms/Bedrock.ts
@@ -348,9 +348,6 @@ class Bedrock extends BaseLLM {
               budget_tokens: options.reasoningBudgetTokens,
             }
           : undefined,
-        anthropic_beta: options.model.includes("claude")
-          ? ["fine-grained-tool-streaming-2025-05-14"]
-          : undefined,
       },
     };
   }


### PR DESCRIPTION
The Bedrock provider was unconditionally sending anthropic_beta: ["fine-grained-tool-streaming-2025-05-14"] in additionalModelRequestFields for all Claude models. The Bedrock Converse API does not support Anthropic beta flags, causing all Claude requests to fail with "invalid beta flag".

Fixes #8297

Description
Removed the anthropic_beta field from additionalModelRequestFields in the Bedrock Converse API request builder (core/llm/llms/Bedrock.ts).

The fine-grained-tool-streaming-2025-05-14 beta flag is an Anthropic direct API feature that is not supported by the Bedrock Converse API. Bedrock validates additionalModelRequestFields and rejects unrecognised beta flags, causing all Claude model requests via Bedrock to fail.

Confirmed affected in v1.2.18 and v1.2.21.

AI Code Review
Team members only: AI review runs automatically when PR is opened or marked ready for review

Team members can also trigger a review by commenting @continue-review

Checklist
 I've read the contributing guide
 The relevant docs, if any, have been updated or created
 The relevant tests, if any, have been updated or created
Screen recording or screenshot
Before fix: All Claude requests via Bedrock fail with:

The model returned the following errors: invalid beta flag

Copy
After fix: Claude requests via Bedrock Converse API succeed as expected.

Tests
No new tests added. The fix is a single line removal. Verified manually by invoking Claude models (anthropic.claude-3-haiku-20240307-v1:0, eu.anthropic.claude-sonnet-4-20250514-v1:0) via the Bedrock provider — requests succeed after the change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unsupported `anthropic_beta: ["fine-grained-tool-streaming-2025-05-14"]` from Bedrock Converse API `additionalModelRequestFields` to stop "invalid beta flag" errors and restore Claude requests via Bedrock.

<sup>Written for commit b81b4195b8ebd0d8c26d8e85cdc31152f6ebe9b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

