### PR TITLE
fix: strip orphaned fc_ IDs from function_calls when reasoning is pruned from context

### DIFF
--- a/core/llm/openaiTypeConverters.test.ts
+++ b/core/llm/openaiTypeConverters.test.ts
@@ -643,6 +643,142 @@ describe("openaiTypeConverters", () => {
       });
     });
 
+    describe("orphaned fc_ ID stripping (context compaction)", () => {
+      it("should strip fc_ ID from function_call when reasoning was pruned from context", () => {
+        // Scenario: thinking message was removed by compileChatMessages due to context overflow.
+        // The assistant message still has the fc_ ID that references the now-absent reasoning.
+        const messages: ChatMessage[] = [
+          {
+            role: "user",
+            content: "Hello",
+          },
+          // thinking message was pruned — NOT present in messages
+          {
+            role: "assistant",
+            content: "",
+            toolCalls: [
+              {
+                id: "call_001",
+                type: "function",
+                function: { name: "read_file", arguments: '{"path":"a.txt"}' },
+              },
+            ],
+            metadata: {
+              responsesOutputItemIds: ["fc_001"], // fc_ ID orphaned without reasoning
+            },
+          } as ChatMessage,
+          {
+            role: "tool",
+            content: "file contents",
+            toolCallId: "call_001",
+          } as ChatMessage,
+        ];
+
+        const result = toResponsesInput(messages);
+
+        // function_call should be present but WITHOUT its fc_ ID
+        const functionCalls = getFunctionCalls(result);
+        expect(functionCalls.length).toBe(1);
+        expect(functionCalls[0].id).toBeUndefined();
+        expect(functionCalls[0].call_id).toBe("call_001");
+
+        // function_call_output should still be present
+        const outputs = getFunctionCallOutputs(result);
+        expect(outputs.length).toBe(1);
+        expect(outputs[0].call_id).toBe("call_001");
+      });
+
+      it("should keep fc_ ID when reasoning is present before function_call", () => {
+        // Sanity check: valid case should still work
+        const messages: ChatMessage[] = [
+          {
+            role: "thinking",
+            content: "",
+            reasoning_details: [
+              { type: "reasoning_id", id: "rs_001" },
+              {
+                type: "encrypted_content",
+                encrypted_content: "encrypted_data",
+              },
+            ],
+            metadata: { reasoningId: "rs_001", encrypted_content: "encrypted_data" },
+          } as ChatMessage,
+          {
+            role: "assistant",
+            content: "",
+            toolCalls: [
+              {
+                id: "call_001",
+                type: "function",
+                function: { name: "read_file", arguments: '{"path":"a.txt"}' },
+              },
+            ],
+            metadata: {
+              responsesOutputItemIds: ["fc_001"],
+            },
+          } as ChatMessage,
+        ];
+
+        const result = toResponsesInput(messages);
+
+        const reasoning = getReasoningItems(result);
+        expect(reasoning.length).toBe(1);
+
+        const functionCalls = getFunctionCalls(result);
+        expect(functionCalls.length).toBe(1);
+        expect(functionCalls[0].id).toBe("fc_001"); // ID preserved
+      });
+
+      it("should strip fc_ IDs from multiple pruned function_calls", () => {
+        const messages: ChatMessage[] = [
+          {
+            role: "user",
+            content: "Use two tools",
+          },
+          // thinking message pruned
+          {
+            role: "assistant",
+            content: "",
+            toolCalls: [
+              {
+                id: "call_001",
+                type: "function",
+                function: { name: "tool_a", arguments: "{}" },
+              },
+              {
+                id: "call_002",
+                type: "function",
+                function: { name: "tool_b", arguments: "{}" },
+              },
+            ],
+            metadata: {
+              responsesOutputItemIds: ["fc_001", "fc_002"],
+            },
+          } as ChatMessage,
+          {
+            role: "tool",
+            content: "result_a",
+            toolCallId: "call_001",
+          } as ChatMessage,
+          {
+            role: "tool",
+            content: "result_b",
+            toolCallId: "call_002",
+          } as ChatMessage,
+        ];
+
+        const result = toResponsesInput(messages);
+
+        const functionCalls = getFunctionCalls(result);
+        expect(functionCalls.length).toBe(2);
+        // Both fc_ IDs should be stripped
+        expect(functionCalls[0].id).toBeUndefined();
+        expect(functionCalls[1].id).toBeUndefined();
+        expect(functionCalls[0].call_id).toBe("call_001");
+        expect(functionCalls[1].call_id).toBe("call_002");
+      });
+    });
+
     describe("orphaned function_call_output removal", () => {
       it("should remove function_call_output with no matching function_call", () => {
         // This can happen when conversation history is truncated/pruned

--- a/core/llm/openaiTypeConverters.ts
+++ b/core/llm/openaiTypeConverters.ts
@@ -922,6 +922,7 @@ function isValidSuccessor(item: ResponseInputItem | undefined): boolean {
  * - Removes reasoning without encrypted_content; strips id from subsequent items
  * - Removes reasoning not followed by function_call or message
  * - Removes orphaned function_call_output with no matching function_call
+ * - Strips fc_ IDs from function_calls whose reasoning was pruned from context
  */
 function sanitizeResponsesInput(input: ResponseInput): ResponseInput {
   const skipIndices = new Set<number>();
@@ -950,6 +951,47 @@ function sanitizeResponsesInput(input: ResponseInput): ResponseInput {
 
     if (!isValidSuccessor(input[i + 1])) {
       skipIndices.add(i);
+    }
+  }
+
+  // Second pass: strip fc_ IDs from function_calls that have no preceding
+  // (kept) reasoning item in the same turn. This handles the case where a
+  // thinking message was pruned from context during compileChatMessages —
+  // the assistant message still carries fc_ IDs that reference the now-absent
+  // reasoning item, which causes a Responses API 400 error.
+  for (let i = 0; i < input.length; i++) {
+    if (skipIndices.has(i) || stripIdIndices.has(i)) continue;
+
+    const item = input[i];
+    if (!isItemType<ResponseFunctionToolCall>(item, "function_call")) continue;
+
+    const fc = item as ResponseFunctionToolCall;
+    if (!fc.id?.startsWith("fc_")) continue;
+
+    // Scan backward within the same turn (reasoning + function_call block).
+    // Stop at any item that isn't a reasoning or function_call — that signals
+    // a turn boundary (user message, function_call_output, etc.).
+    let foundReasoning = false;
+    for (let j = i - 1; j >= 0; j--) {
+      // Skip items that will be removed (they don't count as valid reasoning)
+      if (skipIndices.has(j)) continue;
+
+      const prev = input[j];
+      if (isItemType<ResponseReasoningItem>(prev, "reasoning")) {
+        foundReasoning = true;
+        break;
+      } else if (isItemType<ResponseFunctionToolCall>(prev, "function_call")) {
+        // Another function_call in the same block — keep looking backward
+        continue;
+      } else {
+        // Any other item (user/assistant message, function_call_output, etc.)
+        // means we crossed a turn boundary without finding a reasoning item
+        break;
+      }
+    }
+
+    if (!foundReasoning) {
+      stripIdIndices.add(i);
     }
   }
 

--- a/gui/src/redux/selectors/index.ts
+++ b/gui/src/redux/selectors/index.ts
@@ -22,7 +22,7 @@ export const selectSlashCommandComboBoxInputs = createSelector(
           description: cmd.description,
           type: "slashCommand" as ComboBoxItemType,
           content: content,
-          source: cmd.source,
+          slashCommandSource: cmd.source,
         } as ComboBoxItem;
       }) || []
     );


### PR DESCRIPTION
Fixes #12056

## Problem

When `compileChatMessages` prunes a `thinking` message from the conversation history due to context window overflow, the associated assistant message still carries `fc_*` IDs in its metadata (referencing the now-absent `rs_*` reasoning item).

The OpenAI Responses API then rejects the next request with a 400 error:

```
Item 'fc_...' of type 'function_call' was provided without its
required 'reasoning' item: 'rs_...'
```

This affects GPT-5, o3, and other reasoning models that use the Responses API when the conversation history grows long enough to trigger context compaction.

## Root Cause

`sanitizeResponsesInput` already handles the case where a `reasoning` item exists in the input but lacks `encrypted_content` — it removes the reasoning and strips `fc_*` IDs from subsequent `function_call` items.

However, it did **not** handle the case where the reasoning item was **never added to the input at all** (because `compileChatMessages` removed the `thinking` message before the messages reached `toResponsesInput`). In this case, the `function_call` items still had their `fc_*` IDs, causing the API rejection.

## Solution

Added a second pass in `sanitizeResponsesInput` that scans backward from each `function_call` with a `fc_*` ID to find whether a kept reasoning item exists in the same turn block. If no reasoning is found (either it was removed in the first pass or was never in the input), the `fc_*` ID is stripped from the `function_call` so the API does not look for the missing reasoning item.

The backward scan correctly:
- Skips over other `function_call` items in the same block (parallel tool calls)
- Skips over already-removed items from the first pass
- Stops at any non-reasoning/non-function_call item (turn boundary)

## Testing

Added test cases covering:
- Single pruned `function_call` with orphaned `fc_*` ID
- Multiple pruned `function_call`s with orphaned `fc_*` IDs  
- Sanity check that valid `fc_*` IDs (with preceding reasoning) are preserved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Responses API 400s by stripping orphaned `fc_*` IDs after context compaction, and fixes slash command filtering in edit mode by returning `slashCommandSource`.

- **Bug Fixes**
  - Add a second pass in `sanitizeResponsesInput` to remove `fc_*` IDs from `function_call` items when no kept reasoning appears earlier in the same turn; the backward scan skips parallel calls and removed items, and stops at turn boundaries.
  - Rename `source` to `slashCommandSource` in `selectSlashCommandComboBoxInputs` so prompt files show up in edit mode.

- **Tests**
  - Add cases for single/multiple orphaned `fc_*` IDs and a sanity check preserving valid IDs.

<sup>Written for commit 4dacecaa53387ca0e8a6fdbd0041265735f59350. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

