### PR TITLE
docs(openrouter): document automatic identification headers

### DIFF
--- a/docs/customize/model-providers/top-level/openrouter.mdx
+++ b/docs/customize/model-providers/top-level/openrouter.mdx
@@ -89,6 +89,54 @@ For example, to prevent extra long prompts from being compressed, you can explic
   </Tab>
 </Tabs>
 
+## App Identification Headers
+
+Continue automatically sends [OpenRouter identification headers](https://openrouter.ai/docs/api-reference/overview#headers) on every request so that activity shows up under Continue in OpenRouter's dashboard and App Showcase:
+
+- `HTTP-Referer: https://www.continue.dev/`
+- `X-OpenRouter-Title: Continue`
+- `X-OpenRouter-Categories: ide-extension`
+
+These are sent by default and require no configuration. If you need to override any of them (for example, to attribute traffic to your own app), set the corresponding header in `requestOptions.headers` — user-provided headers take precedence over the defaults:
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  name: My Config
+  version: 0.0.1
+  schema: v1
+
+  models:
+    - name: <MODEL_NAME>
+      provider: openrouter
+      model: <MODEL_ID>
+      requestOptions:
+        headers:
+          HTTP-Referer: https://your-app.example.com/
+          X-OpenRouter-Title: Your App
+  ```
+  </Tab>
+  <Tab title="JSON (Deprecated)">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "<MODEL_NAME>",
+        "provider": "openrouter",
+        "model": "<MODEL_ID>",
+        "requestOptions": {
+          "headers": {
+            "HTTP-Referer": "https://your-app.example.com/",
+            "X-OpenRouter-Title": "Your App"
+          }
+        }
+      }
+    ]
+  }
+  ```
+  </Tab>
+</Tabs>
+
 ## Model Capabilities
 
 OpenRouter models may require explicit capability configuration because the proxy doesn't always preserve the function calling support of the original model. 


### PR DESCRIPTION
Fixes #12215

## What changed

Adds an "App Identification Headers" section to `docs/customize/model-providers/top-level/openrouter.mdx` covering the three OpenRouter headers Continue now sends on every request:

- `HTTP-Referer: https://www.continue.dev/`
- `X-OpenRouter-Title: Continue`
- `X-OpenRouter-Categories: ide-extension`

Values taken directly from `packages/openai-adapters/src/apis/OpenRouter.ts` (the `OPENROUTER_HEADERS` constant added in #11857 and extended in #11991), so the docs match the shipped code rather than inventing anything.

Also documents that `requestOptions.headers` takes precedence (the spread order `{...OPENROUTER_HEADERS, ...config.requestOptions?.headers}` in `OpenRouterApi`), with a short example for users who want their own traffic attributed to a different app.

Links to [OpenRouter's header docs](https://openrouter.ai/docs/api-reference/overview#headers) per the issue's suggestion.

## Verification

- Header names/values: `grep -n "HTTP-Referer\|X-OpenRouter-Title\|X-OpenRouter-Categories" packages/openai-adapters/src/apis/OpenRouter.ts` (lines 14–16).
- Override precedence: `OpenRouterApi` constructor spreads `OPENROUTER_HEADERS` before `config.requestOptions?.headers`, so user-provided values win — matches what the issue body requested.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an “App Identification Headers” section to the OpenRouter docs that lists the default headers Continue sends: `HTTP-Referer`, `X-OpenRouter-Title`, and `X-OpenRouter-Categories`. Shows how to override them via `requestOptions.headers`, aligns the docs with shipped code, and links to OpenRouter’s header docs (Fixes #12215).

<sup>Written for commit 8077f4b2cc2eec721b686b5dc1b4c38e0d09760f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

