### PR TITLE
fix(terminal): skip -l login flag for csh and tcsh

### DIFF
--- a/core/tools/implementations/runTerminalCommand.ts
+++ b/core/tools/implementations/runTerminalCommand.ts
@@ -32,7 +32,11 @@ function getShellCommand(command: string): { shell: string; args: string[] } {
   } else {
     // Unix/macOS: Use login shell to source .bashrc/.zshrc etc.
     const userShell = process.env.SHELL || "/bin/bash";
-    return { shell: userShell, args: ["-l", "-c", command] };
+    // csh and tcsh do not accept -l as a flag, so skip the login flag for them.
+    const shellName = userShell.split("/").pop() || "";
+    const loginArgs =
+      shellName === "csh" || shellName === "tcsh" ? [] : ["-l"];
+    return { shell: userShell, args: [...loginArgs, "-c", command] };
   }
 }
 

--- a/extensions/cli/src/tools/runTerminalCommand.ts
+++ b/extensions/cli/src/tools/runTerminalCommand.ts
@@ -77,13 +77,26 @@ function getShellCommand(command: string): { shell: string; args: string[] } {
     const wslShell = process.env.SHELL || "/bin/bash";
     return {
       shell: wslShell,
-      args: ["-l", "-c", command],
+      args: [...getLoginShellArgs(wslShell), "-c", command],
     };
   }
 
   // Unix/macOS: Use login shell to source .bashrc/.zshrc etc.
   const userShell = process.env.SHELL || "/bin/bash";
-  return { shell: userShell, args: ["-l", "-c", command] };
+  return {
+    shell: userShell,
+    args: [...getLoginShellArgs(userShell), "-c", command],
+  };
+}
+
+// csh and tcsh do not accept -l as a flag, so skip the login flag for them.
+// They automatically source ~/.cshrc / ~/.tcshrc on every invocation anyway.
+function getLoginShellArgs(shellPath: string): string[] {
+  const shellName = shellPath.split("/").pop() || "";
+  if (shellName === "csh" || shellName === "tcsh") {
+    return [];
+  }
+  return ["-l"];
 }
 
 export function runCommandInBackground(command: string): {


### PR DESCRIPTION
## Problem

When `$SHELL` is set to `tcsh` (or `csh`), every terminal command issued by Continue fails immediately:

```
Unknown option: `-l'
Usage: tcsh [ -bcdefilmnqstvVxX ] [ argument ... ].
Command failed with exit code 1
```

`getShellCommand` in both `core/tools/implementations/runTerminalCommand.ts` and `extensions/cli/src/tools/runTerminalCommand.ts` hardcodes `["-l", "-c", command]` for every Unix shell. `csh` and `tcsh` do not accept `-l` as a flag, so the shell rejects the invocation before the command is ever evaluated.

Fixes #12378.

## Solution

Detect the shell binary name (`basename` of `$SHELL`) and omit the `-l` flag when it is `csh` or `tcsh`. Those shells automatically source `~/.cshrc` / `~/.tcshrc` on every invocation, so the login-shell intent (sourcing rc files) is preserved without the flag.

Behavior is unchanged for bash, zsh, sh, fish, and any other shell — they continue to receive `-l -c <command>`.

## Testing

- `bash` / `zsh`: `getShellCommand("echo hi")` returns `args: ["-l", "-c", "echo hi"]` (unchanged).
- `tcsh` / `csh`: `getShellCommand("echo hi")` returns `args: ["-c", "echo hi"]`, which `tcsh -c "echo hi"` accepts and runs normally.
- Manual repro from the issue (`$SHELL=/bin/tcsh`, ask Continue to run `pwd`) now succeeds instead of erroring with `Unknown option: -l`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the `-l` login flag when invoking `csh`/`tcsh` so terminal commands don’t fail with “Unknown option: -l.” Other shells keep using `-l -c` to load shell configs.

- **Bug Fixes**
  - Detect the shell name and omit `-l` for `csh`/`tcsh`, which auto-source their rc files.
  - Added a small helper to compute login args and applied it in both terminal command implementations (Unix/macOS and WSL paths); `bash`/`zsh` behavior unchanged.

<sup>Written for commit 1ae4cab3e5270fc094ae17bf128fdb3fb5dff39d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

