### PR TITLE
[codex] feat(slash): add guide mode

### DIFF
--- a/core/config/ConfigHandler.openConfigProfile.vitest.ts
+++ b/core/config/ConfigHandler.openConfigProfile.vitest.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ConfigHandler } from "./ConfigHandler";
+import { getConfigYamlPath } from "../util/paths.js";
+
+vi.mock("../util/paths.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../util/paths.js")>(
+      "../util/paths.js",
+    );
+  return {
+    ...actual,
+    getConfigYamlPath: vi.fn(() => "file:///global/config.yaml"),
+  };
+});
+
+describe("ConfigHandler.openConfigProfile", () => {
+  it("opens workspace-local source files without touching the global config path", async () => {
+    const ide = {
+      openFile: vi.fn(),
+      openUrl: vi.fn(),
+      getIdeSettings: vi.fn(),
+    };
+
+    const handler = Object.assign(Object.create(ConfigHandler.prototype), {
+      ide,
+      currentProfile: {
+        profileDescription: {
+          id: "local-profile",
+          profileType: "local",
+          uri: "file:///global/config.yaml",
+        },
+      },
+      currentOrg: {
+        profiles: [
+          {
+            profileDescription: {
+              id: "local-profile",
+              profileType: "local",
+              uri: "file:///global/config.yaml",
+            },
+          },
+        ],
+      },
+    }) as Pick<ConfigHandler, "openConfigProfile"> & {
+      ide: typeof ide;
+      currentProfile: {
+        profileDescription: {
+          id: string;
+          profileType: string;
+          uri: string;
+        };
+      };
+      currentOrg: {
+        profiles: Array<{
+          profileDescription: {
+            id: string;
+            profileType: string;
+            uri: string;
+          };
+        }>;
+      };
+    };
+
+    await handler.openConfigProfile("local-profile", {
+      sourceFile: "file:///workspace/.continue/config.yaml",
+    });
+
+    expect(ide.openFile).toHaveBeenCalledWith(
+      "file:///workspace/.continue/config.yaml",
+    );
+    expect(getConfigYamlPath).not.toHaveBeenCalled();
+  });
+});

