### PR TITLE
docs: add QuickSilver Pro to OpenAI-compatible providers list

### DIFF
--- a/docs/customize/model-providers/top-level/openai.mdx
+++ b/docs/customize/model-providers/top-level/openai.mdx
@@ -61,6 +61,7 @@ OpenAI API compatible providers include
 - [vLLM](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html)
 - [BerriAI/litellm](https://github.com/BerriAI/litellm)
 - [Tetrate Agent Router Service](https://router.tetrate.ai)
+- [QuickSilver Pro](https://quicksilverpro.io) — hosted API for DeepSeek V3, DeepSeek R1, and Qwen3.5-35B-A3B. Use `apiBase: https://api.quicksilverpro.io/v1`.
 
 If you are using an OpenAI API compatible providers, you can change the `apiBase` like this:
 


### PR DESCRIPTION
## Summary

Adds QuickSilver Pro to the bulleted list of OpenAI-compatible providers in \`docs/customize/model-providers/top-level/openai.mdx\`, alongside LiteLLM, vLLM, Tetrate Agent Router Service, etc.

QuickSilver Pro is a hosted OpenAI-compatible API for three open-source LLMs (DeepSeek V3, DeepSeek R1, Qwen3.5-35B-A3B). Users configure it in Continue with \`provider: openai\` + \`apiBase: https://api.quicksilverpro.io/v1\`, which is already documented on the page.

## Diff

\`\`\`
- [vLLM](...)
- [BerriAI/litellm](...)
- [Tetrate Agent Router Service](...)
+ [QuickSilver Pro](https://quicksilverpro.io) — hosted API for DeepSeek V3, DeepSeek R1, and Qwen3.5-35B-A3B. Use \`apiBase: https://api.quicksilverpro.io/v1\`.
\`\`\`

## Follow-up option

If maintainers prefer a first-class provider pattern (like Novita, SiliconFlow — with a \`core/llm/llms/QuickSilverPro.ts\` + docs page in \`model-providers/more/\`), I'm happy to open a follow-up PR with that. The current PR is the minimum useful entry.

## Disclosure

I help operate QuickSilver Pro (MachineFi Inc., Menlo Park, CA).

## Test plan

- [ ] MDX renders correctly (one bullet added to existing list)
- [ ] Link to \`https://quicksilverpro.io\` resolves
- [ ] \`apiBase\` value matches our public docs at quicksilverpro.io/llms.txt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added QuickSilver Pro to the docs list of OpenAI-compatible providers. Includes a link, supported models (DeepSeek V3, DeepSeek R1, Qwen3.5-35B-A3B), and configuration via `apiBase: https://api.quicksilverpro.io/v1`.

<sup>Written for commit b9e53e03984c673597253919c1045b17940f0590. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

