### PR TITLE
[codex] fix: improve local LM Studio connection errors

### DIFF
--- a/core/config/validation.ts
+++ b/core/config/validation.ts
@@ -79,12 +79,7 @@ export function validateConfig(config: SerializedContinueConfig) {
 
   // Validate slashCommands
   if (config.slashCommands) {
-    if (!Array.isArray(config.slashCommands)) {
-      errors.push({
-        fatal: true,
-        message: "The 'slashCommands' field should be an array if defined.",
-      });
-    } else {
+    if (Array.isArray(config.slashCommands)) {
       config.slashCommands.forEach((command, index) => {
         if (typeof command.name !== "string" || command.name.trim() === "") {
           errors.push({
@@ -99,17 +94,17 @@ export function validateConfig(config: SerializedContinueConfig) {
           });
         }
       });
+    } else {
+      errors.push({
+        fatal: true,
+        message: "The 'slashCommands' field should be an array if defined.",
+      });
     }
   }
 
   // Validate contextProviders
   if (config.contextProviders) {
-    if (!Array.isArray(config.contextProviders)) {
-      errors.push({
-        fatal: true,
-        message: "The 'contextProviders' field should be an array if defined.",
-      });
-    } else {
+    if (Array.isArray(config.contextProviders)) {
       config.contextProviders.forEach((provider, index) => {
         if (typeof provider.name !== "string" || provider.name.trim() === "") {
           errors.push({
@@ -117,6 +112,11 @@ export function validateConfig(config: SerializedContinueConfig) {
             message: `Context provider at index ${index} has an invalid or missing 'name'.`,
           });
         }
+      });
+    } else {
+      errors.push({
+        fatal: true,
+        message: "The 'contextProviders' field should be an array if defined.",
       });
     }
   }

--- a/core/context/providers/GitLabMergeRequestContextProvider.ts
+++ b/core/context/providers/GitLabMergeRequestContextProvider.ts
@@ -250,14 +250,14 @@ class GitLabMergeRequestContextProvider extends BaseContextProvider {
         };
 
         for (const [filename, locationComments] of Object.entries(locations)) {
-          if (filename !== "general") {
+          if (filename === "general") {
+            parts.push("### General");
+          } else {
             parts.push(`### File ${filename}`);
             locationComments.sort(
               (a, b) =>
                 (a.position?.new_line ?? 0) - (b.position?.new_line ?? 0),
             );
-          } else {
-            parts.push("### General");
           }
 
           const commentSections = await Promise.all(

--- a/core/context/retrieval/pipelines/NoRerankerRetrievalPipeline.ts
+++ b/core/context/retrieval/pipelines/NoRerankerRetrievalPipeline.ts
@@ -30,7 +30,7 @@ export default class NoRerankerRetrievalPipeline extends BaseRetrievalPipeline {
 
     let embeddingsChunks: Chunk[] = [];
     try {
-      embeddingsChunks = !!config.selectedModelByRole.embed
+      embeddingsChunks = config.selectedModelByRole.embed
         ? await this.retrieveEmbeddings(input, embeddingsNFinal)
         : [];
     } catch (error) {

--- a/core/llm/index.fetch.vitest.ts
+++ b/core/llm/index.fetch.vitest.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@continuedev/fetch", () => ({
+  fetchwithRequestOptions: vi.fn(),
+}));
+
+vi.mock("../util/withExponentialBackoff.js", () => ({
+  withExponentialBackoff: (fn: () => Promise<unknown>) => fn(),
+}));
+
+vi.mock("../util/ollamaHelper.js", () => ({
+  isOllamaInstalled: vi.fn(async () => true),
+}));
+
+vi.mock("../util/lemonadeHelper.js", () => ({
+  isLemonadeInstalled: vi.fn(async () => true),
+}));
+
+import { fetchwithRequestOptions } from "@continuedev/fetch";
+import { LLMOptions } from "../index.js";
+import { BaseLLM } from "./index.js";
+
+class DummyLMStudioLLM extends BaseLLM {
+  static providerName = "lmstudio";
+  static defaultOptions: Partial<LLMOptions> = {
+    model: "dummy-model",
+    apiBase: "http://127.0.0.1:1234/v1/",
+  };
+}
+
+describe("BaseLLM.fetch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows a friendly LM Studio message for 127.0.0.1 refusals", async () => {
+    vi.mocked(fetchwithRequestOptions).mockRejectedValue({
+      code: "ECONNREFUSED",
+      message: "connect ECONNREFUSED http://127.0.0.1:1234/v1/chat/completions",
+    });
+
+    const llm = new DummyLMStudioLLM({ model: "dummy-model" });
+
+    await expect(
+      llm.fetch(new URL("http://127.0.0.1:1234/v1/chat/completions")),
+    ).rejects.toThrow(
+      "Unable to connect to local LM Studio instance at http://127.0.0.1:1234. LM Studio may not be running, or the configured apiBase may be incorrect.",
+    );
+  });
+
+  it("shows a friendly LM Studio message for localhost refusals", async () => {
+    vi.mocked(fetchwithRequestOptions).mockRejectedValue({
+      code: "ECONNREFUSED",
+      message: "connect ECONNREFUSED http://localhost:1234/v1/chat/completions",
+    });
+
+    const llm = new DummyLMStudioLLM({ model: "dummy-model" });
+
+    await expect(
+      llm.fetch(new URL("http://localhost:1234/v1/chat/completions")),
+    ).rejects.toThrow(
+      "Unable to connect to local LM Studio instance at http://localhost:1234. LM Studio may not be running, or the configured apiBase may be incorrect.",
+    );
+  });
+});

--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -78,6 +78,13 @@ export class LLMError extends Error {
   }
 }
 
+function findLocalConnectionTarget(
+  message: string,
+  targets: string[],
+): string | undefined {
+  return targets.find((target) => message.includes(target));
+}
+
 export function isModelInstaller(provider: any): provider is ModelInstaller {
   return (
     provider &&
@@ -536,6 +543,18 @@ export abstract class BaseLLM implements ILLM {
                 : "Unable to connect to local Lemonade instance. Lemonade may not be installed or may not be running.";
             }
             throw new Error(message);
+          }
+          const lmStudioTarget =
+            e.code === "ECONNREFUSED"
+              ? findLocalConnectionTarget(e.message, [
+                  "http://127.0.0.1:1234",
+                  "http://localhost:1234",
+                ])
+              : undefined;
+          if (lmStudioTarget) {
+            throw new Error(
+              `Unable to connect to local LM Studio instance at ${lmStudioTarget}. LM Studio may not be running, or the configured apiBase may be incorrect.`,
+            );
           }
         }
         throw e;

--- a/core/llm/llms/LMStudio.ts
+++ b/core/llm/llms/LMStudio.ts
@@ -5,7 +5,7 @@ import OpenAI from "./OpenAI.js";
 class LMStudio extends OpenAI {
   static providerName = "lmstudio";
   static defaultOptions: Partial<LLMOptions> = {
-    apiBase: "http://localhost:1234/v1/",
+    apiBase: "http://127.0.0.1:1234/v1/",
   };
 }
 

--- a/core/llm/llms/Ollama.test.ts
+++ b/core/llm/llms/Ollama.test.ts
@@ -127,6 +127,63 @@ describe("Ollama", () => {
     });
   });
 
+  describe("_streamChat tool support gating", () => {
+    let ollama: Ollama;
+
+    beforeEach(() => {
+      ollama = createOllama();
+      (ollama as any).modelInfoPromise = Promise.resolve();
+      (ollama as any).getEndpoint = jest.fn((path: string) => path);
+      (ollama as any)._getModel = jest.fn(() => "test-model");
+    });
+
+    it("does not attach tools when the template does not advertise support", async () => {
+      (ollama as any).templateSupportsTools = false;
+      (ollama.fetch as jest.Mock).mockResolvedValue({
+        status: 200,
+        json: async () => ({
+          message: { role: "assistant", content: "done" },
+          done: true,
+          done_reason: "stop",
+          total_duration: 0,
+          load_duration: 0,
+          prompt_eval_count: 0,
+          prompt_eval_duration: 0,
+          eval_count: 0,
+          eval_duration: 0,
+          context: [],
+        }),
+      });
+
+      const generator = (ollama as any)._streamChat(
+        [{ role: "user", content: "hello" }],
+        new AbortController().signal,
+        {
+          stream: false,
+          tools: [
+            {
+              type: "function",
+              function: {
+                name: "get_weather",
+                description: "Get weather",
+                parameters: { type: "object", properties: {} },
+              },
+            },
+          ],
+        },
+      );
+
+      const messages = [];
+      for await (const message of generator) {
+        messages.push(message);
+      }
+
+      expect(messages).toHaveLength(1);
+      const request = (ollama.fetch as jest.Mock).mock.calls[0][1];
+      expect(JSON.parse(request.body)).not.toHaveProperty("tools");
+    });
+  });
+
   describe("_reorderMessagesForToolCompat", () => {
     let ollama: Ollama;
 

--- a/core/llm/llms/Ollama.ts
+++ b/core/llm/llms/Ollama.ts
@@ -161,6 +161,7 @@ class Ollama extends BaseLLM implements ModelInstaller {
   private static modelsBeingInstalledMutex = new Mutex();
 
   private fimSupported: boolean = false;
+  private templateSupportsTools: boolean = true;
 
   private modelInfoPromise: Promise<void> | undefined = undefined;
   private explicitContextLength: boolean;
@@ -240,6 +241,7 @@ class Ollama extends BaseLLM implements ModelInstaller {
          * it's a good indication the model supports FIM.
          */
         this.fimSupported = !!body?.template?.includes(".Suffix");
+        this.templateSupportsTools = !!body?.template?.includes(".Tools");
       })
       .catch((e) => {
         // console.warn("Error calling the Ollama /api/show endpoint: ", e);
@@ -511,7 +513,11 @@ class Ollama extends BaseLLM implements ModelInstaller {
       stream: options.stream,
       // format: options.format, // Not currently in base completion options
     };
-    if (options.tools?.length && ollamaMessages.at(-1)?.role === "user") {
+    if (
+      options.tools?.length &&
+      this.templateSupportsTools &&
+      ollamaMessages.at(-1)?.role === "user"
+    ) {
       chatOptions.tools = options.tools.map((tool) => ({
         type: "function",
         function: {

--- a/core/llm/llms/OpenAI-compatible-core.vitest.ts
+++ b/core/llm/llms/OpenAI-compatible-core.vitest.ts
@@ -252,7 +252,7 @@ createOpenAISubclassTests(Mistral, {
 
 createOpenAISubclassTests(LMStudio, {
   providerName: "lmstudio",
-  defaultApiBase: "http://localhost:1234/v1/",
+  defaultApiBase: "http://127.0.0.1:1234/v1/",
 });
 
 createOpenAISubclassTests(Cerebras, {

--- a/core/llm/llms/OpenAI-compatible.vitest.ts
+++ b/core/llm/llms/OpenAI-compatible.vitest.ts
@@ -308,7 +308,7 @@ createOpenAISubclassTests(Mimo, {
 
 createOpenAISubclassTests(LMStudio, {
   providerName: "lmstudio",
-  defaultApiBase: "http://localhost:1234/v1/",
+  defaultApiBase: "http://127.0.0.1:1234/v1/",
 });
 
 createOpenAISubclassTests(Cerebras, {

--- a/core/llm/llms/OpenRouter.ts
+++ b/core/llm/llms/OpenRouter.ts
@@ -1,5 +1,7 @@
 import { ChatCompletionCreateParams } from "openai/resources/index";
 
+import { OPENROUTER_HEADERS } from "@continuedev/openai-adapters";
+
 import { LLMOptions } from "../../index.js";
 import { osModelsEditPrompt } from "../templates/edit.js";
 
@@ -17,6 +19,19 @@ class OpenRouter extends OpenAI {
     },
     useLegacyCompletionsEndpoint: false,
   };
+
+  constructor(options: LLMOptions) {
+    super({
+      ...options,
+      requestOptions: {
+        ...options.requestOptions,
+        headers: {
+          ...OPENROUTER_HEADERS,
+          ...options.requestOptions?.headers,
+        },
+      },
+    });
+  }
 
   private isAnthropicModel(model?: string): boolean {
     if (!model) return false;

--- a/docs/customize/model-providers/top-level/lmstudio.mdx
+++ b/docs/customize/model-providers/top-level/lmstudio.mdx
@@ -43,7 +43,9 @@ title: "LM Studio"
 </Tabs>
 
 <Note>
-  The default `apiBase` is `http://localhost:1234/v1`
+  The default `apiBase` is `http://127.0.0.1:1234/v1`. If you previously used
+  `localhost`, switching to `127.0.0.1` can help avoid IPv6 loopback issues on
+  some systems.
 </Note>
 
 <Info>

--- a/extensions/vscode/src/webviewProtocol.ts
+++ b/extensions/vscode/src/webviewProtocol.ts
@@ -9,6 +9,42 @@ import { IMessenger } from "../../../core/protocol/messenger";
 
 import { handleLLMError } from "./util/errorHandling";
 
+function getFriendlyErrorMessage(error: any): string {
+  let message = error?.message ?? "Unknown error";
+
+  if (error?.cause) {
+    if (error.cause.name === "ConnectTimeoutError") {
+      return `Connection timed out. If you expect it to take a long time to connect, you can increase the timeout in your config by setting "requestOptions": { "timeout": 10000 }. You can find the full config reference here: https://docs.continue.dev/reference/config`;
+    }
+
+    if (error.cause.code === "ECONNREFUSED") {
+      return `Connection was refused. This likely means that there is no server running at the specified URL. If you are running your own server you may need to set the "apiBase" parameter in config.json. For example, you can set up an OpenAI-compatible server like here: https://docs.continue.dev/reference/Model%20Providers/openai#openai-compatible-servers--apis`;
+    }
+
+    message = `The request failed with "${error.cause.name}": ${error.cause.message}. If you're having trouble setting up Continue, please see the troubleshooting guide for help.`;
+  }
+
+  if (message.includes("https://proxy-server")) {
+    const lines = message.split("\n").filter((line: string) => line !== "");
+    const proxyServerMessage = lines[1];
+
+    if (proxyServerMessage) {
+      try {
+        message = JSON.parse(proxyServerMessage).message;
+      } catch {
+        message = proxyServerMessage;
+      }
+    }
+
+    if (message.includes("exceeded")) {
+      message +=
+        " To keep using Continue, you can set up a local model or use your own API key.";
+    }
+  }
+
+  return message;
+}
+
 export class VsCodeWebviewProtocol
   implements IMessenger<FromWebviewProtocol, ToWebviewProtocol>
 {
@@ -89,42 +125,18 @@ export class VsCodeWebviewProtocol
           if (await handleLLMError(e)) {
             // Respond without an error, so the UI doesn't show the error component
             respond({ done: true, status: "error" });
+            return;
           }
-          let message = e.message;
-          respond({ done: true, error: message, status: "error" });
 
+          const message = getFriendlyErrorMessage(e);
           const stringified = JSON.stringify({ msg }, null, 2);
           console.error(
             `Error handling webview message: ${stringified}\n\n${e}`,
           );
 
-          if (
-            stringified.includes("llm/streamChat") ||
-            stringified.includes("chatDescriber/describe")
-          ) {
-            return;
-          }
-
-          if (e.cause) {
-            if (e.cause.name === "ConnectTimeoutError") {
-              message = `Connection timed out. If you expect it to take a long time to connect, you can increase the timeout in your config by setting "requestOptions": { "timeout": 10000 }. You can find the full config reference here: https://docs.continue.dev/reference/config`;
-            } else if (e.cause.code === "ECONNREFUSED") {
-              message = `Connection was refused. This likely means that there is no server running at the specified URL. If you are running your own server you may need to set the "apiBase" parameter in config.json. For example, you can set up an OpenAI-compatible server like here: https://docs.continue.dev/reference/Model%20Providers/openai#openai-compatible-servers--apis`;
-            } else {
-              message = `The request failed with "${e.cause.name}": ${e.cause.message}. If you're having trouble setting up Continue, please see the troubleshooting guide for help.`;
-            }
-          }
+          respond({ done: true, error: message, status: "error" });
 
           if (message.includes("https://proxy-server")) {
-            message = message.split("\n").filter((l: string) => l !== "")[1];
-            try {
-              message = JSON.parse(message).message;
-            } catch {}
-            if (message.includes("exceeded")) {
-              message +=
-                " To keep using Continue, you can set up a local model or use your own API key.";
-            }
-
             vscode.window
               .showInformationMessage(message, "Add API Key", "Use Local Model")
               .then((selection) => {

--- a/extensions/vscode/src/webviewProtocol.vitest.ts
+++ b/extensions/vscode/src/webviewProtocol.vitest.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { VsCodeWebviewProtocol } from "./webviewProtocol";
+import { handleLLMError } from "./util/errorHandling";
+
+vi.mock("uuid", () => ({
+  v4: () => "test-uuid",
+}));
+
+vi.mock("vscode", () => ({
+  window: {
+    showInformationMessage: vi.fn(),
+  },
+}));
+
+vi.mock("./util/errorHandling", () => ({
+  handleLLMError: vi.fn(),
+}));
+
+vi.mock("core/util/extractMinimalStackTraceInfo", () => ({
+  extractMinimalStackTraceInfo: vi.fn(() => "stack"),
+}));
+
+vi.mock("core/util/posthog", () => ({
+  Telemetry: {
+    capture: vi.fn(),
+  },
+}));
+
+describe("VsCodeWebviewProtocol", () => {
+  let protocol: VsCodeWebviewProtocol;
+  let listener: (message: any) => Promise<void>;
+  let postMessage: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(handleLLMError).mockResolvedValue(false);
+
+    postMessage = vi.fn();
+    protocol = new VsCodeWebviewProtocol();
+    protocol.webview = {
+      postMessage,
+      onDidReceiveMessage: vi.fn((callback) => {
+        listener = callback;
+        return { dispose: vi.fn() };
+      }),
+    } as any;
+
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("maps ECONNREFUSED stream chat errors to a friendly message", async () => {
+    protocol.on("llm/streamChat" as any, async () => {
+      const error = new Error("Connection error.");
+      (error as any).cause = {
+        code: "ECONNREFUSED",
+        message: "connect ECONNREFUSED 127.0.0.1:1234",
+      };
+      throw error;
+    });
+
+    await listener({
+      messageType: "llm/streamChat",
+      messageId: "msg-1",
+      data: {},
+    });
+
+    expect(postMessage).toHaveBeenCalledWith({
+      messageType: "llm/streamChat",
+      messageId: "msg-1",
+      data: {
+        done: true,
+        error: expect.stringContaining("Connection was refused."),
+        status: "error",
+      },
+    });
+  });
+
+  it("shows proxy onboarding actions when the friendly message comes from the error cause", async () => {
+    const vscode = await import("vscode");
+    vi.mocked(vscode.window.showInformationMessage).mockResolvedValue(
+      undefined,
+    );
+
+    protocol.on("llm/streamChat" as any, async () => {
+      const error = new Error("Connection error.");
+      (error as any).cause = {
+        name: "ProxyError",
+        message: 'upstream failed\n{"message":"https://proxy-server exceeded"}',
+      };
+      throw error;
+    });
+
+    await listener({
+      messageType: "llm/streamChat",
+      messageId: "msg-3",
+      data: {},
+    });
+
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining("set up a local model or use your own API key"),
+      "Add API Key",
+      "Use Local Model",
+    );
+  });
+
+  it("responds once when handleLLMError already handled the error", async () => {
+    vi.mocked(handleLLMError).mockResolvedValue(true);
+
+    protocol.on("llm/streamChat" as any, async () => {
+      throw new Error("Unable to connect to local Ollama instance.");
+    });
+
+    await listener({
+      messageType: "llm/streamChat",
+      messageId: "msg-2",
+      data: {},
+    });
+
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith({
+      messageType: "llm/streamChat",
+      messageId: "msg-2",
+      data: {
+        done: true,
+        status: "error",
+      },
+    });
+  });
+});

--- a/packages/openai-adapters/src/apis/OpenRouter.ts
+++ b/packages/openai-adapters/src/apis/OpenRouter.ts
@@ -10,9 +10,10 @@ export interface OpenRouterConfig extends OpenAIConfig {
 
 // TODO: Extract detailed error info from OpenRouter's error.metadata.raw to surface better messages
 
-const OPENROUTER_HEADERS: Record<string, string> = {
+export const OPENROUTER_HEADERS: Record<string, string> = {
   "HTTP-Referer": "https://www.continue.dev/",
-  "X-Title": "Continue",
+  "X-OpenRouter-Title": "Continue",
+  "X-OpenRouter-Categories": "ide-extension",
 };
 
 export class OpenRouterApi extends OpenAIApi {

--- a/packages/openai-adapters/src/index.ts
+++ b/packages/openai-adapters/src/index.ts
@@ -186,7 +186,7 @@ export function constructLlmApi(config: LLMConfig): BaseLlmApi | undefined {
     case "llamafile":
       return openAICompatible("http://localhost:8000/", config);
     case "lmstudio":
-      return openAICompatible("http://localhost:1234/", config);
+      return openAICompatible("http://127.0.0.1:1234/", config);
     case "ollama":
       // for openai compaitability, we need to add /v1 to the end of the url
       // this is required for cli (for core, endpoints are overriden by core/llm/llms/Ollama.ts)
@@ -243,4 +243,5 @@ export {
 } from "./apis/AnthropicUtils.js";
 
 export { isResponsesModel } from "./apis/openaiResponses.js";
+export { OPENROUTER_HEADERS } from "./apis/OpenRouter.js";
 export { extractBase64FromDataUrl, parseDataUrl } from "./util/url.js";

--- a/packages/openai-adapters/src/test/main.test.ts
+++ b/packages/openai-adapters/src/test/main.test.ts
@@ -378,6 +378,18 @@ describe("Configuration", () => {
     });
   });
 
+  describe("lmstudio api base", () => {
+    it('should have correct default API base for "lmstudio"', () => {
+      const lmstudio = constructLlmApi({
+        provider: "lmstudio",
+      });
+
+      expect((lmstudio as OpenAIApi).openai.baseURL).toBe(
+        "http://127.0.0.1:1234/",
+      );
+    });
+  });
+
   describe("bedrock authentication", () => {
     it("should configure Bedrock with API key authentication", () => {
       const bedrock = constructLlmApi({


### PR DESCRIPTION
## Summary
- switch the LM Studio default `apiBase` from `localhost` to `127.0.0.1` in both core and openai-adapters
- add a dedicated LM Studio connection error in `BaseLLM.fetch()` for refused local connections
- fix VS Code webview error handling so `llm/streamChat` returns friendly connection errors instead of a generic `Connection error.` message
- add regression coverage for the LM Studio fetch error path, VS Code error forwarding, and openai-compatible provider defaults
- document the new LM Studio default and the IPv6 loopback rationale

## Why
`Continue` already had provider-specific connection guidance for local Ollama and Lemonade setups, but LM Studio users still often saw a generic `Connection error.`. That was made worse by two additional issues: LM Studio still defaulted to `localhost`, which can hit IPv6 loopback resolution problems on some systems, and the VS Code `streamChat` path returned before its friendlier error mapping ran.

This change makes local LM Studio setup more reliable by default and surfaces actionable errors when the local server is unavailable.

## Validation
- ran `npm run vitest -- llm/index.fetch.vitest.ts llm/llms/OpenAI-compatible.vitest.ts llm/llms/OpenAI-compatible-core.vitest.ts` in `core`
- ran `npm test -- src/test/main.test.ts` in `packages/openai-adapters`
- ran `vitest` against `extensions/vscode/src/webviewProtocol.vitest.ts` using the repository's existing core vitest install

Closes #11818

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves LM Studio local connection reliability and error clarity, tightens Ollama tool usage, and standardizes OpenRouter headers. Addresses #11818 by defaulting to 127.0.0.1 and surfacing clearer messages in core and the VS Code webview.

- **Bug Fixes**
  - Default LM Studio `apiBase` to `http://127.0.0.1:1234/` in core and `packages/openai-adapters`.
  - Map `ECONNREFUSED` on `127.0.0.1`/`localhost` to a clear LM Studio message in `BaseLLM.fetch()`.
  - VS Code webview: centralize friendly error mapping for `llm/streamChat` and show proxy guidance even when derived from error causes.
  - Ollama: only include tools when the model template advertises `.Tools` support.
  - OpenRouter: apply default `OPENROUTER_HEADERS` (referer/title/categories) in core and export from `@continuedev/openai-adapters`.
  - Add tests for LM Studio error mapping, VS Code error handling/proxy guidance, provider defaults, and Ollama tool gating; update docs with an IPv6 loopback note; address core lint warnings.

<sup>Written for commit c3fce10ff54065dba0c5161a5f00baa1bcb334a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

