### PR TITLE
docs: add QuickSilver Pro model provider page

### DIFF
--- a/docs/customize/model-providers/more/quicksilverpro.mdx
+++ b/docs/customize/model-providers/more/quicksilverpro.mdx
@@ -1,0 +1,61 @@
+---
+title: "QuickSilver Pro"
+description: "Configure QuickSilver Pro with Continue to access 12 frontier open-source models (DeepSeek V4, R1, Qwen 3.6, Kimi K2.6, Gemini 3) through one OpenAI-compatible key"
+---
+
+<Tip>
+  QuickSilver Pro is an OpenAI-compatible gateway for 12 frontier open-source
+  models: DeepSeek V4 Flash / V4 Pro / V3 / R1, Qwen 3.5 / 3.6, Kimi K2.6,
+  and the Gemini 2.5 / 3 family. ~20% under OpenRouter on the shared set.
+</Tip>
+
+<Info>
+  Get an API key from the [QuickSilver Pro dashboard](https://quicksilverpro.io/dashboard/).
+</Info>
+
+## Configuration
+
+Because QuickSilver Pro speaks the OpenAI Chat Completions API, use the
+`openai` provider with an `apiBase` override:
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  name: My Config
+  version: 0.0.1
+  schema: v1
+
+  models:
+    - name: DeepSeek V4 Pro (QSP)
+      provider: openai
+      model: deepseek-v4-pro
+      apiBase: https://api.quicksilverpro.io/v1
+      apiKey: <YOUR_QUICKSILVERPRO_API_KEY>
+  ```
+  </Tab>
+  <Tab title="JSON (Deprecated)">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "DeepSeek V4 Pro (QSP)",
+        "provider": "openai",
+        "model": "deepseek-v4-pro",
+        "apiBase": "https://api.quicksilverpro.io/v1",
+        "apiKey": "<YOUR_QUICKSILVERPRO_API_KEY>"
+      }
+    ]
+  }
+  ```
+  </Tab>
+</Tabs>
+
+Swap `model` for any of:
+`deepseek-v4-flash`, `deepseek-v4-pro`, `deepseek-v3`, `deepseek-r1`,
+`qwen3.6-35b`, `qwen3.5-35b`, `kimi-k2.6`, `gemini-2.5-flash`,
+`gemini-2.5-flash-lite`, `gemini-3-flash-preview`.
+
+<Info>
+  Full model list, pricing, and integration tips for other tools:
+  [quicksilverpro.io/docs/integrations](https://quicksilverpro.io/docs/integrations/).
+</Info>


### PR DESCRIPTION
## Summary

Adds a [QuickSilver Pro](https://quicksilverpro.io) provider page under `docs/customize/model-providers/more/`, following the same template as the other OpenAI-compatible gateway entries. QuickSilver Pro hosts 12 frontier open-source models (DeepSeek V4 Flash/Pro, V3, R1, Qwen 3.5/3.6, Kimi K2.6, Gemini 2.5/3 family) through a standard OpenAI Chat Completions surface — drop-in for Continue's `provider: openai` config with an `apiBase` override.

## Config that works

```yaml
models:
  - name: DeepSeek V4 Pro (QSP)
    provider: openai
    model: deepseek-v4-pro
    apiBase: https://api.quicksilverpro.io/v1
    apiKey: <YOUR_QUICKSILVERPRO_API_KEY>
```

## Disclosure

I'm the maintainer of QuickSilver Pro — happy to revise the framing or move the mention to a different doc page if there's a better fit. Setup reference: <https://quicksilverpro.io/docs/integrations/>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a QuickSilver Pro model provider page showing how to connect Continue to QuickSilver Pro through the OpenAI-compatible chat completions API. Includes `provider: openai` config with `apiBase: https://api.quicksilverpro.io/v1`, example YAML/JSON, and supported model IDs.

<sup>Written for commit 4cd7e094bb42c0b3d48e712c86ce48fc6802f76d. Summary will update on new commits. <a href="https://cubic.dev/pr/continuedev/continue/pull/12436?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

