### PR TITLE
fix(prompts): normalize CRLF line endings before frontmatter split

### DIFF
--- a/core/promptFiles/parsePromptFile.test.ts
+++ b/core/promptFiles/parsePromptFile.test.ts
@@ -1,0 +1,68 @@
+import { parsePromptFile } from "./parsePromptFile.js";
+
+describe("parsePromptFile", () => {
+  describe("LF baseline", () => {
+    it("should parse content with LF separators and extract name and description from YAML", () => {
+      const content = `name: test-prompt\ndescription: Test description\n---\nHello world`;
+      const result = parsePromptFile("/path/to/test.prompt", content);
+      expect(result.name).toBe("test-prompt");
+      expect(result.description).toBe("Test description");
+      expect(result.prompt).toBe("Hello world");
+    });
+  });
+
+  describe("CRLF regression", () => {
+    it("should parse content with CRLF endings and extract name from YAML (not filename)", () => {
+      const content = `name: my-prompt\r\ndescription: My Description\r\n---\r\nPrompt body`;
+      const result = parsePromptFile("/path/to/ignore.prompt", content);
+      expect(result.name).toBe("my-prompt");
+      expect(result.description).toBe("My Description");
+      expect(result.prompt).toBe("Prompt body");
+    });
+  });
+
+  describe("CRLF with system tag", () => {
+    it("should extract systemMessage from content with CRLF and <system> tag", () => {
+      const content = `name: system-test\r\n---\r\n<system>System message here</system>\r\nMain prompt body`;
+      const result = parsePromptFile("/path/to/file.prompt", content);
+      expect(result.name).toBe("system-test");
+      expect(result.systemMessage).toBe("System message here");
+      expect(result.prompt).toBe("Main prompt body");
+    });
+  });
+
+  describe("No frontmatter fallback", () => {
+    it("should fall back to path segment when no frontmatter is present", () => {
+      const content = `Just some prompt content without any YAML`;
+      const result = parsePromptFile("/path/to/myfile.prompt", content);
+      expect(result.name).toBe("myfile");
+      expect(result.prompt).toBe("Just some prompt content without any YAML");
+    });
+  });
+
+  describe("Mixed line endings", () => {
+    it("should normalize mixed line endings in body with CRLF frontmatter and LF body", () => {
+      const content = `name: mixed-test\r\ndescription: Mixed test\r\n---\nBody with\nLF endings`;
+      const result = parsePromptFile("/path/to/file.prompt", content);
+      expect(result.name).toBe("mixed-test");
+      expect(result.description).toBe("Mixed test");
+      expect(result.prompt).toBe("Body with\nLF endings");
+    });
+  });
+
+  describe("Default version", () => {
+    it("should use version 2 when no version is specified in frontmatter", () => {
+      const content = `name: no-version\r\n---\r\nPrompt`;
+      const result = parsePromptFile("/path/to/file.prompt", content);
+      expect(result.version).toBe(2);
+    });
+  });
+
+  describe("Explicit version", () => {
+    it("should use explicit version when specified in frontmatter", () => {
+      const content = `name: with-version\r\nversion: 1\r\n---\r\nPrompt`;
+      const result = parsePromptFile("/path/to/file.prompt", content);
+      expect(result.version).toBe(1);
+    });
+  });
+});

--- a/core/promptFiles/parsePromptFile.ts
+++ b/core/promptFiles/parsePromptFile.ts
@@ -3,6 +3,7 @@ import * as YAML from "yaml";
 import { getLastNPathParts } from "../util/uri";
 
 export function parsePromptFile(path: string, content: string) {
+  content = content.replace(/\r\n/g, "\n");
   let [preambleRaw, prompt] = content.split("\n---\n");
   if (prompt === undefined) {
     prompt = preambleRaw;


### PR DESCRIPTION
## Summary

Prompt files saved on Windows with CRLF line endings are silently unparseable: the slash
command list shows the raw file content instead of the `name` from the YAML block.
`parsePromptFile()` splits on `"\n---\n"` (core/promptFiles/parsePromptFile.ts:6) but CRLF
files contain `"\r\n---\r\n"`, so the split finds nothing and the entire file is treated as
the prompt body with no frontmatter. A one-line CRLF normalization at the top of the function
mirrors the fix already in place in the rule parser.

## Root cause

`core/promptFiles/parsePromptFile.ts:6` — `content.split("\n---\n")` — receives raw file
content without line-ending normalization. On Windows, VS Code's workspace file APIs and the
Node `fs` module both preserve CRLF when files are saved that way, so the separator the code
expects never appears. The sibling parser
`packages/config-yaml/src/markdown/markdownToRule.ts:25` already handles this with
`content.replace(/\r\n/g, "\n")` before splitting; `parsePromptFile` predates that pattern
and was never updated.

## Changes

- `core/promptFiles/parsePromptFile.ts`: add `content = content.replace(/\r\n/g, "\n");`
 before the frontmatter split on line 6
- `core/promptFiles/parsePromptFile.test.ts`: new Jest test file — 7 cases covering LF
 baseline, CRLF frontmatter (the regression), mixed endings, no-frontmatter fallback,
 `<system>` tag with CRLF, default version, and explicit version field

## Prior work

Prior work: #11942 previously proposed the same CRLF normalization for the upstream report and was closed unmerged without maintainer rejection. This PR revives that approach on the current base with focused Jest coverage.

## What this doesn't change

`packages/config-yaml/src/markdown/markdownToRule.ts` (rule files) already normalizes — no
change needed there. `core/promptFiles/getPromptFiles.ts` (the file-read path) is untouched;
normalization stays at parse time to keep I/O concerns separate.

## Checklist

- [x] I've read the contributing guide
- [ ] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

**Before** (CRLF file):
```
/ command list shows:
---
name: HelloWorld
description: A simple prompt
invokable: true
---

Write "Hello World".
```

**After** (CRLF file, same behavior as LF):
```
/ command list shows:
HelloWorld — A simple prompt
```

## Tests

Run: `cd core && npx jest promptFiles/parsePromptFile.test.ts`

Result: **7 passed, 7 total** (100% pass rate, 0 existing + 7 new)

The tests cover:
- LF baseline: YAML frontmatter correctly parsed with LF separators
- CRLF regression: same YAML content with CRLF endings now correctly parsed (the bug being fixed)
- CRLF with `<system>` tag: systemMessage extraction works with CRLF line endings
- No frontmatter fallback: name correctly falls back to last path segment when no YAML present
- Mixed line endings: body with mixed LF/CRLF properly normalized
- Default version: version field defaults to 2 when not specified
- Explicit version: explicit version (v1) correctly extracted from frontmatter

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes CRLF line endings in prompt files before splitting frontmatter so Windows parsing works and the command list shows the YAML `name` instead of raw content.

- **Bug Fixes**
 - `core/promptFiles/parsePromptFile.ts`: replace `\r\n` with `\n` before splitting on `\n---\n`.
 - `core/promptFiles/parsePromptFile.test.ts`: add 7 tests for LF/CRLF, mixed endings, no frontmatter fallback, `<system>` tag, and version default/explicit.

<sup>Written for commit 059df558bdfcdf0eb76bfc8fb2e7cfbc22f83b36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Upstream

Closes #11876.
Reported by @SteenH68.
