### PR TITLE
fix(core): emit message before function_calls in toResponsesInput

### DIFF
--- a/core/llm/openaiTypeConverters.ts
+++ b/core/llm/openaiTypeConverters.ts
@@ -1038,8 +1038,9 @@ export function toResponsesInput(messages: ChatMessage[]): ResponseInput {
           (respId?.startsWith("msg_") ? respId : undefined);
 
         if (Array.isArray(toolCalls) && toolCalls.length > 0) {
-          emitFunctionCallsFromToolCalls(toolCalls, fcIds, input);
-
+          // Emit text message BEFORE function_call items so that a preceding
+          // reasoning item stays adjacent to its message output, satisfying
+          // the OpenAI Responses API's sequencing requirements (#11994).
           if (text && text.trim()) {
             if (msgId) {
               const outputMessageItem: ResponseOutputMessage = {
@@ -1060,6 +1061,8 @@ export function toResponsesInput(messages: ChatMessage[]): ResponseInput {
               pushMessage("assistant", text);
             }
           }
+
+          emitFunctionCallsFromToolCalls(toolCalls, fcIds, input);
         } else if (msgId) {
           const outputMessageItem: ResponseOutputMessage = {
             id: msgId,


### PR DESCRIPTION
## Summary
Fixes #11994 — Resolves `400 Bad Request: 'Missing reasoning item'` errors when using reasoning models (o1, o3) through the OpenAI Responses API.

## Problem
In `toResponsesInput`, when an assistant message contains both text and tool calls, `function_call` items were emitted **before** the text `message` item. This separates a preceding `reasoning` item from its associated `message`, violating the Responses API's sequencing requirements:

```
// Before (broken): reasoning → function_call → function_call → message
// After (fixed):   reasoning → message → function_call → function_call
```

## Solution
Swapped the emission order in the `case "assistant"` block so the text message is pushed **before** the function_call items. This keeps the reasoning item adjacent to its message output.

## Test plan
- [ ] Verify reasoning models (o1/o3) no longer produce 400 errors during multi-step tool-calling turns
- [ ] Verify non-reasoning models still work correctly with tool calls
- [ ] Existing test suite passes (lint-staged/prettier verified on commit)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves #11994 by fixing Responses API sequencing in `toResponsesInput`: emit the assistant text message before `function_call` items. This keeps a preceding `reasoning` item adjacent to its message and prevents 400 "Missing reasoning item" errors with o1/o3.

<sup>Written for commit f272d7e52454fd0f58e67f38756e840ae98976ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

