### PR TITLE
Fix OpenAI optional header casing in locale-sensitive environments

### DIFF
--- a/packages/openai-adapters/src/apis/OpenAI.ts
+++ b/packages/openai-adapters/src/apis/OpenAI.ts
@@ -44,6 +44,10 @@ export class OpenAIApi implements BaseLlmApi {
       // Necessary because `new OpenAI()` will throw an error if there is no API Key
       apiKey: config.apiKey ?? "",
       baseURL: this.apiBase,
+      defaultHeaders: {
+        "openai-organization": undefined,
+        "openai-project": undefined,
+      },
       fetch: customFetch(config.requestOptions),
       timeout: config?.requestOptions?.timeout || undefined,
     });

--- a/packages/openai-adapters/src/test/main.test.ts
+++ b/packages/openai-adapters/src/test/main.test.ts
@@ -235,6 +235,19 @@ describe("Configuration", () => {
     );
   });
 
+  it("should disable optional OpenAI org/project headers with lowercase keys", () => {
+    const openai = constructLlmApi({
+      provider: "openai",
+      apiKey: "sk-xxx",
+      apiBase: "https://openrouter.ai/api/v1/",
+    }) as OpenAIApi;
+
+    expect((openai.openai as any)._options.defaultHeaders).toMatchObject({
+      "openai-organization": undefined,
+      "openai-project": undefined,
+    });
+  });
+
   it("should configure Inception OpenAI client with correct apiBase and apiKey", () => {
     const inception = constructLlmApi({
       provider: "inception",


### PR DESCRIPTION
## Summary
- explicitly disables optional OpenAI organization/project headers with lowercase keys
- adds a regression test for the OpenAI adapter client options

## Context
Fixes #12568. In Turkish locales, the OpenAI SDK's normalization of `OpenAI-Organization`/`OpenAI-Project` can produce dotless-i header names. Passing lowercase keys with `undefined` prevents the optional SDK headers from being injected/normalized for users who have not configured them.

## Validation
- `npm test -- src/test/main.test.ts`
- `npm run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explicitly disable optional OpenAI org/project headers to prevent locale-sensitive casing issues (e.g., Turkish dotless-i) that broke requests when those headers weren’t configured. This stabilizes OpenAI request handling in `openai-adapters`.

- **Bug Fixes**
  - Set `defaultHeaders` with lowercase "openai-organization" and "openai-project" to `undefined` in `OpenAIApi`.
  - Added a regression test to ensure these headers stay disabled.

<sup>Written for commit 5ebdb79276889f7254d3a44b9913c8e7660b7789. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

