### PR TITLE
fix: add mhchem support to markdown renderer

### DIFF
--- a/gui/src/components/StyledMarkdownPreview/index.tsx
+++ b/gui/src/components/StyledMarkdownPreview/index.tsx
@@ -2,6 +2,7 @@ import { ctxItemToRifWithContents } from "core/commands/util";
 import { memo, useEffect, useMemo, useRef } from "react";
 import { useRemark } from "react-remark";
 import rehypeKatex from "rehype-katex";
+import "katex/contrib/mhchem";
 import remarkMath from "remark-math";
 import styled from "styled-components";
 import { visit } from "unist-util-visit";


### PR DESCRIPTION
## Description

Adds the KaTeX `mhchem` contrib import to the GUI markdown renderer so chemistry notation like `\ce{H2O}` and `\pu{...}` can render correctly instead of causing KaTeX parsing errors.

Fixes #12561

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Tested locally in the VS Code Extension Development Host. The block reaction `$$\ce{CO2 + C -> 2 CO}$$` renders successfully as a typeset chemical reaction instead of crashing/stopping the message render.

## Tests

Manual testing in the locally-built Continue extension:

- Tested inline chemistry notation with `$\ce{H2O}$`
- Tested ion notation with `$\ce{Fe^{2+}}$`
- Tested block reaction rendering with `$$\ce{CO2 + C -> 2 CO}$$`
- Tested units with `$\pu{5 mol}$`

Confirmed the message renders without stopping mid-output.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `katex/contrib/mhchem` to the GUI markdown renderer so chemistry notation (`\ce{...}`, `\pu{...}`) renders correctly instead of throwing KaTeX parse errors. Fixes #12561.

<sup>Written for commit dec323a9c6f380451655aa230c7db57d28dd1d46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

