### PR TITLE
Fix docs local preview script

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
   "description": "Click on `Use this template` to copy the Mintlify starter kit. The starter kit contains examples including",
   "main": "index.js",
   "scripts": {
-    "dev": "mintlify dev",
+    "dev": "mint dev",
     "build": "mintlify build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
## Summary
- Update the docs package dev script to use `mint dev` for Mintlify local preview.
- Leave the existing build script unchanged.

Fixes #12267

## Test plan
- `node -e "const pkg=require('./docs/package.json'); if (pkg.scripts?.dev !== 'mint dev') { console.error('Expected docs dev script to be mint dev, got:', pkg.scripts?.dev); process.exit(1); } console.log('docs dev script:', pkg.scripts.dev);"`
- `git diff --check`
- Searched the repository for remaining `mintlify dev` references.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Mintlify local preview by switching the `docs` package dev script from `mintlify dev` to `mint dev`. The build script stays the same.

<sup>Written for commit 5e5d4fc108c66cf4463f48b223a904f7b7d322c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

