### PR TITLE
fix(gemini): forward requestOptions.headers to GoogleGenAI httpOptions

### DIFF
--- a/packages/openai-adapters/src/apis/Gemini.ts
+++ b/packages/openai-adapters/src/apis/Gemini.ts
@@ -75,10 +75,16 @@ export class GeminiApi implements BaseLlmApi {
     this.apiBase = config.apiBase ?? this.apiBase;
     // Create GoogleGenAI with native fetch to avoid pollution
     // from Vercel AI SDK packages that can break stream handling
+    const customHeaders = this.config.requestOptions?.headers;
     this.genAI = withNativeFetch(
       () =>
         new GoogleGenAI({
           apiKey: this.config.apiKey,
+          ...(customHeaders && {
+            httpOptions: {
+              headers: customHeaders,
+            },
+          }),
         }),
     );
   }


### PR DESCRIPTION
## Problem

The `GeminiApi` constructor initializes `GoogleGenAI` without forwarding `requestOptions.headers` to the SDK. Custom headers configured via `requestOptions.headers` in `config.yaml` (e.g. `x-api-key` for enterprise Gemini endpoints) are silently dropped for all chat/streaming requests, causing authentication errors like:

```json
{"error": {"code": 400, "message": "API key not valid.", "status": "INVALID_ARGUMENT"}}
```

## Root cause

In `packages/openai-adapters/src/apis/Gemini.ts`, the `GoogleGenAI` instance is created without `httpOptions`:

```ts
this.genAI = withNativeFetch(() =>
  new GoogleGenAI({
    apiKey: this.config.apiKey,
    // requestOptions.headers not forwarded here
  }),
);
```

Custom headers work in `embed()` because it uses `customFetch(this.config.requestOptions)`, which does merge `requestOptions.headers`. But chat goes through `this.genAI`, which never sees them.

## What changed

Pass `requestOptions.headers` to `GoogleGenAI` via the `httpOptions.headers` field, which the `@google/genai` SDK fully supports (`HttpOptions.headers: Record<string, string>`):

```ts
const customHeaders = this.config.requestOptions?.headers;
this.genAI = withNativeFetch(() =>
  new GoogleGenAI({
    apiKey: this.config.apiKey,
    ...(customHeaders && { httpOptions: { headers: customHeaders } }),
  }),
);
```

## How to test

Configure a Gemini model with a custom header that replaces the API key auth:

```yaml
name: Gemini
models:
  - name: Gemini Flash
    provider: gemini
    model: gemini-2.5-flash
    apiBase: https://your-enterprise-endpoint/v1/
    requestOptions:
      headers:
        x-api-key: your-key
```

With this fix, the header is forwarded and chat requests succeed instead of returning `401`/`400`.

Fixes #12008

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward custom headers from `requestOptions.headers` to `@google/genai` via `httpOptions.headers`. This makes Gemini chat and streaming requests include enterprise auth (e.g., `x-api-key`) and fixes invalid API key errors.

- **Bug Fixes**
  - Pass `requestOptions.headers` when constructing `GoogleGenAI` (inside `withNativeFetch`).

<sup>Written for commit 3cf379862bb4df33dbed7afb71b7b022ca763531. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

