### PR TITLE
fix: enable prompt file slash commands in edit mode

### DIFF
--- a/gui/src/redux/selectors/index.ts
+++ b/gui/src/redux/selectors/index.ts
@@ -22,7 +22,7 @@ export const selectSlashCommandComboBoxInputs = createSelector(
           description: cmd.description,
           type: "slashCommand" as ComboBoxItemType,
           content: content,
-          source: cmd.source,
+          slashCommandSource: cmd.source,
         } as ComboBoxItem;
       }) || []
     );


### PR DESCRIPTION
Fixes #12087

## Problem

Users reported that prompt files from `.continue/prompts` could be used via slash commands (e.g. `/prompt-name`) in chat and agent modes, but not in edit mode (opened via `Ctrl+I`).

The root cause is a property name mismatch in `gui/src/redux/selectors/index.ts`. The `selectSlashCommandComboBoxInputs` selector was returning the slash command source field as `source`, but `ContinueInputBox.tsx` filters slash commands in edit mode by checking `cmd.slashCommandSource`:

```typescript
// ContinueInputBox.tsx — the filter checks slashCommandSource
return availableSlashCommands.filter((cmd) =>
  cmd.slashCommandSource
    ? EDIT_ALLOWED_SLASH_COMMAND_SOURCES.includes(cmd.slashCommandSource)
    : false,
);
```

Because `source` was returned instead of `slashCommandSource`, `cmd.slashCommandSource` was always `undefined`, so the filter always returned `false` — blocking all slash commands (including prompt files) in edit mode.

## Solution

Rename the property from `source` to `slashCommandSource` in the selector return value to align with the `ComboBoxItem` type definition and the filter logic. This ensures prompt files (`prompt-file-v1`, `prompt-file-v2`) and other allowed sources are correctly included when using edit mode.

## Testing

1. Create a prompt file in `.continue/prompts/my-prompt.md`
2. Select some code and open edit mode (`Ctrl+I`)
3. Type `/my-prompt` — it should now appear in the dropdown and be usable

Previously step 3 would show no results; after this fix the prompt appears correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return the correct `slashCommandSource` in the slash-command selector to re-enable prompt-file slash commands in edit mode (Ctrl+I). Users can now type `/my-prompt` from `.continue/prompts` and see it in the dropdown.

- **Bug Fixes**
  - In `gui/src/redux/selectors/index.ts`, renamed `source` to `slashCommandSource` in `selectSlashCommandComboBoxInputs` to match `ComboBoxItem` and the `ContinueInputBox` filter.

<sup>Written for commit ae6f31d81d5ff03fa5355c9e7640c7e1ef5a85a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

