### PR TITLE
a11y: add aria-label to response action buttons for screen readers

### DIFF
--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/ApplyActions.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/ApplyActions.tsx
@@ -39,6 +39,7 @@ export function ApplyActions(props: ApplyActionsProps) {
           <div className="flex items-center">
             <ToolbarButtonWithTooltip
               data-testid="codeblock-toolbar-reject"
+              aria-label="Reject all diffs"
               onClick={onClickReject}
               tooltipContent={`Reject all (${getMetaKeyLabel()}⇧⌫)`}
             >
@@ -47,6 +48,7 @@ export function ApplyActions(props: ApplyActionsProps) {
 
             <ToolbarButtonWithTooltip
               data-testid="codeblock-toolbar-accept"
+              aria-label="Accept all diffs"
               onClick={props.onClickAccept}
               tooltipContent={`Accept all (${getMetaKeyLabel()}⇧⏎)`}
             >
@@ -69,6 +71,7 @@ export function ApplyActions(props: ApplyActionsProps) {
           >
             <button
               data-testid="codeblock-toolbar-apply"
+              aria-label="Apply changes"
               className="text-lightgray flex cursor-pointer items-center border-none bg-transparent pl-0 text-xs outline-none hover:brightness-125"
               onClick={props.onClickApply}
             >

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/CopyButton.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/CopyButton.tsx
@@ -14,6 +14,8 @@ export function CopyButton({ text }: CopyButtonProps) {
     <ToolTip place="top" content="Copy Code">
       <HoverItem className="!p-0">
         <div
+          role="button"
+          aria-label={copied ? "Code copied" : "Copy code block"}
           className="text-lightgray flex cursor-pointer items-center border-none bg-transparent text-xs outline-none hover:brightness-125"
           onClick={copyText}
         >

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/CreateFileButton.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/CreateFileButton.tsx
@@ -13,6 +13,7 @@ export function CreateFileButton({ onClick }: CreateFileButtonProps) {
       <HoverItem className="!p-0">
         <button
           data-testid="codeblock-toolbar-create"
+          aria-label="Create file with code"
           className={`text-lightgray flex items-center border-none bg-transparent pl-0 text-xs text-[${vscForeground}] cursor-pointer outline-none hover:brightness-125`}
           onClick={onClick}
         >

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/InsertButton.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/InsertButton.tsx
@@ -17,6 +17,8 @@ export function InsertButton({ onInsert }: InsertButtonProps) {
     >
       <ToolTip place="top" content="Insert Code">
         <div
+          role="button"
+          aria-label="Insert at cursor"
           className="text-lightgray flex cursor-pointer items-center border-none bg-transparent text-xs outline-none hover:brightness-125"
           onClick={onInsert}
         >

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/RunInTerminalButton.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/RunInTerminalButton.tsx
@@ -19,6 +19,8 @@ export function RunInTerminalButton({ command }: RunInTerminalButtonProps) {
 
   return (
     <div
+      role="button"
+      aria-label="Run command in terminal"
       className={`text-lightgray flex items-center border-none bg-transparent text-xs text-[${vscForeground}] cursor-pointer outline-none hover:brightness-125`}
       onClick={runInTerminal}
     >

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/ToolbarButtonWithTooltip.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/ToolbarButtonWithTooltip.tsx
@@ -6,6 +6,7 @@ interface ToolbarButtonWithTooltipProps {
   children: ReactNode;
   tooltipContent: string;
   "data-testid"?: string;
+  "aria-label"?: string;
 }
 
 export function ToolbarButtonWithTooltip({
@@ -13,10 +14,13 @@ export function ToolbarButtonWithTooltip({
   children,
   tooltipContent,
   "data-testid": testId,
+  "aria-label": ariaLabel,
 }: ToolbarButtonWithTooltipProps) {
   return (
     <ToolTip place="top" content={tooltipContent}>
       <div
+        role="button"
+        aria-label={ariaLabel ?? tooltipContent}
         onClick={(e) => {
           e.stopPropagation();
           onClick();

--- a/gui/src/components/gui/HeaderButtonWithToolTip.tsx
+++ b/gui/src/components/gui/HeaderButtonWithToolTip.tsx
@@ -18,6 +18,7 @@ interface HeaderButtonWithToolTipProps {
   hoverBackgroundColor?: string;
   tooltipPlacement?: PlacesType;
   testId?: string;
+  "aria-label"?: string;
 }
 
 const HeaderButtonWithToolTip = React.forwardRef<
@@ -41,6 +42,7 @@ const HeaderButtonWithToolTip = React.forwardRef<
         style={props.style}
         ref={ref}
         tabIndex={props.tabIndex}
+        aria-label={props["aria-label"] ?? props.text}
       >
         {props.children}
       </HeaderButton>


### PR DESCRIPTION
## Summary

Fixes #12326 (problem 1 only — chat response action buttons).

The Insert / Copy / Apply / Diff / Compact / Generate-rule / Continue / Delete / Helpful / Unhelpful buttons in chat responses are pure-icon elements with a hover tooltip but no accessible name. NVDA and other screen readers announce them as just \"button\" or \"unlabeled button,\" which is the specific blocker called out in the issue.

This PR adds an aria-label to each toolbar button, matching the user-visible action. Pure prop additions, no behavior or styling changes.

## Changes

- gui/src/components/gui/HeaderButtonWithToolTip.tsx — accept an optional aria-label prop and default it to the existing tooltip text so every consumer (FeedbackButtons, CopyIconButton, ResponseActions, History rows, etc.) gains an accessible name automatically.
- gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/*.tsx — add aria-label (and role=\"button\" for div-based clickables) to:
  - InsertButton -> \"Insert at cursor\"
  - CopyButton -> \"Copy code block\" / \"Code copied\"
  - ApplyActions Apply -> \"Apply changes\"
  - ApplyActions Accept / Reject (via ToolbarButtonWithTooltip) -> \"Accept all diffs\" / \"Reject all diffs\"
  - CreateFileButton -> \"Create file with code\"
  - RunInTerminalButton -> \"Run command in terminal\"

The broader sidebar / settings / model-selector accessibility audit described in #12325 is out of scope for this first cut; this is the buttons-only piece called out in #12326.

## Test plan

- [ ] Build the GUI and confirm chat response action buttons announce their action name in NVDA / VoiceOver / Narrator.
- [ ] Hover tooltips still appear unchanged.
- [ ] Visual layout of the action toolbar is unchanged.
- [ ] No regressions in existing keyboard / click behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add aria-labels to chat response action buttons so screen readers announce clear names. Fixes #12326 for buttons only with no visual or behavior changes.

- **Bug Fixes**
  - Labeled buttons: Insert, Copy (incl. “Code copied”), Apply, Accept all diffs, Reject all diffs, Create file, Run in terminal.
  - `HeaderButtonWithToolTip` and `ToolbarButtonWithTooltip` accept `aria-label` and default to the tooltip; added role="button" for div-based clickables.
  - Matches the button-accessibility requirement in #12326; tooltips and layout remain unchanged.

<sup>Written for commit f05e209589fd1de9ed3a41208c80fdf440d5004c. Summary will update on new commits. <a href="https://cubic.dev/pr/continuedev/continue/pull/12457?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

