### PR TITLE
fix(paths): use XDG Base Directory for config on Linux

### DIFF
--- a/core/util/paths.test.ts
+++ b/core/util/paths.test.ts
@@ -15,7 +15,7 @@ describe("getDefaultContinueGlobalDir", () => {
       expect(result).toBe(path.join(HOME, ".config", "continue"));
     });
 
-    it("uses $XDG_CONFIG_HOME/continue when XDG_CONFIG_HOME is set and no legacy dir exists", () => {
+    it("uses $XDG_CONFIG_HOME/continue when XDG_CONFIG_HOME is a valid absolute path", () => {
       const result = getDefaultContinueGlobalDir({
         platform: "linux",
         homedir: HOME,
@@ -23,6 +23,26 @@ describe("getDefaultContinueGlobalDir", () => {
         legacyDirExists: false,
       });
       expect(result).toBe("/custom/config/continue");
+    });
+
+    it("ignores XDG_CONFIG_HOME when it is an empty string", () => {
+      const result = getDefaultContinueGlobalDir({
+        platform: "linux",
+        homedir: HOME,
+        xdgConfigHome: "",
+        legacyDirExists: false,
+      });
+      expect(result).toBe(path.join(HOME, ".config", "continue"));
+    });
+
+    it("ignores XDG_CONFIG_HOME when it is a relative path", () => {
+      const result = getDefaultContinueGlobalDir({
+        platform: "linux",
+        homedir: HOME,
+        xdgConfigHome: "relative/path",
+        legacyDirExists: false,
+      });
+      expect(result).toBe(path.join(HOME, ".config", "continue"));
     });
 
     it("falls back to ~/.continue when the legacy dir already exists", () => {

--- a/core/util/paths.test.ts
+++ b/core/util/paths.test.ts
@@ -1,0 +1,62 @@
+import * as path from "path";
+import { getDefaultContinueGlobalDir } from "./paths";
+
+describe("getDefaultContinueGlobalDir", () => {
+  const HOME = "/home/user";
+
+  describe("on Linux", () => {
+    it("uses ~/.config/continue when no legacy dir exists and XDG_CONFIG_HOME is unset", () => {
+      const result = getDefaultContinueGlobalDir({
+        platform: "linux",
+        homedir: HOME,
+        xdgConfigHome: undefined,
+        legacyDirExists: false,
+      });
+      expect(result).toBe(path.join(HOME, ".config", "continue"));
+    });
+
+    it("uses $XDG_CONFIG_HOME/continue when XDG_CONFIG_HOME is set and no legacy dir exists", () => {
+      const result = getDefaultContinueGlobalDir({
+        platform: "linux",
+        homedir: HOME,
+        xdgConfigHome: "/custom/config",
+        legacyDirExists: false,
+      });
+      expect(result).toBe("/custom/config/continue");
+    });
+
+    it("falls back to ~/.continue when the legacy dir already exists", () => {
+      const result = getDefaultContinueGlobalDir({
+        platform: "linux",
+        homedir: HOME,
+        xdgConfigHome: "/custom/config",
+        legacyDirExists: true,
+      });
+      expect(result).toBe(path.join(HOME, ".continue"));
+    });
+  });
+
+  describe("on macOS", () => {
+    it("always uses ~/.continue", () => {
+      const result = getDefaultContinueGlobalDir({
+        platform: "darwin",
+        homedir: HOME,
+        xdgConfigHome: "/custom/config",
+        legacyDirExists: false,
+      });
+      expect(result).toBe(path.join(HOME, ".continue"));
+    });
+  });
+
+  describe("on Windows", () => {
+    it("always uses ~/.continue", () => {
+      const result = getDefaultContinueGlobalDir({
+        platform: "win32",
+        homedir: "C:\\Users\\user",
+        xdgConfigHome: undefined,
+        legacyDirExists: false,
+      });
+      expect(result).toBe(path.join("C:\\Users\\user", ".continue"));
+    });
+  });
+});

--- a/core/util/paths.ts
+++ b/core/util/paths.ts
@@ -49,7 +49,13 @@ export function getDefaultContinueGlobalDir(opts: {
     if (legacyDirExists) {
       return legacyPath;
     }
-    const xdgBase = xdgConfigHome ?? path.join(homedir, ".config");
+    // Only accept XDG_CONFIG_HOME when it is a non-empty absolute path;
+    // an empty string or a relative path would place the config dir in an
+    // unexpected location (e.g. the current working directory).
+    const xdgBase =
+      xdgConfigHome && path.isAbsolute(xdgConfigHome)
+        ? xdgConfigHome
+        : path.join(homedir, ".config");
     return path.join(xdgBase, "continue");
   }
 
@@ -106,10 +112,12 @@ export function getGlobalContinueIgnorePath(): string {
 }
 
 export function getContinueGlobalPath(): string {
-  // This is ~/.continue on mac/linux
+  // This is ~/.continue on mac/linux (or ~/.config/continue on Linux for new installs)
   const continuePath = CONTINUE_GLOBAL_DIR;
   if (!fs.existsSync(continuePath)) {
-    fs.mkdirSync(continuePath);
+    // Use recursive so intermediate directories (e.g. ~/.config) are created
+    // when the XDG path is used on Linux.
+    fs.mkdirSync(continuePath, { recursive: true });
   }
   return continuePath;
 }

--- a/core/util/paths.ts
+++ b/core/util/paths.ts
@@ -24,6 +24,38 @@ export function setConfigFilePermissions(filePath: string): void {
   }
 }
 
+/**
+ * Resolves the default Continue global directory path.
+ *
+ * On Linux the XDG Base Directory Specification is followed:
+ *   - $XDG_CONFIG_HOME/continue  (when XDG_CONFIG_HOME is set)
+ *   - ~/.config/continue         (otherwise)
+ *
+ * The legacy ~/.continue location is returned as-is on Linux when it already
+ * exists so that existing installations are not silently relocated.
+ *
+ * On all other platforms ~/.continue is used.
+ */
+export function getDefaultContinueGlobalDir(opts: {
+  platform: NodeJS.Platform;
+  homedir: string;
+  xdgConfigHome: string | undefined;
+  legacyDirExists: boolean;
+}): string {
+  const { platform, homedir, xdgConfigHome, legacyDirExists } = opts;
+  const legacyPath = path.join(homedir, ".continue");
+
+  if (platform === "linux") {
+    if (legacyDirExists) {
+      return legacyPath;
+    }
+    const xdgBase = xdgConfigHome ?? path.join(homedir, ".config");
+    return path.join(xdgBase, "continue");
+  }
+
+  return legacyPath;
+}
+
 const CONTINUE_GLOBAL_DIR = (() => {
   const configPath = process.env.CONTINUE_GLOBAL_DIR;
   if (configPath) {
@@ -32,7 +64,14 @@ const CONTINUE_GLOBAL_DIR = (() => {
       ? configPath
       : path.resolve(process.cwd(), configPath);
   }
-  return path.join(os.homedir(), ".continue");
+
+  const homedir = os.homedir();
+  return getDefaultContinueGlobalDir({
+    platform: os.platform(),
+    homedir,
+    xdgConfigHome: process.env.XDG_CONFIG_HOME,
+    legacyDirExists: fs.existsSync(path.join(homedir, ".continue")),
+  });
 })();
 
 // export const DEFAULT_CONFIG_TS_CONTENTS = `import { Config } from "./types"\n\nexport function modifyConfig(config: Config): Config {


### PR DESCRIPTION
## Summary

Fixes #5397.

On Linux, most distributions expect user configuration to live in `~/.config/` (or `$XDG_CONFIG_HOME`) rather than directly in the home directory.

This change makes Continue follow the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/) on Linux:

| Condition | Path used |
|-----------|-----------|
| `XDG_CONFIG_HOME` is set | `$XDG_CONFIG_HOME/continue` |
| `XDG_CONFIG_HOME` is not set | `~/.config/continue` |
| `~/.continue` already exists (existing install) | `~/.continue` ← unchanged |

macOS and Windows behaviour is **unchanged** — they continue using `~/.continue`.

## Backward compatibility

Existing Linux users with a `~/.continue` directory are **not affected** — the legacy path is detected at startup and used as-is. No data is moved without user action.

New Linux installations will automatically get the XDG-compliant path.

## Changes

- `core/util/paths.ts` — extracted `getDefaultContinueGlobalDir()` helper that encapsulates the platform/XDG logic, wired into `CONTINUE_GLOBAL_DIR`
- `core/util/paths.test.ts` — unit tests covering all four cases (Linux+XDG, Linux+default, Linux+legacy fallback, macOS, Windows)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the default config directory on Linux to follow the XDG Base Directory spec: `$XDG_CONFIG_HOME/continue` or `~/.config/continue`. Existing `~/.continue` installs are preserved, and macOS/Windows behavior is unchanged.

- **Bug Fixes**
  - Added `getDefaultContinueGlobalDir` for platform-aware paths with legacy `~/.continue` fallback.
  - Validates `XDG_CONFIG_HOME` (non-empty absolute only); falls back to `~/.config` otherwise.
  - Uses recursive `fs.mkdirSync` in `getContinueGlobalPath` to create missing parent dirs.
  - Added unit tests for Linux (XDG set/unset, empty/relative, legacy), macOS, and Windows.

<sup>Written for commit 65d065ab8046b4ecd8288cd7c78b5bf7581a6177. Summary will update on new commits. <a href="https://cubic.dev/pr/continuedev/continue/pull/12255?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

