### PR TITLE
docs: add EmpirioLabs provider configuration page

### DIFF
--- a/docs/customize/model-providers/more/empiriolabs.mdx
+++ b/docs/customize/model-providers/more/empiriolabs.mdx
@@ -1,0 +1,67 @@
+---
+title: "How to Configure EmpirioLabs with Continue"
+sidebarTitle: "EmpirioLabs"
+---
+
+<Info>
+  [EmpirioLabs AI](https://empiriolabs.ai) is an OpenAI-compatible multi-model
+  API hosting open and proprietary models (Qwen, DeepSeek, GLM, Kimi, MiniMax,
+  Gemma, and more) with pay-as-you-go pricing.
+</Info>
+
+<Tip>
+  Get an API key from the [EmpirioLabs dashboard](https://platform.empiriolabs.ai/dashboard/api-keys). The model catalog with per-model pricing and context windows is at [empiriolabs.ai/models](https://empiriolabs.ai/models).
+</Tip>
+
+## Configuration
+
+EmpirioLabs serves the OpenAI-compatible Chat Completions API, so it works through the `openai` provider with a custom `apiBase`:
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  name: My Config
+  version: 0.0.1
+  schema: v1
+
+  models:
+    - name: Qwen3.7 Plus
+      provider: openai
+      model: qwen3-7-plus
+      apiBase: https://api.empiriolabs.ai/v1
+      apiKey: <YOUR_EMPIRIOLABS_API_KEY>
+      roles:
+        - chat
+        - edit
+        - apply
+  ```
+  </Tab>
+  <Tab title="JSON (Deprecated)">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "Qwen3.7 Plus",
+        "provider": "openai",
+        "model": "qwen3-7-plus",
+        "apiBase": "https://api.empiriolabs.ai/v1",
+        "apiKey": "<YOUR_EMPIRIOLABS_API_KEY>"
+      }
+    ]
+  }
+  ```
+  </Tab>
+</Tabs>
+
+## Popular Models
+
+| Model | Context | Best For |
+|-------|---------|----------|
+| `qwen3-7-max` | 1M tokens | Coding, agents, deep thinking |
+| `qwen3-7-plus` | 1M tokens | Cost-effective multimodal coding |
+| `deepseek-v4-pro` | 1M tokens | Flagship reasoning |
+| `deepseek-v4-flash` | 1M tokens | Fast, low-cost reasoning |
+| `glm-5-1` | 202K tokens | Long-context tool use |
+| `kimi-k2-6` | 256K tokens | Agentic multimodal reasoning |
+
+Reasoning-capable models accept the `reasoning_effort` request option (`none`, `low`, `medium`, `high`, `max`).

--- a/docs/customize/model-providers/more/empiriolabs.mdx
+++ b/docs/customize/model-providers/more/empiriolabs.mdx
@@ -15,7 +15,32 @@ sidebarTitle: "EmpirioLabs"
 
 ## Configuration
 
-EmpirioLabs serves the OpenAI-compatible Chat Completions API, so it works through the `openai` provider with a custom `apiBase`:
+EmpirioLabs serves the OpenAI-compatible Chat Completions API, so it works through the `openai` provider with a custom `apiBase`.
+
+### Load every model automatically
+
+Set `model: AUTODETECT` and Continue fetches the full model list from the EmpirioLabs `/v1/models` endpoint, so every model on your account appears in the picker without listing them by hand:
+
+```yaml title="config.yaml"
+name: My Config
+version: 0.0.1
+schema: v1
+
+models:
+  - name: EmpirioLabs
+    provider: openai
+    model: AUTODETECT
+    apiBase: https://api.empiriolabs.ai/v1
+    apiKey: <YOUR_EMPIRIOLABS_API_KEY>
+    roles:
+      - chat
+      - edit
+      - apply
+```
+
+### Configure a single model
+
+To pin one model, set its slug as the `model`:
 
 <Tabs>
   <Tab title="YAML">

--- a/docs/customize/model-providers/more/empiriolabs.mdx
+++ b/docs/customize/model-providers/more/empiriolabs.mdx
@@ -1,6 +1,6 @@
 ---
-title: "How to Configure EmpirioLabs with Continue"
-sidebarTitle: "EmpirioLabs"
+title: "How to Configure EmpirioLabs AI with Continue"
+sidebarTitle: "EmpirioLabs AI"
 ---
 
 <Info>
@@ -27,7 +27,7 @@ version: 0.0.1
 schema: v1
 
 models:
-  - name: EmpirioLabs
+  - name: EmpirioLabs AI
     provider: openai
     model: AUTODETECT
     apiBase: https://api.empiriolabs.ai/v1

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -109,6 +109,7 @@
                       "customize/model-providers/more/clawrouter",
                       "customize/model-providers/more/deepseek",
                       "customize/model-providers/more/deepinfra",
+                      "customize/model-providers/more/empiriolabs",
                       "customize/model-providers/more/groq",
                       "customize/model-providers/more/llamacpp",
                       "customize/model-providers/more/llamastack",


### PR DESCRIPTION
Adds a configuration page for [EmpirioLabs AI](https://empiriolabs.ai) (an OpenAI-compatible multi-model API) under More Providers, following the existing page format (Info/Tip, YAML + deprecated JSON tabs, model table). Uses the standard `openai` provider with a custom `apiBase`, so no code changes are needed; the configuration was verified against the live API. Registered in docs.json navigation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an EmpirioLabs AI configuration page showing how to use the `openai` provider with `apiBase: https://api.empiriolabs.ai/v1`, including `AUTODETECT` to auto-load all EmpirioLabs models. Uses "EmpirioLabs AI" as the provider display name, includes YAML and deprecated JSON examples, a popular models table with context sizes, Info/Tip callouts, and a note on the `reasoning_effort` request option; registered in `docs.json` under More Providers.

<sup>Written for commit 5df63568f6030bf6dacd44858d699c6b2b12b3e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

