### PR TITLE
fix(tools): return raw content from read_currently_open_file to prevent false Run button

### DIFF
--- a/core/tools/implementations/readCurrentlyOpenFile.ts
+++ b/core/tools/implementations/readCurrentlyOpenFile.ts
@@ -15,7 +15,7 @@ export const readCurrentlyOpenFileImpl: ToolImpl = async (_, extras) => {
       extras.config.selectedModelByRole.chat,
     );
 
-    const { relativePathOrBasename, last2Parts, baseName } = getUriDescription(
+    const { last2Parts, baseName } = getUriDescription(
       result.path,
       await extras.ide.getWorkspaceDirs(),
     );
@@ -24,7 +24,7 @@ export const readCurrentlyOpenFileImpl: ToolImpl = async (_, extras) => {
       {
         name: `Current file: ${baseName}`,
         description: last2Parts,
-        content: `\`\`\`${relativePathOrBasename}\n${result.contents}\n\`\`\``,
+        content: result.contents,
         uri: {
           type: "file",
           value: result.path,

--- a/core/tools/implementations/readCurrentlyOpenFile.vitest.ts
+++ b/core/tools/implementations/readCurrentlyOpenFile.vitest.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import { readCurrentlyOpenFileImpl } from "./readCurrentlyOpenFile";
+
+vi.mock("../../indexing/ignore", () => ({
+  throwIfFileIsSecurityConcern: vi.fn(),
+}));
+
+vi.mock("./readFileLimit", () => ({
+  throwIfFileExceedsHalfOfContext: vi.fn(),
+}));
+
+const makeExtras = (
+  path: string,
+  contents: string,
+  workspaceDirs: string[],
+) => ({
+  ide: {
+    getCurrentFile: vi.fn().mockResolvedValue({ path, contents }),
+    getWorkspaceDirs: vi.fn().mockResolvedValue(workspaceDirs),
+  },
+  config: {
+    selectedModelByRole: { chat: { contextLength: 100_000 } },
+  },
+});
+
+describe("readCurrentlyOpenFileImpl output format", () => {
+  it("returns raw file content without a code fence", async () => {
+    const extras = makeExtras(
+      "file:///workspace/src/app.ts",
+      'console.log("hello");',
+      ["file:///workspace"],
+    );
+    const result = await readCurrentlyOpenFileImpl({}, extras as any);
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBe('console.log("hello");');
+    expect(result[0].content).not.toMatch(/^```/);
+  });
+
+  it("returns raw content for extension-less files (no code fence to trigger Run button)", async () => {
+    const extras = makeExtras(
+      "file:///workspace/Makefile",
+      "build:\n\tmake all",
+      ["file:///workspace"],
+    );
+    const result = await readCurrentlyOpenFileImpl({}, extras as any);
+    expect(result[0].content).toBe("build:\n\tmake all");
+    expect(result[0].content).not.toMatch(/^```/);
+  });
+
+  it("returns raw content for single-line files (no Run button risk)", async () => {
+    const extras = makeExtras("file:///workspace/hello", "hello", [
+      "file:///workspace",
+    ]);
+    const result = await readCurrentlyOpenFileImpl({}, extras as any);
+    expect(result[0].content).toBe("hello");
+    expect(result[0].content).not.toMatch(/^```/);
+  });
+
+  it("name and description still identify the file", async () => {
+    const extras = makeExtras(
+      "file:///workspace/src/app.ts",
+      "export default {};",
+      ["file:///workspace"],
+    );
+    const result = await readCurrentlyOpenFileImpl({}, extras as any);
+    expect(result[0].name).toContain("app.ts");
+    expect(result[0].description).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

`read_currently_open_file` wraps file content in a markdown code fence using the file path as the language tag. The GUI's terminal-block heuristic doesn't recognize paths as languages, so for extension-less names or single-line files `isTerminalCodeBlock()` misclassifies the block and renders a Run-in-terminal button on plain file content — clicking it would execute the file's text in the shell.

## Root cause

`core/tools/implementations/readCurrentlyOpenFile.ts:27` returns:

```ts
content: `\`\`\`${relativePathOrBasename}\n${result.contents}\n\`\`\``,
```

In the GUI, `StyledMarkdownPreview` strips the extension from dot-containing fence tags, but extension-less tags pass through, `getLanguageFromClassName()` yields `null`, and `isTerminalCodeBlock(null, content)` returns true for short content. The sibling `readFile` tool already returns raw content; the `name` and `description` fields of the context item carry the file identity, so the fence adds nothing.

## Changes

- `core/tools/implementations/readCurrentlyOpenFile.ts`: return `result.contents` raw, matching `readFile.ts` (1 line)
- `core/tools/implementations/readCurrentlyOpenFile.vitest.ts`: new test file, 4 cases

## What this doesn't change

- The GUI heuristic in `gui/src/components/StyledMarkdownPreview/utils.ts` — fixing the tool output is the root-cause fix; the heuristic still behaves as designed for genuine terminal blocks
- `readFile.ts` (already raw) and the tool schema definition
- The `name`/`description` display contract for the context item

## Checklist

- [x] I've read the contributing guide
- [ ] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A — tool output format change; the user-visible effect is the absence of the spurious Run button described in the upstream report.

## Tests

- `cd core && npx vitest run tools/implementations/readCurrentlyOpenFile.vitest.ts` — 4/4 passing (all new). Covers: raw content for multi-line .ts files, extension-less files (the heuristic trigger case), single-line files, and that `name`/`description` still identify the file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return raw content from `read_currently_open_file` instead of wrapping it in a code fence. This prevents the GUI from showing a false Run-in-terminal button on plain file content and aligns the tool with `readFile`.

- **Bug Fixes**
 - In `core/tools/implementations/readCurrentlyOpenFile.ts`, return `result.contents` without a code fence; keep `name`/`description` for file identity.
 - Added `vitest` cases in `core/tools/implementations/readCurrentlyOpenFile.vitest.ts` for extension-less, single-line, and `.ts` files to confirm raw output and correct metadata.

<sup>Written for commit 539dabf4563373c05105634c0de0df7a34ece0fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Upstream

Closes #11440.
Reported by @shanevcantwell.
