### PR TITLE
fix(fetch): keep no_proxy suffix matches on domain boundaries

### DIFF
--- a/packages/fetch/src/util.test.ts
+++ b/packages/fetch/src/util.test.ts
@@ -76,6 +76,7 @@ test("patternMatchesHostname with wildcard domains", () => {
 test("patternMatchesHostname with domain suffix", () => {
   expect(patternMatchesHostname("sub.example.com", ".example.com")).toBe(true);
   expect(patternMatchesHostname("example.com", ".example.com")).toBe(true);
+  expect(patternMatchesHostname("badexample.com", ".example.com")).toBe(false);
   expect(patternMatchesHostname("different.com", ".example.com")).toBe(false);
 });
 
@@ -122,6 +123,9 @@ test("patternMatchesHostname with domain suffix and ports", () => {
     true,
   );
   expect(
+    patternMatchesHostname("badexample.com:8080", ".example.com:8080"),
+  ).toBe(false);
+  expect(
     patternMatchesHostname("sub.example.com:9090", ".example.com:8080"),
   ).toBe(false);
 });
@@ -157,6 +161,7 @@ test("shouldBypassProxy works with domain suffix", () => {
   process.env.NO_PROXY = ".example.com";
   expect(shouldBypassProxy("sub.example.com", undefined)).toBe(true);
   expect(shouldBypassProxy("example.com", undefined)).toBe(true);
+  expect(shouldBypassProxy("badexample.com", undefined)).toBe(false);
   expect(shouldBypassProxy("different.com", undefined)).toBe(false);
 });
 
@@ -166,6 +171,7 @@ test("shouldBypassProxy handles multiple entries with different patterns", () =>
   expect(shouldBypassProxy("sub.example.com", undefined)).toBe(true);
   expect(shouldBypassProxy("sub.test.com", undefined)).toBe(true);
   expect(shouldBypassProxy("test.com", undefined)).toBe(true);
+  expect(shouldBypassProxy("contest.com", undefined)).toBe(false);
   expect(shouldBypassProxy("example.org", undefined)).toBe(false);
 });
 
@@ -182,6 +188,7 @@ test("shouldBypassProxy with ports in NO_PROXY", () => {
   expect(shouldBypassProxy("sub.test.org:443", undefined)).toBe(true);
   expect(shouldBypassProxy("sub.internal.net:8443", undefined)).toBe(true);
   expect(shouldBypassProxy("internal.net:8443", undefined)).toBe(true);
+  expect(shouldBypassProxy("notinternal.net:8443", undefined)).toBe(false);
 });
 
 test("shouldBypassProxy accepts options with noProxy patterns", () => {

--- a/packages/fetch/src/util.ts
+++ b/packages/fetch/src/util.ts
@@ -74,11 +74,14 @@ export function patternMatchesHostname(hostname: string, pattern: string) {
     return true;
   }
   // Domain suffix match (.example.com)
-  if (
-    patternWithoutPort.startsWith(".") &&
-    hostnameWithoutPort.endsWith(patternWithoutPort.slice(1))
-  ) {
-    return true;
+  if (patternWithoutPort.startsWith(".")) {
+    const suffixWithoutDot = patternWithoutPort.slice(1);
+    if (
+      hostnameWithoutPort === suffixWithoutDot ||
+      hostnameWithoutPort.endsWith(patternWithoutPort)
+    ) {
+      return true;
+    }
   }
 
   // TODO IP address ranges


### PR DESCRIPTION
## Description

`NO_PROXY=.example.com` was matching unrelated hostnames like `badexample.com` because the suffix matcher stripped the leading dot before calling `endsWith`. The same issue affected configured `requestOptions.noProxy` patterns and port-qualified suffixes.

This keeps the existing behavior where `.example.com` matches both `example.com` and subdomains, but requires subdomain matches to end with `.example.com` so lookalike sibling domains do not bypass the proxy.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Not applicable. The change is in `packages/fetch` and has no UI surface. The observable result is which hostnames bypass the proxy, which the tests below assert directly.

## Tests

Five boundary assertions added to `packages/fetch/src/util.test.ts`, covering `badexample.com`, `contest.com` and `notinternal.net:8443`.

- RED: `npm test -- src/util.test.ts` failed the 5 new assertions.
- GREEN: `npm test -- src/util.test.ts` passed, 31/31.
- Full package: `npm test` passed, 97/97.
- Build: `npm run build` passed for `@continuedev/fetch`, after building the linked local `@continuedev/config-types` package.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes NO_PROXY suffix matching to enforce domain boundaries in `@continuedev/fetch`. `.example.com` now matches `example.com` and subdomains only, not lookalikes like `badexample.com` (with or without ports).

- **Bug Fixes**
  - Leading-dot patterns are boundary-aware: exact match to suffix or endsWith(".suffix"); keeps subdomain matching.
  - Applies to both NO_PROXY and requestOptions.noProxy, including port-qualified entries.
  - Added boundary tests; all tests pass (97/97) and package build succeeds.

<sup>Written for commit 6628a94fe932aabf0f7da1a2b656d93f78e85919. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


