### PR TITLE
fix(gui): ignore stale provider model fetch results after provider switch

### DIFF
--- a/gui/src/forms/AddModelForm.dynamicFetchRace.test.tsx
+++ b/gui/src/forms/AddModelForm.dynamicFetchRace.test.tsx
@@ -115,4 +115,30 @@ describe("AddModelForm dynamic fetch race", () => {
       );
     });
   });
+
+  it("clears the previous provider API key before a newly selected keyed provider can fetch models", async () => {
+    fetchProviderModelsMock.mockResolvedValue([]);
+
+    const { user } = await renderWithProviders(
+      <AddModelForm onDone={vi.fn()} />,
+    );
+
+    const apiKeyInput = screen.getByPlaceholderText(
+      /Enter your OpenAI API key/i,
+    );
+    await user.type(apiKeyInput, "sk-openai-secret");
+    expect(apiKeyInput).toHaveValue("sk-openai-secret");
+
+    await user.click(screen.getByRole("button", { name: "Anthropic" }));
+
+    const anthropicApiKeyInput = screen.getByPlaceholderText(
+      /Enter your Anthropic API key/i,
+    );
+    expect(anthropicApiKeyInput).toHaveValue("");
+
+    const fetchButton = screen.getByTitle(/fetch available models/i);
+    await user.click(fetchButton);
+
+    expect(fetchProviderModelsMock).not.toHaveBeenCalled();
+  });
 });

--- a/gui/src/forms/AddModelForm.dynamicFetchRace.test.tsx
+++ b/gui/src/forms/AddModelForm.dynamicFetchRace.test.tsx
@@ -1,0 +1,110 @@
+import { act, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { AddModelForm } from "./AddModelForm";
+import { renderWithProviders } from "../util/test/render";
+
+const fetchProviderModelsMock = vi.hoisted(() => vi.fn());
+const initializeDynamicModelsMock = vi.hoisted(() => vi.fn(async () => {}));
+
+vi.mock("../pages/AddNewModel/configs/fetchProviderModels", () => ({
+  fetchProviderModels: fetchProviderModelsMock,
+  initializeDynamicModels: initializeDynamicModelsMock,
+}));
+
+vi.mock("../components/modelSelection/ModelSelectionListbox", () => ({
+  default: ({
+    selectedProvider,
+    setSelectedProvider,
+    topOptions = [],
+    otherOptions = [],
+    searchPlaceholder,
+  }: any) => (
+    <div data-testid={searchPlaceholder ? "provider-listbox" : "model-listbox"}>
+      <div data-testid={searchPlaceholder ? "provider-current" : "model-current"}>
+        {selectedProvider.title}
+      </div>
+      <div>
+        {topOptions.map((option: any) => (
+          <button
+            key={option.title}
+            type="button"
+            onClick={() => setSelectedProvider(option)}
+          >
+            {option.title}
+          </button>
+        ))}
+      </div>
+      <div>
+        {otherOptions.map((option: any) => (
+          <div key={option.title} data-testid="model-other-option">
+            {option.title}
+          </div>
+        ))}
+      </div>
+    </div>
+  ),
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function makeFetchedModel(title: string) {
+  return {
+    title,
+    description: title,
+    params: {
+      title,
+      model: title.toLowerCase().replace(/\s+/g, "-"),
+    },
+    isOpenSource: false,
+    providerOptions: ["openai"],
+  };
+}
+
+describe("AddModelForm dynamic fetch race", () => {
+  beforeEach(() => {
+    fetchProviderModelsMock.mockReset();
+    initializeDynamicModelsMock.mockClear();
+  });
+
+  it("does not leak stale models from the previous provider if the earlier fetch resolves late", async () => {
+    const pendingOpenAiFetch = deferred<any[]>();
+
+    fetchProviderModelsMock.mockImplementation((_messenger: unknown, provider: string) => {
+      if (provider === "openai") {
+        return pendingOpenAiFetch.promise;
+      }
+      return Promise.resolve([]);
+    });
+
+    const { user } = await renderWithProviders(<AddModelForm onDone={vi.fn()} />);
+
+    await user.type(
+      screen.getByPlaceholderText(/Enter your OpenAI API key/i),
+      "sk-test-key",
+    );
+    await user.click(screen.getByTitle(/fetch available models/i));
+
+    await user.click(screen.getByRole("button", { name: "Anthropic" }));
+    expect(screen.getByTestId("provider-current")).toHaveTextContent("Anthropic");
+
+    await act(async () => {
+      pendingOpenAiFetch.resolve([makeFetchedModel("OpenAI Dynamic Model")]);
+      await pendingOpenAiFetch.promise;
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("provider-current")).toHaveTextContent(
+        "Anthropic",
+      );
+      expect(screen.getByTestId("model-listbox")).not.toHaveTextContent(
+        "OpenAI Dynamic Model",
+      );
+    });
+  });
+});

--- a/gui/src/forms/AddModelForm.dynamicFetchRace.test.tsx
+++ b/gui/src/forms/AddModelForm.dynamicFetchRace.test.tsx
@@ -141,4 +141,67 @@ describe("AddModelForm dynamic fetch race", () => {
 
     expect(fetchProviderModelsMock).not.toHaveBeenCalled();
   });
+
+  it("releases the previous provider fetch lock so the newly selected provider can fetch immediately", async () => {
+    const pendingOpenAiFetch = deferred<any[]>();
+
+    fetchProviderModelsMock.mockImplementation(
+      (_messenger: unknown, provider: string) => {
+        if (provider === "openai") {
+          return pendingOpenAiFetch.promise;
+        }
+        if (provider === "anthropic") {
+          return Promise.resolve([makeFetchedModel("Anthropic Dynamic Model")]);
+        }
+        return Promise.resolve([]);
+      },
+    );
+
+    const { user } = await renderWithProviders(
+      <AddModelForm onDone={vi.fn()} />,
+    );
+
+    await user.type(
+      screen.getByPlaceholderText(/Enter your OpenAI API key/i),
+      "sk-openai-secret",
+    );
+    await user.click(screen.getByTitle(/fetch available models/i));
+
+    await user.click(screen.getByRole("button", { name: "Anthropic" }));
+
+    const anthropicApiKeyInput = screen.getByPlaceholderText(
+      /Enter your Anthropic API key/i,
+    );
+    await user.type(anthropicApiKeyInput, "sk-anthropic-secret");
+
+    const fetchButton = screen.getByTitle(/fetch available models/i);
+    expect(fetchButton).not.toBeDisabled();
+    await user.click(fetchButton);
+
+    await waitFor(() => {
+      expect(fetchProviderModelsMock).toHaveBeenCalledWith(
+        expect.anything(),
+        "anthropic",
+        "sk-anthropic-secret",
+        undefined,
+      );
+      expect(screen.getByTestId("model-listbox")).toHaveTextContent(
+        "Anthropic Dynamic Model",
+      );
+    });
+
+    await act(async () => {
+      pendingOpenAiFetch.resolve([makeFetchedModel("OpenAI Dynamic Model")]);
+      await pendingOpenAiFetch.promise;
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("model-listbox")).toHaveTextContent(
+        "Anthropic Dynamic Model",
+      );
+      expect(screen.getByTestId("model-listbox")).not.toHaveTextContent(
+        "OpenAI Dynamic Model",
+      );
+    });
+  });
 });

