### PR TITLE
fix(cli): skip onboarding when ~/.continue/config.yaml exists

### DIFF
--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -36,6 +36,8 @@ This shows your available assistants and local configs. The selection is saved f
 
 If you're not logged in to Continue, `cn` looks for `~/.continue/config.yaml`. This file uses the same format as the IDE extensions — see [config.yaml reference](/customize/deep-dives/configuration) for the full schema.
 
+If this file exists when you first run `cn`, the onboarding prompt is skipped — `cn` treats you as already configured and loads the file. This matches the IDE behaviour and is the recommended setup for local-LLM workflows that don't need a Continue account or an API key.
+
 ## CLI-specific flags
 
 Several flags inject configuration at launch without editing a file:

--- a/docs/cli/quickstart.mdx
+++ b/docs/cli/quickstart.mdx
@@ -35,7 +35,7 @@ cd your-project
 cn
 ```
 
-On first launch you'll be asked to log in with [Continue](https://continue.dev) or enter an Anthropic API key. After that, you're in a session and can start typing.
+On first launch you'll be asked to log in with [Continue](https://continue.dev) or enter an Anthropic API key. If you already have a `~/.continue/config.yaml` (for example a local LLM setup), `cn` skips the prompt and uses that file directly. After onboarding, you're in a session and can start typing.
 
 ## Authentication
 

--- a/extensions/cli/src/onboarding.existingConfig.test.ts
+++ b/extensions/cli/src/onboarding.existingConfig.test.ts
@@ -1,0 +1,133 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+import type { AuthConfig } from "./auth/workos.js";
+
+// `env.continueHome` must be a getter so we can swap the underlying tmp
+// dir per-test. Vitest hoists vi.mock above imports.
+let homeDir: string;
+
+vi.mock("./env.js", () => ({
+  env: {
+    apiBase: "https://api.continue.dev/",
+    workOsClientId: "test-client",
+    appUrl: "https://continue.dev",
+    get continueHome() {
+      return homeDir;
+    },
+  },
+}));
+
+// `loadConfiguration` is exercised heavily elsewhere — stub it here so these
+// tests focus on the onboarding gate, not the config loader.
+const loadConfigurationMock = vi.fn();
+vi.mock("./configLoader.js", () => ({
+  loadConfiguration: loadConfigurationMock,
+}));
+
+// `getApiClient` reaches out to the network in real life; stub.
+vi.mock("./config.js", () => ({
+  getApiClient: vi.fn(() => ({})),
+}));
+
+let initializeWithOnboarding: typeof import("./onboarding.js").initializeWithOnboarding;
+let onboardingCompleteFlag: string;
+
+const mockAuthConfig: AuthConfig = {
+  userId: "test-user",
+  userEmail: "test@example.com",
+  accessToken: "test-token",
+  refreshToken: "test-refresh",
+  expiresAt: Date.now() + 3_600_000,
+  organizationId: "test-org",
+};
+
+beforeEach(async () => {
+  homeDir = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "cn-onboarding-")),
+  );
+  onboardingCompleteFlag = path.join(homeDir, ".onboarding_complete");
+
+  loadConfigurationMock.mockReset();
+
+  // Reset modules so the env mock's getter is consulted fresh per test.
+  vi.resetModules();
+  ({ initializeWithOnboarding } = await import("./onboarding.js"));
+});
+
+afterEach(() => {
+  fs.rmSync(homeDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+test("skips onboarding when ~/.continue/config.yaml already exists", async () => {
+  // First-time user (no .onboarding_complete) but has a config.yaml in place.
+  fs.writeFileSync(
+    path.join(homeDir, "config.yaml"),
+    `name: Local
+version: 1.0.0
+schema: v1
+models:
+  - name: Local
+    provider: anthropic
+    model: claude-3-5-sonnet-20241022
+    apiKey: dummy
+`,
+  );
+  expect(fs.existsSync(onboardingCompleteFlag)).toBe(false);
+
+  await initializeWithOnboarding(null, undefined);
+
+  expect(fs.existsSync(onboardingCompleteFlag)).toBe(true);
+  // No --config was provided, so loadConfiguration must not have been called
+  // either — the new branch skips both onboarding *and* validation.
+  expect(loadConfigurationMock).not.toHaveBeenCalled();
+});
+
+test("does not mark onboarding complete when no config.yaml exists", async () => {
+  // First-time, no config. The non-TTY test environment causes
+  // runOnboardingFlow to short-circuit and return false, so the flag must
+  // remain unset — proving our fix's check did *not* fire.
+  expect(fs.existsSync(path.join(homeDir, "config.yaml"))).toBe(false);
+
+  await initializeWithOnboarding(null, undefined);
+
+  expect(fs.existsSync(onboardingCompleteFlag)).toBe(false);
+});
+
+test("marks onboarding complete after a successful --config load", async () => {
+  // No default config.yaml present; user passes --config explicitly.
+  loadConfigurationMock.mockResolvedValue({
+    config: {},
+    source: { type: "cli-flag" },
+  });
+  expect(fs.existsSync(onboardingCompleteFlag)).toBe(false);
+
+  await initializeWithOnboarding(mockAuthConfig, "/some/explicit/path.yaml");
+
+  expect(loadConfigurationMock).toHaveBeenCalledOnce();
+  expect(fs.existsSync(onboardingCompleteFlag)).toBe(true);
+});
+
+test("does not mark onboarding complete when --config load fails", async () => {
+  loadConfigurationMock.mockRejectedValue(new Error("boom"));
+
+  await expect(
+    initializeWithOnboarding(mockAuthConfig, "/bad/path.yaml"),
+  ).rejects.toThrow(/Failed to load config from "/);
+
+  expect(fs.existsSync(onboardingCompleteFlag)).toBe(false);
+});
+
+test("does not re-mark when onboarding was already complete", async () => {
+  fs.writeFileSync(onboardingCompleteFlag, new Date().toISOString());
+  const beforeMtime = fs.statSync(onboardingCompleteFlag).mtimeMs;
+
+  await new Promise((r) => setTimeout(r, 5));
+  await initializeWithOnboarding(null, undefined);
+
+  expect(fs.statSync(onboardingCompleteFlag).mtimeMs).toBe(beforeMtime);
+});

--- a/extensions/cli/src/onboarding.ts
+++ b/extensions/cli/src/onboarding.ts
@@ -156,9 +156,26 @@ export async function initializeWithOnboarding(
         `Failed to load config from "${configPath}": ${errorMessage}`,
       );
     }
+    // A successful explicit --config load implies the user is set up.
+    // Mark onboarding complete so subsequent runs without --config can
+    // fall through to their existing configuration.
+    if (firstTime) {
+      await markOnboardingComplete();
+    }
   }
 
   if (!firstTime) return;
+
+  // If the user already has a `~/.continue/config.yaml`, treat them as
+  // already configured — match the IDE behaviour and the unauthenticated
+  // fallback in configLoader.ts. No prompt, no forced login.
+  if (
+    configPath === undefined &&
+    fs.existsSync(path.join(env.continueHome, "config.yaml"))
+  ) {
+    await markOnboardingComplete();
+    return;
+  }
 
   const wasOnboarded = await runOnboardingFlow(configPath);
   if (wasOnboarded) {


### PR DESCRIPTION
## Summary

- Closes #12258.
- `cn` now treats a pre-existing `~/.continue/config.yaml` as "already onboarded" and skips the "Log in / Enter API key" prompt — parity with the IDE plugin and with the unauthenticated fallback already implemented at `extensions/cli/src/configLoader.ts:128`.
- A successful `--config <path>` load now also marks onboarding complete, so a one-time `cn --config <path>` invocation has lasting effect (subsequent plain `cn` no longer re-prompts — that was a separate latent issue).
- Docs updated: `docs/cli/quickstart.mdx` and `docs/cli/configuration.mdx` now describe the existing-config fast path.

## Why

Local-LLM users (e.g. Ollama configs in `~/.continue/config.yaml`) had no way to launch `cn` without either logging in to Continue Hub or entering an Anthropic API key, even though their config was already complete and the IDE plugin honours such files transparently. Reproduced on multiple machines.

## Test plan

- [x] New: `extensions/cli/src/onboarding.existingConfig.test.ts` — 5 tests covering existing-config skip, no-config no-skip, `--config` success marks complete, `--config` failure does not mark complete, idempotent on already-onboarded users.
- [x] Existing `extensions/cli/src/onboarding.test.ts` still passes (9/9). Combined run: 14/14.
- [x] `eslint` and `prettier --check` clean on the four changed files.
- [ ] Manual: on a fresh `~/.continue/` containing only `config.yaml`, run `cn` — no prompt, session starts.
- [ ] Manual: on a fresh `~/.continue/`, run `cn --config ~/somewhere/cfg.yaml` once, then plain `cn` — no prompt on the second invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip CLI onboarding when `~/.continue/config.yaml` exists and mark onboarding complete after a successful `--config <path>` load, aligning `cn` with the IDE behavior. This lets local-LLM users start `cn` without login or an API key and prevents repeat prompts.

- **Bug Fixes**
  - Skip onboarding if `~/.continue/config.yaml` exists (matches IDE behavior). Closes #12258.
  - Mark onboarding complete after a successful `--config <path>` load; no prompt on later runs.
  - Do not mark complete on failed `--config` loads; no change for already-onboarded users.
  - Docs updated to describe the existing-config fast path; tests added for skip logic and `--config` flows.

<sup>Written for commit 89e1cc22af8f7a08c22f4f8e9f35859ccd843c60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

