### PR TITLE
fix: avoid login flag for csh shells

### DIFF
--- a/core/tools/implementations/runTerminalCommand.ts
+++ b/core/tools/implementations/runTerminalCommand.ts
@@ -22,7 +22,10 @@ function getDecodedOutput(data: Buffer): string {
     return data.toString();
   }
 } // Simple helper function to use login shell on Unix/macOS and PowerShell on Windows
-function getShellCommand(command: string): { shell: string; args: string[] } {
+export function getShellCommand(command: string): {
+  shell: string;
+  args: string[];
+} {
   if (process.platform === "win32") {
     // Windows: Use PowerShell
     return {
@@ -32,8 +35,18 @@ function getShellCommand(command: string): { shell: string; args: string[] } {
   } else {
     // Unix/macOS: Use login shell to source .bashrc/.zshrc etc.
     const userShell = process.env.SHELL || "/bin/bash";
-    return { shell: userShell, args: ["-l", "-c", command] };
+    return {
+      shell: userShell,
+      args: shellSupportsLoginFlag(userShell)
+        ? ["-l", "-c", command]
+        : ["-c", command],
+    };
   }
+}
+
+function shellSupportsLoginFlag(shell: string): boolean {
+  const shellName = shell.split(/[\\/]/).pop()?.toLowerCase();
+  return shellName !== "csh" && shellName !== "tcsh";
 }
 
 import { fileURLToPath } from "node:url";

--- a/core/tools/implementations/runTerminalCommand.vitest.ts
+++ b/core/tools/implementations/runTerminalCommand.vitest.ts
@@ -858,15 +858,22 @@ describe("runTerminalCommandTool.evaluateToolCallPolicy", () => {
     expect(result).toBe("allowedWithPermission");
   });
 
-  it("does not pass login-shell flag to csh-family shells", () => {
-    const previousShell = process.env.SHELL;
-    process.env.SHELL = "/bin/tcsh";
-    try {
-      const { shell, args } = getShellCommand("pwd");
-      expect(shell).toBe("/bin/tcsh");
-      expect(args).toEqual(["-c", "pwd"]);
-    } finally {
-      process.env.SHELL = previousShell;
-    }
-  });
+  it.runIf(process.platform !== "win32")(
+    "does not pass login-shell flag to csh-family shells",
+    () => {
+      const previousShell = process.env.SHELL;
+      process.env.SHELL = "/bin/tcsh";
+      try {
+        const { shell, args } = getShellCommand("pwd");
+        expect(shell).toBe("/bin/tcsh");
+        expect(args).toEqual(["-c", "pwd"]);
+      } finally {
+        if (previousShell === undefined) {
+          delete process.env.SHELL;
+        } else {
+          process.env.SHELL = previousShell;
+        }
+      }
+    },
+  );
 });

--- a/core/tools/implementations/runTerminalCommand.vitest.ts
+++ b/core/tools/implementations/runTerminalCommand.vitest.ts
@@ -15,7 +15,7 @@ import {
 import { IDE, ToolExtras } from "../..";
 import * as processTerminalStates from "../../util/processTerminalStates";
 import { runTerminalCommandTool } from "../definitions/runTerminalCommand";
-import { runTerminalCommandImpl } from "./runTerminalCommand";
+import { getShellCommand, runTerminalCommandImpl } from "./runTerminalCommand";
 
 // We're using real child processes, so ensure these aren't mocked
 vi.unmock("node:child_process");
@@ -856,5 +856,17 @@ describe("runTerminalCommandTool.evaluateToolCallPolicy", () => {
     );
 
     expect(result).toBe("allowedWithPermission");
+  });
+
+  it("does not pass login-shell flag to csh-family shells", () => {
+    const previousShell = process.env.SHELL;
+    process.env.SHELL = "/bin/tcsh";
+    try {
+      const { shell, args } = getShellCommand("pwd");
+      expect(shell).toBe("/bin/tcsh");
+      expect(args).toEqual(["-c", "pwd"]);
+    } finally {
+      process.env.SHELL = previousShell;
+    }
   });
 });

--- a/extensions/cli/src/tools/runTerminalCommand.test.ts
+++ b/extensions/cli/src/tools/runTerminalCommand.test.ts
@@ -1,4 +1,5 @@
 import {
+  getShellCommand,
   isRunningInWsl,
   runTerminalCommandTool,
 } from "./runTerminalCommand.js";
@@ -120,5 +121,19 @@ describe("runTerminalCommandTool", () => {
         expect(isRunningInWsl()).toBe(false);
       });
     }
