### PR TITLE
fix(chat): cancel tool call when user sends message without accepting/rejecting diff

### DIFF
--- a/gui/src/pages/gui/Chat.tsx
+++ b/gui/src/pages/gui/Chat.tsx
@@ -243,6 +243,16 @@ export function Chat() {
       // Reject all pending apply states
       latestPendingApplyStates.forEach((applyState) => {
         if (applyState.status !== "closed") {
+          // Cancel the associated tool call so the model receives a cancellation
+          // signal instead of "No tool output" when the user sends a new message
+          // without accepting or rejecting the diff
+          if (applyState.toolCallId) {
+            dispatch(
+              cancelToolCall({
+                toolCallId: applyState.toolCallId,
+              }),
+            );
+          }
           ideMessenger.post("rejectDiff", applyState);
         }
       });


### PR DESCRIPTION
Fixes #12051

## Problem

When `multi_edit` (or similar tools with `respondImmediately: false`) presents a diff and the user sends a new message without clicking Accept or Reject, the tool call remains in `calling` state with no output. `constructMessages` emits `"No tool output"`, making the model assume the edit succeeded. Subsequent `multi_edit` calls then fail because their `old_string` values no longer match the actual (unmodified) file.

## Solution

When pending apply states (status `"done"`) are rejected because the user sends a new message, we now also dispatch `cancelToolCall` for any associated tool call IDs. The tool call transitions from `calling` to `canceled` status before messages are constructed and sent to the model.

The model now receives `"The user cancelled this tool call."` instead of `"No tool output"`, correctly signaling that the edit was not applied.

## Testing

- Ask the agent to edit a file using `multi_edit`
- When the diff appears, type a new message in chat without clicking Accept or Reject
- Before: model receives `"No tool output"` and proceeds as if edit succeeded
- After: model receives cancellation message and knows the edit was not applied

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancel `multi_edit` (and other `respondImmediately: false` tools) when the user sends a new chat message without accepting/rejecting the diff. The tool call now moves to `canceled`, and the model sees a clear cancellation instead of "No tool output."

- **Bug Fixes**
  - Dispatch `cancelToolCall` when rejecting pending apply states on new message.
  - Prevents false assumptions about applied edits and `multi_edit` failures from mismatched `old_string` values.

<sup>Written for commit 25bd83dcf7243f2106a8a7ecdb8c1f03ea4d4aa9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

