### PR TITLE
fix: fall back to cmd.exe when PowerShell is unavailable on Windows

### DIFF
--- a/core/nextEdit/DocumentHistoryTracker.ts
+++ b/core/nextEdit/DocumentHistoryTracker.ts
@@ -61,7 +61,7 @@ export class DocumentHistoryTracker {
     const documentHistory = this.documentContentHistoryMap.get(documentPath);
 
     if (!astHistory || !documentHistory) {
-      console.error(`Document ${documentPath} not found in AST tracker`);
+      console.debug(`Document ${documentPath} not found in AST tracker, adding it`);
       this.addDocument(documentPath, documentContent, ast);
       return; // Early return - document was added with initial state
     }

--- a/core/tools/implementations/runTerminalCommand.ts
+++ b/core/tools/implementations/runTerminalCommand.ts
@@ -21,13 +21,27 @@ function getDecodedOutput(data: Buffer): string {
   } else {
     return data.toString();
   }
-} // Simple helper function to use login shell on Unix/macOS and PowerShell on Windows
+}
+
+// Tracks whether PowerShell failed to spawn on Windows (e.g., blocked by corporate policy)
+// so subsequent calls can fall back to cmd.exe without retrying PowerShell.
+let _powershellUnavailable = false;
+
+// Simple helper function to use login shell on Unix/macOS and PowerShell on Windows
 function getShellCommand(command: string): { shell: string; args: string[] } {
   if (process.platform === "win32") {
-    // Windows: Use PowerShell
+    if (!_powershellUnavailable) {
+      // Windows: prefer PowerShell for richer command support
+      return {
+        shell: "powershell.exe",
+        args: ["-NoLogo", "-ExecutionPolicy", "Bypass", "-Command", command],
+      };
+    }
+    // PowerShell unavailable (e.g., blocked by corporate security policy);
+    // fall back to cmd.exe via COMSPEC.
     return {
-      shell: "powershell.exe",
-      args: ["-NoLogo", "-ExecutionPolicy", "Bypass", "-Command", command],
+      shell: process.env.COMSPEC || "cmd.exe",
+      args: ["/D", "/S", "/C", command],
     };
   } else {
     // Unix/macOS: Use login shell to source .bashrc/.zshrc etc.
@@ -339,7 +353,7 @@ export const runTerminalCommandImpl: ToolImpl = async (args, extras) => {
             }
           });
 
-          childProc.on("error", (error) => {
+          childProc.on("error", (error: NodeJS.ErrnoException) => {
             // Clear timeout on error
             if (timeoutId) {
               clearTimeout(timeoutId);
@@ -358,6 +372,15 @@ export const runTerminalCommandImpl: ToolImpl = async (args, extras) => {
               }
               // Remove from foreground tracking if it was tracked
               removeRunningProcess(toolCallId);
+            }
+
+            // If PowerShell failed to spawn on Windows (e.g., blocked by corporate policy),
+            // mark it unavailable so future calls fall back to cmd.exe automatically.
+            if (
+              process.platform === "win32" &&
+              (error.code === "UNKNOWN" || error.code === "ENOENT")
+            ) {
+              _powershellUnavailable = true;
             }
 
             reject(error);
@@ -458,7 +481,7 @@ export const runTerminalCommandImpl: ToolImpl = async (args, extras) => {
                 }
               });
 
-              childProc.on("error", (error) => {
+              childProc.on("error", (error: NodeJS.ErrnoException) => {
                 // Clear timeout on error
                 if (timeoutId) {
                   clearTimeout(timeoutId);
@@ -473,6 +496,16 @@ export const runTerminalCommandImpl: ToolImpl = async (args, extras) => {
                 if (toolCallId) {
                   removeRunningProcess(toolCallId);
                 }
+
+                // If PowerShell failed to spawn on Windows (e.g., blocked by corporate policy),
+                // mark it unavailable so future calls fall back to cmd.exe automatically.
+                if (
+                  process.platform === "win32" &&
+                  (error.code === "UNKNOWN" || error.code === "ENOENT")
+                ) {
+                  _powershellUnavailable = true;
+                }
+
                 reject(error);
               });
             },
@@ -521,9 +554,16 @@ export const runTerminalCommandImpl: ToolImpl = async (args, extras) => {
             }
           });
 
-          childProc.on("error", () => {
+          childProc.on("error", (error: NodeJS.ErrnoException) => {
             if (isProcessBackgrounded(toolCallId)) {
               removeBackgroundedProcess(toolCallId);
+            }
+            // If PowerShell failed to spawn on Windows, mark it unavailable for future calls.
+            if (
+              process.platform === "win32" &&
+              (error.code === "UNKNOWN" || error.code === "ENOENT")
+            ) {
+              _powershellUnavailable = true;
             }
           });
 


### PR DESCRIPTION
Fixes #11960

## Problem

On Windows environments where PowerShell is blocked by corporate security policy (e.g., AppLocker), `run_terminal_command` fails immediately with:

```
run_terminal_command failed with the message: spawn UNKNOWN
```

This happens because `getShellCommand()` always returns `powershell.exe` on Windows, even when PowerShell cannot be executed.

## Solution

Introduce a module-level flag `_powershellUnavailable` that is set to `true` when a PowerShell spawn fails with an `UNKNOWN` or `ENOENT` error code. Once set, `getShellCommand()` falls back to `cmd.exe` (via `COMSPEC`) for all subsequent invocations in the session.

This approach:
- Preserves existing PowerShell behavior for users where it works
- Automatically recovers for restricted environments on the next command invocation
- Requires no configuration changes from the user

## Testing

- On non-Windows: no behavior change (existing tests still pass)
- On Windows with PowerShell available: no behavior change
- On Windows with PowerShell blocked: first call fails with the existing error; subsequent calls use `cmd.exe` and succeed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically fall back to `cmd.exe` when PowerShell can't start on Windows, so `run_terminal_command` keeps working in restricted environments (fixes #11960). Also reduces a noisy error log in the document history tracker (addresses #11919).

- **Bug Fixes**
  - Windows: detect PowerShell spawn errors (`UNKNOWN`/`ENOENT`), set a session flag, and route subsequent commands to `cmd.exe` via `COMSPEC`; no change for users where PowerShell works.
  - DocumentHistoryTracker: downgrade `console.error` to `console.debug` when a document isn’t in the tracker, avoiding noisy logs while still adding the document.

<sup>Written for commit 26c16ad36e6f6bc273f6aabed287dce6ed5037d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

