### PR TITLE
docs: document .continue/configs/ directory for local config profiles

### DIFF
--- a/docs/customize/deep-dives/configuration.mdx
+++ b/docs/customize/deep-dives/configuration.mdx
@@ -28,6 +28,49 @@ When editing this file, you can see the available options suggested as you type,
 
 See the full reference for `config.yaml` [here](/reference).
 
+## How to Use Local Config Profiles
+
+In addition to the main `config.yaml`, you can create multiple local config profiles by placing YAML files in special subdirectories inside `.continue/`. This works at both the workspace level (inside your project) and the global level (`~/.continue/`).
+
+Continue discovers, watches, and loads YAML files from any of these three directories as selectable profiles:
+
+| Directory | Scope | Purpose |
+|---|---|---|
+| `.continue/agents/` | workspace or `~/.continue/` | Agent-specific configurations |
+| `.continue/assistants/` | workspace or `~/.continue/` | Assistant configurations (legacy name) |
+| `.continue/configs/` | workspace or `~/.continue/` | General local config profiles |
+
+### How to create a local config profile
+
+1. Create the directory if it doesn't exist:
+
+```bash
+# Inside your project (workspace-level)
+mkdir -p .continue/configs
+
+# Or globally
+mkdir -p ~/.continue/configs
+```
+
+2. Add a YAML file with your profile configuration:
+
+```yaml title=".continue/configs/my-profile.yaml"
+name: My Custom Profile
+version: 0.0.1
+models:
+  - name: My Model
+    provider: anthropic
+    model: claude-sonnet-4-5
+```
+
+3. The profile will automatically appear in the config selector in your IDE — no restart needed. Continue watches these directories and reloads when files are added, changed, or deleted.
+
+### Which directory should I use?
+
+All three directories behave identically in terms of discovery and loading. Use `.continue/configs/` for general-purpose profiles, `.continue/agents/` for agent-specific setups, and `.continue/assistants/` if you have existing files there (it is supported for backwards compatibility).
+
+You can version-control workspace-level profiles (`.continue/configs/`, `.continue/agents/`, `.continue/assistants/`) by committing them to your repository, making it easy to share profiles with your team.
+
 ## Legacy Configuration Methods (Deprecated)
 
 <Info>

--- a/docs/guides/understanding-configs.mdx
+++ b/docs/guides/understanding-configs.mdx
@@ -101,6 +101,35 @@ The first time you use Continue, it generates a `config.yaml` with sensible defa
 
 For the complete configuration reference, see our [config.yaml documentation](/reference).
 
+### How to Use Multiple Local Config Profiles
+
+Beyond the single `config.yaml`, you can create multiple local profiles by placing YAML files in these directories:
+
+- `.continue/configs/` — general-purpose local profiles
+- `.continue/agents/` — agent-specific configurations
+- `.continue/assistants/` — assistant configurations (supported for backwards compatibility)
+
+These directories work at both the workspace level (inside your project folder) and the global level (`~/.continue/`). Continue automatically discovers, watches, and loads any YAML files placed there as selectable profiles in your IDE.
+
+**Example:** To create a workspace profile for a specific tech stack:
+
+```bash
+mkdir -p .continue/configs
+```
+
+```yaml title=".continue/configs/frontend.yaml"
+name: Frontend Profile
+version: 0.0.1
+models:
+  - name: Claude
+    provider: anthropic
+    model: claude-sonnet-4-5
+```
+
+The profile appears instantly in your config selector — no restart needed. Commit these files to version control to share profiles with your team.
+
+For more detail, see [How to Use Local Config Profiles](/customize/deep-dives/configuration#how-to-use-local-config-profiles).
+
 ## How to Make the Right Choice
 
 The decision between Hub and Local configs often comes down to your specific needs and constraints. Here's a framework to help you decide:


### PR DESCRIPTION
## Description

Documents the `.continue/configs/` directory added in #11935 as a third option for local config profiles, alongside the existing `.continue/agents/` and `.continue/assistants/` directories.

- `docs/customize/deep-dives/configuration.mdx` — Added "How to Use Local Config Profiles" section with a comparison table, bash + YAML examples, and guidance on which directory to use
- `docs/guides/understanding-configs.mdx` — Added "How to Use Multiple Local Config Profiles" sub-section inside the existing Local Configs section

Closes #12395

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A — documentation-only change, no UI changes.

## Tests

N/A — documentation-only change. No code logic was modified.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the `.continue/configs/` directory as a third option for local config profiles, alongside `.continue/agents/` and `.continue/assistants/`. Clarifies how to create, select, and share profiles at workspace or global scope.

- **Documentation**
  - Added “How to Use Local Config Profiles” to `docs/customize/deep-dives/configuration.mdx` with directory comparison, bash/YAML examples, auto-discovery/watch behavior, guidance on which directory to use, and notes on version control and backwards compatibility.
  - Updated `docs/guides/understanding-configs.mdx` with “How to Use Multiple Local Config Profiles,” a quick example, and a link to the deep dive.

<sup>Written for commit 066631210575295504d840baa5c92c80880da3e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

