### PR TITLE
fix: update link to customize/models docs

### DIFF
--- a/core/config/createNewAssistantFile.ts
+++ b/core/config/createNewAssistantFile.ts
@@ -9,7 +9,7 @@ version: 1.0.0
 schema: v1
 
 # Define which models can be used
-# https://docs.continue.dev/customization/models
+# https://docs.continue.dev/customize/models
 models:
   - name: my gpt-5
     provider: openai


### PR DESCRIPTION
## Description

Updated documentation link that was 404

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A

## Tests

N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a broken docs link in the assistant config template by updating it to https://docs.continue.dev/customize/models to avoid 404s.
Change is in core/config/createNewAssistantFile.ts.

<sup>Written for commit c360b4f1fb6cd707e29cb9fb5614ded762e932b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

