### PR TITLE
Fix exponential backoff for provider: {anthropic,openai}

### DIFF
--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -460,9 +460,11 @@ export abstract class BaseLLM implements ILLM {
         );
       }
     }
-    return new Error(
+    const error = new Error(
       `HTTP ${resp.status} ${resp.statusText} from ${resp.url}\n\n${text}`,
-    );
+    ) as any;
+    error.response = resp;
+    return error;
   }
 
   fetch(url: RequestInfo | URL, init?: RequestInit): Promise<Response> {
@@ -543,7 +545,7 @@ export abstract class BaseLLM implements ILLM {
     };
     return withExponentialBackoff<Response>(
       () => customFetch(url, init) as any,
-      5,
+      8,
       0.5,
     );
   }

--- a/core/util/withExponentialBackoff.test.ts
+++ b/core/util/withExponentialBackoff.test.ts
@@ -6,7 +6,7 @@ import {
   RETRY_AFTER_HEADER,
 } from "./withExponentialBackoff";
 
-describe.skip("withExponentialBackoff", () => {
+describe("withExponentialBackoff", () => {
   it("should return result when apiCall succeeds on first attempt", async () => {
     // Arrange
     const apiCall = jest.fn().mockResolvedValue("Success");
@@ -112,7 +112,7 @@ describe.skip("withExponentialBackoff", () => {
     // Act & Assert
     await expect(
       withExponentialBackoff(apiCall, maxTries, initialDelaySeconds),
-    ).rejects.toThrow("Failed to make API call after max tries");
+    ).rejects.toThrow(`Failed to make API call after ${maxTries} retries`);
 
     expect(apiCall).toHaveBeenCalledTimes(maxTries);
   });
@@ -135,7 +135,7 @@ describe.skip("withExponentialBackoff", () => {
 
     await expect(
       withExponentialBackoff(apiCall, maxTries, initialDelaySeconds),
-    ).rejects.toThrow("Failed to make API call after max tries");
+    ).rejects.toThrow(`Failed to make API call after ${maxTries} retries`);
 
     expect(apiCall).toHaveBeenCalledTimes(0);
   });

--- a/packages/openai-adapters/src/apis/OpenAI.ts
+++ b/packages/openai-adapters/src/apis/OpenAI.ts
@@ -46,6 +46,7 @@ export class OpenAIApi implements BaseLlmApi {
       baseURL: this.apiBase,
       fetch: customFetch(config.requestOptions),
       timeout: config?.requestOptions?.timeout || undefined,
+      maxRetries: 8,
     });
   }
   modifyChatBody<T extends ChatCompletionCreateParams>(body: T): T {


### PR DESCRIPTION
Exponential backoff was broken for anthropic. The reason is that ParseError() returned a plain Error with no .response property. withExponentialBackoff() only triggers the backoff logic when when error.response?.status == 429. Without that property, it immediately rethrows the error. With this fix, it correctly backs off on an HTTP 429 error.

`provider: openai` bypasses BaseLLM.fetch() and uses the openai SDK.

Fix the tests so that they pass again.

Some APIs have a per minute rate-limt, so increase the max retries in both codepaths to 8 so that it it retries up to 127.5s until it fails.

I have built the extension and verified both codepaths now work with the rate-limited API in question.

## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
