### PR TITLE
docs: add Claudexia as OpenAI-compatible provider

### DIFF
--- a/docs/customize/model-providers/more/claudexia.mdx
+++ b/docs/customize/model-providers/more/claudexia.mdx
@@ -1,0 +1,114 @@
+---
+title: "Claudexia"
+description: "Configure Claudexia with Continue — a pay-per-token Claude API gateway with OpenAI- and Anthropic-compatible endpoints"
+---
+
+<Info>
+  [Claudexia](https://claudexia.tech) is a pay-per-token gateway to Claude (and other frontier models) with OpenAI- and Anthropic-compatible APIs. Get an API key from the [Claudexia dashboard](https://claudexia.tech).
+</Info>
+
+Claudexia exposes an OpenAI-compatible endpoint at `https://api.claudexia.tech/v1`, so you can use it with Continue via the `openai` provider by setting `apiBase`.
+
+## Chat Model
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  name: My Config
+  version: 0.0.1
+  schema: v1
+
+  models:
+    - name: Claude Sonnet 4.6 (Claudexia)
+      provider: openai
+      model: claude-sonnet-4-6
+      apiKey: <YOUR_CLAUDEXIA_API_KEY>
+      apiBase: https://api.claudexia.tech/v1
+  ```
+  </Tab>
+  <Tab title="JSON">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "Claude Sonnet 4.6 (Claudexia)",
+        "provider": "openai",
+        "model": "claude-sonnet-4-6",
+        "apiKey": "<YOUR_CLAUDEXIA_API_KEY>",
+        "apiBase": "https://api.claudexia.tech/v1"
+      }
+    ]
+  }
+  ```
+  </Tab>
+</Tabs>
+
+## Available Models
+
+Claudexia routes to Anthropic's Claude family and other frontier models. Common model IDs:
+
+- `claude-opus-4-7`
+- `claude-sonnet-4-6`
+- `claude-haiku-4-5`
+- `gpt-5.5`
+
+See the full list at [claudexia.tech](https://claudexia.tech).
+
+## Multiple Models
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  name: My Config
+  version: 0.0.1
+  schema: v1
+
+  models:
+    - name: Claude Opus 4.7
+      provider: openai
+      model: claude-opus-4-7
+      apiKey: <YOUR_CLAUDEXIA_API_KEY>
+      apiBase: https://api.claudexia.tech/v1
+      roles:
+        - chat
+        - edit
+
+    - name: Claude Haiku 4.5
+      provider: openai
+      model: claude-haiku-4-5
+      apiKey: <YOUR_CLAUDEXIA_API_KEY>
+      apiBase: https://api.claudexia.tech/v1
+      roles:
+        - autocomplete
+        - apply
+  ```
+  </Tab>
+  <Tab title="JSON">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "Claude Opus 4.7",
+        "provider": "openai",
+        "model": "claude-opus-4-7",
+        "apiKey": "<YOUR_CLAUDEXIA_API_KEY>",
+        "apiBase": "https://api.claudexia.tech/v1",
+        "roles": ["chat", "edit"]
+      },
+      {
+        "title": "Claude Haiku 4.5",
+        "provider": "openai",
+        "model": "claude-haiku-4-5",
+        "apiKey": "<YOUR_CLAUDEXIA_API_KEY>",
+        "apiBase": "https://api.claudexia.tech/v1",
+        "roles": ["autocomplete", "apply"]
+      }
+    ]
+  }
+  ```
+  </Tab>
+</Tabs>
+
+<Tip>
+  Sign up and grab an API key at [claudexia.tech](https://claudexia.tech). Pay-per-token billing supports SBP, card, and USDT — no VPN required.
+</Tip>

--- a/docs/customize/model-providers/overview.mdx
+++ b/docs/customize/model-providers/overview.mdx
@@ -34,6 +34,7 @@ Beyond the top-level providers, Continue supports many other options:
 | [Together AI](/customize/model-providers/more/together)                | Platform for running a variety of open models              |
 | [DeepInfra](/customize/model-providers/more/deepinfra)                 | Hosting for various open source models                     |
 | [OpenRouter](/customize/model-providers/top-level/openrouter)          | Gateway to multiple model providers                        |
+| [Claudexia](/customize/model-providers/more/claudexia)                 | Pay-per-token Claude API gateway, OpenAI/Anthropic-compatible        |
 | [ClawRouter](/customize/model-providers/more/clawrouter)               | Open-source LLM router with automatic cost-optimized model selection |
 | [Tetrate Agent Router Service](/customize/model-providers/top-level/tetrate_agent_router_service) | Gateway with intelligent routing across multiple model providers |
 | [Cohere](/customize/model-providers/more/cohere)                       | Models specialized for semantic search and text generation |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -169,6 +169,7 @@
                     "group": "More Providers",
                     "pages": [
                       "customize/model-providers/more/asksage",
+                      "customize/model-providers/more/claudexia",
                       "customize/model-providers/more/clawrouter",
                       "customize/model-providers/more/deepseek",
                       "customize/model-providers/more/deepinfra",


### PR DESCRIPTION
## Summary

Adds a docs page for [Claudexia](https://claudexia.tech) as an OpenAI-compatible provider example. Claudexia is a pay-per-token Claude API gateway (also Anthropic-compatible) — useful for users who want to access Claude models via Continue's existing `openai` provider by setting `apiBase`.

## What's added

- New page: `docs/customize/model-providers/more/claudexia.mdx` — `config.yaml` + `config.json` snippets showing how to wire Claudexia as an OpenAI-compatible provider, plus example model IDs and a multi-model role example.
- `docs/customize/model-providers/overview.mdx` — Claudexia listed under Hosted Services (alphabetical).
- `docs/docs.json` — sidebar entry under "More Providers" (alphabetical).

Pure docs change — no source, schema, or registry edits. Formatting mirrors existing sibling provider docs.

More info: https://claudexia.tech


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add docs for configuring Claudexia as an OpenAI-compatible provider, with YAML/JSON examples using the `openai` provider and `apiBase` set to `https://api.claudexia.tech/v1`. Also adds Claudexia to the providers overview and sidebar, with common model IDs and a multi-model roles example.

<sup>Written for commit 84629564d2a72f3acf63a333a94048c357732221. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

