### PR TITLE
 add SaladCloud AI Gateway provider

### DIFF
--- a/core/llm/llms/OpenAI-compatible.vitest.ts
+++ b/core/llm/llms/OpenAI-compatible.vitest.ts
@@ -33,6 +33,7 @@ import NCompass from "./NCompass.js";
 import LlamaStack from "./LlamaStack.js";
 import Nebius from "./Nebius.js";
 import OVHcloud from "./OVHcloud.js";
+import SaladCloud from "./SaladCloud.js";
 
 // Base OpenAI tests
 import { afterEach, describe, expect, test, vi } from "vitest";
@@ -456,4 +457,14 @@ createOpenAISubclassTests(Nebius, {
 createOpenAISubclassTests(OVHcloud, {
   providerName: "ovhcloud",
   defaultApiBase: "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1/",
+});
+
+createOpenAISubclassTests(SaladCloud, {
+  providerName: "saladcloud",
+  defaultApiBase: "https://ai.salad.cloud/v1/",
+  customBodyOptions: {
+    chat_template_kwargs: {
+      enable_thinking: false,
+    },
+  },
 });

--- a/core/llm/llms/SaladCloud.ts
+++ b/core/llm/llms/SaladCloud.ts
@@ -1,0 +1,13 @@
+import { LLMOptions } from "../..";
+
+import OpenAI from "./OpenAI";
+
+class SaladCloud extends OpenAI {
+  static providerName = "saladcloud";
+  static defaultOptions: Partial<LLMOptions> = {
+    apiBase: "https://ai.salad.cloud/v1/",
+    useLegacyCompletionsEndpoint: false,
+  };
+}
+
+export default SaladCloud;

--- a/core/llm/llms/SaladCloud.ts
+++ b/core/llm/llms/SaladCloud.ts
@@ -1,4 +1,5 @@
-import { LLMOptions } from "../..";
+import { ChatCompletionCreateParams } from "openai/resources/index";
+import { ChatMessage, CompletionOptions, LLMOptions } from "../..";
 
 import OpenAI from "./OpenAI";
 
@@ -8,6 +9,42 @@ class SaladCloud extends OpenAI {
     apiBase: "https://ai.salad.cloud/v1/",
     useLegacyCompletionsEndpoint: false,
   };
+
+  protected _convertArgs(
+    options: CompletionOptions,
+    messages: ChatMessage[],
+  ): ChatCompletionCreateParams {
+    return this.addDefaultChatTemplateKwargs(
+      super._convertArgs(options, messages),
+    );
+  }
+
+  protected modifyChatBody(
+    body: ChatCompletionCreateParams,
+  ): ChatCompletionCreateParams {
+    return this.addDefaultChatTemplateKwargs(super.modifyChatBody(body));
+  }
+
+  private addDefaultChatTemplateKwargs(
+    body: ChatCompletionCreateParams,
+  ): ChatCompletionCreateParams {
+    const extendedBody = body as ChatCompletionCreateParams & {
+      chat_template_kwargs?: Record<string, unknown>;
+    };
+    const existingKwargs =
+      extendedBody.chat_template_kwargs &&
+      typeof extendedBody.chat_template_kwargs === "object" &&
+      !Array.isArray(extendedBody.chat_template_kwargs)
+        ? extendedBody.chat_template_kwargs
+        : {};
+
+    extendedBody.chat_template_kwargs = {
+      enable_thinking: false,
+      ...existingKwargs,
+    };
+
+    return extendedBody;
+  }
 }
 
 export default SaladCloud;

--- a/core/llm/llms/SaladCloud.vitest.ts
+++ b/core/llm/llms/SaladCloud.vitest.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import SaladCloud from "./SaladCloud.js";
+
+describe("SaladCloud", () => {
+  it("disables Qwen thinking output by default", () => {
+    const saladCloud = new SaladCloud({
+      apiKey: "test-api-key",
+      model: "qwen3.6-35b-a3b",
+    });
+
+    const body = (saladCloud as any)._convertArgs(
+      {
+        model: "qwen3.6-35b-a3b",
+        maxTokens: 128,
+      },
+      [{ role: "user", content: "hello" }],
+    );
+
+    expect(body.chat_template_kwargs).toEqual({
+      enable_thinking: false,
+    });
+  });
+
+  it("preserves explicitly provided chat template kwargs", () => {
+    const saladCloud = new SaladCloud({
+      apiKey: "test-api-key",
+      model: "qwen3.6-35b-a3b",
+    });
+
+    const body = (saladCloud as any).modifyChatBody({
+      model: "qwen3.6-35b-a3b",
+      messages: [],
+      chat_template_kwargs: {
+        enable_thinking: true,
+        custom: "value",
+      },
+    });
+
+    expect(body.chat_template_kwargs).toEqual({
+      enable_thinking: true,
+      custom: "value",
+    });
+  });
+});

--- a/core/llm/llms/index.ts
+++ b/core/llm/llms/index.ts
@@ -55,6 +55,7 @@ import OVHcloud from "./OVHcloud";
 import { Relace } from "./Relace";
 import Replicate from "./Replicate";
 import SageMaker from "./SageMaker";
+import SaladCloud from "./SaladCloud";
 import SambaNova from "./SambaNova";
 import Scaleway from "./Scaleway";
 import SiliconFlow from "./SiliconFlow";
@@ -115,6 +116,7 @@ export const LLMClasses = [
   ClawRouter,
   Nvidia,
   Vllm,
+  SaladCloud,
   SambaNova,
   MockLLM,
   TestLLM,

--- a/core/llm/toolSupport.test.ts
+++ b/core/llm/toolSupport.test.ts
@@ -125,6 +125,20 @@ describe("PROVIDER_TOOL_SUPPORT", () => {
     });
   });
 
