### PR TITLE
Fix: Interleave tool calls with assistant thoughts and prevent duplication during streaming

### DIFF
--- a/core/llm/openaiTypeConverters.ts
+++ b/core/llm/openaiTypeConverters.ts
@@ -985,6 +985,7 @@ function sanitizeResponsesInput(input: ResponseInput): ResponseInput {
 
 export function toResponsesInput(messages: ChatMessage[]): ResponseInput {
   const input: ResponseInput = [];
+  const itemIdToIndex: Record<string, number> = {};
 
   const pushMessage = (
     role: "user" | "assistant" | "system" | "developer",
@@ -1038,7 +1039,18 @@ export function toResponsesInput(messages: ChatMessage[]): ResponseInput {
           (respId?.startsWith("msg_") ? respId : undefined);
 
         if (Array.isArray(toolCalls) && toolCalls.length > 0) {
-          emitFunctionCallsFromToolCalls(toolCalls, fcIds, input);
+          const tcCount = toolCalls.length;
+          const generatedFcIds = Array.from({ length: tcCount }, (_, i) => {
+            const tc = toolCalls[i];
+            const call_id = tc.id;
+            if (call_id && itemIdToIndex[call_id] === undefined) {
+              itemIdToIndex[call_id] = Object.keys(itemIdToIndex).length;
+            }
+            const idx = call_id ? itemIdToIndex[call_id] : i;
+            return `${(msg as any).id || (msg as any).messageId || "msg"}-${idx}`;
+          });
+
+          emitFunctionCallsFromToolCalls(toolCalls, generatedFcIds, input);
 
           if (text && text.trim()) {
             if (msgId) {

--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -629,9 +629,6 @@ export const sessionSlice = createSlice({
               ) {
                 lastItem.reasoning.text += messageContent;
               }
-            } else {
-              // Note this only works because new message above
-              // was already rendered from parts to string
               if (
                 lastMessage.content.length > 0 ||
                 messageContent.trim().length > 0
@@ -648,6 +645,26 @@ export const sessionSlice = createSlice({
             message.toolCalls?.length &&
             lastMessage.role === "assistant"
           ) {
+            // Detect modality switch (from text content to tool calls)
+            const lastContent = lastMessage.content;
+            const hasContent =
+              typeof lastContent === "string"
+                ? lastContent.trim().length > 0
+                : Array.isArray(lastContent) && lastContent.length > 0;
+
+            if (hasContent && !lastItem.toolCallStates?.length) {
+              const historyItem: ChatHistoryItemWithMessageId = {
+                message: {
+                  ...message,
+                  content: "",
+                  id: uuidv4(),
+                },
+                contextItems: [],
+              };
+              state.history.push(historyItem);
+              lastItem = state.history[state.history.length - 1];
+              lastMessage = lastItem.message;
+            }
             handleStreamingToolCallUpdates(message, lastItem);
           }
 


### PR DESCRIPTION
This PR addresses two critical UI issues during LLM streaming:

1. **Tool Call Accumulation**: In streaming environments (especially with local LLMs), tool calls were accumulating at the bottom of the chat interface instead of being correctly interleaved with assistant thoughts. This PR implements state-based message splitting in `sessionSlice.ts` to separate text content from tool calls when a modality switch is detected.
2. **Tool Call Duplication**: Resolves tool call duplication issues in the Responses API by assigning stable streaming indices via `itemIdToIndex`, ensuring that updates to existing tool calls are correctly mapped in the GUI.

These changes significantly improve the visual flow and consistency of agentic interactions during streaming.
