### PR TITLE
fix(cli): critical security fixes for subagent permissions, writeFile boundary, and policy bypass

### DIFF
--- a/extensions/cli/src/permissions/permissionChecker.test.ts
+++ b/extensions/cli/src/permissions/permissionChecker.test.ts
@@ -597,7 +597,7 @@ describe("Permission Checker", () => {
         );
       });
 
-      it("should allow risky commands based on user preference (curl)", () => {
+      it("should ask for risky commands based on dynamic evaluation (curl)", () => {
         mockEvaluateToolCallPolicy.mockReturnValue("allowedWithPermission");
 
         const result = checkToolPermission(
@@ -605,7 +605,7 @@ describe("Permission Checker", () => {
           permissions,
         );
 
-        expect(result.permission).toBe("allow"); // User preference wins over "ask"
+        expect(result.permission).toBe("ask"); // Dynamic evaluation wins over "allow"
         expect(mockEvaluateToolCallPolicy).toHaveBeenCalledWith(
           "allowedWithoutPermission", // converted from "allow"
           { command: "curl https://example.com" },
@@ -759,26 +759,26 @@ describe("Permission Checker", () => {
           expected: "allow",
         },
 
-        // Risky commands (user preference wins when not disabled)
+        // Risky commands (dynamic evaluation wins when not disabled)
         {
           command: "npm install pkg",
           dynamicResult: "allowedWithPermission",
-          expected: "allow",
+          expected: "ask",
         },
         {
           command: "rm file.txt",
           dynamicResult: "allowedWithPermission",
-          expected: "allow",
+          expected: "ask",
         },
         {
           command: "curl https://api.example.com",
           dynamicResult: "allowedWithPermission",
-          expected: "allow",
+          expected: "ask",
         },
         {
           command: "wget https://example.com/file",
           dynamicResult: "allowedWithPermission",
-          expected: "allow",
+          expected: "ask",
         },
 
         // Dangerous commands (always blocked)
@@ -860,7 +860,7 @@ describe("Permission Checker", () => {
           permissions,
         );
 
-        expect(result.permission).toBe("allow");
+        expect(result.permission).toBe("ask");
         expect(mockEvaluateToolCallPolicy).toHaveBeenCalledWith(
           "allowedWithoutPermission",
           {},

--- a/extensions/cli/src/permissions/permissionChecker.ts
+++ b/extensions/cli/src/permissions/permissionChecker.ts
@@ -122,6 +122,37 @@ function permissionPolicyToToolPolicy(
 }
 
 /**
+ * Converts core's ToolPolicy back to CLI's PermissionPolicy
+ */
+function toolPolicyToPermissionPolicy(policy: ToolPolicy): PermissionPolicy {
+  switch (policy) {
+    case "allowedWithoutPermission":
+      return "allow";
+    case "allowedWithPermission":
+      return "ask";
+    case "disabled":
+      return "exclude";
+    default:
+      return "ask";
+  }
+}
+
+/**
+ * Returns the most restrictive of two permission policies.
+ */
+function getMostRestrictivePermissionPolicy(
+  a: PermissionPolicy,
+  b: PermissionPolicy,
+): PermissionPolicy {
+  const order: Record<PermissionPolicy, number> = {
+    exclude: 3,
+    ask: 2,
+    allow: 1,
+  };
+  return order[a] >= order[b] ? a : b;
+}
+
+/**
  * Evaluates a tool call request against a set of permission policies.
  * Returns the permission for the first matching policy.
  */
@@ -158,17 +189,26 @@ export function checkToolPermission(
       toolCall.arguments,
     );
 
-    // If dynamic evaluation says disabled, that ALWAYS takes precedence
-    if (evaluatedPolicy === "disabled") {
+    const validPolicies: ToolPolicy[] = [
+      "allowedWithoutPermission",
+      "allowedWithPermission",
+      "disabled",
+    ];
+
+    if (!validPolicies.includes(evaluatedPolicy)) {
       return {
-        permission: "exclude",
+        permission: basePermission,
         matchedPolicy,
       };
     }
 
-    // Otherwise, user preference wins - return the original base permission
+    // Dynamic evaluation can only restrict further, never relax
+    const evaluatedPermission = toolPolicyToPermissionPolicy(evaluatedPolicy);
     return {
-      permission: basePermission,
+      permission: getMostRestrictivePermissionPolicy(
+        basePermission,
+        evaluatedPermission,
+      ),
       matchedPolicy,
     };
   }

--- a/extensions/cli/src/subagent/executor.ts
+++ b/extensions/cli/src/subagent/executor.ts
@@ -75,19 +75,6 @@ export async function executeSubAgent(
       throw new Error("Model or LLM API not available");
     }
 
-    // allow all tools for now
-    // todo: eventually we want to show the same prompt in a dialog whether asking whether that tool call is allowed or not
-
-    serviceContainer.set<ToolPermissionServiceState>(
-      SERVICE_NAMES.TOOL_PERMISSIONS,
-      {
-        ...mainAgentPermissionsState,
-        permissions: {
-          policies: [{ tool: "*", permission: "allow" }],
-        },
-      },
-    );
-
     // Build agent system message
     const systemMessage = await buildAgentSystemMessage(subAgent, services);
 

--- a/extensions/cli/src/tools/writeFile.ts
+++ b/extensions/cli/src/tools/writeFile.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 
+import { throwIfFileIsSecurityConcern } from "core/indexing/ignore.js";
 import { ContinueError, ContinueErrorReason } from "core/util/errors.js";
 import { createTwoFilesPatch } from "diff";
 
@@ -57,6 +58,7 @@ export const writeFileTool: Tool = {
     if (typeof content !== "string") {
       throw new Error("New file content must be a string");
     }
+    throwIfFileIsSecurityConcern(filepath);
     try {
       if (fs.existsSync(filepath)) {
         const oldContent = fs.readFileSync(filepath, "utf-8");
@@ -118,6 +120,7 @@ export const writeFileTool: Tool = {
     };
   },
   run: async (args: { filepath: string; content: string }): Promise<string> => {
+    throwIfFileIsSecurityConcern(args.filepath);
     try {
       const dirPath = path.dirname(args.filepath);
       if (!fs.existsSync(dirPath)) {


### PR DESCRIPTION
## Summary

Addresses three critical/high security findings from the 2026-04-28 AI Tooling Security Audit:

1. **Subagent bypasses permissions** (Critical) — Removed the hard-coded `policies: [{ tool: "*", permission: "allow" }]` override in `extensions/cli/src/subagent/executor.ts` so subagents now inherit the main agent's tool permission policies instead of unconditionally allowing all tools.

2. **writeFile no boundary** (High) — Added `throwIfFileIsSecurityConcern` checks to both the `preprocess` and `run` functions in `extensions/cli/src/tools/writeFile.ts`, aligning it with the security posture of `readFile` and `edit` tools.

3. **Policy bypass** (High) — Fixed `extensions/cli/src/permissions/permissionChecker.ts` so that dynamic tool policy evaluation (e.g., terminal command security analysis) is respected rather than being overridden by static user `allow` policies. The fix takes the most restrictive of the static policy and the dynamically evaluated policy, and gracefully handles invalid evaluator responses.

## Test Results

- All existing CLI tests pass (1,848 passed, 29 skipped).
- `permissionChecker.test.ts` and `permissionChecker.integration.test.ts` updated and passing.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three critical/high security issues in the CLI: subagents now inherit tool permissions, `writeFile` enforces path safety checks, and dynamic tool policy evaluation can’t be bypassed.

- **Bug Fixes**
  - Subagent permissions: removed the allow-all override so subagents inherit the main agent’s tool policies.
  - `writeFile` boundary: added `throwIfFileIsSecurityConcern` in both preprocess and run to match `readFile`/`edit` posture.
  - Policy evaluation: `permissionChecker` now takes the most restrictive result between static policy and dynamic evaluation, and safely handles invalid evaluator outputs.
  - Tests: updated `permissionChecker` unit/integration tests; all CLI tests pass.

<sup>Written for commit 5b77e11716e39c336e62aeb76e876eb8d3cc80a4. Summary will update on new commits. <a href="https://cubic.dev/pr/continuedev/continue/pull/12248?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

