### PR TITLE
fix: prevent rejected pending edits from reporting success

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1496,6 +1496,7 @@ export interface ApplyState {
   fileContent?: string;
   originalFileContent?: string;
   toolCallId?: string;
+  accepted?: boolean;
   autoFormattingDiff?: string;
 }
 

--- a/extensions/vscode/src/diff/processDiff.ts
+++ b/extensions/vscode/src/diff/processDiff.ts
@@ -90,6 +90,7 @@ export async function processDiff(
       status: "closed",
       numDiffs: 0,
       toolCallId,
+      accepted: action === "accept",
       autoFormattingDiff, // Include autoformatting diff
     });
   } else {

--- a/extensions/vscode/src/diff/vertical/handler.ts
+++ b/extensions/vscode/src/diff/vertical/handler.ts
@@ -20,6 +20,7 @@ export interface VerticalDiffHandlerOptions {
     status?: ApplyState["status"],
     numDiffs?: ApplyState["numDiffs"],
     fileContent?: ApplyState["fileContent"],
+    accepted?: ApplyState["accepted"],
   ) => void;
   streamId?: string;
 }
@@ -145,6 +146,7 @@ export class VerticalDiffHandler implements vscode.Disposable {
       "closed",
       this.editorToVerticalDiffCodeLens.get(this.fileUri)?.length ?? 0,
       this.editor.document.getText(),
+      accept,
     );
 
     this.cancelled = true;
@@ -279,6 +281,7 @@ export class VerticalDiffHandler implements vscode.Disposable {
         status,
         numDiffs,
         this.editor.document.getText(),
+        status === "closed" ? accept : undefined,
       );
     }
   }

