### PR TITLE
fix: parse XML-like function.arguments from OpenAI-compatible models

### DIFF
--- a/core/tools/parseArgs.ts
+++ b/core/tools/parseArgs.ts
@@ -1,5 +1,46 @@
 import { ToolCallDelta } from "..";
 
+/**
+ * Coerce a raw string value from XML-like tool arguments to an appropriate JS type.
+ * Applies scalar coercion in this order: boolean, number, JSON parse, string.
+ */
+function coerceXmlValue(value: string): any {
+  if (value.toLowerCase() === "true") return true;
+  if (value.toLowerCase() === "false") return false;
+
+  // Numeric coercion — only if the string is entirely numeric
+  if (value.trim() !== "" && !isNaN(Number(value))) return Number(value);
+
+  // JSON coercion (for embedded arrays/objects/quoted strings)
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Parse XML-like tool call arguments of the form:
+ *   <parameter=name>value</parameter>
+ *
+ * Some OpenAI-compatible models (e.g. local Qwen) emit function.arguments in
+ * this XML-like format instead of JSON.  Returns an empty object when no
+ * <parameter=…> tags are found so callers can detect a failed parse.
+ */
+export function parseXmlToolCallArgs(argsStr: string): Record<string, any> {
+  const result: Record<string, any> = {};
+  const paramRegex = /<parameter=([^>]+)>([\s\S]*?)<\/parameter>/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = paramRegex.exec(argsStr)) !== null) {
+    const name = match[1].trim();
+    const rawValue = match[2].trim();
+    result[name] = coerceXmlValue(rawValue);
+  }
+
+  return result;
+}
+
 export function safeParseToolCallArgs(
   toolCall: ToolCallDelta,
 ): Record<string, any> {
@@ -14,12 +55,16 @@ export function safeParseToolCallArgs(
     return args;
   }
 
+  const argsStr = toolCall.function?.arguments?.trim() || "{}";
+
   try {
-    return JSON.parse(toolCall.function?.arguments?.trim() || "{}");
+    return JSON.parse(argsStr);
   } catch (e) {
-    //console.error(
-    //  `Failed to parse tool call arguments:\nTool call: ${toolCall.function?.name + " " + toolCall.id}\nArgs:${toolCall.function?.arguments}\n`,
-    //);
+    // Fall back to XML-like <parameter=name>value</parameter> parsing
+    const xmlParsed = parseXmlToolCallArgs(argsStr);
+    if (Object.keys(xmlParsed).length > 0) {
+      return xmlParsed;
+    }
     return {};
   }
 }

--- a/core/tools/parseArgs.vitest.ts
+++ b/core/tools/parseArgs.vitest.ts
@@ -36,17 +36,78 @@ describe("safeParseToolCallArgs", () => {
     expect(result).toEqual({ name: "test", value: 123 });
   });
 
