### PR TITLE
fix: show local agent config names

### DIFF
--- a/core/config/profile/LocalProfileLoader.ts
+++ b/core/config/profile/LocalProfileLoader.ts
@@ -1,4 +1,5 @@
 import { ConfigResult } from "@continuedev/config-yaml";
+import * as YAML from "yaml";
 
 import { ControlPlaneClient } from "../../control-plane/client.js";
 import { ContinueConfig, IDE, ILLMLogger } from "../../index.js";
@@ -9,6 +10,26 @@ import { localPathToUri } from "../../util/pathToUri.js";
 import { getUriPathBasename } from "../../util/uri.js";
 import doLoadConfig from "./doLoadConfig.js";
 import { IProfileLoader } from "./IProfileLoader.js";
+
+function getDisplayTitle(overrideAssistantFile?: {
+  path: string;
+  content: string;
+}) {
+  if (!overrideAssistantFile?.path) {
+    return "Local Config";
+  }
+
+  try {
+    const parsed = YAML.parse(overrideAssistantFile.content);
+    if (typeof parsed?.name === "string" && parsed.name.trim()) {
+      return parsed.name;
+    }
+  } catch {
+    // Invalid YAML is handled during config loading; keep the selector usable.
+  }
+
+  return getUriPathBasename(overrideAssistantFile.path);
+}
 
 export default class LocalProfileLoader implements IProfileLoader {
   static ID = "local";
@@ -32,9 +53,7 @@ export default class LocalProfileLoader implements IProfileLoader {
         versionSlug: "",
       },
       iconUrl: "",
-      title: overrideAssistantFile?.path
-        ? getUriPathBasename(overrideAssistantFile.path)
-        : "Local Config",
+      title: getDisplayTitle(overrideAssistantFile),
       errors: undefined,
       uri:
         overrideAssistantFile?.path ??

--- a/core/config/profile/LocalProfileLoader.vitest.ts
+++ b/core/config/profile/LocalProfileLoader.vitest.ts
@@ -49,6 +49,38 @@ describe("LocalProfileLoader", () => {
     );
   });
 
+  it("should initialize override file title from config name", () => {
+    const overrideFile = {
+      path: "file:///workspace/.continue/agents/example.yaml",
+      content: "name: My Custom Config\nversion: 1.0.0\nschema: v1\n",
+    };
+
+    const loader = new LocalProfileLoader(
+      testIde,
+      controlPlaneClient,
+      llmLogger,
+      overrideFile,
+    );
+
+    expect(loader.description.title).toBe("My Custom Config");
+  });
+
+  it("should fall back to filename when override file has no config name", () => {
+    const overrideFile = {
+      path: "file:///workspace/.continue/agents/example.yaml",
+      content: "version: 1.0.0\nschema: v1\n",
+    };
+
+    const loader = new LocalProfileLoader(
+      testIde,
+      controlPlaneClient,
+      llmLogger,
+      overrideFile,
+    );
+
+    expect(loader.description.title).toBe("example.yaml");
+  });
+
   it("should not include content in packageIdentifier when no override file", async () => {
     const loader = new LocalProfileLoader(
       testIde,


### PR DESCRIPTION
## Summary
- initialize local agent profile titles from the YAML `name:` field when `.continue/agents/*.yaml` files are discovered
- keep the filename fallback for unnamed or invalid YAML configs so the selector remains usable
- cover both display-name and fallback behavior in `LocalProfileLoader` tests

Fixes #12345

## Tests
- `npm run vitest --prefix core -- config/profile/LocalProfileLoader.vitest.ts`
- `npm run tsc:check --prefix core`
- `npm run lint -- --quiet config/profile/LocalProfileLoader.ts config/profile/LocalProfileLoader.vitest.ts` from `core/`
- `npx prettier --check core/config/profile/LocalProfileLoader.ts core/config/profile/LocalProfileLoader.vitest.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the YAML `name` as the display title for local agent configs in the selector, with sensible fallbacks to keep it usable. Fixes #12345.

- **Bug Fixes**
  - Parse `name` from the override YAML and set `LocalProfileLoader` title.
  - Fallback to the filename when `name` is missing or YAML is invalid; use "Local Config" when no path.
  - Added tests covering named and fallback cases.

<sup>Written for commit e053075f5c69b0f5d34b6cb4e08c210f0f23cb54. Summary will update on new commits. <a href="https://cubic.dev/pr/continuedev/continue/pull/12427?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