+  });
+
+  describe("shell selection", () => {
+    it("does not pass login-shell flag to csh-family shells", () => {
+      const previousShell = process.env.SHELL;
+      process.env.SHELL = "/bin/tcsh";
+      try {
+        const { shell, args } = getShellCommand("pwd");
+        expect(shell).toBe("/bin/tcsh");
+        expect(args).toEqual(["-c", "pwd"]);
+      } finally {
+        process.env.SHELL = previousShell;
+      }
+    });
   });
 });

--- a/extensions/cli/src/tools/runTerminalCommand.test.ts
+++ b/extensions/cli/src/tools/runTerminalCommand.test.ts
@@ -124,16 +124,23 @@ describe("runTerminalCommandTool", () => {
   });
 
   describe("shell selection", () => {
-    it("does not pass login-shell flag to csh-family shells", () => {
-      const previousShell = process.env.SHELL;
-      process.env.SHELL = "/bin/tcsh";
-      try {
-        const { shell, args } = getShellCommand("pwd");
-        expect(shell).toBe("/bin/tcsh");
-        expect(args).toEqual(["-c", "pwd"]);
-      } finally {
-        process.env.SHELL = previousShell;
-      }
-    });
+    it.runIf(!isWindows)(
+      "does not pass login-shell flag to csh-family shells",
+      () => {
+        const previousShell = process.env.SHELL;
+        process.env.SHELL = "/bin/tcsh";
+        try {
+          const { shell, args } = getShellCommand("pwd");
+          expect(shell).toBe("/bin/tcsh");
+          expect(args).toEqual(["-c", "pwd"]);
+        } finally {
+          if (previousShell === undefined) {
+            delete process.env.SHELL;
+          } else {
+            process.env.SHELL = previousShell;
+          }
+        }
+      },
+    );
   });
 });

--- a/extensions/cli/src/tools/runTerminalCommand.ts
+++ b/extensions/cli/src/tools/runTerminalCommand.ts
@@ -63,7 +63,10 @@ function getBashMaxLines(): number {
 }
 
 // Helper function to use login shell on Unix/macOS and PowerShell on Windows and available shell in WSL
-function getShellCommand(command: string): { shell: string; args: string[] } {
+export function getShellCommand(command: string): {
+  shell: string;
+  args: string[];
+} {
   if (process.platform === "win32") {
     // Windows: Use PowerShell
     return {
@@ -77,13 +80,25 @@ function getShellCommand(command: string): { shell: string; args: string[] } {
     const wslShell = process.env.SHELL || "/bin/bash";
     return {
       shell: wslShell,
-      args: ["-l", "-c", command],
+      args: shellSupportsLoginFlag(wslShell)
+        ? ["-l", "-c", command]
+        : ["-c", command],
     };
   }
 
   // Unix/macOS: Use login shell to source .bashrc/.zshrc etc.
   const userShell = process.env.SHELL || "/bin/bash";
-  return { shell: userShell, args: ["-l", "-c", command] };
+  return {
+    shell: userShell,
+    args: shellSupportsLoginFlag(userShell)
+      ? ["-l", "-c", command]
+      : ["-c", command],
+  };
+}
+
+function shellSupportsLoginFlag(shell: string): boolean {
+  const shellName = shell.split(/[\\/]/).pop()?.toLowerCase();
+  return shellName !== "csh" && shellName !== "tcsh";
 }
 
 export function runCommandInBackground(command: string): {


### PR DESCRIPTION
## Summary

- skip the Unix login-shell `-l` flag when `$SHELL` points at `csh` or `tcsh`
- keep the existing login-shell behavior for bash/zsh-style shells
- cover both the core terminal tool and CLI terminal tool helpers

Fixes #12378

## Validation

- npm run build:local-deps --prefix extensions/cli
- npm run vitest --prefix core -- tools/implementations/runTerminalCommand.vitest.ts
- npm test --prefix extensions/cli -- src/tools/runTerminalCommand.test.ts
- npx prettier --check core/tools/implementations/runTerminalCommand.ts core/tools/implementations/runTerminalCommand.vitest.ts extensions/cli/src/tools/runTerminalCommand.ts extensions/cli/src/tools/runTerminalCommand.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the Unix login-shell flag for `csh`/`tcsh` to prevent command failures, while keeping login behavior for bash/zsh. Applies to both the core terminal tool and the CLI helper. Fixes #12378.

- Bug Fixes
  - Skip `-l` for `csh`/`tcsh` on Unix/macOS and WSL; keep it for bash/zsh; Windows unchanged.
  - Apply logic in both core terminal tool and CLI helper via `getShellCommand`.
  - Export `getShellCommand` and add tests to verify `csh` behavior.

<sup>Written for commit 5f6ec1f6491ddf3dc9326b9bc8f83c33f8e83749. Summary will update on new commits. <a href="https://cubic.dev/pr/continuedev/continue/pull/12426?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

