### PR TITLE
docs: add API NODE OpenAI-compatible example

### DIFF
--- a/docs/customize/model-providers/top-level/openai.mdx
+++ b/docs/customize/model-providers/top-level/openai.mdx
@@ -96,6 +96,40 @@ If you are using an OpenAI API compatible providers, you can change the `apiBase
   </Tab>
 </Tabs>
 
+For example, to use API NODE as an OpenAI-compatible provider:
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  name: My Config
+  version: 0.0.1
+  schema: v1
+
+  models:
+    - name: API NODE GPT-5.5
+      provider: openai
+      model: gpt-5.5
+      apiBase: https://apinode.pro
+      apiKey: <YOUR_APINODE_API_KEY>
+  ```
+  </Tab>
+  <Tab title="JSON (Deprecated)">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "API NODE GPT-5.5",
+        "provider": "openai",
+        "model": "gpt-5.5",
+        "apiKey": "<YOUR_APINODE_API_KEY>",
+        "apiBase": "https://apinode.pro"
+      }
+    ]
+  }
+  ```
+  </Tab>
+</Tabs>
+
 ### How to Force Legacy Completions Endpoint Usage
 
 To force usage of `completions` instead of `chat/completions` endpoint you can set:


### PR DESCRIPTION
## Summary
- Add API NODE as an example OpenAI-compatible provider configuration
- Include both YAML and deprecated JSON config snippets using apiBase

## Testing
- Documentation-only change; not run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an API NODE example to the OpenAI-compatible provider docs, showing how to set `apiBase: https://apinode.pro` and `apiKey`. Provides YAML and deprecated JSON snippets for the `gpt-5.5` model.

<sup>Written for commit b16c1f8af4601f835d8a22790e0b6e50783a7ee8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

