### PR TITLE
[codex] fix(gui): respect model reasoning disablement

### DIFF
--- a/gui/src/redux/thunks/streamNormalInput.ts
+++ b/gui/src/redux/thunks/streamNormalInput.ts
@@ -50,6 +50,10 @@ function buildReasoningCompletionOptions(
   hasReasoningEnabled: boolean | undefined,
   model: ModelDescription,
 ): LLMFullCompletionOptions {
+  if (model.completionOptions?.reasoning === false) {
+    return baseOptions;
+  }
+
   if (hasReasoningEnabled === undefined) {
     return baseOptions;
   }

--- a/gui/src/redux/thunks/streamResponse.test.ts
+++ b/gui/src/redux/thunks/streamResponse.test.ts
@@ -476,6 +476,94 @@ describe("streamResponseThunk", () => {
     });
   });
 
+  it("should preserve model-level reasoning disablement in chat requests", async () => {
+    const initialState = getRootStateWithClaude();
+    initialState.config.config.selectedModelByRole.chat = {
+      title: "Qwen 3 30B",
+      model: "qwen3:30b",
+      provider: "ollama",
+      underlyingProviderName: "ollama",
+      completionOptions: { reasoning: false },
+    };
+    initialState.session.hasReasoningEnabled = true;
+    initialState.session.history = [
+      {
+        message: { id: "1", role: "user", content: "Hello" },
+        contextItems: [],
+      },
+    ];
+
+    const mockStore = createMockStore(initialState);
+    const mockIdeMessenger = mockStore.mockIdeMessenger;
+    const requestSpy = vi.spyOn(mockIdeMessenger, "request");
+
+    mockIdeMessenger.responses["llm/compileChat"] = {
+      compiledChatMessages: [{ role: "user", content: "Hello" }],
+      didPrune: false,
+      contextPercentage: 0.8,
+    };
+
+    async function* mockStreamGenerator(): AsyncGenerator<
+      AssistantChatMessage[],
+      PromptLog
+    > {
+      yield [{ role: "assistant", content: "First chunk" }];
+      return {
+        prompt: "Hello",
+        completion: "Hi there!",
+        modelProvider: "ollama",
+        modelTitle: "Qwen 3 30B",
+      };
+    }
+
+    mockIdeMessenger.llmStreamChat = vi
+      .fn()
+      .mockReturnValue(mockStreamGenerator());
+
+    await mockStore.dispatch(
+      streamResponseThunk({
+        editorState: mockEditorState,
+        modifiers: mockModifiers,
+      }) as any,
+    );
+
+    expect(requestSpy).toHaveBeenCalledWith("llm/compileChat", {
+      messages: [
+        {
+          role: "system",
+          content: "You are a helpful assistant.",
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "Hello",
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "Hello, please help me with this code",
+            },
+          ],
+        },
+      ],
+      options: {},
+    });
+
+    expect(mockIdeMessenger.llmStreamChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        completionOptions: {},
+        title: "Qwen 3 30B",
+      }),
+      expect.any(AbortSignal),
+    );
+  });
+
   it("should execute streaming flow with tool call execution", async () => {
     // Set up auto-approved tool setting for our test tool
     const stateWithToolSettings = getRootStateWithClaude();


### PR DESCRIPTION
## Summary
- stop `streamNormalInput` from overriding chat models that explicitly set `completionOptions.reasoning = false`
- keep the existing session-level reasoning toggle behavior for models that do allow reasoning overrides
- add a GUI regression test that verifies chat requests do not send a forced `reasoning` flag for an Ollama model with reasoning disabled

## Why
`streamNormalInput` always wrote `completionOptions.reasoning` from the session toggle whenever `hasReasoningEnabled` was set. That worked for most providers, but it broke Ollama chat models that explicitly disable reasoning in config, because the GUI would still send `reasoning: true` and Ollama would reject the request with errors like `does not support thinking`.

## Validation
- ran `./node_modules/.bin/vitest run src/redux/thunks/streamResponse.test.ts` in `gui`
- ran `git diff --check`
- ran `./node_modules/.bin/tsc -p ./ --noEmit` in `gui` and only hit the existing unrelated `OPENROUTER_HEADERS` export mismatch from `../core/llm/llms/OpenRouter.ts`

Closes #11265

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect model-level reasoning disablement in chat requests. Ollama models with `completionOptions.reasoning: false` no longer receive a forced `reasoning` flag; the session toggle still applies to models that allow overrides.

- **Bug Fixes**
  - Short-circuit reasoning options when the model sets `completionOptions.reasoning === false` to avoid Ollama “does not support thinking” errors.
  - Add a GUI regression test to verify chat requests omit `reasoning` for disabled Ollama models.

<sup>Written for commit 85f7d1f5df4048113d516f6f357b58d43a5af248. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

