### PR TITLE
docs: fix local dev instructions for Mintlify

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,16 +82,20 @@ You can run the documentation server locally using either of the following metho
 1. Open your terminal and navigate to the `docs` subdirectory of the project. The `favicon.png` file you'll see
    there is a sign you're in the right place.
 
-2. Run the following command to install the necessary dependencies for the documentation server:
-
+2. Install the Mintlify CLI globally : 
    ```bash
-   npm install
+   npm install -g mint
+   ```
+
+3. Install project dependencies 
+   ```bash
+   npm install 
    ```
 
 3. Run the following command to start the documentation server:
 
    ```bash
-   npm run dev
+   mint dev
    ```
 
 #### Method 2: VS Code Task


### PR DESCRIPTION
## Description

Fixes #12267

The current contributing guide suggests using `npm run dev`, which does not work reliably due to Mintlify CLI issues with local installs.

This updates the instructions to use the global CLI (`mint dev`), which is currently the only stable method.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch local docs dev to the global `mint` CLI: run `mint dev` instead of `npm run dev` to avoid issues with local installs. Fixes #12267.

- **Migration**
  - Install `mint` globally: `npm install -g mint`
  - Start docs: `mint dev`

<sup>Written for commit 7495f91b9adf92ac8bbc54e91af56340f1550b73. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

