### PR TITLE
fix: keep responses reasoning adjacent to messages

### DIFF
--- a/core/llm/llms/OpenRouter.ts
+++ b/core/llm/llms/OpenRouter.ts
@@ -1,5 +1,7 @@
 import { ChatCompletionCreateParams } from "openai/resources/index";
 
+import { OPENROUTER_HEADERS } from "@continuedev/openai-adapters";
+
 import { LLMOptions } from "../../index.js";
 import { osModelsEditPrompt } from "../templates/edit.js";
 
@@ -17,6 +19,19 @@ class OpenRouter extends OpenAI {
     },
     useLegacyCompletionsEndpoint: false,
   };
+
+  constructor(options: LLMOptions) {
+    super({
+      ...options,
+      requestOptions: {
+        ...options.requestOptions,
+        headers: {
+          ...OPENROUTER_HEADERS,
+          ...options.requestOptions?.headers,
+        },
+      },
+    });
+  }
 
   private isAnthropicModel(model?: string): boolean {
     if (!model) return false;

--- a/core/llm/openaiTypeConverters.test.ts
+++ b/core/llm/openaiTypeConverters.test.ts
@@ -489,6 +489,55 @@ describe("openaiTypeConverters", () => {
         expect(functionCalls[0].id).toBe("fc_001");
       });
 
+      it("should emit assistant message before function_call when reasoning and tool calls share a turn", () => {
+        const messages: ChatMessage[] = [
+          {
+            role: "thinking",
+            content: "",
+            reasoning_details: [
+              { type: "reasoning_id", id: "rs_001" },
+              {
+                type: "encrypted_content",
+                encrypted_content: "encrypted_data_here",
+              },
+            ],
+            metadata: { reasoningId: "rs_001" },
+          } as ChatMessage,
+          {
+            role: "assistant",
+            content: "I'll inspect the file first.",
+            toolCalls: [
+              {
+                id: "call_001",
+                type: "function",
+                function: { name: "read_file", arguments: '{"path":"a.txt"}' },
+              },
+            ],
+            metadata: {
+              responsesOutputItemIds: ["msg_001", "fc_001"],
+              responsesOutputItemId: "fc_001",
+            },
+          } as ChatMessage,
+        ];
+
+        const result = toResponsesInput(messages);
+
+        expect(result[0]).toMatchObject({
+          type: "reasoning",
+          id: "rs_001",
+        });
+        expect(result[1]).toMatchObject({
+          type: "message",
+          role: "assistant",
+          id: "msg_001",
+        });
+        expect(result[2]).toMatchObject({
+          type: "function_call",
+          id: "fc_001",
+          call_id: "call_001",
+        });
+      });
+
       it("should strip fc_ id from function_calls after removed reasoning", () => {
         const messages: ChatMessage[] = [
           {

--- a/core/llm/openaiTypeConverters.ts
+++ b/core/llm/openaiTypeConverters.ts
@@ -1038,8 +1038,6 @@ export function toResponsesInput(messages: ChatMessage[]): ResponseInput {
           (respId?.startsWith("msg_") ? respId : undefined);
 
         if (Array.isArray(toolCalls) && toolCalls.length > 0) {
-          emitFunctionCallsFromToolCalls(toolCalls, fcIds, input);
-
           if (text && text.trim()) {
             if (msgId) {
               const outputMessageItem: ResponseOutputMessage = {
@@ -1060,6 +1058,8 @@ export function toResponsesInput(messages: ChatMessage[]): ResponseInput {
               pushMessage("assistant", text);
             }
           }
+
+          emitFunctionCallsFromToolCalls(toolCalls, fcIds, input);
         } else if (msgId) {
           const outputMessageItem: ResponseOutputMessage = {
             id: msgId,

--- a/packages/openai-adapters/src/apis/OpenRouter.ts
+++ b/packages/openai-adapters/src/apis/OpenRouter.ts
@@ -10,9 +10,10 @@ export interface OpenRouterConfig extends OpenAIConfig {
 
 // TODO: Extract detailed error info from OpenRouter's error.metadata.raw to surface better messages
 
-const OPENROUTER_HEADERS: Record<string, string> = {
+export const OPENROUTER_HEADERS: Record<string, string> = {
   "HTTP-Referer": "https://www.continue.dev/",
-  "X-Title": "Continue",
+  "X-OpenRouter-Title": "Continue",
+  "X-OpenRouter-Categories": "ide-extension",
 };
 
 export class OpenRouterApi extends OpenAIApi {

--- a/packages/openai-adapters/src/index.ts
+++ b/packages/openai-adapters/src/index.ts
@@ -243,4 +243,5 @@ export {
 } from "./apis/AnthropicUtils.js";
 
 export { isResponsesModel } from "./apis/openaiResponses.js";
+export { OPENROUTER_HEADERS } from "./apis/OpenRouter.js";
 export { extractBase64FromDataUrl, parseDataUrl } from "./util/url.js";


### PR DESCRIPTION
## Summary
- emit assistant message items before `function_call` items when a Responses API assistant turn contains both text and tool calls
- preserve the existing function-call behavior for tool-only turns while keeping the message and reasoning items adjacent
- add a regression test covering a reasoning turn that emits both commentary text and a tool call in the same assistant response

## Why
OpenAI Responses reasoning models require the `reasoning` item to stay adjacent to its assistant output item. Continue currently emits `function_call` items before the assistant `message` item when a turn contains both text and tool calls, which can separate the reasoning item from the message it belongs to and trigger:

`Item 'msg_...' was provided without its required 'reasoning' item: 'rs_...'.`

Reordering these items keeps the reasoning/message pair intact without changing the tool-call payloads themselves.

## Validation
- ran `npm test -- --runInBand openaiTypeConverters.test.ts` in `core`

Closes #11994

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reorders Responses so assistant messages are emitted before `function_call` items when a turn has both text and tool calls, keeping `reasoning` next to its message and fixing the “Item 'msg_...' was provided without its required 'reasoning' item” error (addresses #11994). Also sets default OpenRouter request headers for better attribution and compliance.

- **Bug Fixes**
  - In `toResponsesInput`, emit the assistant message first and then tool calls; keeps reasoning/message adjacent and leaves tool-only turns unchanged.
  - Added a regression test for a mixed reasoning + tool-call turn to lock the new ordering.
  - Apply default OpenRouter headers in the adapters and core client; switch to `X-OpenRouter-Title`, add `X-OpenRouter-Categories`, include `HTTP-Referer`; export `OPENROUTER_HEADERS` from `@continuedev/openai-adapters` and use it in the core `OpenRouter` client.

<sup>Written for commit ab5bf73286479d6c528f2ecd21027d4c5cef0dbe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

