### PR TITLE
docs: add ApogeoAPI MCP server to community examples

### DIFF
--- a/docs/customize/mcp-tools.mdx
+++ b/docs/customize/mcp-tools.mdx
@@ -18,3 +18,28 @@ These servers make it possible to:
 ## Learn More About MCP servers
 
 Learn more in the [MCP deep dive](/customize/deep-dives/mcp), and view [`mcpServers`](/reference#mcpservers) in the YAML Reference for more details.
+
+## Community MCP Servers
+
+### ApogeoAPI — Geographic data and live exchange rates
+
+[ApogeoAPI MCP](https://github.com/APOGEOAPI/apogeoapi-mcp) gives Continue access to 250+ countries, 5K+ states, 150K+ cities, IP geolocation, and 161 live currency rates.
+
+**Install**:
+1. Get an API key at [apogeoapi.com](https://apogeoapi.com) (free tier: 1,000 req/mo)
+2. Add to your `~/.continue/config.yaml`:
+
+```yaml
+mcpServers:
+  - name: ApogeoAPI
+    command: npx
+    args:
+      - "-y"
+      - "@apogeoapi/mcp"
+    env:
+      APOGEOAPI_KEY: your-api-key-here
+```
+
+**Available tools**: `get_country`, `list_countries`, `search_countries`, `get_states`, `get_cities`, `get_currency_rate`, `geolocate_ip`, `global_search`.
+
+**Docs**: [api.apogeoapi.com/api/docs](https://api.apogeoapi.com/api/docs) | **npm**: [@apogeoapi/mcp](https://www.npmjs.com/package/@apogeoapi/mcp)


### PR DESCRIPTION
## Description

Adds **ApogeoAPI** to the `mcp-tools.mdx` page under a new **Community MCP Servers** section.

### What ApogeoAPI MCP provides

- 250+ countries with ISO codes, flags, languages, currencies, timezones, calling codes
- 5,000+ states/provinces
- 150,000+ cities with coordinates and population
- IP geolocation (country, city, ISP, timezone)
- 161 live currency/exchange rates (dual-source, refreshed every 4h)

### Why it fits here

Geographic and locale data is a common need in AI-assisted development (localization, pricing display, user location, country selectors). This gives Continue users a ready-made example they can copy-paste.

### Install

```yaml
mcpServers:
  - name: ApogeoAPI
    command: npx
    args:
      - "-y"
      - "@apogeoapi/mcp"
    env:
      APOGEOAPI_KEY: your-api-key-here
```

- **npm**: [`@apogeoapi/mcp`](https://www.npmjs.com/package/@apogeoapi/mcp) (MIT)
- **Repo**: https://github.com/APOGEOAPI/apogeoapi-mcp
- **Docs**: https://api.apogeoapi.com/api/docs


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the ApogeoAPI MCP server to the docs as a Community MCP Servers example, with install steps for `@apogeoapi/mcp`, tool list, and links. Helps users quickly add geographic data, IP geolocation, and live currency rates to Continue via MCP.

<sup>Written for commit 057f2b50a1220266b30144c62accb794850c1758. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

