### PR TITLE
[codex] feat(vscode): persist prompt logs

### DIFF
--- a/extensions/vscode/src/extension/VsCodeExtension.ts
+++ b/extensions/vscode/src/extension/VsCodeExtension.ts
@@ -42,6 +42,7 @@ import { VsCodeIdeUtils } from "../util/ideUtils";
 import { VsCodeIde } from "../VsCodeIde";
 
 import { ConfigYamlDocumentLinkProvider } from "./ConfigYamlDocumentLinkProvider";
+import { setupPromptLogging } from "./setupPromptLogging";
 import { VsCodeMessenger } from "./VsCodeMessenger";
 
 import { modelSupportsNextEdit } from "core/llm/autodetect";
@@ -292,6 +293,7 @@ export class VsCodeExtension {
     );
 
     this.core = new Core(inProcessMessenger, this.ide);
+    context.subscriptions.push(setupPromptLogging(this.core.llmLogger));
     this.configHandler = this.core.configHandler;
     resolveConfigHandler?.(this.configHandler);
 

--- a/extensions/vscode/src/extension/setupPromptLogging.ts
+++ b/extensions/vscode/src/extension/setupPromptLogging.ts
@@ -1,0 +1,18 @@
+import fs from "node:fs";
+
+import { LLMLogger } from "core/llm/logger";
+import { LLMLogFormatter } from "core/llm/logFormatter";
+import { getPromptLogsPath } from "core/util/paths";
+
+export function setupPromptLogging(llmLogger: LLMLogger) {
+  const promptLogsPath = getPromptLogsPath();
+  const output = fs.createWriteStream(promptLogsPath);
+
+  new LLMLogFormatter(llmLogger, output);
+
+  return {
+    dispose() {
+      output.end();
+    },
+  };
+}

--- a/extensions/vscode/src/extension/setupPromptLogging.vitest.ts
+++ b/extensions/vscode/src/extension/setupPromptLogging.vitest.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockCreateWriteStream,
+  mockEnd,
+  mockGetPromptLogsPath,
+  mockLLMLogFormatter,
+} = vi.hoisted(() => ({
+  mockEnd: vi.fn(),
+  mockCreateWriteStream: vi.fn(() => ({
+    end: vi.fn(),
+  })),
+  mockGetPromptLogsPath: vi.fn(() => "/tmp/prompt.log"),
+  mockLLMLogFormatter: vi.fn(),
+}));
+
+mockCreateWriteStream.mockImplementation(() => ({
+  end: mockEnd,
+}));
+
+vi.mock("node:fs", () => ({
+  __esModule: true,
+  default: {
+    createWriteStream: mockCreateWriteStream,
+  },
+}));
+
+vi.mock("core/util/paths", () => ({
+  getPromptLogsPath: mockGetPromptLogsPath,
+}));
+
+vi.mock("core/llm/logFormatter", () => ({
+  LLMLogFormatter: mockLLMLogFormatter,
+}));
+
+import { setupPromptLogging } from "./setupPromptLogging";
+
+describe("setupPromptLogging", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    mockCreateWriteStream.mockImplementation(() => ({
+      end: mockEnd,
+    }));
+  });
+
+  it("creates a prompt log stream and closes it on dispose", () => {
+    const llmLogger = {} as any;
+
+    const disposable = setupPromptLogging(llmLogger);
+
+    expect(mockGetPromptLogsPath).toHaveBeenCalledTimes(1);
+    expect(mockCreateWriteStream).toHaveBeenCalledWith("/tmp/prompt.log");
+    expect(mockLLMLogFormatter).toHaveBeenCalledWith(
+      llmLogger,
+      expect.objectContaining({ end: mockEnd }),
+    );
+
+    disposable.dispose();
+
+    expect(mockEnd).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add a VS Code prompt logging helper that writes `core.llmLogger` output to `~/.continue/logs/prompt.log`
- register the helper during `VsCodeExtension` activation and dispose the write stream when the extension unloads
- add a regression test covering prompt log stream creation and cleanup

## Why
The binary entrypoint already persists prompt logs to disk, but the VS Code extension runs core in-process and never wired `LLMLogFormatter` to a file stream. That meant users running Continue only through the VS Code extension had no file-based `prompt.log` output for debugging model inputs and outputs.

## Validation
- ran `npm test -- src/extension/setupPromptLogging.vitest.ts` in `extensions/vscode`
- ran `git diff --check`
- attempted `npm run tsc:check` in `extensions/vscode`, but it still fails on existing unrelated repo issues (`core/llm/llms/OpenRouter.ts` export mismatch and missing generated `src/.buildTimestamp`)

Closes #11669

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist prompt logs in the VS Code extension by writing `core.llmLogger` output to `~/.continue/logs/prompt.log`. Matches Linear 11669 to give extension users the same file-based prompt debugging as the binary.

- **New Features**
  - Add `setupPromptLogging` to pipe `llmLogger` through `LLMLogFormatter` to `~/.continue/logs/prompt.log`.
  - Register in `VsCodeExtension` activation and dispose the stream on unload; includes a test for stream creation and cleanup.

<sup>Written for commit ce6d8f5224349166efeb269e1741dff747466486. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

