### PR TITLE
feat(llm): add Perplexity as a model provider

### DIFF
--- a/core/llm/autodetect.ts
+++ b/core/llm/autodetect.ts
@@ -70,6 +70,7 @@ const PROVIDER_HANDLES_TEMPLATING: string[] = [
   "xAI",
   "minimax",
   "groq",
+  "perplexity",
   "gemini",
   "docker",
   "nous",

--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -10,7 +10,7 @@ import {
   ResponseInputMessageContentList,
   Tool as ResponsesTool,
 } from "openai/resources/responses/responses.mjs";
-import {
+import type {
   ChatMessage,
   CompletionOptions,
   LLMOptions,

--- a/core/llm/llms/Perplexity.ts
+++ b/core/llm/llms/Perplexity.ts
@@ -1,4 +1,6 @@
-import { LLMOptions } from "../../index.js";
+import { PERPLEXITY_INTEGRATION_HEADERS } from "@continuedev/openai-adapters";
+
+import type { LLMOptions } from "../../index.js";
 
 import OpenAI from "./OpenAI.js";
 
@@ -18,6 +20,13 @@ class Perplexity extends OpenAI {
     apiBase: "https://api.perplexity.ai/",
     model: "sonar",
   };
+
+  protected _getHeaders() {
+    return {
+      ...super._getHeaders(),
+      ...PERPLEXITY_INTEGRATION_HEADERS,
+    };
+  }
 }
 
 export default Perplexity;

--- a/core/llm/llms/Perplexity.ts
+++ b/core/llm/llms/Perplexity.ts
@@ -1,0 +1,23 @@
+import { LLMOptions } from "../../index.js";
+
+import OpenAI from "./OpenAI.js";
+
+/**
+ * Perplexity provider
+ *
+ * Integrates with Perplexity's OpenAI-compatible chat completions API.
+ * Provides access to Sonar models, which include built-in web search —
+ * useful for coding agents that need to research up-to-date documentation
+ * or APIs while answering.
+ *
+ * More information at: https://docs.perplexity.ai/docs/getting-started
+ */
+class Perplexity extends OpenAI {
+  static providerName = "perplexity";
+  static defaultOptions: Partial<LLMOptions> = {
+    apiBase: "https://api.perplexity.ai/",
+    model: "sonar",
+  };
+}
+
+export default Perplexity;

--- a/core/llm/llms/Perplexity.vitest.ts
+++ b/core/llm/llms/Perplexity.vitest.ts
@@ -1,0 +1,7 @@
+import { createOpenAISubclassTests } from "./test-utils/openai-test-utils.js";
+import Perplexity from "./Perplexity.js";
+
+createOpenAISubclassTests(Perplexity, {
+  providerName: "perplexity",
+  defaultApiBase: "https://api.perplexity.ai/",
+});

--- a/core/llm/llms/Perplexity.vitest.ts
+++ b/core/llm/llms/Perplexity.vitest.ts
@@ -1,7 +1,23 @@
+import { PERPLEXITY_INTEGRATION_HEADER } from "@continuedev/openai-adapters";
+import { describe, expect, it } from "vitest";
+
 import { createOpenAISubclassTests } from "./test-utils/openai-test-utils.js";
 import Perplexity from "./Perplexity.js";
 
 createOpenAISubclassTests(Perplexity, {
   providerName: "perplexity",
   defaultApiBase: "https://api.perplexity.ai/",
+});
+
+describe("perplexity attribution headers", () => {
+  it("sets the Perplexity integration attribution header", () => {
+    const perplexity = new Perplexity({
+      apiKey: "test-api-key",
+      model: "sonar",
+    });
+
+    const headers = perplexity["_getHeaders"]();
+
+    expect(headers[PERPLEXITY_INTEGRATION_HEADER]).toMatch(/^continue\//);
+  });
 });

--- a/core/llm/llms/index.ts
+++ b/core/llm/llms/index.ts
@@ -52,6 +52,7 @@ import OpenAI from "./OpenAI";
 import OpenRouter from "./OpenRouter";
 import ClawRouter from "./ClawRouter";
 import OVHcloud from "./OVHcloud";
+import Perplexity from "./Perplexity";
 import { Relace } from "./Relace";
 import Replicate from "./Replicate";
 import SageMaker from "./SageMaker";
@@ -130,6 +131,7 @@ export const LLMClasses = [
   Scaleway,
   Relace,
   Inception,
+  Perplexity,
   Voyage,
   LlamaStack,
   TARS,

--- a/core/llm/llms/test-utils/openai-test-utils.ts
+++ b/core/llm/llms/test-utils/openai-test-utils.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { ILLM } from "../../../index.js";
+import type { ILLM } from "../../../index.js";
 import OpenAI from "../OpenAI.js";
 
 interface LlmTestCase {

--- a/docs/customize/model-providers/more/perplexity.mdx
+++ b/docs/customize/model-providers/more/perplexity.mdx
@@ -1,0 +1,55 @@
+---
+title: "How to Configure Perplexity with Continue"
+sidebarTitle: "Perplexity"
+---
+
+<Info>
+  Get your API key from the [Perplexity API Keys page](https://www.perplexity.ai/account/api/keys)
+</Info>
+
+Perplexity exposes its Sonar models through an OpenAI-compatible chat
+completions API. Sonar models include built-in web search, which is useful
+for coding agents that need to research up-to-date documentation or APIs
+while answering.
+
+Available models include:
+
+- `sonar`
+- `sonar-pro`
+- `sonar-reasoning`
+- `sonar-reasoning-pro`
+
+## Configuration
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  name: My Config
+  version: 0.0.1
+  schema: v1
+
+  models:
+    - name: Sonar Pro
+      provider: perplexity
+      model: sonar-pro
+      apiKey: <YOUR_PERPLEXITY_API_KEY>
+  ```
+  </Tab>
+  <Tab title="JSON (Deprecated)">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "Sonar Pro",
+        "provider": "perplexity",
+        "model": "sonar-pro",
+        "apiKey": "<YOUR_PERPLEXITY_API_KEY>"
+      }
+    ]
+  }
+  ```
+  </Tab>
+</Tabs>
+
+See the [Perplexity API documentation](https://docs.perplexity.ai/docs/getting-started)
+for more details on available models, parameters, and rate limits.

--- a/docs/customize/model-providers/overview.mdx
+++ b/docs/customize/model-providers/overview.mdx
@@ -31,6 +31,7 @@ Beyond the top-level providers, Continue supports many other options:
 | Provider                                                               | Description                                                |
 | :--------------------------------------------------------------------- | :--------------------------------------------------------- |
 | [Groq](/customize/model-providers/more/groq)                           | Ultra-fast inference for various open models               |
+| [Perplexity](/customize/model-providers/more/perplexity)               | Sonar models with built-in web search                      |
 | [Together AI](/customize/model-providers/more/together)                | Platform for running a variety of open models              |
 | [DeepInfra](/customize/model-providers/more/deepinfra)                 | Hosting for various open source models                     |
 | [OpenRouter](/customize/model-providers/top-level/openrouter)          | Gateway to multiple model providers                        |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -180,6 +180,7 @@
                       "customize/model-providers/more/moonshot",
                       "customize/model-providers/more/nous",
                       "customize/model-providers/more/nvidia",
+                      "customize/model-providers/more/perplexity",
                       "customize/model-providers/more/tensorix",
                       "customize/model-providers/more/together",
                       "customize/model-providers/more/xAI",

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -208,6 +208,7 @@
             "mistral-vertexai",
             "deepinfra",
             "groq",
+            "perplexity",
             "fireworks",
             "ncompass",
             "cloudflare",
@@ -261,6 +262,7 @@
             "### Mistral API on Vertex AI\nTo get started you need to enable the [Vertex AI API](https://console.cloud.google.com/marketplace/product/google/aiplatform.googleapis.com) and set up the [Google Application Default Credentials](https://cloud.google.com/docs/authentication/provide-credentials-adc).",
             "### DeepInfra\n\n> [Reference](https://docs.continue.dev/reference/Model%20Providers/deepinfra)",
             "### Groq\nGroq provides extremely fast inference of open-source language models. To get started, obtain an API key from [their console](https://console.groq.com/keys).",
+            "### Perplexity\nPerplexity offers Sonar models with built-in web search, useful for coding agents that need to research up-to-date documentation. To get started, obtain an API key from [their console](https://www.perplexity.ai/account/api/keys).\n> [Reference](https://docs.perplexity.ai/docs/getting-started)",
             "### Fireworks\nFireworks is a fast inference engine for open-source language models. To get started, obtain an API key from [their console](https://fireworks.ai/api-keys).",
             "### Ncompass\nnCompass is an extremely fast inference engine for open-source language models. To get started, obtain an API key from [their console](https://app.ncompass.tech/api-settings).",
             "### Cloudflare Workers AI\n\n[Reference](https://developers.cloudflare.com/workers-ai/)",
@@ -1322,6 +1324,29 @@
                   "llama3-70b",
                   "llama3.1-8b",
                   "llama3.1-70b",
+                  "AUTODETECT"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "provider": {
+                "enum": ["perplexity"]
+              }
+            },
+            "required": ["provider"]
+          },
+          "then": {
+            "properties": {
+              "model": {
+                "enum": [
+                  "sonar",
+                  "sonar-pro",
+                  "sonar-reasoning",
+                  "sonar-reasoning-pro",
                   "AUTODETECT"
                 ]
               }

--- a/packages/openai-adapters/src/apis/OpenAI.ts
+++ b/packages/openai-adapters/src/apis/OpenAI.ts
@@ -32,11 +32,15 @@ import {
   toResponsesParams,
 } from "./openaiResponses.js";
 
+type OpenAIApiConfig = z.infer<typeof OpenAIConfigSchema> & {
+  defaultHeaders?: Record<string, string>;
+};
+
 export class OpenAIApi implements BaseLlmApi {
   openai: OpenAI;
   apiBase: string = "https://api.openai.com/v1/";
 
-  constructor(protected config: z.infer<typeof OpenAIConfigSchema>) {
+  constructor(protected config: OpenAIApiConfig) {
     this.apiBase = config.apiBase ?? this.apiBase;
 
     // Always create the original OpenAI client for fallback
@@ -46,6 +50,7 @@ export class OpenAIApi implements BaseLlmApi {
       baseURL: this.apiBase,
       fetch: customFetch(config.requestOptions),
       timeout: config?.requestOptions?.timeout || undefined,
+      defaultHeaders: config.defaultHeaders,
     });
   }
   modifyChatBody<T extends ChatCompletionCreateParams>(body: T): T {
@@ -123,6 +128,7 @@ export class OpenAIApi implements BaseLlmApi {
       Accept: "application/json",
       "x-api-key": this.config.apiKey ?? "",
       Authorization: `Bearer ${this.config.apiKey}`,
+      ...this.config.defaultHeaders,
     };
   }
 

--- a/packages/openai-adapters/src/index.ts
+++ b/packages/openai-adapters/src/index.ts
@@ -23,6 +23,7 @@ import { RelaceApi } from "./apis/Relace.js";
 import { VertexAIApi } from "./apis/VertexAI.js";
 import { WatsonXApi } from "./apis/WatsonX.js";
 import { BaseLlmApi } from "./apis/base.js";
+import { PERPLEXITY_INTEGRATION_HEADERS } from "./integrationHeaders.js";
 import { LLMConfig, OpenAIConfigSchema } from "./types.js";
 import { appendPathToUrlIfNotPresent } from "./util/appendPathToUrl.js";
 
@@ -31,10 +32,12 @@ dotenv.config();
 function openAICompatible(
   apiBase: string,
   config: z.infer<typeof OpenAIConfigSchema>,
+  defaultHeaders?: Record<string, string>,
 ): OpenAIApi {
   return new OpenAIApi({
     ...config,
     apiBase: config.apiBase ?? apiBase,
+    defaultHeaders,
   });
 }
 
@@ -144,7 +147,11 @@ export function constructLlmApi(config: LLMConfig): BaseLlmApi | undefined {
     case "groq":
       return openAICompatible("https://api.groq.com/openai/v1/", config);
     case "perplexity":
-      return openAICompatible("https://api.perplexity.ai/", config);
+      return openAICompatible(
+        "https://api.perplexity.ai/",
+        config,
+        PERPLEXITY_INTEGRATION_HEADERS,
+      );
     case "minimax":
       return new MiniMaxApi(config);
     case "sambanova":
@@ -227,6 +234,10 @@ export {
 // export
 export { AiSdkApi } from "./apis/AiSdk.js";
 export type { BaseLlmApi } from "./apis/base.js";
+export {
+  PERPLEXITY_INTEGRATION_HEADER,
+  PERPLEXITY_INTEGRATION_HEADERS,
+} from "./integrationHeaders.js";
 export type {
   AiSdkConfig,
   AskSageResponse,

--- a/packages/openai-adapters/src/index.ts
+++ b/packages/openai-adapters/src/index.ts
@@ -143,6 +143,8 @@ export function constructLlmApi(config: LLMConfig): BaseLlmApi | undefined {
       return openAICompatible("http://localhost:8000/v1/", config);
     case "groq":
       return openAICompatible("https://api.groq.com/openai/v1/", config);
+    case "perplexity":
+      return openAICompatible("https://api.perplexity.ai/", config);
     case "minimax":
       return new MiniMaxApi(config);
     case "sambanova":

--- a/packages/openai-adapters/src/integrationHeaders.ts
+++ b/packages/openai-adapters/src/integrationHeaders.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from "node:fs";
+
+const packageJson = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+) as { version: string };
+
+export const PERPLEXITY_INTEGRATION_HEADER = "X-Pplx-Integration";
+
+export const PERPLEXITY_INTEGRATION_HEADERS = {
+  [PERPLEXITY_INTEGRATION_HEADER]: `continue/${packageJson.version}`,
+};

--- a/packages/openai-adapters/src/test/openai-adapter.vitest.ts
+++ b/packages/openai-adapters/src/test/openai-adapter.vitest.ts
@@ -1,4 +1,5 @@
 import { describe, vi } from "vitest";
+import { PERPLEXITY_INTEGRATION_HEADERS } from "../integrationHeaders.js";
 import { createAdapterTests } from "./adapter-test-utils.js";
 
 // Mock the fetch package (not needed for OpenAI but required by the shared test utils)
@@ -20,6 +21,23 @@ describe("OpenAI Adapter Tests", () => {
     },
     expectedApiBase: "https://api.openai.com/v1/",
     customHeaders: {
+      authorization: "Bearer test-api-key",
+      "content-type": "application/json",
+      accept: "application/json",
+    },
+  });
+});
+
+describe("Perplexity Adapter Tests", () => {
+  createAdapterTests({
+    providerName: "perplexity",
+    config: {
+      provider: "perplexity",
+      apiKey: "test-api-key",
+    },
+    expectedApiBase: "https://api.perplexity.ai/",
+    customHeaders: {
+      ...PERPLEXITY_INTEGRATION_HEADERS,
       authorization: "Bearer test-api-key",
       "content-type": "application/json",
       accept: "application/json",

--- a/packages/openai-adapters/src/types.ts
+++ b/packages/openai-adapters/src/types.ts
@@ -37,6 +37,7 @@ export const OpenAIConfigSchema = BasePlusConfig.extend({
     z.literal("voyage"),
     z.literal("deepinfra"),
     z.literal("groq"),
+    z.literal("perplexity"),
     z.literal("nvidia"),
     z.literal("ovhcloud"),
     z.literal("fireworks"),


### PR DESCRIPTION
## Motivation

Continue's [provider list](https://docs.continue.dev/customize/model-providers/overview) covers 25+ inference services but Perplexity is missing. Perplexity's Sonar family (`sonar`, `sonar-pro`, `sonar-reasoning`, `sonar-reasoning-pro`) ships with built-in web search, which is particularly relevant for coding agents that need to research up-to-date documentation or APIs while answering — a common workflow in Continue.

The Perplexity API is OpenAI-compatible, so this PR mirrors the pattern used by other OpenAI-compatible providers like `Groq`, `Together`, `OpenRouter`, and `Inception`: the provider class subclasses `OpenAI` and only overrides `providerName` and `apiBase`. No custom request/response transformation is needed.

## Changes

- `core/llm/llms/Perplexity.ts` — provider class extending `OpenAI` with `apiBase = "https://api.perplexity.ai/"` and default `model: "sonar"`
- `core/llm/llms/index.ts` — registered in `LLMClasses` (import + array entry)
- `core/llm/autodetect.ts` — added `"perplexity"` to the list of providers that use OpenAI templating
- `packages/openai-adapters/src/types.ts` — added `"perplexity"` to the `OpenAIConfigSchema` union
- `packages/openai-adapters/src/index.ts` — added the `case "perplexity"` factory branch
- `extensions/vscode/config_schema.json` — added `"perplexity"` to the provider enum, the model `if/then` block (Sonar models + `AUTODETECT`), and a markdown description
- `docs/customize/model-providers/more/perplexity.mdx` — new provider page modeled on `groq.mdx`
- `docs/customize/model-providers/overview.mdx` — added to the hosted-services table
- `docs/docs.json` — added to the More providers sidebar group
- `core/llm/llms/Perplexity.vitest.ts` — tests via the existing `createOpenAISubclassTests` helper

## Tests

`core/llm/llms/Perplexity.vitest.ts` calls `createOpenAISubclassTests(Perplexity, ...)`, the same helper used by Groq, Together, and other OpenAI-compatible providers. The helper generates 7 cases covering: providerName, default API base, `streamChat`, `chat`, `streamComplete`, `complete`, and `embed` against a mocked fetch. Run with:

\`\`\`
cd core && npm run vitest -- llms/Perplexity
\`\`\`

## References

- Perplexity API getting started: https://docs.perplexity.ai/docs/getting-started
- Mirrored pattern: \`core/llm/llms/Groq.ts\`, \`core/llm/llms/Together.ts\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Perplexity as a first-class LLM provider using its OpenAI-compatible API, defaulting to `sonar`. Enables Sonar models with built-in web search and sends the required `X-Pplx-Integration` header on all requests.

- **New Features**
  - Added `Perplexity` provider extending `OpenAI` with `apiBase: "https://api.perplexity.ai/"` and default `model: "sonar"`.
  - Registered in `LLMClasses` and added to OpenAI-templated autodetect providers.
  - Updated `@continuedev/openai-adapters` types and factory to support `perplexity`.
  - Updated VS Code `config_schema.json` with provider enum, Sonar model list (`AUTODETECT` supported), and help text.
  - Added docs: provider page, overview entry, and sidebar link.
  - Added unit tests via `createOpenAISubclassTests` for core chat/complete/embed paths.

- **Bug Fixes**
  - Send Perplexity integration attribution header `X-Pplx-Integration: continue/<version>` on all requests via `@continuedev/openai-adapters` and provider `_getHeaders`; added `defaultHeaders` support to `OpenAIApi` and tests.

<sup>Written for commit 38df50a9984552a4028e331a4dccb43e549e8839. Summary will update on new commits. <a href="https://cubic.dev/pr/continuedev/continue/pull/12259?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

