### PR TITLE
fix(openai-adapters): convert requestOptions.timeout from seconds to ms

### DIFF
--- a/packages/openai-adapters/src/apis/OpenAI.test.ts
+++ b/packages/openai-adapters/src/apis/OpenAI.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { OpenAIApi } from "./OpenAI.js";
+
+describe("OpenAIApi requestOptions.timeout", () => {
+  it("converts timeout from seconds to milliseconds for the OpenAI SDK", () => {
+    // requestOptions.timeout is expressed in seconds throughout Continue
+    // (see packages/fetch getAgentOptions, which multiplies by 1000), but the
+    // OpenAI JS SDK expects milliseconds. A value of 300 must become 300000.
+    const api = new OpenAIApi({
+      provider: "openai",
+      apiKey: "test-key",
+      requestOptions: { timeout: 300 },
+    } as any);
+
+    expect(api.openai.timeout).toBe(300_000);
+  });
+
+  it("leaves the SDK default in place when no timeout is set", () => {
+    const api = new OpenAIApi({
+      provider: "openai",
+      apiKey: "test-key",
+    } as any);
+
+    // OpenAI SDK default is 600000 ms (10 minutes).
+    expect(api.openai.timeout).toBe(600_000);
+  });
+});

--- a/packages/openai-adapters/src/apis/OpenAI.ts
+++ b/packages/openai-adapters/src/apis/OpenAI.ts
@@ -45,7 +45,11 @@ export class OpenAIApi implements BaseLlmApi {
       apiKey: config.apiKey ?? "",
       baseURL: this.apiBase,
       fetch: customFetch(config.requestOptions),
-      timeout: config?.requestOptions?.timeout || undefined,
+      // requestOptions.timeout is in seconds (see packages/fetch getAgentOptions);
+      // the OpenAI SDK expects milliseconds.
+      timeout: config?.requestOptions?.timeout
+        ? config.requestOptions.timeout * 1000
+        : undefined,
     });
   }
   modifyChatBody<T extends ChatCompletionCreateParams>(body: T): T {


### PR DESCRIPTION
## Description

`requestOptions.timeout` is expressed in seconds throughout Continue (for example `packages/fetch` `getAgentOptions`: `(timeout ?? 7200) * 1000 // ms`), but `packages/openai-adapters/src/apis/OpenAI.ts` passed the raw value to the OpenAI JS SDK, which reads `timeout` as milliseconds. So `timeout: 300`, meant as 5 minutes, became 300ms. That is about 2000x too short, and it caused immediate "Connection error" failures, especially with local models.

This multiplies by 1000 before passing the value to the SDK.

Fixes #12450. It is also a likely root cause behind #11818 and #11954.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Not applicable. The change is a unit conversion in `packages/openai-adapters` and has no UI surface. The observable result is the timeout value the SDK receives, which the test below asserts directly.

## Tests

Added `src/apis/OpenAI.test.ts`. It asserts the OpenAI client gets `300000` ms when `requestOptions.timeout` is `300`, and that the SDK default of `600000` is preserved when the option is unset. The full `openai-adapters` suite passes, 147 tests. `tsc` and Prettier are clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix timeout unit mismatch in `packages/openai-adapters` by converting `requestOptions.timeout` (seconds) to milliseconds when creating the OpenAI SDK client. Prevents 300s configs being treated as 300ms and avoids instant connection errors, especially with local models.

- **Bug Fixes**
  - Multiply `requestOptions.timeout` by 1000 before passing to the SDK; keep SDK default (10m) when unset.
  - Add tests in `packages/openai-adapters/src/apis/OpenAI.test.ts` to verify conversion and default (600000 ms).

<sup>Written for commit d70e71421625120312113185329826199ae374b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


