### PR TITLE
fix(gui): preserve text selection in code blocks on mouse leave

### DIFF
--- a/gui/src/components/StyledMarkdownPreview/SyntaxHighlightedPre.tsx
+++ b/gui/src/components/StyledMarkdownPreview/SyntaxHighlightedPre.tsx
@@ -26,6 +26,11 @@ const StyledPre = styled.pre<{ theme: any }>`
   max-height: 40vh;
   overflow-y: scroll !important;
 
+  /* Keep code text selectable so a partial selection isn't lost when the
+     cursor leaves the code block while dragging (see issue #3850). */
+  user-select: text;
+  -webkit-user-select: text;
+
   ${(props) => generateThemeStyles(props.theme)}
 `;
 


### PR DESCRIPTION
## Closes #3850

### Problem
Text selected within a chat code block is lost as soon as the cursor leaves the code block while dragging, making it hard to copy a portion of generated code.

### Root cause
The rendered code block element (`StyledPre` in `gui/src/components/StyledMarkdownPreview/SyntaxHighlightedPre.tsx`) had no explicit `user-select` rule. With the scrollable, fixed-max-height `<pre>`, a partial drag-selection could be dropped when the cursor moved outside the element's bounds.

### Fix
Explicitly mark the `<pre>` as `user-select: text` (with `-webkit-` prefix) so selections persist regardless of where the cursor moves.

```css
user-select: text;
-webkit-user-select: text;
```

Minimal, CSS-only change scoped to the chat code block. No behavior change for copy buttons or apply actions.
