### PR TITLE
test(core): fix error message assertions and unskip withExponentialBackoff tests

### DIFF
--- a/core/util/withExponentialBackoff.test.ts
+++ b/core/util/withExponentialBackoff.test.ts
@@ -6,7 +6,7 @@ import {
   RETRY_AFTER_HEADER,
 } from "./withExponentialBackoff";
 
-describe.skip("withExponentialBackoff", () => {
+describe("withExponentialBackoff", () => {
   it("should return result when apiCall succeeds on first attempt", async () => {
     // Arrange
     const apiCall = jest.fn().mockResolvedValue("Success");
@@ -112,7 +112,7 @@ describe.skip("withExponentialBackoff", () => {
     // Act & Assert
     await expect(
       withExponentialBackoff(apiCall, maxTries, initialDelaySeconds),
-    ).rejects.toThrow("Failed to make API call after max tries");
+    ).rejects.toThrow("Failed to make API call after");
 
     expect(apiCall).toHaveBeenCalledTimes(maxTries);
   });
@@ -135,8 +135,43 @@ describe.skip("withExponentialBackoff", () => {
 
     await expect(
       withExponentialBackoff(apiCall, maxTries, initialDelaySeconds),
-    ).rejects.toThrow("Failed to make API call after max tries");
+    ).rejects.toThrow("Failed to make API call after");
 
     expect(apiCall).toHaveBeenCalledTimes(0);
+  });
+
+  it("should retry when error message contains 'overloaded'", async () => {
+    const apiCall = jest.fn();
+    const firstError = new Error("Service overloaded, please try again");
+    apiCall.mockRejectedValueOnce(firstError).mockResolvedValueOnce("Success");
+
+    const result = await withExponentialBackoff(apiCall, 5, 0.01);
+
+    expect(result).toBe("Success");
+    expect(apiCall).toHaveBeenCalledTimes(2);
+  });
+
+  it("should retry when error message contains 'malformed json'", async () => {
+    const apiCall = jest.fn();
+    const firstError = new Error("Received malformed JSON from upstream");
+    apiCall.mockRejectedValueOnce(firstError).mockResolvedValueOnce("Success");
+
+    const result = await withExponentialBackoff(apiCall, 5, 0.01);
+
+    expect(result).toBe("Success");
+    expect(apiCall).toHaveBeenCalledTimes(2);
+  });
+
+  it("should retry when error message contains a 429 code in JSON body", async () => {
+    const apiCall = jest.fn();
+    const firstError = new Error(
+      '{"error": {"code": 429, "message": "Too Many Requests"}}',
+    );
+    apiCall.mockRejectedValueOnce(firstError).mockResolvedValueOnce("Success");
+
+    const result = await withExponentialBackoff(apiCall, 5, 0.01);
+
+    expect(result).toBe("Success");
+    expect(apiCall).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION

## Description

`core/util/withExponentialBackoff.ts` is the retry helper wrapping every LLM call in `core/llm/index.ts` (chat fetch + embeddings). Its test file was skipped wholesale via `describe.skip` because two assertions used an incorrect expected error string: `"Failed to make API call after max tries"` is not a substring of the actual implementation message `"Failed to make API call after ${maxTries} retries"`.

This PR:
1. Fixes the two assertion strings to match the actual error message (uses the stable prefix `"Failed to make API call after"`).
2. Removes `describe.skip` so all 6 existing tests run.
3. Adds 3 new tests covering the previously-untested retry triggers in the implementation: `"overloaded"` substring, `"malformed json"` substring, and `"code": 429` JSON-body regex.

No implementation code is changed.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created — N/A (test-only)
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A — test-only change with no user-visible behavior.

## Tests

All changes are in `core/util/withExponentialBackoff.test.ts`. Verified locally via `cd core && npm test -- withExponentialBackoff` — 9 tests pass (6 previously-skipped + 3 new). ESLint and Prettier clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes and re-enables the `withExponentialBackoff` test suite, and adds coverage for key retry conditions. Test-only; no runtime changes.

- **Bug Fixes**
  - Matched expected error string to the stable prefix “Failed to make API call after”.
  - Unskipped the suite so all existing tests run.

- **New Features**
  - Added tests for retry triggers: “overloaded”, “malformed json”, and JSON body with `"code": 429`.

<sup>Written for commit 8bc8d02d2f9c4bd1c6adaf86e8efd031c07fec18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

