### PR TITLE
fix(cli): serialize subagent execution to prevent tool-permission leak

### DIFF
--- a/extensions/cli/src/subagent/executor.test.ts
+++ b/extensions/cli/src/subagent/executor.test.ts
@@ -1,0 +1,95 @@
+import { describe, test, expect, vi } from "vitest";
+
+// Shared, controllable state for the mocked service container + chat stream so
+// we can drive a deterministic interleave of two concurrent subagent runs.
+const h = vi.hoisted(() => {
+  const MAIN_POLICIES = [{ tool: "read", permission: "allow" }];
+  let toolPermissions: any = { permissions: { policies: MAIN_POLICIES } };
+
+  const enter: Array<() => void> = [];
+  const enteredPromises: Promise<void>[] = [
+    new Promise<void>((r) => (enter[0] = r)),
+    new Promise<void>((r) => (enter[1] = r)),
+  ];
+  const release: Array<() => void> = [];
+  const gate: Promise<void>[] = [
+    new Promise<void>((r) => (release[0] = r)),
+    new Promise<void>((r) => (release[1] = r)),
+  ];
+  let callIndex = 0;
+
+  return {
+    MAIN_POLICIES,
+    getPolicies: () => toolPermissions.permissions.policies,
+    container: {
+      get: async () => toolPermissions,
+      set: (_name: string, value: any) => {
+        toolPermissions = value;
+      },
+    },
+    enteredPromises,
+    release,
+    // i-th stream call signals it has begun, then blocks until released.
+    streamChatResponse: async () => {
+      const i = callIndex++;
+      enter[i]?.();
+      await gate[i];
+    },
+  };
+});
+
+vi.mock("../services/ServiceContainer.js", () => ({
+  serviceContainer: h.container,
+}));
+vi.mock("../services/index.js", () => ({
+  services: { systemMessage: undefined, chatHistory: undefined },
+}));
+vi.mock("../stream/streamChatResponse.js", () => ({
+  streamChatResponse: h.streamChatResponse,
+}));
+vi.mock("../util/cli.js", () => ({
+  escapeEvents: { on: () => {}, removeListener: () => {} },
+}));
+vi.mock("../util/logger.js", () => ({
+  logger: { debug: () => {}, error: () => {}, info: () => {}, warn: () => {} },
+}));
+
+import { executeSubAgent } from "./executor.js";
+
+describe("executeSubAgent concurrency", () => {
+  test("serializes so a concurrent subagent cannot leave main-agent permissions stuck at allow-all", async () => {
+    const agent: any = { model: { name: "sub" }, llmApi: {} };
+    const opts = (id: string): any => ({
+      agent,
+      prompt: id,
+      parentSessionId: "p",
+      abortController: new AbortController(),
+    });
+
+    // A starts and parks mid-stream with the shared permissions set to allow-all.
+    const a = executeSubAgent(opts("A"));
+    await h.enteredPromises[0];
+
+    // B starts. Without the serialization lock it reads the corrupted
+    // (allow-all) state right now and will later "restore" THAT; with the lock
+    // it blocks until A releases and only reads the real (restored) state.
+    const b = executeSubAgent(opts("B"));
+
+    // Let A finish (restore + release the lock).
+    h.release[0]();
+
+    // B reaches the stream only after acquiring the lock (post-A) when serialized.
+    await h.enteredPromises[1];
+    h.release[1]();
+
+    await Promise.all([a, b]);
+
+    // Main-agent permissions must end up restored to the original policy, not
+    // the subagent's allow-all. Fails before the fix (final state = allow-all).
+    expect(h.getPolicies()).toEqual(h.MAIN_POLICIES);
+    expect(h.getPolicies()).not.toContainEqual({
+      tool: "*",
+      permission: "allow",
+    });
+  });
+});

--- a/extensions/cli/src/subagent/executor.ts
+++ b/extensions/cli/src/subagent/executor.ts
@@ -51,11 +51,71 @@ async function buildAgentSystemMessage(
   return baseMessage;
 }
 
