### PR TITLE
fix(config-yaml): unroll markdown prompt files as prompts

### DIFF
--- a/packages/config-yaml/src/load/unroll.test.ts
+++ b/packages/config-yaml/src/load/unroll.test.ts
@@ -4,6 +4,7 @@ import {
   getTemplateVariables,
   parseMarkdownRuleOrAssistantUnrolled,
   replaceInputsWithSecrets,
+  unrollBlocks,
 } from "./unroll.js";
 
 describe("parseMarkdownRuleOrAssistantUnrolled tests", () => {
@@ -91,6 +92,41 @@ model: # should be models
     expect(rule).toHaveProperty("name", "foo/bar");
     expect(rule).toHaveProperty("globs", undefined);
     expect(rule).toHaveProperty("rule", dubiousContent);
+  });
+
+  it("unrolls markdown files used in prompts as prompts", async () => {
+    const markdownContent = `
+---
+name: scotty
+description: A reusable prompt
+---
+Generate a concise repair plan.
+`;
+
+    const registry = {
+      getContent: async () => markdownContent,
+    };
+
+    const result = await unrollBlocks(
+      {
+        name: "Test Agent",
+        version: "1.0.0",
+        prompts: [{ uses: "file://prompts/scotty.md" }],
+      },
+      registry,
+      undefined,
+    );
+
+    expect(result.errors).toBeUndefined();
+    expect(result.config?.rules).toBeUndefined();
+    expect(result.config?.prompts).toEqual([
+      {
+        name: "scotty",
+        description: "A reusable prompt",
+        prompt: "Generate a concise repair plan.",
+        sourceFile: "prompts/scotty.md",
+      },
+    ]);
   });
 });
 

--- a/packages/config-yaml/src/load/unroll.ts
+++ b/packages/config-yaml/src/load/unroll.ts
@@ -22,6 +22,7 @@ import {
   blockSchema,
   ConfigYaml,
   configYamlSchema,
+  Prompt,
   Rule,
 } from "../schemas/index.js";
 import { ConfigResult, ConfigValidationError } from "../validation.js";
@@ -448,6 +449,7 @@ export async function unrollBlocks(
               blockIdentifier,
               unrolledBlock.with,
               registry,
+              section,
             );
             const block = blockConfigYaml[section]?.[0];
             if (block) {
@@ -514,6 +516,7 @@ export async function unrollBlocks(
                 decodePackageIdentifier(rule.uses),
                 rule.with,
                 registry,
+                "rules",
               );
               const block = blockConfigYaml.rules?.[0];
               return { index, rule: block || null, error: null };
@@ -731,6 +734,7 @@ export async function resolveBlock(
   id: PackageIdentifier,
   inputs: Record<string, string | undefined> | undefined,
   registry: Registry,
+  sectionHint?: BlockType,
 ): Promise<AssistantUnrolled> {
   // Retrieve block raw yaml
   const rawYaml = await registry.getContent(id);
@@ -764,7 +768,11 @@ export async function resolveBlock(
   }
 
   // Add source slug for mcp servers
-  const parsed = parseMarkdownRuleOrAssistantUnrolled(templatedYaml, id);
+  const parsed = parseMarkdownRuleOrAssistantUnrolled(
+    templatedYaml,
+    id,
+    sectionHint,
+  );
   if (
     id.uriType === "slug" &&
     "mcpServers" in parsed &&
@@ -779,8 +787,14 @@ export async function resolveBlock(
 export function parseMarkdownRuleOrAssistantUnrolled(
   content: string,
   id: PackageIdentifier,
+  sectionHint?: BlockType,
 ): AssistantUnrolled {
-  return parseYamlOrMarkdownRule<AssistantUnrolled>(content, id, parseBlock);
+  return parseYamlOrMarkdownRule<AssistantUnrolled>(
+    content,
+    id,
+    parseBlock,
+    sectionHint,
+  );
 }
 
 function parseMarkdownRuleOrConfigYaml(
@@ -790,10 +804,21 @@ function parseMarkdownRuleOrConfigYaml(
   return parseYamlOrMarkdownRule<ConfigYaml>(content, id, parseConfigYaml);
 }
 
+function markdownToPrompt(content: string, id: PackageIdentifier): Prompt {
+  const rule = markdownToRule(content, id);
+  return {
+    name: rule.name,
+    description: rule.description,
+    prompt: rule.rule,
+    sourceFile: rule.sourceFile,
+  };
+}
+
 function parseYamlOrMarkdownRule<T>(
   content: string,
   id: PackageIdentifier,
   parseYamlFn: (content: string) => T,
+  sectionHint?: BlockType,
 ): T {
   let parsedYaml: T;
   try {
@@ -808,9 +833,22 @@ function parseYamlOrMarkdownRule<T>(
     }
     // If YAML parsing fails, try parsing as markdown rule
     try {
-      const rule = markdownToRule(content, id);
-      // Convert the rule object to the expected format
-      parsedYaml = { name: rule.name, version: "1.0.0", rules: [rule] } as T;
+      if (sectionHint === "prompts") {
+        const prompt = markdownToPrompt(content, id);
+        parsedYaml = {
+          name: prompt.name,
+          version: "1.0.0",
+          prompts: [prompt],
+        } as T;
+      } else {
+        const rule = markdownToRule(content, id);
+        // Convert the rule object to the expected format
+        parsedYaml = {
+          name: rule.name,
+          version: "1.0.0",
+          rules: [rule],
+        } as T;
+      }
     } catch (markdownError) {
       // If both fail, throw the original YAML error
       throw yamlError;


### PR DESCRIPTION
## Summary
- pass the target section into block resolution so markdown files referenced from `prompts` unroll as prompt blocks instead of rules
- keep existing markdown fallback behavior for rules and other sections
- add a regression test for `prompts: - uses: file://...md`

Fixes #12412.

## Tests
- `npm test -- --runTestsByPath src/load/unroll.test.ts` from `packages/config-yaml`
- `npm run build` from `packages/config-yaml`
- `npx prettier --check packages/config-yaml/src/load/unroll.ts packages/config-yaml/src/load/unroll.test.ts`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect unrolling of markdown files in the `prompts` section so they become prompt blocks instead of rules. Keeps existing markdown fallback for `rules` and other sections, and adds a regression test in `packages/config-yaml`.

- **Bug Fixes**
  - Pass the section hint through block resolution so `prompts` markdown parses as `prompts`.
  - Preserve markdown-to-rule fallback for `rules` and other sections.
  - Add test for `prompts: - uses: file://...md`.

<sup>Written for commit 2aed834906662669a88523627b854fd27777528c. Summary will update on new commits. <a href="https://cubic.dev/pr/continuedev/continue/pull/12433?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

