### PR TITLE
fix: When AGENTS.md does not exist, the traversal will be interrupted…

### DIFF
--- a/core/config/markdown/loadMarkdownRules.ts
+++ b/core/config/markdown/loadMarkdownRules.ts
@@ -42,9 +42,8 @@ export async function loadMarkdownRules(ide: IDE): Promise<{
             alwaysApply: true,
           });
           agentFileFound = true;
+          break; // Use the first found agent file in this workspace
         }
-
-        break; // Use the first found agent file in this workspace
       } catch (e) {
         // File doesn't exist or can't be read, continue to next file
       }


### PR DESCRIPTION
… and the issue of AGENT.md/CLAUDE.md will not be further checked.

## Description

When AGENTS.md does not exist, the traversal will be interrupted and the issue of AGENT.md/CLAUDE.md will not be further checked.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent premature loop exit when `AGENTS.md` is missing by only breaking after a successful read in `core/config/markdown/loadMarkdownRules.ts`. The loader now properly falls back to `AGENT.md` and `CLAUDE.md`.

<sup>Written for commit 4f58180c675566f569ab7f9a68fc0f16bed2502a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

