### PR TITLE
docs: document dynamic model fetching feature

### DIFF
--- a/docs/customize/deep-dives/configuration.mdx
+++ b/docs/customize/deep-dives/configuration.mdx
@@ -28,6 +28,49 @@ When editing this file, you can see the available options suggested as you type,
 
 See the full reference for `config.yaml` [here](/reference).
 
+## How to Use Local Config Profiles
+
+In addition to the main `config.yaml`, you can create multiple local config profiles by placing YAML files in special subdirectories inside `.continue/`. This works at both the workspace level (inside your project) and the global level (`~/.continue/`).
+
+Continue discovers, watches, and loads YAML files from any of these three directories as selectable profiles:
+
+| Directory | Scope | Purpose |
+|---|---|---|
+| `.continue/agents/` | workspace or `~/.continue/` | Agent-specific configurations |
+| `.continue/assistants/` | workspace or `~/.continue/` | Assistant configurations (legacy name) |
+| `.continue/configs/` | workspace or `~/.continue/` | General local config profiles |
+
+### How to create a local config profile
+
+1. Create the directory if it doesn't exist:
+
+```bash
+# Inside your project (workspace-level)
+mkdir -p .continue/configs
+
+# Or globally
+mkdir -p ~/.continue/configs
+```
+
+2. Add a YAML file with your profile configuration:
+
+```yaml title=".continue/configs/my-profile.yaml"
+name: My Custom Profile
+version: 0.0.1
+models:
+  - name: My Model
+    provider: anthropic
+    model: claude-sonnet-4-5
+```
+
+3. The profile will automatically appear in the config selector in your IDE — no restart needed. Continue watches these directories and reloads when files are added, changed, or deleted.
+
+### Which directory should I use?
+
+All three directories behave identically in terms of discovery and loading. Use `.continue/configs/` for general-purpose profiles, `.continue/agents/` for agent-specific setups, and `.continue/assistants/` if you have existing files there (it is supported for backwards compatibility).
+
+You can version-control workspace-level profiles (`.continue/configs/`, `.continue/agents/`, `.continue/assistants/`) by committing them to your repository, making it easy to share profiles with your team.
+
 ## Legacy Configuration Methods (Deprecated)
 
 <Info>

--- a/docs/customize/model-providers/overview.mdx
+++ b/docs/customize/model-providers/overview.mdx
@@ -59,6 +59,33 @@ Beyond the top-level providers, Continue supports many other options:
 | [Sagemaker](/customize/model-providers/more/sagemaker) | AWS machine learning platform         |
 | [Nebius](/customize/model-providers/more/nebius)       | Cloud-based machine learning platform |
 
