### PR TITLE
fix: evaluate process substitution commands

### DIFF
--- a/packages/terminal-security/src/evaluateTerminalCommandSecurity.ts
+++ b/packages/terminal-security/src/evaluateTerminalCommandSecurity.ts
@@ -1156,6 +1156,36 @@ function extractSubstitutedCommands(command: string): string[] {
     idx = endIdx;
   }
 
+  // Extract from process substitution <(...) and >(...).
+  idx = 0;
+  while (idx < command.length - 2) {
+    const markerIdx = command.slice(idx).search(/[<>]\(/);
+    if (markerIdx === -1) break;
+
+    const startIdx = idx + markerIdx + 2;
+    let depth = 1;
+    let endIdx = startIdx;
+    while (endIdx < command.length && depth > 0) {
+      if (command[endIdx] === "(") depth++;
+      else if (command[endIdx] === ")") depth--;
+      endIdx++;
+    }
+
+    if (depth === 0) {
+      const extracted = command.slice(startIdx, endIdx - 1);
+      commands.push(extracted);
+      if (
+        extracted.includes("$(") ||
+        extracted.includes("`") ||
+        extracted.match(/<\(|>\(/)
+      ) {
+        commands.push(...extractSubstitutedCommands(extracted));
+      }
+    }
+
+    idx = endIdx;
+  }
+
   return commands;
 }
 

--- a/packages/terminal-security/test/terminalCommandSecurity.test.ts
+++ b/packages/terminal-security/test/terminalCommandSecurity.test.ts
@@ -990,6 +990,14 @@ describe("evaluateTerminalCommandSecurity", () => {
       );
       expect(result).toBe("allowedWithPermission");
     });
+
+    it("should evaluate critical commands inside process substitution", () => {
+      const result = evaluateTerminalCommandSecurity(
+        "allowedWithoutPermission",
+        "diff <(sudo cat /etc/shadow) expected.txt",
+      );
+      expect(result).toBe("disabled");
+    });
   });
 
   describe("Path Traversal and Directory Navigation", () => {


### PR DESCRIPTION
Evaluates commands inside process substitution so critical commands such as sudo are not downgraded to a generic permission prompt. Adds regression coverage in terminal-security.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Evaluate commands inside process substitution (<(...), >(...)) so critical commands (e.g., sudo) are detected and blocked instead of being downgraded to a generic permission prompt. Adds regression tests in `packages/terminal-security`.

- **Bug Fixes**
  - Parse and extract commands within process substitution, including nested cases, and evaluate them recursively.
  - Add test for diff <(sudo cat /etc/shadow) to assert the command is marked "disabled".

<sup>Written for commit b018666cdb94cc34c7a8c981262af316f01dd4d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

