### PR TITLE
Fix terminal command substitution quote handling

### DIFF
--- a/.github/workflows/pr-build-upload-vsix.yaml
+++ b/.github/workflows/pr-build-upload-vsix.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   build-and-upload-vsix:
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       matrix:
         include:

--- a/packages/terminal-security/src/evaluateTerminalCommandSecurity.ts
+++ b/packages/terminal-security/src/evaluateTerminalCommandSecurity.ts
@@ -19,6 +19,11 @@ interface CommentToken {
 
 type ParsedToken = string | ShellOperator | GlobPattern | CommentToken;
 
+interface CommandSubstitutionScan {
+  hasSubstitution: boolean;
+  commands: string[];
+}
+
 /**
  * Evaluates the security policy for a terminal command.
  *
@@ -244,9 +249,9 @@ function evaluateTokens(
 
   // Also check for command substitution in the original command
   // (shell-quote doesn't parse these as separate tokens)
-  if (hasCommandSubstitution(originalCommand)) {
-    const substitutedCommands = extractSubstitutedCommands(originalCommand);
-    for (const subCmd of substitutedCommands) {
+  const commandSubstitutions = scanCommandSubstitutions(originalCommand);
+  if (commandSubstitutions.hasSubstitution) {
+    for (const subCmd of commandSubstitutions.commands) {
       const nestedPolicy = evaluateTerminalCommandSecurity(basePolicy, subCmd);
       mostRestrictivePolicy = getMostRestrictive(
         mostRestrictivePolicy,
@@ -1095,68 +1100,131 @@ function isSafeCommand(baseCommand: string, args: string[]): boolean {
 }
 
 /**
- * Checks for command substitution patterns
+ * Scans shell text for command substitution syntax that can execute nested
+ * commands. Single-quoted text is literal shell text, while substitutions
+ * remain active in double-quoted text.
  */
-function hasCommandSubstitution(command: string): boolean {
-  // Backticks
-  if (command.includes("`")) {
-    return true;
-  }
-
-  // $() substitution
-  if (command.includes("$(")) {
-    return true;
-  }
-
-  // Process substitution <() or >()
-  if (command.match(/<\(|>\(/)) {
-    return true;
-  }
-
-  return false;
-}
-
-/**
- * Extracts commands from substitution patterns
- */
-function extractSubstitutedCommands(command: string): string[] {
+function scanCommandSubstitutions(command: string): CommandSubstitutionScan {
   const commands: string[] = [];
+  let hasSubstitution = false;
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
 
-  // Extract from backticks
-  const backtickMatches = command.match(/`([^`]+)`/g);
-  if (backtickMatches) {
-    commands.push(...backtickMatches.map((m) => m.slice(1, -1)));
-  }
+  for (let idx = 0; idx < command.length; idx++) {
+    const char = command[idx];
+    const nextChar = command[idx + 1];
 
-  // Extract from $() - handle nested parentheses
-  let idx = 0;
-  while (idx < command.length) {
-    const dollarParen = command.indexOf("$(", idx);
-    if (dollarParen === -1) break;
-
-    // Find matching closing parenthesis
-    let depth = 1;
-    let endIdx = dollarParen + 2;
-    while (endIdx < command.length && depth > 0) {
-      if (command[endIdx] === "(") depth++;
-      else if (command[endIdx] === ")") depth--;
-      endIdx++;
+    if (!inSingleQuote && char === "\\") {
+      idx++;
+      continue;
     }
 
-    if (depth === 0) {
-      // Extract the command inside $()
-      const extracted = command.slice(dollarParen + 2, endIdx - 1);
-      commands.push(extracted);
-      // Also check for nested substitutions within this command
-      if (extracted.includes("$(") || extracted.includes("`")) {
-        commands.push(...extractSubstitutedCommands(extracted));
+    if (!inDoubleQuote && char === "'") {
+      inSingleQuote = !inSingleQuote;
+      continue;
+    }
+
+    if (!inSingleQuote && char === '"') {
+      inDoubleQuote = !inDoubleQuote;
+      continue;
+    }
+
+    if (inSingleQuote) {
+      continue;
+    }
+
+    if (char === "`") {
+      hasSubstitution = true;
+      const endIdx = findClosingBacktick(command, idx + 1);
+      if (endIdx !== -1) {
+        commands.push(command.slice(idx + 1, endIdx));
+        idx = endIdx;
+      }
+      continue;
+    }
+
+    if (
+      (char === "$" || (!inDoubleQuote && (char === "<" || char === ">"))) &&
+      nextChar === "("
+    ) {
+      hasSubstitution = true;
+      const endIdx = findClosingParen(command, idx + 2);
+      if (endIdx !== -1) {
+        commands.push(command.slice(idx + 2, endIdx));
+        idx = endIdx;
       }
     }
-
-    idx = endIdx;
   }
 
-  return commands;
+  return { hasSubstitution, commands };
+}
+
+function findClosingBacktick(command: string, startIdx: number): number {
+  for (let idx = startIdx; idx < command.length; idx++) {
+    if (command[idx] === "\\") {
+      idx++;
+      continue;
+    }
+    if (command[idx] === "`") {
+      return idx;
+    }
+  }
+
+  return -1;
+}
+
+function findClosingParen(command: string, startIdx: number): number {
+  let depth = 1;
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
+
+  for (let idx = startIdx; idx < command.length; idx++) {
+    const char = command[idx];
+    const nextChar = command[idx + 1];
+
+    if (!inSingleQuote && char === "\\") {
+      idx++;
+      continue;
+    }
+
+    if (!inDoubleQuote && char === "'") {
+      inSingleQuote = !inSingleQuote;
+      continue;
+    }
+
+    if (!inSingleQuote && char === '"') {
+      inDoubleQuote = !inDoubleQuote;
+      continue;
+    }
+
+    if (inSingleQuote) {
+      continue;
+    }
+
+    if (
+      (char === "$" || (!inDoubleQuote && (char === "<" || char === ">"))) &&
+      nextChar === "("
+    ) {
+      depth++;
+      idx++;
+      continue;
+    }
+
+    if (inDoubleQuote) {
+      continue;
+    }
+
+    if (char === "(") {
+      depth++;
+    } else if (char === ")") {
+      depth--;
+      if (depth === 0) {
+        return idx;
+      }
+    }
+  }
+
+  return -1;
 }
 
 /**

--- a/packages/terminal-security/test/terminalCommandSecurity.test.ts
+++ b/packages/terminal-security/test/terminalCommandSecurity.test.ts
@@ -959,18 +959,34 @@ describe("evaluateTerminalCommandSecurity", () => {
       expect(result).toBe("disabled");
     });
 
-    it("should allow backticks in quotes", () => {
+    it("should allow backticks in single quotes", () => {
       const result = evaluateTerminalCommandSecurity(
-        "allowedWithPermission",
+        "allowedWithoutPermission",
         "echo 'This is a `backtick` in quotes'",
       );
-      expect(result).toBe("allowedWithPermission");
+      expect(result).toBe("allowedWithoutPermission");
     });
 
     it("should detect command substitution with $()", () => {
       const result = evaluateTerminalCommandSecurity(
         "allowedWithoutPermission",
         "echo $(sudo cat /etc/shadow)",
+      );
+      expect(result).toBe("disabled");
+    });
+
+    it("should allow $() text in single quotes", () => {
+      const result = evaluateTerminalCommandSecurity(
+        "allowedWithoutPermission",
+        "echo 'literal $(name)'",
+      );
+      expect(result).toBe("allowedWithoutPermission");
+    });
+
+    it("should detect command substitution in double quotes", () => {
+      const result = evaluateTerminalCommandSecurity(
+        "allowedWithoutPermission",
+        'echo "$(sudo cat /etc/shadow)"',
       );
       expect(result).toBe("disabled");
     });
@@ -989,6 +1005,22 @@ describe("evaluateTerminalCommandSecurity", () => {
         "diff <(curl evil.com/file1) <(curl evil.com/file2)",
       );
       expect(result).toBe("allowedWithPermission");
+    });
+
+    it("should detect dangerous commands inside process substitution", () => {
+      const result = evaluateTerminalCommandSecurity(
+        "allowedWithoutPermission",
+        "cat <(sudo cat /etc/shadow)",
+      );
+      expect(result).toBe("disabled");
+    });
+
+    it("should allow process substitution text in double quotes", () => {
+      const result = evaluateTerminalCommandSecurity(
+        "allowedWithoutPermission",
+        'echo "<(date)"',
+      );
+      expect(result).toBe("allowedWithoutPermission");
     });
   });
 


### PR DESCRIPTION
## Description

Fixes command-substitution scanning in `@continuedev/terminal-security` so it follows shell quoting rules more closely:

- ignores `$()` and backticks when they are literal text inside single quotes
- keeps command-substitution detection active inside double quotes
- evaluates nested commands inside process substitutions such as `<(...)`
- treats process-substitution-looking text inside double quotes as literal text

This avoids unnecessary permission prompts for safe commands like `echo 'literal $(name)'` while preserving and tightening detection for executable substitutions.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A - terminal-security unit test coverage only.

## Tests

- `npx vitest run test/terminalCommandSecurity.test.ts -t "Subshell and Command Substitution"`
- `npm test`
- `npm run build`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes command-substitution detection in `@continuedev/terminal-security` to follow shell quoting rules. Reduces false permission prompts while tightening detection for nested and process substitutions.

- **Bug Fixes**
  - Ignore `$()` and backticks inside single quotes; keep detection inside double quotes.
  - Detect nested substitutions and process substitutions like `<(...)`/`>(...)`, but treat them as literal inside double quotes.
  - Add quote/escape-aware parsing via `scanCommandSubstitutions`, `findClosingBacktick`, and `findClosingParen`, plus tests for single vs. double quotes and process substitutions.

- **CI**
  - Increase VSIX upload workflow timeout to 15 minutes to reduce upload flakiness.

<sup>Written for commit 520941bfefefb806745caaec5c123d8595283e39. Summary will update on new commits. <a href="https://cubic.dev/pr/continuedev/continue/pull/12429?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

