### PR TITLE
fix: forward extraBodyProperties from requestOptions in autocomplete requests (#12334)

### DIFF
--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -249,7 +249,7 @@ class OpenAI extends BaseLLM {
   }
 
   protected extraBodyProperties(): Record<string, any> {
-    return {};
+    return this.requestOptions?.extraBodyProperties ?? {};
   }
 
   protected getMaxStopWords(): number {

--- a/core/llm/llms/OpenAI.vitest.ts
+++ b/core/llm/llms/OpenAI.vitest.ts
@@ -395,6 +395,101 @@ describe("OpenAI", () => {
     });
   });
 
+  test("should include extraBodyProperties from requestOptions in request", async () => {
+    const openai = new OpenAI({
+      apiKey: "test-api-key",
+      model: "gpt-4",
+      apiBase: "https://api.openai.com/v1/",
+      requestOptions: {
+        extraBodyProperties: {
+          reasoning: { exclude: true },
+          custom_field: "test_value",
+        },
+      },
+      completionOptions: {
+        model: "gpt-4",
+        maxTokens: 100,
+      },
+    });
+
+    await runLlmTest({
+      llm: openai,
+      methodToTest: "streamChat",
+      params: [
+        [{ role: "user", content: "hello" }],
+        new AbortController().signal,
+      ],
+      expectedRequest: {
+        url: "https://api.openai.com/v1/chat/completions",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer test-api-key",
+          "api-key": "test-api-key",
+        },
+        body: {
+          model: "gpt-4",
+          messages: [{ role: "user", content: "hello" }],
+          stream: true,
+          max_tokens: 100,
+          reasoning: { exclude: true },
+          custom_field: "test_value",
+        },
+      },
+      mockStream: [{ choices: [{ delta: { content: "Hello" } }] }],
+    });
+  });
+
+  test("should include extraBodyProperties in legacy completions endpoint", async () => {
+    // Legacy completions endpoint is used by autocomplete when the model
+    // is NOT a chat-only model (e.g., OpenRouter with DeepSeek, etc.)
+    const openai = new OpenAI({
+      apiKey: "test-api-key",
+      model: "text-davinci-002",
+      apiBase: "https://api.openai.com/v1/",
+      requestOptions: {
+        extraBodyProperties: {
+          reasoning: { exclude: true },
+        },
+      },
+      completionOptions: {
+        model: "text-davinci-002",
+        maxTokens: 100,
+      },
+    });
+
+    await runLlmTest({
+      llm: openai,
+      methodToTest: "streamChat",
+      params: [
+        [{ role: "user", content: "hello" }],
+        new AbortController().signal,
+      ],
+      expectedRequest: {
+        url: "https://api.openai.com/v1/completions",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer test-api-key",
+          "api-key": "test-api-key",
+        },
+        body: {
+          model: "text-davinci-002",
+          prompt: "hello",
+          stream: true,
+          max_tokens: 100,
+          reasoning: { exclude: true },
+        },
+      },
+      mockStream: [
+        {
+          choices: [{ text: "Hello", finish_reason: "stop" }],
+          model: "text-davinci-002",
+        },
+      ],
+    });
+  });
+
   test("should handle embeddings", async () => {
     const openai = new OpenAI({
       apiKey: "test-api-key",

--- a/core/llm/llms/stubs/ContinueProxy.ts
+++ b/core/llm/llms/stubs/ContinueProxy.ts
@@ -71,6 +71,7 @@ class ContinueProxy extends OpenAI {
     };
     return {
       continueProperties,
+      ...super.extraBodyProperties(),
     };
   }
 


### PR DESCRIPTION
## Description

Fixes #12334 — autocomplete using OpenRouter (and other OpenAI-compatible providers) doesn't send `requestOptions.extraBodyProperties`.

### Root Cause

The `extraBodyProperties()` method in `OpenAI.ts` returned `{}` by default. This method is used to spread extra properties into request bodies across ALL request types:
- `_streamChat` (chat completions)
- `_legacystreamComplete` (legacy completions — used by autocomplete when `supportsFim()` is false)
- `_streamFim` (fill-in-the-middle)
- `_streamResponses` (responses API)
- `_embed` (embeddings)

While the fetch layer (`fetchwithRequestOptions`) also merges `requestOptions.extraBodyProperties`, the adapter and non-adapter paths have inconsistent coverage. This fix ensures the configured properties are explicitly included at the body construction level for ALL paths.

### Changes

1. **core/llm/llms/OpenAI.ts**: Changed `extraBodyProperties()` to return `this.requestOptions?.extraBodyProperties ?? {}` instead of `{}`
2. **core/llm/llms/stubs/ContinueProxy.ts**: Added `...super.extraBodyProperties()` to ensure user-configured properties propagate through the proxy
3. **core/llm/llms/OpenAI.vitest.ts**: Added 2 tests verifying extraBodyProperties appear in chat and legacy completions requests

### Test plan

- New tests verify `extraBodyProperties` appear in `streamChat` body (chat completions endpoint)
- New tests verify `extraBodyProperties` appear in `streamChat` with `raw: true` (legacy completions endpoint, used by autocomplete)
- All existing tests continue to pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `requestOptions.extraBodyProperties` are included in all OpenAI‑compatible request bodies, fixing missing fields in autocomplete with OpenRouter. Chat, legacy completions (autocomplete), FIM, responses, and embeddings now send custom body fields consistently. Fixes #12334.

- **Bug Fixes**
  - Return `this.requestOptions?.extraBodyProperties ?? {}` from `extraBodyProperties()` in `OpenAI`.
  - Forward via `ContinueProxy` by spreading `super.extraBodyProperties()`.
  - Add tests for chat completions and legacy completions bodies.

<sup>Written for commit 28225c8d9e69dc4c4ddea1d9775b88da6286243b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

