### PR TITLE
fix(llm): guard getMaxStopWords against undefined apiBase

### DIFF
--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -253,11 +253,18 @@ class OpenAI extends BaseLLM {
   }
 
   protected getMaxStopWords(): number {
-    const url = new URL(this.apiBase!);
-
     if (this.maxStopWords !== undefined) {
       return this.maxStopWords;
-    } else if (url.host === "api.deepseek.com") {
+    }
+
+    // apiBase can legitimately be undefined (e.g. continue-proxy, whose
+    // defaultOptions don't carry one), so guard against `new URL(undefined)`.
+    if (!this.apiBase) {
+      return Infinity;
+    }
+
+    const url = new URL(this.apiBase);
+    if (url.host === "api.deepseek.com") {
       return 16;
     } else if (
       url.port === "1337" ||

--- a/core/llm/llms/OpenAI.vitest.ts
+++ b/core/llm/llms/OpenAI.vitest.ts
@@ -424,4 +424,31 @@ describe("OpenAI", () => {
       },
     });
   });
+
+  describe("getMaxStopWords", () => {
+    test("returns Infinity instead of throwing when apiBase is undefined", () => {
+      const openai = new OpenAI({
+        apiKey: "test-api-key",
+        model: "gpt-4",
+        apiBase: "https://api.openai.com/v1/",
+      });
+      // continue-proxy and similar providers can leave apiBase undefined
+      (openai as any).apiBase = undefined;
+
+      expect(() => (openai as any).getMaxStopWords()).not.toThrow();
+      expect((openai as any).getMaxStopWords()).toBe(Infinity);
+    });
+
+    test("honors maxStopWords even when apiBase is undefined", () => {
+      const openai = new OpenAI({
+        apiKey: "test-api-key",
+        model: "gpt-4",
+        apiBase: "https://api.openai.com/v1/",
+      });
+      (openai as any).apiBase = undefined;
+      (openai as any).maxStopWords = 7;
+
+      expect((openai as any).getMaxStopWords()).toBe(7);
+    });
+  });
 });


### PR DESCRIPTION
## Description

`OpenAI.getMaxStopWords()` builds `new URL(this.apiBase!)` at the very top of the method. That non-null assertion is unsafe: `apiBase` can legitimately be `undefined`. The clearest case is `continue-proxy`, whose `static defaultOptions` (`core/llm/llms/stubs/ContinueProxy.ts`) replace the parent `OpenAI.defaultOptions` and do **not** carry an `apiBase`. When it is undefined, `new URL(undefined)` throws:

```
TypeError: Invalid URL
```

…which crashes stop-word trimming (`getMaxStopWords()` is called when building the request args for every completion).

This is one of the root causes called out by @RomneyDa in #11872, who suggested exactly this fix:

> guard `getMaxStopWords()` to handle undefined `apiBase` gracefully (return a safe default like `Infinity`)

### Fix

- Move the `new URL(...)` parse **below** the `maxStopWords` short-circuit, so it is only built when actually needed (previously it was parsed even when `maxStopWords` was set and the URL went unused).
- Return `Infinity` when `apiBase` is absent — the same safe default already used for unknown hosts — and drop the `!` assertion.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A — backend crash fix; covered by the regression tests below.

## Tests

Added a `getMaxStopWords` suite in `core/llm/llms/OpenAI.vitest.ts`:
- returns `Infinity` (instead of throwing) when `apiBase` is undefined
- still honors an explicit `maxStopWords` when `apiBase` is undefined

Verified both **fail on the old code** with `TypeError: Invalid URL` and **pass with the fix**. `npx tsc -p ./ --noEmit` reports 0 errors, `prettier --check` passes, and the full `OpenAI.vitest.ts` suite is green (10/10) locally.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in `OpenAI.getMaxStopWords()` when `apiBase` is undefined by returning `Infinity` and only parsing the URL when needed. Prevents "TypeError: Invalid URL" during stop-word trimming.

- **Bug Fixes**
  - Return `Infinity` when `apiBase` is missing; remove the non-null assertion.
  - Parse the URL only after honoring `maxStopWords`.
  - Add regression tests for undefined `apiBase` and explicit `maxStopWords`.

<sup>Written for commit eec87837403df7efc24460d4b11646c8a4278aea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12518?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

