### PR TITLE
fix(deepseek): replay reasoning content for tool calls

### DIFF
--- a/packages/openai-adapters/src/apis/DeepSeek.ts
+++ b/packages/openai-adapters/src/apis/DeepSeek.ts
@@ -1,5 +1,9 @@
 import { streamSse } from "@continuedev/fetch";
-import { ChatCompletionChunk, Model } from "openai/resources/index";
+import {
+  ChatCompletionChunk,
+  ChatCompletionCreateParams,
+  Model,
+} from "openai/resources/index";
 import { DeepseekConfig } from "../types.js";
 import { chatChunk, customFetch } from "../util.js";
 import { OpenAIApi } from "./OpenAI.js";
@@ -13,6 +17,26 @@ export class DeepSeekApi extends OpenAIApi {
       provider: "openai",
       apiBase: config.apiBase ?? DEEPSEEK_API_BASE,
     });
+  }
+
+  modifyChatBody<T extends ChatCompletionCreateParams>(body: T): T {
+    const modifiedBody = super.modifyChatBody(body);
+
+    modifiedBody.messages = modifiedBody.messages.map((message) => {
+      if (
+        message.role !== "assistant" ||
+        (message as any).reasoning_content !== undefined
+      ) {
+        return message;
+      }
+
+      return {
+        ...message,
+        reasoning_content: "",
+      } as typeof message;
+    }) as T["messages"];
+
+    return modifiedBody;
   }
 
   async *fimStream(

--- a/packages/openai-adapters/src/test/main.test.ts
+++ b/packages/openai-adapters/src/test/main.test.ts
@@ -235,6 +235,76 @@ describe("Configuration", () => {
     );
   });
 
+  it("should add empty DeepSeek reasoning_content when replaying assistant tool calls", () => {
+    const deepseek = constructLlmApi({
+      provider: "deepseek",
+      apiKey: "sk-xxx",
+    }) as OpenAIApi;
+
+    const body = deepseek.modifyChatBody({
+      model: "deepseek-v4-flash",
+      stream: true,
+      messages: [
+        { role: "user", content: "@src/file.ts please review this code" },
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            {
+              id: "call_read",
+              type: "function",
+              function: {
+                name: "Read",
+                arguments: '{"filepath":"src/file.ts"}',
+              },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          tool_call_id: "call_read",
+          content: "file contents",
+        },
+      ],
+    } as any);
+
+    expect((body.messages[1] as any).reasoning_content).toBe("");
+  });
+
+  it("should not overwrite existing DeepSeek reasoning_content", () => {
+    const deepseek = constructLlmApi({
+      provider: "deepseek",
+      apiKey: "sk-xxx",
+    }) as OpenAIApi;
+
+    const body = deepseek.modifyChatBody({
+      model: "deepseek-v4-flash",
+      stream: true,
+      messages: [
+        { role: "user", content: "Use a tool" },
+        {
+          role: "assistant",
+          content: "",
+          reasoning_content: "I should inspect the requested file.",
+          tool_calls: [
+            {
+              id: "call_read",
+              type: "function",
+              function: {
+                name: "Read",
+                arguments: '{"filepath":"src/file.ts"}',
+              },
+            },
+          ],
+        },
+      ],
+    } as any);
+
+    expect((body.messages[1] as any).reasoning_content).toBe(
+      "I should inspect the requested file.",
+    );
+  });
+
   it("should configure Inception OpenAI client with correct apiBase and apiKey", () => {
     const inception = constructLlmApi({
       provider: "inception",


### PR DESCRIPTION
Fixes #12246

## Summary
- Add `reasoning_content: ""` to DeepSeek assistant messages when replaying chat history through the OpenAI-compatible adapter.
- Preserve any existing `reasoning_content` returned by DeepSeek instead of overwriting it.
- Add regression coverage for the assistant tool-call replay shape used by CLI tool-result loops.

## Root Cause
The CLI path uses `@continuedev/openai-adapters` directly. Unlike the core OpenAI converter, the DeepSeek adapter did not add `reasoning_content` when replaying previous assistant messages. During a tool-call loop, DeepSeek's strict API gateway can reject the follow-up request after a local tool result because the previous assistant tool-call message lacks this field.

## Validation
- `npm test -- src/test/main.test.ts -t "DeepSeek"` from `packages/openai-adapters`
- `npm test -- src/test/main.test.ts` from `packages/openai-adapters`
- `npm test` from `packages/openai-adapters`
- `npm run build` from `packages/openai-adapters`
- `npx prettier --check packages/openai-adapters/src/apis/DeepSeek.ts packages/openai-adapters/src/test/main.test.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure DeepSeek assistant tool-call replays include `reasoning_content` so follow-up requests aren’t rejected during CLI tool-result loops. Fixes #12246.

- **Bug Fixes**
  - Add `reasoning_content: ""` to assistant messages during replay in the OpenAI-compatible adapter.
  - Preserve existing `reasoning_content` when provided by DeepSeek.
  - Add regression tests for the CLI assistant tool-call replay shape.

<sup>Written for commit 59509483a02c5a6a1c01f8ebf7f93bf7f7f9a183. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

