### PR TITLE
filter reasoning tokens out of Edit/Apply output and chat utility calls

### DIFF
--- a/core/commands/slash/built-in-legacy/commit.ts
+++ b/core/commands/slash/built-in-legacy/commit.ts
@@ -1,5 +1,5 @@
 import { SlashCommand } from "../../../index.js";
-import { renderChatMessage } from "../../../util/messageContent.js";
+import { renderChatMessageWithoutThinking } from "../../../util/messageContent.js";
 
 const CommitMessageCommand: SlashCommand = {
   name: "commit",
@@ -18,7 +18,7 @@ const CommitMessageCommand: SlashCommand = {
       [{ role: "user", content: prompt }],
       abortController.signal,
     )) {
-      yield renderChatMessage(chunk);
+      yield renderChatMessageWithoutThinking(chunk);
     }
   },
 };

--- a/core/commands/slash/built-in-legacy/draftIssue.ts
+++ b/core/commands/slash/built-in-legacy/draftIssue.ts
@@ -1,6 +1,6 @@
 import { ChatMessage, SlashCommand } from "../../../index.js";
 import { removeQuotesAndEscapes } from "../../../util/index.js";
-import { renderChatMessage } from "../../../util/messageContent.js";
+import { renderChatMessageWithoutThinking } from "../../../util/messageContent.js";
 
 const PROMPT = (
   input: string,
@@ -49,7 +49,7 @@ const DraftIssueCommand: SlashCommand = {
       abortController.signal,
     )) {
       body += chunk.content;
-      yield renderChatMessage(chunk);
+      yield renderChatMessageWithoutThinking(chunk);
     }
 
     const url = `${params.repositoryUrl}/issues/new?title=${encodeURIComponent(

--- a/core/commands/slash/built-in-legacy/onboard.ts
+++ b/core/commands/slash/built-in-legacy/onboard.ts
@@ -3,7 +3,7 @@ import ignore from "ignore";
 import type { FileType, IDE, SlashCommand } from "../../..";
 import { getGlobalContinueIgArray } from "../../../indexing/continueignore";
 import { DEFAULT_IGNORE, gitIgArrayFromFile } from "../../../indexing/ignore";
-import { renderChatMessage } from "../../../util/messageContent";
+import { renderChatMessageWithoutThinking } from "../../../util/messageContent";
 import {
   findUriInDirs,
   getUriPathBasename,
@@ -48,7 +48,7 @@ const OnboardSlashCommand: SlashCommand = {
       [{ role: "user", content: prompt }],
       abortController.signal,
     )) {
-      yield renderChatMessage(chunk);
+      yield renderChatMessageWithoutThinking(chunk);
     }
   },
 };

--- a/core/commands/slash/built-in-legacy/review.ts
+++ b/core/commands/slash/built-in-legacy/review.ts
@@ -1,5 +1,5 @@
 import { ChatMessage, SlashCommand } from "../../../index.js";
-import { renderChatMessage } from "../../../util/messageContent.js";
+import { renderChatMessageWithoutThinking } from "../../../util/messageContent.js";
 
 const prompt = `
      Review the following code, focusing on Readability, Maintainability, Code Smells, Speed, and Memory Performance. Provide feedback with these guidelines:
@@ -47,7 +47,7 @@ const ReviewMessageCommand: SlashCommand = {
       [{ role: "user", content: content }],
       abortController.signal,
     )) {
-      yield renderChatMessage(chunk);
+      yield renderChatMessageWithoutThinking(chunk);
     }
   },
 };

--- a/core/diff/util.ts
+++ b/core/diff/util.ts
@@ -1,7 +1,7 @@
 import { distance } from "fastest-levenshtein";
 
 import { ChatMessage } from "../index.js";
-import { renderChatMessage } from "../util/messageContent.js";
+import { renderChatMessageWithoutThinking } from "../util/messageContent.js";
 
 export type LineStream = AsyncGenerator<string>;
 