+## Dynamic Model Fetching
+
+When you add a model through the Continue UI, the model list for your selected provider is fetched dynamically so you always see up-to-date options.
+
+### How it works per provider
+
+| Provider | Behavior | Requires API Key |
+|---|---|---|
+| **Ollama** | Auto-loads on provider selection — scrapes the [Ollama library](https://ollama.com/library) including model icons and tool support | No |
+| **OpenRouter** | Auto-loads on provider selection — hits the OpenRouter public API | No |
+| **Anthropic** | Refresh button appears after you enter an API key — calls `/v1/models` | Yes |
+| **Gemini** | Refresh button appears after you enter an API key — calls `v1beta/models` | Yes |
+| **Others** | Refresh button appears after you enter an API key — uses the provider's model list API | Depends on provider |
+
+### What information is fetched
+
+For each model, Continue retrieves:
+- **Context length** — the maximum input tokens the model supports
+- **Max tokens** — the maximum output tokens the model can generate
+- **Tool support** — whether the model supports function/tool calling
+
+These values are written to your `config.yaml` automatically when you add the model, so Continue can use them without making additional API calls.
+
+### Model deduplication
+
+Fetched models are merged with Continue's built-in hardcoded model list. If the same model appears in both, the hardcoded entry takes precedence (since it contains curated defaults).
+
 ## How to Choose a Model Provider
 
 When selecting a model provider, consider:

--- a/docs/customize/model-roles/chat.mdx
+++ b/docs/customize/model-roles/chat.mdx
@@ -12,6 +12,15 @@ A "chat model" is an LLM that is trained to respond in a conversational format. 
 
 In Continue, these models are used for normal [Chat](../../ide-extensions/chat/quick-start). The selected chat model will also be used for [Edit](../../ide-extensions/edit/quick-start) and [Apply](./apply.mdx) if no `edit` or `apply` models are specified, respectively.
 
+## Adding a Chat Model
+
+When you select a provider in the Continue UI, the available models are loaded dynamically:
+
+- **Ollama** and **OpenRouter** auto-load their model lists when you select the provider — no API key needed.
+- **Anthropic**, **Gemini**, and most other providers show a **refresh button** once you enter your API key. Click it to fetch the live model list from the provider.
+
+Fetched models include context length, max output tokens, and tool support information, which are saved to your `config.yaml` when you add the model. See [Dynamic Model Fetching](../model-providers/overview#dynamic-model-fetching) for full details.
+
 ## Recommended Chat models
 
 <ModelRecommendations role="chat_edit" />

--- a/docs/guides/understanding-configs.mdx
+++ b/docs/guides/understanding-configs.mdx
@@ -101,6 +101,35 @@ The first time you use Continue, it generates a `config.yaml` with sensible defa
 
 For the complete configuration reference, see our [config.yaml documentation](/reference).
 
+### How to Use Multiple Local Config Profiles
+
+Beyond the single `config.yaml`, you can create multiple local profiles by placing YAML files in these directories:
+
+- `.continue/configs/` — general-purpose local profiles
+- `.continue/agents/` — agent-specific configurations
+- `.continue/assistants/` — assistant configurations (supported for backwards compatibility)
+
+These directories work at both the workspace level (inside your project folder) and the global level (`~/.continue/`). Continue automatically discovers, watches, and loads any YAML files placed there as selectable profiles in your IDE.
+
+**Example:** To create a workspace profile for a specific tech stack:
+
+```bash
+mkdir -p .continue/configs
+```
+
+```yaml title=".continue/configs/frontend.yaml"
+name: Frontend Profile
+version: 0.0.1
+models:
+  - name: Claude
+    provider: anthropic
+    model: claude-sonnet-4-5
+```
+
+The profile appears instantly in your config selector — no restart needed. Commit these files to version control to share profiles with your team.
+
+For more detail, see [How to Use Local Config Profiles](/customize/deep-dives/configuration#how-to-use-local-config-profiles).
+
 ## How to Make the Right Choice
 
 The decision between Hub and Local configs often comes down to your specific needs and constraints. Here's a framework to help you decide:


### PR DESCRIPTION
## Description

Documents the dynamic model fetching feature added in #12046.

- `docs/customize/model-providers/overview.mdx` — Added "Dynamic Model Fetching" section explaining per-provider behavior (auto-load vs refresh button), what data is fetched (contextLength, maxTokens, supportsTools), persistence to config.yaml, and model deduplication
- `docs/customize/model-roles/chat.mdx` — Added "Adding a Chat Model" section explaining how to trigger model fetching from the UI, with a link to the detailed reference

Closes #12396

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A — documentation-only change.

## Tests

N/A — documentation-only change. No code logic was modified.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented dynamic model fetching across providers and how to add chat models from the UI, including per‑provider behavior (auto-load vs refresh), fetched fields (context length, max tokens, tool support), config persistence, and model deduplication. Also added guidance for multiple local config profiles via `.continue/configs/`, `.continue/agents/`, and `.continue/assistants/` with auto-discovery and hot reload.

<sup>Written for commit 2e1ca01c5ab5b882d9393a15a7a0bc96225516d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

