### PR TITLE
docs: fix command palette typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ You can run the documentation server locally using either of the following metho
 
 1. Open VS Code in the root directory of the project.
 
-2. Open the VS Code command pallet (`cmd/ctrl+shift+p`) and select `Tasks: Run Task`.
+2. Open the VS Code command palette (`cmd/ctrl+shift+p`) and select `Tasks: Run Task`.
 
 3. Look for the `docs:start` task and select it.
 
@@ -142,7 +142,7 @@ npm i -g vite
 
 #### VS Code
 
-1. Open the VS Code command pallet (`cmd/ctrl+shift+p`) and select `Tasks: Run Task` and then select
+1. Open the VS Code command palette (`cmd/ctrl+shift+p`) and select `Tasks: Run Task` and then select
    `install-all-dependencies`
 
 2. Start debugging:


### PR DESCRIPTION
## Description

Fixes two instances of "command pallet" to "command palette" in the VS Code task instructions in `CONTRIBUTING.md`.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A - documentation typo fix.

## Tests

- Verified no remaining `command pallet` instances in `CONTRIBUTING.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects two instances of “command pallet” to “command palette” in `CONTRIBUTING.md` VS Code instructions. Clarifies the steps for running tasks via the Command Palette.

<sup>Written for commit 41b70ce0e48ccb39b3309e846b58e57e87f4c517. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

