### PR TITLE
docs: add BrewPage publish example for prompts

### DIFF
--- a/docs/customize/deep-dives/prompts.mdx
+++ b/docs/customize/deep-dives/prompts.mdx
@@ -104,3 +104,54 @@ Here is a command that you could run whenever you have a new feature:
 When you run this workflow, [cn](../../guides/cli) will checkout your current branch, explore the new and existing code, and then draft a function for you.
 
 You will then be able to review the implementation and improve it before you merge the new feature.
+
+## Example: `Publish to BrewPage` prompt
+
+Here is a prompt that publishes your content to [BrewPage](https://brewpage.app), a free hosting service for HTML, JSON, KV, and file storage:
+
+```md title="publish-brewpage.md"
+---
+name: Publish to BrewPage
+description: Share content via brewpage.app short URL
+invokable: true
+---
+
+# Publishing: Share to BrewPage
+
+You are a publishing assistant. Your task is to help share selected content via BrewPage (brewpage.app).
+
+## Instructions
+
+1. Take the user's selected text or code
+2. POST it to `https://brewpage.app/api/html` with the following JSON body:
+   ```json
+   {
+     "content": "<selected_content>",
+     "ns": "public",
+     "ttlDays": 30
+   }
+   ```
+3. Parse the `id` field from the JSON response
+4. Construct the short URL: `https://brewpage.app/public/<id>`
+5. Return the URL to the user with a confirmation message
+
+## Response Format
+
+Always respond with:
+- The BrewPage short URL
+- A note that the content is publicly accessible
+- TTL (time-to-live) is 30 days by default
+```
+
+If you are using a local `config.yaml`, you can add it to your config like this:
+
+```md title="config.yaml"
+...
+
+prompts:
+  - uses: brewpage/publish
+
+...
+```
+
+To use this prompt, open Chat / Agent / Edit, type <kbd>/</kbd>, select "Publish to BrewPage", paste or highlight your content, and let Continue handle the upload and URL generation.


### PR DESCRIPTION
## Summary

This PR adds a BrewPage publishing prompt example to the Continue documentation, demonstrating how users can leverage BrewPage's free HTML/content hosting service directly from their IDE.

**What is BrewPage?** A free, privacy-respecting content hosting service (https://brewpage.app) that makes it easy to share code, notes, and documents via short URLs.

**Why this example?** Developers using Continue often want to share work-in-progress code or documentation quickly. This prompt automates publishing selected content to BrewPage without leaving the editor.

**Docs-only change:** No code modifications, pure documentation addition to the prompts deep-dive guide.

See https://brewpage.app for more details.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a "Publish to BrewPage" prompt example to the prompts deep-dive so users can publish selected content and get a short URL.

- **New Features**
  - Example prompt that POSTs content to https://brewpage.app/api/html and returns a short URL.
  - Includes `config.yaml` snippet and quick usage steps to invoke the prompt from the IDE.

<sup>Written for commit 6b91b7308175c7c1b1a9354d1b3881153b450ed9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