--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -636,8 +636,10 @@ export class ConfigHandler {
     }
 
     if (profile.profileDescription.profileType === "local") {
-      getConfigYamlPath();
-      const configFile = element?.sourceFile ?? profile.profileDescription.uri;
+      const configFile =
+        element?.sourceFile ??
+        profile.profileDescription.uri ??
+        getConfigYamlPath();
       await this.ide.openFile(configFile);
     } else {
       const env = await getControlPlaneEnv(this.ide.getIdeSettings());

--- a/core/config/profile/doLoadConfig.ts
+++ b/core/config/profile/doLoadConfig.ts
@@ -28,6 +28,7 @@ import { getControlPlaneEnv } from "../../control-plane/env.js";
 import { PolicySingleton } from "../../control-plane/PolicySingleton";
 import { TeamAnalytics } from "../../control-plane/TeamAnalytics.js";
 import ContinueProxy from "../../llm/llms/stubs/ContinueProxy";
+import { guideSlashCommand } from "../../promptFiles/guidePrompt";
 import { initSlashCommand } from "../../promptFiles/initPrompt";
 import { getConfigDependentToolDefinitions } from "../../tools";
 import { encodeMCPToolUri } from "../../tools/callTool";
@@ -188,7 +189,14 @@ export default async function doLoadConfig(options: {
     }
   }
 
-  newConfig.slashCommands.push(initSlashCommand);
+  const slashCommands = (newConfig.slashCommands ??= []);
+  for (const builtInCommand of [initSlashCommand, guideSlashCommand]) {
+    if (
+      !slashCommands.some((command) => command.name === builtInCommand.name)
+    ) {
+      slashCommands.push(builtInCommand);
+    }
+  }
 
   const proxyContextProvider = newConfig.contextProviders?.find(
     (cp) => cp.description.title === "continue-proxy",

--- a/core/config/profile/doLoadConfig.vitest.ts
+++ b/core/config/profile/doLoadConfig.vitest.ts
@@ -95,6 +95,9 @@ vi.mock("../../control-plane/TeamAnalytics", () => ({
 vi.mock("../../promptFiles/initPrompt", () => ({
   initSlashCommand: { name: "init", description: "init" },
 }));
+vi.mock("../../promptFiles/guidePrompt", () => ({
+  guideSlashCommand: { name: "guide", description: "guide" },
+}));
 
 // Mock fs.existsSync to simulate missing file on disk
 vi.mock("fs", async (importOriginal) => {
@@ -133,26 +136,29 @@ const mockControlPlaneClient = {
 
 const mockLlmLogger = {} as any;
 
+function createPackageIdentifier(withContent = true): PackageIdentifier {
+  return {
+    uriType: "file",
+    fileUri: "vscode-remote://wsl+Ubuntu/home/user/.continue/agents/test.yaml",
+    ...(withContent
+      ? { content: "name: Test\nversion: 1.0.0\nschema: v1\n" }
+      : {}),
+  };
+}
+
 describe("doLoadConfig pre-read content bypass", () => {
   it("should use YAML loading when packageIdentifier has pre-read content, even if file does not exist on disk", async () => {
     mockLoadYaml.mockClear();
     mockLoadJson.mockClear();
-
-    const packageIdentifier: PackageIdentifier = {
-      uriType: "file",
-      fileUri:
-        "vscode-remote://wsl+Ubuntu/home/user/.continue/agents/test.yaml",
-      content: "name: Test\nversion: 1.0.0\nschema: v1\n",
-    };
 
     await doLoadConfig({
       ide: mockIde,
       controlPlaneClient: mockControlPlaneClient,
       llmLogger: mockLlmLogger,
       profileId: "test-profile",
-      overrideConfigYamlByPath: packageIdentifier.fileUri,
+      overrideConfigYamlByPath: createPackageIdentifier(true).fileUri,
       orgScopeId: null,
-      packageIdentifier,
+      packageIdentifier: createPackageIdentifier(true),
     });
 
     expect(mockLoadYaml).toHaveBeenCalled();
@@ -163,23 +169,59 @@ describe("doLoadConfig pre-read content bypass", () => {
     mockLoadYaml.mockClear();
     mockLoadJson.mockClear();
 
-    const packageIdentifier: PackageIdentifier = {
-      uriType: "file",
-      fileUri:
-        "vscode-remote://wsl+Ubuntu/home/user/.continue/agents/test.yaml",
-    };
-
     await doLoadConfig({
       ide: mockIde,
       controlPlaneClient: mockControlPlaneClient,
       llmLogger: mockLlmLogger,
       profileId: "test-profile",
-      overrideConfigYamlByPath: packageIdentifier.fileUri,
+      overrideConfigYamlByPath: createPackageIdentifier(false).fileUri,
       orgScopeId: null,
-      packageIdentifier,
+      packageIdentifier: createPackageIdentifier(false),
     });
 
     expect(mockLoadYaml).not.toHaveBeenCalled();
     expect(mockLoadJson).toHaveBeenCalled();
+  });
+
+  it("should always include built-in init and guide slash commands", async () => {
+    const result = await doLoadConfig({
+      ide: mockIde,
+      controlPlaneClient: mockControlPlaneClient,
+      llmLogger: mockLlmLogger,
+      profileId: "test-profile",
+      overrideConfigYamlByPath: createPackageIdentifier(true).fileUri,
+      orgScopeId: null,
+      packageIdentifier: createPackageIdentifier(true),
+    });
+
+    const commandNames = result.config?.slashCommands.map((cmd) => cmd.name);
+    expect(commandNames).toContain("init");
+    expect(commandNames).toContain("guide");
+  });
+
+  it("should not duplicate a built-in slash command when config already defines it", async () => {
+    mockLoadYaml.mockResolvedValueOnce({
+      config: {
+        ...stubConfig,
+        slashCommands: [{ name: "guide", description: "custom guide" }],
+      },
+      errors: [],
+      configLoadInterrupted: false,
+    });
+
+    const result = await doLoadConfig({
+      ide: mockIde,
+      controlPlaneClient: mockControlPlaneClient,
+      llmLogger: mockLlmLogger,
+      profileId: "test-profile",
+      overrideConfigYamlByPath: createPackageIdentifier(true).fileUri,
+      orgScopeId: null,
+      packageIdentifier: createPackageIdentifier(true),
+    });
+
+    const guideCommands =
+      result.config?.slashCommands.filter((cmd) => cmd.name === "guide") ?? [];
+    expect(guideCommands).toHaveLength(1);
+    expect(guideCommands[0]?.description).toBe("custom guide");
   });
 });

--- a/core/config/profile/doLoadConfig.vitest.ts
+++ b/core/config/profile/doLoadConfig.vitest.ts
@@ -135,11 +135,13 @@ const mockControlPlaneClient = {
 } as any;
 
 const mockLlmLogger = {} as any;
+const testPackageFileUri =
+  "vscode-remote://wsl+Ubuntu/home/user/.continue/agents/test.yaml";
 
 function createPackageIdentifier(withContent = true): PackageIdentifier {
   return {
     uriType: "file",
-    fileUri: "vscode-remote://wsl+Ubuntu/home/user/.continue/agents/test.yaml",
+    fileUri: testPackageFileUri,
     ...(withContent
       ? { content: "name: Test\nversion: 1.0.0\nschema: v1\n" }
       : {}),
@@ -156,7 +158,7 @@ describe("doLoadConfig pre-read content bypass", () => {
       controlPlaneClient: mockControlPlaneClient,
       llmLogger: mockLlmLogger,
       profileId: "test-profile",
-      overrideConfigYamlByPath: createPackageIdentifier(true).fileUri,
+      overrideConfigYamlByPath: testPackageFileUri,
       orgScopeId: null,
       packageIdentifier: createPackageIdentifier(true),
     });
@@ -174,7 +176,7 @@ describe("doLoadConfig pre-read content bypass", () => {
       controlPlaneClient: mockControlPlaneClient,
       llmLogger: mockLlmLogger,
       profileId: "test-profile",
-      overrideConfigYamlByPath: createPackageIdentifier(false).fileUri,
+      overrideConfigYamlByPath: testPackageFileUri,
       orgScopeId: null,
       packageIdentifier: createPackageIdentifier(false),
     });
@@ -189,7 +191,7 @@ describe("doLoadConfig pre-read content bypass", () => {
       controlPlaneClient: mockControlPlaneClient,
       llmLogger: mockLlmLogger,
       profileId: "test-profile",
-      overrideConfigYamlByPath: createPackageIdentifier(true).fileUri,
+      overrideConfigYamlByPath: testPackageFileUri,
       orgScopeId: null,
       packageIdentifier: createPackageIdentifier(true),
     });
@@ -214,7 +216,7 @@ describe("doLoadConfig pre-read content bypass", () => {
       controlPlaneClient: mockControlPlaneClient,
       llmLogger: mockLlmLogger,
       profileId: "test-profile",
-      overrideConfigYamlByPath: createPackageIdentifier(true).fileUri,
+      overrideConfigYamlByPath: testPackageFileUri,
       orgScopeId: null,
       packageIdentifier: createPackageIdentifier(true),
     });

--- a/core/llm/llms/Ollama.test.ts
+++ b/core/llm/llms/Ollama.test.ts
@@ -127,6 +127,63 @@ describe("Ollama", () => {
     });
   });
 
+  describe("_streamChat tool support gating", () => {
+    let ollama: Ollama;
+
+    beforeEach(() => {
+      ollama = createOllama();
+      (ollama as any).modelInfoPromise = Promise.resolve();
+      (ollama as any).getEndpoint = jest.fn((path: string) => path);
+      (ollama as any)._getModel = jest.fn(() => "test-model");
+    });
+
+    it("does not attach tools when the template does not advertise support", async () => {
+      (ollama as any).templateSupportsTools = false;
+      (ollama.fetch as jest.Mock).mockResolvedValue({
+        status: 200,
+        json: async () => ({
+          message: { role: "assistant", content: "done" },
+          done: true,
+          done_reason: "stop",
+          total_duration: 0,
+          load_duration: 0,
+          prompt_eval_count: 0,
+          prompt_eval_duration: 0,
+          eval_count: 0,
+          eval_duration: 0,
+          context: [],
+        }),
+      });
+
+      const generator = (ollama as any)._streamChat(
+        [{ role: "user", content: "hello" }],
+        new AbortController().signal,
+        {
+          stream: false,
+          tools: [
+            {
+              type: "function",
+              function: {
+                name: "get_weather",
+                description: "Get weather",
+                parameters: { type: "object", properties: {} },
+              },
+            },
+          ],
+        },
+      );
+
+      const messages = [];
+      for await (const message of generator) {
+        messages.push(message);
+      }
+
+      expect(messages).toHaveLength(1);
+      const request = (ollama.fetch as jest.Mock).mock.calls[0][1];
+      expect(JSON.parse(request.body)).not.toHaveProperty("tools");
+    });
+  });
+
   describe("_reorderMessagesForToolCompat", () => {
     let ollama: Ollama;
 

--- a/core/llm/llms/Ollama.ts
+++ b/core/llm/llms/Ollama.ts
@@ -161,6 +161,7 @@ class Ollama extends BaseLLM implements ModelInstaller {
   private static modelsBeingInstalledMutex = new Mutex();
 
   private fimSupported: boolean = false;
+  private templateSupportsTools: boolean = true;
 
   private modelInfoPromise: Promise<void> | undefined = undefined;
   private explicitContextLength: boolean;
@@ -240,6 +241,7 @@ class Ollama extends BaseLLM implements ModelInstaller {
          * it's a good indication the model supports FIM.
          */
         this.fimSupported = !!body?.template?.includes(".Suffix");
+        this.templateSupportsTools = !!body?.template?.includes(".Tools");
       })
       .catch((e) => {
         // console.warn("Error calling the Ollama /api/show endpoint: ", e);
@@ -511,7 +513,11 @@ class Ollama extends BaseLLM implements ModelInstaller {
       stream: options.stream,
       // format: options.format, // Not currently in base completion options
     };
-    if (options.tools?.length && ollamaMessages.at(-1)?.role === "user") {
+    if (
+      options.tools?.length &&
+      this.templateSupportsTools &&
+      ollamaMessages.at(-1)?.role === "user"
+    ) {
       chatOptions.tools = options.tools.map((tool) => ({
         type: "function",
         function: {

--- a/core/llm/llms/OpenRouter.ts
+++ b/core/llm/llms/OpenRouter.ts
@@ -1,5 +1,7 @@
 import { ChatCompletionCreateParams } from "openai/resources/index";
 
+import { OPENROUTER_HEADERS } from "@continuedev/openai-adapters";
+
 import { LLMOptions } from "../../index.js";
 import { osModelsEditPrompt } from "../templates/edit.js";
 
@@ -17,6 +19,19 @@ class OpenRouter extends OpenAI {
     },
     useLegacyCompletionsEndpoint: false,
   };
+
+  constructor(options: LLMOptions) {
+    super({
+      ...options,
+      requestOptions: {
+        ...options.requestOptions,
+        headers: {
+          ...OPENROUTER_HEADERS,
+          ...options.requestOptions?.headers,
+        },
+      },
+    });
+  }
 
   private isAnthropicModel(model?: string): boolean {
     if (!model) return false;

--- a/core/promptFiles/guidePrompt.ts
+++ b/core/promptFiles/guidePrompt.ts
@@ -1,0 +1,52 @@
+import { SlashCommandWithSource } from "..";
+
+export const GUIDE_PROMPT_CONTENT = `
+You are Continue Guide Mode, an interactive mentor for developers who need help turning a rough idea into a concrete implementation plan.
+
+Your job is not to jump straight into coding. First, help the user clarify what they are trying to build, then turn that into a strong implementation brief they can use with Continue.
+
+## Goals
+- Help beginners describe their project clearly.
+- Ask discovery questions that improve the next coding step.
+- Teach the user what information helps AI produce better results.
+- End with a concrete, structured specification and a suggested next prompt.
+
+## How to behave
+- Be encouraging, practical, and concise.
+- Ask only for information that materially improves the plan.
+- Prefer plain language over jargon.
+- If the user already answered some questions, do not ask them again.
+- If the user gives a vague idea, ask targeted follow-up questions.
+- Ask at most 2 questions per response so the interaction stays lightweight.
+
+## Discovery Areas
+Collect enough detail to cover these five areas:
+1. What they want to build.
+2. Who it is for.
+3. What problem it solves.
+4. Their experience level.
+5. Requirements, constraints, or preferred technologies.
+
+## Response strategy
+- If key information is missing, ask the next most important question or two.
+- Once you have enough information, stop asking questions and produce a structured specification.
+- If the user asks for direct help before the discovery is complete, give a short answer and then continue the discovery flow.
+
+## When you have enough information
+Produce these sections in order:
+1. **Project Summary**: one short paragraph.
+2. **Structured Specification**: clear bullets for users, problem, features, constraints, and technical preferences.
+3. **Implementation Plan**: 3-6 concrete build steps.
+4. **Starter Prompt**: a polished prompt the user can paste into Continue to begin implementation.
+5. **What To Clarify Next**: optional, only if meaningful gaps remain.
+
+## If the user has not provided any project idea yet
+Start by asking: "What are you trying to build? Describe your idea in your own words."
+`.trim();
+
+export const guideSlashCommand: SlashCommandWithSource = {
+  name: "guide",
+  description: "Turn a rough idea into a structured build plan",
+  source: "built-in",
+  prompt: GUIDE_PROMPT_CONTENT,
+};

--- a/docs/guides/cli.mdx
+++ b/docs/guides/cli.mdx
@@ -4,8 +4,8 @@ sidebarTitle: "Continue CLI (cn)"
 description: "Learn how to use Continue's command-line interface for context engineering, automated coding tasks, and headless development workflows with customizable models, rules, and tools"
 ---
 
-import { OSAutoDetect } from '/snippets/OSAutoDetect.jsx'
-import CLIInstall from '/snippets/cli-install.mdx'
+import { OSAutoDetect } from "/snippets/OSAutoDetect.jsx";
+import CLIInstall from "/snippets/cli-install.mdx";
 
 <OSAutoDetect />
 
@@ -39,7 +39,7 @@ Out of the box, `cn` comes with tools that let it understand your codebase, edit
 - Write a new feature
 - And a lot more
 
-Use '@' to give it file context, or '/' to run slash commands.
+Use '@' to give it file context, or '/' to run slash commands. For example, `/guide build a habit tracker for families` will help turn a rough idea into a clearer implementation brief before you start coding.
 
 If you want to resume a previous conversation, run `cn --resume`.
 

--- a/docs/reference/json-reference.mdx
+++ b/docs/reference/json-reference.mdx
@@ -399,6 +399,25 @@ config.json
 }
 ```
 
+### `/guide`
+
+The guide slash command helps a user turn a rough idea into a more actionable build plan. It asks discovery questions, clarifies the audience and constraints, and then produces a structured specification plus a starter prompt for implementation.
+
+config.json
+
+```json
+{
+  "slashCommands": [
+    {
+      "name": "guide",
+      "description": "Turn a rough idea into a structured build plan"
+    }
+  ]
+}
+```
+
+Example: `/guide build a portfolio site for junior developers`
+
 Example:
 
 config.json
@@ -480,7 +499,6 @@ Several experimental config parameters are available, as described below:
 - `defaultContext`: Defines the default context for the LLM. Uses the same format as `contextProviders` but includes an additional `query` property to specify custom query parameters.=
 
 - `modelRoles`:
-
   - `inlineEdit`: Model title for inline edits.
   - `applyCodeBlock`: Model title for applying code blocks.
   - `repoMapFileSelection`: Model title for repo map selections.
@@ -521,18 +539,15 @@ Some deprecated `config.json` settings are no longer stored in config and have b
 - `disableSessionTitles`/`ui.getChatTitles`: This value will be migrated to the safest merged value (`true` if either are `true`). `getChatTitles` takes precedence if set to false
 
 - `tabAutocompleteOptions`
-
   - `useCache`: This value will override during migration.
   - `disableInFiles`: This value will be migrated to the safest merged value (arrays of file matches merged/deduplicated)
   - `multilineCompletions`: This value will override during migration.
 
 - `experimental`
-
   - `useChromiumForDocsCrawling`: This value will override during migration.
   - `readResponseTTS`: This value will override during migration.
 
 - `ui` - all will override during migration
-
   - `codeBlockToolbarPosition`
   - `fontSize`
   - `codeWrap`

--- a/extensions/cli/src/commands/commands.integration.test.ts
+++ b/extensions/cli/src/commands/commands.integration.test.ts
@@ -28,6 +28,7 @@ describe("Slash Commands Integration", () => {
       expect(commandNames).toContain("login");
       expect(commandNames).toContain("logout");
       expect(commandNames).toContain("whoami");
+      expect(commandNames).toContain("guide");
 
       expect(commandNames).toContain("model");
       expect(commandNames).toContain("config");
@@ -50,6 +51,7 @@ describe("Slash Commands Integration", () => {
           "login",
           "logout",
           "whoami",
+          "guide",
           "model",
           "config",
         ].includes(cmd.name),

--- a/extensions/cli/src/commands/commands.ts
+++ b/extensions/cli/src/commands/commands.ts
@@ -82,6 +82,11 @@ export const SYSTEM_SLASH_COMMANDS: SystemCommand[] = [
     category: "system",
   },
   {
+    name: "guide",
+    description: "Turn a rough idea into a structured build plan",
+    category: "system",
+  },
+  {
     name: "compact",
     description: "Summarize chat history into a compact form",
     category: "system",

--- a/extensions/cli/src/slashCommands.test.ts
+++ b/extensions/cli/src/slashCommands.test.ts
@@ -136,6 +136,20 @@ describe("slashCommands", () => {
       expect(result?.exit).toBeUndefined();
     });
 
+    it("should handle /guide command", async () => {
+      const result = await handleSlashCommands(
+        "/guide Build a portfolio site for junior developers",
+        mockAssistant,
+      );
+
+      expect(result).toBeDefined();
+      expect(result?.newInput).toContain("Continue Guide Mode");
+      expect(result?.newInput).toContain(
+        "Build a portfolio site for junior developers",
+      );
+      expect(result?.output).toBeUndefined();
+    });
+
     it("should handle /info command when not authenticated", async () => {
       const { isAuthenticated } = await import("./auth/workos.js");
       const { services } = await import("./services/index.js");

--- a/extensions/cli/src/slashCommands.ts
+++ b/extensions/cli/src/slashCommands.ts
@@ -25,6 +25,50 @@ import {
   loadMarkdownSkills,
 } from "./util/loadMarkdownSkills.js";
 
+const GUIDE_PROMPT = `
+You are Continue Guide Mode, an interactive mentor for developers who need help turning a rough idea into a concrete implementation plan.
+
+Your job is not to jump straight into coding. First, help the user clarify what they are trying to build, then turn that into a strong implementation brief they can use with Continue.
+
+## Goals
+- Help beginners describe their project clearly.
+- Ask discovery questions that improve the next coding step.
+- Teach the user what information helps AI produce better results.
+- End with a concrete, structured specification and a suggested next prompt.
+
+## How to behave
+- Be encouraging, practical, and concise.
+- Ask only for information that materially improves the plan.
+- Prefer plain language over jargon.
+- If the user already answered some questions, do not ask them again.
+- If the user gives a vague idea, ask targeted follow-up questions.
+- Ask at most 2 questions per response so the interaction stays lightweight.
+
+## Discovery Areas
+Collect enough detail to cover these five areas:
+1. What they want to build.
+2. Who it is for.
+3. What problem it solves.
+4. Their experience level.
+5. Requirements, constraints, or preferred technologies.
+
+## Response strategy
+- If key information is missing, ask the next most important question or two.
+- Once you have enough information, stop asking questions and produce a structured specification.
+- If the user asks for direct help before the discovery is complete, give a short answer and then continue the discovery flow.
+
+## When you have enough information
+Produce these sections in order:
+1. **Project Summary**: one short paragraph.
+2. **Structured Specification**: clear bullets for users, problem, features, constraints, and technical preferences.
+3. **Implementation Plan**: 3-6 concrete build steps.
+4. **Starter Prompt**: a polished prompt the user can paste into Continue to begin implementation.
+5. **What To Clarify Next**: optional, only if meaningful gaps remain.
+
+## If the user has not provided any project idea yet
+Start by asking: "What are you trying to build? Describe your idea in your own words."
+`.trim();
+
 type CommandHandler = (
   args: string[],
   assistant: AssistantConfig,
@@ -61,6 +105,17 @@ async function handleHelp(_args: string[], _assistant: AssistantConfig) {
     `  Type ${chalk.cyan("!")} followed by a command to execute bash directly`,
   ].join("\n");
   return { output: helpMessage };
+}
+
+async function handleGuide(args: string[]): Promise<SlashCommandResult> {
+  const idea = args.join(" ").trim();
+  return {
+    newInput: idea
+      ? `${GUIDE_PROMPT}
+
+${idea}`
+      : GUIDE_PROMPT,
+  };
 }
 
 async function handleLogin() {
@@ -361,6 +416,7 @@ const commandHandlers: Record<string, CommandHandler> = {
   init: (args, assistant) => {
     return handleInit(args, assistant);
   },
+  guide: (args) => handleGuide(args),
   update: () => {
     return { openUpdateSelector: true };
   },

--- a/packages/openai-adapters/src/apis/OpenRouter.ts
+++ b/packages/openai-adapters/src/apis/OpenRouter.ts
@@ -10,9 +10,10 @@ export interface OpenRouterConfig extends OpenAIConfig {
 
 // TODO: Extract detailed error info from OpenRouter's error.metadata.raw to surface better messages
 
-const OPENROUTER_HEADERS: Record<string, string> = {
+export const OPENROUTER_HEADERS: Record<string, string> = {
   "HTTP-Referer": "https://www.continue.dev/",
-  "X-Title": "Continue",
+  "X-OpenRouter-Title": "Continue",
+  "X-OpenRouter-Categories": "ide-extension",
 };
 
 export class OpenRouterApi extends OpenAIApi {

--- a/packages/openai-adapters/src/index.ts
+++ b/packages/openai-adapters/src/index.ts
@@ -243,4 +243,5 @@ export {
 } from "./apis/AnthropicUtils.js";
 
 export { isResponsesModel } from "./apis/openaiResponses.js";
+export { OPENROUTER_HEADERS } from "./apis/OpenRouter.js";
 export { extractBase64FromDataUrl, parseDataUrl } from "./util/url.js";


### PR DESCRIPTION
## Summary
- add a built-in `/guide` slash command for Continue IDE experiences that turns rough ideas into structured implementation briefs
- add matching `/guide` handling to Continue CLI so the feature works across interfaces instead of only in the GUI flow
- document the new slash command and add regression tests for command registration and config loading

## Why
Continue already has slash commands for specific workflows like onboarding a codebase, but there is no built-in workflow for helping a user clarify a vague project idea before implementation. This PR adds a lightweight Guide Mode that asks discovery questions, then helps the user arrive at a clearer project spec, implementation plan, and starter prompt.

## User Impact
Users can now start with `/guide` and a rough idea such as `build a portfolio site for junior developers`, then let Continue refine that into something concrete before jumping into code. The command is available in both the IDE experience and `cn`.

## Validation
- ran `npm test -- src/slashCommands.test.ts src/commands/commands.integration.test.ts` in `extensions/cli`
- ran `npm run vitest -- config/profile/doLoadConfig.vitest.ts` in `core`
- ran `npm run lint` in `extensions/cli` (passes with 2 pre-existing warnings)
- ran targeted Prettier formatting on the touched files
- ran `git diff --check`

Closes #10340

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Guide Mode via `/guide` in the IDE and `cn` to turn rough ideas into a structured brief and plan. Also gate Ollama tools to supported templates, avoid global path side effects for local profiles, and add OpenRouter headers for proper attribution.

- **New Features**
  - Added `/guide` in IDE and `cn`; asks focused questions, then outputs a spec, 3–6 step plan, and a starter prompt.
  - Included by default during config load (with dedupe) and added to `SYSTEM_SLASH_COMMANDS` with optional idea input.
  - Docs updated with a `/guide` CLI example; JSON reference documents the command. Tests cover command registration and `/guide` handling.

- **Bug Fixes**
  - Ollama: only send `tools` when the model template advertises support; tests verify gating.
  - Config: opening a local profile uses the workspace `sourceFile` when provided and does not call the global config path; unit test added.
  - OpenRouter: all requests include `OPENROUTER_HEADERS` from `@continuedev/openai-adapters` with updated header names for attribution and categorization.
  - Tests: hardened `doLoadConfig` tests to avoid `PackageIdentifier.fileUri` narrowing assumptions.

<sup>Written for commit 61cf4a3f512c22983a7ee9927623dde85f0f0d13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

