### PR TITLE
fix(sdk): surface proxy request validation errors

### DIFF
--- a/packages/continue-sdk/typescript/src/createOpenAIClient.ts
+++ b/packages/continue-sdk/typescript/src/createOpenAIClient.ts
@@ -35,6 +35,51 @@ interface OpenAIClientOptions extends Record<string, any> {
   baseURL?: string;
 }
 
+export function addContinuePropertiesToBody(
+  bodyString: string,
+  assistantModels: AssistantUnrolled["models"],
+  organizationId?: string | null,
+): string {
+  let body: Record<string, any>;
+
+  try {
+    body = JSON.parse(bodyString);
+  } catch {
+    return bodyString;
+  }
+
+  const modelName = body.model;
+
+  // Look up the model in the assistant's models
+  const modelConfig = assistantModels?.find(
+    (m) => m?.model === modelName || m?.model.endsWith(modelName),
+  );
+
+  if (!modelConfig) {
+    throw new Error(`Model ${modelName} not found in assistant configuration`);
+  }
+
+  if (
+    !("apiKeyLocation" in modelConfig) &&
+    !("envSecretLocations" in modelConfig)
+  ) {
+    throw new Error(
+      `Model ${modelName} does not have an apiKeyLocation or envSecretLocations defined`,
+    );
+  }
+
+  const continueProperties: ContinueProperties = {
+    apiKeyLocation: modelConfig.apiKeyLocation,
+    envSecretLocations: modelConfig.envSecretLocations,
+    orgScopeId: organizationId ?? null,
+  };
+
+  return JSON.stringify({
+    ...body,
+    continueProperties,
+  });
+}
+
 /**
  * Create and configure an OpenAI client that uses Continue Hub for authentication
  *
@@ -54,46 +99,16 @@ export function createOpenAIClient({
       // Clone the init object to avoid modifying the original
       const modifiedInit = init ? { ...init } : {};
 
-      if (init?.method === "POST" && init?.body) {
-        try {
-          const body = JSON.parse(init.body as string);
-
-          const modelName = body.model;
-
-          // Look up the model in the assistant's models
-          const modelConfig = assistantModels?.find(
-            (m) => m?.model === modelName || m?.model.endsWith(modelName),
-          );
-
-          if (!modelConfig) {
-            throw new Error(
-              `Model ${modelName} not found in assistant configuration`,
-            );
-          }
-
-          if (
-            !("apiKeyLocation" in modelConfig) &&
-            !("envSecretLocations" in modelConfig)
-          ) {
-            throw new Error(
-              `Model ${modelName} does not have an apiKeyLocation or envSecretLocations defined`,
-            );
-          }
-
-          const continueProperties: ContinueProperties = {
-            apiKeyLocation: modelConfig.apiKeyLocation,
-            envSecretLocations: modelConfig.envSecretLocations,
-            orgScopeId: organizationId ?? null,
-          };
-
-          // Update the request with the modified body
-          modifiedInit.body = JSON.stringify({
-            ...body,
-            continueProperties,
-          });
-        } catch (e) {
-          // If parsing fails, proceed with the original body
-        }
+      if (
+        init?.method === "POST" &&
+        init?.body &&
+        typeof init.body === "string"
+      ) {
+        modifiedInit.body = addContinuePropertiesToBody(
+          init.body,
+          assistantModels,
+          organizationId,
+        );
       }
 
       // Using node-fetch explicitly, otherwise `fetch` has shadowing issues

--- a/packages/continue-sdk/typescript/tests/createOpenAIClient.test.ts
+++ b/packages/continue-sdk/typescript/tests/createOpenAIClient.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "@jest/globals";
+import { addContinuePropertiesToBody } from "../src/createOpenAIClient.js";
+
+describe("addContinuePropertiesToBody", () => {
+  test("adds Continue proxy properties for the requested assistant model", () => {
+    const body = addContinuePropertiesToBody(
+      JSON.stringify({
+        model: "claude-3-7-sonnet-latest",
+        messages: [{ role: "user", content: "Hello" }],
+      }),
+      [
+        {
+          model: "anthropic/claude-3-7-sonnet-latest",
+          apiKeyLocation: "env:ANTHROPIC_API_KEY",
+        },
+      ] as any,
+      "org_123",
+    );
+
+    expect(JSON.parse(body)).toEqual({
+      model: "claude-3-7-sonnet-latest",
+      messages: [{ role: "user", content: "Hello" }],
+      continueProperties: {
+        apiKeyLocation: "env:ANTHROPIC_API_KEY",
+        orgScopeId: "org_123",
+      },
+    });
+  });
+
+  test("keeps non-JSON request bodies unchanged", () => {
+    expect(
+      addContinuePropertiesToBody("not-json", [] as any, "org_123"),
+    ).toBe("not-json");
+  });
+
+  test("throws when the requested model is missing from the assistant", () => {
+    expect(() =>
+      addContinuePropertiesToBody(
+        JSON.stringify({ model: "missing-model" }),
+        [
+          {
+            model: "anthropic/claude-3-7-sonnet-latest",
+            apiKeyLocation: "env:ANTHROPIC_API_KEY",
+          },
+        ] as any,
+      ),
+    ).toThrow("Model missing-model not found in assistant configuration");
+  });
+
+  test("throws when the requested model has no secret location", () => {
+    expect(() =>
+      addContinuePropertiesToBody(
+        JSON.stringify({ model: "claude-3-7-sonnet-latest" }),
+        [
+          {
+            model: "anthropic/claude-3-7-sonnet-latest",
+          },
+        ] as any,
+      ),
+    ).toThrow(
+      "Model claude-3-7-sonnet-latest does not have an apiKeyLocation or envSecretLocations defined",
+    );
+  });
+});


### PR DESCRIPTION
## Description

`createOpenAIClient` currently builds useful validation errors when a request references a model that is missing from the assistant config, or when that model has no `apiKeyLocation` / `envSecretLocations`. Those errors are inside the same broad `try/catch` used for JSON parsing, so they are swallowed and the SDK silently forwards the original request body without `continueProperties`.

This separates JSON parsing fallback from assistant-model validation:

- non-JSON request bodies still pass through unchanged
- missing assistant models now fail fast with the existing error message
- models without a secret location now fail fast instead of sending an unusable proxy request

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A - SDK request validation fix.

## Tests

- `npm.cmd test -- createOpenAIClient.test.ts --runInBand` from `packages/continue-sdk/typescript`
- `git diff --check`

I also tried `npm.cmd test -- --runInBand` and `npx.cmd tsc --noEmit` from `packages/continue-sdk/typescript`. The focused regression test passes, but the full package checks are currently blocked in this local checkout by existing generated/local package resolution issues (`../api/dist/index.js` and `@continuedev/config-yaml`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface proxy request validation errors in the SDK by separating JSON parsing from model validation in `createOpenAIClient`. Non-JSON bodies pass through unchanged; missing models or models without secret locations now fail fast with clear errors.

- **Bug Fixes**
  - Introduced `addContinuePropertiesToBody` to attach `continueProperties` only for JSON bodies.
  - Preserve original body for non-JSON POST requests.
  - Throw clear errors for missing assistant models or missing `apiKeyLocation`/`envSecretLocations`.
  - Added unit tests covering pass-through, success, and error cases.

<sup>Written for commit 97390059978c1f8d22f7d0f206b43ac7c495e847. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

