### PR TITLE
fix: pass editor content for JetBrains autocomplete to fix large file truncation

### DIFF
--- a/docs/customize/deep-dives/configuration.mdx
+++ b/docs/customize/deep-dives/configuration.mdx
@@ -28,6 +28,49 @@ When editing this file, you can see the available options suggested as you type,
 
 See the full reference for `config.yaml` [here](/reference).
 
+## How to Use Local Config Profiles
+
+In addition to the main `config.yaml`, you can create multiple local config profiles by placing YAML files in special subdirectories inside `.continue/`. This works at both the workspace level (inside your project) and the global level (`~/.continue/`).
+
+Continue discovers, watches, and loads YAML files from any of these three directories as selectable profiles:
+
+| Directory | Scope | Purpose |
+|---|---|---|
+| `.continue/agents/` | workspace or `~/.continue/` | Agent-specific configurations |
+| `.continue/assistants/` | workspace or `~/.continue/` | Assistant configurations (legacy name) |
+| `.continue/configs/` | workspace or `~/.continue/` | General local config profiles |
+
+### How to create a local config profile
+
+1. Create the directory if it doesn't exist:
+
+```bash
+# Inside your project (workspace-level)
+mkdir -p .continue/configs
+
+# Or globally
+mkdir -p ~/.continue/configs
+```
+
+2. Add a YAML file with your profile configuration:
+
+```yaml title=".continue/configs/my-profile.yaml"
+name: My Custom Profile
+version: 0.0.1
+models:
+  - name: My Model
+    provider: anthropic
+    model: claude-sonnet-4-5
+```
+
+3. The profile will automatically appear in the config selector in your IDE — no restart needed. Continue watches these directories and reloads when files are added, changed, or deleted.
+
+### Which directory should I use?
+
+All three directories behave identically in terms of discovery and loading. Use `.continue/configs/` for general-purpose profiles, `.continue/agents/` for agent-specific setups, and `.continue/assistants/` if you have existing files there (it is supported for backwards compatibility).
+
+You can version-control workspace-level profiles (`.continue/configs/`, `.continue/agents/`, `.continue/assistants/`) by committing them to your repository, making it easy to share profiles with your team.
+
 ## Legacy Configuration Methods (Deprecated)
 
 <Info>

--- a/docs/customize/model-providers/overview.mdx
+++ b/docs/customize/model-providers/overview.mdx
@@ -59,6 +59,33 @@ Beyond the top-level providers, Continue supports many other options:
 | [Sagemaker](/customize/model-providers/more/sagemaker) | AWS machine learning platform         |
 | [Nebius](/customize/model-providers/more/nebius)       | Cloud-based machine learning platform |
 
