### PR TITLE
fix: downgrade console.error to console.debug in DocumentHistoryTracker.push()

### DIFF
--- a/core/nextEdit/DocumentHistoryTracker.ts
+++ b/core/nextEdit/DocumentHistoryTracker.ts
@@ -61,7 +61,7 @@ export class DocumentHistoryTracker {
     const documentHistory = this.documentContentHistoryMap.get(documentPath);
 
     if (!astHistory || !documentHistory) {
-      console.error(`Document ${documentPath} not found in AST tracker`);
+      console.debug(`Document ${documentPath} not found in AST tracker, adding it`);
       this.addDocument(documentPath, documentContent, ast);
       return; // Early return - document was added with initial state
     }


### PR DESCRIPTION
Fixes #11919

## Problem

Every time a user switches between text editors, `onDidChangeVisibleTextEditors` fires, which calls `deleteChain()`, which calls `DocumentHistoryTracker.push()` for the previously active file.

Because `onDidOpenTextDocument` is currently disabled (pending merge of a related PR), documents are never pre-registered via `addDocument()`. So `push()` always hits its fallback branch and logs:

```
ERR [Extension Host] Document <path> not found in AST tracker
```

This error appears on **every editor switch**, flooding the Extension Host output with misleading noise.

## Solution

The `push()` fallback already handles the missing-document case correctly by calling `addDocument()` — no data is lost and no functionality is broken. The `console.error` is therefore misleading. This PR downgrades it to `console.debug` (with a slightly more descriptive message) so the event remains visible for debugging without polluting the Extension Host console for normal users.

## Testing

- Open two files in VS Code with the Continue extension active
- Switch back and forth between editors
- Verify that the "Document not found in AST tracker" error no longer appears in the Extension Host output
- Next-edit / autocomplete functionality is unaffected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Downgraded console.error to console.debug in DocumentHistoryTracker.push() to stop noisy “Document not found in AST tracker” messages on editor switches. Behavior is unchanged (missing documents are still auto-added), logs stay useful for debugging, and this resolves #11919.

<sup>Written for commit 38334b1a2c1125e1cc3284996ff874f5b5b1aa4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

