### PR TITLE
fix(tools): align system message tool prompt rules with multi-call parser

### DIFF
--- a/core/tools/systemMessageTools/toolCodeblocks/index.ts
+++ b/core/tools/systemMessageTools/toolCodeblocks/index.ts
@@ -72,8 +72,8 @@ CRITICAL: Follow the exact syntax. Do not use XML tags, JSON objects, or any oth
   systemMessageSuffix = `RULES FOR TOOL USE:
 1. To call a tool, output a tool code block using EXACTLY the format shown above.
 2. Always start the code block on a new line.
-3. You can only call ONE tool at a time.
-4. The tool code block MUST be the last thing in your response. Stop immediately after the closing fence.
+3. Call only the tools you need for this step; do not invent parallel calls in a single code block.
+4. You may include explanatory text before or after a tool code block, but do not nest tool calls inside each other.
 5. Do NOT wrap tool calls in XML tags like <tool_call> or <function=...>.
 6. Do NOT use JSON format for tool calls.
 7. Do NOT invent tools that are not listed above.

--- a/core/tools/systemMessageTools/toolCodeblocks/interceptSystemToolCalls.vitest.ts
+++ b/core/tools/systemMessageTools/toolCodeblocks/interceptSystemToolCalls.vitest.ts
@@ -421,3 +421,20 @@ describe("interceptSystemToolCalls", () => {
     ).toBe("true");
   });
 });
+
+describe("SystemMessageToolCodeblocksFramework prompt rules", () => {
+  const framework = new SystemMessageToolCodeblocksFramework();
+
+  it("does not tell models to stop after one tool call", () => {
+    expect(framework.systemMessageSuffix).not.toMatch(/only call ONE tool/i);
+    expect(framework.systemMessageSuffix).not.toMatch(
+      /MUST be the last thing in your response/i,
+    );
+  });
+
+  it("does not instruct models to stop immediately after the closing fence", () => {
+    expect(framework.systemMessageSuffix).not.toMatch(
+      /Stop immediately after the closing/i,
+    );
+  });
+});


### PR DESCRIPTION
Fixes #11074

## Summary

The system-message tools parser supports multiple tool calls per response and preserves content after tool calls since #11092 (merged 2026-03-25), but the system prompt still tells models the opposite: "You can only call ONE tool at a time" and "The tool code block MUST be the last thing in your response. Stop immediately after the closing fence." The prompt forbids what the parser already handles, so models on the system-message path never use the multi-call capability.

## Root cause

#11092 rewrote `interceptSystemToolCalls.ts` to reset `parseState` after each completed tool call instead of breaking the loop, enabling sequential tool calls and post-tool text. Rules 3 and 4 in `SystemMessageToolCodeblocksFramework.systemMessageSuffix` (core/tools/systemMessageTools/toolCodeblocks/index.ts:75-76) date from #10485, were deliberately conservative for the old parser, and were not revisited when the parser fix landed.

## Changes

- `core/tools/systemMessageTools/toolCodeblocks/index.ts`: updated `systemMessageSuffix` rules 3 and 4

  Before:
  ```
  3. You can only call ONE tool at a time.
  4. The tool code block MUST be the last thing in your response. Stop immediately after the closing fence.
  ```

  After:
  ```
  3. Call only the tools you need for this step; do not invent parallel calls in a single code block.
  4. You may include explanatory text before or after a tool code block, but do not nest tool calls inside each other.
  ```

- `core/tools/systemMessageTools/toolCodeblocks/interceptSystemToolCalls.vitest.ts`: 2 new assertions guarding against reintroducing the single-tool / stop-after-fence wording

## What this doesn't change

- `interceptSystemToolCalls.ts` parser logic — #11092's implementation is untouched
- `systemMessagePrefix` and rules 1, 2, 5-9 of the suffix
- The native tools path in `BaseLLM.streamChat()`

## Checklist

- [x] I've read the contributing guide
- [ ] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A — system prompt text change, no UI.

## Tests

- `cd core && npx vitest run tools/systemMessageTools/toolCodeblocks/interceptSystemToolCalls.vitest.ts` — 11/11 passing (9 existing + 2 new). The existing tests already validate multi-tool sequences and post-tool-text preservation in the parser; the new tests pin the prompt rules so the old restrictions cannot silently return.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the system-message tool prompt with the multi-call parser so models can make sequential tool calls and include text before/after tool code blocks. This unlocks the already-supported flow on the system-message path.

- **Bug Fixes**
  - Updated rules 3–4 in `SystemMessageToolCodeblocksFramework.systemMessageSuffix` to allow sequential calls and post-tool text; still forbids nesting or parallel calls in one block.
  - Added tests to pin the prompt wording and prevent reintroducing “single tool only” or “stop after fence” rules.

<sup>Written for commit eb2567e9281a6ca9942540d20430009eb89ee15a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

