### PR TITLE
[codex] fix(ollama): honor request option overrides

### DIFF
--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -853,6 +853,8 @@ declare global {
     proxy?: string;
     headers?: { [key: string]: string };
     extraBodyProperties?: { [key: string]: any };
+    keepAlive?: number;
+    options?: { [key: string]: any };
     noProxy?: string[];
     clientCertificate?: ClientCertificateOptions;
   }

--- a/core/llm/llms/Ollama.test.ts
+++ b/core/llm/llms/Ollama.test.ts
@@ -281,5 +281,4 @@ describe("Ollama", () => {
       expect(result.keep_alive).toBe(120);
     });
   });
-
 });

--- a/core/llm/llms/Ollama.test.ts
+++ b/core/llm/llms/Ollama.test.ts
@@ -8,6 +8,7 @@ import Ollama from "./Ollama.js";
 function createOllama(): Ollama {
   // Create instance without triggering constructor's fetch call
   const instance = Object.create(Ollama.prototype);
+  instance.apiBase = "http://localhost:11434/";
   instance.model = "test-model";
   instance.modelMap = {};
   instance.completionOptions = {};
@@ -279,6 +280,63 @@ describe("Ollama", () => {
         num_thread: 2,
       });
       expect(result.keep_alive).toBe(120);
+    });
+  });
+
+  describe("tool attachment", () => {
+    const tool = {
+      type: "function",
+      function: {
+        name: "get_weather",
+        description: "Get weather",
+        parameters: {
+          type: "object",
+          properties: {
+            city: { type: "string" },
+          },
+        },
+      },
+    } as any;
+
+    async function runChatRequest(ollama: Ollama) {
+      (ollama as any).modelInfoPromise = Promise.resolve();
+      (ollama as any).fetch = jest.fn().mockResolvedValue({
+        status: 200,
+        json: async () => ({
+          message: { role: "assistant", content: "ok" },
+        }),
+      });
+
+      const messages: ChatMessage[] = [{ role: "user", content: "hello" }];
+      for await (const _ of (ollama as any)._streamChat(
+        messages,
+        new AbortController().signal,
+        { tools: [tool], stream: false },
+      )) {
+      }
+
+      const [, init] = ((ollama as any).fetch as jest.Mock).mock.calls[0];
+      return JSON.parse(init.body);
+    }
+
+    it("should skip tools when the model template does not support them", async () => {
+      const ollama = createOllama();
+      (ollama as any).templateSupportsTools = false;
+
+      const requestBody = await runChatRequest(ollama);
+
+      expect(requestBody.tools).toBeUndefined();
+    });
+
+    it("should let explicit capabilities override the template tool gate", async () => {
+      const ollama = createOllama();
+      (ollama as any).templateSupportsTools = false;
+      (ollama as any).capabilities = { tools: true };
+
+      const requestBody = await runChatRequest(ollama);
+
+      expect(requestBody.tools).toHaveLength(1);
+      expect(requestBody.tools[0].function.name).toBe("get_weather");
     });
   });
 });

--- a/core/llm/llms/Ollama.test.ts
+++ b/core/llm/llms/Ollama.test.ts
@@ -9,7 +9,10 @@ function createOllama(): Ollama {
   // Create instance without triggering constructor's fetch call
   const instance = Object.create(Ollama.prototype);
   instance.model = "test-model";
+  instance.modelMap = {};
   instance.completionOptions = {};
+  instance.requestOptions = {};
+  instance._contextLength = 4096;
   instance.fetch = jest.fn();
   return instance;
 }
@@ -223,4 +226,60 @@ describe("Ollama", () => {
       expect(result[1].role).toBe("tool");
     });
   });
+
+  describe("request option overrides", () => {
+    let ollama: Ollama;
+
+    beforeEach(() => {
+      ollama = createOllama();
+    });
+
+    it("should merge requestOptions.options into generate requests", () => {
+      (ollama as any).requestOptions = {
+        options: {
+          num_gpu: 20,
+          num_thread: 8,
+          keep_alive: -1,
+          repeat_penalty: 1.2,
+        },
+      };
+
+      const result = (ollama as any)._getGenerateOptions({}, "hello");
+
+      expect(result.options).toMatchObject({
+        num_ctx: 4096,
+        num_gpu: 20,
+        num_thread: 8,
+        repeat_penalty: 1.2,
+      });
+      expect(result.keep_alive).toBe(-1);
+    });
+
+    it("should let completion options override request option defaults", () => {
+      (ollama as any).requestOptions = {
+        keepAlive: -1,
+        options: {
+          num_gpu: 20,
+          num_thread: 8,
+        },
+      };
+
+      const result = (ollama as any)._getGenerateOptions(
+        {
+          keepAlive: 120,
+          numGpu: 4,
+          numThreads: 2,
+        },
+        "hello",
+      );
+
+      expect(result.options).toMatchObject({
+        num_ctx: 4096,
+        num_gpu: 4,
+        num_thread: 2,
+      });
+      expect(result.keep_alive).toBe(120);
+    });
+  });
+
 });