--- a/gui/src/forms/AddModelForm.dynamicFetchRace.test.tsx
+++ b/gui/src/forms/AddModelForm.dynamicFetchRace.test.tsx
@@ -20,7 +20,9 @@ vi.mock("../components/modelSelection/ModelSelectionListbox", () => ({
     searchPlaceholder,
   }: any) => (
     <div data-testid={searchPlaceholder ? "provider-listbox" : "model-listbox"}>
-      <div data-testid={searchPlaceholder ? "provider-current" : "model-current"}>
+      <div
+        data-testid={searchPlaceholder ? "provider-current" : "model-current"}
+      >
         {selectedProvider.title}
       </div>
       <div>
@@ -75,14 +77,18 @@ describe("AddModelForm dynamic fetch race", () => {
   it("does not leak stale models from the previous provider if the earlier fetch resolves late", async () => {
     const pendingOpenAiFetch = deferred<any[]>();
 
-    fetchProviderModelsMock.mockImplementation((_messenger: unknown, provider: string) => {
-      if (provider === "openai") {
-        return pendingOpenAiFetch.promise;
-      }
-      return Promise.resolve([]);
-    });
+    fetchProviderModelsMock.mockImplementation(
+      (_messenger: unknown, provider: string) => {
+        if (provider === "openai") {
+          return pendingOpenAiFetch.promise;
+        }
+        return Promise.resolve([]);
+      },
+    );
 
-    const { user } = await renderWithProviders(<AddModelForm onDone={vi.fn()} />);
+    const { user } = await renderWithProviders(
+      <AddModelForm onDone={vi.fn()} />,
+    );
 
     await user.type(
       screen.getByPlaceholderText(/Enter your OpenAI API key/i),
@@ -91,7 +97,9 @@ describe("AddModelForm dynamic fetch race", () => {
     await user.click(screen.getByTitle(/fetch available models/i));
 
     await user.click(screen.getByRole("button", { name: "Anthropic" }));
-    expect(screen.getByTestId("provider-current")).toHaveTextContent("Anthropic");
+    expect(screen.getByTestId("provider-current")).toHaveTextContent(
+      "Anthropic",
+    );
 
     await act(async () => {
       pendingOpenAiFetch.resolve([makeFetchedModel("OpenAI Dynamic Model")]);

--- a/gui/src/forms/AddModelForm.tsx
+++ b/gui/src/forms/AddModelForm.tsx
@@ -50,6 +50,7 @@ export function AddModelForm({
   );
   const [isFetchingModels, setIsFetchingModels] = useState(false);
   const selectedProviderRef = useRef(selectedProvider.provider);
+  const fetchGenerationRef = useRef(0);
 
   useEffect(() => {
     void initializeDynamicModels(ideMessenger);
@@ -57,6 +58,8 @@ export function AddModelForm({
 
   useEffect(() => {
     setFetchedModelsList([]);
+    fetchGenerationRef.current += 1;
+    setIsFetchingModels(false);
   }, [selectedProvider]);
 
   const handleFetchModels = useCallback(async () => {
@@ -65,6 +68,8 @@ export function AddModelForm({
     if (!apiKey) return;
 
     const providerAtFetchTime = selectedProvider.provider;
+    const fetchGeneration = fetchGenerationRef.current + 1;
+    fetchGenerationRef.current = fetchGeneration;
     setIsFetchingModels(true);
     try {
       const models = await fetchProviderModels(
@@ -79,7 +84,9 @@ export function AddModelForm({
     } catch (error) {
       console.error("Failed to fetch models:", error);
     } finally {
-      setIsFetchingModels(false);
+      if (fetchGenerationRef.current === fetchGeneration) {
+        setIsFetchingModels(false);
+      }
     }
   }, [ideMessenger, selectedProvider, formMethods]);
 

--- a/gui/src/forms/AddModelForm.tsx
+++ b/gui/src/forms/AddModelForm.tsx
@@ -2,7 +2,7 @@ import {
   ArrowPathIcon,
   ArrowTopRightOnSquareIcon,
 } from "@heroicons/react/24/outline";
-import { useCallback, useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { Button, Input, StyledActionButton } from "../components";
 import Alert from "../components/gui/Alert";
@@ -49,10 +49,15 @@ export function AddModelForm({
     [],
   );
   const [isFetchingModels, setIsFetchingModels] = useState(false);
+  const selectedProviderRef = useRef(selectedProvider.provider);
 
   useEffect(() => {
     void initializeDynamicModels(ideMessenger);
   }, []);
+
+  useEffect(() => {
+    selectedProviderRef.current = selectedProvider.provider;
+  }, [selectedProvider]);
 
   useEffect(() => {
     setFetchedModelsList([]);
@@ -72,9 +77,9 @@ export function AddModelForm({
         apiKey,
         apiBase,
       );
-      setFetchedModelsList((prev) =>
-        selectedProvider.provider === providerAtFetchTime ? models : prev,
-      );
+      if (selectedProviderRef.current === providerAtFetchTime) {
+        setFetchedModelsList(models);
+      }
     } catch (error) {
       console.error("Failed to fetch models:", error);
     } finally {

--- a/gui/src/forms/AddModelForm.tsx
+++ b/gui/src/forms/AddModelForm.tsx
@@ -129,9 +129,7 @@ export function AddModelForm({
 
   useEffect(() => {
     setSelectedModel(selectedProvider.packages[0]);
-    if (!selectedProvider.tags?.includes(ModelProviderTags.RequiresApiKey)) {
-      formMethods.setValue("apiKey", "");
-    }
+    formMethods.setValue("apiKey", "");
   }, [selectedProvider]);
 
   const requiresSkPrefix =

--- a/gui/src/forms/AddModelForm.tsx
+++ b/gui/src/forms/AddModelForm.tsx
@@ -56,10 +56,6 @@ export function AddModelForm({
   }, []);
 
   useEffect(() => {
-    selectedProviderRef.current = selectedProvider.provider;
-  }, [selectedProvider]);
-
-  useEffect(() => {
     setFetchedModelsList([]);
   }, [selectedProvider]);
 
@@ -208,6 +204,7 @@ export function AddModelForm({
                     (provider) => provider.title === val.title,
                   );
                   if (match) {
+                    selectedProviderRef.current = match.provider;
                     setSelectedProvider(match);
                   }
                 }}


### PR DESCRIPTION
Fixes #12150

## Summary
- ignore late dynamic-model fetch results after the selected provider changes
- keep the fix scoped to `AddModelForm` rather than introducing global request cancellation
- add a focused regression test that reproduces the in-flight fetch + provider switch race

## Why this change
PR #12046 introduced dynamic provider model fetching. That flow works, but the current callback in `gui/src/forms/AddModelForm.tsx` closes over `selectedProvider`, so a request started for provider A can still update `fetchedModelsList` after the user has switched to provider B.

That leaves the Add Model UI in an inconsistent state where stale models from the previous provider appear under the newly selected provider.

This PR fixes that by tracking the currently selected provider at resolution time and ignoring outdated async results.

## Test plan
- [x] `cd gui && npm test -- --run src/forms/AddModelForm.dynamicFetchRace.test.tsx`
- [x] Reproduced the stale-result leak locally before the fix using the focused regression test
- [x] Verified the same test passes after the fix
- [ ] Full GUI test suite
- [ ] Manual validation in VS Code / JetBrains
