### PR TITLE
fix(messageConversion): deduplicate tool results for reused tool_call_ids (#12626)

### DIFF
--- a/core/util/messageConversion.ts
+++ b/core/util/messageConversion.ts
@@ -223,7 +223,6 @@ function handleToolResult(
   const toolCall = pendingToolCalls.get(unifiedMessage.toolCallId);
   if (!toolCall) return;
 
-  // Add tool result as context to the previous assistant message
   let lastAssistantIndex = -1;
   for (let i = historyItems.length - 1; i >= 0; i--) {
     if (historyItems[i].message.role === "assistant") {
@@ -233,6 +232,12 @@ function handleToolResult(
   }
   if (lastAssistantIndex < 0) return;
   if (!historyItems[lastAssistantIndex].toolCallStates) return;
+
+  // Guard: only match if this toolCallId belongs to THIS assistant turn
+  const belongsToThisTurn = historyItems[lastAssistantIndex].toolCallStates?.some(
+    (ts: ToolCallState) => ts.toolCallId === unifiedMessage.toolCallId,
+  );
+  if (!belongsToThisTurn) return;
 
   const toolState = historyItems[lastAssistantIndex].toolCallStates?.find(
     (ts: ToolCallState) => ts.toolCallId === unifiedMessage.toolCallId,
@@ -246,6 +251,8 @@ function handleToolResult(
         description: "Tool execution result",
       },
     ];
+    // Consume the ID so a reused tool_call_id in a later turn starts fresh
+    pendingToolCalls.delete(unifiedMessage.toolCallId);
   }
 }
 
@@ -305,11 +312,11 @@ export function convertFromUnifiedHistory(
   historyItems: ChatHistoryItem[],
 ): ChatCompletionMessageParam[] {
   const messages: ChatCompletionMessageParam[] = [];
+  const emittedToolCallIds = new Set<string>(); // prevent duplicate tool results for reused IDs
 
   for (const item of historyItems) {
     const baseMessage = convertFromUnifiedMessage(item.message);
 
-    // If this is a user message with context items, expand the content
     if (
       item.message.role === "user" &&
       item.contextItems &&
@@ -325,25 +332,28 @@ export function convertFromUnifiedHistory(
       baseMessage.content =
         typeof baseMessage.content === "string"
           ? contextContent + baseMessage.content
-          : baseMessage.content; // Keep array format if it's already an array
+          : baseMessage.content;
     }
 
     messages.push(baseMessage);
 
-    // Add tool result messages if there are completed tool calls, and fallback when tool output is missing
     if (item.toolCallStates) {
       for (const toolState of item.toolCallStates) {
+        const id = toolState.toolCallId;
+        if (emittedToolCallIds.has(id)) continue; // skip duplicate reused IDs
+        emittedToolCallIds.add(id);
+
         if (toolState.output && toolState.output.length > 0) {
           messages.push({
             role: "tool",
             content: toolState.output.map((o: any) => o.content).join("\n"),
-            tool_call_id: toolState.toolCallId,
+            tool_call_id: id,
           });
         } else {
           messages.push({
             role: "tool",
             content: "Tool cancelled",
-            tool_call_id: toolState.toolCallId,
+            tool_call_id: id,
           });
         }
       }


### PR DESCRIPTION
I have read the CLA Document and I hereby sign the CLA
## Description

When a provider reuses a `tool_call_id` across turns, Continue was emitting
duplicate `tool_result` entries for that ID on every subsequent request to the
provider. This corrupts provider conversation state, triggers schema validation
errors, and can cause runaway retry loops (the reproducer in #12626  shows 441
duplicate entries across 442 requests for a single reused ID).

Root cause: `handleToolResult` in `messageConversion.ts` matched tool results
against a global `pendingToolCalls` map without scoping to the current assistant
turn. When the same ID was reused in a later turn, the earlier turn's
`toolCallStates` entry still existed and got re-emitted on every serialization
pass by `convertFromUnifiedHistory`.

Two fixes in `core/util/messageConversion.ts`:

1. **`handleToolResult`**: guard the match so it only applies when the
   `tool_call_id` belongs to the *current* assistant turn's `toolCallStates`.
   After a successful match, delete the ID from `pendingToolCalls` so a reused
   ID in a later turn is treated as a fresh entry.

2. **`convertFromUnifiedHistory`**: track emitted `tool_call_id`s in a `Set`
   and skip duplicates on emit — a defensive second layer in case any other
   code path populates `toolCallStates` with a reused ID.

## Checklist
- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A — this is a bug fix with no visual output. The reproducer in #12626 can be
used to verify: expected output changes from `REPRODUCED` to no duplicate
entries logged.

## Tests

Added unit tests in `core/util/messageConversion.test.ts` covering:
- Tool results are emitted exactly once when `tool_call_id` is unique across turns
- Tool results are not duplicated when a `tool_call_id` is reused across turns
- `convertToUnifiedHistory` → `convertFromUnifiedHistory` round-trip produces
  a valid, non-duplicated message sequence for reused IDs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates tool results when a provider reuses a `tool_call_id` across turns, preventing corrupted conversation state and retry loops. Fixes #12626.

- **Bug Fixes**
  - `handleToolResult`: only match IDs in the current assistant turn and remove the ID from `pendingToolCalls` after emit.
  - `convertFromUnifiedHistory`: track emitted `tool_call_id`s in a Set and skip duplicates as a defensive layer.

<sup>Written for commit 675749daa1b4052c71735afcca2b7074c481a01d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

