### PR TITLE
Soften CLI model capability warning

### DIFF
--- a/extensions/cli/src/ui/ModelCapabilityWarning.test.tsx
+++ b/extensions/cli/src/ui/ModelCapabilityWarning.test.tsx
@@ -16,10 +16,9 @@ describe("ModelCapabilityWarning", () => {
     if (frame) {
       expect(frame).toContain("Model Capability Warning");
       expect(frame).toContain("gpt-3-davinci");
-      expect(frame).toContain(
-        "is not recommended for use with cn due to limited reasoning and tool",
-      );
-      expect(frame).toContain("calling capabilities");
+      expect(frame).toContain("has not been verified for cn");
+      expect(frame).toContain("tool-calling features may");
+      expect(frame).toContain("be unreliable");
     }
   });
 

--- a/extensions/cli/src/ui/ModelCapabilityWarning.tsx
+++ b/extensions/cli/src/ui/ModelCapabilityWarning.tsx
@@ -17,8 +17,8 @@ const ModelCapabilityWarning: React.FC<ModelCapabilityWarningProps> = ({
         </Text>
       </Box>
       <Text color="gray">
-        The model "{modelName}" is not recommended for use with cn due to
-        limited reasoning and tool calling capabilities
+        The model "{modelName}" has not been verified for cn. Some reasoning or
+        tool-calling features may be unreliable.
       </Text>
     </Box>
   );


### PR DESCRIPTION
## Summary

Softens the CLI model capability warning for models that have not been verified for `cn`.

## Changes

- Rewords the warning from “not recommended” to “has not been verified”
- Keeps the warning visible while making it less definitive for unknown local/provider models
- Updates the UI test expectations to match the new wording and tolerate terminal line wrapping

## Testing

- `./node_modules/.bin/vitest run src/ui/ModelCapabilityWarning.test.tsx`

Closes #12193


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Softened the CLI model capability warning: unverified models for `cn` now say “has not been verified” and note that reasoning or tool-calling may be unreliable. Updated the UI tests to match the new text and tolerate terminal line wrapping.

<sup>Written for commit 25924d5a67bbf65775a6fd9b0884cddafda82e58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

