### PR TITLE
fix: update Scaleway models list

### DIFF
--- a/core/llm/llms/Scaleway.ts
+++ b/core/llm/llms/Scaleway.ts
@@ -7,22 +7,24 @@ class Scaleway extends OpenAI {
   static providerName = "scaleway";
   static defaultOptions: Partial<LLMOptions> = {
     apiBase: "https://api.scaleway.ai/v1/",
-    model: "qwen3-coder-30b-a3b-instruct",
+    model: "qwen3.6-35b-a3b",
     useLegacyCompletionsEndpoint: false,
   };
 
   private static MODEL_IDS: { [name: string]: string } = {
-    "llama3.1-8b": "llama-3.1-8b-instruct",
     "llama3.3-70b": "llama-3.3-70b-instruct",
     "pixtral-12b": "pixtral-12b-2409",
-    "mistral-small3.1": "mistral-small-3.1-24b-instruct-2503",
     "mistral-small3.2": "mistral-small-3.2-24b-instruct-2506",
-    "devstral-small": "devstral-small-2505",
-    "deepseek-r1-distill-llama-70b": "deepseek-r1-distill-llama-70b",
-    "qwen2.5-coder-32b": "qwen2.5-coder-32b-instruct",
+    "mistral-medium3.5": "mistral-medium-3.5-128b",
+    "devstral-2": "devstral-2-123b-instruct-2512",
     "qwen3-coder-30b-a3b": "qwen3-coder-30b-a3b-instruct",
     "qwen3-235b-a22b": "qwen3-235b-a22b-instruct-2507",
+    "qwen3.5-397b-a17b": "qwen3.5-397b-a17b",
+    "qwen3.6-35b-a3b": "qwen3.6-35b-a3b",
     "gemma-3-27b": "gemma-3-27b-it",
+    "gemma-4-26b-a4b": "gemma-4-26b-a4b-it",
+    "bge-multilingual-gemma2": "bge-multilingual-gemma2",
+    "qwen3-embedding-8b": "qwen3-embedding-8b",
     "gpt-oss-120b": "gpt-oss-120b",
   };
 

--- a/docs/customize/model-providers/more/scaleway.mdx
+++ b/docs/customize/model-providers/more/scaleway.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Scaleway"
-description: "Configure Scaleway Generative APIs with Continue to access AI models hosted in European data centers, offering low latency, data privacy, and EU AI Act compliance with models like Qwen2.5-Coder and BGE-Multilingual-Gemma2"
+description: "Configure Scaleway Generative APIs with Continue to access AI models hosted in European data centers, offering low latency, data privacy, and EU AI Act compliance with models like Qwen3.5-397b, Gemma-4-26b"
 ---
 
 <Info>
@@ -14,7 +14,7 @@ description: "Configure Scaleway Generative APIs with Continue to access AI mode
 
 ## Chat Model
 
-We recommend configuring **Qwen2.5-Coder-32B-Instruct** as your chat model.
+We recommend configuring **Qwen3.6-35b-a3b** as your chat model.
 [Click here](https://www.scaleway.com/en/docs/ai-data/generative-apis/reference-content/supported-models/) to see the list of available chat models.
 
 <Tabs>
@@ -25,9 +25,9 @@ We recommend configuring **Qwen2.5-Coder-32B-Instruct** as your chat model.
     schema: v1
 
     models:
-      - name: Qwen2.5-Coder-32B-Instruct
+      - name: Qwen3.6-35b-a3b
         provider: scaleway
-        model: qwen2.5-coder-32b-instruct
+        model: Qwen3.6-35b-a3b
         apiKey: <YOUR_SCALEWAY_API_KEY>
     ```
     </Tab>
@@ -36,9 +36,9 @@ We recommend configuring **Qwen2.5-Coder-32B-Instruct** as your chat model.
     {
       "models": [
         {
-          "title": "Qwen2.5-Coder-32B-Instruct",
+          "title": "Qwen3.6-35b-a3b",
           "provider": "scaleway",
-          "model": "qwen2.5-coder-32b-instruct",
+          "model": "Qwen3.6-35b-a3b",
           "apiKey": "<YOUR_SCALEWAY_API_KEY>"
         }
       ]


### PR DESCRIPTION
## Description

Updating the Scaleway provider model list
## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Scaleway model mappings to match the latest catalog and set `qwen3.6-35b-a3b` as the default. Docs now recommend `qwen3.6-35b-a3b` and highlight `qwen3.5-397b` and `gemma-4-26b` with updated examples.

- **Bug Fixes**
  - Default model: `qwen3.6-35b-a3b`
  - Added: `mistral-medium3.5`, `devstral-2`, `qwen3.6-35b-a3b`, `gemma-4-26b-a4b`, `qwen3.5-397b-a17b`, `bge-multilingual-gemma2`, `qwen3-embedding-8b`
  - Removed: `llama3.1-8b`, `mistral-small3.1`, `devstral-small`, `deepseek-r1-distill-llama-70b`, `qwen2.5-coder-32b`

<sup>Written for commit 5c4eaf312c8fc914516565deb2f8c7a2cfab010f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

