### PR TITLE
fix(config): parse markdown prompt file blocks as prompts

### DIFF
--- a/packages/config-yaml/src/load/unroll.test.ts
+++ b/packages/config-yaml/src/load/unroll.test.ts
@@ -1,8 +1,10 @@
 import { PackageIdentifier } from "../interfaces/slugs.js";
+import type { Registry } from "../interfaces/index.js";
 import {
   fillTemplateVariables,
   getTemplateVariables,
   parseMarkdownRuleOrAssistantUnrolled,
+  unrollBlocks,
   replaceInputsWithSecrets,
 } from "./unroll.js";
 
@@ -91,6 +93,133 @@ model: # should be models
     expect(rule).toHaveProperty("name", "foo/bar");
     expect(rule).toHaveProperty("globs", undefined);
     expect(rule).toHaveProperty("rule", dubiousContent);
+  });
+});
+
+describe("unrollBlocks markdown file blocks", () => {
+  it("unrolls markdown prompt file blocks into prompts", async () => {
+    const registry: Registry = {
+      async getContent(fullSlug) {
+        if (
+          fullSlug.uriType === "file" &&
+          fullSlug.fileUri === "prompts/scotty.md"
+        ) {
+          return `
+---
+name: Scotty
+description: Engineering prompt
+---
+Use concise engineering language.
+`;
+        }
+
+        throw new Error("Unexpected registry lookup");
+      },
+    };
+
+    const result = await unrollBlocks(
+      {
+        name: "Test Assistant",
+        version: "1.0.0",
+        prompts: [{ uses: "file://prompts/scotty.md" }],
+      },
+      registry,
+      undefined,
+    );
+
+    expect(result.config).toBeDefined();
+    expect(result.config!.prompts).toEqual([
+      {
+        name: "Scotty",
+        description: "Engineering prompt",
+        prompt: "Use concise engineering language.",
+        sourceFile: "prompts/scotty.md",
+      },
+    ]);
+    expect(result.config!.rules).toBeUndefined();
+  });
+
+  it("uses markdown prompt filenames when frontmatter omits name", async () => {
+    const registry: Registry = {
+      async getContent(fullSlug) {
+        if (
+          fullSlug.uriType === "file" &&
+          fullSlug.fileUri === "prompts/fallback.md"
+        ) {
+          return `
+---
+description: Fallback prompt
+---
+Use the fallback filename.
+`;
+        }
+
+        throw new Error("Unexpected registry lookup");
+      },
+    };
+
+    const result = await unrollBlocks(
+      {
+        name: "Test Assistant",
+        version: "1.0.0",
+        prompts: [{ uses: "file://prompts/fallback.md" }],
+      },
+      registry,
+      undefined,
+    );
+
+    expect(result.config?.prompts?.[0]).toEqual({
+      name: "fallback",
+      description: "Fallback prompt",
+      prompt: "Use the fallback filename.",
+      sourceFile: "prompts/fallback.md",
+    });
+  });
+
+  it("keeps markdown rule blocks resolving as rules", async () => {
+    const registry: Registry = {
+      async getContent(fullSlug) {
+        if (
+          fullSlug.uriType === "file" &&
+          fullSlug.fileUri === "rules/concise.md"
+        ) {
+          return `
+---
+name: concise-rule
+description: Keep replies concise
+---
+Respond in short paragraphs.
+`;
+        }
+
+        throw new Error("Unexpected registry lookup");
+      },
+    };
+
+    const result = await unrollBlocks(
+      {
+        name: "Test Assistant",
+        version: "1.0.0",
+        rules: [{ uses: "file://rules/concise.md" }],
+      },
+      registry,
+      undefined,
+    );
+
+    expect(result.config).toBeDefined();
+    expect(result.config!.rules).toEqual([
+      {
+        name: "concise-rule",
+        description: "Keep replies concise",
+        globs: undefined,
+        regex: undefined,
+        alwaysApply: undefined,
+        invokable: undefined,
+        rule: "Respond in short paragraphs.",
+        sourceFile: "rules/concise.md",
+      },
+    ]);
+    expect(result.config!.prompts).toBeUndefined();
   });
 });
 

