### PR TITLE
docs: document local config profiles

### DIFF
--- a/docs/customize/deep-dives/configuration.mdx
+++ b/docs/customize/deep-dives/configuration.mdx
@@ -28,6 +28,25 @@ When editing this file, you can see the available options suggested as you type,
 
 See the full reference for `config.yaml` [here](/reference).
 
+### Local configuration profiles
+
+Use `.continue/configs/` to define additional local YAML config profiles. Continue searches for YAML files in both workspace and user-level folders:
+
+- `<workspace>/.continue/configs/*.yaml`
+- `<workspace>/.continue/configs/*.yml`
+- `~/.continue/configs/*.yaml` (MacOS / Linux)
+- `%USERPROFILE%\.continue\configs\*.yaml` (Windows)
+
+Each file is loaded as a separate local config profile and appears in the config selector. Creating or deleting a file in `.continue/configs/` refreshes the list of local profiles. Saving a config file reloads Continue with the updated settings.
+
+Use the local config folders for different types of local definitions:
+
+| Folder | Purpose |
+| --- | --- |
+| `.continue/configs/` | General local config profiles |
+| `.continue/agents/` | Agent definitions |
+| `.continue/assistants/` | Legacy assistant definitions |
+
 ## Legacy Configuration Methods (Deprecated)
 
 <Info>


### PR DESCRIPTION
## Summary

- Document `.continue/configs/` as a local YAML config profiles directory.
- List workspace and user-level config profile locations.
- Explain how `.continue/configs/`, `.continue/agents/`, and `.continue/assistants/` differ.
- Note reload behavior when local config profile files are created, deleted, or saved.

## Related issue

Closes #12377

## Test plan

- Ran a lightweight docs check to confirm the new `.continue/configs/` paths and folder comparison table are present.
- Confirmed markdown code fences remain balanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document local YAML config profiles in `.continue/configs/`, including workspace and user paths, reload behavior, and how this differs from `.continue/agents/` and `.continue/assistants/`. Closes #12377.

<sup>Written for commit a1ebae675b286c0a3c07d4e5f574cba7b11b97d4. Summary will update on new commits. <a href="https://cubic.dev/pr/continuedev/continue/pull/12458?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

