### PR TITLE
fix(mcp): keep global TLS opt-out from disabling MCP verification

### DIFF
--- a/core/config/load.ts
+++ b/core/config/load.ts
@@ -70,6 +70,7 @@ import {
   serializePromptTemplates,
 } from "./util";
 import { validateConfig } from "./validation.js";
+import { mergeMcpRequestOptions } from "./yaml/yamlToContinueConfig";
 
 export function resolveSerializedConfig(
   filepath: string,
@@ -526,7 +527,7 @@ async function intermediateToFinalConfig({
     ).map((server, index) => ({
       id: `continue-mcp-server-${index + 1}`,
       name: `MCP Server`,
-      requestOptions: mergeConfigYamlRequestOptions(
+      requestOptions: mergeMcpRequestOptions(
         server.transport.type !== "stdio"
           ? server.transport.requestOptions
           : undefined,

--- a/core/config/yaml/loadYaml.vitest.ts
+++ b/core/config/yaml/loadYaml.vitest.ts
@@ -3,6 +3,7 @@ import {
   validateConfigYaml,
 } from "@continuedev/config-yaml";
 import { describe, expect, it } from "vitest";
+import { convertYamlMcpConfigToInternalMcpOptions } from "./yamlToContinueConfig";
 
 describe("MCP Server cwd configuration", () => {
   describe("YAML schema validation", () => {
@@ -124,5 +125,108 @@ describe("MCP Server cwd configuration", () => {
         expect(errors).toHaveLength(0);
       });
     });
+  });
+});
+
+describe("convertYamlMcpConfigToInternalMcpOptions", () => {
+  it("does not inherit global verifySsl false into remote MCP request options", () => {
+    const result = convertYamlMcpConfigToInternalMcpOptions(
+      {
+        name: "remote",
+        type: "sse",
+        url: "https://mcp.example.com",
+      },
+      {
+        verifySsl: false,
+        headers: {
+          "X-Test": "1",
+        },
+        proxy: "https://proxy.example.com",
+      },
+    );
+
+    expect("requestOptions" in result).toBe(true);
+    expect(result.requestOptions).toEqual({
+      headers: {
+        "X-Test": "1",
+      },
+      proxy: "https://proxy.example.com",
+    });
+    expect(result.requestOptions?.verifySsl).toBeUndefined();
+    expect(result.requestOptions).not.toHaveProperty("verifySsl");
+  });
+
+  it("does not inherit global verifySsl false into streamable HTTP MCP options", () => {
+    const result = convertYamlMcpConfigToInternalMcpOptions(
+      {
+        name: "remote",
+        type: "streamable-http",
+        url: "https://mcp.example.com",
+      },
+      {
+        verifySsl: false,
+        timeout: 30,
+      },
+    );
+
+    expect("requestOptions" in result).toBe(true);
+    expect(result.requestOptions).toEqual({
+      timeout: 30,
+    });
+    expect(result.requestOptions).not.toHaveProperty("verifySsl");
+  });
+
+  it("preserves explicit per-server verifySsl false", () => {
+    const result = convertYamlMcpConfigToInternalMcpOptions(
+      {
+        name: "remote",
+        type: "sse",
+        url: "https://mcp.example.com",
+        requestOptions: {
+          verifySsl: false,
+        },
+      },
+      {
+        verifySsl: false,
+      },
+    );
+
+    expect("requestOptions" in result).toBe(true);
+    expect(result.requestOptions?.verifySsl).toBe(false);
+  });
+
+  it("preserves explicit per-server verifySsl true", () => {
+    const result = convertYamlMcpConfigToInternalMcpOptions(
+      {
+        name: "remote",
+        type: "streamable-http",
+        url: "https://mcp.example.com",
+        requestOptions: {
+          verifySsl: true,
+        },
+      },
+      {
+        verifySsl: false,
+      },
+    );
+
+    expect("requestOptions" in result).toBe(true);
+    expect(result.requestOptions?.verifySsl).toBe(true);
+  });
+
+  it("returns no request options when only global verifySsl is set", () => {
+    const result = convertYamlMcpConfigToInternalMcpOptions(
+      {
+        name: "remote",
+        type: "sse",
+        url: "https://mcp.example.com",
+      },
+      {
+        verifySsl: false,
+      },
+    );
+
+    expect("requestOptions" in result).toBe(true);
+    expect(result.requestOptions).toBeUndefined();
   });
 });

--- a/core/config/yaml/yamlToContinueConfig.ts
+++ b/core/config/yaml/yamlToContinueConfig.ts
@@ -32,6 +32,31 @@ export function convertYamlRuleToContinueRule(rule: Rule): RuleWithSource {
   }
 }
 
+export function mergeMcpRequestOptions(
+  requestOptions?: RequestOptions,
+  globalRequestOptions?: RequestOptions,
+): RequestOptions | undefined {
+  if (!globalRequestOptions) {
+    return requestOptions;
+  }
+
+  const {
+    verifySsl: _globalVerifySsl,
+    ...globalRequestOptionsWithoutVerifySsl
+  } = globalRequestOptions;
+
+  // Global verifySsl can disable MCP certificate validation without a server-specific opt-out.
+  const sanitizedGlobalRequestOptions =
+    Object.keys(globalRequestOptionsWithoutVerifySsl).length > 0
+      ? globalRequestOptionsWithoutVerifySsl
+      : undefined;
+
+  return mergeConfigYamlRequestOptions(
+    requestOptions,
+    sanitizedGlobalRequestOptions,
+  );
+}
+
 export function convertYamlMcpConfigToInternalMcpOptions(
   config: MCPServer,
   globalRequestOptions?: RequestOptions,
@@ -66,7 +91,7 @@ export function convertYamlMcpConfigToInternalMcpOptions(
     type,
     url,
     apiKey,
-    requestOptions: mergeConfigYamlRequestOptions(
+    requestOptions: mergeMcpRequestOptions(
       requestOptions,
       globalRequestOptions,
     ),


### PR DESCRIPTION
## Summary

Global `requestOptions.verifySsl: false` was flowing into remote MCP server configs even when the MCP server block did not opt out of TLS verification. That made `core/context/mcp/MCPConnection.ts` build `HttpsAgent({ rejectUnauthorized: false })` for SSE and streamable HTTP transports based on a global provider setting.

This change scopes MCP request-option inheritance more narrowly. Remote MCP servers still inherit unrelated global request options such as headers and proxy settings, but `verifySsl` only applies when it is set explicitly on that MCP server.

Addresses the TLS verification part of the upstream report.

## Changes

- Add an MCP-specific request-options merge helper in `core/config/yaml/yamlToContinueConfig.ts` that strips `verifySsl` from global request options before merging.
- Use the same MCP merge policy in `core/config/load.ts` for `experimental.modelContextProtocolServers` non-stdio transports.
- Extend `core/config/yaml/loadYaml.vitest.ts` with regression coverage for global `verifySsl: false` on SSE and streamable HTTP, explicit per-server `verifySsl: false`, explicit per-server `verifySsl: true`, empty-options behavior, and preservation of unrelated global request options.

## What This Doesn't Change

- Model and provider `requestOptions` inheritance is unchanged.
- Explicit per-server MCP `requestOptions.verifySsl: false` remains the escape hatch for insecure TLS.
- Other global request options, including headers, proxy, timeouts, CA bundles, and client certificates, still inherit into MCP server configs.
- OAuth-related behavior from the upstream report is intentionally out of scope here.

## Test Plan

- [x] `cd core && npx vitest run config/yaml/loadYaml.vitest.ts`
 10/10 passing. Covers the MCP config conversion path, including the base-regression case where global `verifySsl: false` used to propagate into remote MCP request options, plus explicit per-server `verifySsl` overrides, empty-options behavior, and inheritance of unrelated global request options.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented global `requestOptions.verifySsl: false` from disabling TLS checks for remote MCP servers. Only server-level MCP `verifySsl` now opts out; headers, proxy, timeouts, and cert options still inherit from global settings.

- **Bug Fixes**
 - Added `mergeMcpRequestOptions` to strip global `verifySsl` before merging into MCP configs.
 - Applied this policy in YAML conversion and non-stdio MCP loading to keep TLS verification on by default.
 - Added regression tests for SSE and streamable HTTP, explicit per-server `verifySsl` true/false, empty options, and inheritance of unrelated options.

<sup>Written for commit a37a04633dc87338cb7bc286d08f06ae8fe2e902. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Upstream

Closes #11468.
Reported by @hhhashexe.
