### PR TITLE
docs: update Inception provider documentation for mercury-2 models

### DIFF
--- a/docs/customize/model-providers/top-level/inception.mdx
+++ b/docs/customize/model-providers/top-level/inception.mdx
@@ -9,7 +9,19 @@ sidebarTitle: "Inception"
 </Tip>
 
 <Info>
-  Get an API key from [Inception Platform](https://platform.inceptionlabs.ai/dashboard/api-keys)
+  Get an API key from the [Inception Platform](https://platform.inceptionlabs.ai/dashboard/api-keys)
+</Info>
+
+## Models
+
+Inception offers several models tailored for specific developer workflows:
+
+- **mercury-2**: A general-purpose model supporting tool calling and a 128k context window.
+- **mercury-edit-2**: Optimized for code editing and complex transformations.
+- **mercury-coder-small**: A lightweight model designed for low-latency coding completions.
+
+<Info>
+  The Inception provider inherits from the OpenAI class, supporting dynamic model discovery via the `listModels()` method.
 </Info>
 
 ## Configuration
@@ -22,9 +34,9 @@ sidebarTitle: "Inception"
   schema: v1
 
   models:
-    - name: <MODEL_NAME>
+    - name: Inception Mercury-2
       provider: inception
-      model: <MODEL_ID>
+      model: mercury-2
       apiKey: <INCEPTION_API_KEY>
   ```
   </Tab>
@@ -33,9 +45,9 @@ sidebarTitle: "Inception"
   {
     "models": [
       {
-        "title": "<MODEL_NAME>",
+        "title": "Inception Mercury-2",
         "provider": "inception",
-        "model": "<MODEL_ID>",
+        "model": "mercury-2",
         "apiKey": "<INCEPTION_API_KEY>"
       }
     ]
@@ -45,5 +57,5 @@ sidebarTitle: "Inception"
 </Tabs>
 
 <Info>
-  **Check out a more advanced configuration [here](https://continue.dev/inceptionlabs/mercury-coder?view=config)**
+  **View more advanced configuration options [here](https://continue.dev/inceptionlabs/mercury-coder?view=config)**
 </Info>


### PR DESCRIPTION
## Description

Updates the Inception provider documentation to include newly supported Mercury models and capabilities.

Changes include:

* Added `mercury-2`
* Added `mercury-edit-2`
* Added `mercury-coder-small`
* Documented tool calling support
* Documented 128k context window support
* Added information about dynamic model discovery support
* Updated configuration examples to use `mercury-2`

Closes #12253

## AI Code Review

* **Team members only**: AI review runs automatically when PR is opened or marked ready for review
* Team members can also trigger a review by commenting `@continue-review`

## Checklist

* [x] I've read the contributing guide
* [x] The relevant docs, if any, have been updated or created
* [ ] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Not applicable (documentation-only change).

## Tests

Not applicable (documentation-only change).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Inception provider docs to cover the Mercury-2 lineup and new capabilities, and refreshes config examples to use `mercury-2`.
Adds `mercury-2`, `mercury-edit-2`, and `mercury-coder-small`; documents tool calling, 128k context window, and dynamic model discovery via `listModels()`.

<sup>Written for commit e5a41940e39dfd16955908a042c642c438984468. Summary will update on new commits. <a href="https://cubic.dev/pr/continuedev/continue/pull/12256?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

