### PR TITLE
fix(cli): report missing npm during install

### DIFF
--- a/extensions/cli/scripts/install.sh
+++ b/extensions/cli/scripts/install.sh
@@ -240,15 +240,35 @@ add_to_profile() {
     grep -q "$check" "$SHELL_PROFILE" 2>/dev/null || echo "$line" >> "$SHELL_PROFILE"
 }
 
+get_npm_prefix() {
+    if ! command -v npm &>/dev/null; then
+        error "Node.js was found but npm is missing or misconfigured. Please install npm or reinstall Node.js with npm support."
+    fi
+
+    local npm_prefix
+    if ! npm_prefix="$(npm config get prefix 2>/dev/null)" || [ -z "$npm_prefix" ]; then
+        error "Node.js was found but npm is missing or misconfigured. Unable to read npm's global prefix."
+    fi
+
+    case "$npm_prefix" in
+        /|/bin|/usr/bin)
+            error "Node.js was found but npm is missing or misconfigured. npm global prefix resolved to '$npm_prefix'."
+            ;;
+    esac
+
+    printf "%s\n" "$npm_prefix"
+}
+
 setup_npm_path() {
-    local npm_bin
-    npm_bin="$(npm config get prefix 2>/dev/null)/bin"
+    local npm_prefix npm_bin
+    npm_prefix="$(get_npm_prefix)"
+    npm_bin="$npm_prefix/bin"
     [ -d "$npm_bin" ] && export PATH="$npm_bin:$PATH"
 }
 
 check_npm_permissions() {
     local npm_prefix
-    npm_prefix="$(npm config get prefix 2>/dev/null)"
+    npm_prefix="$(get_npm_prefix)"
 
     # Check if we can write to npm global directory
     if [ -d "$npm_prefix/lib" ] && [ ! -w "$npm_prefix/lib" ]; then


### PR DESCRIPTION
## Description

Fixes #12192.

Adds explicit npm validation before the CLI installer uses `npm config get prefix`. If Node.js is present but npm is missing or its global prefix cannot be read / resolves to an unsafe value, the installer now prints a targeted `Node.js was found but npm is missing or misconfigured` error instead of only exiting through the generic cleanup message.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Not applicable; this is installer error handling.

## Tests

- `bash -n extensions/cli/scripts/install.sh`
- `git diff --check`
- Temporary fake-PATH harness for `setup_npm_path` with no `npm` available: verified it exits non-zero with the targeted npm diagnostic.
- Temporary installer main-flow harness with fake Node.js `v22.22.2` and no `npm` available: verified it exits non-zero after reporting the targeted npm diagnostic.
