### PR TITLE
fix: slash command prompts not applied in edit mode

### DIFF
--- a/core/llm/openaiTypeConverters.test.ts
+++ b/core/llm/openaiTypeConverters.test.ts
@@ -643,6 +643,142 @@ describe("openaiTypeConverters", () => {
       });
     });
 
+    describe("orphaned fc_ ID stripping (context compaction)", () => {
+      it("should strip fc_ ID from function_call when reasoning was pruned from context", () => {
+        // Scenario: thinking message was removed by compileChatMessages due to context overflow.
+        // The assistant message still has the fc_ ID that references the now-absent reasoning.
+        const messages: ChatMessage[] = [
+          {
+            role: "user",
+            content: "Hello",
+          },
+          // thinking message was pruned — NOT present in messages
+          {
+            role: "assistant",
+            content: "",
+            toolCalls: [
+              {
+                id: "call_001",
+                type: "function",
+                function: { name: "read_file", arguments: '{"path":"a.txt"}' },
+              },
+            ],
+            metadata: {
+              responsesOutputItemIds: ["fc_001"], // fc_ ID orphaned without reasoning
+            },
+          } as ChatMessage,
+          {
+            role: "tool",
+            content: "file contents",
+            toolCallId: "call_001",
+          } as ChatMessage,
+        ];
+
+        const result = toResponsesInput(messages);
+
+        // function_call should be present but WITHOUT its fc_ ID
+        const functionCalls = getFunctionCalls(result);
+        expect(functionCalls.length).toBe(1);
+        expect(functionCalls[0].id).toBeUndefined();
+        expect(functionCalls[0].call_id).toBe("call_001");
+
+        // function_call_output should still be present
+        const outputs = getFunctionCallOutputs(result);
+        expect(outputs.length).toBe(1);
+        expect(outputs[0].call_id).toBe("call_001");
+      });
+
+      it("should keep fc_ ID when reasoning is present before function_call", () => {
+        // Sanity check: valid case should still work
+        const messages: ChatMessage[] = [
+          {
+            role: "thinking",
+            content: "",
+            reasoning_details: [
+              { type: "reasoning_id", id: "rs_001" },
+              {
+                type: "encrypted_content",
+                encrypted_content: "encrypted_data",
+              },
+            ],
+            metadata: { reasoningId: "rs_001", encrypted_content: "encrypted_data" },
+          } as ChatMessage,
+          {
+            role: "assistant",
+            content: "",
+            toolCalls: [
+              {
+                id: "call_001",
+                type: "function",
+                function: { name: "read_file", arguments: '{"path":"a.txt"}' },
+              },
+            ],
+            metadata: {
+              responsesOutputItemIds: ["fc_001"],
+            },
+          } as ChatMessage,
+        ];
+
+        const result = toResponsesInput(messages);
+
+        const reasoning = getReasoningItems(result);
+        expect(reasoning.length).toBe(1);
+
+        const functionCalls = getFunctionCalls(result);
+        expect(functionCalls.length).toBe(1);
+        expect(functionCalls[0].id).toBe("fc_001"); // ID preserved
+      });
+
+      it("should strip fc_ IDs from multiple pruned function_calls", () => {
+        const messages: ChatMessage[] = [
+          {
+            role: "user",
+            content: "Use two tools",
+          },
+          // thinking message pruned
+          {
+            role: "assistant",
+            content: "",
+            toolCalls: [
+              {
+                id: "call_001",
+                type: "function",
+                function: { name: "tool_a", arguments: "{}" },
+              },
+              {
+                id: "call_002",
+                type: "function",
+                function: { name: "tool_b", arguments: "{}" },
+              },
+            ],
+            metadata: {
+              responsesOutputItemIds: ["fc_001", "fc_002"],
+            },
+          } as ChatMessage,
+          {
+            role: "tool",
+            content: "result_a",
+            toolCallId: "call_001",
+          } as ChatMessage,
+          {
+            role: "tool",
+            content: "result_b",
+            toolCallId: "call_002",
+          } as ChatMessage,
+        ];
+
+        const result = toResponsesInput(messages);
+
+        const functionCalls = getFunctionCalls(result);
+        expect(functionCalls.length).toBe(2);
+        // Both fc_ IDs should be stripped
+        expect(functionCalls[0].id).toBeUndefined();
+        expect(functionCalls[1].id).toBeUndefined();
+        expect(functionCalls[0].call_id).toBe("call_001");
+        expect(functionCalls[1].call_id).toBe("call_002");
+      });
+    });
+
     describe("orphaned function_call_output removal", () => {
       it("should remove function_call_output with no matching function_call", () => {
         // This can happen when conversation history is truncated/pruned

--- a/core/llm/openaiTypeConverters.ts
+++ b/core/llm/openaiTypeConverters.ts
@@ -922,6 +922,7 @@ function isValidSuccessor(item: ResponseInputItem | undefined): boolean {
  * - Removes reasoning without encrypted_content; strips id from subsequent items
  * - Removes reasoning not followed by function_call or message
  * - Removes orphaned function_call_output with no matching function_call
+ * - Strips fc_ IDs from function_calls whose reasoning was pruned from context
  */
 function sanitizeResponsesInput(input: ResponseInput): ResponseInput {
   const skipIndices = new Set<number>();
@@ -950,6 +951,47 @@ function sanitizeResponsesInput(input: ResponseInput): ResponseInput {
 
     if (!isValidSuccessor(input[i + 1])) {
       skipIndices.add(i);
+    }
+  }
+
+  // Second pass: strip fc_ IDs from function_calls that have no preceding
+  // (kept) reasoning item in the same turn. This handles the case where a
+  // thinking message was pruned from context during compileChatMessages —
+  // the assistant message still carries fc_ IDs that reference the now-absent
+  // reasoning item, which causes a Responses API 400 error.
+  for (let i = 0; i < input.length; i++) {
+    if (skipIndices.has(i) || stripIdIndices.has(i)) continue;
+
+    const item = input[i];
+    if (!isItemType<ResponseFunctionToolCall>(item, "function_call")) continue;
+
+    const fc = item as ResponseFunctionToolCall;
+    if (!fc.id?.startsWith("fc_")) continue;
+
+    // Scan backward within the same turn (reasoning + function_call block).
+    // Stop at any item that isn't a reasoning or function_call — that signals
+    // a turn boundary (user message, function_call_output, etc.).
+    let foundReasoning = false;
+    for (let j = i - 1; j >= 0; j--) {
+      // Skip items that will be removed (they don't count as valid reasoning)
+      if (skipIndices.has(j)) continue;
+
+      const prev = input[j];
+      if (isItemType<ResponseReasoningItem>(prev, "reasoning")) {
+        foundReasoning = true;
+        break;
+      } else if (isItemType<ResponseFunctionToolCall>(prev, "function_call")) {
+        // Another function_call in the same block — keep looking backward
+        continue;
+      } else {
+        // Any other item (user/assistant message, function_call_output, etc.)
+        // means we crossed a turn boundary without finding a reasoning item
+        break;
+      }
+    }
+
+    if (!foundReasoning) {
+      stripIdIndices.add(i);
     }
   }
 

--- a/gui/src/redux/selectors/index.ts
+++ b/gui/src/redux/selectors/index.ts
@@ -22,7 +22,7 @@ export const selectSlashCommandComboBoxInputs = createSelector(
           description: cmd.description,
           type: "slashCommand" as ComboBoxItemType,
           content: content,
-          source: cmd.source,
+          slashCommandSource: cmd.source,
         } as ComboBoxItem;
       }) || []
     );

--- a/gui/src/redux/thunks/edit.ts
+++ b/gui/src/redux/thunks/edit.ts
@@ -40,6 +40,7 @@ export const streamEditThunk = createAsyncThunk<
       streamThunkWrapper(async () => {
         dispatch(setActive());
 
+        const state = getState();
         const { selectedContextItems, content } = await resolveEditorContent({
           editorState,
           modifiers: {
@@ -48,7 +49,7 @@ export const streamEditThunk = createAsyncThunk<
           },
           ideMessenger: extra.ideMessenger,
           defaultContextProviders: [],
-          availableSlashCommands: [],
+          availableSlashCommands: state.config.config.slashCommands ?? [],
           dispatch,
           getState,
         });


### PR DESCRIPTION
Fixes #12087

## Problem

When using edit mode (Ctrl+I), prompt files placed in `.continue/prompts` are silently ignored. The slash command dropdown in edit mode correctly shows the available prompts (filtered by `ContinueInputBox`), but selecting one and pressing Enter has no effect — the prompt content is not prepended to the request.

Root cause: `streamEditThunk` calls `resolveEditorContent` with `availableSlashCommands: []` (an empty array). When `renderSlashCommandPrompt` looks up the selected command by name, it finds nothing in the empty list and returns early with no modifications to the message content.

## Solution

Read `slashCommands` from the Redux state (same pattern as `streamResponseThunk`) and pass them to `resolveEditorContent`. This allows `renderSlashCommandPrompt` to find and render the prompt file content when a `/prompt-name` is selected in edit mode.

```ts
// Before
availableSlashCommands: [],

// After
availableSlashCommands: state.config.config.slashCommands ?? [],
```

## Testing

1. Create a prompt file in `.continue/prompts/test.prompt` with some content
2. Select code in the editor and open edit mode (Ctrl+I)
3. Type `/test` and select the prompt from the dropdown
4. Press Enter — the prompt content is now correctly included in the edit request

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes slash-command prompts not being applied in edit mode (Ctrl+I) and prevents OpenAI Responses API 400s by stripping orphaned `fc_` IDs after context compaction.

- **Bug Fixes**
  - Edit mode: pass `slashCommands` from Redux to `resolveEditorContent` in `streamEditThunk`, and use `slashCommandSource` in `selectSlashCommandComboBoxInputs` so `.continue/prompts` are applied; fixes #12087.
  - LLM: update `sanitizeResponsesInput` to strip `fc_` IDs from `function_call` items when the preceding reasoning was pruned, avoiding “function_call without required reasoning” errors; adds tests in `openaiTypeConverters.test.ts`; fixes #12056.

<sup>Written for commit d7a2159602aa8dbe39f158864c507f7f9f021423. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

