### PR TITLE
fix: support lazy apply for non-Sonnet models like qwen3-coder-plus

### DIFF
--- a/core/edit/lazy/prompts.ts
+++ b/core/edit/lazy/prompts.ts
@@ -54,10 +54,6 @@ function claudeSonnetLazyApplyPrompt(
 export function lazyApplyPromptForModel(
   model: string,
   provider: string,
-): LazyApplyPrompt | undefined {
-  if (model.includes("sonnet")) {
-    return claudeSonnetLazyApplyPrompt;
-  }
-
-  return undefined;
+): LazyApplyPrompt {
+  return claudeSonnetLazyApplyPrompt;
 }

--- a/core/edit/lazy/streamLazyApply.ts
+++ b/core/edit/lazy/streamLazyApply.ts
@@ -19,10 +19,6 @@ export async function* streamLazyApply(
   abortController: AbortController,
 ): AsyncGenerator<DiffLine> {
   const promptFactory = lazyApplyPromptForModel(llm.model, llm.providerName);
-  if (!promptFactory) {
-    throw new Error(`Lazy apply not supported for model ${llm.model}`);
-  }
-
   const promptMessages = promptFactory(oldCode, filename, newCode);
   const lazyCompletion = llm.streamChat(promptMessages, abortController.signal);
 


### PR DESCRIPTION
Title: fix: support lazy apply for non-Sonnet models like qwen3-coder-plus

lazyApplyPromptForModel returned undefined for any model not containing 'sonnet', causing streamLazyApply to throw 'Lazy apply not supported' whenever edit_existing_file fell back to the LLM-based apply path. Use the general-purpose prompt as the default for all models.

Description

edit_existing_file fails silently for non-Sonnet models (e.g. qwen3-coder-plus, gpt-4o, deepseek-coder, etc.) when the model generates lazy edits with // ... existing code ... placeholders. The deterministic apply path skips those (since onlyFullFileRewrite: true), so it falls through to streamLazyApply — which threw an error because lazyApplyPromptForModel only returned a prompt for models containing "sonnet" in their name.

The claudeSonnetLazyApplyPrompt is a general-purpose lazy-apply prompt (the name is just historical). This PR removes the model-name guard and makes it the default for all models, eliminating the error and making edit_existing_file work across providers.

Fixes the issue reported with qwen3-coder-plus via DashScope where users had to add rules to force the agent away from edit_existing_file.

Checklist

- I've read the contributing guide (https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- The relevant docs, if any, have been updated or created
- The relevant tests, if any, have been updated or created

Screen recording or screenshot

N/A — the fix is in the apply pipeline; visible effect is that edit_existing_file no longer fails with a silent error for non-Sonnet models.

Tests

Existing tests in core/edit/lazy/streamLazyApply.test.ts continue to pass. No new tests added — the previous code path that threw was unreachable by any test since all mock LLMs used a "sonnet" model name.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable lazy apply for all models by defaulting to the general-purpose prompt. Prevents silent failures in `edit_existing_file` for non-Sonnet models like `qwen3-coder-plus`, `gpt-4o`, and `deepseek-coder`.

- **Bug Fixes**
  - `lazyApplyPromptForModel` always returns the general-purpose `claudeSonnetLazyApplyPrompt`; removed the model-name check.
  - Removed the "Lazy apply not supported" error path in `streamLazyApply`, allowing LLM-based apply across providers.

<sup>Written for commit 46f092250bd561d97484fbf74eeee5ceec792abe. Summary will update on new commits. <a href="https://cubic.dev/pr/continuedev/continue/pull/12470?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

