### PR TITLE
docs: clarify headers config for streamable-http and sse MCP servers

### DIFF
--- a/docs/reference.mdx
+++ b/docs/reference.mdx
@@ -318,6 +318,22 @@ The [Model Context Protocol](https://modelcontextprotocol.io/introduction) is a 
 - `requestOptions`: Optional request options for `sse` and `streamable-http` servers. Same format as [model requestOptions](#models).
 - `connectionTimeout`: Optional timeout for _initial_ connection to MCP server
 
+For `sse` and `streamable-http` MCP servers, configure custom HTTP headers under `requestOptions.headers`:
+
+```yaml title="config.yaml"
+name: My Config
+version: 1.0.0
+schema: v1
+mcpServers:
+  - name: My HTTP MCP Server
+    type: streamable-http
+    url: https://mcp.example.com
+    requestOptions:
+      headers:
+        X-API-Key: your-api-key
+        X-Client: continue
+```
+
 **Example:**
 
 ```yaml title="config.yaml"


### PR DESCRIPTION
## Description

Clarified mcpServers docs for remote MCP transports by explicitly documenting that custom request headers for sse and streamable-http should be configured under requestOptions.headers in YAML.

Also added a concrete YAML example for a streamable-http server with custom headers to reduce confusion between YAML config and JSON-style MCP configs.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A (documentation-only change).

## Tests
No runtime tests were added (documentation-only change).
I validated the updated docs content and ensured no linter issues were introduced in the edited file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies how to configure custom HTTP headers for `sse` and `streamable-http` MCP servers by specifying them under `requestOptions.headers` in YAML. Adds a concise YAML example to avoid confusion with JSON-style configs.

<sup>Written for commit b1dfdc03ad9598b55923ec9ce8207e5c7726c401. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

