### PR TITLE
fix(ollama): add Gemma to tool support heuristic for Ollama and LM Studio

### DIFF
--- a/core/llm/toolSupport.test.ts
+++ b/core/llm/toolSupport.test.ts
@@ -260,6 +260,13 @@ describe("PROVIDER_TOOL_SUPPORT", () => {
       expect(supportsFn("devstral-24b")).toBe(true);
     });
 
+    it("should return true for Gemma models", () => {
+      expect(supportsFn("gemma3")).toBe(true);
+      expect(supportsFn("gemma4")).toBe(true);
+      expect(supportsFn("gemma3:27b")).toBe(true);
+      expect(supportsFn("gemma4:27b")).toBe(true);
+    });
+
     it("should return false for explicitly unsupported models", () => {
       expect(supportsFn("vision")).toBe(false);
       expect(supportsFn("math")).toBe(false);
@@ -290,6 +297,14 @@ describe("PROVIDER_TOOL_SUPPORT", () => {
       expect(supportsFn("qwen2")).toBe(true);
       expect(supportsFn("mixtral-8x7b")).toBe(true);
       expect(supportsFn("mistral-7b")).toBe(true);
+    });
+
+    it("should return true for Gemma models via LM Studio", () => {
+      // Gemma 3/4 support function calling per Google's documentation
+      expect(supportsFn("gemma3")).toBe(true);
+      expect(supportsFn("gemma4")).toBe(true);
+      expect(supportsFn("Gemma-3-27B-Instruct-GGUF")).toBe(true);
+      expect(supportsFn("Gemma-4-27B-Instruct-GGUF")).toBe(true);
     });
 
     it("should return true for LM Studio hyphenated model IDs", () => {

--- a/core/llm/toolSupport.ts
+++ b/core/llm/toolSupport.ts
@@ -213,6 +213,8 @@ export const PROVIDER_TOOL_SUPPORT: Record<string, (model: string) => boolean> =
           "glm-5",
           "deepseek",
           "dolphin",
+          // https://ai.google.dev/gemma/docs/capabilities/function-calling
+          "gemma",
         ].some((part) => modelName.toLowerCase().includes(part))
       ) {
         return true;


### PR DESCRIPTION
Fixes #12131

## Problem

Gemma 3/4 models running via Ollama or LM Studio are not recognized as supporting tool calling, so Continue never offers tools to them. This affects users who run Gemma models locally through either provider.

The root cause: the Ollama provider's static model heuristic in `toolSupport.ts` is missing `"gemma"`. The LM Studio provider delegates to Ollama's heuristic, so both are affected.

Without this entry, `modelSupportsNativeTools()` returns `false` for any Gemma model, and tools are never offered or sent — even if the model's Ollama template includes `.Tools` support (the secondary check added in #11670).

Note: the `openai` provider already lists Gemma as supported, and the existing test suite confirms this (lines 109-113 in `toolSupport.test.ts`).

## Solution

Add `"gemma"` to the Ollama supported-models list with a reference to Google's function calling documentation:
https://ai.google.dev/gemma/docs/capabilities/function-calling

For Ollama, the `/api/show` template check (from #11670) will still act as a secondary gate — if the specific Gemma model's template doesn't include `.Tools`, tools will be skipped. This PR only removes the pre-filter that was blocking Gemma entirely.

## Testing

Added test cases for Gemma models in both `ollama` and `lmstudio` provider sections. All 83 tests pass.

```
Tests: 83 passed, 83 total
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable native tool calling for Gemma 3/4 models when run via `ollama` or `lmstudio`. Adds "gemma" to the Ollama tool-support heuristic so Continue offers tools; LM Studio inherits this, and the existing `/api/show` template check still gates per-model support.

<sup>Written for commit 990aa9ea4a5797631a2c76c93fd13a73fb52d16b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

