### PR TITLE
fix: render markdown tables correctly in chat responses

### DIFF
--- a/gui/src/components/StyledMarkdownPreview/index.tsx
+++ b/gui/src/components/StyledMarkdownPreview/index.tsx
@@ -141,6 +141,30 @@ const StyledMarkdown = styled.div<{
   > *:last-child {
     margin-bottom: 0;
   }
+
+  table {
+    border-collapse: collapse;
+    display: block;
+    width: max-content;
+    max-width: 100%;
+    overflow: auto;
+    margin-bottom: 16px;
+  }
+
+  table th,
+  table td {
+    padding: 6px 13px;
+    border: 1px solid var(--vscode-editorWidget-border, #454545);
+  }
+
+  table th {
+    font-weight: 600;
+    background-color: var(--vscode-editor-background);
+  }
+
+  table tr:nth-child(2n) {
+    background-color: var(--vscode-list-hoverBackground, rgba(255,255,255,0.04));
+  }
 `;
 
 interface StyledMarkdownPreviewProps {

--- a/gui/src/components/StyledMarkdownPreview/utils/remarkTables.tsx
+++ b/gui/src/components/StyledMarkdownPreview/utils/remarkTables.tsx
@@ -105,8 +105,7 @@ export function remarkTables() {
               {
                 type: "tableRow",
                 children: headerCells.map((cell, i) => ({
-                  type: "element",
-                  tagName: "th",
+                  type: "tableCell",
                   align: alignments[i],
                   children: [{ type: "text", value: cell }],
                 })),


### PR DESCRIPTION
## Description

Fix markdown tables rendering as unformatted text in chat responses.

Two issues were causing this:
1. In `remarkTables.tsx`, header cells were built with `type: "element", tagName: "th"` — a raw hast node injected into an MDAST tree. The remark-to-rehype pipeline doesn't handle this correctly, causing header cells to fall through as plain text. Changed to `type: "tableCell"` to match how body cells are built.
2. In `StyledMarkdownPreview/index.tsx`, the `StyledMarkdown` component had no `table`, `th`, or `td` CSS rules. Table styles in `markdown.css` are scoped to `.wmde-markdown` which is never applied here, so tables had no borders or styling. Added table styles using VS Code CSS variables for theme compatibility.

Fixes #12167

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created


<img width="1470" height="956" alt="Screenshot 2026-05-17 at 2 50 02 PM" src="https://github.com/user-attachments/assets/535a9f98-7229-40e3-b72c-222941fba427" />

## Tests

No new tests added. The existing `remarkTables` plugin logic is covered by the change to use the correct MDAST node type (`tableCell`), which is consistent with how body rows were already being built. Manual testing confirmed tables now render with proper borders, bold headers, and alternating row colors in the VS Code extension chat.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes markdown tables rendering as plain text in chat responses. Header cells now parse correctly, and tables use theme-aware styles with borders and alternating rows.

- **Bug Fixes**
  - Changed header cells from a raw hast `element th` to MDAST `tableCell` in the remark-to-rehype pipeline so headers render properly.
  - Added CSS for `table`, `th`, and `td` in StyledMarkdown using VS Code variables for borders, bold headers, and zebra striping.

<sup>Written for commit 5566065033859321b2a7c25f4dfd59fe83655702. Summary will update on new commits. <a href="https://cubic.dev/pr/continuedev/continue/pull/12430?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

