### PR TITLE
fix: update OSPO action references to canonical org path

### DIFF
--- a/.github/workflows/metrics.yaml
+++ b/.github/workflows/metrics.yaml
@@ -36,7 +36,7 @@ jobs:
           echo "last_month=$first_day..$last_day" >> "$GITHUB_ENV"
 
       - name: Run issue-metrics tool
-        uses: github/issue-metrics@v3
+        uses: github-community-projects/issue-metrics@v3
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEARCH_QUERY: 'repo:continuedev/continue created:${{ env.last_month }} -reason:"not planned"'


### PR DESCRIPTION
Updates GitHub Actions workflow references from the legacy `github/` org path to the canonical `github-community-projects/` path.

The following OSPO actions have been transferred to the `github-community-projects` organization:

| Legacy path | Canonical path |
|---|---|
| `github/issue-metrics` | `github-community-projects/issue-metrics` |

While GitHub's repo redirect ensures the old paths still work today, updating to the canonical path avoids depending on the redirect and ensures long-term stability.

**No functional changes** - the same action versions are referenced.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the metrics workflow to use the canonical OSPO action path `github-community-projects/issue-metrics@v3` instead of `github/issue-metrics@v3`. Removes reliance on repo redirects; no functional changes.

<sup>Written for commit d9d3a59712b45adeda39c66c69bc62bffc5a6341. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

