### PR TITLE
Fix incorrect chat title generation for reasoning/thinking mode conversations.

### DIFF
--- a/core/util/chatDescriber.ts
+++ b/core/util/chatDescriber.ts
@@ -30,6 +30,7 @@ export class ChatDescriber {
     }
 
     completionOptions.maxTokens = ChatDescriber.maxTokens;
+    completionOptions.reasoning = false;
 
     // Prompt the user's current LLM for the title
     const titleResponse = await model.chat(


### PR DESCRIPTION
Root Cause

The title generation logic was including reasoning/thinking content, which caused noisy or irrelevant titles.

Changes
Filtered reasoning content before title generation
Preserved existing behavior for standard chats
Testing
Verified normal chats still generate correct titles
Verified reasoning mode chats now generate accurate titles
Tested with long prompts and multi-turn conversations

Fixes #12338

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes noisy chat titles in reasoning/thinking mode by disabling reasoning in the title-generation request so titles only reflect user-visible content. Standard chats are unchanged.

<sup>Written for commit db1dca07fcaeba5bfc407656d0dc2c0f062bad86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

