### PR TITLE
fix(bedrock): opt into httpBearerAuth when apiKey is set

### DIFF
--- a/core/llm/llms/Bedrock.ts
+++ b/core/llm/llms/Bedrock.ts
@@ -77,7 +77,8 @@ class Bedrock extends BaseLLM {
         region: this.region,
         endpoint: this.apiBase,
         token: async () => ({ token: this.apiKey! }),
-      });
+        authSchemePreference: ["httpBearerAuth"],
+      } as any);
     }
 
     // IAM credential authentication


### PR DESCRIPTION
## Description
I was using the config file from [doc](https://docs.continue.dev/customize/model-providers/top-level/bedrock)
```
models:
  - name: Claude Sonnet
    provider: bedrock
    model: us.anthropic.claude-sonnet-4-20250514-v1:0
    apiKey: ${{ secrets.BEDROCK_API_KEY }}
    env:
      region: us-east-1
    roles:
      - chat
```
it failed with 
```
  Could not load credentials from any providers                                                                                                                      
 ```             
  The apiKey value is correctly read into this.apiKey and the bearer-token branch at core/llm/llms/Bedrock.ts:74-81 is entered, but the AWS SDK silently falls back to SigV4 auth and tries to resolve IAM credentials, this is with @aws-sdk/client-bedrock-runtime 3.1017.0, the version resolved from the ^3.931.0 pin.
```
// node_modules/@aws-sdk/client-bedrock-runtime/dist-cjs/auth/httpAuthSchemeProvider.js
  options.push(createAwsAuthSigv4HttpAuthOption(authParameters));          // 1st                                                                                    
  options.push(createSmithyApiHttpBearerAuthHttpAuthOption(authParameters)); // 2nd                                                                                  
```                                                                                                                                                                     
  Without an explicit authSchemePreference, the resolver picks the first scheme (SigV4), ignores the supplied token, and invokes the IAM credential provider chain. Only the env-var path (AWS_BEARER_TOKEN_BEDROCK) works today, because the SDK auto-detects that and injects the preference for us. 
(as `any` because `BedrockRuntimeClientConfig` types `authSchemePreference` loosely across SDK minor releases — happy to drop if reviewers prefer.)  

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forces the Bedrock client to use HTTP Bearer auth when an `apiKey` is set, so the token is used instead of SigV4. Fixes "Could not load credentials from any providers" when using the documented `apiKey` config.

- **Bug Fixes**
  - Set `authSchemePreference: ["httpBearerAuth"]` when `apiKey` is provided to prevent `@aws-sdk/client-bedrock-runtime` from defaulting to SigV4/IAM.

<sup>Written for commit aef2b14e6bdc2d57e66bca3853d08aab54ebab15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

