### PR TITLE
feat: cache hub assistants for offline fallback

### DIFF
--- a/core/config/ConfigHandler.hubCache.vitest.ts
+++ b/core/config/ConfigHandler.hubCache.vitest.ts
@@ -1,0 +1,133 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+describe("ConfigHandler hub assistant cache fallback", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "continue-hub-cache-"));
+    process.env.CONTINUE_GLOBAL_DIR = path.join(tempDir, ".continue-global");
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.CONTINUE_GLOBAL_DIR;
+    fs.rmSync(tempDir, { force: true, recursive: true });
+  });
+
+  test("uses cached hub assistants when the hub becomes unavailable", async () => {
+    const [{ ConfigHandler }, { LLMLogger }, { default: FileSystemIde }] =
+      await Promise.all([
+        import("./ConfigHandler"),
+        import("../llm/logger"),
+        import("../util/filesystem"),
+      ]);
+
+    class TestIde extends FileSystemIde {
+      override async fileExists(fileUri: string): Promise<boolean> {
+        const filepath = fileUri.startsWith("file://")
+          ? fileURLToPath(fileUri)
+          : fileUri;
+        return fs.existsSync(filepath);
+      }
+    }
+
+    const ide = new TestIde(tempDir);
+    const handler = new ConfigHandler(
+      ide,
+      new LLMLogger(),
+      Promise.resolve(undefined),
+    );
+    await handler.isInitialized;
+
+    const personalAssistant = {
+      configResult: {
+        config: {
+          name: "Local LlamaCpp",
+          version: "1.0.0",
+        },
+        configLoadInterrupted: false,
+        errors: [],
+      },
+      iconUrl: "https://example.com/personal.png",
+      ownerSlug: "lemonade",
+      packageSlug: "llamacpp",
+      rawYaml: "name: Local LlamaCpp",
+    };
+    const orgAssistant = {
+      configResult: {
+        config: {
+          name: "Org Assistant",
+          version: "2.0.0",
+        },
+        configLoadInterrupted: false,
+        errors: [],
+      },
+      iconUrl: "https://example.com/org.png",
+      ownerSlug: "continuedev",
+      packageSlug: "team-assistant",
+      rawYaml: "name: Org Assistant",
+    };
+
+    let outage = false;
+    (handler as any).controlPlaneClient = {
+      getPolicy: vi.fn().mockResolvedValue(null),
+      isSignedIn: vi.fn().mockResolvedValue(true),
+      listOrganizations: vi.fn().mockImplementation(async () => {
+        if (outage) {
+          return null;
+        }
+
+        return [
+          {
+            iconUrl: "https://example.com/org.png",
+            id: "org-1",
+            name: "Org One",
+            slug: "org-one",
+          },
+        ];
+      }),
+      listAssistants: vi
+        .fn()
+        .mockImplementation(async (orgId: string | null) => {
+          if (outage) {
+            return null;
+          }
+
+          return orgId === null ? [personalAssistant] : [orgAssistant];
+        }),
+    };
+
+    const warm = await (handler as any).getOrgs();
+    expect(warm.errors ?? []).toHaveLength(0);
+
+    outage = true;
+
+    const fallback = await (handler as any).getOrgs();
+    expect(fallback.errors?.map((error: any) => error.message)).toContain(
+      "Continue Hub is unavailable. Using cached Hub assistants until the service recovers.",
+    );
+
+    const personalOrg = fallback.orgs.find((org: any) => org.id === "personal");
+    expect(
+      personalOrg?.profiles.some(
+        (profile: any) =>
+          profile.profileDescription.id === "lemonade/llamacpp" &&
+          profile.profileDescription.title === "Local LlamaCpp",
+      ),
+    ).toBe(true);
+
+    const org = fallback.orgs.find((entry: any) => entry.id === "org-1");
+    expect(
+      org?.profiles.some(
+        (profile: any) =>
+          profile.profileDescription.id === "continuedev/team-assistant" &&
+          profile.profileDescription.title === "Org Assistant",
+      ),
+    ).toBe(true);
+  });
+});

--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -9,7 +9,11 @@ import {
   IdeSettings,
   ILLMLogger,
 } from "../index.js";
