### PR TITLE
fix: exclude thinking/reasoning chunks from chat title generation

### DIFF
--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -964,6 +964,11 @@ export abstract class BaseLLM implements ILLM {
   ) {
     let completion = "";
     for await (const message of this.streamChat(messages, signal, options)) {
+      // Skip thinking/reasoning messages so the returned completion only
+      // contains the visible assistant response, not internal reasoning text.
+      if (message.role === "thinking") {
+        continue;
+      }
       completion += renderChatMessage(message);
     }
     return { role: "assistant" as const, content: completion };

--- a/core/util/chatDescriber.test.ts
+++ b/core/util/chatDescriber.test.ts
@@ -65,5 +65,23 @@ describe("ChatDescriber", () => {
         ChatDescriber.describe(testLLM, completionOptions, message),
       ).rejects.toThrow();
     });
+
+    it("should exclude thinking/reasoning content from the generated title", async () => {
+      const message = "Help me write a sorting algorithm";
+
+      // Simulate a model that emits a thinking chunk followed by an assistant chunk
+      testLLM.chatStreams = [
+        [
+          { role: "thinking", content: "Here is my thinking process, I need to consider various sorting algorithms..." },
+          { role: "assistant", content: "Sorting Algorithm Help" },
+        ],
+      ];
+
+      const result = await ChatDescriber.describe(testLLM, {}, message);
+
+      // The title should come from the assistant chunk, not the thinking chunk
+      expect(result).toBe("Sorting Algorithm Help");
+      expect(result).not.toContain("thinking process");
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #12338 — chat titles were generated from thinking/reasoning content instead of the actual assistant response when using models with extended thinking (Qwen3, DeepSeek-R1, Anthropic extended thinking, etc.).

**Root cause:** `BaseLLM.chat()` in `core/llm/index.ts` streams all chunks and accumulates them with `renderChatMessage()`. This includes `role: "thinking"` chunks, so the returned completion string contained both the internal reasoning text and the actual response. `ChatDescriber.describe()` then passed this combined string to the title model, which would produce titles like "Here is Thinking Process" from the reasoning preamble.

**Fix:** Skip `role: "thinking"` chunks in `chat()` so callers receive only the visible assistant response. This is a one-liner change.

**Test:** Added a test case in `chatDescriber.test.ts` that verifies thinking chunks are excluded when `ChatDescriber.describe()` calls `model.chat()`.

## Changes

- `core/llm/index.ts` — skip `role: "thinking"` messages in `BaseLLM.chat()`
- `core/util/chatDescriber.test.ts` — new test for thinking-chunk exclusion

## Test plan

- [ ] Run `core/util/chatDescriber.test.ts` — new test should pass
- [ ] In VS Code with a thinking-mode model (e.g. Qwen3 via Ollama), verify chat titles are based on the actual response, not reasoning text

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop including internal “thinking/reasoning” chunks in chat title generation. Titles now come from the visible assistant reply, fixing cases with models that emit reasoning (e.g., Qwen3, DeepSeek-R1, Anthropic extended thinking).

- **Bug Fixes**
  - Skip `role: "thinking"` messages in `BaseLLM.chat()` when building the completion string.
  - Add a test in `core/util/chatDescriber.test.ts` to ensure `ChatDescriber.describe()` ignores thinking content.

<sup>Written for commit 618b592188ea2c2a2d4664a62db0a9f4dc9135e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

