### PR TITLE
feat: add AGIone provider

### DIFF
--- a/core/llm/llms/AGIone.ts
+++ b/core/llm/llms/AGIone.ts
@@ -1,0 +1,26 @@
+import { LLMOptions } from "../../index.js";
+
+import OpenAI from "./OpenAI.js";
+
+class AGIone extends OpenAI {
+  static providerName = "agione";
+  static defaultOptions: Partial<LLMOptions> = {
+    apiBase: "https://agione.pro/hyperone/xapi/api/v1/",
+    model: "openai/GPT-5.5/c6fbe",
+    useLegacyCompletionsEndpoint: false,
+  };
+
+  async listModels(): Promise<string[]> {
+    const modelsEndpoint = new URL("../models", this.apiBase);
+    const response = await this.fetch(modelsEndpoint, {
+      method: "GET",
+      headers: this._getHeaders(),
+    });
+
+    const data = await response.json();
+    const models = Array.isArray(data) ? data : (data.data ?? []);
+    return models.map((m: any) => m.id);
+  }
+}
+
+export default AGIone;

--- a/core/llm/llms/OpenAI-compatible-core.vitest.ts
+++ b/core/llm/llms/OpenAI-compatible-core.vitest.ts
@@ -1,6 +1,7 @@
 import { createOpenAISubclassTests } from "./test-utils/openai-test-utils.js";
 
 // Import core OpenAI-compatible providers
+import AGIone from "./AGIone.js";
 import OpenAI from "./OpenAI.js";
 import Groq from "./Groq.js";
 import Fireworks from "./Fireworks.js";
@@ -16,6 +17,11 @@ import Nvidia from "./Nvidia.js";
 import CometAPI from "./CometAPI.js";
 
 // Base OpenAI tests
+createOpenAISubclassTests(AGIone, {
+  providerName: "agione",
+  defaultApiBase: "https://agione.pro/hyperone/xapi/api/v1/",
+});
+
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { ILLM } from "../../index.js";
 

--- a/core/llm/llms/index.ts
+++ b/core/llm/llms/index.ts
@@ -9,6 +9,7 @@ import {
 } from "../..";
 import { renderTemplatedString } from "../../util/handlebars/renderTemplatedString";
 import { BaseLLM } from "../index";
+import AGIone from "./AGIone";
 import Anthropic from "./Anthropic";
 import Asksage from "./Asksage";
 import Azure from "./Azure";