-import { GlobalContext } from "../util/GlobalContext.js";
+import {
+  CachedHubAssistant,
+  CachedHubOrganization,
+  GlobalContext,
+} from "../util/GlobalContext.js";
 import { getConfigYamlPath } from "../util/paths.js";
 
 import EventEmitter from "node:events";
@@ -176,30 +180,71 @@ export class ConfigHandler {
     const isSignedIn = await this.controlPlaneClient.isSignedIn();
     if (isSignedIn) {
       try {
+        let usedCachedHubData = false;
+
         // TODO use policy returned with org, not policy endpoint
         const policyResponse = await this.controlPlaneClient.getPolicy();
         PolicySingleton.getInstance().policy = policyResponse;
+
+        const cachedHubOrganizations = this.getCachedHubOrganizations();
         const orgDescriptions =
           await this.controlPlaneClient.listOrganizations();
-        const orgsWithPolicy = orgDescriptions.map((d) => ({
-          ...d,
-          policy: policyResponse?.policy,
-        }));
+        const orgsWithPolicy = (orgDescriptions ?? cachedHubOrganizations)
+          .filter((org) => org.id !== this.PERSONAL_ORG_DESC.id)
+          .map((d) => ({
+            iconUrl: d.iconUrl,
+            id: d.id,
+            name: d.name,
+            slug: d.slug,
+            policy: policyResponse?.policy,
+          }));
+
+        if (orgDescriptions === null && cachedHubOrganizations.length > 0) {
+          usedCachedHubData = true;
+        }
 
         if (policyResponse?.policy?.allowOtherOrgs === false) {
           if (orgsWithPolicy.length === 0) {
             return { orgs: [] };
           } else {
             const firstOrg = await this.getNonPersonalHubOrg(orgsWithPolicy[0]);
-            return { orgs: [firstOrg] };
+            if (firstOrg.usedCache) {
+              usedCachedHubData = true;
+            }
+            if (usedCachedHubData) {
+              errors.push({
+                fatal: false,
+                message:
+                  "Continue Hub is unavailable. Using cached Hub assistants until the service recovers.",
+              });
+            }
+            return { orgs: [firstOrg.org], errors };
           }
         }
-        const orgs = await Promise.all([
-          this.getPersonalHubOrg(),
-          ...orgsWithPolicy.map((org) => this.getNonPersonalHubOrg(org)),
-        ]);
+
+        const personalOrg = await this.getPersonalHubOrg();
+        const nonPersonalOrgs = await Promise.all(
+          orgsWithPolicy.map((org) => this.getNonPersonalHubOrg(org)),
+        );
+        if (
+          personalOrg.usedCache ||
+          nonPersonalOrgs.some((org) => org.usedCache)
+        ) {
+          usedCachedHubData = true;
+        }
+        if (usedCachedHubData) {
+          errors.push({
+            fatal: false,
+            message:
+              "Continue Hub is unavailable. Using cached Hub assistants until the service recovers.",
+          });
+        }
+        const orgs = [
+          personalOrg.org,
+          ...nonPersonalOrgs.map((org) => org.org),
+        ];
         // TODO make try/catch more granular here, to catch specific org errors
-        return { orgs };
+        return { orgs, errors };
       } catch (e) {
         errors.push({
           fatal: false,
@@ -236,9 +281,21 @@ export class ConfigHandler {
     }));
   }
 
-  private async getHubProfiles(orgScopeId: string | null) {
-    const assistants = await this.controlPlaneClient.listAssistants(orgScopeId);
+  private getCachedHubOrganizations(): CachedHubOrganization[] {
+    return this.globalContext.get("cachedHubOrganizations") ?? [];
+  }
 
+  private updateCachedHubOrganization(org: CachedHubOrganization) {
+    const cached = this.getCachedHubOrganizations().filter(
+      (existing) => existing.id !== org.id,
+    );
+    this.globalContext.update("cachedHubOrganizations", [...cached, org]);
+  }
+
+  private async createPlatformProfiles(
+    assistants: CachedHubAssistant[],
+    orgScopeId: string | null,
+  ) {
     return await Promise.all(
       assistants.map(async (assistant) => {
         const profileLoader = await PlatformProfileLoader.create({
@@ -254,7 +311,7 @@ export class ConfigHandler {
           ide: this.ide,
           llmLogger: this.llmLogger,
           rawYaml: assistant.rawYaml,
-          orgScopeId: orgScopeId,
+          orgScopeId,
         });
 
         return new ProfileLifecycleManager(profileLoader, this.ide);
@@ -262,15 +319,50 @@ export class ConfigHandler {
     );
   }
 
+  private async loadHubProfiles(
+    orgScopeId: string | null,
+    org: OrganizationDescription,
+  ): Promise<{ profiles: ProfileLifecycleManager[]; usedCache: boolean }> {
+    const assistants = await this.controlPlaneClient.listAssistants(orgScopeId);
+    if (assistants !== null) {
+      this.updateCachedHubOrganization({
+        id: org.id,
+        iconUrl: org.iconUrl,
+        name: org.name,
+        slug: org.slug,
+        profiles: assistants,
+      });
+      return {
+        profiles: await this.createPlatformProfiles(assistants, orgScopeId),
+        usedCache: false,
+      };
+    }
+
+    const cachedProfiles =
+      this.getCachedHubOrganizations().find((entry) => entry.id === org.id)
+        ?.profiles ?? [];
+    return {
+      profiles: await this.createPlatformProfiles(cachedProfiles, orgScopeId),
+      usedCache: cachedProfiles.length > 0,
+    };
+  }
+
   private async getNonPersonalHubOrg(
     org: OrganizationDescription,
-  ): Promise<OrgWithProfiles> {
+  ): Promise<{ org: OrgWithProfiles; usedCache: boolean }> {
     const localProfiles = await this.getLocalProfiles({
       includeGlobal: false,
       includeWorkspace: true,
     });
-    const profiles = [...(await this.getHubProfiles(org.id)), ...localProfiles];
-    return this.rectifyProfilesForOrg(org, profiles);
+    const { profiles: hubProfiles, usedCache } = await this.loadHubProfiles(
+      org.id,
+      org,
+    );
+    const profiles = [...hubProfiles, ...localProfiles];
+    return {
+      org: await this.rectifyProfilesForOrg(org, profiles),
+      usedCache,
+    };
   }
 
   private PERSONAL_ORG_DESC: OrganizationDescription = {
@@ -279,14 +371,23 @@ export class ConfigHandler {
     name: "Personal",
     slug: undefined,
   };
-  private async getPersonalHubOrg() {
+  private async getPersonalHubOrg(): Promise<{
+    org: OrgWithProfiles;
+    usedCache: boolean;
+  }> {
     const localProfiles = await this.getLocalProfiles({
       includeGlobal: true,
       includeWorkspace: true,
     });
-    const hubProfiles = await this.getHubProfiles(null);
+    const { profiles: hubProfiles, usedCache } = await this.loadHubProfiles(
+      null,
+      this.PERSONAL_ORG_DESC,
+    );
     const profiles = [...hubProfiles, ...localProfiles];
-    return this.rectifyProfilesForOrg(this.PERSONAL_ORG_DESC, profiles);
+    return {
+      org: await this.rectifyProfilesForOrg(this.PERSONAL_ORG_DESC, profiles),
+      usedCache,
+    };
   }
 
   private async getLocalOrg() {

--- a/core/control-plane/client.ts
+++ b/core/control-plane/client.ts
@@ -170,16 +170,17 @@ export class ControlPlaneClient {
   }
 
   public async listAssistants(organizationId: string | null): Promise<
-    {
-      configResult: ConfigResult<AssistantUnrolled>;
-      ownerSlug: string;
-      packageSlug: string;
-      iconUrl: string;
-      rawYaml: string;
-    }[]
+    | {
+        configResult: ConfigResult<AssistantUnrolled>;
+        ownerSlug: string;
+        packageSlug: string;
+        iconUrl: string;
+        rawYaml: string;
+      }[]
+    | null
   > {
     if (!(await this.isSignedIn())) {
-      return [];
+      return null;
     }
 
     try {
@@ -197,11 +198,11 @@ export class ControlPlaneClient {
         context: "control_plane_list_assistants",
         organizationId,
       });
-      return [];
+      return null;
     }
   }
 
-  public async listOrganizations(): Promise<Array<OrganizationDescription>> {
+  public async listOrganizations(): Promise<Array<OrganizationDescription> | null> {
     if (!(await this.isSignedIn())) {
       return [];
     }
@@ -225,7 +226,7 @@ export class ControlPlaneClient {
           console.warn(
             `Failed to list organizations after ${maxRetries} retries: user not found`,
           );
-          return [];
+          return null;
         }
         const waitTime = Math.min(
           Math.pow(2, retries) * 100,
@@ -237,7 +238,7 @@ export class ControlPlaneClient {
         console.warn(
           `Failed to list organizations (${resp.status}): ${await resp.text()}`,
         );
-        return [];
+        return null;
       }
       const { organizations } = (await resp.json()) as any;
       return organizations;
@@ -247,7 +248,7 @@ export class ControlPlaneClient {
     console.warn(
       `Failed to list organizations after ${maxRetries} retries: maximum attempts exceeded`,
     );
-    return [];
+    return null;
   }
 
   public async listAssistantFullSlugs(

--- a/core/util/GlobalContext.ts
+++ b/core/util/GlobalContext.ts
@@ -1,6 +1,10 @@
 import fs from "node:fs";
 
-import { ModelRole } from "@continuedev/config-yaml";
+import {
+  AssistantUnrolled,
+  ConfigResult,
+  ModelRole,
+} from "@continuedev/config-yaml";
 import {
   OAuthClientInformationFull,
   OAuthTokens,
@@ -19,6 +23,22 @@ export type GlobalContextModelSelections = Partial<
   Record<ModelRole, string | null>
 >;
 
+export type CachedHubAssistant = {
+  configResult: ConfigResult<AssistantUnrolled>;
+  ownerSlug: string;
+  packageSlug: string;
+  iconUrl: string;
+  rawYaml: string;
+};
+
+export type CachedHubOrganization = {
+  id: string;
+  iconUrl: string;
+  name: string;
+  slug: string | undefined;
+  profiles: CachedHubAssistant[];
+};
+
 export type GlobalContextType = {
   indexingPaused: boolean;
   lastSelectedProfileForWorkspace: {
@@ -27,6 +47,7 @@ export type GlobalContextType = {
   lastSelectedOrgIdForWorkspace: {
     [workspaceIdentifier: string]: string | null;
   };
+  cachedHubOrganizations: CachedHubOrganization[];
   selectedModelsByProfileId: {
     [profileId: string]: GlobalContextModelSelections;
   };


### PR DESCRIPTION
## Summary
- cache successfully loaded Hub assistant metadata in global context so installed Hub profiles can be reconstructed without a live Hub response
- fall back to cached Hub organizations and assistant definitions when `listOrganizations` or `listAssistants` fails
- add a regression test that warms the cache, simulates a Hub outage, and verifies both personal and org-scoped Hub assistants remain available

## Why
Right now, if Continue Hub goes down, profiles installed from the Hub can disappear entirely even when they only target local backends like `llama.cpp` or LM Studio. That makes previously working local models fail with missing-profile and config-loading errors even though the model runtime itself is still healthy.

This change makes Hub-backed local profiles resilient to temporary Hub outages by reusing the last successfully loaded assistant definitions.

## Validation
- ran `npm run vitest -- config/ConfigHandler.hubCache.vitest.ts` in `core`

Closes #6893

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache Hub organizations and assistant definitions and use them when the Hub is down, so installed Hub-backed profiles stay available and local models keep working during outages.

- **New Features**
  - Store loaded Hub data in global context as `cachedHubOrganizations` with `CachedHubOrganization`/`CachedHubAssistant` types.
  - Fallback to cached orgs and assistants when `listOrganizations`/`listAssistants` return `null`, and surface a non-fatal warning.
  - Regression test warms the cache, simulates a Hub outage, and verifies personal and org-scoped assistants remain available.

- **Refactors**
  - `ControlPlaneClient.listOrganizations` and `listAssistants` now return `null` on failure (instead of empty arrays) to signal outages; `ConfigHandler` handles this and builds profiles via cached data.

<sup>Written for commit 5c7b87325d8dfe8abe3ffd6653d398284467ccc7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

