### PR TITLE
fix(openai-adapters): convert request timeout to milliseconds

### DIFF
--- a/packages/openai-adapters/src/apis/OpenAI.test.ts
+++ b/packages/openai-adapters/src/apis/OpenAI.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import { OpenAIApi } from "./OpenAI.js";
+
+describe("OpenAIApi", () => {
+  test("converts Continue request timeout seconds to OpenAI SDK milliseconds", () => {
+    const api = new OpenAIApi({
+      provider: "openai",
+      apiKey: "test-api-key",
+      requestOptions: { timeout: 300 },
+    });
+
+    expect(api.openai.timeout).toBe(300_000);
+  });
+
+  test("preserves an omitted timeout so the OpenAI SDK default still applies", () => {
+    const api = new OpenAIApi({
+      provider: "openai",
+      apiKey: "test-api-key",
+    });
+
+    expect(api.openai.timeout).toBe(600_000);
+  });
+
+  test("preserves an explicit zero timeout instead of treating it as omitted", () => {
+    const api = new OpenAIApi({
+      provider: "openai",
+      apiKey: "test-api-key",
+      requestOptions: { timeout: 0 },
+    });
+
+    expect(api.openai.timeout).toBe(0);
+  });
+});

--- a/packages/openai-adapters/src/apis/OpenAI.ts
+++ b/packages/openai-adapters/src/apis/OpenAI.ts
@@ -32,6 +32,10 @@ import {
   toResponsesParams,
 } from "./openaiResponses.js";
 
+function toOpenAISdkTimeout(timeoutSeconds?: number): number | undefined {
+  return timeoutSeconds === undefined ? undefined : timeoutSeconds * 1000;
+}
+
 export class OpenAIApi implements BaseLlmApi {
   openai: OpenAI;
   apiBase: string = "https://api.openai.com/v1/";
@@ -45,7 +49,7 @@ export class OpenAIApi implements BaseLlmApi {
       apiKey: config.apiKey ?? "",
       baseURL: this.apiBase,
       fetch: customFetch(config.requestOptions),
-      timeout: config?.requestOptions?.timeout || undefined,
+      timeout: toOpenAISdkTimeout(config?.requestOptions?.timeout),
     });
   }
   modifyChatBody<T extends ChatCompletionCreateParams>(body: T): T {


### PR DESCRIPTION
## Summary
- Convert `requestOptions.timeout` from Continue's documented seconds to the OpenAI SDK's milliseconds before constructing the client.
- Preserve omitted timeouts so the SDK default still applies.
- Preserve explicit `0` instead of treating it as unset.

Fixes #12450.

## Testing
- `npm test -- --run src/apis/OpenAI.test.ts src/test/openai-adapter.vitest.ts`
- `npm run build -- --pretty false`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Convert `requestOptions.timeout` in `openai-adapters` from seconds to milliseconds for the `openai` SDK to fix incorrect request timeouts. Preserves the SDK default when unset and respects an explicit `0`.

- **Bug Fixes**
  - Convert seconds to milliseconds before constructing the `openai` client.
  - Omit the timeout when not provided so the SDK default applies.
  - Respect `0` (no timeout) and add unit tests for conversion, omitted, and zero cases.

<sup>Written for commit a7c5fef70df0602937a96f081b3913261238a43d. Summary will update on new commits. <a href="https://cubic.dev/pr/continuedev/continue/pull/12453?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

