### PR TITLE
Update tsconfig.json with model configurations

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,1 +1,24 @@
-{}
+{{
+  "models": [
+    {
+      "title": "Groq Llama 3.3",
+      "provider": "openai",
+      "model": "llama-3.3-70b-versatile",
+      "apiKey": "ضع_مفتاح_groq_الخاص_بك_هنا",
+      "apiBase": "https://api.groq.com/openai/v1"
+    },
+    {
+      "title": "Gemini 1.5 Pro",
+      "provider": "gemini",
+      "model": "gemini-1.5-pro",
+      "apiKey": "ضع_مفتاح_جوجل_الخاص_بك_هنا"
+    }
+  ],
+  "tabAutocompleteModel": {
+    "title": "Groq Autocomplete",
+    "provider": "openai",
+    "model": "llama-3.3-70b-versatile",
+    "apiKey": "ضع_مفتاح_groq_الخاص_بك_هنا",
+    "apiBase": "https://api.groq.com/openai/v1"
+  }
+}}


### PR DESCRIPTION
Added configuration for Groq Llama and Gemini models with API keys.

## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds model configs for Groq Llama 3.3 and Gemini 1.5 Pro, and sets Groq as the tab autocomplete model using an `openai`-compatible endpoint. Replaces the empty `tsconfig.json` with these settings.

- New Features
  - Added `models` entries for Groq Llama 3.3 (`provider`: `openai`, `apiBase`: Groq) and Gemini 1.5 Pro (`provider`: `gemini`).
  - Set `tabAutocompleteModel` to Groq Llama 3.3.
  - Included placeholder API keys for both providers.

- Migration
  - Replace the placeholder API keys with valid credentials before use.

<sup>Written for commit d96cd760c162ee52ec7d3d89fef9ba815ee7181a. Summary will update on new commits. <a href="https://cubic.dev/pr/continuedev/continue/pull/12441?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

