### PR TITLE
feat: add Zima as privacy-preserving OpenAI-compatible provider

### DIFF
--- a/packages/llm-info/src/providers/zima.ts
+++ b/packages/llm-info/src/providers/zima.ts
@@ -1,0 +1,26 @@
+import { ModelProvider } from "../types.js";
+
+export const Zima: ModelProvider = {
+  models: [
+    {
+      model: "gpt-4o",
+      displayName: "GPT-4o (Zima)",
+      contextLength: 128000,
+      description:
+        "OpenAI's GPT-4o served through Zima's privacy-preserving infrastructure. Zima's hardware ensures prompts and outputs are never visible to the provider.",
+      regex: /gpt-4o/i,
+      recommendedFor: ["chat"],
+    },
+    {
+      model: "gpt-4o-mini",
+      displayName: "GPT-4o Mini (Zima)",
+      contextLength: 128000,
+      description:
+        "Faster, lightweight GPT-4o Mini served through Zima's privacy-preserving infrastructure.",
+      regex: /gpt-4o-mini/i,
+      recommendedFor: ["chat", "autocomplete"],
+    },
+  ],
+  id: "zima",
+  displayName: "Zima",
+};


### PR DESCRIPTION
Hey, been using Zima for a while and kept wiring it into config manually, figured I'd just upstream it. Zima is OpenAI-compatible so the diff is small (~10 lines)... Zima doesn't store any of my data or LLM usage — they have special hardware and infrastructure so Zima as a provider can't see the prompts, inputs, or outputs...

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `zima` as an OpenAI-compatible provider with `gpt-4o` and `gpt-4o-mini`, served via Zima’s privacy-preserving infrastructure. Enables chat (and autocomplete for `gpt-4o-mini`) with 128k context.

<sup>Written for commit 412822dd0c0498776749d5297456a52348f226e7. Summary will update on new commits. <a href="https://cubic.dev/pr/continuedev/continue/pull/12472?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

