### PR TITLE
feat(openrouter): send HTTP-Referer and X-Title headers in core/llm OpenRouter class

### DIFF
--- a/core/llm/llms/OpenRouter.ts
+++ b/core/llm/llms/OpenRouter.ts
@@ -1,15 +1,11 @@
 import { ChatCompletionCreateParams } from "openai/resources/index";
 
+import { OPENROUTER_HEADERS } from "@continuedev/openai-adapters";
+
 import { LLMOptions } from "../../index.js";
 import { osModelsEditPrompt } from "../templates/edit.js";
 
 import OpenAI from "./OpenAI.js";
-
-const OPENROUTER_HEADERS: Record<string, string> = {
-  "HTTP-Referer": "https://www.continue.dev/",
-  "X-OpenRouter-Title": "Continue",
-  "X-OpenRouter-Categories": "ide-extension",
-};
 
 class OpenRouter extends OpenAI {
   static providerName = "openrouter";

--- a/packages/openai-adapters/src/apis/OpenRouter.ts
+++ b/packages/openai-adapters/src/apis/OpenRouter.ts
@@ -10,7 +10,7 @@ export interface OpenRouterConfig extends OpenAIConfig {
 
 // TODO: Extract detailed error info from OpenRouter's error.metadata.raw to surface better messages
 
-const OPENROUTER_HEADERS: Record<string, string> = {
+export const OPENROUTER_HEADERS: Record<string, string> = {
   "HTTP-Referer": "https://www.continue.dev/",
   "X-OpenRouter-Title": "Continue",
   "X-OpenRouter-Categories": "ide-extension",

--- a/packages/openai-adapters/src/index.ts
+++ b/packages/openai-adapters/src/index.ts
@@ -243,4 +243,5 @@ export {
 } from "./apis/AnthropicUtils.js";
 
 export { isResponsesModel } from "./apis/openaiResponses.js";
+export { OPENROUTER_HEADERS } from "./apis/OpenRouter.js";
 export { extractBase64FromDataUrl, parseDataUrl } from "./util/url.js";


### PR DESCRIPTION
## Summary

- Adds `HTTP-Referer`, `X-OpenRouter-Title`, and `X-OpenRouter-Categories` headers to the **core/llm** `OpenRouter` class, matching what #11857 did for the openai-adapters `OpenRouter` class
- Uses `X-OpenRouter-Title` (the newer official header) instead of `X-Title`
- Adds `X-OpenRouter-Categories: ide-extension` for marketplace attribution
- Deduplicates headers by exporting `OPENROUTER_HEADERS` from openai-adapters and importing it in core
- User-configured `requestOptions.headers` take precedence over the defaults

Builds on #11857

## Test plan

- [ ] Verify OpenRouter requests from the core/llm path include `HTTP-Referer`, `X-OpenRouter-Title`, and `X-OpenRouter-Categories` headers
- [ ] Verify user-configured `requestOptions.headers` can still override these defaults
- [ ] Confirm the OpenRouter activity dashboard shows "Continue" in the App column