### PR TITLE
fix: respect Python indentation significance in Apply diff pipeline

### DIFF
--- a/core/diff/streamDiff.ts
+++ b/core/diff/streamDiff.ts
@@ -14,6 +14,7 @@ import { LineStream, matchLine } from "./util.js";
 export async function* streamDiff(
   oldLines: string[],
   newLines: LineStream,
+  filename?: string,
 ): AsyncGenerator<DiffLine> {
   const oldLinesCopy = [...oldLines];
 
@@ -27,6 +28,7 @@ export async function* streamDiff(
       newLineResult.value,
       oldLinesCopy,
       seenIndentationMistake,
+      filename,
     );
 
     if (!seenIndentationMistake && newLineResult.value !== newLine) {

--- a/core/diff/util.ts
+++ b/core/diff/util.ts
@@ -49,6 +49,7 @@ export function matchLine(
   newLine: string,
   oldLines: string[],
   permissiveAboutIndentation = false,
+  filename?: string,
 ): MatchLineResult {
   // Only match empty lines if it's the next one:
   if (newLine.trim() === "" && oldLines[0]?.trim() === "") {
@@ -77,9 +78,14 @@ export function matchLine(
     }
     if (linesMatch(newLineTrimmed, oldLineTrimmed, i)) {
       // This is a way to fix indentation, but only for sufficiently long lines to avoid matching whitespace or short lines
+      // For Python files, indentation is syntax and should never be permissive
+      const isPythonFile = filename?.endsWith(".py");
+      const shouldBePermissive =
+        !isPythonFile &&
+        (permissiveAboutIndentation || newLine.trim().length > 8);
       if (
         newLineTrimmed.trimStart() === oldLineTrimmed.trimStart() &&
-        (permissiveAboutIndentation || newLine.trim().length > 8)
+        shouldBePermissive
       ) {
         return {
           matchIndex: i,

--- a/core/edit/lazy/deterministic-python.vitest.ts
+++ b/core/edit/lazy/deterministic-python.vitest.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest";
+
+import { DiffLine } from "../..";
+import { streamDiff } from "../../diff/streamDiff";
+
+async function* toLineStream(
+  lines: string[],
+): AsyncGenerator<string, void, unknown> {
+  for (const line of lines) {
+    yield line;
+  }
+}
+
+async function collectStreamDiff(
+  oldText: string,
+  newText: string,
+  filename: string,
+): Promise<DiffLine[]> {
+  const oldLines = oldText.split("\n");
+  const newLines = toLineStream(newText.split("\n"));
+  const diffs: DiffLine[] = [];
+  for await (const line of streamDiff(oldLines, newLines, filename)) {
+    diffs.push(line);
+  }
+  return diffs;
+}
+
+describe("streamDiff python indentation awareness", () => {
+  test("treats indentation changes as real diffs for .py files", async () => {
+    const oldText = 'def hello():\n    print("world")';
+    const newText = 'def hello():\n  print("world")';
+
+    const diffs = await collectStreamDiff(oldText, newText, "example.py");
+
+    const newLines = diffs.filter((d) => d.type === "new").map((d) => d.line);
+    const oldLines = diffs.filter((d) => d.type === "old").map((d) => d.line);
+    expect(newLines).toContain('  print("world")');
+    expect(oldLines).toContain('    print("world")');
+  });
+
+  test("still treats indentation as cosmetic for non-python files", async () => {
+    const oldText = 'function hello() {\n    console.log("world");\n}';
+    const newText = 'function hello() {\n  console.log("world");\n}';
+
+    const diffs = await collectStreamDiff(oldText, newText, "example.js");
+
+    const allSame = diffs.every((d) => d.type === "same");
+    expect(allSame).toBe(true);
+  });
+});

--- a/core/edit/lazy/streamLazyApply.ts
+++ b/core/edit/lazy/streamLazyApply.ts
@@ -62,7 +62,7 @@ export async function* streamLazyApply(
 
   // Convert output to diff
   const oldLines = oldCode.split(/\r?\n/);
-  let diffLines = streamDiff(oldLines, lines);
+  let diffLines = streamDiff(oldLines, lines, filename);
   diffLines = filterLeadingAndTrailingNewLineInsertion(diffLines);
   for await (const diffLine of diffLines) {
     yield diffLine;

--- a/core/edit/streamDiffLines.ts
+++ b/core/edit/streamDiffLines.ts
@@ -176,7 +176,7 @@ export async function* streamDiffLines(
     lines = filterEnglishLinesAtEnd(lines);
   }
 
-  let diffLines = streamDiff(oldLines, lines);
+  let diffLines = streamDiff(oldLines, lines, options.fileUri);
   diffLines = filterLeadingAndTrailingNewLineInsertion(diffLines);
   if (highlighted.length === 0) {
     const line = prefix.split("\n").slice(-1)[0];


### PR DESCRIPTION
Fixes #12455

## Summary

"Apply" silently fails on Python files because the diff pipeline treats indentation differences as cosmetic. For Python, indentation is syntax, so changes to nesting depth or tabs-vs-spaces are real structural edits that get discarded.

## Root cause

`core/diff/util.ts:matchLine()` has a `permissiveAboutIndentation` path that returns the old line's content when two lines differ only in leading whitespace. This is correct for C++ and JS where indentation is cosmetic, but wrong for Python where indentation defines block structure. When an LLM produces Python code with different indentation, the diff sees every line as "same" and produces a no-op edit. The buffer stays unchanged despite the highlight appearing briefly.

Additionally, `core/edit/lazy/deterministic.ts:shouldRejectDiff()` has a 30% removal threshold that Python indentation diffs routinely exceed (every re-indented line counts as a removal + addition), forcing a fallback to the non-instant path where the indentation permissiveness then discards the changes entirely.

## Changes

- `core/diff/util.ts`: add `filename` parameter to `matchLine()`, skip `permissiveAboutIndentation` for `.py` files
- `core/diff/streamDiff.ts`: thread `filename` through to `matchLine()`
- `core/edit/lazy/streamLazyApply.ts`: pass `filename` through to `streamDiff()`
- `core/edit/streamDiffLines.ts`: pass `options.fileUri` through to `streamDiff()` so the LLM-assisted edit path also respects Python indentation
- `core/edit/lazy/deterministic-python.vitest.ts`: new test verifying `streamDiff` preserves Python indentation changes

## Prior work

PR #11289 (merged 2026-03-24) fixed indentation corruption in the search-and-replace fallback path by adding `adjustReplacementIndentation()`. That fix covers the `searchAndReplace` code path where `trimmedMatch` / `whitespaceIgnoredMatch` strategies apply. This PR addresses a different code path: `deterministicApplyLazyEdit` → `shouldRejectDiff` → non-instant fallback, where `matchLine()`'s `permissiveAboutIndentation` discards Python indentation changes before the search-and-replace path is ever reached.

## What this doesn't change

The 30% removal threshold is untouched. Indentation permissiveness for non-Python files is unchanged. The `VerticalDiffHandler` UI layer and the search-and-replace path (including the #11289 fix) are not modified.

## Checklist

- [x] I've read the contributing guide
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A — the fix is in the diff pipeline, not the UI.

## Tests

- `cd core && npx vitest run edit/lazy/deterministic-python.vitest.ts` — new test verifying `streamDiff` preserves Python indentation changes
- `cd core && npx vitest run diff/streamDiff.vitest.ts` — existing `fastapi-tabs-vs-spaces` test still passes, confirming no regression


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent no-ops when applying edits to Python files by treating indentation changes as real diffs. Threads the filename through the diff pipeline and disables indentation permissiveness for `.py`, leaving other languages unchanged.

- **Bug Fixes**
  - `core/diff/util.ts`: add `filename` to `matchLine()` and skip indentation permissiveness for `.py`.
  - `core/diff/streamDiff.ts`, `core/edit/lazy/streamLazyApply.ts`, `core/edit/streamDiffLines.ts`: pass `filename`/`fileUri` through to ensure Python indentation is respected in all paths.
  - Add `core/edit/lazy/deterministic-python.vitest.ts` to verify Python indentation diffs; existing JS indentation test still passes.

<sup>Written for commit cc579d9bfc5c4a19cc0b10a2fe842324edca42eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

