### PR TITLE
docs: add Ollama local setup guide to community resources

### DIFF
--- a/docs/guides/overview.mdx
+++ b/docs/guides/overview.mdx
@@ -89,6 +89,12 @@ Step-by-step guides for integrating Model Context Protocol (MCP) servers with Co
 - [Codebase and Documentation Awareness](/guides/codebase-documentation-awareness) - Make agent mode aware of codebases and documentation
 - [Custom Code RAG](/guides/custom-code-rag) - Advanced: Build custom retrieval-augmented generation for large codebases
 
+## Community Tutorials
+
+External guides from the community:
+
+- [Continue.dev + Ollama Local AI Coding Stack (2026)](https://runaihome.com/blog/continue-dev-ollama-local-ai-coding-stack-2026/) — Practical walkthrough of running Continue with a local Ollama backend: model selection, dual-model setup (fast autocomplete + slower chat), and config.yaml patterns for everyday use
+
 ## How to Contribute to Guides
 
 Have a guide idea or found an issue? We welcome contributions! Check our [GitHub repository](https://github.com/continuedev/continue) to get involved.


### PR DESCRIPTION
## What this adds

A new **Community Tutorials** section at the bottom of `docs/guides/overview.mdx` with one external guide:

> [Continue.dev + Ollama Local AI Coding Stack (2026)](https://runaihome.com/blog/continue-dev-ollama-local-ai-coding-stack-2026/)

## Why it's useful

The existing Ollama guide in this directory covers model setup. This community article fills a different gap: it walks through a **complete working stack** — picking the right Ollama model for autocomplete vs. chat, writing the `config.yaml` dual-model config, and troubleshooting the latency vs. quality trade-off in everyday use.

Several people in Discord ask "how do I actually use Continue with Ollama day-to-day?" This article answers that question end-to-end.

## Change scope

- One file edited: `docs/guides/overview.mdx`
- 6 lines added, 0 deleted
- No code changes, no dependency changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Community Tutorials section to docs/guides/overview.mdx with a link to a guide for running Continue with a local Ollama backend. Helps users set up a practical dual‑model config (fast autocomplete + slower chat) and understand everyday performance trade-offs.

<sup>Written for commit a17dacc28a4181d5b25b04fcad6ffaee20685247. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