@@ -72,6 +73,7 @@ import WatsonX from "./WatsonX";
 import xAI from "./xAI";
 import zAI from "./zAI";
 export const LLMClasses = [
+  AGIone,
   Anthropic,
   Cohere,
   CometAPI,

--- a/gui/src/pages/AddNewModel/configs/models.ts
+++ b/gui/src/pages/AddNewModel/configs/models.ts
@@ -3014,6 +3014,47 @@ export const models: { [key: string]: ModelPackage } = {
     icon: "cometapi.png",
     isOpenSource: false,
   },
+
+  // AGIone models
+  agioneGpt55: {
+    title: "GPT-5.5",
+    description: "GPT-5.5 via AGIone's OpenAI-compatible API.",
+    params: {
+      model: "openai/GPT-5.5/c6fbe",
+      contextLength: 128_000,
+      title: "GPT-5.5",
+      apiKey: "",
+    },
+    providerOptions: ["agione"],
+    icon: "openai.png",
+    isOpenSource: false,
+  },
+  agioneClaudeOpus47: {
+    title: "Claude Opus 4.7",
+    description: "Claude Opus 4.7 via AGIone's OpenAI-compatible API.",
+    params: {
+      model: "anthropic/Claude-opus-4.7/a4d5d",
+      contextLength: 200_000,
+      title: "Claude Opus 4.7",
+      apiKey: "",
+    },
+    providerOptions: ["agione"],
+    icon: "anthropic.png",
+    isOpenSource: false,
+  },
+  agioneDeepseekV32: {
+    title: "DeepSeek V3.2",
+    description: "DeepSeek V3.2 via AGIone's OpenAI-compatible API.",
+    params: {
+      model: "deepseek/deepseek-v3.2/0000n",
+      contextLength: 128_000,
+      title: "DeepSeek V3.2",
+      apiKey: "",
+    },
+    providerOptions: ["agione"],
+    icon: "deepseek.png",
+    isOpenSource: false,
+  },
   asksageclaude35Sonnet: {
     title: "Claude 3.5 Sonnet",
     description:

--- a/gui/src/pages/AddNewModel/configs/providers.ts
+++ b/gui/src/pages/AddNewModel/configs/providers.ts
@@ -113,6 +113,40 @@ export const providers: Partial<Record<string, ProviderInfo>> = {
     ],
     apiKeyUrl: "https://api.cometapi.com/console/token",
   },
+  agione: {
+    title: "AGIone",
+    provider: "agione",
+    description:
+      "OpenAI-compatible API for LLM, vision, image, and video models",
+    longDescription:
+      "Use AGIone through its OpenAI-compatible endpoint at https://agione.pro/hyperone/xapi/api/v1/.",
+    icon: "openai.png",
+    tags: [ModelProviderTags.RequiresApiKey],
+    collectInputFor: [
+      {
+        inputType: "text",
+        key: "apiKey",
+        label: "Auth Token",
+        placeholder: "Enter your AGIone Auth Token",
+        required: true,
+      },
+      apiBaseInput,
+      ...completionParamsInputsConfigs,
+    ],
+    packages: [
+      models.agioneGpt55,
+      models.agioneClaudeOpus47,
+      models.agioneDeepseekV32,
+      {
+        ...models.AUTODETECT,
+        params: {
+          ...models.AUTODETECT.params,
+          title: "AGIone",
+        },
+      },
+    ],
+    apiKeyUrl: "https://agione.pro",
+  },
   openai: {
     title: "OpenAI",
     provider: "openai",

--- a/packages/llm-info/src/index.ts
+++ b/packages/llm-info/src/index.ts
@@ -1,3 +1,4 @@
+import { AGIone } from "./providers/agione.js";
 import { Anthropic } from "./providers/anthropic.js";
 import { Azure } from "./providers/azure.js";
 import { Bedrock } from "./providers/bedrock.js";
@@ -17,6 +18,7 @@ import { LlmInfoWithProvider, ModelProvider, UseCase } from "./types.js";
 
 export const allModelProviders: ModelProvider[] = [
   OpenAi,
+  AGIone,
   Gemini,
   Anthropic,
   Mistral,

--- a/packages/llm-info/src/providers/agione.ts
+++ b/packages/llm-info/src/providers/agione.ts
@@ -1,0 +1,29 @@
+import { ModelProvider } from "../types.js";
+
+export const AGIone: ModelProvider = {
+  id: "agione",
+  displayName: "AGIone",
+  models: [
+    {
+      model: "openai/GPT-5.5/c6fbe",
+      displayName: "GPT-5.5",
+      contextLength: 128000,
+      description: "GPT-5.5 via AGIone's OpenAI-compatible API.",
+      recommendedFor: ["chat"],
+    },
+    {
+      model: "anthropic/Claude-opus-4.7/a4d5d",
+      displayName: "Claude Opus 4.7",
+      contextLength: 200000,
+      description: "Claude Opus 4.7 via AGIone's OpenAI-compatible API.",
+      recommendedFor: ["chat"],
+    },
+    {
+      model: "deepseek/deepseek-v3.2/0000n",
+      displayName: "DeepSeek V3.2",
+      contextLength: 128000,
+      description: "DeepSeek V3.2 via AGIone's OpenAI-compatible API.",
+      recommendedFor: ["chat"],
+    },
+  ],
+};

--- a/packages/openai-adapters/src/index.ts
+++ b/packages/openai-adapters/src/index.ts
@@ -97,6 +97,11 @@ export function constructLlmApi(config: LLMConfig): BaseLlmApi | undefined {
   switch (config.provider) {
     case "openai":
       return new OpenAIApi(config);
+    case "agione":
+      return openAICompatible(
+        "https://agione.pro/hyperone/xapi/api/v1/",
+        config,
+      );
     case "azure":
       return new AzureApi(config);
     case "bedrock":

--- a/packages/openai-adapters/src/types.ts
+++ b/packages/openai-adapters/src/types.ts
@@ -33,6 +33,7 @@ export const OpenAIConfigSchema = BasePlusConfig.extend({
   useResponsesApi: z.boolean().optional(),
   provider: z.union([
     z.literal("openai"),
+    z.literal("agione"),
     z.literal("mistral"),
     z.literal("voyage"),
     z.literal("deepinfra"),


### PR DESCRIPTION
## Description

Add AGIone as an OpenAI-compatible model provider in Continue.

This PR wires AGIone into the same provider paths used by other OpenAI-compatible services:

- Adds a core `AGIone` LLM class with default API base `https://agione.pro/hyperone/xapi/api/v1/`.
- Registers AGIone in the LLM class list and `@continuedev/llm-info` provider metadata.
- Adds three AGIone model presets for chat/coding use cases:
  - `openai/GPT-5.5/c6fbe`
  - `anthropic/Claude-opus-4.7/a4d5d`
  - `deepseek/deepseek-v3.2/0000n`
- Adds AGIone to the Add Model provider UI with Auth Token input and optional API Base override.
- Adds AGIone to the OpenAI adapter provider schema.

AGIone uses the standard OpenAI-compatible chat completions path under `/v1/chat/completions`. Its model listing endpoint is `/hyperone/xapi/api/models`, so the provider overrides `listModels()` to avoid calling `/v1/models`.

Submitted by the AGIone team.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Not included; this is a provider wiring change. The test commands below verify formatting, package builds, URL construction, and the absence of committed credentials.

## Tests

```bash
npx prettier --no-config --check \
  core/llm/llms/AGIone.ts \
  core/llm/llms/OpenAI-compatible-core.vitest.ts \
  core/llm/llms/index.ts \
  gui/src/pages/AddNewModel/configs/models.ts \
  gui/src/pages/AddNewModel/configs/providers.ts \
  packages/llm-info/src/providers/agione.ts \
  packages/llm-info/src/index.ts \
  packages/openai-adapters/src/index.ts \
  packages/openai-adapters/src/types.ts
```

```bash
cd packages/llm-info && npm ci --ignore-scripts && npm run build
```

```bash
cd packages/openai-adapters && npm ci --ignore-scripts && npm run build
```

```bash
node - <<'JS'
const apiBase = 'https://agione.pro/hyperone/xapi/api/v1/';
console.log(new URL('chat/completions', apiBase).toString());
console.log(new URL('../models', apiBase).toString());
JS
```

Output:

```text
https://agione.pro/hyperone/xapi/api/v1/chat/completions
https://agione.pro/hyperone/xapi/api/models
```

Credential scan on the committed diff:

```bash
git diff origin/main..HEAD | grep -E 'ak-[A-Za-z0-9_-]{12,}|sk-[A-Za-z0-9_-]{12,}|Bearer [A-Za-z0-9._-]{12,}' || echo clean
```

Output:

```text
clean
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add AGIone as an OpenAI-compatible provider so users can choose and run AGIone models in Continue. Includes three presets and wires the UI and adapter with the default base `https://agione.pro/hyperone/xapi/api/v1/`.

- **New Features**
  - Core `AGIone` class registered; uses `/v1/chat/completions` and lists models via `/hyperone/xapi/api/models`.
  - Added provider in Add Model UI with Auth Token and optional API Base; presets for GPT-5.5, Claude Opus 4.7, and DeepSeek V3.2.
  - Provider metadata added to `@continuedev/llm-info`; `openai-adapters` now accepts `agione` and constructs the API with the default base.
  - OpenAI-compatible tests added for provider name and default API base.

<sup>Written for commit f2a55d7d0b5f68cb32d9c6a5baaa886dd25f56cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

