### PR TITLE
[codex] fix: cap IntelliJ file search results

### DIFF
--- a/binary/test/binary.test.ts
+++ b/binary/test/binary.test.ts
@@ -69,7 +69,7 @@ class BinaryIdeHandler {
     h["getCurrentFile"] = () => ide.getCurrentFile();
     h["getPinnedFiles"] = () => ide.getPinnedFiles();
     h["getSearchResults"] = (d) => ide.getSearchResults(d.query, d.maxResults);
-    h["getFileResults"] = (d) => ide.getFileResults(d.pattern);
+    h["getFileResults"] = (d) => ide.getFileResults(d.pattern, d.maxResults);
     h["getProblems"] = (d) => ide.getProblems(d.filepath);
     h["getBranch"] = (d) => ide.getBranch(d.dir);
     h["subprocess"] = (d) => ide.subprocess(d.command, d.cwd);

--- a/core/protocol/messenger/messageIde.test.ts
+++ b/core/protocol/messenger/messageIde.test.ts
@@ -1,0 +1,15 @@
+import { MessageIde } from "./messageIde";
+
+describe("MessageIde", () => {
+  it("passes maxResults to getFileResults requests", async () => {
+    const request = jest.fn().mockResolvedValue(["src/index.ts"]);
+    const ide = new MessageIde(request as any, jest.fn() as any);
+
+    await ide.getFileResults("**/*.ts", 100);
+
+    expect(request).toHaveBeenCalledWith("getFileResults", {
+      pattern: "**/*.ts",
+      maxResults: 100,
+    });
+  });
+});

--- a/core/protocol/messenger/messageIde.ts
+++ b/core/protocol/messenger/messageIde.ts
@@ -212,8 +212,8 @@ export class MessageIde implements IDE {
     return this.request("getSearchResults", { query, maxResults });
   }
 
-  getFileResults(pattern: string): Promise<string[]> {
-    return this.request("getFileResults", { pattern });
+  getFileResults(pattern: string, maxResults?: number): Promise<string[]> {
+    return this.request("getFileResults", { pattern, maxResults });
   }
 
   getProblems(fileUri: string): Promise<Problem[]> {

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IntelliJIde.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/IntelliJIde.kt
@@ -445,7 +445,12 @@ class IntelliJIDE(
 
                 command.setWorkDirectory(project.basePath)
                 val results = ExecUtil.execAndGetOutput(command).stdout
-                return results.split("\n")
+                val files = results.lineSequence()
+                    .map { it.trim() }
+                    .filter { it.isNotEmpty() }
+                    .toList()
+
+                return if (maxResults != null) files.take(maxResults) else files
             } catch (exception: Exception) {
                 val message = "Error executing ripgrep: ${exception.message}"
                 service<ContinueSentryService>().report(exception, message)


### PR DESCRIPTION
## Summary
- pass `maxResults` through `MessageIde.getFileResults`
- update the binary IDE bridge to forward `maxResults` for `getFileResults`
- explicitly truncate IntelliJ file search results after ripgrep returns them
- add a regression test covering `MessageIde` file-result forwarding

## Why
IntelliJ file searches could return far more matches than intended because the core messenger was not forwarding `maxResults` for `getFileResults`, and the IntelliJ implementation relied on ripgrep's `--max-count` with `--files`, which does not reliably cap the total number of returned files. This could overflow context windows and waste tokens in large workspaces.

## Validation
- ran `cd core && npm test -- --runTestsByPath protocol/messenger/messageIde.test.ts`
- attempted `cd binary && npx tsc --noEmit -p tsconfig.json`, but the repo still has unresolved local package setup errors unrelated to this patch
- could not run IntelliJ/Gradle validation in this environment because `java` is not installed

Closes #11977

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap IntelliJ file search results by forwarding `maxResults` end-to-end and enforcing the cap after ripgrep, preventing oversized contexts and wasted tokens (closes #11977).

- **Bug Fixes**
  - Forward `maxResults` for `getFileResults` through `MessageIde` and the binary IDE bridge; add a regression test.
  - IntelliJ: split/trim ripgrep `--files` output, drop empties, and apply `maxResults` to cap results.

<sup>Written for commit ae830feb1a93f8b9c892289a338f8d29b02553fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

