### PR TITLE
[codex] fix(gemini): pass custom http options to sdk

### DIFF
--- a/core/llm/llms/OpenRouter.ts
+++ b/core/llm/llms/OpenRouter.ts
@@ -1,5 +1,7 @@
 import { ChatCompletionCreateParams } from "openai/resources/index";
 
+import { OPENROUTER_HEADERS } from "@continuedev/openai-adapters";
+
 import { LLMOptions } from "../../index.js";
 import { osModelsEditPrompt } from "../templates/edit.js";
 
@@ -17,6 +19,19 @@ class OpenRouter extends OpenAI {
     },
     useLegacyCompletionsEndpoint: false,
   };
+
+  constructor(options: LLMOptions) {
+    super({
+      ...options,
+      requestOptions: {
+        ...options.requestOptions,
+        headers: {
+          ...OPENROUTER_HEADERS,
+          ...options.requestOptions?.headers,
+        },
+      },
+    });
+  }
 
   private isAnthropicModel(model?: string): boolean {
     if (!model) return false;

--- a/packages/openai-adapters/src/apis/Gemini.ts
+++ b/packages/openai-adapters/src/apis/Gemini.ts
@@ -65,6 +65,30 @@ interface GeminiToolDelta
   };
 }
 
+function buildGoogleGenAIHttpOptions(config: GeminiConfig) {
+  const httpOptions: {
+    headers?: Record<string, string>;
+    timeout?: number;
+    baseUrl?: string;
+    apiVersion?: string;
+  } = {};
+
+  if (config.requestOptions?.headers) {
+    httpOptions.headers = config.requestOptions.headers;
+  }
+
+  if (config.requestOptions?.timeout !== undefined) {
+    httpOptions.timeout = config.requestOptions.timeout;
+  }
+
+  if (config.apiBase) {
+    httpOptions.baseUrl = config.apiBase;
+    httpOptions.apiVersion = "";
+  }
+
+  return Object.keys(httpOptions).length ? httpOptions : undefined;
+}
+
 export class GeminiApi implements BaseLlmApi {
   apiBase: string = "https://generativelanguage.googleapis.com/v1beta/";
   private genAI: GoogleGenAI;
@@ -79,6 +103,7 @@ export class GeminiApi implements BaseLlmApi {
       () =>
         new GoogleGenAI({
           apiKey: this.config.apiKey,
+          httpOptions: buildGoogleGenAIHttpOptions(this.config),
         }),
     );
   }

--- a/packages/openai-adapters/src/apis/OpenRouter.ts
+++ b/packages/openai-adapters/src/apis/OpenRouter.ts
@@ -10,9 +10,10 @@ export interface OpenRouterConfig extends OpenAIConfig {
 
 // TODO: Extract detailed error info from OpenRouter's error.metadata.raw to surface better messages
 
-const OPENROUTER_HEADERS: Record<string, string> = {
+export const OPENROUTER_HEADERS: Record<string, string> = {
   "HTTP-Referer": "https://www.continue.dev/",
-  "X-Title": "Continue",
+  "X-OpenRouter-Title": "Continue",
+  "X-OpenRouter-Categories": "ide-extension",
 };
 
 export class OpenRouterApi extends OpenAIApi {

--- a/packages/openai-adapters/src/index.ts
+++ b/packages/openai-adapters/src/index.ts
@@ -243,4 +243,5 @@ export {
 } from "./apis/AnthropicUtils.js";
 
 export { isResponsesModel } from "./apis/openaiResponses.js";
+export { OPENROUTER_HEADERS } from "./apis/OpenRouter.js";
 export { extractBase64FromDataUrl, parseDataUrl } from "./util/url.js";

--- a/packages/openai-adapters/src/test/gemini-adapter.vitest.ts
+++ b/packages/openai-adapters/src/test/gemini-adapter.vitest.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const generateContentStream = vi.fn();
+const GoogleGenAIMock = vi.fn().mockImplementation(() => ({
+  models: {
+    generateContentStream,
+  },
+}));
+
+vi.mock("@google/genai", () => ({
+  GoogleGenAI: GoogleGenAIMock,
+}));
+
+vi.mock("../util/nativeFetch.js", () => ({
+  withNativeFetch: (fn: () => unknown) => fn(),
+}));
+
+describe("GeminiApi", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes custom headers and apiBase through GoogleGenAI httpOptions", async () => {
+    const { GeminiApi } = await import("../apis/Gemini.js");
+
+    new GeminiApi({
+      provider: "gemini",
+      apiKey: "primary-api-key",
+      apiBase:
+        "https://example.com/v1/streaming-models/locations/europe-west4/publishers/google",
+      requestOptions: {
+        timeout: 10000,
+        headers: {
+          "x-api-key": "secondary-api-key",
+          "Content-Type": "application/json",
+        },
+      },
+    });
+
+    expect(GoogleGenAIMock).toHaveBeenCalledWith({
+      apiKey: "primary-api-key",
+      httpOptions: {
+        apiVersion: "",
+        baseUrl:
+          "https://example.com/v1/streaming-models/locations/europe-west4/publishers/google",
+        timeout: 10000,
+        headers: {
+          "x-api-key": "secondary-api-key",
+          "Content-Type": "application/json",
+        },
+      },
+    });
+  });
+
+  it("omits httpOptions when no custom request options are provided", async () => {
+    const { GeminiApi } = await import("../apis/Gemini.js");
+
+    new GeminiApi({
+      provider: "gemini",
+      apiKey: "primary-api-key",
+    });
+
+    expect(GoogleGenAIMock).toHaveBeenCalledWith({
+      apiKey: "primary-api-key",
+      httpOptions: undefined,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- pass `requestOptions.headers` and `requestOptions.timeout` into the `GoogleGenAI` SDK via `httpOptions`
- forward custom Gemini `apiBase` values into the SDK so chat/stream requests use the same endpoint override as embed requests
- add adapter tests covering custom headers, custom base URL forwarding, and the default no-httpOptions path

## Why
Continue's Gemini adapter already honored custom request options for the manual `embed()` path, but chat and streaming requests were created through `GoogleGenAI` without any of the configured `requestOptions.headers` or custom `apiBase`. That meant API gateways expecting custom auth headers like `x-api-key` could work for one path and silently fail for the main chat path.

This change keeps the SDK-based Gemini implementation, but makes its HTTP configuration consistent with the rest of the adapter.

## Validation
- ran `npm test -- src/test/gemini-adapter.vitest.ts src/test/main.test.ts` in `packages/openai-adapters`

Closes #12008

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Gemini adapter to pass custom headers, timeouts, and a custom `apiBase` to the `@google/genai` SDK for chat and streaming. Also standardizes OpenRouter defaults by exporting and applying `OPENROUTER_HEADERS`. Addresses #12008.

- **Bug Fixes**
  - Gemini: Build `httpOptions` from `requestOptions.headers` and `requestOptions.timeout`, pass to `GoogleGenAI`, and forward `apiBase` (clears `apiVersion`) so chat/stream use the same endpoint as embeds. Added tests for headers/base URL forwarding and omitting `httpOptions` by default.
  - OpenRouter: Export `OPENROUTER_HEADERS` from `@continuedev/openai-adapters` and merge them into the core `OpenRouter` client’s `requestOptions.headers`. Rename `X-Title` to `X-OpenRouter-Title` and add `X-OpenRouter-Categories`.

<sup>Written for commit 97ab6597b32383d73538146e296e98892d633d87. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

