### PR TITLE
docs(openai): add Kelly Intelligence to OpenAI-compatible providers list

### DIFF
--- a/docs/customize/model-providers/top-level/openai.mdx
+++ b/docs/customize/model-providers/top-level/openai.mdx
@@ -61,6 +61,7 @@ OpenAI API compatible providers include
 - [vLLM](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html)
 - [BerriAI/litellm](https://github.com/BerriAI/litellm)
 - [Tetrate Agent Router Service](https://router.tetrate.ai)
+- [Kelly Intelligence](https://api.thedailylesson.com) (OpenAI-compatible API with built-in vocabulary RAG, operated by [Lesson of the Day, PBC](https://lotdpbc.com))
 
 If you are using an OpenAI API compatible providers, you can change the `apiBase` like this:
 


### PR DESCRIPTION
## Description

One-line addition to the **OpenAI API compatible providers** bullet list in `docs/customize/model-providers/top-level/openai.mdx`.

[Kelly Intelligence](https://api.thedailylesson.com) is an OpenAI-compatible API with a built-in vocabulary RAG layer (162,000 words across 47 languages) and an AI tutor persona, built on top of Claude. It's operated by [Lesson of the Day, PBC](https://lotdpbc.com), a public benefit corporation building education infrastructure. The free tier requires no credit card.

It works with Continue out of the box using the existing `provider: openai` + `apiBase` pattern that's already documented on the same page — **no new provider integration, no code changes**, just one new bullet alongside KoboldCpp, LocalAI, vLLM, BerriAI/litellm, and Tetrate Agent Router Service.

### Example config (uses existing `provider: openai` + `apiBase`)

```yaml
name: My Config
version: 0.0.1
schema: v1

models:
  - name: Kelly Haiku
    provider: openai
    model: kelly-haiku
    apiBase: https://api.thedailylesson.com/v1
    apiKey: <YOUR_KELLY_API_KEY>
```

### Try without an API key

Kelly Intelligence has a public `/v1/demo` endpoint for trying the API without any signup (5 requests/hour per IP):

```bash
curl -X POST https://api.thedailylesson.com/v1/demo \
  -H "Content-Type: application/json" \
  -d '{"messages":[{"role":"user","content":"What does ephemeral mean?"}]}'
```

This is the same wire format as `/v1/chat/completions` — useful for verifying the integration before adding a key to your Continue config.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created (n/a — docs-only, single bullet addition)

## Screen recording or screenshot

n/a — single-line documentation addition to an existing bullet list.

## Tests

n/a — docs-only change, no code touched. The example config above has been verified end-to-end against the live `https://api.thedailylesson.com/v1` endpoint.

---

**Note on positioning:** Kelly Intelligence is **complementary** to direct provider access, not a replacement for the official Anthropic SDK. It's the right fit when an application needs the OpenAI wire format **and** vocabulary / language-learning RAG features without building that data layer in-house.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Kelly Intelligence to the OpenAI-compatible providers list in `docs/customize/model-providers/top-level/openai.mdx`. It works via the existing `provider: openai` + `apiBase` pattern.

<sup>Written for commit fa22e26a6cf431283b88c2c611a9027286fe61f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