+  describe("saladcloud", () => {
+    const supportsFn = PROVIDER_TOOL_SUPPORT["saladcloud"];
+
+    it("should return true for SaladCloud Qwen models", () => {
+      expect(supportsFn("qwen3.6-35b-a3b")).toBe(true);
+      expect(supportsFn("qwen3.6-27b")).toBe(true);
+      expect(supportsFn("qwen3.5-9b")).toBe(true);
+    });
+
+    it("should return false for unverified SaladCloud models", () => {
+      expect(supportsFn("gemma-4-26b-a4b-instruct")).toBe(false);
+    });
+  });
+
   describe("cohere", () => {
     const supportsFn = PROVIDER_TOOL_SUPPORT["cohere"];
 

--- a/core/llm/toolSupport.ts
+++ b/core/llm/toolSupport.ts
@@ -79,6 +79,10 @@ export const PROVIDER_TOOL_SUPPORT: Record<string, (model: string) => boolean> =
 
       return false;
     },
+    saladcloud: (model) => {
+      const lower = model.toLowerCase();
+      return lower.startsWith("qwen3.5-") || lower.startsWith("qwen3.6-");
+    },
     cohere: (model) => {
       const lower = model.toLowerCase();
       if (lower.startsWith("command-a-vision")) {

--- a/docs/customize/model-providers/more/saladcloud.mdx
+++ b/docs/customize/model-providers/more/saladcloud.mdx
@@ -1,0 +1,46 @@
+---
+title: "SaladCloud"
+description: "Configure SaladCloud AI Gateway with Continue"
+---
+
+You can get an API key from the [SaladCloud portal](https://portal.salad.com/api-key)
+
+## Available Models
+
+Available models can be found on the [SaladCloud AI Gateway docs](https://docs.salad.com/ai-gateway/explanation/overview)
+
+## Chat Model
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  name: My Config
+  version: 0.0.1
+  schema: v1
+
+  models:
+    - name: Qwen 3.5 35B A3B
+      provider: saladcloud
+      model: qwen3.5-35b-a3b
+      apiKey: <YOUR_SALAD_API_KEY>
+  ```
+  </Tab>
+  <Tab title="JSON">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "Qwen 3.5 35B A3B",
+        "provider": "saladcloud",
+        "model": "qwen3.5-35b-a3b",
+        "apiKey": "<YOUR_SALAD_API_KEY>"
+      }
+    ]
+  }
+  ```
+  </Tab>
+</Tabs>
+
+## Embeddings Model
+
+SaladCloud AI Gateway currently focuses on chat/completion models. For embeddings, consider using a dedicated embeddings provider.

--- a/docs/customize/model-providers/more/saladcloud.mdx
+++ b/docs/customize/model-providers/more/saladcloud.mdx
@@ -43,4 +43,4 @@ Available models can be found on the [SaladCloud AI Gateway docs](https://docs.s
 
 ## Embeddings Model
 
-SaladCloud AI Gateway currently focuses on chat/completion models. For embeddings, consider using a dedicated embeddings provider.
+SaladCloud AI Gateway currently focuses on chat/completion models.

--- a/docs/customize/model-providers/more/saladcloud.mdx
+++ b/docs/customize/model-providers/more/saladcloud.mdx
@@ -7,7 +7,7 @@ You can get an API key from the [SaladCloud portal](https://portal.salad.com/api
 
 ## Available Models
 
-Available models can be found on the [SaladCloud AI Gateway pricing page](https://docs.salad.com/ai-gateway/reference/pricing)
+Available models can be found on the [SaladCloud AI Gateway pricing page](https://docs.salad.com/ai-gateway/reference/pricing). Continue includes presets for the Qwen models currently returned by SaladCloud's `/v1/models` endpoint: `qwen3.6-35b-a3b`, `qwen3.6-27b`, and `qwen3.5-9b`.
 
 ## Chat Model
 
@@ -40,6 +40,13 @@ Available models can be found on the [SaladCloud AI Gateway pricing page](https:
   ```
   </Tab>
 </Tabs>
+
+<Note>
+  Continue disables Qwen thinking output by default with
+  `chat_template_kwargs.enable_thinking: false`. To enable thinking, add
+  `requestOptions.extraBodyProperties.chat_template_kwargs.enable_thinking` and
+  set it to `true` in your model configuration.
+</Note>
 
 ## Embeddings Model
 

--- a/docs/customize/model-providers/more/saladcloud.mdx
+++ b/docs/customize/model-providers/more/saladcloud.mdx
@@ -7,7 +7,7 @@ You can get an API key from the [SaladCloud portal](https://portal.salad.com/api
 
 ## Available Models
 
-Available models can be found on the [SaladCloud AI Gateway docs](https://docs.salad.com/ai-gateway/explanation/overview)
+Available models can be found on the [SaladCloud AI Gateway pricing page](https://docs.salad.com/ai-gateway/reference/pricing)
 
 ## Chat Model
 
@@ -19,10 +19,10 @@ Available models can be found on the [SaladCloud AI Gateway docs](https://docs.s
   schema: v1
 
   models:
-    - name: Qwen 3.5 35B A3B
+    - name: Qwen 3.6 35B A3B
       provider: saladcloud
-      model: qwen3.5-35b-a3b
-      apiKey: <YOUR_SALAD_API_KEY>
+      model: qwen3.6-35b-a3b
+      apiKey: <YOUR_SALAD_CLOUD_API_KEY>
   ```
   </Tab>
   <Tab title="JSON">
@@ -30,10 +30,10 @@ Available models can be found on the [SaladCloud AI Gateway docs](https://docs.s
   {
     "models": [
       {
-        "title": "Qwen 3.5 35B A3B",
+        "title": "Qwen 3.6 35B A3B",
         "provider": "saladcloud",
-        "model": "qwen3.5-35b-a3b",
-        "apiKey": "<YOUR_SALAD_API_KEY>"
+        "model": "qwen3.6-35b-a3b",
+        "apiKey": "<YOUR_SALAD_CLOUD_API_KEY>"
       }
     ]
   }

--- a/gui/src/pages/AddNewModel/configs/models.ts
+++ b/gui/src/pages/AddNewModel/configs/models.ts
@@ -3310,6 +3310,50 @@ export const models: { [key: string]: ModelPackage } = {
     isOpenSource: false,
   },
 
+  // SaladCloud models
+  saladQwen35_35bA3B: {
+    title: "Qwen 3.5 35B A3B",
+    description:
+      "Qwen 3.5 35B A3B is a fast mixture-of-experts model with 35B total parameters and 3B active, offering strong performance at low cost via SaladCloud AI Gateway.",
+    refUrl: "https://docs.salad.com/ai-gateway/explanation/overview",
+    params: {
+      title: "Qwen 3.5 35B A3B",
+      model: "qwen3.5-35b-a3b",
+      contextLength: 131_072,
+    },
+    icon: "qwen.png",
+    providerOptions: ["saladcloud"],
+    isOpenSource: true,
+  },
+  saladQwen35_27b: {
+    title: "Qwen 3.5 27B",
+    description:
+      "Qwen 3.5 27B is a capable instruction-tuned model available via SaladCloud AI Gateway with 128K context window.",
+    refUrl: "https://docs.salad.com/ai-gateway/explanation/overview",
+    params: {
+      title: "Qwen 3.5 27B",
+      model: "qwen3.5-27b",
+      contextLength: 131_072,
+    },
+    icon: "qwen.png",
+    providerOptions: ["saladcloud"],
+    isOpenSource: true,
+  },
+  saladQwen35_9b: {
+    title: "Qwen 3.5 9B",
+    description:
+      "Qwen 3.5 9B is a lightweight and efficient instruction-tuned model available via SaladCloud AI Gateway.",
+    refUrl: "https://docs.salad.com/ai-gateway/explanation/overview",
+    params: {
+      title: "Qwen 3.5 9B",
+      model: "qwen3.5-9b",
+      contextLength: 131_072,
+    },
+    icon: "qwen.png",
+    providerOptions: ["saladcloud"],
+    isOpenSource: true,
+  },
+
   // Xiaomi Mimo models
   mimoV2Flash: {
     title: "mimo-v2-flash",

--- a/gui/src/pages/AddNewModel/configs/models.ts
+++ b/gui/src/pages/AddNewModel/configs/models.ts
@@ -3311,29 +3311,29 @@ export const models: { [key: string]: ModelPackage } = {
   },
 
   // SaladCloud models
-  saladQwen35_35bA3B: {
-    title: "Qwen 3.5 35B A3B",
+  saladQwen36_35bA3B: {
+    title: "Qwen 3.6 35B A3B",
     description:
-      "Qwen 3.5 35B A3B is a fast mixture-of-experts model with 35B total parameters and 3B active, offering strong performance at low cost via SaladCloud AI Gateway.",
+      "Qwen 3.6 35B A3B is a fast mixture-of-experts model with 35B total parameters and 3B active, supporting vision and reasoning via SaladCloud AI Gateway.",
     refUrl: "https://docs.salad.com/ai-gateway/explanation/overview",
     params: {
-      title: "Qwen 3.5 35B A3B",
-      model: "qwen3.5-35b-a3b",
-      contextLength: 131_072,
+      title: "Qwen 3.6 35B A3B",
+      model: "qwen3.6-35b-a3b",
+      contextLength: 262_144,
     },
     icon: "qwen.png",
     providerOptions: ["saladcloud"],
     isOpenSource: true,
   },
-  saladQwen35_27b: {
-    title: "Qwen 3.5 27B",
+  saladQwen36_27b: {
+    title: "Qwen 3.6 27B",
     description:
-      "Qwen 3.5 27B is a capable instruction-tuned model available via SaladCloud AI Gateway with 128K context window.",
+      "Qwen 3.6 27B is a capable instruction-tuned model with vision and reasoning support, available via SaladCloud AI Gateway with 256K context window.",
     refUrl: "https://docs.salad.com/ai-gateway/explanation/overview",
     params: {
-      title: "Qwen 3.5 27B",
-      model: "qwen3.5-27b",
-      contextLength: 131_072,
+      title: "Qwen 3.6 27B",
+      model: "qwen3.6-27b",
+      contextLength: 262_144,
     },
     icon: "qwen.png",
     providerOptions: ["saladcloud"],
@@ -3342,14 +3342,28 @@ export const models: { [key: string]: ModelPackage } = {
   saladQwen35_9b: {
     title: "Qwen 3.5 9B",
     description:
-      "Qwen 3.5 9B is a lightweight and efficient instruction-tuned model available via SaladCloud AI Gateway.",
+      "Qwen 3.5 9B is a lightweight and efficient model with vision and reasoning support, available via SaladCloud AI Gateway.",
     refUrl: "https://docs.salad.com/ai-gateway/explanation/overview",
     params: {
       title: "Qwen 3.5 9B",
       model: "qwen3.5-9b",
-      contextLength: 131_072,
+      contextLength: 262_144,
     },
     icon: "qwen.png",
+    providerOptions: ["saladcloud"],
+    isOpenSource: true,
+  },
+  saladGemma4_26bA4B: {
+    title: "Gemma 4 26B A4B Instruct",
+    description:
+      "Gemma 4 26B A4B Instruct is a mixture-of-experts model from Google with vision and reasoning support, available via SaladCloud AI Gateway.",
+    refUrl: "https://docs.salad.com/ai-gateway/explanation/overview",
+    params: {
+      title: "Gemma 4 26B A4B Instruct",
+      model: "gemma-4-26b-a4b-instruct",
+      contextLength: 262_144,
+    },
+    icon: "gemini.png",
     providerOptions: ["saladcloud"],
     isOpenSource: true,
   },

--- a/gui/src/pages/AddNewModel/configs/models.ts
+++ b/gui/src/pages/AddNewModel/configs/models.ts
@@ -3314,12 +3314,13 @@ export const models: { [key: string]: ModelPackage } = {
   saladQwen36_35bA3B: {
     title: "Qwen 3.6 35B A3B",
     description:
-      "Qwen 3.6 35B A3B is a fast mixture-of-experts model with 35B total parameters and 3B active, supporting vision and reasoning via SaladCloud AI Gateway.",
+      "Qwen 3.6 35B A3B is a fast mixture-of-experts model with 35B total parameters and 3B active, available via SaladCloud AI Gateway.",
     refUrl: "https://docs.salad.com/ai-gateway/explanation/overview",
     params: {
       title: "Qwen 3.6 35B A3B",
       model: "qwen3.6-35b-a3b",
       contextLength: 262_144,
+      capabilities: { tools: true },
     },
     icon: "qwen.png",
     providerOptions: ["saladcloud"],
@@ -3328,12 +3329,13 @@ export const models: { [key: string]: ModelPackage } = {
   saladQwen36_27b: {
     title: "Qwen 3.6 27B",
     description:
-      "Qwen 3.6 27B is a capable instruction-tuned model with vision and reasoning support, available via SaladCloud AI Gateway with 256K context window.",
+      "Qwen 3.6 27B is a capable instruction-tuned model available via SaladCloud AI Gateway with a 256K context window.",
     refUrl: "https://docs.salad.com/ai-gateway/explanation/overview",
     params: {
       title: "Qwen 3.6 27B",
       model: "qwen3.6-27b",
       contextLength: 262_144,
+      capabilities: { tools: true },
     },
     icon: "qwen.png",
     providerOptions: ["saladcloud"],
@@ -3342,32 +3344,18 @@ export const models: { [key: string]: ModelPackage } = {
   saladQwen35_9b: {
     title: "Qwen 3.5 9B",
     description:
-      "Qwen 3.5 9B is a lightweight and efficient model with vision and reasoning support, available via SaladCloud AI Gateway.",
+      "Qwen 3.5 9B is a lightweight and efficient model available via SaladCloud AI Gateway.",
     refUrl: "https://docs.salad.com/ai-gateway/explanation/overview",
     params: {
       title: "Qwen 3.5 9B",
       model: "qwen3.5-9b",
       contextLength: 262_144,
+      capabilities: { tools: true },
     },
     icon: "qwen.png",
     providerOptions: ["saladcloud"],
     isOpenSource: true,
   },
-  saladGemma4_26bA4B: {
-    title: "Gemma 4 26B A4B Instruct",
-    description:
-      "Gemma 4 26B A4B Instruct is a mixture-of-experts model from Google with vision and reasoning support, available via SaladCloud AI Gateway.",
-    refUrl: "https://docs.salad.com/ai-gateway/explanation/overview",
-    params: {
-      title: "Gemma 4 26B A4B Instruct",
-      model: "gemma-4-26b-a4b-instruct",
-      contextLength: 262_144,
-    },
-    icon: "gemini.png",
-    providerOptions: ["saladcloud"],
-    isOpenSource: true,
-  },
-
   // Xiaomi Mimo models
   mimoV2Flash: {
     title: "mimo-v2-flash",

--- a/gui/src/pages/AddNewModel/configs/providers.ts
+++ b/gui/src/pages/AddNewModel/configs/providers.ts
@@ -996,6 +996,33 @@ To get started, [register](https://dataplatform.cloud.ibm.com/registration/stepo
       models.MetaLlama3,
     ],
   },
+  saladcloud: {
+    title: "SaladCloud",
+    provider: "saladcloud",
+    refPage: "saladcloud",
+    description: "Use SaladCloud AI Gateway to access open-source models",
+    longDescription: `SaladCloud AI Gateway provides OpenAI-compatible access to open-source models at flat-rate pricing. To get started:\n1. Sign up at [salad.com](https://salad.com)\n2. Obtain an API key from the [SaladCloud portal](https://portal.salad.com)\n3. Paste below\n4. Select a model preset`,
+    tags: [ModelProviderTags.RequiresApiKey, ModelProviderTags.OpenSource],
+    params: {
+      apiKey: "",
+    },
+    collectInputFor: [
+      {
+        inputType: "text",
+        key: "apiKey",
+        label: "API Key",
+        placeholder: "Enter your SaladCloud API key",
+        required: true,
+      },
+      ...completionParamsInputsConfigs,
+    ],
+    packages: [
+      models.saladQwen35_35bA3B,
+      models.saladQwen35_27b,
+      models.saladQwen35_9b,
+    ],
+    apiKeyUrl: "https://portal.salad.com/api-key",
+  },
   sambanova: {
     title: "SambaNova",
     provider: "sambanova",

--- a/gui/src/pages/AddNewModel/configs/providers.ts
+++ b/gui/src/pages/AddNewModel/configs/providers.ts
@@ -1020,7 +1020,6 @@ To get started, [register](https://dataplatform.cloud.ibm.com/registration/stepo
       models.saladQwen36_35bA3B,
       models.saladQwen36_27b,
       models.saladQwen35_9b,
-      models.saladGemma4_26bA4B,
     ],
     apiKeyUrl: "https://portal.salad.com/api-key",
   },

--- a/gui/src/pages/AddNewModel/configs/providers.ts
+++ b/gui/src/pages/AddNewModel/configs/providers.ts
@@ -1017,9 +1017,10 @@ To get started, [register](https://dataplatform.cloud.ibm.com/registration/stepo
       ...completionParamsInputsConfigs,
     ],
     packages: [
-      models.saladQwen35_35bA3B,
-      models.saladQwen35_27b,
+      models.saladQwen36_35bA3B,
+      models.saladQwen36_27b,
       models.saladQwen35_9b,
+      models.saladGemma4_26bA4B,
     ],
     apiKeyUrl: "https://portal.salad.com/api-key",
   },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `saladcloud` as an OpenAI-compatible provider for SaladCloud AI Gateway, with presets for Qwen 3.6/3.5 models and docs. Qwen “thinking” output is disabled by default, with an option to enable it.

- **New Features**
  - Core: added `SaladCloud` class (extends `OpenAI`) with `apiBase` `https://ai.salad.cloud/v1/` and `useLegacyCompletionsEndpoint: false`; injects `chat_template_kwargs.enable_thinking: false` while preserving user overrides; registered in `LLMClasses`.
  - Tooling: added `saladcloud` to `PROVIDER_TOOL_SUPPORT` (allows tools for Qwen `3.5-` and `3.6-` models).
  - GUI: new `saladcloud` provider with API key input and presets:
    - Qwen 3.6 35B A3B (`qwen3.6-35b-a3b`, 262,144 context)
    - Qwen 3.6 27B (`qwen3.6-27b`, 262,144 context)
    - Qwen 3.5 9B (`qwen3.5-9b`, 262,144 context)
  - Docs: new SaladCloud page with API key link, model reference, YAML/JSON examples, note on enabling thinking via `requestOptions.extraBodyProperties.chat_template_kwargs.enable_thinking`; embeddings not supported.

<sup>Written for commit cc843645c1ce9106c78b21b05e1bb02c7f90efe3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

