### PR TITLE
docs: add verified Entroly MCP integration guide

### DIFF
--- a/docs/guides/entroly-mcp-cost-optimization.mdx
+++ b/docs/guides/entroly-mcp-cost-optimization.mdx
@@ -1,0 +1,121 @@
+---
+title: "Reduce LLM API Costs with Entroly MCP and Continue"
+description: "Use Continue with the Entroly MCP server to compress context by 70-95%, align provider caches, and cut LLM API bills without losing answer quality."
+sidebarTitle: "Cost Reduction with Entroly"
+---
+
+<Card title="What You'll Build" icon="compress">
+  A cost-optimized AI coding workflow that uses Continue with the Entroly MCP server to:
+  - Compress context by 70-95% before sending to the LLM
+  - Align prefixes for provider cache discounts (Anthropic 90%, OpenAI 50%)
+  - Verify model outputs against supplied evidence with WITNESS
+  - Monitor real-time savings via a local dashboard
+</Card>
+
+## Prerequisites
+
+Before starting, ensure you have:
+
+- Continue installed in your IDE (VS Code, JetBrains, etc.)
+- Python 3.10+ installed
+- An LLM API key (Anthropic, OpenAI, etc.)
+
+## Setup
+
+<Steps>
+<Step title="Install Entroly">
+  ```bash
+  pip install entroly
+  ```
+</Step>
+
+<Step title="Add Entroly MCP Server to Continue">
+  Add the following to your Continue config:
+
+  ```yaml title="config.yaml"
+  mcpServers:
+    - name: Entroly
+      command: uvx
+      args:
+        - "--from"
+        - "entroly"
+        - "entroly"
+        - "serve"
+  ```
+</Step>
+
+<Step title="Verify the Connection">
+  Launch Continue and type `@` — you should see Entroly in the context providers list.
+
+  Try asking:
+  ```
+  Use Entroly to analyze this repository and show me the token savings estimate.
+  ```
+</Step>
+</Steps>
+
+## Alternative: Proxy Mode
+
+For transparent cost reduction without changing your Continue config, run Entroly as a local proxy:
+
+```bash
+entroly proxy
+```
+
+Then update your provider's base URL in Continue to point at the proxy:
+
+```yaml title="config.yaml"
+models:
+  - name: claude-sonnet
+    provider: anthropic
+    apiBase: http://localhost:9377
+```
+
+All requests are compressed transparently — no other config changes needed.
+
+## How It Works
+
+```
+Continue IDE  ──►  Entroly (local)  ──►  LLM Provider
+                   │
+                   ├─ Rank repo files      (BM25 + entropy + dep-graph)
+                   ├─ Select under budget  (knapsack, reversible)
+                   ├─ Cache-align prefix   (keep provider cache hot)
+                   └─ Verify the reply     (WITNESS hallucination guard)
+```
+
+## Monitor Savings
+
+Open the Entroly dashboard to see real-time cost metrics:
+
+```bash
+entroly dashboard
+# Opens http://localhost:9378
+```
+
+The dashboard shows:
+- Tokens saved per request
+- Cumulative dollar savings
+- Cache hit rates
+- Per-lever cost breakdown
+
+## Key Benefits for Continue Users
+
+| Feature | Benefit |
+|---|---|
+| **Context compression** | 70-95% fewer input tokens on large repos |
+| **Cache alignment** | Captures provider prefix-cache discounts |
+| **Reversible compression** | Original context recoverable via CCR handles |
+| **WITNESS guard** | $0 hallucination check on every response |
+| **Local-first** | No code sent for analysis — runs on-device |
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card title="Entroly Repository" icon="github" href="https://github.com/juyterman1000/entroly">
+    Full documentation, benchmarks, and source code
+  </Card>
+  <Card title="MCP in Continue" icon="book" href="/customize/deep-dives/mcp">
+    How MCP works with Continue agents
+  </Card>
+</CardGroup>

