### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/core/llm/llms/MiniMax.ts
+++ b/core/llm/llms/MiniMax.ts
@@ -6,7 +6,7 @@ class MiniMax extends OpenAI {
   static providerName = "minimax";
   static defaultOptions: Partial<LLMOptions> = {
     apiBase: "https://api.minimax.io/v1/",
-    model: "MiniMax-M2.7",
+    model: "MiniMax-M3",
     useLegacyCompletionsEndpoint: false,
   };
 

--- a/docs/customize/model-providers/more/minimax.mdx
+++ b/docs/customize/model-providers/more/minimax.mdx
@@ -17,9 +17,9 @@ sidebarTitle: "MiniMax"
   schema: v1
 
   models:
-    - name: MiniMax M2.7
+    - name: MiniMax M3
       provider: minimax
-      model: MiniMax-M2.7
+      model: MiniMax-M3
       apiKey: <YOUR_MINIMAX_API_KEY>
   ```
   </Tab>
@@ -28,9 +28,9 @@ sidebarTitle: "MiniMax"
   {
     "models": [
       {
-        "title": "MiniMax M2.7",
+        "title": "MiniMax M3",
         "provider": "minimax",
-        "model": "MiniMax-M2.7",
+        "model": "MiniMax-M3",
         "apiKey": "<YOUR_MINIMAX_API_KEY>"
       }
     ]
@@ -43,10 +43,9 @@ sidebarTitle: "MiniMax"
 
 | Model | Description |
 | :---- | :---------- |
-| `MiniMax-M2.7` | Latest flagship model with enhanced reasoning and coding. 204K context window. |
+| `MiniMax-M3` | Latest flagship model with 512K context window, 128K max output, and image input support. |
+| `MiniMax-M2.7` | Previous flagship model with enhanced reasoning and coding. 204K context window. |
 | `MiniMax-M2.7-highspeed` | High-speed version of M2.7 for low-latency scenarios. 204K context window. |
-| `MiniMax-M2.5` | Peak performance with ultimate value. 204K context window. |
-| `MiniMax-M2.5-highspeed` | Same performance, faster and more agile. 204K context window. |
 
 ## Notes
 

--- a/gui/src/pages/AddNewModel/configs/models.ts
+++ b/gui/src/pages/AddNewModel/configs/models.ts
@@ -2699,10 +2699,22 @@ export const models: { [key: string]: ModelPackage } = {
     providerOptions: ["sambanova"],
     isOpenSource: true,
   },
+  minimaxM3: {
+    title: "MiniMax M3",
+    description:
+      "Latest flagship model with a 512K context window, 128K max output, and image input support.",
+    params: {
+      title: "MiniMax M3",
+      model: "MiniMax-M3",
+      contextLength: 524_288,
+    },
+    providerOptions: ["minimax"],
+    isOpenSource: false,
+  },
   minimaxM27: {
     title: "MiniMax M2.7",
     description:
-      "Latest flagship model with enhanced reasoning and coding capabilities. 204K context window.",
+      "Previous flagship model with enhanced reasoning and coding capabilities. 204K context window.",
     params: {
       title: "MiniMax M2.7",
       model: "MiniMax-M2.7",
@@ -2718,30 +2730,6 @@ export const models: { [key: string]: ModelPackage } = {
     params: {
       title: "MiniMax M2.7 Highspeed",
       model: "MiniMax-M2.7-highspeed",
-      contextLength: 204_800,
-    },
-    providerOptions: ["minimax"],
-    isOpenSource: false,
-  },
-  minimaxM25: {
-    title: "MiniMax M2.5",
-    description:
-      "Peak performance with ultimate value. Excels at complex reasoning, code generation, and multi-step tasks with a 204K context window.",
-    params: {
-      title: "MiniMax M2.5",
-      model: "MiniMax-M2.5",
-      contextLength: 204_800,
-    },
-    providerOptions: ["minimax"],
-    isOpenSource: false,
-  },
-  minimaxM25Highspeed: {
-    title: "MiniMax M2.5 Highspeed",
-    description:
-      "Same performance as M2.5, faster and more agile for latency-sensitive tasks with a 204K context window.",
-    params: {
-      title: "MiniMax M2.5 Highspeed",
-      model: "MiniMax-M2.5-highspeed",
       contextLength: 204_800,
     },
     providerOptions: ["minimax"],

--- a/gui/src/pages/AddNewModel/configs/providers.ts
+++ b/gui/src/pages/AddNewModel/configs/providers.ts
@@ -576,10 +576,9 @@ Select the \`GPT-4o\` model below to complete your provider configuration, but n
       },
     ],
     packages: [
+      models.minimaxM3,
       models.minimaxM27,
       models.minimaxM27Highspeed,
-      models.minimaxM25,
-      models.minimaxM25Highspeed,
       {
         ...models.AUTODETECT,
         params: {

--- a/packages/llm-info/src/providers/minimax.ts
+++ b/packages/llm-info/src/providers/minimax.ts
@@ -3,12 +3,22 @@ import { ModelProvider } from "../types.js";
 export const MiniMax: ModelProvider = {
   models: [
     {
+      model: "MiniMax-M3",
+      displayName: "MiniMax M3",
+      contextLength: 524288,
+      maxCompletionTokens: 131072,
+      description:
+        "Latest flagship model with a 512K context window, 128K max output, and image input support.",
+      regex: /MiniMax-M3$/i,
+      recommendedFor: ["chat"],
+    },
+    {
       model: "MiniMax-M2.7",
       displayName: "MiniMax M2.7",
       contextLength: 204800,
       maxCompletionTokens: 192000,
       description:
-        "Latest flagship model with enhanced reasoning and coding capabilities.",
+        "Previous flagship model with enhanced reasoning and coding capabilities.",
       regex: /MiniMax-M2\.7$/i,
       recommendedFor: ["chat"],
     },
@@ -19,26 +29,6 @@ export const MiniMax: ModelProvider = {
       maxCompletionTokens: 192000,
       description: "High-speed version of M2.7 for low-latency scenarios.",
       regex: /MiniMax-M2\.7-highspeed/i,
-      recommendedFor: ["chat"],
-    },
-    {
-      model: "MiniMax-M2.5",
-      displayName: "MiniMax M2.5",
-      contextLength: 204800,
-      maxCompletionTokens: 192000,
-      description:
-        "Peak performance with ultimate value. Excels at complex reasoning, code generation, and multi-step tasks.",
-      regex: /MiniMax-M2\.5$/i,
-      recommendedFor: ["chat"],
-    },
-    {
-      model: "MiniMax-M2.5-highspeed",
-      displayName: "MiniMax M2.5 Highspeed",
-      contextLength: 204800,
-      maxCompletionTokens: 192000,
-      description:
-        "Same performance as M2.5, faster and more agile for latency-sensitive tasks.",
-      regex: /MiniMax-M2\.5-highspeed/i,
       recommendedFor: ["chat"],
     },
   ],


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to include the latest M3 model as default.

## Changes
- Add `MiniMax-M3` to the model selection list and set it as the new default
- Retain `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as available alternatives
- Remove deprecated `MiniMax-M2.5` and `MiniMax-M2.5-highspeed` from the list
- Update docs and GUI model selection to reflect M3 as flagship

## Why
MiniMax-M3 is the new flagship model with a 512K context window, 128K max output, and image input support across the OpenAI-compatible API.

## Models
| Model | Description |
| :---- | :---------- |
| `MiniMax-M3` (default) | Latest flagship with 512K context, 128K max output, image input. |
| `MiniMax-M2.7` | Previous flagship with enhanced reasoning and coding. 204K context. |
| `MiniMax-M2.7-highspeed` | High-speed M2.7 for low-latency scenarios. 204K context. |

## Testing
- Prettier formatting checked
- All MiniMax model IDs verified against the MiniMax platform

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set MiniMax M3 as the default model and update docs/GUI to make it the flagship. Removes M2.5 variants; M3 offers a 512K context, 128K max output, and image input.

- **New Features**
  - Default `minimax` model set to MiniMax-M3.
  - GUI and provider updates: add M3; keep M2.7 and M2.7-highspeed; remove M2.5 variants (`packages/llm-info`, GUI configs).
  - Docs updated with M3 examples and model table.

- **Migration**
  - No action needed if you use the default `minimax` model.
  - Replace any `MiniMax-M2.5*` references with `MiniMax-M3`, `MiniMax-M2.7`, or `MiniMax-M2.7-highspeed`.

<sup>Written for commit c1a26eccf7b92951d3c0ee665d10967441d19d16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

