### PR TITLE
feat: Add Windows WSL [Ubuntu] Agent Shell Support for Intellij -- Code and Generic Terminal/Bash Execution

### DIFF
--- a/core/tools/implementations/runTerminalCommand.ts
+++ b/core/tools/implementations/runTerminalCommand.ts
@@ -21,8 +21,42 @@ function getDecodedOutput(data: Buffer): string {
   } else {
     return data.toString();
   }
-} // Simple helper function to use login shell on Unix/macOS and PowerShell on Windows
-function getShellCommand(command: string): { shell: string; args: string[] } {
+}
+
+// Simple helper function to use login shell on Unix/macOS and PowerShell on Windows
+// Detects WSL paths and uses the appropriate WSL shell
+function getShellCommand(
+  command: string,
+  cwd?: string,
+): { shell: string; args: string[] } {
+  // Check if the working directory is in WSL on Intellij
+  const isWslPath =
+    cwd && (cwd.includes("\\wsl.localhost\\") || cwd.includes("\\wsl$\\"));
+
+  if (isWslPath) {
+    // Extract the WSL distribution name from the path
+    // Path format: \\wsl.localhost\UbuntuAny\home\user\project
+    // or: \\wsl$\UbuntuAny\home\user\project
+    let distroName = "Ubuntu"; // Default fallback
+    try {
+      const wslPathSegments = cwd.split(/\\+/);
+      // Find the segment after wsl.localhost or wsl$
+      const wslIndex = wslPathSegments.findIndex(
+        (seg) => seg.includes("wsl.localhost") || seg.includes("wsl$"),
+      );
+      if (wslIndex !== -1 && wslIndex + 1 < wslPathSegments.length) {
+        distroName = wslPathSegments[wslIndex + 1];
+      }
+    } catch {
+      // If parsing fails, use default Ubuntu
+    }
+    // Use wsl.exe to run commands in the specific distribution
+    return {
+      shell: "wsl.exe",
+      args: ["-d", distroName, "-e", "bash", "-c", command],
+    };
+  }
+
   if (process.platform === "win32") {
     // Windows: Use PowerShell
     return {
@@ -52,6 +86,17 @@ import { getBooleanArg, getStringArg } from "../parseArgs";
  * Falls back to home directory or temp directory if no workspace is available.
  */
 function resolveWorkingDirectory(workspaceDirs: string[]): string {
+  // Check for valid existing local paths first (IntelliJ support) so \\wsl$\ or \\wsl.local\ can pass
+  for (const dir of workspaceDirs) {
+    try {
+      if (dir.startsWith("file:////wsl")) {
+        return path.normalize(dir.replace("file://", ""));
+      }
+    } catch {
+      // Ignore errors (e.g. invalid path formats)
+    }
+  }
+
   // Handle file:// URIs (local workspaces)
   const fileWorkspaceDir = workspaceDirs.find((dir) =>
     dir.startsWith("file:/"),
@@ -145,7 +190,7 @@ export const runTerminalCommandImpl: ToolImpl = async (args, extras) => {
           }
 
           // Use spawn with color environment
-          const { shell, args } = getShellCommand(command);
+          const { shell, args } = getShellCommand(command, cwd);
           const childProc = childProcess.spawn(shell, args, {
             cwd,
             env: getColorEnv(), // Add enhanced environment for colors
@@ -376,7 +421,7 @@ export const runTerminalCommandImpl: ToolImpl = async (args, extras) => {
         try {
           // Use spawn approach for consistency with streaming version
           const { shell: nonStreamingShell, args: nonStreamingArgs } =
-            getShellCommand(command);
+            getShellCommand(command, cwd);
           const output = await new Promise<{ stdout: string; stderr: string }>(
             (resolve, reject) => {
               let timeoutId: ReturnType<typeof setTimeout> | undefined;
@@ -503,8 +548,10 @@ export const runTerminalCommandImpl: ToolImpl = async (args, extras) => {
         // but don't attach any listeners other than error
         try {
           // Use spawn with color environment
-          const { shell: detachedShell, args: detachedArgs } =
-            getShellCommand(command);
+          const { shell: detachedShell, args: detachedArgs } = getShellCommand(
+            command,
+            cwd,
+          );
           const childProc = childProcess.spawn(detachedShell, detachedArgs, {
             cwd,
             env: getColorEnv(), // Add color environment

--- a/core/tools/implementations/runTerminalCommand.ts
+++ b/core/tools/implementations/runTerminalCommand.ts
@@ -2,6 +2,7 @@ import iconv from "iconv-lite";
 import childProcess from "node:child_process";
 import os from "node:os";
 import { ContinueError, ContinueErrorReason } from "../../util/errors";
+import * as path from "node:path";
 
 // Default timeout for terminal commands (2 minutes)
 const DEFAULT_TOOL_TIMEOUT_MS = 120_000;

--- a/extensions/intellij/.run/Run Continue WSL (CE).run.xml
+++ b/extensions/intellij/.run/Run Continue WSL (CE).run.xml
@@ -1,0 +1,9 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run Continue WSL (CE)" type="CompoundRunConfigurationType">
+    <toRun name="Run Extension WSL (use TCP)" type="GradleRunConfiguration" />
+    <toRun name="Prompt Logs" type="ShConfigurationType" />
+    <toRun name="Start Core Dev Server (CE)" type="ShConfigurationType" />
+    <toRun name="Start GUI Dev Server" type="ShConfigurationType" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/extensions/intellij/.run/Run Continue WSL.run.xml
+++ b/extensions/intellij/.run/Run Continue WSL.run.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run Continue WSL" type="CompoundRunConfigurationType">
+        <toRun name="Run Extension WSL (use TCP)" type="GradleRunConfiguration" />
+        <toRun name="Start Core Dev Server" type="NodeJSConfigurationType" />
+        <toRun name="IDE Logs" type="ShConfigurationType" />
+        <toRun name="Prompt Logs" type="ShConfigurationType" />
+        <toRun name="Start GUI Dev Server" type="ShConfigurationType" />
+        <method v="2" />
+    </configuration>
+</component>

--- a/extensions/intellij/.run/Run Extension WSL (use TCP).run.xml
+++ b/extensions/intellij/.run/Run Extension WSL (use TCP).run.xml
@@ -4,7 +4,7 @@
       <option name="env">
         <map>
           <entry key="GUI_URL" value="http://localhost:5173/jetbrains_index.html" />
-          <entry key="WSL_KERNEL" value="UbuntuRestored" />
+          <entry key="WSL_KERNEL" value="Ubuntu" />
           <entry key="USE_TCP" value="true" />
         </map>
       </option>

--- a/extensions/intellij/.run/Run Extension WSL (use TCP).run.xml
+++ b/extensions/intellij/.run/Run Extension WSL (use TCP).run.xml
@@ -1,0 +1,31 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run Extension WSL (use TCP)" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="env">
+        <map>
+          <entry key="GUI_URL" value="http://localhost:5173/jetbrains_index.html" />
+          <entry key="WSL_KERNEL" value="UbuntuRestored" />
+          <entry key="USE_TCP" value="true" />
+        </map>
+      </option>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/extensions/intellij" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="runIde" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/extensions/intellij/build.gradle.kts
+++ b/extensions/intellij/build.gradle.kts
@@ -119,16 +119,82 @@ tasks {
     }
 
     runIde {
-        val openProject = "$projectDir/../../manual-testing-sandbox"
-        argumentProviders += CommandLineArgumentProvider {
-            listOf(openProject, "$openProject/test.kt")
+        val wslKernel = environment("WSL_KERNEL").getOrElse("")
+        val openProject = if (wslKernel.isNotEmpty()) {
+            //If gradle.properties >= 2025.X -- can direct run mount from WSL windows path in Intellij
+            // instead of copy to /tmp -- IE \\wsl?\Ubuntu\mnt\c\Users
+            val pluginVersion = providers.gradleProperty("platformVersion").getOrElse("2024.1")
+            val majorVersion = pluginVersion.split(".").firstOrNull()?.toIntOrNull() ?: 2024
+
+            if (majorVersion >= 2025) {
+                "\\\\wsl$\\$wslKernel\\mnt\\c" + projectDir.absolutePath.replace("C:", "").replace("/extensions/intellij/", "")
+                    .replace("/", "\\") + "\\..\\..\\manual-testing-sandbox"
+            }
+            //For now we must copy the test file to WSL filesystem to be cleaned up at exit
+            else {
+                val wslSourcePath = "/mnt/c" + projectDir.absolutePath.replace("C:", "")
+                    .replace("\\", "/") + "/../../manual-testing-sandbox"
+                val wslDestPath = "/tmp/manual-testing-sandbox"
+                val command = listOf("wsl", "-d", wslKernel, "-e", "cp", "-r", wslSourcePath, wslDestPath)
+                val process = ProcessBuilder(command).start()
+                val exitCode = process.waitFor()
+                if (exitCode != 0) {
+                    throw GradleException(
+                        "Failed to copy $wslSourcePath to $wslKernel:$wslDestPath\" via WSL: ${
+                            process.errorStream.bufferedReader().readText()
+                        }"
+                    )
+                } else {
+                    logger.lifecycle("Successfully copied $wslSourcePath to $wslKernel:$wslDestPath")
+                }
+                "\\\\wsl$\\$wslKernel" + wslDestPath.replace("/", "\\")
+            }
+        } else {
+            "$projectDir/../../manual-testing-sandbox"
         }
+        argumentProviders += CommandLineArgumentProvider {
+            listOf(openProject)
+        }
+        finalizedBy("cleanupAfterRunIde")
     }
 
     test {
         useJUnitPlatform()
         environment("CONTINUE_GLOBAL_DIR", "${rootProject.projectDir}/src/test/kotlin/com/github/continuedev/continueintellijextension/test-continue")
         jvmArgumentProviders += CommandLineArgumentProvider { listOf("-Dide.browser.jcef.sandbox.enable=false") }
+    }
+}
+
+tasks.register("cleanupAfterRunIde") {
+    doLast {
+        val pluginVersion = providers.gradleProperty("platformVersion").getOrElse("2024.1")
+        val majorVersion = pluginVersion.split(".").firstOrNull()?.toIntOrNull() ?: 2024
+        //cleanup the temp file created in runIde if WSL test was used
+        if (majorVersion < 2025) {
+            val wslKernel = environment("WSL_KERNEL").getOrElse("")
+            if (wslKernel.isNotEmpty()) {
+                val wslDestPath = "/tmp/manual-testing-sandbox"
+                logger.lifecycle("Cleaning up WSL temp file: $wslDestPath in $wslKernel")
+                val command = listOf("wsl", "-d", wslKernel, "-e", "rm", "-rf", wslDestPath)
+                try {
+                    val process = ProcessBuilder(command).start()
+                    val exitCode = process.waitFor()
+                    if (exitCode != 0) {
+                        logger.lifecycle(
+                            "Warning: Failed to cleanup WSL temp file: ${
+                                process.errorStream.bufferedReader().readText()
+                            }"
+                        )
+                    } else {
+                        logger.lifecycle("Successfully cleaned up $wslDestPath")
+                    }
+                } catch (e: Exception) {
+                    logger.lifecycle("Error during cleanup: ${e.message}")
+                }
+
+            }
+            logger.lifecycle("IDE stopped. Performing cleanup...")
+        }
     }
 }
 

--- a/extensions/intellij/build.gradle.kts
+++ b/extensions/intellij/build.gradle.kts
@@ -121,18 +121,19 @@ tasks {
     runIde {
         val wslKernel = environment("WSL_KERNEL").getOrElse("")
         val openProject = if (wslKernel.isNotEmpty()) {
+            val currentDrive = projectDir.absolutePath.first().lowercase()
             //If gradle.properties >= 2025.X -- can direct run mount from WSL windows path in Intellij
             // instead of copy to /tmp -- IE \\wsl?\Ubuntu\mnt\c\Users
             val pluginVersion = providers.gradleProperty("platformVersion").getOrElse("2024.1")
             val majorVersion = pluginVersion.split(".").firstOrNull()?.toIntOrNull() ?: 2024
 
             if (majorVersion >= 2025) {
-                "\\\\wsl$\\$wslKernel\\mnt\\c" + projectDir.absolutePath.replace("C:", "").replace("/extensions/intellij/", "")
+                "\\\\wsl$\\$wslKernel\\mnt\\$currentDrive" + projectDir.absolutePath.substring(2).replace("/extensions/intellij/", "")
                     .replace("/", "\\") + "\\..\\..\\manual-testing-sandbox"
             }
             //For now we must copy the test file to WSL filesystem to be cleaned up at exit
             else {
-                val wslSourcePath = "/mnt/c" + projectDir.absolutePath.replace("C:", "")
+                val wslSourcePath = "/mnt/$currentDrive" + projectDir.absolutePath.substring(2)
                     .replace("\\", "/") + "/../../manual-testing-sandbox"
                 val wslDestPath = "/tmp/manual-testing-sandbox"
                 val command = listOf("wsl", "-d", wslKernel, "-e", "cp", "-r", wslSourcePath, wslDestPath)

--- a/extensions/intellij/build.gradle.kts
+++ b/extensions/intellij/build.gradle.kts
@@ -120,19 +120,27 @@ tasks {
 
     runIde {
         val wslKernel = environment("WSL_KERNEL").getOrElse("")
+        val pluginVersion = providers.gradleProperty("platformVersion").getOrElse("2024.1")
+        val majorVersion = pluginVersion.split(".").firstOrNull()?.toIntOrNull() ?: 2024
+        val currentDrive = projectDir.absolutePath.first().lowercase()
+
         val openProject = if (wslKernel.isNotEmpty()) {
-            val currentDrive = projectDir.absolutePath.first().lowercase()
             //If gradle.properties >= 2025.X -- can direct run mount from WSL windows path in Intellij
             // instead of copy to /tmp -- IE \\wsl?\Ubuntu\mnt\c\Users
-            val pluginVersion = providers.gradleProperty("platformVersion").getOrElse("2024.1")
-            val majorVersion = pluginVersion.split(".").firstOrNull()?.toIntOrNull() ?: 2024
-
             if (majorVersion >= 2025) {
                 "\\\\wsl$\\$wslKernel\\mnt\\$currentDrive" + projectDir.absolutePath.substring(2).replace("/extensions/intellij/", "")
                     .replace("/", "\\") + "\\..\\..\\manual-testing-sandbox"
             }
             //For now we must copy the test file to WSL filesystem to be cleaned up at exit
             else {
+                "\\\\wsl$\\$wslKernel\\tmp\\manual-testing-sandbox"
+            }
+        } else {
+            "$projectDir/../../manual-testing-sandbox"
+        }
+
+        doFirst {
+            if (wslKernel.isNotEmpty() && majorVersion < 2025) {
                 val wslSourcePath = "/mnt/$currentDrive" + projectDir.absolutePath.substring(2)
                     .replace("\\", "/") + "/../../manual-testing-sandbox"
                 val wslDestPath = "/tmp/manual-testing-sandbox"
@@ -148,13 +156,10 @@ tasks {
                 } else {
                     logger.lifecycle("Successfully copied $wslSourcePath to $wslKernel:$wslDestPath")
                 }
-                "\\\\wsl$\\$wslKernel" + wslDestPath.replace("/", "\\")
             }
-        } else {
-            "$projectDir/../../manual-testing-sandbox"
         }
         argumentProviders += CommandLineArgumentProvider {
-            listOf(openProject)
+            listOf(openProject, "$openProject/test.kt")
         }
         finalizedBy("cleanupAfterRunIde")
     }


### PR DESCRIPTION
Add support for Intellij on Windows Agents using Windows Subsystem For Linux (WSL) and add user facing test(s) supporting multiple Intellij version ranges

## Description
### The Problem
The current IntelliJ continue plugin fails to support agent code execution -- happening via the **runTerminalCommand**  -- when opening a notebook in the Windows Subsystem for Linux (Ubuntu) filesystem. This prevents agents from doing almost anything useful when using IntelliJ on WSL. IntelliJ itself supports WSL based projects, and even changes the terminal to use Ubuntu instead of windows which is incredibly useful for engineers who preferer require multiple isolated environments, use separate WSL backends to manage dependencies, or even want a separate isolated development environment to run agents on. The current behavior for agents used in WSL notebooks is to default to powershell commands, which means agents cannot execute code in the same isolated environment as the user and code -- making them quite less useful.  

### The Solution
* Modified the **resolveWorkingDirectories** in the core tools *"runTerminalCommand.ts"* to add a new cwd and shell check that ONLY triggers on IntelliJ Notebooks that are opened from the Windows Subsystem For Linux. A  lightweight file path check to correctly identify the desired WSL environment and pass it through is triggered before getShellCommand logic 
* Modified the **getShellCommand** in the core tools "runTerminalCommand.ts" to identify the passthrough cwd when it is WSL, and even dynamically parse out the correct or custom Kernel to use (in the case of multiple separate WSL backends with differing names). This can only affect windows IntelliJ users because vscode uses a separate backend for WSL (that is still correctly identified as a remote server), a two part fix was required to maintain the existing plugin architecture.

#### User Info
 If you stumbled across this as an IntelliJ user, you don't need to set anything for this change to work for you. To debug any issues with the continue plugin on WSL with Intellij yourself I suggest launching like this from a windows command prompt -- this forces legacy "wsl$" instead of default "wsl.localhost" in the path which may resolve some bugs you could experience. 
 * Change your jetbrains path to match your install.
 * Change *Ubuntu* to your wsl linux distribution (note it must support bash) 
 
 ```console
 "C:\Program Files\JetBrains\IntelliJ IDEA 2026.2\bin\idea64.exe" \\wsl$\Ubuntu\home\<yourusername>\<YourIntellijProject>
 ```
 
## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

This example shows the new tests being used to run the new Ubuntu agent execution feature as well as the existing Powershell agent and each respectively running bash and powershell code depending on whether they are in standard windows or WSL Ubuntu. 

https://github.com/user-attachments/assets/139862cb-2864-4d79-a7ed-6c6fcd8f1d53

## Tests

I created a new "Run Continue WSL" configuration/test, added for both CE and Ultimate distributions of IntelliJ, that allows any standard windows user to launch the existing *manual-testing-sandbox* testing Intellij sample project and select a WSL backend in addition to the standard test (which can be any WSL custom name in the "Run Continue WSL (use TCP).run.xml file -- defaults to "Ubuntu", the base/standard WSL distribution). **This can be used as a future test to validate any WSL related functionality in Intellij.**

<img width="1660" height="437" alt="image" src="https://github.com/user-attachments/assets/5ac7a57e-fcd2-4111-a687-fc264d730d5e" />


### Detailed Test Breakdown
 I identified a slightly frustrating behavior with the current gradle.properties Intellij 2024.1, where it cannot directly launch notebooks using WSL backend(s) with files located in standard windows C path, which makes testing more painful. To solve for this I added a gradle.properties check that will automatically do this "optimal path" in 2025 and newer major versions (same physical test files used to launch). With the current 2024 major version test I solved for this by copying the test files to a WSL "tmp" location at test launch (before the actual launch happens). I also added and validated a "postLaunch/shutdown" hook that cleans these temp files no matter how shutdown is called. In this way nothing appears no different to users testing -- although it is recommended to them to setup the continue config.yaml file in standard windows before running the WSL test. 
 
## Dependencies 

If you want to run this test you need to have a windows subsystem for linux installed and enabled + IntelliJ. 

Suggested is to install Ubuntu from the Microsoft Store which is the default
<img width="869" height="513" alt="image" src="https://github.com/user-attachments/assets/26d9d9c4-5ba7-4351-a047-d4bbd6935814" />

## Configuration [Only required for TESTING]

If you use something other than "Vanilla" Ubuntu in your Windows Subsystem for Linux, you can change the test to use it instead of the default. 

<img width="756" height="528" alt="image" src="https://github.com/user-attachments/assets/e0257c91-f5cc-4a98-adcc-c729e9c61930" />

The change is an environment variable matching your WSL distribution name. 
<img width="1205" height="691" alt="image" src="https://github.com/user-attachments/assets/4b8e442a-e69c-494b-9343-03ebc62da19a" />

If you are unsure you can find it in the file browser under "Linux"

## Related 
* https://github.com/continuedev/continue/issues/5996

---
 I have read the CLA Document and I hereby sign the CLA
---
