### PR TITLE
Modify close issue message in stale issue workflow

### DIFF
--- a/.github/workflows/stale-issue-helper.yaml
+++ b/.github/workflows/stale-issue-helper.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/stale@v10
         with:
-          close-issue-message: "This issue was closed because it wasn't updated for 10 days after being marked stale. If it's still important, please reopen + comment and we'll gladly take another look!"
+          close-issue-message: "This issue was closed because it wasn't updated for 10 days after being marked stale. If it's still important, you are welcome to leave a comment and this will keep the issue open. However please note that this repo is no longer being actively maintained."
           stale-issue-message: "This issue hasn't been updated in 90 days and will be closed after an additional 10 days without activity. If it's still important, please leave a comment and share any new information that would help us address the issue."
           days-before-stale: 90
           days-before-close: 10


### PR DESCRIPTION
Updated the close issue message to inform users about the repository's maintenance status.

## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the stale issue workflow close message to say that comments keep the issue open and that the repository is not actively maintained. This sets clearer expectations for users when issues are auto-closed.

<sup>Written for commit 68b95e40eab3ede6888482548d73f2c28cb1dd74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

