### PR TITLE
fix(vllm): add tool support detection so agent mode sends tools parameter

### DIFF
--- a/core/llm/toolSupport.test.ts
+++ b/core/llm/toolSupport.test.ts
@@ -396,6 +396,31 @@ describe("PROVIDER_TOOL_SUPPORT", () => {
       expect(PROVIDER_TOOL_SUPPORT["non-existent"]).toBe(undefined);
     });
   });
+
+  describe("vllm", () => {
+    const supportsFn = PROVIDER_TOOL_SUPPORT["vllm"];
+
+    it("should return true for qwen3", () => {
+      expect(supportsFn("qwen3")).toBe(true);
+    });
+
+    it("should return true for Qwen3-72B-Instruct", () => {
+      expect(supportsFn("Qwen3-72B-Instruct")).toBe(true);
+    });
+
+    it("should return true for llama3.1", () => {
+      expect(supportsFn("llama3.1")).toBe(true);
+    });
+
+    it("should return true for deepseek models", () => {
+      expect(supportsFn("deepseek")).toBe(true);
+      expect(supportsFn("deepseek-r1")).toBe(true);
+    });
+
+    it("should return false for llama2", () => {
+      expect(supportsFn("llama2")).toBe(false);
+    });
+  });
 });
 
 describe("isRecommendedAgentModel", () => {

--- a/core/llm/toolSupport.ts
+++ b/core/llm/toolSupport.ts
@@ -485,6 +485,12 @@ export const PROVIDER_TOOL_SUPPORT: Record<string, (model: string) => boolean> =
 
       return false;
     },
+    vllm: (model) => {
+      // vLLM serves many of the same models as Ollama; reuse its heuristic.
+      // Users can override per-model with `capabilities: [tool_use]` in config.yaml.
+      const ollamaFn = PROVIDER_TOOL_SUPPORT["ollama"];
+      return ollamaFn(model);
+    },
   };
 
 export function isRecommendedAgentModel(modelName: string): boolean {


### PR DESCRIPTION
Fixes #5508

## Summary

Agent mode with the vLLM provider never executes tools: the model replies with plain text or raw tool-call syntax leaks into chat. The request sent to vLLM never includes the `tools` parameter, so the model has nothing to call, regardless of how well the server supports OpenAI-compatible tool calling.

## Root cause

`PROVIDER_TOOL_SUPPORT` in `core/llm/toolSupport.ts` has no `vllm` entry. `modelSupportsNativeTools()` (core/llm/toolSupport.ts:513) returns `false` for any provider absent from the map, so `gui/src/redux/thunks/streamNormalInput.ts:116` sets `useNativeTools = false`, routes the request through the system-message code-block framework, and never populates `completionOptions.tools`. The downstream streaming path (`fromChatCompletionChunk` in core/llm/openaiTypeConverters.ts, `addToolCallDeltaToState` in gui/src/util/toolCallState.ts) already reassembles streamed `tool_calls` deltas correctly; it is simply never reached.

## Changes

- `core/llm/toolSupport.ts`: add a `vllm` entry to `PROVIDER_TOOL_SUPPORT`, delegating to the existing `ollama` model heuristic (the same delegation pattern `lmstudio` uses), since vLLM commonly serves the same model families (Qwen3, Llama 3.x, DeepSeek, Hermes)
- `core/llm/toolSupport.test.ts`: new `describe("vllm")` block covering Qwen3, Llama 3.1, DeepSeek (true) and a non-tool model (false)

## What this doesn't change

- The SSE chunk reassembly path: `fromChatCompletionChunk` and `addToolCallDeltaToState` are untouched
- `Vllm.ts`: it inherits the OpenAI adapter path, which correctly sends `tools` once populated
- Other providers' `PROVIDER_TOOL_SUPPORT` entries
- The `capabilities: [tools]` config override remains the escape hatch for unusual vLLM deployments

## Checklist

- [x] I've read the contributing guide
- [ ] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A — no UI change.

## Tests

- `cd core && npm test -- llm/toolSupport.test.ts` — 78/78 passing (73 existing + 5 new). Covers: vLLM provider tool-support detection for Qwen3 (the model cited in the issue), Llama 3.1, and DeepSeek model names, plus the negative case for llama2.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes agent mode with `vllm` so tool calls work. We now detect tool support and send the `tools` parameter, enabling proper tool execution.

- **Bug Fixes**
  - Added `vllm` to `PROVIDER_TOOL_SUPPORT`, reusing the `ollama` heuristic so compatible models (Qwen3, Llama 3.1, DeepSeek) include `tools` in requests.
  - Added tests for Qwen3, Llama 3.1, DeepSeek, and a negative case for Llama 2.

<sup>Written for commit 7ad76ae88bfc64b3304e657f190d9bf519ca6dad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

