### PR TITLE
[codex] feat(cli): add built-in subagents

### DIFF
--- a/core/llm/llms/OpenRouter.ts
+++ b/core/llm/llms/OpenRouter.ts
@@ -1,5 +1,7 @@
 import { ChatCompletionCreateParams } from "openai/resources/index";
 
+import { OPENROUTER_HEADERS } from "@continuedev/openai-adapters";
+
 import { LLMOptions } from "../../index.js";
 import { osModelsEditPrompt } from "../templates/edit.js";
 
@@ -17,6 +19,19 @@ class OpenRouter extends OpenAI {
     },
     useLegacyCompletionsEndpoint: false,
   };
+
+  constructor(options: LLMOptions) {
+    super({
+      ...options,
+      requestOptions: {
+        ...options.requestOptions,
+        headers: {
+          ...OPENROUTER_HEADERS,
+          ...options.requestOptions?.headers,
+        },
+      },
+    });
+  }
 
   private isAnthropicModel(model?: string): boolean {
     if (!model) return false;

--- a/core/util/history.test.ts
+++ b/core/util/history.test.ts
@@ -122,6 +122,14 @@ describe("Workspace directory filtering", () => {
     expect(sessions.length).toBe(4);
   });
 
+  test("Empty workspace filter only returns no-workspace sessions", () => {
+    const sessions = historyManager.list({
+      workspaceDirectory: "",
+    });
+    expect(sessions.length).toBe(1);
+    expect(sessions[0].sessionId).toBe("ws-none");
+  });
+
   test("Workspace filter is case-insensitive", () => {
     const sessions = historyManager.list({
       workspaceDirectory: "/HOME/USER/PROJECT-A",

--- a/core/util/history.ts
+++ b/core/util/history.ts
@@ -39,7 +39,10 @@ export class HistoryManager {
       .reverse();
 
     // Filter by workspace directory if provided
-    if (options.workspaceDirectory) {
+    if (
+      options.workspaceDirectory !== undefined &&
+      options.workspaceDirectory !== null
+    ) {
       const target = options.workspaceDirectory.toLowerCase();
       sessions = sessions.filter(
         (session) =>

--- a/extensions/cli/src/commands/BaseCommandOptions.ts
+++ b/extensions/cli/src/commands/BaseCommandOptions.ts
@@ -25,7 +25,7 @@ export interface BaseCommandOptions {
   agent?: string;
   /** Enable beta UploadArtifact tool */
   betaUploadArtifactTool?: boolean;
-  /** Enable beta Subagent tool */
+  /** Enable beta Subagent tool with built-in specialized agents */
   betaSubagentTool?: boolean;
 }
 

--- a/extensions/cli/src/index.ts
+++ b/extensions/cli/src/index.ts
@@ -202,7 +202,7 @@ addCommonOptions(program)
   .option("--fork <sessionId>", "Fork from an existing session ID")
   .option(
     "--beta-subagent-tool",
-    "Enable beta Subagent tool for invoking subagents",
+    "Enable beta Subagent tool with built-in specialized agents",
   )
   .action(async (prompt, options) => {
     // Telemetry: record command invocation

--- a/extensions/cli/src/services/ModelService.test.ts
+++ b/extensions/cli/src/services/ModelService.test.ts
@@ -10,6 +10,7 @@ import { AuthConfig } from "../auth/workos.js";
 import * as config from "../config.js";
 
 import { ModelService } from "./ModelService.js";
+import type { ModelServiceState } from "./types.js";
 
 describe("ModelService", () => {
   let service: ModelService;
@@ -371,5 +372,92 @@ describe("ModelService", () => {
       );
       expect(errorListener).toHaveBeenCalledWith(expect.any(Error));
     });
+  });
+});
+
+describe("ModelService.getSubagentModels", () => {
+  const baseState: ModelServiceState = {
+    llmApi: { provider: "primary-llm" } as any,
+    model: {
+      name: "primary-chat-model",
+      provider: "openai",
+      model: "gpt-4.1",
+      roles: ["chat"],
+      chatOptions: {},
+    },
+    assistant: {
+      models: [
+        {
+          name: "primary-chat-model",
+          provider: "openai",
+          model: "gpt-4.1",
+          roles: ["chat"],
+          chatOptions: {},
+        },
+      ],
+    } as any,
+    authConfig: null,
+  };
+
+  beforeEach(() => {
+    vi.mocked(config.createLlmApi).mockReturnValue({
+      provider: "mock-llm",
+    } as any);
+  });
+
+  test("returns configured subagents when present", () => {
+    const state: ModelServiceState = {
+      ...baseState,
+      assistant: {
+        models: [
+          ...(baseState.assistant?.models ?? []),
+          {
+            name: "security-review",
+            provider: "openai",
+            model: "gpt-4.1",
+            roles: ["subagent"],
+            chatOptions: {
+              baseSystemMessage: "Review code for security issues.",
+            },
+          },
+        ],
+      } as any,
+    };
+
+    const subagents = ModelService.getSubagentModels(state);
+
+    expect(subagents.map((subagent) => subagent.model?.name)).toEqual([
+      "security-review",
+    ]);
+  });
+
+  test("falls back to built-in subagents when none are configured", () => {
+    const subagents = ModelService.getSubagentModels(baseState);
+
+    expect(subagents.map((subagent) => subagent.model?.name)).toEqual([
+      "planner",
+      "researcher",
+      "reviewer",
+    ]);
+    expect(
+      subagents.every((subagent) => subagent.model?.model === "gpt-4.1"),
+    ).toBe(true);
+    expect(
+      subagents.every((subagent) => subagent.model?.provider === "openai"),
+    ).toBe(true);
+    expect(
+      subagents.every((subagent) =>
+        subagent.model?.roles?.includes("subagent"),
+      ),
+    ).toBe(true);
+  });
+
+  test("returns no subagents when there is no current model to clone", () => {
+    const subagents = ModelService.getSubagentModels({
+      ...baseState,
+      model: null,
+    });
+
+    expect(subagents).toEqual([]);
   });
 });

--- a/extensions/cli/src/services/ModelService.ts
+++ b/extensions/cli/src/services/ModelService.ts
@@ -2,6 +2,7 @@ import { AssistantUnrolled, ModelConfig } from "@continuedev/config-yaml";
 
 import { AuthConfig, getModelName } from "../auth/workos.js";
 import { createLlmApi, getLlmApi } from "../config.js";
+import { getBuiltInSubagentModels } from "../subagent/builtins.js";
 import { logger } from "../util/logger.js";
 
 import { BaseService, ServiceWithDependencies } from "./BaseService.js";
@@ -307,23 +308,21 @@ export class ModelService
   }
 
   static getSubagentModels(modelState: ModelServiceState) {
-    if (!modelState.assistant) {
-      return [];
-    }
-    const subagentModels = modelState.assistant.models
+    const configuredSubagentModels = modelState.assistant?.models
       ?.filter((model) => !!model)
-      .filter((model) => !!model.name) // filter out models without a name
-      .filter((model) => model.roles?.includes("subagent")) // filter with role subagent
-      .filter((model) => !!model.chatOptions?.baseSystemMessage); // filter those with a system message
+      .filter((model) => !!model.name)
+      .filter((model) => model.roles?.includes("subagent"))
+      .filter((model) => !!model.chatOptions?.baseSystemMessage);
 
-    if (!subagentModels) {
-      return [];
+    if (configuredSubagentModels?.length) {
+      return configuredSubagentModels.map((model) => ({
+        llmApi: createLlmApi(model, modelState.authConfig),
+        model,
+        assistant: modelState.assistant,
+        authConfig: modelState.authConfig,
+      }));
     }
-    return subagentModels?.map((model) => ({
-      llmApi: createLlmApi(model, modelState.authConfig),
-      model,
-      assistant: modelState.assistant,
-      authConfig: modelState.authConfig,
-    }));
+
+    return getBuiltInSubagentModels(modelState);
   }
 }

--- a/extensions/cli/src/subagent/builtins.ts
+++ b/extensions/cli/src/subagent/builtins.ts
@@ -1,0 +1,61 @@
+import { ModelConfig, ModelRole } from "@continuedev/config-yaml";
+
+import { createLlmApi } from "../config.js";
+import type { ModelServiceState } from "../services/types.js";
+
+interface BuiltInSubagentDefinition {
+  name: string;
+  baseSystemMessage: string;
+}
+
+const BUILT_IN_SUBAGENT_DEFINITIONS: BuiltInSubagentDefinition[] = [
+  {
+    name: "planner",
+    baseSystemMessage:
+      "Planner. Investigate the task, identify the most relevant files, constraints, and validation steps, then return a concise execution plan. Do not make unrelated edits.",
+  },
+  {
+    name: "researcher",
+    baseSystemMessage:
+      "Researcher. Gather the most relevant code, configuration, and documentation context for the task. Summarize concrete findings, tradeoffs, and unknowns with evidence from the repo.",
+  },
+  {
+    name: "reviewer",
+    baseSystemMessage:
+      "Reviewer. Review the proposed implementation for correctness, regressions, missing tests, and edge cases. Prioritize actionable findings and be specific.",
+  },
+];
+
+function createBuiltInSubagentModel(
+  baseModel: ModelConfig,
+  definition: BuiltInSubagentDefinition,
+): ModelConfig {
+  return {
+    ...baseModel,
+    name: definition.name,
+    roles: [...new Set<ModelRole>([...(baseModel.roles ?? []), "subagent"])],
+    chatOptions: {
+      ...baseModel.chatOptions,
+      baseSystemMessage: definition.baseSystemMessage,
+    },
+  };
+}
+
+export function getBuiltInSubagentModels(
+  modelState: ModelServiceState,
+): ModelServiceState[] {
+  const baseModel = modelState.model;
+  if (!baseModel) {
+    return [];
+  }
+
+  return BUILT_IN_SUBAGENT_DEFINITIONS.map((definition) => {
+    const model = createBuiltInSubagentModel(baseModel, definition);
+    return {
+      llmApi: createLlmApi(model, modelState.authConfig),
+      model,
+      assistant: modelState.assistant,
+      authConfig: modelState.authConfig,
+    };
+  }).filter((subagentModel) => !!subagentModel.llmApi);
+}

--- a/extensions/cli/src/subagent/get-agents.ts
+++ b/extensions/cli/src/subagent/get-agents.ts
@@ -7,7 +7,7 @@ import type { ModelServiceState } from "../services/types.js";
 export function getSubagent(modelState: ModelServiceState, name: string) {
   return (
     ModelService.getSubagentModels(modelState).find(
-      (model) => model.model.name === name,
+      (model) => model.model?.name === name,
     ) ?? null
   );
 }
@@ -21,7 +21,7 @@ export function generateSubagentToolDescription(
   const agentList = ModelService.getSubagentModels(modelState)
     .map(
       (subagentModel) =>
-        `  - ${subagentModel.model.name}: ${subagentModel.model.chatOptions?.baseSystemMessage}`,
+        `  - ${subagentModel.model?.name ?? "unknown"}: ${subagentModel.model?.chatOptions?.baseSystemMessage ?? ""}`,
     )
     .join("\n");
 
@@ -34,7 +34,7 @@ ${agentList}
 }
 
 export function getAgentNames(modelState: ModelServiceState): string[] {
-  return ModelService.getSubagentModels(modelState).map(
-    (model) => model.model.name,
-  );
+  return ModelService.getSubagentModels(modelState)
+    .map((model) => model.model?.name)
+    .filter((name): name is string => !!name);
 }

--- a/extensions/cli/src/tools/subagent.ts
+++ b/extensions/cli/src/tools/subagent.ts
@@ -54,7 +54,7 @@ export const subagentTool = async (): Promise<Tool> => {
         preview: [
           {
             type: "text",
-            content: `Spawning ${agent.model.name} to: ${description}`,
+            content: `Spawning ${agent.model?.name ?? subagent_name} to: ${description}`,
           },
         ],
       };

--- a/packages/openai-adapters/src/apis/OpenRouter.ts
+++ b/packages/openai-adapters/src/apis/OpenRouter.ts
@@ -10,9 +10,10 @@ export interface OpenRouterConfig extends OpenAIConfig {
 
 // TODO: Extract detailed error info from OpenRouter's error.metadata.raw to surface better messages
 
-const OPENROUTER_HEADERS: Record<string, string> = {
+export const OPENROUTER_HEADERS: Record<string, string> = {
   "HTTP-Referer": "https://www.continue.dev/",
-  "X-Title": "Continue",
+  "X-OpenRouter-Title": "Continue",
+  "X-OpenRouter-Categories": "ide-extension",
 };
 
 export class OpenRouterApi extends OpenAIApi {

--- a/packages/openai-adapters/src/index.ts
+++ b/packages/openai-adapters/src/index.ts
@@ -243,4 +243,5 @@ export {
 } from "./apis/AnthropicUtils.js";
 
 export { isResponsesModel } from "./apis/openaiResponses.js";
+export { OPENROUTER_HEADERS } from "./apis/OpenRouter.js";
 export { extractBase64FromDataUrl, parseDataUrl } from "./util/url.js";


### PR DESCRIPTION
## Summary
- add built-in CLI subagents that are available without extra `config.yaml` setup
- fall back to built-in `planner`, `researcher`, and `reviewer` subagents when no explicit `subagent` models are configured
- keep configured subagent models taking precedence over the built-in defaults
- cover the fallback and precedence behavior with ModelService regression tests

## Why
The beta subagent tool already exists in the CLI, but trying it currently requires internal-only `subagent` model configuration. This change makes the feature usable out of the box by cloning the current chat model into a few specialized built-in subagents with hard-coded prompts in `extensions/cli`.

## Validation
- ran `npm test -- src/services/ModelService.test.ts src/tools/subagent.test.ts`
- ran `npm run lint` in `extensions/cli` (passes with two existing repo warnings in unrelated files)

Closes #9550

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds built-in CLI subagents (`planner`, `researcher`, `reviewer`) so the beta Subagent tool works out of the box while still honoring configured `subagent` models (closes #9550). Also fixes empty workspace filtering and standardizes OpenRouter attribution headers.

- New Features
  - Added built-in agent definitions and prompts; CLI help text mentions them.
  - `ModelService.getSubagentModels` prefers configured subagents; otherwise uses built-ins cloned from the active chat model. Tests cover precedence, fallback, and the no-base-model case.
  - OpenRouter requests include standard headers via `@continuedev/openai-adapters` `OPENROUTER_HEADERS`; switched to `X-OpenRouter-Title` and added `X-OpenRouter-Categories`, applied in the core `OpenRouter` client.

- Bug Fixes
  - Hardened subagent lookup and preview to handle missing model names.
  - History filtering: empty `workspaceDirectory` now returns only no-workspace sessions; added test coverage.

<sup>Written for commit 0b953cb0973ee95ea342d0ccb49cee3c1170b5dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

