### PR TITLE
fix: remove reasoning summary that requires OpenAI org verification

### DIFF
--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -332,7 +332,6 @@ class OpenAI extends BaseLLM {
       top_p: options.topP ?? null,
       reasoning: {
         effort: "medium",
-        summary: "auto",
       },
       include: ["reasoning.encrypted_content"],
     };


### PR DESCRIPTION
Fixes #12030

## Problem

Users with unverified OpenAI organizations receive a 400 error when using o3 and other reasoning models through the Responses API:

```
Your organization must be verified to generate reasoning summaries. Please go to:
https://platform.openai.com/settings/organization/general and click on Verify Organization.
```

This occurs because `summary: "auto"` is hard-coded in `_convertArgsResponses()` in `OpenAI.ts`, and OpenAI requires organization verification to generate reasoning summaries.

## Solution

Remove `summary: "auto"` from the hard-coded `reasoning` config in `_convertArgsResponses()`. The reasoning effort (`"medium"`) is still set, preserving the reasoning capability. Reasoning summary generation is an optional feature that requires org verification — it should not be requested by default.

## Testing

Users with unverified OpenAI organizations can now use o3 and other reasoning models without receiving the 400 error. The reasoning functionality itself is preserved through the `effort: "medium"` setting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `summary: "auto"` from the `reasoning` config in `OpenAI.ts` to prevent 400 errors for unverified OpenAI orgs when using o3 and other reasoning models via the Responses API (fixes #12030). Reasoning stays enabled with `effort: "medium"`; we just stop requesting optional summaries by default.

<sup>Written for commit 0df382405142801e5380127f77c84c8c5e1510ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

