### PR TITLE
docs(mcp): add Pictify to mcpServers secrets example

### DIFF
--- a/docs/customize/deep-dives/mcp.mdx
+++ b/docs/customize/deep-dives/mcp.mdx
@@ -175,5 +175,14 @@ mcpServers:
       - "@modelcontextprotocol/server-github"
     env:
       GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
+  - name: Pictify
+    command: npx
+    args:
+      - "-y"
+      - "@pictify/mcp-server"
+    env:
+      PICTIFY_API_KEY: ${{ secrets.PICTIFY_API_KEY }}
 # ...
 ```
+
+The Pictify MCP server lets the agent render images, GIFs, and PDFs from HTML, URLs, or reusable templates — useful when a chat turn needs to produce a publish-ready file (OG image, social card, invoice, certificate) rather than just describing one. See [`@pictify/mcp-server`](https://github.com/pictify-io/mcp) for the full tool list.


### PR DESCRIPTION
## Description

Adds `@pictify/mcp-server` as a third concrete example in the **Work with Secrets in MCP Servers** section of the MCP deep-dive, alongside the existing Supabase and GitHub entries.

## Why

Pictify is an MCP server that lets agents render images, GIFs, and PDFs from HTML/CSS, URLs, or reusable templates — closing the gap between an agent describing an image, slide, or document and actually producing a publish-ready file (OG images, social cards, invoices, certificates, shipping labels, etc.). It's a reasonably common need that none of the existing example servers (database, source control, browser) cover.

The package follows the same `npx + env` pattern as the existing examples, so the addition fits the section's shape without changing structure.

## Links

- Source: https://github.com/pictify-io/mcp
- npm: https://www.npmjs.com/package/@pictify/mcp-server
- MCP: hosted remote also available at `https://mcp.pictify.io` (not added to docs here — kept this PR to the stdio + secrets pattern of the section)

## Checklist

- [x] Single small, scoped doc edit (9 lines added, no existing examples touched)
- [x] Same code-block format as siblings (Supabase / GitHub)
- [x] Short rationale paragraph after the YAML block linking to the source repo
- [x] No images, no other pages touched

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `@pictify/mcp-server` as a third example in the “Work with Secrets in MCP Servers” section, alongside Supabase and GitHub. The example shows npx + env setup with `PICTIFY_API_KEY`, enabling agents to render images, GIFs, and PDFs from HTML, URLs, or templates.

<sup>Written for commit 90b8f5c950872bef2c720d5e32b43906ea179b62. Summary will update on new commits. <a href="https://cubic.dev/pr/continuedev/continue/pull/12486?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

