### PR TITLE
feat: add Chutes AI as a model provider

### DIFF
--- a/core/llm/autodetect.ts
+++ b/core/llm/autodetect.ts
@@ -70,6 +70,7 @@ const PROVIDER_HANDLES_TEMPLATING: string[] = [
   "xAI",
   "minimax",
   "groq",
+  "chutes",
   "gemini",
   "docker",
   "nous",

--- a/core/llm/llms/Chutes.ts
+++ b/core/llm/llms/Chutes.ts
@@ -1,0 +1,13 @@
+import { LLMOptions } from "../../index.js";
+import OpenAI from "./OpenAI.js";
+
+class Chutes extends OpenAI {
+  static providerName = "chutes";
+
+  static defaultOptions: Partial<LLMOptions> = {
+    apiBase: "https://llm.chutes.ai/v1/",
+    useLegacyCompletionsEndpoint: false,
+  };
+}
+
+export default Chutes;

--- a/core/llm/llms/index.ts
+++ b/core/llm/llms/index.ts
@@ -15,6 +15,7 @@ import Azure from "./Azure";
 import Bedrock from "./Bedrock";
 import BedrockImport from "./BedrockImport";
 import Cerebras from "./Cerebras";
+import Chutes from "./Chutes";
 import Cloudflare from "./Cloudflare";
 import Cohere from "./Cohere";
 import CometAPI from "./CometAPI";
@@ -119,6 +120,7 @@ export const LLMClasses = [
   MockLLM,
   TestLLM,
   Cerebras,
+  Chutes,
   Asksage,
   Nebius,
   Nous,

--- a/packages/llm-info/src/index.ts
+++ b/packages/llm-info/src/index.ts
@@ -11,6 +11,7 @@ import { OpenAi } from "./providers/openai.js";
 import { Vllm } from "./providers/vllm.js";
 import { Voyage } from "./providers/voyage.js";
 import { xAI } from "./providers/xAI.js";
+import { Chutes } from "./providers/chutes.js";
 import { zAI } from "./providers/zai.js";
 import { LlmInfoWithProvider, ModelProvider, UseCase } from "./types.js";
 
@@ -29,6 +30,7 @@ export const allModelProviders: ModelProvider[] = [
   MiniMax,
   xAI,
   zAI,
+  Chutes,
 ];
 
 export const allLlms: LlmInfoWithProvider[] = allModelProviders.flatMap(

--- a/packages/llm-info/src/providers/chutes.ts
+++ b/packages/llm-info/src/providers/chutes.ts
@@ -1,0 +1,29 @@
+import { ModelProvider } from "../types.js";
+
+export const Chutes: ModelProvider = {
+  models: [
+    {
+      model: "chutes/DeepSeek-V3.2-TEE",
+      displayName: "DeepSeek V3.2 TEE",
+      contextLength: 65536,
+      recommendedFor: ["chat"],
+      regex: /DeepSeek-V3\.2-TEE/,
+    },
+    {
+      model: "chutes/Qwen3-32B-TEE",
+      displayName: "Qwen3 32B TEE",
+      contextLength: 131072,
+      recommendedFor: ["chat"],
+      regex: /Qwen3-32B-TEE/,
+    },
+    {
+      model: "chutes/Kimi-K2.5-TEE",
+      displayName: "Kimi K2.5 TEE",
+      contextLength: 262144,
+      recommendedFor: ["chat"],
+      regex: /Kimi-K2\.5-TEE/,
+    },
+  ],
+  id: "chutes",
+  displayName: "Chutes AI",
+};


### PR DESCRIPTION
Adds Chutes AI as a built-in model provider, following the same pattern as existing providers (Groq, DeepSeek, zAI, etc).

Chutes is a serverless AI inference provider with TEE (Trusted Execution Environment) models. OpenAI-compatible API at https://llm.chutes.ai/v1/.

## Changes

5 files, 47 lines added (all additive, no breaking changes):

- core/llm/llms/Chutes.ts — Provider class extending OpenAI with Chutes base URL
- core/llm/llms/index.ts — Register Chutes in LLMClasses
- core/llm/autodetect.ts — Add to autodetect provider list
- packages/llm-info/src/providers/chutes.ts — Model catalog (DeepSeek-V3.2-TEE, Qwen3-32B-TEE, Kimi-K2.5-TEE)
- packages/llm-info/src/index.ts — Register in allModelProviders

## Configuration

In config.yaml:

models:
  - provider: chutes
    model: chutes/DeepSeek-V3.2-TEE
    apiKey: your-chutes-api-key

## Provider Details

Provider ID: chutes
Base URL: https://llm.chutes.ai/v1/
API Type: OpenAI-compatible
Auth: API key (CHUTES_API_KEY env var or apiKey in config)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Chutes AI as a built-in, OpenAI-compatible provider to enable secure TEE models out of the box.

- **New Features**
  - New `chutes` provider with base `https://llm.chutes.ai/v1/` (extends OpenAI client).
  - Registered in LLMClasses and added to provider autodetect.
  - Model catalog in `packages/llm-info`: `chutes/DeepSeek-V3.2-TEE`, `chutes/Qwen3-32B-TEE`, `chutes/Kimi-K2.5-TEE`.
  - Configure with `provider: chutes`, select a model above, and set `CHUTES_API_KEY` or an `apiKey`.

<sup>Written for commit 8212002fec9d1df15df7529129255b8aaeb36739. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