+## Dynamic Model Fetching
+
+When you add a model through the Continue UI, the model list for your selected provider is fetched dynamically so you always see up-to-date options.
+
+### How it works per provider
+
+| Provider | Behavior | Requires API Key |
+|---|---|---|
+| **Ollama** | Auto-loads on provider selection — scrapes the [Ollama library](https://ollama.com/library) including model icons and tool support | No |
+| **OpenRouter** | Auto-loads on provider selection — hits the OpenRouter public API | No |
+| **Anthropic** | Refresh button appears after you enter an API key — calls `/v1/models` | Yes |
+| **Gemini** | Refresh button appears after you enter an API key — calls `v1beta/models` | Yes |
+| **Others** | Refresh button appears after you enter an API key — uses the provider's model list API | Depends on provider |
+
+### What information is fetched
+
+For each model, Continue retrieves:
+- **Context length** — the maximum input tokens the model supports
+- **Max tokens** — the maximum output tokens the model can generate
+- **Tool support** — whether the model supports function/tool calling
+
+These values are written to your `config.yaml` automatically when you add the model, so Continue can use them without making additional API calls.
+
+### Model deduplication
+
+Fetched models are merged with Continue's built-in hardcoded model list. If the same model appears in both, the hardcoded entry takes precedence (since it contains curated defaults).
+
 ## How to Choose a Model Provider
 
 When selecting a model provider, consider:

--- a/docs/customize/model-roles/chat.mdx
+++ b/docs/customize/model-roles/chat.mdx
@@ -12,6 +12,15 @@ A "chat model" is an LLM that is trained to respond in a conversational format. 
 
 In Continue, these models are used for normal [Chat](../../ide-extensions/chat/quick-start). The selected chat model will also be used for [Edit](../../ide-extensions/edit/quick-start) and [Apply](./apply.mdx) if no `edit` or `apply` models are specified, respectively.
 
+## Adding a Chat Model
+
+When you select a provider in the Continue UI, the available models are loaded dynamically:
+
+- **Ollama** and **OpenRouter** auto-load their model lists when you select the provider — no API key needed.
+- **Anthropic**, **Gemini**, and most other providers show a **refresh button** once you enter your API key. Click it to fetch the live model list from the provider.
+
+Fetched models include context length, max output tokens, and tool support information, which are saved to your `config.yaml` when you add the model. See [Dynamic Model Fetching](../model-providers/overview#dynamic-model-fetching) for full details.
+
 ## Recommended Chat models
 
 <ModelRecommendations role="chat_edit" />

--- a/docs/guides/understanding-configs.mdx
+++ b/docs/guides/understanding-configs.mdx
@@ -101,6 +101,35 @@ The first time you use Continue, it generates a `config.yaml` with sensible defa
 
 For the complete configuration reference, see our [config.yaml documentation](/reference).
 
+### How to Use Multiple Local Config Profiles
+
+Beyond the single `config.yaml`, you can create multiple local profiles by placing YAML files in these directories:
+
+- `.continue/configs/` — general-purpose local profiles
+- `.continue/agents/` — agent-specific configurations
+- `.continue/assistants/` — assistant configurations (supported for backwards compatibility)
+
+These directories work at both the workspace level (inside your project folder) and the global level (`~/.continue/`). Continue automatically discovers, watches, and loads any YAML files placed there as selectable profiles in your IDE.
+
+**Example:** To create a workspace profile for a specific tech stack:
+
+```bash
+mkdir -p .continue/configs
+```
+
+```yaml title=".continue/configs/frontend.yaml"
+name: Frontend Profile
+version: 0.0.1
+models:
+  - name: Claude
+    provider: anthropic
+    model: claude-sonnet-4-5
+```
+
+The profile appears instantly in your config selector — no restart needed. Commit these files to version control to share profiles with your team.
+
+For more detail, see [How to Use Local Config Profiles](/customize/deep-dives/configuration#how-to-use-local-config-profiles).
+
 ## How to Make the Right Choice
 
 The decision between Hub and Local configs often comes down to your specific needs and constraints. Here's a framework to help you decide:

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/CompletionService.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/CompletionService.kt
@@ -3,7 +3,7 @@ package com.github.continuedev.continueintellijextension.autocomplete
 
 interface CompletionService {
 
-    suspend fun getAutocomplete(uuid: String, url: String, line: Int, column: Int): String?
+    suspend fun getAutocomplete(uuid: String, url: String, line: Int, column: Int, fileContents: String? = null): String?
 
     fun acceptAutocomplete(uuid: String?)
 

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/ContinueCompletionService.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/ContinueCompletionService.kt
@@ -13,8 +13,8 @@ import kotlin.time.Duration.Companion.milliseconds
 @Service(Service.Level.PROJECT)
 class ContinueCompletionService(private val project: Project) : CompletionService {
 
-    override suspend fun getAutocomplete(uuid: String, url: String, line: Int, column: Int): String? {
-        val requestInput = getCompletionInput(uuid, url, line, column)
+    override suspend fun getAutocomplete(uuid: String, url: String, line: Int, column: Int, fileContents: String?): String? {
+        val requestInput = getCompletionInput(uuid, url, line, column, fileContents)
         val modelTimeout = project.service<ProfileInfoService>().fetchModelTimeoutOrNull() ?: 1000.0
         return withTimeoutOrNull(modelTimeout.milliseconds * 3) {
             suspendCancellableCoroutine { continuation ->
@@ -38,13 +38,14 @@ class ContinueCompletionService(private val project: Project) : CompletionServic
         ) {}
     }
 
-    private fun getCompletionInput(uuid: String, filepath: String, line: Int, character: Int): Map<String, *> = mapOf(
+    private fun getCompletionInput(uuid: String, filepath: String, line: Int, character: Int, fileContents: String?): Map<String, *> = mapOf(
         "completionId" to uuid,
         "filepath" to filepath,
         "pos" to mapOf(
             "line" to line,
             "character" to character
         ),
+        "manuallyPassFileContents" to fileContents,
         "clipboardText" to "",
         "recentlyEditedRanges" to emptyList<Any>(),
         "recentlyVisitedRanges" to emptyList<Any>(),

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/ContinueInlineCompletionProvider.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/ContinueInlineCompletionProvider.kt
@@ -125,7 +125,8 @@ class ContinueInlineCompletionProvider : InlineCompletionProvider {
                 lastUuid!!,
                 editor.virtualFile.url,
                 editor.caretModel.primaryCaret.logicalPosition.line,
-                editor.caretModel.primaryCaret.logicalPosition.column
+                editor.caretModel.primaryCaret.logicalPosition.column,
+                editor.document.text
             )
             if (variant == null)
                 return InlineCompletionSuggestion.Empty

--- a/extensions/intellij/src/test/kotlin/com/github/continuedev/continueintellijextension/unit/ContinueInlineCompletionProviderTest.kt
+++ b/extensions/intellij/src/test/kotlin/com/github/continuedev/continueintellijextension/unit/ContinueInlineCompletionProviderTest.kt
@@ -111,7 +111,7 @@ class ContinueInlineCompletionProviderTest : BasePlatformTestCase() {
         myFixture.project.replaceService(
             CompletionService::class.java,
             object : CompletionService {
-                override suspend fun getAutocomplete(uuid: String, url: String, line: Int, column: Int): String? =
+                override suspend fun getAutocomplete(uuid: String, url: String, line: Int, column: Int, fileContents: String?): String? =
                     variant
 
                 override fun acceptAutocomplete(uuid: String?) =


### PR DESCRIPTION
## Description

Fixes #12390 : autocomplete showing wrong/static prefix & suffix on files larger than ~3000 lines in JetBrains.

**Root cause:** `FileUtils.readFile()` caps file content at 100,000 characters. For large files this truncates the content always from line 0, so the core computed the same wrong prefix/suffix regardless of cursor position.

**Fix:** Pass `editor.document.text` (full live in-memory content, no size limit) as `manuallyPassFileContents` in the autocomplete request, exactly mirroring what the VS Code extension already does via `openTextDocument.getText()`. When `manuallyPassFileContents` is present, the core skips the disk/file read entirely.

Changes:
- `CompletionService.kt` : added optional `fileContents` parameter to interface
- `ContinueCompletionService.kt` : passes `manuallyPassFileContents` in the request payload
- `ContinueInlineCompletionProvider.kt` : reads `editor.document.text` and passes it to the service

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [ ] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A: The fix mirrors the existing VS Code implementation and was verified by code inspection.

## Tests

No new tests added. The fix mirrors the VS Code extension's approach (`openTextDocument.getText()`). 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes wrong/static autocomplete prefixes and suffixes in JetBrains for large files by sending the full in-memory editor text instead of reading from disk. Also updates docs to cover local config profiles and dynamic model fetching in the UI.

- **Bug Fixes**
  - Pass `editor.document.text` as `manuallyPassFileContents` so the core skips disk reads and uses the full file content.
  - Add optional `fileContents` to `CompletionService` and wire it through `ContinueCompletionService` and `ContinueInlineCompletionProvider`.
  - Update unit test mock to match the new `getAutocomplete` signature.

<sup>Written for commit bccf2479db963ab802ccdef90628f2b4c80aacc8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

