### PR TITLE
update broken documentation references

### DIFF
--- a/docs/guides/netlify-mcp-continuous-deployment.mdx
+++ b/docs/guides/netlify-mcp-continuous-deployment.mdx
@@ -724,4 +724,4 @@ The Netlify Performance Rules enforce:
 - [Netlify MCP on Continue Mission Control](https://continue.dev/netlify/netlify-mcp)
 - [Core Web Vitals Guide](https://web.dev/vitals/)
 - [Netlify Analytics Documentation](https://docs.netlify.com/analytics/)
-- [Continue Performance Guides](https://docs.continue.dev/guides)
+- [Continue Guides](https://docs.continue.dev/guides/configuring-models-rules-tools)

--- a/docs/guides/running-continue-without-internet.mdx
+++ b/docs/guides/running-continue-without-internet.mdx
@@ -4,6 +4,6 @@ description: "Learn how to set up Continue for air-gapped or offline environment
 ---
 
 1. Download the latest .vsix file from the [GitHub Releases page](https://github.com/continuedev/continue/releases) and [install it to VS Code](https://code.visualstudio.com/docs/editor/extension-marketplace#_install-from-a-vsix).
-2. Turn off "Allow Anonymous Telemetry" in the user settings. This will stop Continue from attempting requests to PostHog for [anonymous telemetry](https://docs.continue.dev/reference/telemetry).
-3. In your `config.yaml` file (or through the Continue UI), set the default model to a local model. You can find available local model options [here](https://docs.continue.dev/reference/model-providers/ollama).
+2. Turn off "Allow Anonymous Telemetry" in the user settings. This will stop Continue from attempting requests to PostHog for [anonymous telemetry](https://docs.continue.dev/customize/telemetry).
+3. In your `config.yaml` file (or through the Continue UI), set the default model to a local model. You can find available local model options [here](https://docs.continue.dev/customize/model-providers/top-level/ollama).
 4. Restart VS Code to ensure that the changes to `config.yaml` take effect.

--- a/docs/reference.mdx
+++ b/docs/reference.mdx
@@ -298,7 +298,7 @@ version: 1.0.0
 schema: v1
 docs:
   - name: Continue
-    startUrl: https://docs.continue.dev/intro
+    startUrl: https://docs.continue.dev/index
     favicon: https://docs.continue.dev/favicon.ico
 ```
 

--- a/docs/reference/json-reference.mdx
+++ b/docs/reference/json-reference.mdx
@@ -279,7 +279,13 @@ Example
 config.json
 
 ```
-"docs": [    {    "title": "Continue",    "startUrl": "https://docs.continue.dev/intro",    "faviconUrl": "https://docs.continue.dev/favicon.ico",  }]
+"docs": [
+  {
+    "title": "Continue",
+    "startUrl": "https://docs.continue.dev/getting-started/overview",
+    "faviconUrl": "https://www.continue.dev/favicon.png"
+  }
+]
 ```
 
 ## `slashCommands`


### PR DESCRIPTION
## Description

This PR updates broken links to working ones.
The broken links seem to be forgotten during updates.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix broken and outdated documentation links across guides and reference examples so readers land on the correct pages. Updates example URLs to match the current docs structure.

- **Bug Fixes**
  - Running offline guide: telemetry link to /customize/telemetry; Ollama provider link to /customize/model-providers/top-level/ollama.
  - Reference examples: startUrl to /index; JSON example startUrl to /getting-started/overview and favicon to https://www.continue.dev/favicon.png.
  - Netlify MCP guide: update "Continue Guides" link to /guides/configuring-models-rules-tools.

<sup>Written for commit b3e1249a40796d77db8ad9d83ef42374833d9157. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

