### PR TITLE
fix: route Azure embed requests through deployment endpoint

### DIFF
--- a/core/llm/llms/OpenAI-compatible.vitest.ts
+++ b/core/llm/llms/OpenAI-compatible.vitest.ts
@@ -388,6 +388,8 @@ createOpenAISubclassTests(Kindo, {
 
 createOpenAISubclassTests(Azure, {
   providerName: "azure",
+  customEmbeddingsUrl:
+    "https://api.openai.com/v1/openai/deployments/text-embedding-ada-002/embeddings?api-version=2023-07-01-preview",
 });
 
 createOpenAISubclassTests(Inception, {

--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -705,11 +705,14 @@ class OpenAI extends BaseLLM {
       );
     }
 
-    if (this.apiType === "azure") {
-      return new URL(
-        `openai/deployments/${this.deployment}/embeddings?api-version=${this.apiVersion}`,
-        this.apiBase,
-      );
+    if (this.apiType?.includes("azure")) {
+      const isAzureOpenAI =
+        this.apiType === "azure-openai" || this.apiType === "azure";
+      const path = isAzureOpenAI
+        ? `openai/deployments/${this.deployment}/embeddings`
+        : "embeddings";
+      const version = this.apiVersion ? `?api-version=${this.apiVersion}` : "";
+      return new URL(`${path}${version}`, this.apiBase);
     }
     return new URL("embeddings", this.apiBase);
   }

--- a/core/llm/llms/OpenAI.vitest.ts
+++ b/core/llm/llms/OpenAI.vitest.ts
@@ -424,4 +424,38 @@ describe("OpenAI", () => {
       },
     });
   });
+
+  test("_getEmbedEndpoint should construct correct Azure deployment URL", () => {
+    const openai = new OpenAI({
+      apiType: "azure-openai",
+      apiBase: "https://test.openai.azure.com/",
+      deployment: "gpt-5.4",
+      apiVersion: "2024-02-15-preview",
+      model: "gpt-5.4",
+      apiKey: "test-key",
+    });
+
+    const endpoint = (openai as any)["_getEmbedEndpoint"]();
+    const url = endpoint.toString();
+
+    expect(url).toContain("openai/deployments/gpt-5.4/embeddings");
+    expect(url).toContain("api-version=2024-02-15-preview");
+  });
+
+  test("_getEmbedEndpoint should not use deployment path for azure-foundry", () => {
+    const openai = new OpenAI({
+      apiType: "azure-foundry",
+      apiBase: "https://test.services.ai.azure.com/",
+      apiVersion: "2024-05-01-preview",
+      model: "text-embedding-ada-002",
+      apiKey: "test-key",
+    });
+
+    const endpoint = (openai as any)["_getEmbedEndpoint"]();
+    const url = endpoint.toString();
+
+    expect(url).not.toContain("openai/deployments");
+    expect(url).toContain("embeddings");
+    expect(url).toContain("api-version=2024-05-01-preview");
+  });
 });


### PR DESCRIPTION
Fixes #12554

## Summary

Azure OpenAI embed requests can 404 because `_getEmbedEndpoint` checks `apiType === "azure"` while the Azure adapter sets `apiType: "azure-openai"`. The strict check misses the Azure deployment route, so embed requests go to `/embeddings` instead of `/openai/deployments/{deployment}/embeddings?api-version={version}`. This change follows the Azure routing pattern already used by `_getEndpoint` for chat requests.

## Root cause

`core/llm/llms/OpenAI.ts:708` used strict equality for the embed endpoint, but `Azure.ts:17` sets `apiType: "azure-openai"`. The condition never matched, so Azure OpenAI embeddings skipped the deployment path. `azure-foundry` should still use the plain `embeddings` path, so the fix distinguishes `azure` and `azure-openai` from other Azure-flavored `apiType` values.

## Changes

- `core/llm/llms/OpenAI.ts`: route `azure` and `azure-openai` embed requests through `openai/deployments/{deployment}/embeddings`, while keeping `azure-foundry` on the plain `embeddings` path
- `core/llm/llms/OpenAI.vitest.ts`: add coverage for both Azure OpenAI deployment routing and Azure Foundry plain-path routing
- `core/llm/llms/OpenAI-compatible.vitest.ts`: update the Azure subclass expectation to cover the deployment embed URL

## Scope note

This PR no longer changes generic webview error logging. The related `webviewProtocol.ts` stringify guard is handled separately in #12589, so this branch stays focused on Azure embedding endpoint routing.

## What this doesn't change

The chat/completions routing (`_getEndpoint`) and Responses API gate (`canUseOpenAIResponses`) are already correct for Azure and untouched. No model selection, parameter conversion, streaming logic, or generic webview error handling is modified.

## Checklist

- [x] I've read the contributing guide
- [ ] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A, provider endpoint routing fix covered by tests.

## Tests

Attempted locally: `cd core && npx vitest run llm/llms/OpenAI.vitest.ts llm/llms/OpenAI-compatible.vitest.ts`

Blocked before test collection because the local checkout is running Node `v24.15.0` while `.nvmrc` requires `v20.20.1`, and `sqlite3` has no native binding for the active Node version. The command failed with `Could not locate the bindings file ... sqlite3 ... compiled\24.15.0\win32\x64\node_sqlite3.node`.