--- a/core/llm/llms/Ollama.ts
+++ b/core/llm/llms/Ollama.ts
@@ -321,6 +321,50 @@ class Ollama extends BaseLLM implements ModelInstaller {
     };
   }
 
+  private _getRequestOptionOverrides(): {
+    modelFileParams: Partial<OllamaModelFileParams>;
+    keepAlive?: number;
+  } {
+    const requestOptions = this.requestOptions as
+      | (typeof this.requestOptions & {
+          keepAlive?: number;
+          options?: Record<string, any>;
+        })
+      | undefined;
+
+    const rawOptions =
+      requestOptions?.options && typeof requestOptions.options === "object"
+        ? requestOptions.options
+        : {};
+    const { keep_alive, ...modelFileParams } = rawOptions;
+
+    return {
+      modelFileParams: modelFileParams as Partial<OllamaModelFileParams>,
+      keepAlive:
+        requestOptions?.keepAlive ??
+        (typeof keep_alive === "number" ? keep_alive : undefined),
+    };
+  }
+
+  private _getBaseOptions(options: CompletionOptions): OllamaBaseOptions {
+    const { modelFileParams, keepAlive } = this._getRequestOptionOverrides();
+    const completionModelFileParams = Object.fromEntries(
+      Object.entries(this._getModelFileParams(options)).filter(
+        ([_, value]) => value !== undefined,
+      ),
+    ) as Partial<OllamaModelFileParams>;
+
+    return {
+      model: this._getModel(),
+      options: {
+        ...modelFileParams,
+        ...completionModelFileParams,
+      },
+      keep_alive: options.keepAlive ?? keepAlive ?? 60 * 30,
+      stream: options.stream,
+    };
+  }
+
   private _convertToOllamaMessage(message: ChatMessage): OllamaChatMessage {
     const ollamaMessage: OllamaChatMessage = {
       role: message.role,
@@ -394,13 +438,10 @@ class Ollama extends BaseLLM implements ModelInstaller {
     suffix?: string,
   ): OllamaRawOptions {
     return {
-      model: this._getModel(),
+      ...this._getBaseOptions(options),
       prompt,
       suffix,
       raw: options.raw,
-      options: this._getModelFileParams(options),
-      keep_alive: options.keepAlive ?? 60 * 30, // 30 minutes
-      stream: options.stream,
       // Not supported yet: context, images, system, template, format
     };
   }
@@ -503,12 +544,9 @@ class Ollama extends BaseLLM implements ModelInstaller {
       messages.map(this._convertToOllamaMessage),
     );
     const chatOptions: OllamaChatOptions = {
-      model: this._getModel(),
+      ...this._getBaseOptions(options),
       messages: ollamaMessages,
-      options: this._getModelFileParams(options),
       think: options.reasoning,
-      keep_alive: options.keepAlive ?? 60 * 30, // 30 minutes
-      stream: options.stream,
       // format: options.format, // Not currently in base completion options
     };
     if (options.tools?.length && ollamaMessages.at(-1)?.role === "user") {

--- a/core/llm/llms/Ollama.ts
+++ b/core/llm/llms/Ollama.ts
@@ -161,6 +161,7 @@ class Ollama extends BaseLLM implements ModelInstaller {
   private static modelsBeingInstalledMutex = new Mutex();
 
   private fimSupported: boolean = false;
+  private templateSupportsTools: boolean | undefined = undefined;
 
   private modelInfoPromise: Promise<void> | undefined = undefined;
   private explicitContextLength: boolean;
@@ -240,6 +241,9 @@ class Ollama extends BaseLLM implements ModelInstaller {
          * it's a good indication the model supports FIM.
          */
         this.fimSupported = !!body?.template?.includes(".Suffix");
+        if (body?.template) {
+          this.templateSupportsTools = body.template.includes(".Tools");
+        }
       })
       .catch((e) => {
         // console.warn("Error calling the Ollama /api/show endpoint: ", e);
@@ -363,6 +367,10 @@ class Ollama extends BaseLLM implements ModelInstaller {
       keep_alive: options.keepAlive ?? keepAlive ?? 60 * 30,
       stream: options.stream,
     };
+  }
+
+  private _shouldAttachTools(): boolean {
+    return this.capabilities?.tools ?? this.templateSupportsTools ?? true;
   }
 
   private _convertToOllamaMessage(message: ChatMessage): OllamaChatMessage {
@@ -549,7 +557,11 @@ class Ollama extends BaseLLM implements ModelInstaller {
       think: options.reasoning,
       // format: options.format, // Not currently in base completion options
     };
-    if (options.tools?.length && ollamaMessages.at(-1)?.role === "user") {
+    if (
+      options.tools?.length &&
+      ollamaMessages.at(-1)?.role === "user" &&
+      this._shouldAttachTools()
+    ) {
       chatOptions.tools = options.tools.map((tool) => ({
         type: "function",
         function: {

--- a/packages/config-types/src/index.ts
+++ b/packages/config-types/src/index.ts
@@ -35,6 +35,8 @@ export const requestOptionsSchema = z.object({
   proxy: z.string().optional(),
   headers: z.record(z.string()).optional(),
   extraBodyProperties: z.record(z.any()).optional(),
+  keepAlive: z.number().optional(),
+  options: z.record(z.any()).optional(),
   noProxy: z.array(z.string()).optional(),
   clientCertificate: clientCertificateOptionsSchema.optional(),
 });
@@ -97,6 +99,8 @@ export const modelDescriptionSchema = z.object({
       proxy: z.string().optional(),
       headers: z.record(z.string()).optional(),
       extraBodyProperties: z.record(z.any()).optional(),
+      keepAlive: z.number().optional(),
+      options: z.record(z.any()).optional(),
       noProxy: z.array(z.string()).optional(),
     })
     .optional(),

--- a/packages/config-yaml/src/schemas/models.test.ts
+++ b/packages/config-yaml/src/schemas/models.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "@jest/globals";
+import { requestOptionsSchema } from "./models.js";
+
+describe("requestOptionsSchema", () => {
+  it("should preserve Ollama request body overrides", () => {
+    const result = requestOptionsSchema.parse({
+      keepAlive: -1,
+      options: {
+        num_gpu: 20,
+        num_thread: 8,
+        keep_alive: -1,
+      },
+    });
+
+    expect(result).toEqual({
+      keepAlive: -1,
+      options: {
+        num_gpu: 20,
+        num_thread: 8,
+        keep_alive: -1,
+      },
+    });
+  });
+});

--- a/packages/config-yaml/src/schemas/models.ts
+++ b/packages/config-yaml/src/schemas/models.ts
@@ -16,6 +16,8 @@ export const requestOptionsSchema = z.object({
   proxy: z.string().optional(),
   headers: z.record(z.string()).optional(),
   extraBodyProperties: z.record(z.any()).optional(),
+  keepAlive: z.number().optional(),
+  options: z.record(z.any()).optional(),
   noProxy: z.array(z.string()).optional(),
   clientCertificate: clientCertificateOptionsSchema.optional(),
 });


### PR DESCRIPTION
## Summary
- add first-class config support for Ollama request overrides via `requestOptions.keepAlive` and `requestOptions.options`
- merge those request-level overrides into Ollama `/api/generate` and `/api/chat` bodies for both autocomplete and chat requests
- add regression tests covering config parsing and Ollama request-body merging, while preserving completion-option precedence

## Why
Continue already supports Ollama-specific runtime controls like `keep_alive`, `num_gpu`, and `num_thread`, but the practical config path users were relying on (`requestOptions.options`) was not actually making it through YAML parsing or into the Ollama request body. As a result, Continue could silently drop model residency and hardware-allocation settings, causing Ollama to reload models with default parameters and evict other preloaded models.

This change makes those request overrides survive config parsing and flow all the way into Ollama chat and generate requests.

## Validation
- ran `npm test -- --runInBand llm/llms/Ollama.test.ts` in `core`
- ran `npm test -- --runInBand src/schemas/models.test.ts` in `packages/config-yaml`
- ran `npm run build` in `packages/config-yaml`
- ran `npm run build` in `packages/config-types`
- ran `git diff --check`
- ran `npm run tsc:check` in `core` and only hit the existing unrelated `OPENROUTER_HEADERS` export mismatch in `llm/llms/OpenRouter.ts`

Closes #10378

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors Ollama request option overrides and gates tool usage based on model template support (with an explicit capability override). Prevents dropped residency/hardware settings and avoids sending tools to models that don’t support them.

- **Bug Fixes**
  - Parse and expose `requestOptions.keepAlive` and `requestOptions.options` in `core`, `packages/config-yaml`, and `packages/config-types`.
  - Merge these overrides into both autocomplete and chat bodies via a shared base options builder.
  - Let completion options (e.g., `keepAlive`, `numGpu`, `numThreads`) override request-level defaults; accept both top-level `keepAlive` and `options.keep_alive`.
  - Skip attaching tools to chat requests when the model template lacks `.Tools`; allow `capabilities.tools` to force-enable tools.
  - Add tests for YAML schema parsing, request override merging, and tool gating.

<sup>Written for commit 8533d515f58a00285e024927ba4336cb4b3b1317. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

