### PR TITLE
fix(openai): omit stop parameter for o-series and gpt-5+ models

### DIFF
--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -285,6 +285,7 @@ class OpenAI extends BaseLLM {
 
     // OpenAI o1-preview and o1-mini or o3-mini:
     if (this.isOSeriesOrGpt5PlusModel(options.model)) {
+      finalOptions.stop = undefined;
       // a) use max_completion_tokens instead of max_tokens
       finalOptions.max_completion_tokens = options.maxTokens;
       finalOptions.max_tokens = undefined;
@@ -441,6 +442,7 @@ class OpenAI extends BaseLLM {
 
     // OpenAI o1-preview and o1-mini or o3-mini:
     if (this.isOSeriesOrGpt5PlusModel(body.model)) {
+      body.stop = undefined;
       // a) use max_completion_tokens instead of max_tokens
       body.max_completion_tokens = body.max_tokens;
       body.max_tokens = undefined;

--- a/core/llm/llms/OpenAI.vitest.ts
+++ b/core/llm/llms/OpenAI.vitest.ts
@@ -424,4 +424,133 @@ describe("OpenAI", () => {
       },
     });
   });
+
+  test("streamChat for gpt-5-nano should not include stop parameter", async () => {
+    const openai = new OpenAI({
+      apiKey: "test-api-key",
+      model: "gpt-5-nano",
+      apiBase: "https://api.openai.com/v1/",
+    });
+
+    const testCase: LlmTestCase = {
+      llm: openai,
+      methodToTest: "streamChat",
+      params: [
+        [{ role: "user", content: "hello" }],
+        new AbortController().signal,
+        { stop: ["<|fim_suffix|>"] },
+      ],
+      mockStream: [{ choices: [{ delta: { content: "Hello world" } }] }],
+      expectedRequest: {
+        url: "https://api.openai.com/v1/chat/completions",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    };
+
+    const mockFetch = setupMockFetch(undefined, testCase.mockStream);
+    setupReadableStreamPolyfill();
+    (openai as any).fetch = mockFetch;
+    (openai as any).useOpenAIAdapterFor = [];
+
+    await executeLlmMethod(
+      testCase.llm,
+      testCase.methodToTest,
+      testCase.params,
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [, options] = mockFetch.mock.calls[0];
+    const actualBody = JSON.parse(options.body as string);
+    expect(actualBody.model).toBe("gpt-5-nano");
+    expect(actualBody.stop).toBeUndefined();
+  });
+
+  test("streamChat for o3-mini should not include stop parameter", async () => {
+    const openai = new OpenAI({
+      apiKey: "test-api-key",
+      model: "o3-mini",
+      apiBase: "https://api.openai.com/v1/",
+    });
+
+    const testCase: LlmTestCase = {
+      llm: openai,
+      methodToTest: "streamChat",
+      params: [
+        [{ role: "user", content: "hello" }],
+        new AbortController().signal,
+        { stop: ["<|fim_suffix|>"] },
+      ],
+      mockStream: [{ choices: [{ delta: { content: "Hello world" } }] }],
+      expectedRequest: {
+        url: "https://api.openai.com/v1/chat/completions",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    };
+
+    const mockFetch = setupMockFetch(undefined, testCase.mockStream);
+    setupReadableStreamPolyfill();
+    (openai as any).fetch = mockFetch;
+    (openai as any).useOpenAIAdapterFor = [];
+
+    await executeLlmMethod(
+      testCase.llm,
+      testCase.methodToTest,
+      testCase.params,
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [, options] = mockFetch.mock.calls[0];
+    const actualBody = JSON.parse(options.body as string);
+    expect(actualBody.model).toBe("o3-mini");
+    expect(actualBody.stop).toBeUndefined();
+  });
+
+  test("streamChat for gpt-4o should include stop parameter (regression guard)", async () => {
+    const openai = new OpenAI({
+      apiKey: "test-api-key",
+      model: "gpt-4o",
+      apiBase: "https://api.openai.com/v1/",
+    });
+
+    const testCase: LlmTestCase = {
+      llm: openai,
+      methodToTest: "streamChat",
+      params: [
+        [{ role: "user", content: "hello" }],
+        new AbortController().signal,
+        { stop: ["<|fim_suffix|>"] },
+      ],
+      mockStream: [{ choices: [{ delta: { content: "Hello world" } }] }],
+      expectedRequest: {
+        url: "https://api.openai.com/v1/chat/completions",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    };
+
+    const mockFetch = setupMockFetch(undefined, testCase.mockStream);
+    setupReadableStreamPolyfill();
+    (openai as any).fetch = mockFetch;
+    (openai as any).useOpenAIAdapterFor = [];
+
+    await executeLlmMethod(
+      testCase.llm,
+      testCase.methodToTest,
+      testCase.params,
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [, options] = mockFetch.mock.calls[0];
+    const actualBody = JSON.parse(options.body as string);
+    expect(actualBody.model).toBe("gpt-4o");
+    expect(actualBody.stop).toEqual(["<|fim_suffix|>"]);
+  });
 });

--- a/packages/openai-adapters/src/apis/OpenAI.ts
+++ b/packages/openai-adapters/src/apis/OpenAI.ts
@@ -64,10 +64,18 @@ export class OpenAIApi implements BaseLlmApi {
       body.max_tokens = undefined;
     }
 
-    // o-series models - only apply for official OpenAI API
+    // o-series and gpt-5+ models don't support stop parameter
+    const isOSeriesOrGpt5Plus = !!(
+      body.model.match(/^o[0-9]/) || body.model.match(/gpt-[5-9]/i)
+    );
+    if (isOSeriesOrGpt5Plus) {
+      body.stop = undefined;
+    }
+
+    // Additional handling for official OpenAI API
     const isOfficialOpenAIAPI = this.apiBase === "https://api.openai.com/v1/";
     if (isOfficialOpenAIAPI) {
-      if (body.model.startsWith("o") || body.model.includes("gpt-5")) {
+      if (isOSeriesOrGpt5Plus) {
         // a) use max_completion_tokens instead of max_tokens
         body.max_completion_tokens = body.max_tokens;
         body.max_tokens = undefined;

--- a/packages/openai-adapters/src/test/openai-adapter.vitest.ts
+++ b/packages/openai-adapters/src/test/openai-adapter.vitest.ts
@@ -1,5 +1,5 @@
-import { describe, vi } from "vitest";
-import { createAdapterTests } from "./adapter-test-utils.js";
+import { describe, expect, test, vi } from "vitest";
+import { createAdapterTests, runAdapterTest } from "./adapter-test-utils.js";
 
 // Mock the fetch package (not needed for OpenAI but required by the shared test utils)
 vi.mock("@continuedev/fetch", async () => {
@@ -24,5 +24,245 @@ describe("OpenAI Adapter Tests", () => {
       "content-type": "application/json",
       accept: "application/json",
     },
+  });
+
+  describe("o-series and gpt-5+ models strip stop parameter", () => {
+    test("should strip stop parameter for o3 models on Azure-style apiBase", async () => {
+      await runAdapterTest({
+        config: {
+          provider: "openai",
+          apiKey: "test-api-key",
+          apiBase:
+            "https://custom-azure.openai.azure.com/openai/deployments/o3",
+        },
+        methodToTest: "chatCompletionNonStream",
+        params: [
+          {
+            model: "o3",
+            messages: [{ role: "user", content: "hello" }],
+            stop: ["<|im_end|>"],
+          },
+          new AbortController().signal,
+        ],
+        expectedRequest: {
+          url: "https://custom-azure.openai.azure.com/openai/deployments/o3/chat/completions",
+          method: "POST",
+          body: {
+            model: "o3",
+            messages: [{ role: "user", content: "hello" }],
+            stop: undefined,
+          },
+        },
+        mockResponse: {
+          id: "test-id",
+          object: "chat.completion",
+          created: 1234567890,
+          model: "o3",
+          choices: [
+            {
+              index: 0,
+              message: { role: "assistant", content: "Hello" },
+              finish_reason: "stop",
+            },
+          ],
+          usage: {
+            prompt_tokens: 10,
+            completion_tokens: 15,
+            total_tokens: 25,
+          },
+        },
+      });
+    });
+
+    test("should strip stop parameter for gpt-5 models on Azure-style apiBase", async () => {
+      await runAdapterTest({
+        config: {
+          provider: "openai",
+          apiKey: "test-api-key",
+          apiBase:
+            "https://custom-azure.openai.azure.com/openai/deployments/gpt-5",
+        },
+        methodToTest: "chatCompletionNonStream",
+        params: [
+          {
+            model: "gpt-5",
+            messages: [{ role: "user", content: "hello" }],
+            stop: ["<|im_end|>"],
+          },
+          new AbortController().signal,
+        ],
+        expectedRequest: {
+          url: "https://custom-azure.openai.azure.com/openai/deployments/gpt-5/chat/completions",
+          method: "POST",
+          body: {
+            model: "gpt-5",
+            messages: [{ role: "user", content: "hello" }],
+            stop: undefined,
+          },
+        },
+        mockResponse: {
+          id: "test-id",
+          object: "chat.completion",
+          created: 1234567890,
+          model: "gpt-5",
+          choices: [
+            {
+              index: 0,
+              message: { role: "assistant", content: "Hello" },
+              finish_reason: "stop",
+            },
+          ],
+          usage: {
+            prompt_tokens: 10,
+            completion_tokens: 15,
+            total_tokens: 25,
+          },
+        },
+      });
+    });
+
+    test("should keep stop parameter for gpt-4o models", async () => {
+      await runAdapterTest({
+        config: {
+          provider: "openai",
+          apiKey: "test-api-key",
+          apiBase:
+            "https://custom-azure.openai.azure.com/openai/deployments/gpt-4o",
+        },
+        methodToTest: "chatCompletionNonStream",
+        params: [
+          {
+            model: "gpt-4o",
+            messages: [{ role: "user", content: "hello" }],
+            stop: ["<|im_end|>"],
+          },
+          new AbortController().signal,
+        ],
+        expectedRequest: {
+          url: "https://custom-azure.openai.azure.com/openai/deployments/gpt-4o/chat/completions",
+          method: "POST",
+          body: {
+            model: "gpt-4o",
+            messages: [{ role: "user", content: "hello" }],
+            stop: ["<|im_end|>"],
+          },
+        },
+        mockResponse: {
+          id: "test-id",
+          object: "chat.completion",
+          created: 1234567890,
+          model: "gpt-4o",
+          choices: [
+            {
+              index: 0,
+              message: { role: "assistant", content: "Hello" },
+              finish_reason: "stop",
+            },
+          ],
+          usage: {
+            prompt_tokens: 10,
+            completion_tokens: 15,
+            total_tokens: 25,
+          },
+        },
+      });
+    });
+
+    test("should strip stop parameter for gpt-6 models (non-official API)", async () => {
+      // For gpt-5+ on non-official API (Azure-style), only strip stop parameter.
+      // Message role conversion and max_tokens->max_completion_tokens only happen on official API.
+      await runAdapterTest({
+        config: {
+          provider: "openai",
+          apiKey: "test-api-key",
+          apiBase:
+            "https://custom-azure.openai.azure.com/openai/deployments/gpt-6",
+        },
+        methodToTest: "chatCompletionNonStream",
+        params: [
+          {
+            model: "gpt-6",
+            messages: [{ role: "user", content: "hello" }],
+            stop: ["<|im_end|>"],
+            max_tokens: 2048,
+          },
+          new AbortController().signal,
+        ],
+        expectedRequest: {
+          url: "https://custom-azure.openai.azure.com/openai/deployments/gpt-6/chat/completions",
+          method: "POST",
+          body: {
+            model: "gpt-6",
+            messages: [{ role: "user", content: "hello" }],
+            stop: undefined,
+            max_tokens: 2048,
+          },
+        },
+        mockResponse: {
+          id: "test-id",
+          object: "chat.completion",
+          created: 1234567890,
+          model: "gpt-6",
+          choices: [
+            {
+              index: 0,
+              message: { role: "assistant", content: "Hello" },
+              finish_reason: "stop",
+            },
+          ],
+          usage: {
+            prompt_tokens: 10,
+            completion_tokens: 15,
+            total_tokens: 25,
+          },
+        },
+      });
+    });
+
+    test("should not strip stop for models like openchat", async () => {
+      await runAdapterTest({
+        config: {
+          provider: "openai",
+          apiKey: "test-api-key",
+          apiBase: "https://api.openai.com/v1/",
+        },
+        methodToTest: "chatCompletionNonStream",
+        params: [
+          {
+            model: "openchat-3.5",
+            messages: [{ role: "user", content: "hello" }],
+            stop: ["<|im_end|>"],
+          },
+          new AbortController().signal,
+        ],
+        expectedRequest: {
+          url: "https://api.openai.com/v1/chat/completions",
+          method: "POST",
+          body: {
+            model: "openchat-3.5",
+            messages: [{ role: "user", content: "hello" }],
+            stop: ["<|im_end|>"],
+          },
+        },
+        mockResponse: {
+          id: "test-id",
+          object: "chat.completion",
+          created: 1234567890,
+          model: "openchat-3.5",
+          choices: [
+            {
+              index: 0,
+              message: { role: "assistant", content: "Hello" },
+              finish_reason: "stop",
+            },
+          ],
+          usage: {
+            prompt_tokens: 10,
+            completion_tokens: 15,
+            total_tokens: 25,
+          },
+        },
+      });
+    });
   });
 });


### PR DESCRIPTION
Fixes #8184

## Summary

GPT-5-nano, gpt-5-mini, o1, o1-mini, o3, o3-mini, and related models return HTTP 400
`"Unsupported parameter: 'stop' is not supported with this model."` for every chat and autocomplete
request. The autocomplete template always supplies stop tokens, and `getMaxStopWords()` caps them to 4
(for `api.openai.com`) but never omits the field entirely. Setting `stop: []` in config does not help —
the field is overwritten from the template before the request is sent. The fix is to clear `stop` to
`undefined` inside the existing `isOSeriesOrGpt5PlusModel` branch, which already handles the other
API differences for these models.

## Root cause

`OpenAI._convertArgs()` at `core/llm/llms/OpenAI.ts:284` sets `finalOptions.stop` from the autocomplete
template before the model-capability branch:

```ts
finalOptions.stop = options.stop?.slice(0, this.getMaxStopWords());  // line 284

if (this.isOSeriesOrGpt5PlusModel(options.model)) {
  // handles max_tokens and messages — but not stop
}
```

`OpenAI.modifyChatBody()` at `core/llm/llms/OpenAI.ts:440` does the same for the adapter path.
`packages/openai-adapters/src/apis/OpenAI.ts:70` has a parallel block for the official OpenAI API
adapter that also does not clear `stop`. `isOSeriesOrGpt5PlusModel` (line 221-223) already matches
all affected models — no new model detection is needed.

## Changes

- `core/llm/llms/OpenAI.ts`: add `finalOptions.stop = undefined` as the first statement inside the
  `isOSeriesOrGpt5PlusModel` branch in both `_convertArgs()` and `modifyChatBody()`.
- `packages/openai-adapters/src/apis/OpenAI.ts`: strip `stop` in `OpenAIApi.modifyChatBody()` via a
  new `isOSeriesOrGpt5Plus` predicate (`/^o[0-9]/` or `/gpt-[5-9]/i`, so `openchat` doesn't match)
  that runs for all hosts, not just `api.openai.com` — Azure deployments route through
  `AzureApi.modifyChatBody() → super.modifyChatBody()` and previously kept sending `stop`. The
  predicate matches the core path's `gpt-[5-9]` definition (gpt-6, gpt-7-turbo, etc.), wider than
  the official-API block's `includes("gpt-5")` check.

## What this doesn't change

- `getMaxStopWords()` is unchanged — it still serves providers that accept stop tokens.
- `OpenAI._convertArgsResponses()` is unchanged — the Responses API path does not expose a `stop` field.
- All non-o-series, non-gpt-5+ models (gpt-4, gpt-4o, gpt-4-turbo, etc.) are unaffected; their `stop`
  is still populated.
- Azure — `Azure.ts` (core) sets `useOpenAIAdapterFor: []`, so it routes through
  `OpenAI.modifyChatBody()`; the adapter-side `AzureApi` inherits the new model-based strip from
  `OpenAIApi.modifyChatBody()`. No change to either Azure class is needed.
- The `max_completion_tokens` conversion stays gated to the official OpenAI API, exactly as before.
- The workaround `requestOptions.extraBodyProperties.stop: null` noted in the issue continues to work
  but is no longer necessary for standard deployments.

## Checklist

- [x] I've read the contributing guide
- [ ] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Before (gpt-5-nano autocomplete request body):
```json
{ "model": "gpt-5-nano", "stop": ["<|fim_suffix|>", "\n\n", ...], "max_completion_tokens": 256 }
```

After:
```json
{ "model": "gpt-5-nano", "max_completion_tokens": 256 }
```

N/A — no UI change. Error disappears from the network tab.

## Tests

**Vitest (core/llm/llms/OpenAI.vitest.ts):**
- `cd core && npx vitest run llm/llms/OpenAI.vitest.ts` — **11 tests pass, 0 failures**.
- Coverage: 8 existing tests (streamChat/chat/complete, O1 models, tools, max tokens, embeddings) + 3 new cases:
  - gpt-5-nano streamChat: verifies `stop` is undefined in request body.
  - o3-mini streamChat: verifies `stop` is undefined in request body.
  - gpt-4o streamChat (regression): verifies non-o-series models still include `stop`.

**Vitest (packages/openai-adapters):**
- `cd packages/openai-adapters && npx vitest run src/test/openai-adapter.vitest.ts src/test/main.test.ts` — **25 tests pass, 0 failures** (20 existing + 5 new).
- New coverage: o3 and gpt-5 on an Azure-style apiBase strip `stop`; gpt-4o on Azure-style apiBase keeps `stop`; gpt-6 on a non-official host strips `stop` without the official-API conversions; `openchat` keeps `stop` (predicate guard).

**Jest (core/llm/llms/OpenAI.test.ts):**
- Tests `isOSeriesOrGpt5PlusModel()` model detection logic. No new assertions needed for this change.

**Prettier:**
- All modified files pass formatting checks after `prettier --write`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Omit the `stop` parameter for o-series and `gpt-5+` models to prevent HTTP 400 errors and restore chat/autocomplete. Applies to both core and adapter paths, including Azure-style endpoints.

- **Bug Fixes**
  - Core `core/llm/llms/OpenAI.ts`: clear `stop` in `_convertArgs()` and `modifyChatBody()` when `isOSeriesOrGpt5PlusModel` is true.
  - Adapter `packages/openai-adapters/src/apis/OpenAI.ts`: strip `stop` for o-series and `gpt-5+` on all hosts; keep official-API-only conversions unchanged.
  - Tests: add coverage for gpt-5-nano and o3-mini (no `stop`), gpt-4o (keeps `stop`), Azure-style endpoints, non-official hosts (gpt-6 strips only `stop`), and guard non-matching models like `openchat`.

<sup>Written for commit c854a3e1c7343bca5a54df8b32226431589ec6a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

