### PR TITLE
fix: prefilter autocomplete on config.yaml to stop AST tracker errors

### DIFF
--- a/core/autocomplete/prefiltering/index.ts
+++ b/core/autocomplete/prefiltering/index.ts
@@ -48,8 +48,11 @@ export async function shouldPrefilter(
     return true;
   }
 
-  // Check whether we're in the continue config.json file
-  if (helper.filepath === getConfigJsonPath()) {
+  // Check whether we're in the continue config.json or config.yaml file
+  if (
+    helper.filepath === getConfigJsonPath() ||
+    helper.filepath === getConfigJsonPath().replace(/\.json$/, ".yaml")
+  ) {
     return true;
   }
 

--- a/core/autocomplete/prefiltering/prefiltering.vitest.ts
+++ b/core/autocomplete/prefiltering/prefiltering.vitest.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { IDE } from "../..";
+import { shouldPrefilter } from ".";
+import { getConfigJsonPath } from "../../util/paths";
+import { HelperVars } from "../util/HelperVars";
+import { AutocompleteLanguageInfo } from "../constants/AutocompleteLanguageInfo";
+
+describe("shouldPrefilter", () => {
+  const mockLanguage: AutocompleteLanguageInfo = {
+    name: "TypeScript",
+    topLevelKeywords: [],
+    singleLineComment: "//",
+    endOfLine: [";"],
+  };
+
+  const mockIde: IDE = {
+    getWorkspaceDirs: vi.fn().mockResolvedValue([]),
+  } as unknown as IDE;
+
+  function createMockHelper(filepath: string): HelperVars {
+    return {
+      filepath,
+      pos: { line: 0, character: 0 },
+      fileContents: "test content",
+      fileLines: ["test content"],
+      lang: mockLanguage,
+      options: {},
+    } as unknown as HelperVars;
+  }
+
+  it("returns true when helper.filepath matches getConfigJsonPath()", async () => {
+    const helper = createMockHelper(getConfigJsonPath());
+    const result = await shouldPrefilter(helper, mockIde);
+    expect(result).toBe(true);
+  });
+
+  it("returns true when helper.filepath matches config.yaml path", async () => {
+    const yamlPath = getConfigJsonPath().replace(/\.json$/, ".yaml");
+    const helper = createMockHelper(yamlPath);
+    const result = await shouldPrefilter(helper, mockIde);
+    expect(result).toBe(true);
+  });
+
+  it("returns false for a normal file path", async () => {
+    const helper = createMockHelper("file:///home/user/project/main.ts");
+    const result = await shouldPrefilter(helper, mockIde);
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #12562

## Summary

Autocomplete runs on `config.yaml` because the prefilter only checks for `config.json`. Since YAML lacks tree-sitter support, every autocomplete attempt on the config file logs "Document not found in AST tracker" errors. This adds `config.yaml` to the same guard that already blocks `config.json`.

## Root cause

`core/autocomplete/prefiltering/index.ts:52` compares `helper.filepath` against `getConfigJsonPath()` only. When Continue switched its default config format to YAML, this guard was never updated. The tree-sitter parser returns `undefined` for `.yaml` files (the WASM is explicitly disabled in `core/util/treeSitter.ts`), so the AST tracker never has an entry for it.

## Changes

- `core/autocomplete/prefiltering/index.ts`: derive the YAML config path from `getConfigJsonPath().replace(/\.json$/, ".yaml")` and add it to the filepath check on line 52, avoiding `getConfigYamlPath()` which creates the file as a side effect
- `core/autocomplete/prefiltering/prefiltering.vitest.ts`: new test verifying both config paths are prefiltered

## What this doesn't change

The autocomplete pipeline, AST tracker, tree-sitter language support, and the existing `config.json` guard are all untouched. No new dependencies.

## Checklist

- [x] I've read the contributing guide
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A — no UI change.

## Tests

- `cd core && npx vitest run autocomplete/prefiltering/prefiltering.vitest.ts` — new test covering both config.json and config.yaml prefilter paths

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop autocomplete from running on `config.yaml` by extending the prefilter to treat it like `config.json`. This prevents “Document not found in AST tracker” errors and adds a test covering both config paths.

<sup>Written for commit 5240d3f5e4e426563ed58667eae6c1629e69bcef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

