### PR TITLE
feat: add TokenMix as a model provider

### DIFF
--- a/core/llm/llms/Tokenmix.ts
+++ b/core/llm/llms/Tokenmix.ts
@@ -1,0 +1,14 @@
+import OpenAI from "./OpenAI.js";
+
+import type { LLMOptions } from "../../index.js";
+
+class Tokenmix extends OpenAI {
+  static providerName = "tokenmix";
+  static defaultOptions: Partial<LLMOptions> = {
+    apiBase: "https://api.tokenmix.ai/v1/",
+    model: "deepseek/deepseek-v4-pro",
+    useLegacyCompletionsEndpoint: false,
+  };
+}
+
+export default Tokenmix;

--- a/core/llm/llms/index.ts
+++ b/core/llm/llms/index.ts
@@ -63,6 +63,7 @@ import TARS from "./TARS";
 import TestLLM from "./Test";
 import TextGenWebUI from "./TextGenWebUI";
 import Together from "./Together";
+import Tokenmix from "./Tokenmix";
 import Venice from "./Venice";
 import VertexAI from "./VertexAI";
 import Vllm from "./Vllm";
@@ -125,6 +126,7 @@ export const LLMClasses = [
   xAI,
   SiliconFlow,
   Tensorix,
+  Tokenmix,
   Scaleway,
   Relace,
   Inception,

--- a/docs/customize/model-providers/more/tokenmix.mdx
+++ b/docs/customize/model-providers/more/tokenmix.mdx
@@ -1,0 +1,93 @@
+---
+title: "TokenMix"
+description: "Configure TokenMix with Continue to access DeepSeek, Qwen, Kimi, GLM, MiniMax, and other models through a single OpenAI-compatible API gateway"
+---
+
+[TokenMix](https://tokenmix.ai) is an OpenAI-compatible API gateway that provides access to DeepSeek, Qwen, Kimi, GLM, MiniMax, and other models through one endpoint and one API key. Pay-as-you-go with no subscription required.
+
+<Info>
+  You can get an API key from
+  [tokenmix.ai](https://tokenmix.ai).
+</Info>
+
+## Chat Model
+
+We recommend configuring **deepseek/deepseek-v4-pro** as your chat model.
+
+<Tabs>
+    <Tab title="YAML">
+    ```yaml title="config.yaml"
+    name: My Config
+    version: 0.0.1
+    schema: v1
+
+    models:
+      - name: DeepSeek V4 Pro
+        provider: tokenmix
+        model: deepseek/deepseek-v4-pro
+        apiKey: <YOUR_TOKENMIX_API_KEY>
+        roles:
+          - chat
+    ```
+    </Tab>
+    <Tab title="JSON">
+    ```json title="config.json"
+    {
+      "models": [
+        {
+          "title": "DeepSeek V4 Pro",
+          "provider": "tokenmix",
+          "model": "deepseek/deepseek-v4-pro",
+          "apiKey": "<YOUR_TOKENMIX_API_KEY>"
+        }
+      ]
+    }
+    ```
+    </Tab>
+</Tabs>
+
+## Autocomplete Model
+
+<Tabs>
+    <Tab title="YAML">
+    ```yaml title="config.yaml"
+    name: My Config
+    version: 0.0.1
+    schema: v1
+
+    models:
+      - name: DeepSeek V4 Pro
+        provider: tokenmix
+        model: deepseek/deepseek-v4-pro
+        apiKey: <YOUR_TOKENMIX_API_KEY>
+        roles:
+          - autocomplete
+    ```
+    </Tab>
+    <Tab title="JSON">
+    ```json title="config.json"
+    {
+      "models": [
+        {
+          "title": "DeepSeek V4 Pro",
+          "provider": "tokenmix",
+          "model": "deepseek/deepseek-v4-pro",
+          "apiKey": "<YOUR_TOKENMIX_API_KEY>"
+        }
+      ],
+      "tabAutocompleteModel": {
+        "title": "DeepSeek V4 Pro",
+        "provider": "tokenmix",
+        "model": "deepseek/deepseek-v4-pro",
+        "apiKey": "<YOUR_TOKENMIX_API_KEY>"
+      }
+    }
+    ```
+    </Tab>
+</Tabs>
+
+## Embeddings Model
+
+TokenMix provides access to various models. [Click here](https://tokenmix.ai/models) to see a list of available models.
+
+[View the source](https://github.com/continuedev/continue/blob/main/core/llm/llms/Tokenmix.ts)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -119,6 +119,7 @@
                       "customize/model-providers/more/nvidia",
                       "customize/model-providers/more/tensorix",
                       "customize/model-providers/more/together",
+                      "customize/model-providers/more/tokenmix",
                       "customize/model-providers/more/xAI",
                       "customize/model-providers/more/zai"
                     ]

--- a/gui/src/pages/AddNewModel/configs/providers.ts
+++ b/gui/src/pages/AddNewModel/configs/providers.ts
@@ -1270,6 +1270,26 @@ To get started, [register](https://dataplatform.cloud.ibm.com/registration/stepo
     packages: [{ ...models.AUTODETECT }],
     apiKeyUrl: "https://app.tensorix.ai",
   },
+  tokenmix: {
+    title: "TokenMix",
+    provider: "tokenmix",
+    description:
+      "TokenMix is an OpenAI-compatible API gateway with access to DeepSeek, Qwen, Kimi, GLM, MiniMax, and other models.",
+    longDescription:
+      "To get started with TokenMix, create an account and get an API key at [tokenmix.ai](https://tokenmix.ai).",
+    tags: [ModelProviderTags.RequiresApiKey],
+    collectInputFor: [
+      {
+        inputType: "text",
+        key: "apiKey",
+        label: "API Key",
+        placeholder: "Enter your TokenMix API key",
+        required: true,
+      },
+    ],
+    packages: [{ ...models.AUTODETECT }],
+    apiKeyUrl: "https://tokenmix.ai",
+  },
   venice: {
     title: "Venice",
     provider: "venice",

--- a/packages/openai-adapters/src/index.ts
+++ b/packages/openai-adapters/src/index.ts
@@ -176,6 +176,8 @@ export function constructLlmApi(config: LLMConfig): BaseLlmApi | undefined {
       return openAICompatible("https://api.function.network/v1/", config);
     case "tensorix":
       return openAICompatible("https://api.tensorix.ai/v1/", config);
+    case "tokenmix":
+      return openAICompatible("https://api.tokenmix.ai/v1/", config);
     case "openrouter":
       return new OpenRouterApi(config);
     case "clawrouter":

--- a/packages/openai-adapters/src/types.ts
+++ b/packages/openai-adapters/src/types.ts
@@ -60,6 +60,7 @@ export const OpenAIConfigSchema = BasePlusConfig.extend({
     z.literal("zAI"),
     z.literal("scaleway"),
     z.literal("tensorix"),
+    z.literal("tokenmix"),
     z.literal("ncompass"),
     z.literal("relace"),
     z.literal("huggingface-inference-api"),


### PR DESCRIPTION
## Description

Adds [TokenMix](https://tokenmix.ai) as a model provider. TokenMix is an OpenAI-compatible API gateway that exposes DeepSeek, Qwen, Kimi, GLM, MiniMax and other models through a single endpoint (`https://api.tokenmix.ai/v1`) and one API key, so it slots in as a standard OpenAI-compatible provider.

Usage:

```yaml
models:
  - name: DeepSeek V4 Pro
    provider: tokenmix
    model: deepseek/deepseek-v4-pro
    apiKey: <YOUR_TOKENMIX_API_KEY>
    roles:
      - chat
```

## Changes

- `core/llm/llms/Tokenmix.ts` — new provider class extending `OpenAI` (mirrors `Tensorix`/`zAI`)
- `core/llm/llms/index.ts` — register `Tokenmix` in `LLMClasses`
- `packages/openai-adapters/src/types.ts` — add `tokenmix` to the `OpenAIConfigSchema` provider union
- `packages/openai-adapters/src/index.ts` — route `tokenmix` through `openAICompatible(...)`
- `gui/src/pages/AddNewModel/configs/providers.ts` — Add-Model tile (models auto-detected via `/v1/models`)
- `docs/customize/model-providers/more/tokenmix.mdx` + `docs/docs.json` — docs page and nav entry

## Checklist

- [x] The relevant docs, if any, have been updated or created
- [x] `packages/openai-adapters` typechecks clean (`tsc --noEmit`)
- [x] Prettier formatting verified on all changed source/JSON files
- [x] New provider follows the existing OpenAI-compatible provider pattern (`Tensorix`, `zAI`)

## Tests

The provider is a thin OpenAI-compatible wrapper following the same pattern as existing gateways (`Tensorix`, `zAI`, `Nebius`). No new test fixtures were added, consistent with those providers.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds TokenMix as a new OpenAI-compatible provider so you can use DeepSeek, Qwen, Kimi, GLM, MiniMax, and more through one endpoint and API key.
Default base is https://api.tokenmix.ai/v1 and default model is deepseek/deepseek-v4-pro.

- **New Features**
  - Added `Tokenmix` provider class extending `OpenAI` with `apiBase` `https://api.tokenmix.ai/v1/` and default model `deepseek/deepseek-v4-pro`.
  - Registered provider in `core/llm/llms/index.ts` and `packages/openai-adapters` (provider union + `openAICompatible(...)` routing).
  - Added Add-Model GUI tile with API key input and model autodetect via `/v1/models`.
  - Added docs page and navigation entry for TokenMix configuration.

<sup>Written for commit 913361544fe74fbb87ad5ee813c7a99d879b47db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