--- a/packages/config-yaml/src/load/unroll.ts
+++ b/packages/config-yaml/src/load/unroll.ts
@@ -14,7 +14,7 @@ import {
   PackageSlug,
   packageSlugsEqual,
 } from "../interfaces/slugs.js";
-import { markdownToRule } from "../markdown/index.js";
+import { markdownToRule, parseMarkdownPrompt } from "../markdown/index.js";
 import {
   AssistantUnrolled,
   assistantUnrolledSchema,
@@ -437,6 +437,7 @@ export async function unrollBlocks(
               blockIdentifier,
               unrolledBlock.with,
               registry,
+              section,
             );
             const block = blockConfigYaml[section]?.[0];
             if (block) {
@@ -720,6 +721,7 @@ export async function resolveBlock(
   id: PackageIdentifier,
   inputs: Record<string, string | undefined> | undefined,
   registry: Registry,
+  sectionHint?: keyof AssistantUnrolled,
 ): Promise<AssistantUnrolled> {
   // Retrieve block raw yaml
   const rawYaml = await registry.getContent(id);
@@ -753,7 +755,11 @@ export async function resolveBlock(
   }
 
   // Add source slug for mcp servers
-  const parsed = parseMarkdownRuleOrAssistantUnrolled(templatedYaml, id);
+  const parsed = parseMarkdownRuleOrAssistantUnrolled(
+    templatedYaml,
+    id,
+    sectionHint,
+  );
   if (
     id.uriType === "slug" &&
     "mcpServers" in parsed &&
@@ -768,8 +774,14 @@ export async function resolveBlock(
 export function parseMarkdownRuleOrAssistantUnrolled(
   content: string,
   id: PackageIdentifier,
+  sectionHint?: keyof AssistantUnrolled,
 ): AssistantUnrolled {
-  return parseYamlOrMarkdownRule<AssistantUnrolled>(content, id, parseBlock);
+  return parseYamlOrMarkdownRule<AssistantUnrolled>(
+    content,
+    id,
+    parseBlock,
+    sectionHint,
+  );
 }
 
 function parseMarkdownRuleOrConfigYaml(
@@ -783,6 +795,7 @@ function parseYamlOrMarkdownRule<T>(
   content: string,
   id: PackageIdentifier,
   parseYamlFn: (content: string) => T,
+  sectionHint?: keyof AssistantUnrolled,
 ): T {
   let parsedYaml: T;
   try {
@@ -797,6 +810,16 @@ function parseYamlOrMarkdownRule<T>(
     }
     // If YAML parsing fails, try parsing as markdown rule
     try {
+      if (sectionHint === "prompts") {
+        const prompt = parseMarkdownPrompt(content, id);
+        parsedYaml = {
+          name: prompt.name,
+          version: "1.0.0",
+          prompts: [prompt],
+        } as T;
+        return parsedYaml;
+      }
+
       const rule = markdownToRule(content, id);
       // Convert the rule object to the expected format
       parsedYaml = { name: rule.name, version: "1.0.0", rules: [rule] } as T;

--- a/packages/config-yaml/src/markdown/index.ts
+++ b/packages/config-yaml/src/markdown/index.ts
@@ -2,4 +2,5 @@ export * from "./createMarkdownPrompt.js";
 export * from "./createMarkdownRule.js";
 export * from "./getRuleType.js";
 export * from "./markdownToRule.js";
+export * from "./parseMarkdownPrompt.js";
 export * from "./agentFiles.js";

--- a/packages/config-yaml/src/markdown/parseMarkdownPrompt.ts
+++ b/packages/config-yaml/src/markdown/parseMarkdownPrompt.ts
@@ -1,0 +1,37 @@
+import {
+  PackageIdentifier,
+  packageIdentifierToDisplayName,
+} from "../browser.js";
+import { Prompt } from "../schemas/index.js";
+import { parseMarkdownRule, RuleFrontmatter } from "./markdownToRule.js";
+
+function getPromptName(
+  frontmatter: RuleFrontmatter,
+  id: PackageIdentifier,
+): string {
+  if (frontmatter.name) {
+    return frontmatter.name;
+  }
+
+  if (id.uriType === "file") {
+    const segments = id.fileUri.split(/[/\\]/);
+    const basename = segments.at(-1) || id.fileUri;
+    return basename.replace(/\.md$/i, "");
+  }
+
+  return packageIdentifierToDisplayName(id);
+}
+
+export function parseMarkdownPrompt(
+  content: string,
+  id: PackageIdentifier,
+): Prompt {
+  const { frontmatter, markdown } = parseMarkdownRule(content);
+
+  return {
+    name: getPromptName(frontmatter, id),
+    description: frontmatter.description,
+    prompt: markdown,
+    sourceFile: id.uriType === "file" ? id.fileUri : undefined,
+  };
+}


### PR DESCRIPTION
Fixes #12412

## Summary

Markdown files referenced from `config.yaml` `prompts` blocks are currently resolved but then dropped, because markdown fallback parsing always wraps the file as a rule. This changes block unrolling so markdown files resolved for the `prompts` section become prompt blocks instead.

## Root cause

`packages/config-yaml/src/load/unroll.ts:436-441` resolves `uses` blocks and then reads the array for the current section, such as `blockConfigYaml.prompts`. But `resolveBlock` parses markdown fallback content through `parseMarkdownRuleOrAssistantUnrolled`, and `parseYamlOrMarkdownRule` at `unroll.ts:798-802` always wraps markdown as `{ rules: [...] }`. For a `prompts` block, that leaves `blockConfigYaml.prompts` undefined, so the prompt is silently skipped.

## Changes

- `packages/config-yaml/src/markdown/parseMarkdownPrompt.ts`: add a small markdown prompt parser that preserves frontmatter name, description, prompt body, and source file.
- `packages/config-yaml/src/markdown/index.ts`: export the prompt parser.
- `packages/config-yaml/src/load/unroll.ts`: pass the target section into resolved block parsing and wrap markdown prompt files under `prompts`.
- `packages/config-yaml/src/load/unroll.test.ts`: cover markdown prompt block unrolling and existing markdown rule fallback.

## What this doesn't change

This does not change YAML prompt blocks, injected blocks, or local prompt-file discovery in `core/config/yaml/loadYaml.ts`. It also keeps markdown fallback as rules for non-`prompts` sections.

## Checklist

- [x] I've read the contributing guide
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A, no UI change.

## Tests

- `cd packages/config-yaml && npm test -- src/load/unroll.test.ts` — blocked before this test file executes by existing `TS7006` diagnostics in `src/converter.ts` on unchanged `origin/main` lines.
- `cd packages/config-yaml && cross-env NODE_OPTIONS=--experimental-vm-modules npx jest src/load/unroll.test.ts --globals '{"ts-jest":{"diagnostics":false}}'` — 30/30 passing. Covers markdown prompt block unrolling, frontmatter parsing, filename fallback, source file propagation, and unchanged markdown rule fallback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parse markdown files referenced in `config.yaml` `prompts` blocks as prompts instead of rules, so referenced prompts are no longer dropped. Non-`prompts` markdown fallbacks still parse as rules.

- **Bug Fixes**
  - Unroll markdown prompt file blocks into `prompts` by passing a section hint through `unroll.ts`.
  - Added `parseMarkdownPrompt` and exported from `packages/config-yaml/src/markdown/index.ts` to keep name, description, body, and `sourceFile`.
  - Tests in `packages/config-yaml/src/load/unroll.test.ts` cover prompt parsing, filename fallback, source propagation, and unchanged rule fallback.

<sup>Written for commit ca4e36adc00e7e82188bf0a77622fd35be611410. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

