### PR TITLE
fix(prompt-files): avoid crash when <system> tag is unclosed

### DIFF
--- a/core/promptFiles/parsePromptFile.ts
+++ b/core/promptFiles/parsePromptFile.ts
@@ -15,7 +15,9 @@ export function parsePromptFile(path: string, content: string) {
   const version = preamble.version ?? 2;
 
   let systemMessage: string | undefined = undefined;
-  if (prompt.includes("<system>")) {
+  // Require both tags: a `<system>` with no matching `</system>` would make
+  // `split("</system>")[1]` undefined and crash on `.trim()`.
+  if (prompt.includes("<system>") && prompt.includes("</system>")) {
     systemMessage = prompt.split("<system>")[1].split("</system>")[0].trim();
     prompt = prompt.split("</system>")[1].trim();
   }

--- a/core/promptFiles/parsePromptFile.vitest.ts
+++ b/core/promptFiles/parsePromptFile.vitest.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { parsePromptFile } from "./parsePromptFile.js";
+
+describe("parsePromptFile", () => {
+  it("extracts the system message when both tags are present", () => {
+    const result = parsePromptFile(
+      "greeting.prompt",
+      "<system>You are helpful</system>\nSummarize the file",
+    );
+
+    expect(result.systemMessage).toBe("You are helpful");
+    expect(result.prompt).toBe("Summarize the file");
+  });
+
+  it("does not throw when <system> has no closing tag", () => {
+    const content = "<system>You forgot to close the tag\nSummarize the file";
+
+    expect(() => parsePromptFile("broken.prompt", content)).not.toThrow();
+
+    const result = parsePromptFile("broken.prompt", content);
+    expect(result.systemMessage).toBeUndefined();
+    expect(result.prompt).toBe(content);
+  });
+
+  it("leaves the prompt untouched when there is no system block", () => {
+    const result = parsePromptFile("plain.prompt", "Just a prompt body");
+
+    expect(result.systemMessage).toBeUndefined();
+    expect(result.prompt).toBe("Just a prompt body");
+  });
+});


### PR DESCRIPTION
## Description

`parsePromptFile` only checks for an opening `<system>` tag before splitting on the closing one:

```ts
if (prompt.includes("<system>")) {
  systemMessage = prompt.split("<system>")[1].split("</system>")[0].trim();
  prompt = prompt.split("</system>")[1].trim();
}
```

If a `.prompt` file contains `<system>` but omits the closing `</system>` (an easy authoring typo), `prompt.split("</system>")` returns a single-element array, so `[1]` is `undefined` and `.trim()` throws:

```
TypeError: Cannot read properties of undefined (reading 'trim')
```

Because `.prompt` files are parsed during config / slash-command load, one malformed file breaks loading instead of degrading gracefully.

### Fix

Require **both** `<system>` and `</system>` before parsing the system block. An unclosed tag now falls through and the entire body is treated as the prompt (no crash).

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A — parser crash fix; covered by the new tests.

## Tests

Added `core/promptFiles/parsePromptFile.vitest.ts` covering:
- a well-formed `<system>…</system>` block (parsed correctly)
- an unclosed `<system>` tag (no longer throws; whole body kept as the prompt)
- no system block at all

Verified the unclosed case **fails on the old code** with `Cannot read properties of undefined (reading 'trim')` and **passes with the fix**. `tsc -p ./ --noEmit` reports 0 errors and `prettier --check` passes locally.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix prevents a crash when a .prompt file includes <system> without a closing </system>. The parser now only extracts a system message if both tags are present; otherwise it treats the content as the prompt.

- **Bug Fixes**
  - Check for both <system> and </system> before parsing to avoid split/trim TypeError.
  - Add tests for closed, unclosed, and no-system cases.

<sup>Written for commit 84c0f345612fb1672be05af732c80f7893aa9276. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12519?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

