### PR TITLE
fix: update context providers docs link

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor/utils/getSuggestion.ts
+++ b/gui/src/components/mainInput/TipTapEditor/utils/getSuggestion.ts
@@ -169,7 +169,7 @@ export function getContextProviderDropdownOptions(
         action: () => {
           ideMessenger.post(
             "openUrl",
-            "https://docs.continue.dev/customization/context-providers#built-in-context-providers",
+            "https://docs.continue.dev/customize/deep-dives/custom-providers",
           );
         },
         description: "",


### PR DESCRIPTION
## Summary
- update the @ dropdown "Add more context providers" action to open the current Context Providers docs page
- replace the old redirected URL that lands on Page not found

Fixes #12507

## Test plan
- Verified the old docs URL lands on Page not found
- Verified https://docs.continue.dev/customize/deep-dives/custom-providers loads the Context Providers page
- Ran `git diff --check`
- Ran `git grep` for the old and new Continue docs URLs in the changed file

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the `@` dropdown “Add more context providers” action to open the current Context Providers docs, replacing a stale URL that 404s.

<sup>Written for commit 9df64870c6d3891a9267f2240ff146ab4c965876. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

