### PR TITLE
fixes for failure to configure prompts from md files, described in issue #12412

### DIFF
--- a/core/config/profile/doLoadConfig.ts
+++ b/core/config/profile/doLoadConfig.ts
@@ -343,6 +343,11 @@ export default async function doLoadConfig(options: {
         fatal: false,
         message: `Duplicate (${count}) tools named "${toolName}" detected. Permissions will conflict and usage may be unpredictable`,
       });
+      console.warn(
+        `[Tool] Duplicate tool name found: ${toolName} (${count} times).`,
+      );
+    } else {
+      console.debug(`[Tool] Unique tool name found: ${toolName}.`);
     }
   });
 
@@ -363,6 +368,11 @@ export default async function doLoadConfig(options: {
         fatal: false,
         message: `Duplicate (${count}) rules named "${ruleName}" detected. This may cause unexpected behavior`,
       });
+      console.warn(
+        `[Rule] Duplicate rule name found: ${ruleName} (${count} times).`,
+      );
+    } else {
+      console.debug(`[Rule] Unique rule name found: ${ruleName}.`);
     }
   });
 

--- a/extensions/cli/build.mjs
+++ b/extensions/cli/build.mjs
@@ -54,7 +54,7 @@ try {
     alias: {
       "@continuedev/config-yaml": resolve(
         __dirname,
-        "../../packages/config-yaml/dist/index.js",
+        "../../packages/config-yaml",
       ),
       "@continuedev/openai-adapters": resolve(
         __dirname,

--- a/extensions/cli/src/configLoader.ts
+++ b/extensions/cli/src/configLoader.ts
@@ -60,6 +60,9 @@ export async function loadConfiguration(
     cliConfigPath,
     isHeadless,
   );
+  logger.debug(
+    `Determined configuration source: ${JSON.stringify(configSource)}`,
+  );
 
   // Step 2: Load configuration from the determined source
   const config = await loadFromSource(
@@ -69,11 +72,13 @@ export async function loadConfiguration(
     apiClient,
     injectBlocks,
   );
+  logger.debug(`Successfully loaded configuration from ${configSource.type}`);
 
   // Step 3: Save config URI for session continuity (only for file-based auth)
   if (!isEnvironmentAuthConfig(authConfig) && authConfig !== null) {
     const uri = getUriFromSource(configSource);
     if (uri) {
+      logger.debug(`Persisting configuration URI for session: ${uri}`);
       updateConfigUri(uri);
     }
   }
@@ -237,6 +242,7 @@ async function loadFromCliFlag(
   injectBlocks: PackageIdentifier[],
 ): Promise<AssistantUnrolled> {
   if (isFilePath(configPath)) {
+    logger.debug(`Loading configuration from CLI file path: ${configPath}`);
     // Load local YAML file
     return await loadConfigYaml(
       configPath,
@@ -246,6 +252,9 @@ async function loadFromCliFlag(
       injectBlocks,
     );
   } else {
+    logger.debug(
+      `Loading configuration from CLI assistant slug: ${configPath}`,
+    );
     // Load assistant slug
     return await loadAssistantSlug(
       configPath,
@@ -267,6 +276,7 @@ async function loadFromSavedUri(
   apiClient: DefaultApiInterface,
   injectBlocks: PackageIdentifier[],
 ): Promise<AssistantUnrolled> {
+  logger.debug(`Loading configuration from saved URI: ${uri}`);
   const filePath = uriToPath(uri);
   if (filePath) {
     return await loadConfigYaml(
@@ -301,12 +311,16 @@ async function loadUserAssistantWithFallback(
   accessToken: string | null,
   injectBlocks: PackageIdentifier[],
 ): Promise<AssistantUnrolled> {
+  logger.debug("Attempting to load first available user assistant");
   const assistants = await apiClient.listAssistants({
     alwaysUseProxy: "false",
     organizationId: organizationId ?? undefined,
   });
 
   if (assistants.length > 0) {
+    logger.debug(
+      `Found ${assistants.length} user assistants, using the first one: ${assistants[0].name}`,
+    );
     const result = assistants[0].configResult;
     if (!result.config) {
       throw new Error(result.errors?.join("\n") ?? "Failed to load assistant.");
@@ -321,6 +335,9 @@ async function loadUserAssistantWithFallback(
     }
     let apiConfig = result.config as AssistantUnrolled;
     if (injectBlocks.length > 0) {
+      logger.debug(
+        `Injecting ${injectBlocks.length} blocks into user assistant config`,
+      );
       const injectedConfig = await unrollPackageIdentifiersAsConfigYaml(
         injectBlocks,
         accessToken,
@@ -334,6 +351,9 @@ async function loadUserAssistantWithFallback(
   }
 
   // No user assistants, fall back to default agent
+  logger.debug(
+    "No user assistants found, falling back to default configuration",
+  );
   return await loadDefaultConfig(
     organizationId,
     apiClient,
@@ -352,6 +372,7 @@ async function loadLocalConfigYaml(
   injectBlocks: PackageIdentifier[],
 ): Promise<AssistantUnrolled> {
   const defaultConfigPath = path.join(env.continueHome, "config.yaml");
+  logger.debug(`Loading local config.yaml from: ${defaultConfigPath}`);
   return await loadConfigYaml(
     defaultConfigPath,
     accessToken,
@@ -370,6 +391,7 @@ async function loadDefaultConfig(
   accessToken: string | null,
   injectBlocks: PackageIdentifier[],
 ): Promise<AssistantUnrolled> {
+  logger.debug("Loading default continuedev/default-cli-config from remote");
   const resp = await apiClient.getAssistant({
     ownerSlug: "continuedev",
     packageSlug: "default-cli-config",
@@ -401,6 +423,9 @@ export async function unrollPackageIdentifiersAsConfigYaml(
   organizationId: string | null,
   apiClient: DefaultApiInterface,
 ): Promise<AssistantUnrolled> {
+  logger.debug(
+    `Unrolling ${packageIdentifiers.length} package identifiers as config YAML`,
+  );
   const unrollResult = await unrollAssistantFromContent(
     {
       uriType: "file",
@@ -441,6 +466,9 @@ async function unrollAssistantWithConfig(
   apiClient: DefaultApiInterface,
   injectBlocks: PackageIdentifier[],
 ): Promise<AssistantUnrolled> {
+  logger.debug(
+    `Unrolling assistant with config for identifier: ${JSON.stringify(packageIdentifier)}`,
+  );
   const unrollResult = await unrollAssistant(
     packageIdentifier,
     new RegistryClient({

--- a/extensions/cli/src/index.ts
+++ b/extensions/cli/src/index.ts
@@ -257,6 +257,10 @@ addCommonOptions(program)
 
     if (options.verbose) {
       logger.setLevel("debug");
+
+      const { enableDebugLogging } = await import("./init.js");
+      enableDebugLogging((msg) => logger.debug(msg));
+
       const logPath = logger.getLogPath();
       const sessionId = logger.getSessionId();
       // In headless mode, suppress these verbose logs

--- a/extensions/cli/src/init.ts
+++ b/extensions/cli/src/init.ts
@@ -79,6 +79,22 @@ if (isHeadlessMode) {
 }
 
 /**
+ * Enable console.debug to be routed to the winston logger
+ * This allows capturing debug logs from shared packages like config-yaml
+ */
+export function enableDebugLogging(winstonDebug: (msg: string) => void): void {
+  console.debug = function (message: any, ...optionalParams: any[]) {
+    const formattedMessage =
+      typeof message === "string" ? message : JSON.stringify(message, null, 2);
+    const extra =
+      optionalParams.length > 0
+        ? ` ${optionalParams.map((p) => (typeof p === "string" ? p : JSON.stringify(p))).join(" ")}`
+        : "";
+    winstonDebug(`${formattedMessage}${extra}`);
+  };
+}
+
+/**
  * Configure console for headless mode
  * Since init.ts already blocks everything, this just tracks state
  * and provides the safe output functions

--- a/extensions/cli/src/services/ConfigService.ts
+++ b/extensions/cli/src/services/ConfigService.ts
@@ -119,11 +119,21 @@ export class ConfigService
     const allModels = [...models];
     if (agentFileState?.agentFile?.model) {
       allModels.push(agentFileState.agentFile.model);
+      logger.debug(
+        `ConfigService: Added model from agent file: ${agentFileState.agentFile.model}`,
+      );
+    }
+
+    if (models.length > 0) {
+      logger.debug(
+        `ConfigService: Processing ${models.length} models from CLI options`,
+      );
     }
 
     for (const model of allModels) {
       try {
         packageIdentifiers.push(decodePackageIdentifier(model));
+        logger.debug(`ConfigService: Decoded model identifier: ${model}`);
       } catch (e) {
         logger.warn(`Failed to add model "${model}": ${getErrorString(e)}`);
       }
@@ -141,14 +151,27 @@ export class ConfigService
       ...(agentFileState?.parsedTools?.mcpServers || []),
     ];
 
+    if (mcps.length > 0) {
+      logger.debug(
+        `ConfigService: Processing ${mcps.length} MCP servers from CLI options`,
+      );
+    }
+    if (agentFileState?.parsedTools?.mcpServers?.length) {
+      logger.debug(
+        `ConfigService: Found ${agentFileState.parsedTools.mcpServers.length} MCP servers in agent file`,
+      );
+    }
+
     for (const mcp of allMcps) {
       try {
         if (this.isUrl(mcp)) {
+          logger.debug(`ConfigService: Adding MCP server from URL: ${mcp}`);
           additional.mcpServers!.push({
             name: new URL(mcp).hostname,
             url: mcp,
           });
         } else {
+          logger.debug(`ConfigService: Decoding MCP server identifier: ${mcp}`);
           packageIdentifiers.push(decodePackageIdentifier(mcp));
         }
       } catch (e) {
@@ -161,8 +184,14 @@ export class ConfigService
     agentFileState: AgentFileServiceState | undefined,
     packageIdentifiers: PackageIdentifier[],
   ): void {
+    if (agentFileState?.parsedRules?.length) {
+      logger.debug(
+        `ConfigService: Processing ${agentFileState.parsedRules.length} rules from agent file`,
+      );
+    }
     for (const rule of agentFileState?.parsedRules || []) {
       try {
+        logger.debug(`ConfigService: Decoding agent rule identifier: ${rule}`);
         packageIdentifiers.push(decodePackageIdentifier(rule));
       } catch (e) {
         logger.warn(
@@ -180,11 +209,26 @@ export class ConfigService
   ): void {
     const allRulesAndPrompts = [...rules, ...prompts];
 
+    if (rules.length > 0) {
+      logger.debug(
+        `ConfigService: Processing ${rules.length} rules from CLI options`,
+      );
+    }
+    if (prompts.length > 0) {
+      logger.debug(
+        `ConfigService: Processing ${prompts.length} prompts from CLI options`,
+      );
+    }
+
     for (const item of allRulesAndPrompts) {
       try {
         if (isStringRule(item)) {
+          logger.debug(`ConfigService: Adding string-based rule or prompt`);
           additional.rules!.push(item);
         } else {
+          logger.debug(
+            `ConfigService: Decoding rule or prompt identifier: ${item}`,
+          );
           packageIdentifiers.push(decodePackageIdentifier(item));
         }
       } catch (e) {
@@ -200,6 +244,9 @@ export class ConfigService
     additional: AssistantUnrolled,
   ): void {
     if (agentFileState?.agentFile?.prompt) {
+      logger.debug(
+        `ConfigService: Adding custom prompt from agent file: ${agentFileState.agentFile.name}`,
+      );
       additional.prompts!.push({
         name: `Agent prompt (${agentFileState.agentFile.name})`,
         prompt: agentFileState.agentFile.prompt,
@@ -222,6 +269,9 @@ export class ConfigService
       (m) => !!m && (!m.roles || m.roles.includes("chat")),
     );
     if (!hasChatModel) {
+      logger.debug(
+        "ConfigService: No chat model found in configuration, attempting to add default model",
+      );
       try {
         const modelConfig = await unrollPackageIdentifiersAsConfigYaml(
           [DEFAULT_MODEL_IDENTIFIER],
@@ -234,6 +284,9 @@ export class ConfigService
           throw new Error("Loaded default model contained no model block");
         }
         config.models = [...(config.models || []), defaultModel];
+        logger.debug(
+          `ConfigService: Successfully added default chat model: ${defaultModel.name || "unnamed"}`,
+        );
       } catch (e) {
         if (isHeadless) {
           throw new Error(
@@ -246,6 +299,10 @@ export class ConfigService
           );
         }
       }
+    } else {
+      logger.debug(
+        "ConfigService: Chat model already present in configuration",
+      );
     }
     return config;
   }
@@ -260,10 +317,21 @@ export class ConfigService
       injectedConfigOptions,
       agentFileState,
     } = init;
+
+    logger.debug(
+      `ConfigService: Starting load process for path: ${configPath || "default"}`,
+    );
+
     const { injected, additional } = this.getAdditionalBlocksFromOptions(
       injectedConfigOptions,
       agentFileState,
     );
+
+    if (injected.length > 0) {
+      logger.debug(
+        `ConfigService: Processing ${injected.length} injected package identifiers from CLI options`,
+      );
+    }
 
     const result = await loadConfiguration(
       authConfig,
@@ -274,10 +342,20 @@ export class ConfigService
     );
 
     const loadedConfig = result.config;
+    logger.debug(
+      `ConfigService: Successfully loaded base configuration "${loadedConfig.name || "unnamed"}" from ${result.source.type}`,
+    );
+
     const merged = mergeUnrolledAssistants(loadedConfig, additional);
+    logger.debug(
+      "ConfigService: Merged additional blocks from CLI options into configuration",
+    );
 
     const markdownRules = loadMarkdownRulesWithMetadata();
     if (markdownRules.length > 0) {
+      logger.debug(
+        `ConfigService: Found ${markdownRules.length} local markdown rules to inject`,
+      );
       const existingRuleContents = new Set(
         (merged.rules ?? []).map((r) => (typeof r === "string" ? r : r?.rule)),
       );
@@ -285,6 +363,9 @@ export class ConfigService
         (r) => !existingRuleContents.has(r.rule),
       );
       merged.rules = [...(merged.rules ?? []), ...newRules];
+      logger.debug(
+        `ConfigService: Injected ${newRules.length} new markdown rules after de-duplication`,
+      );
     }
 
     const withModel = await this.addDefaultChatModelIfNone(
@@ -295,7 +376,7 @@ export class ConfigService
     );
 
     // Config URI persistence is now handled by the streamlined loader
-    logger.debug("ConfigService initialized successfully");
+    logger.debug("ConfigService: Final configuration processed and ready");
 
     const state = {
       config: withModel,
@@ -312,8 +393,7 @@ export class ConfigService
   async doInitialize(init: ConfigServiceInit): Promise<ConfigServiceState> {
     const result = await this.loadConfig(init);
 
-    // Config URI persistence is now handled by the streamlined loader
-    logger.debug("ConfigService initialized successfully");
+    logger.debug("ConfigService: Initialized successfully");
 
     return result;
   }
@@ -322,20 +402,20 @@ export class ConfigService
    * Switch to a new configuration
    */
   async switchConfig(init: ConfigServiceInit): Promise<ConfigServiceState> {
-    logger.debug("Switching configuration", {
+    logger.debug("ConfigService: Switching configuration", {
       from: this.currentState.configPath,
       to: init.configPath,
     });
 
     try {
       const state = await this.loadConfig(init);
-      logger.debug("Configuration switched successfully", {
+      logger.debug("ConfigService: Configuration switched successfully", {
         newConfigPath: init.configPath,
       });
 
       return state;
     } catch (error: any) {
-      logger.error("Failed to switch configuration:", error);
+      logger.error("ConfigService: Failed to switch configuration:", error);
       this.emit("error", error);
       throw error;
     }
@@ -351,7 +431,7 @@ export class ConfigService
       throw new Error("No configuration path available for reload");
     }
 
-    logger.debug("Reloading current configuration");
+    logger.debug("ConfigService: Reloading current configuration");
 
     return this.switchConfig({
       ...init,
@@ -364,7 +444,7 @@ export class ConfigService
    * This triggers automatic dependent service reloads via the reactive system
    */
   async updateConfigPath(newConfigPath: string | undefined): Promise<void> {
-    logger.debug("Updating config path", {
+    logger.debug("ConfigService: Updating config path", {
       from: this.currentState.configPath,
       to: newConfigPath,
     });
@@ -402,12 +482,15 @@ export class ConfigService
       await serviceContainer.reload(SERVICE_NAMES.MODEL);
       await serviceContainer.reload(SERVICE_NAMES.MCP);
 
-      logger.debug("Configuration path updated successfully", {
+      logger.debug("ConfigService: Configuration path updated successfully", {
         newConfigPath,
         configName: result.config?.name,
       });
     } catch (error: any) {
-      logger.error("Failed to update configuration path:", error);
+      logger.error(
+        "ConfigService: Failed to update configuration path:",
+        error,
+      );
       this.emit("error", error);
       throw error;
     }

--- a/packages/config-yaml/src/load/getBlockType.ts
+++ b/packages/config-yaml/src/load/getBlockType.ts
@@ -14,21 +14,27 @@ export type BlockType = (typeof BLOCK_TYPES)[number];
 export const blockTypeSchema = z.enum(BLOCK_TYPES);
 
 export function getBlockType(block: ConfigYaml): BlockType | undefined {
+  let type: BlockType | undefined;
   if (block.context?.length) {
-    return "context";
+    type = "context";
   } else if (block.models?.length) {
-    return "models";
+    type = "models";
   } else if (block.docs?.length) {
-    return "docs";
+    type = "docs";
   } else if (block.mcpServers?.length) {
-    return "mcpServers";
+    type = "mcpServers";
   } else if (block.data?.length) {
-    return "data";
+    type = "data";
   } else if (block.rules?.length) {
-    return "rules";
+    type = "rules";
   } else if (block.prompts?.length) {
-    return "prompts";
+    type = "prompts";
   } else {
-    return undefined;
+    type = undefined;
   }
+
+  console.debug(
+    `getBlockType: Categorized block "${block.name || "unnamed"}" as type: ${type || "none"}`,
+  );
+  return type;
 }

--- a/packages/config-yaml/src/load/unroll.test.ts
+++ b/packages/config-yaml/src/load/unroll.test.ts
@@ -2,11 +2,13 @@ import { PackageIdentifier } from "../interfaces/slugs.js";
 import {
   fillTemplateVariables,
   getTemplateVariables,
-  parseMarkdownRuleOrAssistantUnrolled,
+  parseMarkdownContentOrAssistantUnrolled,
   replaceInputsWithSecrets,
+  unrollBlocks,
 } from "./unroll.js";
+import { ConfigYaml } from "../schemas/index.js";
 
-describe("parseMarkdownRuleOrAssistantUnrolled tests", () => {
+describe("parseMarkdownContentOrAssistantUnrolled tests", () => {
   it("parses valid YAML content as AssistantUnrolled", () => {
     const mockId: PackageIdentifier = {
       uriType: "file",
@@ -21,7 +23,7 @@ models:
     model: modelname
     provider: ollama
 `;
-    const result = parseMarkdownRuleOrAssistantUnrolled(yamlContent, mockId);
+    const result = parseMarkdownContentOrAssistantUnrolled(yamlContent, mockId);
     expect(result).toHaveProperty("name", "Test Agent");
     expect(result).toHaveProperty("version", "1.0.0");
     expect(result.models?.length).toBe(1);
@@ -40,7 +42,7 @@ description: my rule description
 ---
 This is the rule 
 `;
-    const result = parseMarkdownRuleOrAssistantUnrolled(
+    const result = parseMarkdownContentOrAssistantUnrolled(
       markdownContent,
       mockId,
     );
@@ -71,17 +73,20 @@ model: # should be models
     provider: ollama
 `;
     expect(() =>
-      parseMarkdownRuleOrAssistantUnrolled(invalidContent, mockId),
+      parseMarkdownContentOrAssistantUnrolled(invalidContent, mockId),
     ).toThrow();
   });
 
-  it("Every non-YAML file is a rule", () => {
+  it("wraps non-YAML content in a 'rules' array by default when no section hint is provided", () => {
     const mockId: PackageIdentifier = {
       uriType: "file",
       fileUri: "file:///foo/bar",
     };
     const dubiousContent = `This is not \nproper #YAML#`;
-    const result = parseMarkdownRuleOrAssistantUnrolled(dubiousContent, mockId);
+    const result = parseMarkdownContentOrAssistantUnrolled(
+      dubiousContent,
+      mockId,
+    );
     expect(result).toHaveProperty("name");
     expect(result).toHaveProperty("version");
     expect(Array.isArray(result.rules)).toBe(true);
@@ -91,6 +96,27 @@ model: # should be models
     expect(rule).toHaveProperty("name", "foo/bar");
     expect(rule).toHaveProperty("globs", undefined);
     expect(rule).toHaveProperty("rule", dubiousContent);
+  });
+
+  it("wraps non-YAML content in a 'prompts' array when 'prompts' section hint is provided", () => {
+    const mockId: PackageIdentifier = {
+      uriType: "file",
+      fileUri: "file:///foo/bar",
+    };
+    const dubiousContent = `This is not \nproper #YAML#`;
+    const result = parseMarkdownContentOrAssistantUnrolled(
+      dubiousContent,
+      mockId,
+      "prompts",
+    );
+    expect(result).toHaveProperty("name");
+    expect(result).toHaveProperty("version");
+    expect(Array.isArray(result.prompts)).toBe(true);
+    expect(result.prompts).toBeDefined();
+    expect(result.prompts!.length).toBe(1);
+    const prompt = result.prompts![0];
+    expect(prompt).toHaveProperty("name", "foo/bar");
+    expect(prompt).toHaveProperty("prompt", dubiousContent);
   });
 });
 
@@ -274,6 +300,39 @@ data:
     expect(result).not.toContain("inputs.style");
     expect(result).not.toContain("inputs.dbHost");
     expect(result).not.toContain("inputs.dbPassword");
+  });
+  it("handles markdown files in prompts section correctly", async () => {
+    const registry = {
+      getContent: async () => `---
+name: Scotty
+---
+You are Lt. Commander Montgomery Scott (Scotty), a fictional character from the Star Trek franchise, renowned for his engineering skills and for his distinct scottish accent and speaking style.`,
+    };
+
+    const config: ConfigYaml = {
+      name: "Test Assistant",
+      version: "1.0.0",
+      prompts: [
+        {
+          uses: "file://prompts/scotty.md",
+        },
+      ],
+    };
+
+    const result = await unrollBlocks(
+      config,
+      registry as any,
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expect(result.config?.prompts).toBeDefined();
+    expect(result.config?.prompts?.length).toBe(1);
+    expect(result.config?.prompts?.[0]?.name).toBe("Scotty");
+    expect(result.config?.prompts?.[0]?.prompt).toBe(
+      "You are Lt. Commander Montgomery Scott (Scotty), a fictional character from the Star Trek franchise, renowned for his engineering skills and for his distinct scottish accent and speaking style.",
+    );
   });
 });
 

--- a/packages/config-yaml/src/load/unroll.ts
+++ b/packages/config-yaml/src/load/unroll.ts
@@ -284,7 +284,7 @@ export async function unrollAssistantFromContent(
   options: UnrollAssistantOptions,
 ): Promise<ConfigResult<AssistantUnrolled>> {
   // Parse string to Zod-validated YAML
-  let parsedYaml = parseMarkdownRuleOrConfigYaml(rawYaml, id);
+  let parsedYaml = parseMarkdownContentOrConfigYaml(rawYaml, id);
 
   // Unroll blocks and convert their secrets to FQSNs
   const {
@@ -417,6 +417,10 @@ export async function unrollBlocks(
       return { section, blocks: null };
     }
 
+    console.debug(
+      `unrollBlocks: Processing section "${section}" with ${assistant[section].length} items`,
+    );
+
     // Process all blocks in this section in parallel
     const blockPromises = assistant[section].map(
       async (unrolledBlock, index) => {
@@ -424,6 +428,9 @@ export async function unrollBlocks(
         if ("uses" in unrolledBlock) {
           try {
             const blockIdentifier = decodePackageIdentifier(unrolledBlock.uses);
+            console.debug(
+              `unrollBlocks: Resolving "uses" block: ${JSON.stringify(unrolledBlock.uses)}`,
+            );
 
             if (
               !isPackageAllowed(
@@ -448,15 +455,22 @@ export async function unrollBlocks(
               blockIdentifier,
               unrolledBlock.with,
               registry,
+              section,
             );
             const block = blockConfigYaml[section]?.[0];
             if (block) {
+              console.debug(
+                `unrollBlocks: Successfully extracted item for "${section}" from resolved block`,
+              );
               return {
                 index,
                 block: mergeOverrides(block, unrolledBlock.override ?? {}),
                 error: null,
               };
             }
+            console.debug(
+              `unrollBlocks: WARNING - Section "${section}" not found in resolved block config`,
+            );
             return { index, block: null, error: null };
           } catch (err) {
             let msg = "";
@@ -514,6 +528,7 @@ export async function unrollBlocks(
                 decodePackageIdentifier(rule.uses),
                 rule.with,
                 registry,
+                "rules",
               );
               const block = blockConfigYaml.rules?.[0];
               return { index, rule: block || null, error: null };
@@ -569,7 +584,7 @@ export async function unrollBlocks(
                 ]),
               },
             );
-            const resolvedBlock = parseMarkdownRuleOrConfigYaml(
+            const resolvedBlock = parseMarkdownContentOrConfigYaml(
               blockConfigYamlWithFQSNs,
               injectBlock,
             );
@@ -731,6 +746,7 @@ export async function resolveBlock(
   id: PackageIdentifier,
   inputs: Record<string, string | undefined> | undefined,
   registry: Registry,
+  sectionHint?: string,
 ): Promise<AssistantUnrolled> {
   // Retrieve block raw yaml
   const rawYaml = await registry.getContent(id);
@@ -764,7 +780,11 @@ export async function resolveBlock(
   }
 
   // Add source slug for mcp servers
-  const parsed = parseMarkdownRuleOrAssistantUnrolled(templatedYaml, id);
+  const parsed = parseMarkdownContentOrAssistantUnrolled(
+    templatedYaml,
+    id,
+    sectionHint,
+  );
   if (
     id.uriType === "slug" &&
     "mcpServers" in parsed &&
@@ -776,24 +796,37 @@ export async function resolveBlock(
   return parsed;
 }
 
-export function parseMarkdownRuleOrAssistantUnrolled(
+export function parseMarkdownContentOrAssistantUnrolled(
   content: string,
   id: PackageIdentifier,
+  sectionHint?: string,
 ): AssistantUnrolled {
-  return parseYamlOrMarkdownRule<AssistantUnrolled>(content, id, parseBlock);
+  return parseYamlOrMarkdownContent<AssistantUnrolled>(
+    content,
+    id,
+    parseBlock,
+    sectionHint,
+  );
 }
 
-function parseMarkdownRuleOrConfigYaml(
+function parseMarkdownContentOrConfigYaml(
   content: string,
   id: PackageIdentifier,
+  sectionHint?: string,
 ): ConfigYaml {
-  return parseYamlOrMarkdownRule<ConfigYaml>(content, id, parseConfigYaml);
+  return parseYamlOrMarkdownContent<ConfigYaml>(
+    content,
+    id,
+    parseConfigYaml,
+    sectionHint,
+  );
 }
 
-function parseYamlOrMarkdownRule<T>(
+function parseYamlOrMarkdownContent<T>(
   content: string,
   id: PackageIdentifier,
   parseYamlFn: (content: string) => T,
+  sectionHint?: string,
 ): T {
   let parsedYaml: T;
   try {
@@ -806,11 +839,33 @@ function parseYamlOrMarkdownRule<T>(
     ) {
       throw yamlError;
     }
-    // If YAML parsing fails, try parsing as markdown rule
+    // If YAML parsing fails, try parsing as markdown rule/prompt
     try {
       const rule = markdownToRule(content, id);
-      // Convert the rule object to the expected format
-      parsedYaml = { name: rule.name, version: "1.0.0", rules: [rule] } as T;
+
+      if (sectionHint === "prompts") {
+        console.debug(
+          `parseYamlOrMarkdownContent: Wrapping markdown in "prompts" for block: ${id.uriType === "file" ? id.fileUri : id.fullSlug.packageSlug}`,
+        );
+        parsedYaml = {
+          name: rule.name,
+          version: "1.0.0",
+          prompts: [
+            {
+              name: rule.name,
+              description: rule.description,
+              prompt: rule.rule,
+              invokable: rule.invokable,
+            },
+          ],
+        } as T;
+      } else {
+        console.debug(
+          `parseYamlOrMarkdownContent: Wrapping markdown in "rules" for block: ${id.uriType === "file" ? id.fileUri : id.fullSlug.packageSlug}`,
+        );
+        // Convert the rule object to the expected format
+        parsedYaml = { name: rule.name, version: "1.0.0", rules: [rule] } as T;
+      }
     } catch (markdownError) {
       // If both fail, throw the original YAML error
       throw yamlError;

--- a/packages/config-yaml/src/registryClient.ts
+++ b/packages/config-yaml/src/registryClient.ts
@@ -26,13 +26,22 @@ export class RegistryClient implements Registry {
   async getContent(id: PackageIdentifier): Promise<string> {
     // Return pre-read content if available (for vscode-remote:// URIs in WSL)
     if (id.uriType === "file" && id.content !== undefined) {
+      console.debug(
+        `RegistryClient: Using pre-read content for file: ${id.fileUri}`,
+      );
       return id.content;
     }
 
     switch (id.uriType) {
       case "file":
+        console.debug(
+          `RegistryClient: Getting content from file: ${id.fileUri}`,
+        );
         return this.getContentFromFilePath(id.fileUri);
       case "slug":
+        console.debug(
+          `RegistryClient: Getting content from slug: ${id.fullSlug.ownerSlug}/${id.fullSlug.packageSlug}`,
+        );
         return this.getContentFromSlug(id.fullSlug);
       default:
         throw new Error(
@@ -42,38 +51,72 @@ export class RegistryClient implements Registry {
   }
 
   private getContentFromFilePath(filepath: string): string {
-    if (filepath.startsWith("file://")) {
-      // For Windows file:///C:/path/to/file, we need to handle it properly
-      // On other systems, we might have file:///path/to/file
-      return fs.readFileSync(new URL(filepath), "utf8");
-    } else if (path.isAbsolute(filepath)) {
-      return fs.readFileSync(filepath, "utf8");
-    } else {
-      // Try to resolve relative to current working directory first
-      const resolvedPath = path.resolve(filepath);
-      if (fs.existsSync(resolvedPath)) {
-        return fs.readFileSync(resolvedPath, "utf8");
+    try {
+      if (filepath.startsWith("file://")) {
+        // For Windows file:///C:/path/to/file, we need to handle it properly
+        // On other systems, we might have file:///path/to/file
+        console.debug(`RegistryClient: Reading file from URL: ${filepath}`);
+        const content = fs.readFileSync(new URL(filepath), "utf8");
+        console.debug(
+          `RegistryClient: Successfully read ${content.length} bytes from URL`,
+        );
+        return content;
+      } else if (path.isAbsolute(filepath)) {
+        console.debug(`RegistryClient: Reading absolute path: ${filepath}`);
+        const content = fs.readFileSync(filepath, "utf8");
+        console.debug(
+          `RegistryClient: Successfully read ${content.length} bytes from absolute path`,
+        );
+        return content;
+      } else {
+        // Try to resolve relative to current working directory first
+        const resolvedPath = path.resolve(filepath);
+        if (fs.existsSync(resolvedPath)) {
+          console.debug(
+            `RegistryClient: Reading path relative to CWD: ${resolvedPath}`,
+          );
+          const content = fs.readFileSync(resolvedPath, "utf8");
+          console.debug(
+            `RegistryClient: Successfully read ${content.length} bytes from CWD-relative path`,
+          );
+          return content;
+        }
+        // Fall back to rootPath if file doesn't exist relative to cwd
+        if (this.rootPath) {
+          const joinedPath = path.join(this.rootPath, filepath);
+          console.debug(
+            `RegistryClient: Reading path relative to rootPath (${this.rootPath}): ${joinedPath}`,
+          );
+          const content = fs.readFileSync(joinedPath, "utf8");
+          console.debug(
+            `RegistryClient: Successfully read ${content.length} bytes from rootPath-relative path`,
+          );
+          return content;
+        }
+        throw new Error("No rootPath provided for relative file path");
       }
-      // Fall back to rootPath if file doesn't exist relative to cwd
-      if (this.rootPath) {
-        return fs.readFileSync(path.join(this.rootPath, filepath), "utf8");
-      }
-      throw new Error("No rootPath provided for relative file path");
+    } catch (error) {
+      console.error(
+        `RegistryClient: Error reading file at ${filepath}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      throw error;
     }
   }
 
   private async getContentFromSlug(fullSlug: FullSlug): Promise<string> {
-    const response = await fetch(
-      `${this.apiBase}registry/v1/${fullSlug.ownerSlug}/${fullSlug.packageSlug}/${fullSlug.versionSlug}`,
-      {
-        headers: {
-          ...(this.accessToken
-            ? { Authorization: `Bearer ${this.accessToken}` }
-            : {}),
-        },
+    const url = `${this.apiBase}registry/v1/${fullSlug.ownerSlug}/${fullSlug.packageSlug}/${fullSlug.versionSlug}`;
+    console.debug(`RegistryClient: Fetching content from slug URL: ${url}`);
+    const response = await fetch(url, {
+      headers: {
+        ...(this.accessToken
+          ? { Authorization: `Bearer ${this.accessToken}` }
+          : {}),
       },
-    );
+    });
     const data = await response.json();
+    console.debug(
+      `RegistryClient: Successfully fetched ${data.content?.length || 0} bytes from slug`,
+    );
     return data.content;
   }
 }


### PR DESCRIPTION
## Description

This PR resolves the issue where markdown files referenced in the `prompts` section of `config.yaml` were incorrectly identified as "Rules" and subsequently dropped from the configuration.

The fix involves introducing a `sectionHint` to the configuration unrolling logic. When a block is being resolved for the `prompts` section, the parser is now informed of this context. If the content is markdown, it is correctly wrapped in a `prompts` array instead of the default `rules` array.
This also includes a series of logging enhancements across the `extensions/cli` and `packages/config-yaml` modules. The goal is to provide full transparency into the configuration loading and unrolling process, enabling easier debugging of complex issues like missing prompts or unresolved identifiers.


### Key Changes:
- Updated `parseYamlOrMarkdownContent` (and its wrapper `parseMarkdownContentOrAssistantUnrolled`) to accept an optional `sectionHint`.
- Modified `unrollBlocks` to pass the current section name (e.g., "prompts", "rules") as a hint when resolving blocks.
- Added a new test case in `packages/config-yaml/src/load/unroll.test.ts` to verify that markdown files in the `prompts` section are correctly parsed and preserved.
- Refactored parsing function names for better clarity (e.g., `parseMarkdownRuleOrAssistantUnrolled` -> `parseMarkdownContentOrAssistantUnrolled`).
- Added extensive debug logging across the configuration loading pipeline to improve observability of file resolution and block categorization.

**Architectural Logging Upgrades**

- **Console Routing:** Updated `extensions/cli/src/init.ts` to capture and route all `console.debug` calls to the Winston logger when `--verbose` is enabled. This allows the CLI to capture debug logs from shared packages (like `config-yaml`) without them needing a direct dependency on the CLI's logger.
- **Verbose Activation:** Linked the `--verbose` flag to the dynamic activation of this routing in `extensions/cli/src/index.ts`.
**CLI Service Transparency (`extensions/cli/src/services`)**

- **ConfigService:** Added comprehensive debug logs for the entire configuration lifecycle:
  - Initial load start and completion.
  - Path updates and reactive service reloads.
  - Granular processing of models, MCP servers, rules, and prompts.
  - Detection of source (CLI flag, saved URI, default config).
  - Success/Failure of injecting default fallback models.

**Core Configuration Tracing (`packages/config-yaml`)**

- **RegistryClient:** Added granular logs for file resolution, including:
  - URI type (file vs. slug).
  - Resolution strategy (absolute, CWD-relative, or rootPath-relative).
  - Read success confirmation and payload size.
- **Unrolling Logic:** Updated `unroll.ts` and `getBlockType.ts` to log:
  - Start of section processing (models, prompts, etc.).
  - Every attempt to resolve a `uses` directive.
  - Explicit warnings when a resolved block fails to contain the expected section (directly instrumental in identifying the Prompt Parsing bug).
  - Block categorization outcomes.
  - 
## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ N/A - Logic fix for configuration loading ]

## Tests
Verified with `node extensions/cli/dist/cn.js --verbose`:

- Logs now correctly show the sequence from `RegistryClient` reading a file to `unrollBlocks` processing the result.
- Successfully identified a "silent drop" bug in the prompt processing logic via the new `WARNING - Section not found` log message.

- Added unit test in `packages/config-yaml/src/load/unroll.test.ts`: `handles markdown files in prompts section correctly`.
- Verified that `parseMarkdownContentOrAssistantUnrolled` wraps non-YAML content in a `prompts` array when the `prompts` hint is provided.
- Manually verified (via logs) that `file://` URIs pointing to `.md` files in the `prompts` section are now correctly resolved and applied.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #12412: markdown files referenced in the `prompts` section are now parsed as prompts (not rules) and preserved. Also improves file resolution for config sources and adds detailed debug logging across the load/unroll pipeline.

- **Bug Fixes**
  - Added `sectionHint` to unrolling and parsing so markdown under `prompts` is wrapped into `prompts` (not `rules`); `unrollBlocks` now passes the current section.
  - Improved file/URI resolution and error handling in `packages/config-yaml` `RegistryClient` (absolute, CWD-relative, and `rootPath`-relative reads).
  - Clear warnings when a resolved block lacks the expected section; added categorization logs in `getBlockType`.
  - Ensured default chat model injection is attempted if none is present; added warnings for duplicate tools/rules.
  - New test verifies markdown files in `prompts` are correctly parsed and kept.

- **Refactors**
  - Renamed parsing helpers: `parseMarkdownRuleOrAssistantUnrolled` -> `parseMarkdownContentOrAssistantUnrolled`; generalized YAML/markdown parsing.
  - Routed `console.debug` to the CLI logger when `--verbose` is enabled; added granular debug logs in `extensions/cli` and `packages/config-yaml`.
  - Updated build alias to use `@continuedev/config-yaml` package root instead of `dist/index.js`.

<sup>Written for commit c1acdfeed309842fa1a61e9eb7eddc6a15af249d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