--- a/extensions/vscode/src/diff/vertical/manager.ts
+++ b/extensions/vscode/src/diff/vertical/manager.ts
@@ -196,7 +196,7 @@ export class VerticalDiffManager {
     );
 
     if (blocks.length === 1) {
-      this.clearForfileUri(fileUri, true);
+      this.clearForfileUri(fileUri, accept);
     } else {
       // Re-enable listener for user changes to file
       this.enableDocumentChangeListener();
@@ -239,7 +239,7 @@ export class VerticalDiffManager {
       endLine,
       {
         instant,
-        onStatusUpdate: (status, numDiffs, fileContent) =>
+        onStatusUpdate: (status, numDiffs, fileContent, accepted) =>
           void this.webviewProtocol.request("updateApplyState", {
             streamId,
             status,
@@ -247,6 +247,7 @@ export class VerticalDiffManager {
             fileContent,
             filepath: fileUri,
             toolCallId,
+            accepted,
           }),
         streamId,
       },
@@ -318,7 +319,7 @@ export class VerticalDiffManager {
       editor.document.lineCount - 1,
       {
         instant: true,
-        onStatusUpdate: (status, numDiffs, fileContent) =>
+        onStatusUpdate: (status, numDiffs, fileContent, accepted) =>
           void this.webviewProtocol.request("updateApplyState", {
             streamId,
             status,
@@ -326,6 +327,7 @@ export class VerticalDiffManager {
             fileContent,
             filepath: fileUri,
             toolCallId,
+            accepted,
           }),
         streamId,
       },
@@ -446,7 +448,7 @@ export class VerticalDiffManager {
       {
         instant: isFastApplyModel(llm),
         input,
-        onStatusUpdate: (status, numDiffs, fileContent) =>
+        onStatusUpdate: (status, numDiffs, fileContent, accepted) =>
           streamId &&
           void this.webviewProtocol.request("updateApplyState", {
             streamId,
@@ -455,6 +457,7 @@ export class VerticalDiffManager {
             fileContent,
             filepath: fileUri,
             toolCallId,
+            accepted,
           }),
         streamId,
       },

--- a/gui/src/redux/slices/sessionSlice.ts
+++ b/gui/src/redux/slices/sessionSlice.ts
@@ -821,6 +821,9 @@ export const sessionSlice = createSlice({
         applyState.fileContent = payload.fileContent ?? applyState.fileContent;
         applyState.originalFileContent =
           payload.originalFileContent ?? applyState.originalFileContent;
+        applyState.accepted = payload.accepted ?? applyState.accepted;
+        applyState.autoFormattingDiff =
+          payload.autoFormattingDiff ?? applyState.autoFormattingDiff;
       }
 
       if (payload.status === "done") {

--- a/gui/src/redux/thunks/handleApplyStateUpdate.test.ts
+++ b/gui/src/redux/thunks/handleApplyStateUpdate.test.ts
@@ -264,6 +264,62 @@ describe("handleApplyStateUpdate", () => {
       expect(streamResponseAfterToolCall).not.toHaveBeenCalled();
     });
 
+    it("should not mark a rejected closed apply state as accepted", async () => {
+      const toolCallState: ToolCallState = {
+        toolCallId: "test-tool-call",
+        status: "done",
+        ...UNUSED_TOOL_CALL_PARAMS,
+      };
+      const newApplyState = { streamId: "chat-stream" };
+
+      vi.mocked(findToolCallById).mockReturnValue(toolCallState);
+      mockGetState.mockReturnValue({
+        session: {
+          history: [],
+          codeBlockApplyStates: {
+            states: [newApplyState],
+          },
+        },
+        config: { config: {} },
+      });
+
+      const applyState: ApplyState = {
+        streamId: "chat-stream",
+        toolCallId: "test-tool-call",
+        status: "closed",
+        filepath: "test.txt",
+        numDiffs: 0,
+        accepted: false,
+      };
+
+      const thunk = handleApplyStateUpdate(applyState);
+      await thunk(mockDispatch, mockGetState, mockExtra);
+
+      expect(logToolUsage).toHaveBeenCalledWith(
+        toolCallState,
+        false,
+        true,
+        mockExtra.ideMessenger,
+      );
+      expect(logAgentModeEditOutcome).toHaveBeenCalledWith(
+        [],
+        {},
+        toolCallState,
+        newApplyState,
+        false,
+        mockExtra.ideMessenger,
+      );
+      expect(acceptToolCall).not.toHaveBeenCalled();
+      expect(updateToolCallOutput).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          contextItems: expect.arrayContaining([
+            expect.objectContaining({ name: "Edit Success" }),
+          ]),
+        }),
+      );
+      expect(streamResponseAfterToolCall).not.toHaveBeenCalled();
+    });
+
     it("should handle errored tool call closure", async () => {
       const toolCallState: ToolCallState = {
         toolCallId: "test-tool-call",

--- a/gui/src/redux/thunks/handleApplyStateUpdate.ts
+++ b/gui/src/redux/thunks/handleApplyStateUpdate.ts
@@ -63,7 +63,11 @@ export const handleApplyStateUpdate = createAsyncThunk<
 
         if (applyState.status === "closed") {
           if (toolCallState) {
-            const accepted = toolCallState.status !== "canceled";
+            // Closing a diff does not always mean the user accepted it.
+            // Only report edit success when the close event confirms acceptance.
+            const accepted =
+              toolCallState.status !== "canceled" &&
+              applyState.accepted !== false;
 
             logToolUsage(toolCallState, accepted, true, extra.ideMessenger);
 


### PR DESCRIPTION
Fixes #12269

## Summary

This PR fixes the pending edit desync case described in the issue.

If a user sends a follow-up while an edit is still pending, the pending diff can be closed without the edit actually being applied. In that case, Continue should not treat the edit as successful, because the file on disk has not changed.

This change carries the accept/reject result through the pending edit flow and only reports edit success when the edit was actually accepted/applied.

## Testing

- Ran `npm.cmd --prefix gui test -- src/redux/thunks/handleApplyStateUpdate.test.ts`
- Ran `git diff --check`

## Notes

I was not able to run a full live VS Code extension repro in my local setup, so I added focused regression coverage for the false success path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents pending edits that were rejected or auto-closed from being reported as successful by carrying an explicit acceptance flag through the diff flow. Fixes #12269.

- **Bug Fixes**
  - Added `accepted` to `ApplyState` and propagated it through VS Code diff (`processDiff`, vertical handler/manager) to webview updates.
  - Updated GUI session state to store `accepted`; only mark a closed edit as successful when it was accepted.
  - Adjusted `handleApplyStateUpdate` to require `accepted` (and a non-canceled tool call) before logging success or continuing the flow.
  - Added a regression test to ensure rejected closed edits are not treated as successful.

<sup>Written for commit d395e728fe51105176ed129445d6b597c948c3cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

