### PR TITLE
docs: document Inception Mercury models

### DIFF
--- a/docs/customize/model-providers/top-level/inception.mdx
+++ b/docs/customize/model-providers/top-level/inception.mdx
@@ -22,9 +22,9 @@ sidebarTitle: "Inception"
   schema: v1
 
   models:
-    - name: <MODEL_NAME>
+    - name: Mercury 2
       provider: inception
-      model: <MODEL_ID>
+      model: mercury-2
       apiKey: <INCEPTION_API_KEY>
   ```
   </Tab>
@@ -33,9 +33,9 @@ sidebarTitle: "Inception"
   {
     "models": [
       {
-        "title": "<MODEL_NAME>",
+        "title": "Mercury 2",
         "provider": "inception",
-        "model": "<MODEL_ID>",
+        "model": "mercury-2",
         "apiKey": "<INCEPTION_API_KEY>"
       }
     ]
@@ -43,6 +43,16 @@ sidebarTitle: "Inception"
   ```
   </Tab>
 </Tabs>
+
+## Available models
+
+| Model | Context length | Recommended use |
+| --- | --- | --- |
+| `mercury-2` | 128k | Chat with tool calling and structured outputs |
+| `mercury-edit-2` | 32k | Autocomplete, apply edit, and next edit suggestions |
+| `mercury-coder-small` | 32k | Coding tasks |
+
+`mercury-2` supports tool calling in Continue.
 
 <Info>
   **Check out a more advanced configuration [here](https://continue.dev/inceptionlabs/mercury-coder?view=config)**


### PR DESCRIPTION
## Summary

- Replace the generic Inception config placeholders with a concrete `mercury-2` example.
- Add an available models table for `mercury-2`, `mercury-edit-2`, and `mercury-coder-small`.
- Document context length and recommended usage for each model.
- Note that `mercury-2` supports tool calling in Continue.

## Related issue

Closes #12466

## Test plan

- Verified model names and context lengths against `packages/llm-info/src/providers/inception.ts`.
- Verified `mercury-2` tool calling support against `core/llm/toolSupport.ts`.
- Ran a lightweight docs check confirming the model names, context length, and tool calling note are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Inception provider docs with a concrete `mercury-2` config example and a models table for `mercury-2`, `mercury-edit-2`, and `mercury-coder-small`, including context limits and recommended uses. Also note that `mercury-2` supports tool calling in Continue.

<sup>Written for commit c6b7ac44b4af7a26145b284f910f1d1e0f998d1a. Summary will update on new commits. <a href="https://cubic.dev/pr/continuedev/continue/pull/12480?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

