### PR TITLE
docs: document dynamic model fetching feature

### DIFF
--- a/docs/customize/models.mdx
+++ b/docs/customize/models.mdx
@@ -28,6 +28,44 @@ If no model is specified, Continue automatically uses the default agent with our
 Explore models in [The Hub](https://continue.dev/hub?type=models).
 </Info>
 
+## Dynamic Model Discovery
+
+Continue can automatically discover and load models from your configured providers, making it easy to access the latest models without manual configuration.
+
+### Supported Providers
+
+The following providers support dynamic model fetching:
+
+| Provider | Auto-loads on startup | Refresh with API key |
+|----------|----------------------|---------------------|
+| **Ollama** | ✅ Yes | ✅ Yes |
+| **OpenRouter** | ✅ Yes | ✅ Yes |
+| **Anthropic** | ❌ No | ✅ Yes |
+| **Google Gemini** | ❌ No | ✅ Yes |
+| **OpenAI** | ❌ No | ✅ Yes |
+| **Other providers** | ❌ No | ✅ Yes (if supported) |
+
+### How It Works
+
+1. **Automatic loading**: Ollama and OpenRouter models are automatically loaded when you open Continue
+2. **Manual refresh**: For other providers, enter your API key in the "Add Model" UI and click the refresh icon to fetch available models
+3. **Capability detection**: Continue automatically detects model capabilities (`contextLength`, `maxTokens`, `supportsTools`) and saves them to your `config.yaml`
+
+### Using the Refresh Button
+
+When adding a model from a provider that requires an API key:
+
+1. Open the model selector and click "Add Model"
+2. Select your provider (e.g., Anthropic, OpenAI, Gemini)
+3. Enter your API key
+4. Click the **refresh icon** that appears next to the model dropdown
+5. Continue will fetch all available models from that provider
+6. Select the model you want to add
+
+<Tip>
+Model capabilities like context length and tool support are automatically detected and saved when you add a model this way.
+</Tip>
+
 ## Learn More About Models
 
 Continue supports [many model providers](/customize/model-providers/top-level/openai), including Anthropic, OpenAI, Gemini, Ollama, Amazon Bedrock, Azure, xAI, and more. Models can have various roles like `chat`, `edit`, `apply`, `autocomplete`, `embed`, and `rerank`.


### PR DESCRIPTION
## Summary

This PR adds documentation for the dynamic model fetching capability introduced in PR #12046.

## Changes

Added a new "Dynamic Model Discovery" section to `docs/customize/models.mdx` that covers:

1. **Supported Providers Table** - Shows which providers support auto-loading vs manual refresh:
   - Ollama and OpenRouter auto-load models on startup
   - Anthropic, Gemini, OpenAI, and others support refresh with API key

2. **How It Works** - Explains the three-step process:
   - Automatic loading for Ollama/OpenRouter
   - Manual refresh using the API key
   - Automatic capability detection

3. **Using the Refresh Button** - Step-by-step guide for adding models from providers that require API keys

4. **Tip** - Notes that capabilities (contextLength, maxTokens, tools) are automatically detected and saved

## Related Issues

Fixes #12097

## Related PR

- #12046 (feat: fetch provider models dynamically and fix isOpenSource pollution)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document dynamic model discovery in `docs/customize/models.mdx` to explain how models auto-load or refresh across providers. Covers providers that auto-load (Ollama, OpenRouter), those requiring an API key and refresh (Anthropic, Gemini, OpenAI), how to use the refresh button, and that capabilities are auto-detected and saved.

<sup>Written for commit af574a686263f6c308bc707f0f2f9ed35beab361. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

