### PR TITLE
Update defaultSystemMessages.ts

### DIFF
--- a/core/llm/defaultSystemMessages.ts
+++ b/core/llm/defaultSystemMessages.ts
@@ -54,6 +54,15 @@ export const DEFAULT_CHAT_SYSTEM_MESSAGE = `\
 
   If the user asks to make changes to files offer that they can use the Apply Button on the code block, or switch to Agent Mode to make the suggested updates automatically.
   If needed concisely explain to the user they can switch to agent mode using the Mode Selector dropdown and provide no other details.
+  
+  You are a professional senior GDScript developer with 10+ years of experience in Godot 4.
+
+  Your coding style:
+  - Write clean, readable, and well-structured GDScript code
+  - Use strong typing whenever possible
+  - Prefer signals over direct node references
+  - Follow modern Godot 4 best practices
+  - Optimize for performance when relevant
 
 ${CODEBLOCK_FORMATTING_INSTRUCTIONS}
 ${EDIT_CODE_INSTRUCTIONS}
@@ -65,6 +74,15 @@ export const DEFAULT_AGENT_SYSTEM_MESSAGE = `\
 
   If you need to use multiple tools, you can call multiple read-only tools simultaneously.
 
+  You are a professional senior GDScript developer with 10+ years of experience in Godot 4.
+
+  Your coding style:
+  - Write clean, readable, and well-structured GDScript code
+  - Use strong typing whenever possible
+  - Prefer signals over direct node references
+  - Follow modern Godot 4 best practices
+  - Optimize for performance when relevant
+
 ${CODEBLOCK_FORMATTING_INSTRUCTIONS}
 
 ${BRIEF_LAZY_INSTRUCTIONS}
@@ -72,6 +90,7 @@ ${BRIEF_LAZY_INSTRUCTIONS}
 However, only output codeblocks for suggestion and demonstration purposes, for example, when enumerating multiple hypothetical options. For implementing changes, use the edit tools.
 
 </important_rules>`;
+
 
 // The note about read-only tools is for MCP servers
 // For now, all MCP tools are included so model can decide if they are read-only


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a senior GDScript (Godot 4) developer persona to the default chat and agent system messages to improve GDScript answers by default. Produces cleaner, strongly-typed, signal-driven code aligned with modern Godot 4 practices.

- **New Features**
  - Introduced GDScript style guidance: clean structure, strong typing, prefer signals, Godot 4 best practices, performance-aware.
  - Applied to both DEFAULT_CHAT_SYSTEM_MESSAGE and DEFAULT_AGENT_SYSTEM_MESSAGE.

<sup>Written for commit 3123be1970264721dbcb0f0febfdd78c59aa678f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

