### PR TITLE
[codex] fix(vscode): run commands in remote terminals

### DIFF
--- a/core/llm/llms/OpenRouter.ts
+++ b/core/llm/llms/OpenRouter.ts
@@ -1,5 +1,7 @@
 import { ChatCompletionCreateParams } from "openai/resources/index";
 
+import { OPENROUTER_HEADERS } from "@continuedev/openai-adapters";
+
 import { LLMOptions } from "../../index.js";
 import { osModelsEditPrompt } from "../templates/edit.js";
 
@@ -17,6 +19,19 @@ class OpenRouter extends OpenAI {
     },
     useLegacyCompletionsEndpoint: false,
   };
+
+  constructor(options: LLMOptions) {
+    super({
+      ...options,
+      requestOptions: {
+        ...options.requestOptions,
+        headers: {
+          ...OPENROUTER_HEADERS,
+          ...options.requestOptions?.headers,
+        },
+      },
+    });
+  }
 
   private isAnthropicModel(model?: string): boolean {
     if (!model) return false;

--- a/extensions/vscode/src/VsCodeIde.ts
+++ b/extensions/vscode/src/VsCodeIde.ts
@@ -15,6 +15,7 @@ import {
 import { Repository } from "./otherExtensions/git";
 import { SecretStorage } from "./stubs/SecretStorage";
 import { VsCodeIdeUtils } from "./util/ideUtils";
+import { runCommandInTerminal } from "./util/runCommandInTerminal";
 import { getExtensionVersion, isExtensionPrerelease } from "./util/util";
 import { getExtensionUri, openEditorAndRevealRange } from "./util/vscode";
 import { VsCodeWebviewProtocol } from "./webviewProtocol";
@@ -337,22 +338,7 @@ class VsCodeIde implements IDE {
     command: string,
     options: TerminalOptions = { reuseTerminal: true },
   ): Promise<void> {
-    let terminal: vscode.Terminal | undefined;
-    if (vscode.window.terminals.length && options.reuseTerminal) {
-      if (options.terminalName) {
-        terminal = vscode.window.terminals.find(
-          (t) => t?.name === options.terminalName,
-        );
-      } else {
-        terminal = vscode.window.activeTerminal ?? vscode.window.terminals[0];
-      }
-    }
-
-    if (!terminal) {
-      terminal = vscode.window.createTerminal(options?.terminalName);
-    }
-    terminal.show();
-    terminal.sendText(command, false);
+    await runCommandInTerminal(command, options);
   }
 
   async saveFile(fileUri: string): Promise<void> {

--- a/extensions/vscode/src/util/runCommandInTerminal.ts
+++ b/extensions/vscode/src/util/runCommandInTerminal.ts
@@ -1,0 +1,118 @@
+import type { TerminalOptions } from "core";
+import * as vscode from "vscode";
+
+const REMOTE_TERMINAL_TIMEOUT_MS = 5000;
+
+const terminalCacheByName = new Map<string, vscode.Terminal>();
+
+function getReusableTerminal(
+  options: TerminalOptions,
+): vscode.Terminal | undefined {
+  if (!vscode.window.terminals.length || !options.reuseTerminal) {
+    return undefined;
+  }
+
+  if (options.terminalName) {
+    const cachedTerminal = terminalCacheByName.get(options.terminalName);
+    if (cachedTerminal && vscode.window.terminals.includes(cachedTerminal)) {
+      return cachedTerminal;
+    }
+
+    terminalCacheByName.delete(options.terminalName);
+    return vscode.window.terminals.find(
+      (terminal) => terminal?.name === options.terminalName,
+    );
+  }
+
+  return vscode.window.activeTerminal ?? vscode.window.terminals[0];
+}
+
+async function createTerminal(
+  options: TerminalOptions,
+): Promise<vscode.Terminal> {
+  if (!vscode.env.remoteName) {
+    return vscode.window.createTerminal(options.terminalName);
+  }
+
+  const existingTerminals = new Set(vscode.window.terminals);
+
+  return await new Promise<vscode.Terminal>((resolve, reject) => {
+    let settled = false;
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
+    const cleanup = () => {
+      terminalListener.dispose();
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+    };
+
+    const resolveIfNewTerminalExists = () => {
+      const newTerminal = vscode.window.terminals.find(
+        (terminal) => !existingTerminals.has(terminal),
+      );
+      if (!newTerminal) {
+        return false;
+      }
+
+      settled = true;
+      cleanup();
+      resolve(newTerminal);
+      return true;
+    };
+
+    const terminalListener = vscode.window.onDidOpenTerminal((terminal) => {
+      if (settled || existingTerminals.has(terminal)) {
+        return;
+      }
+
+      settled = true;
+      cleanup();
+      resolve(terminal);
+    });
+
+    timeoutHandle = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      cleanup();
+      reject(new Error("Timed out waiting for remote terminal to open"));
+    }, REMOTE_TERMINAL_TIMEOUT_MS);
+
+    if (resolveIfNewTerminalExists()) {
+      return;
+    }
+
+    void vscode.commands.executeCommand("workbench.action.terminal.new").then(
+      () => {
+        resolveIfNewTerminalExists();
+      },
+      (error: unknown) => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}
+
+export async function runCommandInTerminal(
+  command: string,
+  options: TerminalOptions = { reuseTerminal: true },
+): Promise<void> {
+  const terminal =
+    getReusableTerminal(options) ?? (await createTerminal(options));
+
+  if (options.terminalName) {
+    terminalCacheByName.set(options.terminalName, terminal);
+  }
+
+  terminal.show();
+  terminal.sendText(command, true);
+}

--- a/extensions/vscode/src/util/runCommandInTerminal.ts
+++ b/extensions/vscode/src/util/runCommandInTerminal.ts
@@ -5,6 +5,17 @@ const REMOTE_TERMINAL_TIMEOUT_MS = 5000;
 
 const terminalCacheByName = new Map<string, vscode.Terminal>();
 
+function getNewActiveTerminal(
+  existingTerminals: Set<vscode.Terminal>,
+): vscode.Terminal | undefined {
+  const activeTerminal = vscode.window.activeTerminal;
+  if (!activeTerminal || existingTerminals.has(activeTerminal)) {
+    return undefined;
+  }
+
+  return activeTerminal;
+}
+
 function getReusableTerminal(
   options: TerminalOptions,
 ): vscode.Terminal | undefined {
@@ -35,22 +46,27 @@ async function createTerminal(
   }
 
   const existingTerminals = new Set(vscode.window.terminals);
+  await vscode.commands.executeCommand("workbench.action.terminal.new");
+
+  const newActiveTerminal = getNewActiveTerminal(existingTerminals);
+  if (newActiveTerminal) {
+    return newActiveTerminal;
+  }
 
   return await new Promise<vscode.Terminal>((resolve, reject) => {
     let settled = false;
     let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
 
     const cleanup = () => {
-      terminalListener.dispose();
+      terminalOpenListener.dispose();
+      activeTerminalListener.dispose();
       if (timeoutHandle) {
         clearTimeout(timeoutHandle);
       }
     };
 
-    const resolveIfNewTerminalExists = () => {
-      const newTerminal = vscode.window.terminals.find(
-        (terminal) => !existingTerminals.has(terminal),
-      );
+    const resolveIfNewActiveTerminalExists = () => {
+      const newTerminal = getNewActiveTerminal(existingTerminals);
       if (!newTerminal) {
         return false;
       }
@@ -61,16 +77,34 @@ async function createTerminal(
       return true;
     };
 
-    const terminalListener = vscode.window.onDidOpenTerminal((terminal) => {
-      if (settled || existingTerminals.has(terminal)) {
+    const terminalOpenListener = vscode.window.onDidOpenTerminal(() => {
+      if (settled) {
         return;
       }
 
-      settled = true;
-      cleanup();
-      resolve(terminal);
+      resolveIfNewActiveTerminalExists();
     });
 
+    const activeTerminalListener = vscode.window.onDidChangeActiveTerminal(
+      (terminal) => {
+        if (settled || !terminal || existingTerminals.has(terminal)) {
+          return;
+        }
+
+        settled = true;
+        cleanup();
+        resolve(terminal);
+      },
+    );
+
+    if (resolveIfNewActiveTerminalExists()) {
+      return;
+    }
+
+    // `workbench.action.terminal.new` should focus the new terminal in remote
+    // workspaces. If another terminal opens concurrently, wait until VS Code
+    // actually switches the active terminal instead of grabbing the first one
+    // that appears.
     timeoutHandle = setTimeout(() => {
       if (settled) {
         return;
@@ -80,25 +114,6 @@ async function createTerminal(
       cleanup();
       reject(new Error("Timed out waiting for remote terminal to open"));
     }, REMOTE_TERMINAL_TIMEOUT_MS);
-
-    if (resolveIfNewTerminalExists()) {
-      return;
-    }
-
-    void vscode.commands.executeCommand("workbench.action.terminal.new").then(
-      () => {
-        resolveIfNewTerminalExists();
-      },
-      (error: unknown) => {
-        if (settled) {
-          return;
-        }
-
-        settled = true;
-        cleanup();
-        reject(error);
-      },
-    );
   });
 }
 

--- a/extensions/vscode/src/util/runCommandInTerminal.vitest.ts
+++ b/extensions/vscode/src/util/runCommandInTerminal.vitest.ts
@@ -7,6 +7,9 @@ type MockTerminal = {
 };
 
 const terminalListeners = new Set<(terminal: MockTerminal) => void>();
+const activeTerminalListeners = new Set<
+  (terminal: MockTerminal | undefined) => void
+>();
 const terminals: MockTerminal[] = [];
 
 const windowMock = {
@@ -19,6 +22,14 @@ const windowMock = {
       dispose: vi.fn(() => terminalListeners.delete(listener)),
     };
   }),
+  onDidChangeActiveTerminal: vi.fn(
+    (listener: (terminal: MockTerminal | undefined) => void) => {
+      activeTerminalListeners.add(listener);
+      return {
+        dispose: vi.fn(() => activeTerminalListeners.delete(listener)),
+      };
+    },
+  ),
 };
 
 const commandsMock = {
@@ -43,6 +54,19 @@ function createTerminal(name: string): MockTerminal {
   };
 }
 
+function notifyTerminalOpened(terminal: MockTerminal) {
+  for (const listener of terminalListeners) {
+    listener(terminal);
+  }
+}
+
+function setActiveTerminal(terminal: MockTerminal | undefined) {
+  windowMock.activeTerminal = terminal;
+  for (const listener of activeTerminalListeners) {
+    listener(terminal);
+  }
+}
+
 describe("runCommandInTerminal", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -50,7 +74,8 @@ describe("runCommandInTerminal", () => {
 
     terminals.length = 0;
     terminalListeners.clear();
-    windowMock.activeTerminal = undefined;
+    activeTerminalListeners.clear();
+    setActiveTerminal(undefined);
     envMock.remoteName = undefined;
 
     windowMock.createTerminal.mockImplementation((name?: string) => {
@@ -67,7 +92,7 @@ describe("runCommandInTerminal", () => {
   it("reuses the active terminal and sends an executing command", async () => {
     const terminal = createTerminal("Active");
     terminals.push(terminal);
-    windowMock.activeTerminal = terminal;
+    setActiveTerminal(terminal);
 
     const { runCommandInTerminal } = await import("./runCommandInTerminal");
 
@@ -101,9 +126,8 @@ describe("runCommandInTerminal", () => {
       expect(command).toBe("workbench.action.terminal.new");
       const terminal = createTerminal("Remote Shell");
       terminals.push(terminal);
-      for (const listener of terminalListeners) {
-        listener(terminal);
-      }
+      setActiveTerminal(terminal);
+      notifyTerminalOpened(terminal);
     });
 
     const { runCommandInTerminal } = await import("./runCommandInTerminal");
@@ -128,9 +152,8 @@ describe("runCommandInTerminal", () => {
       createdCount += 1;
       const terminal = createTerminal("Remote " + createdCount);
       terminals.push(terminal);
-      for (const listener of terminalListeners) {
-        listener(terminal);
-      }
+      setActiveTerminal(terminal);
+      notifyTerminalOpened(terminal);
     });
 
     const { runCommandInTerminal } = await import("./runCommandInTerminal");
@@ -155,5 +178,26 @@ describe("runCommandInTerminal", () => {
       "ollama serve",
       true,
     );
+  });
+
+  it("ignores unrelated remote terminals that open before the command terminal becomes active", async () => {
+    envMock.remoteName = "dev-container";
+    commandsMock.executeCommand.mockImplementation(async () => {
+      const unrelatedTerminal = createTerminal("Unrelated");
+      terminals.push(unrelatedTerminal);
+      notifyTerminalOpened(unrelatedTerminal);
+
+      const commandTerminal = createTerminal("Remote Command");
+      terminals.push(commandTerminal);
+      setActiveTerminal(commandTerminal);
+      notifyTerminalOpened(commandTerminal);
+    });
+
+    const { runCommandInTerminal } = await import("./runCommandInTerminal");
+
+    await runCommandInTerminal("pwd", { reuseTerminal: true });
+
+    expect(terminals[0].sendText).not.toHaveBeenCalled();
+    expect(terminals[1].sendText).toHaveBeenCalledWith("pwd", true);
   });
 });

--- a/extensions/vscode/src/util/runCommandInTerminal.vitest.ts
+++ b/extensions/vscode/src/util/runCommandInTerminal.vitest.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type MockTerminal = {
+  name: string;
+  show: ReturnType<typeof vi.fn>;
+  sendText: ReturnType<typeof vi.fn>;
+};
+
+const terminalListeners = new Set<(terminal: MockTerminal) => void>();
+const terminals: MockTerminal[] = [];
+
+const windowMock = {
+  terminals,
+  activeTerminal: undefined as MockTerminal | undefined,
+  createTerminal: vi.fn<(name?: string) => MockTerminal>(),
+  onDidOpenTerminal: vi.fn((listener: (terminal: MockTerminal) => void) => {
+    terminalListeners.add(listener);
+    return {
+      dispose: vi.fn(() => terminalListeners.delete(listener)),
+    };
+  }),
+};
+
+const commandsMock = {
+  executeCommand: vi.fn<(command: string) => Promise<void>>(),
+};
+
+const envMock = {
+  remoteName: undefined as string | undefined,
+};
+
+vi.mock("vscode", () => ({
+  window: windowMock,
+  commands: commandsMock,
+  env: envMock,
+}));
+
+function createTerminal(name: string): MockTerminal {
+  return {
+    name,
+    show: vi.fn(),
+    sendText: vi.fn(),
+  };
+}
+
+describe("runCommandInTerminal", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    terminals.length = 0;
+    terminalListeners.clear();
+    windowMock.activeTerminal = undefined;
+    envMock.remoteName = undefined;
+
+    windowMock.createTerminal.mockImplementation((name?: string) => {
+      const terminal = createTerminal(
+        name ?? "Terminal " + (terminals.length + 1),
+      );
+      terminals.push(terminal);
+      return terminal;
+    });
+
+    commandsMock.executeCommand.mockResolvedValue();
+  });
+
+  it("reuses the active terminal and sends an executing command", async () => {
+    const terminal = createTerminal("Active");
+    terminals.push(terminal);
+    windowMock.activeTerminal = terminal;
+
+    const { runCommandInTerminal } = await import("./runCommandInTerminal");
+
+    await runCommandInTerminal("echo hello");
+
+    expect(windowMock.createTerminal).not.toHaveBeenCalled();
+    expect(commandsMock.executeCommand).not.toHaveBeenCalled();
+    expect(terminal.show).toHaveBeenCalledOnce();
+    expect(terminal.sendText).toHaveBeenCalledWith("echo hello", true);
+  });
+
+  it("creates a named local terminal when no reusable terminal exists", async () => {
+    const { runCommandInTerminal } = await import("./runCommandInTerminal");
+
+    await runCommandInTerminal("npm test", {
+      reuseTerminal: true,
+      terminalName: "Start Ollama",
+    });
+
+    expect(windowMock.createTerminal).toHaveBeenCalledWith("Start Ollama");
+    expect(commandsMock.executeCommand).not.toHaveBeenCalled();
+
+    const createdTerminal = terminals[0];
+    expect(createdTerminal.show).toHaveBeenCalledOnce();
+    expect(createdTerminal.sendText).toHaveBeenCalledWith("npm test", true);
+  });
+
+  it("creates remote terminals through the remote-aware VS Code command", async () => {
+    envMock.remoteName = "ssh-remote";
+    commandsMock.executeCommand.mockImplementation(async (command: string) => {
+      expect(command).toBe("workbench.action.terminal.new");
+      const terminal = createTerminal("Remote Shell");
+      terminals.push(terminal);
+      for (const listener of terminalListeners) {
+        listener(terminal);
+      }
+    });
+
+    const { runCommandInTerminal } = await import("./runCommandInTerminal");
+
+    await runCommandInTerminal("pwd", { reuseTerminal: true });
+
+    expect(windowMock.createTerminal).not.toHaveBeenCalled();
+    expect(commandsMock.executeCommand).toHaveBeenCalledWith(
+      "workbench.action.terminal.new",
+    );
+
+    const createdTerminal = terminals[0];
+    expect(createdTerminal.show).toHaveBeenCalledOnce();
+    expect(createdTerminal.sendText).toHaveBeenCalledWith("pwd", true);
+  });
+
+  it("reuses cached remote terminals for named commands", async () => {
+    envMock.remoteName = "dev-container";
+
+    let createdCount = 0;
+    commandsMock.executeCommand.mockImplementation(async () => {
+      createdCount += 1;
+      const terminal = createTerminal("Remote " + createdCount);
+      terminals.push(terminal);
+      for (const listener of terminalListeners) {
+        listener(terminal);
+      }
+    });
+
+    const { runCommandInTerminal } = await import("./runCommandInTerminal");
+
+    await runCommandInTerminal("ollama serve", {
+      reuseTerminal: true,
+      terminalName: "Start Ollama",
+    });
+    await runCommandInTerminal("ollama serve", {
+      reuseTerminal: true,
+      terminalName: "Start Ollama",
+    });
+
+    expect(commandsMock.executeCommand).toHaveBeenCalledTimes(1);
+    expect(terminals[0].sendText).toHaveBeenNthCalledWith(
+      1,
+      "ollama serve",
+      true,
+    );
+    expect(terminals[0].sendText).toHaveBeenNthCalledWith(
+      2,
+      "ollama serve",
+      true,
+    );
+  });
+});

--- a/packages/openai-adapters/src/apis/OpenRouter.ts
+++ b/packages/openai-adapters/src/apis/OpenRouter.ts
@@ -10,9 +10,10 @@ export interface OpenRouterConfig extends OpenAIConfig {
 
 // TODO: Extract detailed error info from OpenRouter's error.metadata.raw to surface better messages
 
-const OPENROUTER_HEADERS: Record<string, string> = {
+export const OPENROUTER_HEADERS: Record<string, string> = {
   "HTTP-Referer": "https://www.continue.dev/",
-  "X-Title": "Continue",
+  "X-OpenRouter-Title": "Continue",
+  "X-OpenRouter-Categories": "ide-extension",
 };
 
 export class OpenRouterApi extends OpenAIApi {

--- a/packages/openai-adapters/src/index.ts
+++ b/packages/openai-adapters/src/index.ts
@@ -243,4 +243,5 @@ export {
 } from "./apis/AnthropicUtils.js";
 
 export { isResponsesModel } from "./apis/openaiResponses.js";
+export { OPENROUTER_HEADERS } from "./apis/OpenRouter.js";
 export { extractBase64FromDataUrl, parseDataUrl } from "./util/url.js";


### PR DESCRIPTION
## Summary
- route `VsCodeIde.runCommand()` through a dedicated terminal helper
- create new terminals with `workbench.action.terminal.new` when the workspace is remote, so SSH/devcontainer/codespaces commands start on the correct machine
- always send commands with a trailing newline and add regression tests for local reuse, remote creation, and named remote terminal reuse

## Why
`VsCodeIde.runCommand()` currently has two remote-terminal bugs:
- `sendText(command, false)` types the command but never executes it
- `createTerminal()` from the UI-side extension host creates a local terminal instead of a remote one

That breaks `/cmd`, Ollama/Lemonade startup helpers, and any terminal-tool fallback path in remote workspaces.

## Validation
- ran `npm test -- src/util/runCommandInTerminal.vitest.ts` in `extensions/vscode`
- ran `git diff --check`
- ran `npm run tsc:check` in `extensions/vscode` and only hit existing repo issues unrelated to this patch:
  - `../../core/llm/llms/OpenRouter.ts`: missing `OPENROUTER_HEADERS` export
  - `src/extension.ts`: missing `./.buildTimestamp` declaration

Closes #10542

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes command execution in VS Code terminals across remote workspaces and restores `/cmd`, Ollama/Lemonade helpers, and terminal-tool fallbacks. Adds default OpenRouter metadata headers in the core `OpenRouter` client.

- **Bug Fixes**
  - Route `VsCodeIde.runCommand()` through `runCommandInTerminal`; in remote workspaces create terminals via `workbench.action.terminal.new`, wait until the new terminal is active, and ignore unrelated terminals (5s timeout).
  - Always send commands with a trailing newline; cache and reuse named terminals.
  - Add tests for local reuse, remote creation, named remote reuse, and ignoring unrelated remote terminals.

- **Dependencies**
  - Export `OPENROUTER_HEADERS` from `@continuedev/openai-adapters` and apply them in core `OpenRouter` (adds `HTTP-Referer`, `X-OpenRouter-Title`, and `X-OpenRouter-Categories`).

<sup>Written for commit abd96ca088fb116f93b27b2cb45e0b1f3b02a4f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