--- a/docs/guides/entroly-mcp-cost-optimization.mdx
+++ b/docs/guides/entroly-mcp-cost-optimization.mdx
@@ -1,0 +1,90 @@
+---
+title: "Use Entroly MCP with Continue"
+description: "Add Entroly's local context-selection, recovery, and receipt tools to Continue Agent mode."
+sidebarTitle: "Entroly MCP"
+---
+
+Entroly can run as a local MCP server for Continue. This gives the agent tools for
+selecting repository evidence under a token budget, recovering omitted source from
+content-addressed handles, and creating auditable Context Receipts.
+
+MCP attachment does not automatically intercept Continue's model requests or prove
+provider-billed token savings. Measure behavior on your own repository before using
+separate proxy routing.
+
+## Prerequisites
+
+- Continue installed in VS Code or JetBrains
+- Python 3.10 or newer
+- [`uv`](https://docs.astral.sh/uv/getting-started/installation/) installed; `uvx` is included with `uv`
+- A model configured for Continue Agent mode
+
+## Configure the MCP server
+
+Create `.continue/mcpServers/entroly.yaml` in your workspace:
+
+```yaml
+name: Entroly
+version: 0.0.1
+schema: v1
+mcpServers:
+  - name: Entroly
+    type: stdio
+    command: uvx
+    args:
+      - "--from"
+      - "entroly"
+      - "entroly"
+      - "serve"
+    env:
+      ENTROLY_NO_DOCKER: "1"
+```
+
+`ENTROLY_NO_DOCKER=1` selects Entroly's local Python fallback when the optional
+native engine is unavailable. Remove it if you intentionally use Entroly's Docker
+or native-engine setup.
+
+Restart Continue after saving the file. MCP tools are available in Agent mode.
+
+## Verify Entroly locally
+
+Run Entroly's bounded verifier from the repository you want to inspect:
+
+```bash
+uvx --from entroly entroly verify-claims --max-files 30
+```
+
+The verifier checks SDK loading, local indexing, budgeted context selection,
+content-addressed recovery, and engine mode without requiring an LLM API key.
+Results depend on the repository and selected sample; they are not a universal
+compression or answer-quality guarantee.
+
+## Use the tools in Continue
+
+In Agent mode, ask Continue to use an Entroly tool explicitly, for example:
+
+```text
+Use Entroly to select the most relevant repository evidence for this task and
+return the Context Receipt with the result.
+```
+
+Review the selected sources and receipt before relying on the result. Recovery
+handles let the agent retrieve exact omitted source when more detail is needed.
+
+## Measurement boundary
+
+| What this setup provides | What it does not claim |
+|---|---|
+| Local MCP context-selection tools | Automatic interception of every model request |
+| Content-addressed source recovery | Universal token or dollar savings |
+| Auditable Context Receipts | No quality loss on every task |
+| Local verification without an LLM key | Provider billing evidence from MCP attachment alone |
+
+For provider-bound accounting, the request must be deliberately routed through an
+Entroly proxy deployment. Keep MCP tool use and proxy traffic measurements separate.
+
+## Resources
+
+- [Entroly repository](https://github.com/juyterman1000/entroly)
+- [Entroly limitations](https://github.com/juyterman1000/entroly/blob/main/docs/limitations.md)
+- [Continue MCP setup](/customize/deep-dives/mcp)


### PR DESCRIPTION
Adds a verified, current Entroly MCP integration guide for Continue Agent mode.

- Uses Continue's standalone `.continue/mcpServers/entroly.yaml` format
- Documents the required `uv`/`uvx` prerequisite
- Sets `ENTROLY_NO_DOCKER=1` for the explicit local Python fallback path
- Removes universal compression, answer-quality, provider-discount, and billing claims
- Separates MCP tool attachment from provider-bound proxy accounting
- Includes a bounded local `entroly verify-claims` command

The branch is rebuilt as one commit on current Continue `main`. Disclosure: I maintain Entroly.

The contributor CLA still requires my personal acceptance and is intentionally not asserted by automation.