### PR TITLE
fix(fetch): emit final streamJSON line without trailing newline

### DIFF
--- a/packages/fetch/src/stream.test.ts
+++ b/packages/fetch/src/stream.test.ts
@@ -1,6 +1,6 @@
 import { Readable } from "stream";
 import { describe, expect, it, test } from "vitest";
-import { parseDataLine, streamSse } from "./stream.js";
+import { parseDataLine, streamJSON, streamSse } from "./stream.js";
 
 function createMockResponse(sseLines: string[]): Response {
   // Create a Readable stream that emits the SSE lines
@@ -14,6 +14,23 @@ function createMockResponse(sseLines: string[]): Response {
   }) as any;
 
   // Minimal Response mock
+  return {
+    status: 200,
+    body: stream,
+    text: async () => "",
+  } as unknown as Response;
+}
+
+function createRawMockResponse(chunks: string[]): Response {
+  const stream = new Readable({
+    read() {
+      for (const chunk of chunks) {
+        this.push(chunk);
+      }
+      this.push(null);
+    },
+  }) as any;
+
   return {
     status: 200,
     body: stream,
@@ -60,6 +77,19 @@ describe("streamSse", () => {
 
     const iterator = streamSse(response)[Symbol.asyncIterator]();
     await expect(iterator.next()).rejects.toThrow(/Malformed JSON/);
+  });
+});
+
+describe("streamJSON", () => {
+  it("yields the final JSON object even without a trailing newline", async () => {
+    const response = createRawMockResponse(['{"foo":"bar"}\n', '{"baz":42}']);
+
+    const results = [];
+    for await (const data of streamJSON(response)) {
+      results.push(data);
+    }
+
+    expect(results).toEqual([{ foo: "bar" }, { baz: 42 }]);
   });
 });
 

--- a/packages/fetch/src/stream.ts
+++ b/packages/fetch/src/stream.ts
@@ -166,4 +166,13 @@ export async function* streamJSON(response: Response): AsyncGenerator<any> {
       buffer = buffer.slice(position + 1);
     }
   }
+
+  if (buffer.length > 0) {
+    try {
+      const data = JSON.parse(buffer);
+      yield data;
+    } catch (e) {
+      throw new Error(`Malformed JSON sent from server: ${buffer}`);
+    }
+  }
 }


### PR DESCRIPTION
## Description

`streamJSON()` only parsed JSON objects when a newline arrived. If a JSON-lines response ended with a valid final object and no trailing `\n`, that object stayed in the buffer and was silently dropped when the stream ended.

`streamSse()` already drains its leftover buffer after `streamResponse()` completes. This applies the same EOF handling to `streamJSON()` and keeps malformed final JSON reporting the existing `Malformed JSON sent from server` error shape.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Not applicable. The change is in `packages/fetch` and has no UI surface. The observable result is whether the last object of a stream reaches the caller, which the tests below assert directly.

## Tests

Added to `packages/fetch/src/stream.test.ts`.

- RED: `npm test -- src/stream.test.ts` failed because `streamJSON()` yielded only `[{ foo: "bar" }]` and dropped the final `{ baz: 42 }` object.
- GREEN: `npm test -- src/stream.test.ts` passed, 12/12.
- Full package: `npm test` passed, 98/98.
- Build: `npm run build` passed for `@continuedev/fetch`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `streamJSON()` so it emits the final JSON object when a JSON-lines response ends without a trailing newline, preventing data loss. Matches `streamSse()` EOF behavior and keeps the same malformed JSON error.

- **Bug Fixes**
  - Drain and parse the remaining buffer at stream end; yield the last object if valid.
  - If invalid, throw `Malformed JSON sent from server: ...` (unchanged error shape).
  - Added a unit test for JSON-lines without a trailing newline.

<sup>Written for commit c24009654983c8b5e703d1fc234e8358c0505d8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


