### PR TITLE
fix(cli): display full model name in TUI without trimming at slash delimiter

### DIFF
--- a/extensions/cli/src/ui/IntroMessage.test.tsx
+++ b/extensions/cli/src/ui/IntroMessage.test.tsx
@@ -72,7 +72,19 @@ describe("IntroMessage", () => {
     const { lastFrame } = render(<IntroMessage model={model} />);
 
     expect(lastFrame()).toContain("Model:");
-    expect(lastFrame()).toContain("model-name");
+    expect(lastFrame()).toContain("provider/model-name");
+  });
+
+  it("renders full model name including slashes without trimming", () => {
+    const model = {
+      name: "local/large",
+      provider: "openai",
+      model: "local/large",
+    };
+
+    const { lastFrame } = render(<IntroMessage model={model} />);
+
+    expect(lastFrame()).toContain("local/large");
   });
 
   it("shows loading state when model is not provided", () => {

--- a/extensions/cli/src/ui/IntroMessage.tsx
+++ b/extensions/cli/src/ui/IntroMessage.tsx
@@ -117,8 +117,7 @@ const IntroMessage: React.FC<IntroMessageProps> = ({
       {/* Model */}
       {model ? (
         <Text color="blue">
-          <Text bold>Model:</Text>{" "}
-          <Text color="white">{model.name.split("/").pop()}</Text>
+          <Text bold>Model:</Text> <Text color="white">{model.name}</Text>
         </Text>
       ) : (
         <Text color="blue">
@@ -131,9 +130,7 @@ const IntroMessage: React.FC<IntroMessageProps> = ({
       {/* Model capability warning */}
       {model && !modelCapable && (
         <>
-          <ModelCapabilityWarning
-            modelName={model.name.split("/").pop() || model.name}
-          />
+          <ModelCapabilityWarning modelName={model.name} />
           <Text> </Text>
         </>
       )}


### PR DESCRIPTION
Fixes #12191

## Problem

Model names containing `/` or `-` delimiters (e.g. `local/large`) were incorrectly displayed as just the last segment (e.g. `large`) in the CLI intro message and model capability warning. This happened because `IntroMessage.tsx` applied `.split("/").pop()` to `model.name`, which is the user-configured display name and should be shown verbatim.

## Solution

Remove the `.split("/").pop()` calls in `IntroMessage.tsx` and pass `model.name` directly to both the model display text and the `ModelCapabilityWarning` component. Updated the existing test to assert the full model name is displayed, and added a new test covering the exact reported scenario (`local/large`).

## Testing

- All 9 existing tests in `IntroMessage.test.tsx` pass
- New test `renders full model name including slashes without trimming` verifies the fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the full model name in the CLI intro screen and capability warning. We no longer trim at "/" so names like `local/large` display correctly.

- **Bug Fixes**
  - Removed `.split("/")` trimming in the intro message; pass `model.name` directly.
  - Updated tests to expect full names; added a case for `local/large`.

<sup>Written for commit d14dbc9e1764599c23bb9774a99999460f9f6aa3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

