### PR TITLE
fix(openai-adapters): convert requestOptions.timeout from seconds to milliseconds

### DIFF
--- a/packages/openai-adapters/src/apis/OpenAI.timeout.test.ts
+++ b/packages/openai-adapters/src/apis/OpenAI.timeout.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { timeoutSecondsToMs } from "./OpenAI.js";
+
+describe("timeoutSecondsToMs", () => {
+  it("converts a seconds timeout to milliseconds", () => {
+    expect(timeoutSecondsToMs(300)).toBe(300_000);
+  });
+
+  it("returns undefined when no timeout is provided", () => {
+    expect(timeoutSecondsToMs(undefined)).toBeUndefined();
+  });
+
+  it("treats a 0 timeout as unset so the SDK default applies", () => {
+    expect(timeoutSecondsToMs(0)).toBeUndefined();
+  });
+});

--- a/packages/openai-adapters/src/apis/OpenAI.ts
+++ b/packages/openai-adapters/src/apis/OpenAI.ts
@@ -32,6 +32,18 @@ import {
   toResponsesParams,
 } from "./openaiResponses.js";
 
+/**
+ * `requestOptions.timeout` is specified in seconds (see getAgentOptions in
+ * @continuedev/fetch, which multiplies by 1000), but the OpenAI SDK expects
+ * milliseconds. Convert so a user setting `timeout: 300` gets 300 seconds, not
+ * 300 milliseconds. Returns undefined when unset so the SDK keeps its own default.
+ */
+export function timeoutSecondsToMs(
+  timeoutSeconds?: number,
+): number | undefined {
+  return timeoutSeconds ? timeoutSeconds * 1000 : undefined;
+}
+
 export class OpenAIApi implements BaseLlmApi {
   openai: OpenAI;
   apiBase: string = "https://api.openai.com/v1/";
@@ -45,7 +57,7 @@ export class OpenAIApi implements BaseLlmApi {
       apiKey: config.apiKey ?? "",
       baseURL: this.apiBase,
       fetch: customFetch(config.requestOptions),
-      timeout: config?.requestOptions?.timeout || undefined,
+      timeout: timeoutSecondsToMs(config?.requestOptions?.timeout),
     });
   }
   modifyChatBody<T extends ChatCompletionCreateParams>(body: T): T {


### PR DESCRIPTION
Closes #12450.

`requestOptions.timeout` is specified in **seconds** throughout Continue — `getAgentOptions` in `@continuedev/fetch` does `(requestOptions?.timeout ?? TIMEOUT) * 1000; // measured in ms`. But `packages/openai-adapters/src/apis/OpenAI.ts` passed the value straight to the OpenAI SDK constructor, which expects **milliseconds**.

So a user setting `timeout: 300` (intending 5 minutes) got a **300 ms** timeout — ~2000× too short — causing immediate "Connection error" failures, especially with local models that need time to load and process prompts. This matches the reports referenced in #11818 / #11954.

**Fix:** multiply by 1000 to convert seconds → ms, consistent with `getAgentOptions`. When `timeout` is unset, `undefined` is passed so the OpenAI SDK keeps its own default (600000 ms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the OpenAI adapter timeout by converting `requestOptions.timeout` from seconds to milliseconds before passing it to the SDK. Prevents premature connection errors (300s no longer becomes 300ms); 0/undefined are treated as unset so the SDK default applies.

- **Bug Fixes**
  - Added `timeoutSecondsToMs` utility with unit tests and used it when setting the SDK `timeout`.

<sup>Written for commit c57f33ad1f392db0ae6e4803976aa60ce4d8b526. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

