### PR TITLE
[codex] fix(skills): load symlinked markdown skills

### DIFF
--- a/core/config/markdown/loadMarkdownSkills.ts
+++ b/core/config/markdown/loadMarkdownSkills.ts
@@ -3,12 +3,12 @@ import {
   parseMarkdownRule,
 } from "@continuedev/config-yaml";
 import z from "zod";
-import { IDE, Skill } from "../..";
+import type { IDE, Skill } from "../..";
 import { walkDir } from "../../indexing/walkDir";
-import { localPathToUri } from "../../util/pathToUri";
 import { getGlobalFolderWithName } from "../../util/paths";
+import { localPathToUri } from "../../util/pathToUri";
 import { findUriInDirs, joinPathsToUri } from "../../util/uri";
-import { getAllDotContinueDefinitionFiles } from "../loadLocalAssistants";
+import { getDotContinueSubDirs } from "../loadLocalAssistants";
 
 const skillFrontmatterSchema = z.object({
   name: z.string().min(1),
@@ -16,6 +16,34 @@ const skillFrontmatterSchema = z.object({
 });
 
 const SKILLS_DIR = "skills";
+const DIRECTORY_FILE_TYPE = 2;
+const SYMBOLIC_LINK_FILE_TYPE = 64;
+
+async function getSkillFilesFromDir(dir: string, ide: IDE): Promise<string[]> {
+  const exists = await ide.fileExists(dir);
+  if (!exists) {
+    return [];
+  }
+
+  const entries = await ide.listDir(dir);
+  return (
+    await Promise.all(
+      entries.map(async ([name, type]) => {
+        if (type !== DIRECTORY_FILE_TYPE && type !== SYMBOLIC_LINK_FILE_TYPE) {
+          return null;
+        }
+
+        const skillDirUri = joinPathsToUri(dir, name);
+        const skillFileUri = joinPathsToUri(skillDirUri, "SKILL.md");
+        return (await ide.fileExists(skillFileUri)) ? skillFileUri : null;
+      }),
+    )
+  ).filter((skillFileUri): skillFileUri is string => Boolean(skillFileUri));
+}
+
+async function getSkillFilesFromDirs(dirs: string[], ide: IDE): Promise<string[]> {
+  return (await Promise.all(dirs.map((dir) => getSkillFilesFromDir(dir, ide)))).flat();
+}
 
 /**
  * Get skills from .claude/skills directory
@@ -27,19 +55,7 @@ async function getClaudeSkillsDir(ide: IDE) {
 
   fullDirs.push(localPathToUri(getGlobalFolderWithName(SKILLS_DIR)));
 
-  return (
-    await Promise.all(
-      fullDirs.map(async (dir) => {
-        const exists = await ide.fileExists(dir);
-        if (!exists) return [];
-        const uris = await walkDir(dir, ide, {
-          source: "get .claude skills files",
-        });
-        // filter markdown files only
-        return uris.filter((uri) => uri.endsWith(".md"));
-      }),
-    )
-  ).flat();
+  return getSkillFilesFromDirs(fullDirs, ide);
 }
 
 export async function loadMarkdownSkills(ide: IDE) {
@@ -47,18 +63,21 @@ export async function loadMarkdownSkills(ide: IDE) {
   const skills: Skill[] = [];
 
   try {
+    const workspaceDirs = await ide.getWorkspaceDirs();
     const yamlAndMarkdownFileUris = [
-      ...(
-        await getAllDotContinueDefinitionFiles(
+      ...(await getSkillFilesFromDirs(
+        getDotContinueSubDirs(
           ide,
           {
             includeGlobal: true,
             includeWorkspace: true,
             fileExtType: "markdown",
           },
+          workspaceDirs,
           SKILLS_DIR,
-        )
-      ).map((file) => file.path),
+        ),
+        ide,
+      )),
       ...(await getClaudeSkillsDir(ide)),
     ];
 
@@ -66,7 +85,6 @@ export async function loadMarkdownSkills(ide: IDE) {
       path.endsWith("SKILL.md"),
     );
 
-    const workspaceDirs = await ide.getWorkspaceDirs();
     for (const fileUri of skillFiles) {
       try {
         const content = await ide.readFile(fileUri);

--- a/core/config/markdown/loadMarkdownSkills.ts
+++ b/core/config/markdown/loadMarkdownSkills.ts
@@ -41,8 +41,13 @@ async function getSkillFilesFromDir(dir: string, ide: IDE): Promise<string[]> {
   ).filter((skillFileUri): skillFileUri is string => Boolean(skillFileUri));
 }
 
-async function getSkillFilesFromDirs(dirs: string[], ide: IDE): Promise<string[]> {
-  return (await Promise.all(dirs.map((dir) => getSkillFilesFromDir(dir, ide)))).flat();
+async function getSkillFilesFromDirs(
+  dirs: string[],
+  ide: IDE,
+): Promise<string[]> {
+  return (
+    await Promise.all(dirs.map((dir) => getSkillFilesFromDir(dir, ide)))
+  ).flat();
 }
 
 /**

--- a/core/config/markdown/loadMarkdownSkills.vitest.ts
+++ b/core/config/markdown/loadMarkdownSkills.vitest.ts
@@ -4,10 +4,18 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { loadMarkdownSkills } from "./loadMarkdownSkills";
 import { readSkillImpl } from "../../tools/implementations/readSkill";
 import { testIde } from "../../test/fixtures";
-import { setUpTestDir, tearDownTestDir, TEST_DIR_PATH } from "../../test/testDir";
+import {
+  setUpTestDir,
+  tearDownTestDir,
+  TEST_DIR_PATH,
+} from "../../test/testDir";
 
 function createDirectorySymlink(target: string, linkPath: string) {
-  fs.symlinkSync(target, linkPath, process.platform === "win32" ? "junction" : "dir");
+  fs.symlinkSync(
+    target,
+    linkPath,
+    process.platform === "win32" ? "junction" : "dir",
+  );
 }
 
 describe("loadMarkdownSkills", () => {
@@ -39,22 +47,26 @@ description: Creates skills
 
     const skillsDir = path.join(TEST_DIR_PATH, ".continue", "skills");
     fs.mkdirSync(skillsDir, { recursive: true });
-    createDirectorySymlink(targetSkillDir, path.join(skillsDir, "skill-creator"));
+    createDirectorySymlink(
+      targetSkillDir,
+      path.join(skillsDir, "skill-creator"),
+    );
 
     const result = await loadMarkdownSkills(testIde);
 
     expect(result.errors).toEqual([]);
     expect(result.skills).toHaveLength(1);
     expect(result.skills[0].name).toBe("Skill Creator");
-    expect(result.skills[0].path).toBe(".continue/skills/skill-creator/SKILL.md");
+    expect(result.skills[0].path).toBe(
+      ".continue/skills/skill-creator/SKILL.md",
+    );
     expect(
       result.skills[0].files.some((file) => file.endsWith("helper.ts")),
     ).toBe(true);
 
-    const readResult = await readSkillImpl(
-      { skillName: "Skill Creator" },
-      { ide: testIde } as any,
-    );
+    const readResult = await readSkillImpl({ skillName: "Skill Creator" }, {
+      ide: testIde,
+    } as any);
 
     expect(readResult[0]?.name).toBe("Skill: Skill Creator");
     expect(readResult[0]?.content).toContain("# Skill Creator");

--- a/core/config/markdown/loadMarkdownSkills.vitest.ts
+++ b/core/config/markdown/loadMarkdownSkills.vitest.ts
@@ -1,0 +1,63 @@
+import fs from "fs";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadMarkdownSkills } from "./loadMarkdownSkills";
+import { readSkillImpl } from "../../tools/implementations/readSkill";
+import { testIde } from "../../test/fixtures";
+import { setUpTestDir, tearDownTestDir, TEST_DIR_PATH } from "../../test/testDir";
+
+function createDirectorySymlink(target: string, linkPath: string) {
+  fs.symlinkSync(target, linkPath, process.platform === "win32" ? "junction" : "dir");
+}
+
+describe("loadMarkdownSkills", () => {
+  beforeEach(() => {
+    setUpTestDir();
+  });
+
+  afterEach(() => {
+    tearDownTestDir();
+  });
+
+  it("loads symlinked project skills and makes them readable through read_skill", async () => {
+    const targetSkillDir = path.join(TEST_DIR_PATH, "shared-skill-target");
+    fs.mkdirSync(targetSkillDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(targetSkillDir, "SKILL.md"),
+      `---
+name: Skill Creator
+description: Creates skills
+---
+
+# Skill Creator
+`,
+    );
+    fs.writeFileSync(
+      path.join(targetSkillDir, "helper.ts"),
+      "// helper code\n",
+    );
+
+    const skillsDir = path.join(TEST_DIR_PATH, ".continue", "skills");
+    fs.mkdirSync(skillsDir, { recursive: true });
+    createDirectorySymlink(targetSkillDir, path.join(skillsDir, "skill-creator"));
+
+    const result = await loadMarkdownSkills(testIde);
+
+    expect(result.errors).toEqual([]);
+    expect(result.skills).toHaveLength(1);
+    expect(result.skills[0].name).toBe("Skill Creator");
+    expect(result.skills[0].path).toBe(".continue/skills/skill-creator/SKILL.md");
+    expect(
+      result.skills[0].files.some((file) => file.endsWith("helper.ts")),
+    ).toBe(true);
+
+    const readResult = await readSkillImpl(
+      { skillName: "Skill Creator" },
+      { ide: testIde } as any,
+    );
+
+    expect(readResult[0]?.name).toBe("Skill: Skill Creator");
+    expect(readResult[0]?.content).toContain("# Skill Creator");
+    expect(readResult[0]?.content).toContain("helper.ts");
+  });
+});

--- a/extensions/cli/src/util/loadMarkdownSkills.test.ts
+++ b/extensions/cli/src/util/loadMarkdownSkills.test.ts
@@ -77,6 +77,43 @@ This is the skill body.
     );
   });
 
+  it("loads a skill from a symlinked project skill directory", async () => {
+    const targetSkillDir = path.join(tmpDir, "shared-skill-target");
+    fs.mkdirSync(targetSkillDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(targetSkillDir, "SKILL.md"),
+      `---
+name: Skill Creator
+description: Creates skills
+---
+
+# Skill Creator
+`,
+    );
+    fs.writeFileSync(path.join(targetSkillDir, "helper.ts"), "// helper code");
+
+    const skillsDir = path.join(tmpDir, ".continue", "skills");
+    fs.mkdirSync(skillsDir, { recursive: true });
+    const symlinkPath = path.join(skillsDir, "skill-creator");
+    fs.symlinkSync(
+      targetSkillDir,
+      symlinkPath,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+
+    const result = await loadMarkdownSkills();
+
+    expect(result.errors).toEqual([]);
+    expect(result.skills).toHaveLength(1);
+    expect(result.skills[0].name).toBe("Skill Creator");
+    expect(result.skills[0].path).toBe(
+      path.join(".", ".continue", "skills", "skill-creator", "SKILL.md"),
+    );
+    expect(result.skills[0].files).toContain(
+      path.join(".", ".continue", "skills", "skill-creator", "helper.ts"),
+    );
+  });
+
   it("returns error for invalid frontmatter", async () => {
     const skillDir = path.join(tmpDir, ".continue", "skills", "bad-skill");
     fs.mkdirSync(skillDir, { recursive: true });

--- a/extensions/cli/src/util/loadMarkdownSkills.ts
+++ b/extensions/cli/src/util/loadMarkdownSkills.ts
@@ -57,18 +57,42 @@ function getFilePathsInSkillDirectory(
     .map((filePath) => getRelativePath(cwd, filePath));
 }
 
-/**get the SKILL.md files from the given directory */
-async function getSkillFilesFromDir(dirPath: string): Promise<string[]> {
-  // check if dirPath exists
+async function getSkillDirectoriesFromDir(dirPath: string): Promise<string[]> {
   try {
     await fsPromises.stat(dirPath);
   } catch {
     return [];
   }
 
-  const skillDirs = (await fsPromises.readdir(dirPath, { withFileTypes: true }))
-    .filter((dir) => dir.isDirectory())
-    .map((dir) => path.join(dirPath, dir.name));
+  const dirEntries = await fsPromises.readdir(dirPath, { withFileTypes: true });
+
+  return (
+    await Promise.all(
+      dirEntries.map(async (dirEntry) => {
+        const candidatePath = path.join(dirPath, dirEntry.name);
+
+        if (dirEntry.isDirectory()) {
+          return candidatePath;
+        }
+
+        if (!dirEntry.isSymbolicLink()) {
+          return null;
+        }
+
+        try {
+          const stats = await fsPromises.stat(candidatePath);
+          return stats.isDirectory() ? candidatePath : null;
+        } catch {
+          return null;
+        }
+      }),
+    )
+  ).filter((candidatePath): candidatePath is string => Boolean(candidatePath));
+}
+
+/**get the SKILL.md files from the given directory */
+async function getSkillFilesFromDir(dirPath: string): Promise<string[]> {
+  const skillDirs = await getSkillDirectoriesFromDir(dirPath);
 
   return (
     await Promise.all(
@@ -82,7 +106,7 @@ async function getSkillFilesFromDir(dirPath: string): Promise<string[]> {
         }
       }),
     )
-  ).filter((path) => typeof path === "string");
+  ).filter((skillFilePath): skillFilePath is string => Boolean(skillFilePath));
 }
 
 export async function loadMarkdownSkills(): Promise<LoadSkillsResult> {


### PR DESCRIPTION
## Summary
- load project and global markdown skills from symlinked skill directories in both the CLI and core loaders
- keep `read_skill` working by enumerating first-level skill directories instead of relying on recursive directory walks that skip symlinks
- add regression tests covering symlinked `.continue/skills/<skill>` directories for both loaders

## Why
`npx skills add ... --skill <name>` can install skills into a project via symlink. Before this change, those symlinked skill directories were skipped during skill discovery, so CLI skill listings and the `read_skill` tool could not find the installed skill.

## Validation
- ran `npm test -- src/util/loadMarkdownSkills.test.ts` in `extensions/cli`
- ran `npm run vitest -- config/markdown/loadMarkdownSkills.vitest.ts` in `core`
- ran `npm run lint` in `extensions/cli` (passes with 2 pre-existing warnings)
- ran `git diff --check`

Closes #11985

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include symlinked markdown skills in discovery for core and the CLI so skills installed via symlink appear in lists and are readable by `read_skill`. Adds tests in both loaders to prevent regressions.

- **Bug Fixes**
  - Treat first-level skill entries (dirs or symlinks/junctions) as skill dirs and load `SKILL.md`, avoiding recursive walks that skipped them.
  - Discover symlinked skills in project `./.continue/skills` and global `.claude/skills`.
  - Ensure `read_skill` returns content and files from symlinked skills; add core (`vitest`) and CLI tests.

<sup>Written for commit 3d8a5218ddc4de3e1879fb87113508ba5eb3e2fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