@@ -108,7 +108,9 @@ export async function* streamLines(
   try {
     for await (const update of streamCompletion) {
       const chunk =
-        typeof update === "string" ? update : renderChatMessage(update);
+        typeof update === "string"
+          ? update
+          : renderChatMessageWithoutThinking(update);
       buffer += chunk;
       const lines = buffer.split("\n");
       buffer = lines.pop() ?? "";

--- a/core/edit/recursiveStream.ts
+++ b/core/edit/recursiveStream.ts
@@ -7,7 +7,7 @@ import {
 } from "..";
 import { DEFAULT_MAX_TOKENS } from "../llm/constants";
 import { countTokens } from "../llm/countTokens";
-import { renderChatMessage } from "../util/messageContent";
+import { renderChatMessageWithoutThinking } from "../util/messageContent";
 import { APPLY_UNIQUE_TOKEN } from "./constants.js";
 
 const INFINITE_STREAM_SAFETY = 0.9;
@@ -85,7 +85,7 @@ export async function* recursiveStream(
 
     for await (const chunk of generator) {
       yield chunk;
-      const rendered = renderChatMessage(chunk);
+      const rendered = renderChatMessageWithoutThinking(chunk);
       buffer += rendered;
       totalTokens += countTokens(chunk.content);
 

--- a/core/edit/recursiveStream.ts
+++ b/core/edit/recursiveStream.ts
@@ -7,7 +7,7 @@ import {
 } from "..";
 import { DEFAULT_MAX_TOKENS } from "../llm/constants";
 import { countTokens } from "../llm/countTokens";
-import { renderChatMessageWithoutThinking } from "../util/messageContent";
+import { renderChatMessage } from "../util/messageContent";
 import { APPLY_UNIQUE_TOKEN } from "./constants.js";
 
 const INFINITE_STREAM_SAFETY = 0.9;
@@ -85,7 +85,7 @@ export async function* recursiveStream(
 
     for await (const chunk of generator) {
       yield chunk;
-      const rendered = renderChatMessageWithoutThinking(chunk);
+      const rendered = renderChatMessage(chunk);
       buffer += rendered;
       totalTokens += countTokens(chunk.content);
 

--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -35,7 +35,10 @@ import { isAbortError } from "../util/isAbortError.js";
 import { isLemonadeInstalled } from "../util/lemonadeHelper.js";
 import { Logger } from "../util/Logger.js";
 import mergeJson from "../util/merge.js";
-import { renderChatMessage } from "../util/messageContent.js";
+import {
+  renderChatMessage,
+  renderChatMessageWithoutThinking,
+} from "../util/messageContent.js";
 import { isOllamaInstalled } from "../util/ollamaHelper.js";
 import { TokensBatchingService } from "../util/TokensBatchingService.js";
 import { withExponentialBackoff } from "../util/withExponentialBackoff.js";
@@ -964,7 +967,7 @@ export abstract class BaseLLM implements ILLM {
   ) {
     let completion = "";
     for await (const message of this.streamChat(messages, signal, options)) {
-      completion += renderChatMessage(message);
+      completion += renderChatMessageWithoutThinking(message);
     }
     return { role: "assistant" as const, content: completion };
   }

--- a/core/llm/llms/Anthropic.ts
+++ b/core/llm/llms/Anthropic.ts
@@ -27,7 +27,11 @@ import {
   Usage,
 } from "../../index.js";
 import { safeParseToolCallArgs } from "../../tools/parseArgs.js";
-import { renderChatMessage, stripImages } from "../../util/messageContent.js";
+import {
+  renderChatMessage,
+  renderChatMessageWithoutThinking,
+  stripImages,
+} from "../../util/messageContent.js";
 import { extractBase64FromDataUrl } from "../../util/url.js";
 import { DEFAULT_REASONING_TOKENS } from "../constants.js";
 import { BaseLLM } from "../index.js";
@@ -258,7 +262,7 @@ class Anthropic extends BaseLLM {
   ): AsyncGenerator<string> {
     const messages = [{ role: "user" as const, content: prompt }];
     for await (const update of this._streamChat(messages, signal, options)) {
-      yield renderChatMessage(update);
+      yield renderChatMessageWithoutThinking(update);
     }
   }
 

--- a/core/llm/llms/Bedrock.ts
+++ b/core/llm/llms/Bedrock.ts
@@ -20,7 +20,10 @@ import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
 import type { CompletionOptions } from "../../index.js";
 import { ChatMessage, Chunk, LLMOptions, MessageContent } from "../../index.js";
 import { safeParseToolCallArgs } from "../../tools/parseArgs.js";
-import { renderChatMessage, stripImages } from "../../util/messageContent.js";
+import {
+  renderChatMessageWithoutThinking,
+  stripImages,
+} from "../../util/messageContent.js";
 import { parseDataUrl } from "../../util/url.js";
 import { BaseLLM } from "../index.js";
 import { PROVIDER_TOOL_SUPPORT } from "../toolSupport.js";
@@ -100,7 +103,7 @@ class Bedrock extends BaseLLM {
   ): AsyncGenerator<string> {
     const messages = [{ role: "user" as const, content: prompt }];
     for await (const update of this._streamChat(messages, signal, options)) {
-      yield renderChatMessage(update);
+      yield renderChatMessageWithoutThinking(update);
     }
   }
 

--- a/core/llm/llms/Cloudflare.ts
+++ b/core/llm/llms/Cloudflare.ts
@@ -1,6 +1,6 @@
 import { streamSse } from "@continuedev/fetch";
 import { ChatMessage, CompletionOptions } from "../../index.js";
-import { renderChatMessage } from "../../util/messageContent.js";
+import { renderChatMessageWithoutThinking } from "../../util/messageContent.js";
 import { BaseLLM } from "../index.js";
 
 export default class Cloudflare extends BaseLLM {
@@ -59,7 +59,7 @@ export default class Cloudflare extends BaseLLM {
       signal,
       options,
     )) {
-      yield renderChatMessage(chunk);
+      yield renderChatMessageWithoutThinking(chunk);
     }
   }
 }

--- a/core/llm/llms/Cohere.ts
+++ b/core/llm/llms/Cohere.ts
@@ -5,7 +5,10 @@ import {
   CompletionOptions,
   LLMOptions,
 } from "../../index.js";
-import { renderChatMessage, stripImages } from "../../util/messageContent.js";
+import {
+  renderChatMessageWithoutThinking,
+  stripImages,
+} from "../../util/messageContent.js";
 import { BaseLLM } from "../index.js";
 import { DEFAULT_REASONING_TOKENS } from "../constants.js";
 
@@ -148,7 +151,7 @@ class Cohere extends BaseLLM {
   ): AsyncGenerator<string> {
     const messages = [{ role: "user" as const, content: prompt }];
     for await (const update of this._streamChat(messages, signal, options)) {
-      yield renderChatMessage(update);
+      yield renderChatMessageWithoutThinking(update);
     }
   }
 

--- a/core/llm/llms/CustomLLM.ts
+++ b/core/llm/llms/CustomLLM.ts
@@ -1,5 +1,5 @@
 import { ChatMessage, CompletionOptions, CustomLLM } from "../../index.js";
-import { renderChatMessage } from "../../util/messageContent.js";
+import { renderChatMessageWithoutThinking } from "../../util/messageContent.js";
 import { BaseLLM } from "../index.js";
 
 class CustomLLMClass extends BaseLLM {
@@ -76,7 +76,7 @@ class CustomLLMClass extends BaseLLM {
         if (typeof content === "string") {
           yield content;
         } else {
-          yield renderChatMessage(content);
+          yield renderChatMessageWithoutThinking(content);
         }
       }
     } else {

--- a/core/llm/llms/Flowise.ts
+++ b/core/llm/llms/Flowise.ts
@@ -1,7 +1,7 @@
 import socketIOClient, { Socket } from "socket.io-client";
 
 import { ChatMessage, CompletionOptions, LLMOptions } from "../../index.js";
-import { renderChatMessage } from "../../util/messageContent.js";
+import { renderChatMessageWithoutThinking } from "../../util/messageContent.js";
 import { BaseLLM } from "../index.js";
 
 interface IFlowiseApiOptions {
@@ -121,7 +121,7 @@ class Flowise extends BaseLLM {
   ): AsyncGenerator<string> {
     const message: ChatMessage = { role: "user", content: prompt };
     for await (const chunk of this._streamChat([message], signal, options)) {
-      yield renderChatMessage(chunk);
+      yield renderChatMessageWithoutThinking(chunk);
     }
   }
 

--- a/core/llm/llms/Gemini.ts
+++ b/core/llm/llms/Gemini.ts
@@ -10,7 +10,10 @@ import {
   ToolCallDelta,
 } from "../../index.js";
 import { safeParseToolCallArgs } from "../../tools/parseArgs.js";
-import { renderChatMessage, stripImages } from "../../util/messageContent.js";
+import {
+  renderChatMessageWithoutThinking,
+  stripImages,
+} from "../../util/messageContent.js";
 import { extractBase64FromDataUrl } from "../../util/url.js";
 import { BaseLLM } from "../index.js";
 import { LlmApiRequestType } from "../openaiTypeConverters.js";
@@ -89,7 +92,7 @@ class Gemini extends BaseLLM {
       signal,
       options,
     )) {
-      yield renderChatMessage(message);
+      yield renderChatMessageWithoutThinking(message);
     }
   }
 

--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -16,7 +16,10 @@ import {
   LLMOptions,
   Tool,
 } from "../../index.js";
-import { renderChatMessage } from "../../util/messageContent.js";
+import {
+  renderChatMessage,
+  renderChatMessageWithoutThinking,
+} from "../../util/messageContent.js";
 import { BaseLLM } from "../index.js";
 import {
   fromChatCompletionChunk,
@@ -430,7 +433,7 @@ class OpenAI extends BaseLLM {
       signal,
       options,
     )) {
-      yield renderChatMessage(chunk);
+      yield renderChatMessageWithoutThinking(chunk);
     }
   }
 

--- a/core/llm/llms/VertexAI.ts
+++ b/core/llm/llms/VertexAI.ts
@@ -2,7 +2,10 @@ import { AuthClient, GoogleAuth, JWT, auth } from "google-auth-library";
 
 import { streamResponse, streamSse } from "@continuedev/fetch";
 import { ChatMessage, CompletionOptions, LLMOptions } from "../../index.js";
-import { renderChatMessage, stripImages } from "../../util/messageContent.js";
+import {
+  renderChatMessageWithoutThinking,
+  stripImages,
+} from "../../util/messageContent.js";
 import { BaseLLM } from "../index.js";
 
 import { LlmApiRequestType } from "../openaiTypeConverters.js";
@@ -489,7 +492,7 @@ class VertexAI extends BaseLLM {
       signal,
       options,
     )) {
-      yield renderChatMessage(message);
+      yield renderChatMessageWithoutThinking(message);
     }
   }
 

--- a/core/util/historyUtils.ts
+++ b/core/util/historyUtils.ts
@@ -5,7 +5,7 @@ import path from "path";
 
 import { languageForFilepath } from "../autocomplete/constants/AutocompleteLanguageInfo.js";
 import { ChatMessage, IDE } from "../index.js";
-import { renderChatMessage } from "../util/messageContent.js";
+import { renderChatMessageWithoutThinking } from "../util/messageContent.js";
 import { getContinueGlobalPath } from "../util/paths.js";
 
 // If useful elsewhere, helper funcs should move to core/util/index.ts or similar
@@ -45,7 +45,7 @@ export function toMarkDown(history: ChatMessage[], time?: Date): string {
   let content = `### [Continue](https://continue.dev) session transcript\n Exported: ${time.toLocaleString()}`;
 
   for (const msg of history) {
-    let msgText = renderChatMessage(msg);
+    let msgText = renderChatMessageWithoutThinking(msg);
     if (!msgText) {
       continue; // Skip messages without content
     }

--- a/core/util/messageContent.ts
+++ b/core/util/messageContent.ts
@@ -17,6 +17,11 @@ export function stripImages(messageContent: MessageContent): string {
     .join("\n");
 }
 
+export function renderChatMessageWithoutThinking(message: ChatMessage): string {
+  if (message.role === "thinking") return "";
+  return renderChatMessage(message);
+}
+
 export function renderChatMessage(message: ChatMessage): string {
   switch (message?.role) {
     case "user":


### PR DESCRIPTION
## Description

### Problem

When using a reasoning model (Anthropic extended thinking, DeepSeek R1, xAI Grok, or any provider that emits `delta.reasoning_content` / `thinking_delta`) for **Edit (Cmd+I)** or **Apply**, the model's internal reasoning is written into the file alongside the actual code changes.

Continue converts all provider-specific reasoning formats into an internal `ChatMessage` with `role: "thinking"`. The bug is that `renderChatMessage()` in `core/util/messageContent.ts` handles `"thinking"` in the same switch branch as `"assistant"`:

```ts
case "thinking":   // ← falls through to the same return as "assistant"
case "assistant":
  return stripImages(message.content);
```

This makes thinking content indistinguishable from code output at every point downstream. The existing post-processing filters in `streamDiffLines.ts` (`filterEnglishLinesAtStart`, `filterCodeBlockLines`, etc.) operate only on string content and have no awareness of message roles — they provide no meaningful protection. The `reasoning: false` LLM option is a best-effort hint to the provider and does not suppress chunks that have already arrived.

The result: reasoning text enters the diff pipeline tagged as `DiffLine { type: "new" }` and is accepted into the file as code.

This is tracked in GitHub issue **#11590** ("Edit Model failed to apply, but just paste its reasoning process to my code").

The same root cause affects several internal one-shot utility calls that use `BaseLLM.chat()` — a non-streaming wrapper around `streamChat()` that accumulates all chunks into a single completion string. Without filtering, thinking content is silently merged into that string and corrupts the results of: chat title generation, repo map summarisation, context retrieval tool selection, next-edit prediction, and conversation compaction.

---

### Fix

#### New function

A new `renderChatMessageWithoutThinking()` is added to `core/util/messageContent.ts`:

```ts
export function renderChatMessageWithoutThinking(message: ChatMessage): string {
  if (message.role === "thinking") return "";
  return renderChatMessage(message);
}
```

`renderChatMessage()` is left unchanged because `gui/src/pages/gui/Chat.tsx` legitimately reads thinking content to populate the `ThinkingBlockPeek` collapsible UI component.

#### Call site changes — three categories

**Category 1 — Streaming chat, line-oriented output** (`core/diff/util.ts`)

`streamLines()` is the conversion point from `ChatMessage` chunks to strings for all Edit/Apply paths: the main edit flow (`streamDiffLines` → `recursiveStream` → `llm.streamChat()`), lazy apply (`streamLazyApply`), and lazy replace. A single fix here covers all three:

```ts
// before:
const chunk = typeof update === "string" ? update : renderChatMessage(update);
// after:
const chunk = typeof update === "string" ? update : renderChatMessageWithoutThinking(update);
```

**Category 2 — Streaming complete, provider uses Chat API internally** (9 provider files)

When Edit runs without rules, `llm.streamComplete()` is called. Each provider implements `_streamComplete()` by calling its Chat API internally and converting `ChatMessage` chunks to strings before yielding them. The fix is applied at that conversion point in each provider:

`OpenAI.ts`, `Anthropic.ts`, `Bedrock.ts`, `Gemini.ts`, `VertexAI.ts`, `Cohere.ts`, `Cloudflare.ts`, `Flowise.ts`, `CustomLLM.ts`

```ts
// before:
yield renderChatMessage(chunk);
// after:
yield renderChatMessageWithoutThinking(chunk);
```

**Category 3 — Non-streaming chat** (`core/llm/index.ts`)

`BaseLLM.chat()` is a non-streaming wrapper around `streamChat()` used for one-shot utility calls (title generation, repo map summarisation, tool selection, next-edit prediction, conversation compaction). Without the fix, thinking content would be merged into the returned completion string.

```ts
// before:
completion += renderChatMessage(message);
// after:
completion += renderChatMessageWithoutThinking(message);
```

#### Additional call sites (follow-up)

The same fix is applied to `core/util/historyUtils.ts` (`toMarkDown()`) and the four built-in legacy slash commands (`/commit`, `/review`, `/draftIssue`, `/onboard`), which all stream `ChatMessage` chunks directly to the chat UI.

#### Call site intentionally not changed

`core/edit/recursiveStream.ts` accumulates streamed chunks into an internal buffer intended as a faithful reproduction of all model output, for use by a recursive continuation mechanism (currently inactive) that re-prompts the model when it hits its token limit mid-edit. Stripping thinking content from this buffer would corrupt the continuation context. Thinking is filtered downstream by `streamLines()` (Category 1 above), so nothing reaches the diff pipeline or the UI regardless.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Not applicable

## Tests

No tests added, existing tests work (except for tests requiring API key, which couldn't be verified)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents reasoning/“thinking” tokens from being inserted into files and utility outputs by filtering them at render time. Fixes cases where Edit/Apply and internal helpers pasted model reasoning into code (fixes #11590).

- **Bug Fixes**
  - Added `renderChatMessageWithoutThinking()` to drop `role: "thinking"` chunks.
  - Applied to `streamLines()` (Edit/Apply), all providers’ `_streamComplete()` paths, `BaseLLM.chat()`, `toMarkDown()`, and legacy slash commands (`/commit`, `/review`, `/draftIssue`, `/onboard`).
  - Kept `renderChatMessage()` unchanged for chat UI; left `recursiveStream` buffer unfiltered to preserve continuation context.

<sup>Written for commit ef340a0a6c868bf0f0a6bc147cbdf11ac5ea4b68. Summary will update on new commits. <a href="https://cubic.dev/pr/continuedev/continue/pull/12420?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

