### PR TITLE
fix: correct typo in create_new_file success message

### DIFF
--- a/core/indexing/CodebaseIndexer.test.ts
+++ b/core/indexing/CodebaseIndexer.test.ts
@@ -208,7 +208,7 @@ describe("CodebaseIndexer", () => {
       expect(indexed.some((file) => file.endsWith("main.py"))).toBe(true);
     });
 
-    test("should successfuly re-index specific files", async () => {
+    test("should successfully re-index specific files", async () => {
       // Could add more specific tests for this but uses similar logic
       const before = await getAllIndexedFiles();
       await codebaseIndexer.refreshCodebaseIndexFiles(before);

--- a/core/tools/implementations/createNewFile.ts
+++ b/core/tools/implementations/createNewFile.ts
@@ -33,7 +33,7 @@ export const createNewFileImpl: ToolImpl = async (args, extras) => {
       {
         name: getUriPathBasename(resolvedFileUri),
         description: getCleanUriPath(resolvedFileUri),
-        content: "File created successfuly",
+        content: "File created successfully",
         uri: {
           type: "file",
           value: resolvedFileUri,


### PR DESCRIPTION
Fixes #12052

## Problem
The success message returned by the `create_new_file` tool contains a spelling typo: "successfuly" (missing an 'l') instead of "successfully". There was also an identical typo in a test description in `CodebaseIndexer.test.ts`.

## Solution
- Fixed `core/tools/implementations/createNewFile.ts` line 36: `"File created successfuly"` → `"File created successfully"`
- Fixed `core/indexing/CodebaseIndexer.test.ts` line 211: test description string with the same typo

## Testing
This is a string literal change with no logic impact. Existing tests continue to pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #12052 by correcting the typo in the `create_new_file` tool’s success message ("successfuly" → "successfully") and updating the matching test in `CodebaseIndexer.test.ts`.

<sup>Written for commit cb81b978cd3c572a516b8cf486239133e190d1d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

