### PR TITLE
docs: add Tuning Engines OpenAI-compatible example

### DIFF
--- a/docs/customize/model-providers/top-level/openai.mdx
+++ b/docs/customize/model-providers/top-level/openai.mdx
@@ -61,6 +61,7 @@ OpenAI API compatible providers include
 - [vLLM](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html)
 - [BerriAI/litellm](https://github.com/BerriAI/litellm)
 - [Tetrate Agent Router Service](https://router.tetrate.ai)
+- [Tuning Engines](https://tuningengines.com)
 
 If you are using an OpenAI API compatible providers, you can change the `apiBase` like this:
 
@@ -95,6 +96,22 @@ If you are using an OpenAI API compatible providers, you can change the `apiBase
   ```
   </Tab>
 </Tabs>
+
+For Tuning Engines, use the hosted OpenAI-compatible endpoint and an inference
+key from your workspace:
+
+```yaml title="config.yaml"
+name: My Config
+version: 0.0.1
+schema: v1
+
+models:
+  - name: Tuning Engines
+    provider: openai
+    model: <YOUR_MODEL_ALIAS>
+    apiBase: https://api.tuningengines.com/v1
+    apiKey: <YOUR_TUNING_ENGINES_INFERENCE_KEY>
+```
 
 ### How to Force Legacy Completions Endpoint Usage
 


### PR DESCRIPTION
## Description

Adds Tuning Engines to the OpenAI API-compatible provider docs. The example uses Continue's existing `provider: openai` plus `apiBase` configuration path, so this is documentation-only and does not add a new provider enum.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A; docs-only change.

## Tests

Not run; docs-only change to a model provider configuration page.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Tuning Engines to the OpenAI‑compatible provider docs, with a YAML config example using `provider: openai`, apiBase https://api.tuningengines.com/v1, and a workspace inference key.

<sup>Written for commit 844bc046d7481f69331d1f5177f7ae8060010f13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

