### PR TITLE
Respect adapter endpoint routing in CLI stream retries

### DIFF
--- a/extensions/cli/src/stream/streamChatResponse.test.ts
+++ b/extensions/cli/src/stream/streamChatResponse.test.ts
@@ -256,7 +256,7 @@ describe("processStreamingResponse - content preservation", () => {
     expect(result.finalContent).toBe("Hello world!");
   });
 
-  it("routes gpt-5 models through responsesStream and preserves streaming tool updates", async () => {
+  it("routes gpt-5 models through chatCompletionStream and preserves streaming tool updates", async () => {
     const gpt5Chunks: ChatCompletionChunk[] = [
       {
         id: "resp_gpt5",
@@ -348,12 +348,12 @@ describe("processStreamingResponse - content preservation", () => {
     ];
 
     const responsesStream = vi.fn().mockImplementation(async function* () {
+      throw new Error("responsesStream should stay adapter-owned in CLI");
+    });
+    const chatCompletionStream = vi.fn().mockImplementation(async function* () {
       for (const chunk of gpt5Chunks) {
         yield chunk;
       }
-    });
-    const chatCompletionStream = vi.fn().mockImplementation(async function* () {
-      throw new Error("chatCompletionStream should not be used for gpt-5");
     });
 
     mockLlmApi = {
@@ -374,8 +374,8 @@ describe("processStreamingResponse - content preservation", () => {
       systemMessage: "You are a helpful assistant.",
     });
 
-    expect(responsesStream).toHaveBeenCalledTimes(1);
-    expect(chatCompletionStream).not.toHaveBeenCalled();
+    expect(chatCompletionStream).toHaveBeenCalledTimes(1);
+    expect(responsesStream).not.toHaveBeenCalled();
     expect(result.content).toBe("Analyzing repository…");
     expect(result.toolCalls).toHaveLength(1);
     expect(result.toolCalls[0]).toMatchObject({

--- a/extensions/cli/src/util/exponentialBackoff.test.ts
+++ b/extensions/cli/src/util/exponentialBackoff.test.ts
@@ -1,6 +1,10 @@
+import { BaseLlmApi } from "@continuedev/openai-adapters";
 import { vi } from "vitest";
 
-import { ExponentialBackoffOptions } from "./exponentialBackoff.js";
+import {
+  chatCompletionStreamWithBackoff,
+  ExponentialBackoffOptions,
+} from "./exponentialBackoff.js";
 
 // Since the functions are not exported, we need to recreate them for testing
 function isRetryableError(error: any): boolean {
@@ -69,6 +73,43 @@ function calculateDelay(
 }
 
 describe("exponentialBackoff utilities", () => {
+  describe("chatCompletionStreamWithBackoff", () => {
+    it("delegates response-capable model routing to chatCompletionStream", async () => {
+      const abortController = new AbortController();
+      const chatCompletionStream = vi
+        .fn()
+        .mockImplementation(async function* () {
+          yield { choices: [{ delta: { content: "chat path" } }] };
+        });
+      const responsesStream = vi.fn().mockImplementation(async function* () {
+        yield { choices: [{ delta: { content: "responses path" } }] };
+      });
+      const llmApi = {
+        chatCompletionStream,
+        responsesStream,
+      } as unknown as BaseLlmApi;
+
+      const stream = await chatCompletionStreamWithBackoff(
+        llmApi,
+        {
+          model: "gpt-5",
+          messages: [{ role: "user", content: "hello" }],
+          stream: true,
+        },
+        abortController.signal,
+      );
+
+      const chunks = [];
+      for await (const chunk of stream) {
+        chunks.push(chunk);
+      }
+
+      expect(chatCompletionStream).toHaveBeenCalledTimes(1);
+      expect(responsesStream).not.toHaveBeenCalled();
+      expect(chunks[0].choices[0].delta.content).toBe("chat path");
+    });
+  });
+
   describe("isRetryableError", () => {
     it("should return true for network connection errors", () => {
       const error = { code: "ECONNRESET" };

--- a/extensions/cli/src/util/exponentialBackoff.ts
+++ b/extensions/cli/src/util/exponentialBackoff.ts
@@ -1,4 +1,4 @@
-import { BaseLlmApi, isResponsesModel } from "@continuedev/openai-adapters";
+import { BaseLlmApi } from "@continuedev/openai-adapters";
 import type { ChatCompletionCreateParamsStreaming } from "openai/resources.mjs";
 
 import { error, warn } from "../logging.js";
@@ -180,14 +180,6 @@ export async function chatCompletionStreamWithBackoff(
       // Check if we should abort before making the request
       if (abortSignal.aborted) {
         throw new Error("Request aborted");
-      }
-
-      const useResponses =
-        typeof llmApi.responsesStream === "function" &&
-        isResponsesModel(params.model);
-
-      if (useResponses) {
-        return llmApi.responsesStream!(params, abortSignal);
       }
 
       return llmApi.chatCompletionStream(params, abortSignal);


### PR DESCRIPTION
## Summary

Fixes #10474.

The CLI retry helper was routing Responses-capable model names directly to `llmApi.responsesStream()` whenever that optional method existed. That bypassed the OpenAI adapter's `apiBase` guard, so OpenAI-compatible providers and proxies could be sent to `/v1/responses` even when they only support `/v1/chat/completions`.

This change keeps endpoint selection inside the adapter by having `chatCompletionStreamWithBackoff()` delegate streaming calls to the required `llmApi.chatCompletionStream()` contract. The OpenAI adapter still uses the Responses API for official OpenAI endpoints when appropriate, but custom `apiBase` values stay on the chat-completions path.

## Changes

- Remove the CLI helper's direct `responsesStream()` routing branch.
- Add a regression test proving a Responses-capable request with both adapter methods present still goes through `chatCompletionStream()`.
- Update the streaming/tool-call preservation test so it fails if the CLI calls `responsesStream()` directly.

## Verification

- `npm --prefix extensions/cli test`
- `npm --prefix packages/openai-adapters test -- --run`
- `npm --prefix extensions/cli run build`
- `npm --prefix extensions/cli run test:e2e`
- `npm --prefix extensions/cli run test:smoke`
- `npm --prefix extensions/cli run typecheck`
- `git diff --check`

I also ran two manual regression smokes:

- a local OpenAI-compatible proxy with a Responses-capable model name and custom `apiBase`, which hit `/v1/chat/completions` once and `/v1/responses` zero times;
- the official OpenAI path with a Responses-capable model, to confirm adapter-owned Responses routing still streams successfully.