-  it("should return empty object for invalid JSON", () => {
+  it("should return empty object for invalid JSON with no XML", () => {
     const toolCall: ToolCallDelta = {
       id: "1",
       function: {
         name: "testFunction",
-        arguments: '{"name": "test", value: 123', // Invalid JSON
+        arguments: '{"name": "test", value: 123', // Invalid JSON, no XML params
       },
     };
 
     const result = safeParseToolCallArgs(toolCall);
     expect(result).toEqual({});
+  });
+
+  it("should parse XML-like arguments when JSON parsing fails", () => {
+    const toolCall: ToolCallDelta = {
+      id: "1",
+      function: {
+        name: "ls",
+        arguments: `<tool_call>
+<function=ls>
+<parameter=dirPath>src</parameter>
+<parameter=recursive>True</parameter>
+</function>
+</tool_call>`,
+      },
+    };
+
+    const result = safeParseToolCallArgs(toolCall);
+    expect(result).toEqual({ dirPath: "src", recursive: true });
+  });
+
+  it("should coerce XML parameter values: booleans", () => {
+    const toolCall: ToolCallDelta = {
+      id: "1",
+      function: {
+        name: "fn",
+        arguments:
+          "<parameter=flagTrue>true</parameter><parameter=flagFalse>False</parameter>",
+      },
+    };
+
+    const result = safeParseToolCallArgs(toolCall);
+    expect(result.flagTrue).toBe(true);
+    expect(result.flagFalse).toBe(false);
+  });
+
+  it("should coerce XML parameter values: numbers", () => {
+    const toolCall: ToolCallDelta = {
+      id: "1",
+      function: {
+        name: "fn",
+        arguments:
+          "<parameter=count>42</parameter><parameter=ratio>3.14</parameter>",
+      },
+    };
+
+    const result = safeParseToolCallArgs(toolCall);
+    expect(result.count).toBe(42);
+    expect(result.ratio).toBe(3.14);
+  });
+
+  it("should keep XML parameter values as strings when not coercible", () => {
+    const toolCall: ToolCallDelta = {
+      id: "1",
+      function: {
+        name: "fn",
+        arguments: "<parameter=path>/some/path/to/file.ts</parameter>",
+      },
+    };
+
+    const result = safeParseToolCallArgs(toolCall);
+    expect(result.path).toBe("/some/path/to/file.ts");
   });
 
   it("should return empty object when arguments is empty", () => {

--- a/extensions/cli/src/stream/streamChatResponse.ts
+++ b/extensions/cli/src/stream/streamChatResponse.ts
@@ -14,6 +14,7 @@ import { posthogService } from "../telemetry/posthogService.js";
 import { telemetryService } from "../telemetry/telemetryService.js";
 import { applyChatCompletionToolOverrides } from "../tools/applyToolOverrides.js";
 import { ToolCall } from "../tools/index.js";
+import { parseXmlToolCallArgs } from "core/tools/parseArgs.js";
 import {
   chatCompletionStreamWithBackoff,
   isContextLengthError,
@@ -401,6 +402,17 @@ export async function processStreamingResponse(
   }
 
   const toolCalls = Array.from(toolCallsMap.values());
+
+  // For any tool call whose arguments weren't JSON-parseable during streaming,
+  // attempt XML-like <parameter=name>value</parameter> parsing as a fallback.
+  for (const tc of toolCalls) {
+    if (Object.keys(tc.arguments).length === 0 && tc.argumentsStr) {
+      const xmlParsed = parseXmlToolCallArgs(tc.argumentsStr);
+      if (Object.keys(xmlParsed).length > 0) {
+        tc.arguments = xmlParsed;
+      }
+    }
+  }
 
   // Validate tool calls have complete arguments
   const validToolCalls = toolCalls.filter((tc) => {


### PR DESCRIPTION
Fixes #11453

## Problem

Some OpenAI-compatible models (e.g. local Qwen endpoints) return `tool_calls[].function.arguments` in an XML-like format rather than JSON:

```
<tool_call>
<function=ls>
<parameter=dirPath>src</parameter>
<parameter=recursive>True</parameter>
</function>
</tool_call>
```

Continue assumed JSON-only arguments in all tool-call parsing paths. When `JSON.parse()` failed, it silently returned `{}`, causing all required-argument validation to fail and tool calls to never execute correctly.

## Solution

Add `parseXmlToolCallArgs()` to `core/tools/parseArgs.ts` as a fallback when JSON parsing fails. The function:
- Extracts `<parameter=name>value</parameter>` pairs via regex
- Applies scalar coercion: `"true"`/`"false"` → boolean, numeric strings → number, JSON-parseable strings → parsed value, everything else stays as a string

`safeParseToolCallArgs()` now tries XML parsing before returning `{}`.

The CLI streaming path (`extensions/cli/src/stream/streamChatResponse.ts`) also gets the same fallback: after all streaming chunks arrive, any tool call whose `argumentsStr` was never JSON-parseable is retried through `parseXmlToolCallArgs()`.

## Testing

- Added unit tests in `core/tools/parseArgs.vitest.ts` covering:
  - Full XML-wrapped payload with boolean and string params
  - Boolean coercion (`True`/`False`)
  - Numeric coercion (integer and float)
  - Plain string values that don't coerce
  - Existing JSON path is unchanged (no regression)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tool-call parsing when some OpenAI-compatible models return XML-like function.arguments, so tools receive correct parameters. Adds a fallback parser with simple type coercion and uses it in core parsing and CLI streaming.

- **Bug Fixes**
  - Added XML-like fallback in `safeParseToolCallArgs()`: parses `<parameter=name>value</parameter>` and coerces booleans, numbers, and JSON literals.
  - Applied the same fallback in the CLI streaming path after the stream ends for calls that never produced valid JSON.
  - Added tests covering XML parsing, value coercion, and no-regression for JSON inputs.

<sup>Written for commit f175f3b84135e382296611fcfd1f917812c95edc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