+let subagentExecutionChain: Promise<void> = Promise.resolve();
+
 /**
- * Execute a subagent in a child session
+ * Run `fn` exclusively with respect to other subagent executions.
+ *
+ * @remarks
+ * {@link executeSubAgent} temporarily flips the shared `TOOL_PERMISSIONS`
+ * service state to allow-all and restores the main agent's permissions in a
+ * `finally`. If two executions run concurrently the read/restore interleaves:
+ * the second reads the allow-all state as its "main" and later restores *that*,
+ * leaving the main agent permanently escalated to allow-all. Chaining every
+ * execution onto a single promise guarantees one-at-a-time execution, so the
+ * restore is never lost. A rejected `fn` still releases the lock.
+ *
+ * @typeParam T - Resolved type of `fn`.
+ * @param fn - The async execution to serialize; awaited while the lock is held.
+ * @returns The value resolved by `fn`.
+ */
+async function withSubagentExecutionLock<T>(fn: () => Promise<T>): Promise<T> {
+  const previous = subagentExecutionChain;
+  let release!: () => void;
+  subagentExecutionChain = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await previous;
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}
+
+/**
+ * Execute a subagent in a child session.
+ *
+ * @remarks
+ * Serialized via {@link withSubagentExecutionLock} so concurrent subagents can
+ * never interleave the shared `TOOL_PERMISSIONS` read/restore — which would
+ * otherwise strand the main agent's permissions at allow-all. The public
+ * signature is identical to the pre-serialization implementation; only mutual
+ * exclusion is added (no behavior change for a single subagent).
+ *
+ * @param options - Subagent, prompt, parent session id, abort controller, and
+ *   optional output callback. See {@link SubAgentExecutionOptions}.
+ * @returns The subagent result: success flag, accumulated response text, and an
+ *   optional error message when execution fails.
+ */
+export async function executeSubAgent(
+  options: SubAgentExecutionOptions,
+): Promise<SubAgentResult> {
+  return withSubagentExecutionLock(() => executeSubAgentImpl(options));
+}
+
+/**
+ * Implementation of {@link executeSubAgent}.
+ *
+ * @remarks
+ * Always invoke via {@link executeSubAgent}; calling this directly re-opens the
+ * concurrent permission-escalation race this module exists to close.
+ *
+ * @param options - See {@link SubAgentExecutionOptions}.
+ * @returns The subagent result. See {@link executeSubAgent}.
  */
 // eslint-disable-next-line complexity
-export async function executeSubAgent(
+async function executeSubAgentImpl(
   options: SubAgentExecutionOptions,
 ): Promise<SubAgentResult> {
   const { agent: subAgent, prompt, abortController, onOutputUpdate } = options;


### PR DESCRIPTION
## Description

Serializes subagent execution to close a tool-permission escalation race. `executeSubAgent` reads the main agent's `TOOL_PERMISSIONS`, flips the shared state to allow-all so the subagent can call any tool, then restores the captured main permissions in a `finally`. With two subagents running concurrently the read/restore interleaves: the second reads the *allow-all* state as its "main" and later restores **that**, leaving the main agent **permanently escalated to allow-all**. This wraps execution in a single-promise chain (`withSubagentExecutionLock`) so only one subagent runs at a time and the restore is never lost.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A — internal CLI logic fix (subagent-executor concurrency); no user-facing UI change.

## Tests

Added `extensions/cli/src/subagent/executor.test.ts` — a behavioral concurrency test that drives the exact "A parks mid-stream with allow-all set, B starts" interleave over parsed permission objects and asserts the final `TOOL_PERMISSIONS` policy equals the original main policy. It fails before the fix (final state stuck at allow-all) and passes after. `npm run lint` and `npm test` pass in `extensions/cli`.

<sub>Full forensic verification evidence (AIV-L3) is in the comment below.</sub>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serializes subagent execution in the CLI to prevent a tool-permission escalation race. Only one subagent runs at a time, ensuring the main agent’s `TOOL_PERMISSIONS` are always restored.

- Bug Fixes
  - Wrapped `executeSubAgent` with `withSubagentExecutionLock` (single-promise chain) for exclusive execution.
  - Removed the read/restore interleave that could leave the main agent stuck at allow-all.
  - Added a deterministic concurrency test validating final `TOOL_PERMISSIONS` match the original policies.

<sup>Written for commit b62cc9c20296939e70deac55d5bcef7505ce5f32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

