### PR TITLE
fix(openai-adapters): read Gemini embeddings from correct response field

### DIFF
--- a/packages/openai-adapters/src/apis/Gemini.test.ts
+++ b/packages/openai-adapters/src/apis/Gemini.test.ts
@@ -1,6 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { GeminiApi } from "./Gemini.js";
+
+// Mock the fetch package so the embeddings test can stub the HTTP response.
+vi.mock("@continuedev/fetch", async () => {
+  const actual = await vi.importActual("@continuedev/fetch");
+  return {
+    ...actual,
+    fetchwithRequestOptions: vi.fn(),
+  };
+});
 
 describe("GeminiApi", () => {
   const api = new GeminiApi({
@@ -131,6 +140,45 @@ describe("GeminiApi", () => {
       expect(result.contents[0].role).toBe("user");
       expect(result.contents[1].role).toBe("model");
       expect(result.contents[2].role).toBe("user");
+    });
+  });
+
+  describe("embed", () => {
+    afterEach(() => {
+      vi.clearAllMocks();
+      vi.unstubAllGlobals();
+    });
+
+    it("parses the 'embeddings' field from the batchEmbedContents response", async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            embeddings: [
+              { values: [0.1, 0.2, 0.3] },
+              { values: [0.4, 0.5, 0.6] },
+            ],
+          }),
+          { headers: { "Content-Type": "application/json" } },
+        ),
+      );
+      vi.stubGlobal("fetch", mockFetch);
+      const fetchPackage = await import("@continuedev/fetch");
+      vi.mocked(fetchPackage.fetchwithRequestOptions).mockImplementation(
+        mockFetch as any,
+      );
+
+      const response = await api.embed({
+        model: "gemini-embedding-001",
+        input: ["Hello", "World"],
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url] = mockFetch.mock.calls[0];
+      expect(url.toString()).toContain(":batchEmbedContents");
+      expect(response.data.map((d) => d.embedding)).toEqual([
+        [0.1, 0.2, 0.3],
+        [0.4, 0.5, 0.6],
+      ]);
     });
   });
 });

--- a/packages/openai-adapters/src/apis/Gemini.ts
+++ b/packages/openai-adapters/src/apis/Gemini.ts
@@ -494,11 +494,7 @@ export class GeminiApi implements BaseLlmApi {
     const data = (await response.json()) as any;
     return embedding({
       model: body.model,
-      usage: {
-        total_tokens: data.total_tokens,
-        prompt_tokens: data.prompt_tokens,
-      },
-      data: data.batchEmbedContents.map((embedding: any) => embedding.values),
+      data: data.embeddings.map((embedding: any) => embedding.values),
     });
   }
 


### PR DESCRIPTION
## Description

The Gemini embeddings adapter reads the wrong field from the `:batchEmbedContents` response. In `packages/openai-adapters/src/apis/Gemini.ts`, `embed()` did:

```ts
data: data.batchEmbedContents.map((embedding: any) => embedding.values),
```

but the Gemini API returns the vectors under `embeddings`, not `batchEmbedContents`. That field is always `undefined`, so **every** embeddings request through the Gemini adapter throws:

```
TypeError: Cannot read properties of undefined (reading 'map')
```

This breaks embeddings (e.g. `@codebase` / `@docs` indexing) for anyone configuring Gemini as their `embed` model. The path is reachable: `core/llm/llms/Gemini.ts` sets `useOpenAIAdapterFor = ["chat", "embed", ...]`, so embeddings go through `GeminiApi.embed()`.

The fix mirrors the **core** implementation, which already reads the correct field:

```ts
// core/llm/llms/Gemini.ts
return data.embeddings.map((embedding: any) => embedding.values);
```

I also removed the `usage` block, which read two more non-existent fields (`data.total_tokens` / `data.prompt_tokens`). The batchEmbedContents response carries no token usage, and `embedding()` already defaults usage to zeros — matching core, which sets no usage.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A — backend crash fix; covered by the regression test below.

## Tests

Added an `embed` test in `packages/openai-adapters/src/apis/Gemini.test.ts` that mocks the real `:batchEmbedContents` response shape (`{ embeddings: [{ values }] }`) and asserts the parsed vectors. Verified it **fails on the old code** with `Cannot read properties of undefined (reading 'map')` and **passes with the fix**. `npx tsc --noEmit` and `prettier --check` both pass locally.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in the Gemini embeddings adapter by reading vectors from the correct response field. Restores embeddings for Gemini `embed` models and aligns adapter behavior with core.

- **Bug Fixes**
  - `packages/openai-adapters/src/apis/Gemini.ts`: `embed()` now reads `data.embeddings` instead of `data.batchEmbedContents`.
  - Removed the invalid `usage` block (nonexistent token fields).

- **Tests**
  - Added a regression test in `packages/openai-adapters/src/apis/Gemini.test.ts` that mocks the `:batchEmbedContents` response and asserts parsed vectors.

<sup>Written for commit e5f15485871bdbedf50369b20c3be3909983bcaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12517?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

