### PR TITLE
bug: Fix install script

### DIFF
--- a/extensions/cli/scripts/install.sh
+++ b/extensions/cli/scripts/install.sh
@@ -179,8 +179,8 @@ check_node() {
 }
 
 install_node() {
-    # Only mark for cleanup if fnm directory doesn't already exist
-    if [ ! -d "$FNM_INSTALL_DIR" ]; then
+    # Only mark for cleanup if fnm isn't already available
+    if ! command -v fnm &>/dev/null; then
         CLEANUP_FNM=true
     fi
     info "Installing fnm (Fast Node Manager)..."
@@ -191,11 +191,11 @@ install_node() {
         error "Failed to install fnm. Check your network connection and try again."
     fi
 
-    if [ ! -x "$FNM_INSTALL_DIR/fnm" ]; then
-        error "fnm installation failed - binary not found at $FNM_INSTALL_DIR/fnm"
-    fi
-
     export PATH="$FNM_INSTALL_DIR:$PATH"
+
+    if ! command -v fnm &>/dev/null; then
+        error "fnm installation failed - binary not found"
+    fi
 
     # Initialize fnm for current session
     if ! eval "$(fnm env --shell bash 2>/dev/null)"; then


### PR DESCRIPTION
The installation script failed to check if `fnm` binary is installed.

closes: #12173

## Description

Installation script was failing to check if `fnm` binary was installed. 

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

```bash
➜ cat ./continue-install.sh | bash

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
           Continue CLI Installer
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

==> Detected platform: darwin-arm64
==> Using shell profile: /Users/rgildein/.zshrc
==> Warning: Node.js is not installed
==> Installing fnm (Fast Node Manager)...
Downloading fnm using Homebrew...
Checking dependencies for the installation script...
Checking availability of curl... OK!
Checking availability of unzip... OK!
Checking availability of Homebrew (brew)... OK!
Warning: fnm 1.39.0 is already installed and up-to-date.
To reinstall 1.39.0, run:
  brew reinstall fnm
==> Installing Node.js v20.20.1...
Installing Node v20.20.1 (arm64)
00:00:01 ██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 20.71 MiB/20.71 MiB (15.65 MiB/s, 0s)
Using Node v20.20.1
==> Node.js v20.20.1 installed
==> Installing @continuedev/cli...
==> @continuedev/cli installed!

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
==> Continue CLI installation complete!
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

==> Ready! Run: cn --help
~
➜ cn --version
1.5.45
```

## Tests

Just manually tested. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the installer to correctly detect the `fnm` binary and prevent false “binary not found” errors during Node setup. Addresses #12173.

- **Bug Fixes**
  - Detect `fnm` with `command -v` (before and after updating PATH) and only mark cleanup when missing, removing the hardcoded `$FNM_INSTALL_DIR/fnm` check.

<sup>Written for commit 21a224352c8b84352d75ced5da0a9af0bf57329d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

