### PR TITLE
fix: migrate legacy tabAutocompleteModel object in config.yaml to roles-based format

### DIFF
--- a/core/config/profile/doLoadConfig.ts
+++ b/core/config/profile/doLoadConfig.ts
@@ -104,7 +104,8 @@ function migrateTabAutocompleteModelInYaml(
     if (
       !rawParsed ||
       typeof rawParsed["tabAutocompleteModel"] !== "object" ||
-      rawParsed["tabAutocompleteModel"] === null
+      rawParsed["tabAutocompleteModel"] === null ||
+      Array.isArray(rawParsed["tabAutocompleteModel"])
     ) {
       return packageIdentifier;
     }

--- a/core/config/profile/doLoadConfig.ts
+++ b/core/config/profile/doLoadConfig.ts
@@ -83,13 +83,11 @@ function migrateTabAutocompleteModelInYaml(
   configYamlPath: string,
   ide: IDE,
 ): PackageIdentifier {
-  if (overrideConfigYaml) {
+  if (overrideConfigYaml || packageIdentifier.uriType !== "file") {
     return packageIdentifier;
   }
 
-  const hasPreReadContent =
-    packageIdentifier.uriType === "file" &&
-    packageIdentifier.content !== undefined;
+  const hasPreReadContent = packageIdentifier.content !== undefined;
 
   if (!hasPreReadContent && !fs.existsSync(configYamlPath)) {
     return packageIdentifier;

--- a/core/config/profile/doLoadConfig.ts
+++ b/core/config/profile/doLoadConfig.ts
@@ -122,14 +122,16 @@ export default async function doLoadConfig(options: {
   // a config.yaml using the JSON-format object style, Zod strips it silently
   // and autocomplete shows "Setup Autocomplete model" with no error.
   // We detect and transform it here so the YAML pipeline sees it correctly.
+  const hasPreReadYamlContent =
+    packageIdentifier.uriType === "file" &&
+    packageIdentifier.content !== undefined;
+
   let effectivePackageIdentifier = packageIdentifier;
-  if (!overrideConfigYaml && fs.existsSync(configYamlPath)) {
+  if (!overrideConfigYaml && (hasPreReadYamlContent || fs.existsSync(configYamlPath))) {
     try {
-      const rawContent =
-        packageIdentifier.uriType === "file" &&
-        packageIdentifier.content !== undefined
-          ? packageIdentifier.content
-          : fs.readFileSync(configYamlPath, "utf8");
+      const rawContent = hasPreReadYamlContent
+        ? packageIdentifier.content!
+        : fs.readFileSync(configYamlPath, "utf8");
       const rawParsed = YAML.parse(rawContent) as Record<string, any> | null;
       if (
         rawParsed &&

--- a/core/config/profile/doLoadConfig.ts
+++ b/core/config/profile/doLoadConfig.ts
@@ -71,6 +71,66 @@ async function loadRules(ide: IDE) {
   return { rules, errors };
 }
 
+/**
+ * If the YAML content contains a legacy config.json-style `tabAutocompleteModel`
+ * object, inject it into `models` with `roles: [autocomplete]` and show a
+ * deprecation toast. Returns an updated PackageIdentifier whose `content` field
+ * carries the transformed YAML; the file on disk is never modified.
+ */
+function migrateTabAutocompleteModelInYaml(
+  packageIdentifier: PackageIdentifier,
+  overrideConfigYaml: AssistantUnrolled | undefined,
+  configYamlPath: string,
+  ide: IDE,
+): PackageIdentifier {
+  if (overrideConfigYaml) {
+    return packageIdentifier;
+  }
+
+  const hasPreReadContent =
+    packageIdentifier.uriType === "file" &&
+    packageIdentifier.content !== undefined;
+
+  if (!hasPreReadContent && !fs.existsSync(configYamlPath)) {
+    return packageIdentifier;
+  }
+
+  try {
+    const rawContent = hasPreReadContent
+      ? packageIdentifier.content!
+      : fs.readFileSync(configYamlPath, "utf8");
+    const rawParsed = YAML.parse(rawContent) as Record<string, any> | null;
+
+    if (
+      !rawParsed ||
+      typeof rawParsed["tabAutocompleteModel"] !== "object" ||
+      rawParsed["tabAutocompleteModel"] === null
+    ) {
+      return packageIdentifier;
+    }
+
+    const transformed: Record<string, any> = {
+      ...rawParsed,
+      models: [
+        ...(rawParsed["models"] ?? []),
+        { ...rawParsed["tabAutocompleteModel"], roles: ["autocomplete"] },
+      ],
+    };
+    delete transformed["tabAutocompleteModel"];
+
+    void ide.showToast(
+      "warning",
+      "config.yaml: 'tabAutocompleteModel' is a config.json field. " +
+        "In config.yaml, add 'roles: [autocomplete]' to your model entry instead. " +
+        "See https://docs.continue.dev/features/tab-autocomplete for migration details.",
+    );
+
+    return { ...packageIdentifier, content: YAML.stringify(transformed) };
+  } catch {
+    return packageIdentifier;
+  }
+}
+
 export default async function doLoadConfig(options: {
   ide: IDE;
   controlPlaneClient: ControlPlaneClient;
@@ -116,53 +176,12 @@ export default async function doLoadConfig(options: {
   let configLoadInterrupted = false;
   let configName: string | undefined;
 
-  // Migrate legacy config.json-style tabAutocompleteModel in config.yaml.
-  // The YAML format has no tabAutocompleteModel field; autocomplete models must
-  // appear in the models array with roles: [autocomplete]. If the user wrote
-  // a config.yaml using the JSON-format object style, Zod strips it silently
-  // and autocomplete shows "Setup Autocomplete model" with no error.
-  // We detect and transform it here so the YAML pipeline sees it correctly.
-  const hasPreReadYamlContent =
-    packageIdentifier.uriType === "file" &&
-    packageIdentifier.content !== undefined;
-
-  let effectivePackageIdentifier = packageIdentifier;
-  if (!overrideConfigYaml && (hasPreReadYamlContent || fs.existsSync(configYamlPath))) {
-    try {
-      const rawContent = hasPreReadYamlContent
-        ? packageIdentifier.content!
-        : fs.readFileSync(configYamlPath, "utf8");
-      const rawParsed = YAML.parse(rawContent) as Record<string, any> | null;
-      if (
-        rawParsed &&
-        rawParsed["tabAutocompleteModel"] !== undefined &&
-        typeof rawParsed["tabAutocompleteModel"] === "object" &&
-        rawParsed["tabAutocompleteModel"] !== null
-      ) {
-        const autocompleteModelEntry = {
-          ...rawParsed["tabAutocompleteModel"],
-          roles: ["autocomplete"],
-        };
-        const transformed: Record<string, any> = {
-          ...rawParsed,
-          models: [...(rawParsed["models"] ?? []), autocompleteModelEntry],
-        };
-        delete transformed["tabAutocompleteModel"];
-        void ide.showToast(
-          "warning",
-          "config.yaml: 'tabAutocompleteModel' is a config.json field. " +
-            "In config.yaml, add 'roles: [autocomplete]' to your model entry instead. " +
-            "See https://docs.continue.dev/features/tab-autocomplete for migration details.",
-        );
-        effectivePackageIdentifier = {
-          ...packageIdentifier,
-          content: YAML.stringify(transformed),
-        };
-      }
-    } catch {
-      // If YAML parsing fails here, let the normal pipeline surface the error
-    }
-  }
+  const effectivePackageIdentifier = migrateTabAutocompleteModelInYaml(
+    packageIdentifier,
+    overrideConfigYaml,
+    configYamlPath,
+    ide,
+  );
 
   const hasPreReadContent =
     effectivePackageIdentifier.uriType === "file" &&

--- a/core/config/profile/doLoadConfig.ts
+++ b/core/config/profile/doLoadConfig.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 
+import * as YAML from "yaml";
 import {
   AssistantUnrolled,
   ConfigResult,
@@ -115,9 +116,55 @@ export default async function doLoadConfig(options: {
   let configLoadInterrupted = false;
   let configName: string | undefined;
 
+  // Migrate legacy config.json-style tabAutocompleteModel in config.yaml.
+  // The YAML format has no tabAutocompleteModel field; autocomplete models must
+  // appear in the models array with roles: [autocomplete]. If the user wrote
+  // a config.yaml using the JSON-format object style, Zod strips it silently
+  // and autocomplete shows "Setup Autocomplete model" with no error.
+  // We detect and transform it here so the YAML pipeline sees it correctly.
+  let effectivePackageIdentifier = packageIdentifier;
+  if (!overrideConfigYaml && fs.existsSync(configYamlPath)) {
+    try {
+      const rawContent =
+        packageIdentifier.uriType === "file" &&
+        packageIdentifier.content !== undefined
+          ? packageIdentifier.content
+          : fs.readFileSync(configYamlPath, "utf8");
+      const rawParsed = YAML.parse(rawContent) as Record<string, any> | null;
+      if (
+        rawParsed &&
+        rawParsed["tabAutocompleteModel"] !== undefined &&
+        typeof rawParsed["tabAutocompleteModel"] === "object" &&
+        rawParsed["tabAutocompleteModel"] !== null
+      ) {
+        const autocompleteModelEntry = {
+          ...rawParsed["tabAutocompleteModel"],
+          roles: ["autocomplete"],
+        };
+        const transformed: Record<string, any> = {
+          ...rawParsed,
+          models: [...(rawParsed["models"] ?? []), autocompleteModelEntry],
+        };
+        delete transformed["tabAutocompleteModel"];
+        void ide.showToast(
+          "warning",
+          "config.yaml: 'tabAutocompleteModel' is a config.json field. " +
+            "In config.yaml, add 'roles: [autocomplete]' to your model entry instead. " +
+            "See https://docs.continue.dev/features/tab-autocomplete for migration details.",
+        );
+        effectivePackageIdentifier = {
+          ...packageIdentifier,
+          content: YAML.stringify(transformed),
+        };
+      }
+    } catch {
+      // If YAML parsing fails here, let the normal pipeline surface the error
+    }
+  }
+
   const hasPreReadContent =
-    packageIdentifier.uriType === "file" &&
-    packageIdentifier.content !== undefined;
+    effectivePackageIdentifier.uriType === "file" &&
+    effectivePackageIdentifier.content !== undefined;
 
   if (
     overrideConfigYaml ||
@@ -133,7 +180,7 @@ export default async function doLoadConfig(options: {
       overrideConfigYaml,
       controlPlaneClient,
       orgScopeId,
-      packageIdentifier,
+      packageIdentifier: effectivePackageIdentifier,
       workOsAccessToken,
     });
     newConfig = result.config;

--- a/core/config/profile/doLoadConfig.vitest.ts
+++ b/core/config/profile/doLoadConfig.vitest.ts
@@ -183,3 +183,99 @@ describe("doLoadConfig pre-read content bypass", () => {
     expect(mockLoadJson).toHaveBeenCalled();
   });
 });
+
+describe("doLoadConfig tabAutocompleteModel migration", () => {
+  it("should transform a JSON-style tabAutocompleteModel object into a roles-based model entry", async () => {
+    mockLoadYaml.mockClear();
+    mockLoadJson.mockClear();
+    (mockIde.showToast as ReturnType<typeof vi.fn>).mockClear();
+
+    // Simulate a config.yaml with the legacy config.json-style tabAutocompleteModel
+    const yamlWithLegacyField = [
+      "name: My Config",
+      "version: 1.0.0",
+      "schema: v1",
+      "models:",
+      "  - name: ChatModel",
+      "    provider: openai",
+      "    model: gpt-4",
+      "tabAutocompleteModel:",
+      "  name: Qwen 2.5 Coder",
+      "  provider: openai",
+      "  model: qwen2.5-coder:1.5b",
+      "  apiBase: http://localhost:11434/v1",
+    ].join("\n");
+
+    const packageIdentifier: PackageIdentifier = {
+      uriType: "file",
+      fileUri: "/home/user/.continue/config.yaml",
+      content: yamlWithLegacyField,
+    };
+
+    await doLoadConfig({
+      ide: mockIde,
+      controlPlaneClient: mockControlPlaneClient,
+      llmLogger: mockLlmLogger,
+      profileId: "test-profile",
+      orgScopeId: null,
+      packageIdentifier,
+    });
+
+    expect(mockLoadYaml).toHaveBeenCalled();
+    const calledWith = mockLoadYaml.mock.calls[0][0];
+    const passedContent = calledWith.packageIdentifier.content as string;
+
+    // The transformed content should not contain tabAutocompleteModel
+    expect(passedContent).not.toContain("tabAutocompleteModel");
+
+    // The autocomplete model should have been injected with roles: [autocomplete]
+    expect(passedContent).toContain("qwen2.5-coder:1.5b");
+    expect(passedContent).toContain("autocomplete");
+
+    // A deprecation warning toast should have been shown
+    expect(mockIde.showToast).toHaveBeenCalledWith(
+      "warning",
+      expect.stringContaining("tabAutocompleteModel"),
+    );
+  });
+
+  it("should leave config unchanged when tabAutocompleteModel is absent", async () => {
+    mockLoadYaml.mockClear();
+    (mockIde.showToast as ReturnType<typeof vi.fn>).mockClear();
+
+    const yamlWithoutLegacyField = [
+      "name: My Config",
+      "version: 1.0.0",
+      "schema: v1",
+      "models:",
+      "  - name: ChatModel",
+      "    provider: openai",
+      "    model: gpt-4",
+      "  - name: Qwen 2.5 Coder",
+      "    provider: openai",
+      "    model: qwen2.5-coder:1.5b",
+      "    roles:",
+      "      - autocomplete",
+    ].join("\n");
+
+    const packageIdentifier: PackageIdentifier = {
+      uriType: "file",
+      fileUri: "/home/user/.continue/config.yaml",
+      content: yamlWithoutLegacyField,
+    };
+
+    await doLoadConfig({
+      ide: mockIde,
+      controlPlaneClient: mockControlPlaneClient,
+      llmLogger: mockLlmLogger,
+      profileId: "test-profile",
+      orgScopeId: null,
+      packageIdentifier,
+    });
+
+    const calledWith = mockLoadYaml.mock.calls[0][0];
+    // Content should be passed through unmodified (same object reference)
+    expect(calledWith.packageIdentifier).toBe(packageIdentifier);
+    expect(mockIde.showToast).not.toHaveBeenCalled();
+  });
+});

--- a/core/config/profile/doLoadConfig.vitest.ts
+++ b/core/config/profile/doLoadConfig.vitest.ts
@@ -278,4 +278,39 @@ describe("doLoadConfig tabAutocompleteModel migration", () => {
     expect(calledWith.packageIdentifier).toBe(packageIdentifier);
     expect(mockIde.showToast).not.toHaveBeenCalled();
   });
+
+  it("should leave config unchanged when tabAutocompleteModel is an array", async () => {
+    mockLoadYaml.mockClear();
+    (mockIde.showToast as ReturnType<typeof vi.fn>).mockClear();
+
+    // An array is typeof "object" but must not be treated as an inline model
+    const yamlWithArray = [
+      "name: My Config",
+      "version: 1.0.0",
+      "schema: v1",
+      "tabAutocompleteModel:",
+      "  - name: Qwen",
+      "    provider: openai",
+      "    model: qwen2.5-coder:1.5b",
+    ].join("\n");
+
+    const packageIdentifier: PackageIdentifier = {
+      uriType: "file",
+      fileUri: "/home/user/.continue/config.yaml",
+      content: yamlWithArray,
+    };
+
+    await doLoadConfig({
+      ide: mockIde,
+      controlPlaneClient: mockControlPlaneClient,
+      llmLogger: mockLlmLogger,
+      profileId: "test-profile",
+      orgScopeId: null,
+      packageIdentifier,
+    });
+
+    const calledWith = mockLoadYaml.mock.calls[0][0];
+    expect(calledWith.packageIdentifier).toBe(packageIdentifier);
+    expect(mockIde.showToast).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #12544 — autocomplete silently shows "Setup Autocomplete model" when a user writes `config.yaml` using the `config.json`-style `tabAutocompleteModel` inline object.

## Root cause

The YAML config format has no `tabAutocompleteModel` field — that concept belongs to `config.json`. In `config.yaml`, an autocomplete model must be declared inside the `models` array with `roles: [autocomplete]`. When a user writes the JSON-object style instead, Zod silently strips the unrecognised field during schema validation. `configYamlToContinueConfig` then iterates `config.models` looking for `roles: [autocomplete]` entries, finds none, and `modelsByRole.autocomplete` stays empty. The VS Code UI renders "Setup Autocomplete model" with no error shown — chat models work fine because the `models` array entries receive default roles `[chat, summarize, apply, edit]`.

The mention of `config.ts` in the issue title is the reporter's framing of their setup; the bug is reproducible purely from the YAML/object mismatch.

## Fix

In `doLoadConfig` (`core/config/profile/doLoadConfig.ts`), **before** the package identifier is passed to the YAML pipeline, inspect the raw YAML for a `tabAutocompleteModel` value that is an object. If found:

1. Inject the model into the `models` array with `roles: ["autocomplete"]`
2. Remove the legacy `tabAutocompleteModel` key
3. Pass the transformed content via `packageIdentifier.content` so the YAML pipeline sees the correct structure — **the file on disk is never modified**
4. Show a deprecation toast pointing the user to the correct YAML syntax

The guard also covers WSL / `vscode-remote://` users who supply pre-read content without a local file path, which was discovered while writing the tests.

## Changes

- `core/config/profile/doLoadConfig.ts` — migration + deprecation warning
- `core/config/profile/doLoadConfig.vitest.ts` — two new test cases

## Test plan

- [ ] `npm run vitest -- run config/profile/doLoadConfig.vitest.ts` — 4/4 pass
- [ ] Manual: create `~/.continue/config.yaml` with a `tabAutocompleteModel` object entry (no `roles` key); reload extension; confirm autocomplete model loads and deprecation toast appears
- [ ] Manual: correct YAML with `roles: [autocomplete]` on the model — no toast, autocomplete works as before

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates a legacy `tabAutocompleteModel` object in `config.yaml` into a roles-based entry in `models` so autocomplete loads instead of showing “Setup Autocomplete model.” Runs in-memory before the YAML pipeline and shows a deprecation toast.

- **Bug Fixes**
  - Detect a `tabAutocompleteModel` object (ignore arrays) and append it to `models` with `roles: ["autocomplete"]`, then remove the legacy key.
  - Apply the change in-memory via `packageIdentifier.content`; guard on `uriType: "file"` and support pre-read content (WSL/remote). The file on disk is never modified.
  - Show a warning toast with a link to the correct YAML syntax.
  - Add tests covering the migration, the ignore-array guard, and pass-through of correctly formatted configs.

- **Refactors**
  - Extract the migration into `migrateTabAutocompleteModelInYaml` to reduce `doLoadConfig` complexity.

<sup>Written for commit 0f2e62e54b6f5bc2bc749e22e15b0dd5342bde2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

