### PR TITLE
docs: add QVAC to model providers

### DIFF
--- a/docs/customize/model-providers/more/qvac.mdx
+++ b/docs/customize/model-providers/more/qvac.mdx
@@ -4,7 +4,7 @@ description: "Configure QVAC's local-first, OpenAI-compatible server with Contin
 ---
 
 <Info>
-  Get started with [QVAC](https://qvac.com) - an open-source runtime for local-first, peer-to-peer AI
+  Get started with [QVAC](https://qvac.tether.io) - an open-source runtime for local-first, peer-to-peer AI
 </Info>
 
 ## Overview

--- a/docs/customize/model-providers/more/qvac.mdx
+++ b/docs/customize/model-providers/more/qvac.mdx
@@ -1,0 +1,87 @@
+---
+title: "QVAC"
+description: "Configure QVAC's local-first, OpenAI-compatible server with Continue for chat, edit, and agent workflows that run entirely on your machine"
+---
+
+<Info>
+  Get started with [QVAC](https://qvac.com) - an open-source runtime for local-first, peer-to-peer AI
+</Info>
+
+## Overview
+
+QVAC runs models locally and exposes an OpenAI-compatible HTTP server, so you can point Continue at it using the built-in `openai` provider. Everything stays on your machine.
+
+## Installation
+
+Install the CLI and start the OpenAI-compatible server:
+
+```shell
+npm i -g @qvac/cli
+qvac serve openai
+```
+
+The server listens on port `11434` by default. Use `--port` to change it.
+
+Model aliases are defined in a `qvac.config.json` file. The `model` you reference from Continue must match a serve alias:
+
+```json title="qvac.config.json"
+{
+  "serve": {
+    "models": {
+      "gpt-oss-20b": {
+        "model": "GPT_OSS_20B_INST_Q4_K_M",
+        "preload": true,
+        "config": {
+          "ctx_size": 32768
+        }
+      }
+    }
+  }
+}
+```
+
+## Configuration
+
+Use the `openai` provider and point `apiBase` at the QVAC server. The `model` is the alias from `qvac.config.json`. QVAC does not validate the API key, but the field is typically required, so any non-empty string works.
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  name: My Config
+  version: 0.0.1
+  schema: v1
+
+  models:
+    - name: QVAC gpt-oss-20b
+      provider: openai
+      model: gpt-oss-20b
+      apiKey: qvac
+      apiBase: http://127.0.0.1:11434/v1
+      roles:
+        - chat
+        - edit
+        - apply
+  ```
+  </Tab>
+  <Tab title="JSON (Deprecated)">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "QVAC gpt-oss-20b",
+        "provider": "openai",
+        "model": "gpt-oss-20b",
+        "apiKey": "qvac",
+        "apiBase": "http://127.0.0.1:11434/v1"
+      }
+    ]
+  }
+  ```
+  </Tab>
+</Tabs>
+
+## Recommendations
+
+- **Set `ctx_size` explicitly.** QVAC's LLM context size defaults to `1024` tokens, which is too small for most chat and agent prompts. Set it in `qvac.config.json` (e.g. `32768`) as shown above.
+- **Disable reasoning for reasoning-tuned models.** For models such as Qwen3, set `reasoning_budget: 0` in the model `config` to keep responses suited to Continue's chat and edit flows.
+- **Pick a capable model for tools and autocomplete.** Local tool-calling and autocomplete quality is bounded by the model you run. A capable agent-tuned model such as `gpt-oss-20b` is a good default for chat and agent use.

--- a/docs/customize/model-providers/more/qvac.mdx
+++ b/docs/customize/model-providers/more/qvac.mdx
@@ -83,5 +83,5 @@ Use the `openai` provider and point `apiBase` at the QVAC server. The `model` is
 ## Recommendations
 
 - **Set `ctx_size` explicitly.** QVAC's LLM context size defaults to `1024` tokens, which is too small for most chat and agent prompts. Set it in `qvac.config.json` (e.g. `32768`) as shown above.
-- **Disable reasoning for reasoning-tuned models.** For models such as Qwen3, set `reasoning_budget: 0` in the model `config` to keep responses suited to Continue's chat and edit flows.
+- **Disable reasoning for reasoning-tuned models.** For models such as Qwen3.5, set `reasoning_budget: 0` in the model `config` to keep responses suited to Continue's chat and edit flows.
 - **Pick a capable model for tools and autocomplete.** Local tool-calling and autocomplete quality is bounded by the model you run. A capable agent-tuned model such as `gpt-oss-20b` is a good default for chat and agent use.

--- a/docs/customize/model-providers/overview.mdx
+++ b/docs/customize/model-providers/overview.mdx
@@ -49,6 +49,7 @@ Beyond the top-level providers, Continue supports many other options:
 | [llama.cpp](/customize/model-providers/more/llamacpp)    | Optimized C++ implementation for running LLMs |
 | [LlamaStack](/customize/model-providers/more/llamastack) | Stack for running Llama models locally        |
 | [llamafile](/customize/model-providers/more/llamafile)   | Self-contained executable model files         |
+| [QVAC](/customize/model-providers/more/qvac)             | Local-first, OpenAI-compatible runtime        |
 
 ### Enterprise Solutions
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -117,6 +117,7 @@
                       "customize/model-providers/more/moonshot",
                       "customize/model-providers/more/nous",
                       "customize/model-providers/more/nvidia",
+                      "customize/model-providers/more/qvac",
                       "customize/model-providers/more/tensorix",
                       "customize/model-providers/more/together",
                       "customize/model-providers/more/xAI",


### PR DESCRIPTION
## Description

Adds a provider page for [QVAC](https://qvac.com), an open-source, local-first runtime that exposes an OpenAI-compatible HTTP server via `qvac serve openai`. Because the server speaks the OpenAI API, Continue connects to it through the built-in `openai` provider with a local `apiBase` — no new provider type is needed.

The page mirrors the existing local / OpenAI-compatible provider docs (e.g. OpenVINO Model Server, vLLM) and covers:

- Installing the CLI (`npm i -g @qvac/cli`) and starting the server (`qvac serve openai`, default port `11434`).
- Defining model aliases in `qvac.config.json` and matching the `model` field to a serve alias.
- A `config.yaml` / `config.json` example using `provider: openai`, `apiBase: http://127.0.0.1:11434/v1`, and a placeholder `apiKey`.
- Recommendations: set `ctx_size` explicitly (the default is small), set `reasoning_budget: 0` for reasoning-tuned models like Qwen3, and use a capable agent-tuned model such as `gpt-oss-20b` for tool-calling quality.

The page is registered in the **More Providers** navigation and added to the **Local Model Options** table in the providers overview.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Docs-only change.

## Tests

Docs-only change. Verified `docs/docs.json` remains valid JSON after adding the navigation entry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add QVAC to the model providers docs with a new page on running its OpenAI-compatible server and connecting via the built-in `openai` provider using a local `apiBase`. Updates navigation and the providers overview, switches docs to `qvac.tether.io`, and adds a note for reasoning-tuned models (e.g., Qwen3.5).

- **New Features**
  - New QVAC page: install `@qvac/cli`, start with `qvac serve openai` (default port 11434).
  - Config examples using `provider: openai`, `apiBase: http://127.0.0.1:11434/v1`, any non-empty `apiKey`, and model aliases from `qvac.config.json`.
  - Recommendations: set `ctx_size`; set `reasoning_budget: 0` for reasoning-tuned models like Qwen3.5; use a capable model like `gpt-oss-20b` for tools.
  - Added QVAC to the “More Providers” nav and “Local Model Options” table.

<sup>Written for commit 2adf2eab23e3c2352cabeb3f7648b55f06ce5dec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

