### PR TITLE
fix: match gpt-5 and o-series model names case-insensitively

### DIFF
--- a/core/llm/llms/OpenAI.test.ts
+++ b/core/llm/llms/OpenAI.test.ts
@@ -24,6 +24,13 @@ describe("OpenAI", () => {
     expect(openai.isOSeriesOrGpt5PlusModel("gpt-5.4-pro")).toBeTruthy();
     expect(openai.isOSeriesOrGpt5PlusModel("gpt-6")).toBeTruthy();
     expect(openai.isOSeriesOrGpt5PlusModel("gpt-7-turbo")).toBeTruthy();
+
+    // case-insensitive matching (e.g. Azure deployments named in upper case)
+    expect(openai.isOSeriesOrGpt5PlusModel("GPT-5")).toBeTruthy();
+    expect(openai.isOSeriesOrGpt5PlusModel("GPT-5-mini")).toBeTruthy();
+    expect(openai.isOSeriesOrGpt5PlusModel("Gpt-5.4")).toBeTruthy();
+    expect(openai.isOSeriesOrGpt5PlusModel("O1")).toBeTruthy();
+    expect(openai.isOSeriesOrGpt5PlusModel("O3-mini")).toBeTruthy();
   });
   test("should identify incorrect o-series models", () => {
     const openai = new OpenAI({

--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -220,8 +220,7 @@ class OpenAI extends BaseLLM {
 
   public isOSeriesOrGpt5PlusModel(model?: string): boolean {
     return (
-      !!model &&
-      (!!model.match(/^o[0-9]+/i) || !!model.match(/gpt-[5-9]/i))
+      !!model && (!!model.match(/^o[0-9]+/i) || !!model.match(/gpt-[5-9]/i))
     );
   }
 

--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -219,7 +219,10 @@ class OpenAI extends BaseLLM {
   }
 
   public isOSeriesOrGpt5PlusModel(model?: string): boolean {
-    return !!model && (!!model.match(/^o[0-9]+/) || !!model.match(/gpt-[5-9]/));
+    return (
+      !!model &&
+      (!!model.match(/^o[0-9]+/i) || !!model.match(/gpt-[5-9]/i))
+    );
   }
 
   private isFireworksAiModel(model?: string): boolean {

--- a/packages/openai-adapters/src/apis/OpenAI.ts
+++ b/packages/openai-adapters/src/apis/OpenAI.ts
@@ -67,7 +67,8 @@ export class OpenAIApi implements BaseLlmApi {
     // o-series models - only apply for official OpenAI API
     const isOfficialOpenAIAPI = this.apiBase === "https://api.openai.com/v1/";
     if (isOfficialOpenAIAPI) {
-      if (body.model.startsWith("o") || body.model.includes("gpt-5")) {
+      const modelLower = body.model.toLowerCase();
+      if (modelLower.startsWith("o") || modelLower.includes("gpt-5")) {
         // a) use max_completion_tokens instead of max_tokens
         body.max_completion_tokens = body.max_tokens;
         body.max_tokens = undefined;
@@ -80,7 +81,7 @@ export class OpenAIApi implements BaseLlmApi {
           return message;
         });
       }
-      if (body.tools?.length && !body.model.startsWith("o3")) {
+      if (body.tools?.length && !modelLower.startsWith("o3")) {
         body.parallel_tool_calls = false;
       }
     }


### PR DESCRIPTION
## Summary

- `isOSeriesOrGpt5PlusModel` in `core/llm/llms/OpenAI.ts` and the equivalent check in `packages/openai-adapters/src/apis/OpenAI.ts` are case-sensitive, so model names like `GPT-5`, `Gpt-5-mini`, or `O1` slip past the regex and never get their `max_tokens` rewritten to `max_completion_tokens`.
- In practice this breaks Azure OpenAI deployments, which are commonly named in uppercase (e.g. an Azure deployment literally called `GPT-5`). The provider then returns `400 Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead`.
- Fix: add the `i` flag to the regexes in `isOSeriesOrGpt5PlusModel`, and normalize to lower-case before the `startsWith("o")` / `includes("gpt-5")` / `startsWith("o3")` checks in the adapter. Added uppercase/mixed-case test cases.

This mirrors the existing case-insensitive pattern in `packages/openai-adapters/src/apis/openaiResponses.ts` (`/^(?:gpt-5|gpt-5-codex|o[0-9])/i`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make GPT-5 and o‑series model detection case-insensitive. This fixes `max_tokens` → `max_completion_tokens` rewriting for uppercase Azure deployments (e.g., `GPT-5`) and prevents 400 errors.

- **Bug Fixes**
  - `core/llm/llms/OpenAI.ts`: add `i` flag to `o[0-9]+` and `gpt-[5-9]` regexes.
  - `packages/openai-adapters/src/apis/OpenAI.ts`: use `model.toLowerCase()` for `startsWith("o")`, `includes("gpt-5")`, and `startsWith("o3")`.
  - Extend unit tests with uppercase/mixed-case models (`GPT-5`, `Gpt-5.4`, `O1`, `O3-mini`).

<sup>Written for commit 0576ec7be63b7f9cc9b39310a7b0313449afa581. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

