### PR TITLE
fix: remove duplicate-word typos in error message, prompt, and test label

### DIFF
--- a/core/autocomplete/context/root-path-context/test/testCases/typescript.ts
+++ b/core/autocomplete/context/root-path-context/test/testCases/typescript.ts
@@ -298,7 +298,7 @@ const CLASS_METHODS = [
   },
   {
     nodeType:
-      "method_declaration with with generic params and generic return type",
+      "method_declaration with generic params and generic return type",
     fileName: "typescript/classMethods.ts",
     language: "TypeScript",
     cursorPosition: { line: 24, character: 11 },

--- a/core/commands/slash/built-in-legacy/draftIssue.ts
+++ b/core/commands/slash/built-in-legacy/draftIssue.ts
@@ -7,7 +7,7 @@ const PROMPT = (
   title: string,
 ) => `You will be asked to generate the body of a GitHub issue given a user request. You should follow these rules:
 - Be descriptive but do not make up details
-- If the the user request includes any code snippets that are relevant, reference them in code blocks
+- If the user request includes any code snippets that are relevant, reference them in code blocks
 - Describe step by step how to reproduce the problem
 - Describe the ideal solution to the problem
 - Describe the expected behavior after the issue has been resolved

--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -456,7 +456,7 @@ export abstract class BaseLLM implements ILLM {
         );
       } else {
         return new Error(
-          "You are using a Codestral API key, which is not compatible with the Mistral API. Please either obtain a Mistral API key, or use the the Codestral API by setting 'apiBase' to 'https://codestral.mistral.ai/v1' in config.json.",
+          "You are using a Codestral API key, which is not compatible with the Mistral API. Please either obtain a Mistral API key, or use the Codestral API by setting 'apiBase' to 'https://codestral.mistral.ai/v1' in config.json.",
         );
       }
     }


### PR DESCRIPTION
## Summary

Three small duplicated-word typos, each one self-contained:

| File:line | Fix | Why it matters |
|---|---|---|
| \`core/llm/index.ts:459\` | \`use the the Codestral API\` → \`use the Codestral API\` | User-facing error message. The sibling branch one line up (line 455) already reads \"use the Mistral API\" correctly, so this fixes an asymmetry users hit when their API-key/apiBase combination is wrong. |
| \`core/commands/slash/built-in-legacy/draftIssue.ts:10\` | \`If the the user request\` → \`If the user request\` | Part of the LLM prompt for the draft-issue slash command — gets sent to the model verbatim. |
| \`core/autocomplete/context/root-path-context/test/testCases/typescript.ts:301\` | \`method_declaration with with generic params\` → \`method_declaration with generic params\` | \`nodeType\` label only — checked the file: \`nodeType\` is descriptive metadata, never matched against parsed source. Sibling entries on lines 252/262/271/280 follow the singular-\`with\` pattern. |

Diff is exactly 3 lines.

## Novelty

\`gh search prs --repo continuedev/continue\` against \`use the the\`, \`the the user\`, and \`with with generic\` all return empty. The only open typo PR (#12062) fixes a different message in another file — no overlap.

## Test plan

- [x] \`grep -rn \"the the \\| with with \" --include='*.ts' core/\` (excluding node_modules) returns no matches after the fix.
- [x] The error message in \`core/llm/index.ts\` continues to be the same shape as its sibling branch on line 455.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed duplicate-word typos ("the the", "with with") in a user-facing error message, the draft-issue LLM prompt, and a test label to improve clarity and consistency.

<sup>Written for commit 274510e9dae7bdb87bd146668b79805200ac0ce4. Summary will update on new commits. <a href="https://cubic.dev/pr/continuedev/continue/pull/12456?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

