### PR TITLE
fix(tools): resolve PowerShell ENOENT by using full path on Windows

### DIFF
--- a/core/tools/implementations/runTerminalCommand.ts
+++ b/core/tools/implementations/runTerminalCommand.ts
@@ -24,9 +24,14 @@ function getDecodedOutput(data: Buffer): string {
 } // Simple helper function to use login shell on Unix/macOS and PowerShell on Windows
 function getShellCommand(command: string): { shell: string; args: string[] } {
   if (process.platform === "win32") {
-    // Windows: Use PowerShell
+    // Windows: Use PowerShell with full path to avoid ENOENT when the
+    // extension host PATH doesn't include Windows system directories.
+    // SystemRoot is always set on Windows (e.g. C:\Windows).
+    const systemRoot =
+      process.env.SystemRoot || process.env.SYSTEMROOT || "C:\\Windows";
+    const powershellPath = `${systemRoot}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`;
     return {
-      shell: "powershell.exe",
+      shell: powershellPath,
       args: ["-NoLogo", "-ExecutionPolicy", "Bypass", "-Command", command],
     };
   } else {


### PR DESCRIPTION
Fixes #12079

## Problem

On Windows, the `run_terminal_command` tool fails with `spawn powershell.exe ENOENT` for all terminal commands (even simple ones like `echo "test"`). File creation/editing tools work fine, but nothing that uses the terminal works.

The root cause is that the VSCode extension host process may run with a minimal PATH that does not include `%SystemRoot%\System32` (e.g. `C:\Windows\System32`), where `powershell.exe` lives. When `child_process.spawn("powershell.exe", ...)` is called without a full path, Node.js fails to locate the executable.

## Solution

Replace the bare `"powershell.exe"` shell name with the full absolute path constructed from the `SystemRoot` environment variable, which is always present on Windows:

```
C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
```

`SystemRoot` is a guaranteed Windows environment variable that points to the Windows installation directory (typically `C:\Windows`). Using it avoids any dependency on the PATH being set correctly in the extension host.

## Testing

- On non-Windows systems: no change in behavior (the `else` branch handles Unix/macOS).
- On Windows: `powershell.exe` is now resolved via the full path from `SystemRoot`, bypassing PATH lookup issues.
- Existing test suite covers the `runTerminalCommandImpl` function and should continue to pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows terminal commands failing with "spawn powershell.exe ENOENT" by invoking PowerShell via its absolute path built from the `SystemRoot` env var (fallback to C:\Windows) instead of relying on PATH. No behavior change on macOS/Linux.

<sup>Written for commit 8bdb84d8f01046149b20d6e04bb06efa1dad1932. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

