### PR TITLE
docs: fix GitHub Pages subpath base path for docs site

### DIFF
--- a/docs-site/components/docs/DocsSearch.tsx
+++ b/docs-site/components/docs/DocsSearch.tsx
@@ -12,6 +12,7 @@ import {
   CommandList,
 } from "@/components/ui/command";
 import { create, load, search, type AnyOrama } from "@orama/orama";
+import { withBasePath } from "@/lib/basePath";
 
 interface SearchResult {
   title: string;
@@ -44,7 +45,7 @@ export function DocsSearch({ resolve }: { resolve: (path: string) => string }) {
   useEffect(() => {
     if (!open || dbRef.current) return;
     setLoading(true);
-    fetch("/search-index.json")
+    fetch(withBasePath("/search-index.json"))
       .then((res) => res.json())
       .then((data) => {
         const db = create({

--- a/docs-site/components/docs/DocsShell.tsx
+++ b/docs-site/components/docs/DocsShell.tsx
@@ -8,6 +8,7 @@ import { type NavGroup, type NavItem, type NavTab } from "@/config/docsNav";
 import { TableOfContents } from "./TableOfContents";
 import { DocsSearch } from "./DocsSearch";
 import { resolveHref } from "@/lib/resolveHref";
+import { withBasePath } from "@/lib/basePath";
 import type { Heading } from "@/lib/docs";
 
 /* ------------------------------------------------------------------ */
@@ -235,7 +236,7 @@ export function DocsShell({
             >
               <Link href={resolveHref("/")} className="flex items-center">
                 <img
-                  src="/images/continue-logo-light.png"
+                  src={withBasePath("/images/continue-logo-light.png")}
                   alt="Continue"
                   className="h-8 w-auto dark:invert"
                 />
@@ -245,7 +246,7 @@ export function DocsShell({
             <div className="flex items-center px-5 py-3 lg:hidden">
               <Link href={resolveHref("/")} className="flex items-center">
                 <img
-                  src="/images/continue-logo-light.png"
+                  src={withBasePath("/images/continue-logo-light.png")}
                   alt="Continue"
                   className="h-8 w-auto dark:invert"
                 />

--- a/docs-site/components/docs/mdx/index.tsx
+++ b/docs-site/components/docs/mdx/index.tsx
@@ -10,6 +10,7 @@ import { OSAutoDetect } from "./OSAutoDetect";
 import { CodeBlock } from "./CodeBlock";
 import { CodeGroup } from "./CodeGroup";
 import { MdxLink } from "./MdxLink";
+import { withBasePath } from "@/lib/basePath";
 
 export const mdxComponents: MDXComponents = {
   // Mintlify callout variants
@@ -62,8 +63,12 @@ export const mdxComponents: MDXComponents = {
 
   // Rewrite image paths — images are copied to public/images/docs/ at build time
   img: ({ src, alt, ...props }: any) => {
-    if (src && src.startsWith("/images/")) {
+    if (src && src.startsWith("/images/") && !src.startsWith("/images/docs/")) {
       src = `/images/docs${src.slice("/images".length)}`;
+    }
+    // Prefix the deploy base path for raw absolute asset paths (GitHub Pages).
+    if (src && src.startsWith("/")) {
+      src = withBasePath(src);
     }
     return <img src={src} alt={alt || ""} {...props} />;
   },

--- a/docs-site/lib/basePath.ts
+++ b/docs-site/lib/basePath.ts
@@ -1,0 +1,18 @@
+/**
+ * Base path for the deployed docs site.
+ *
+ * On GitHub Pages the site lives under `/continue/`, so raw absolute asset
+ * references (search index, <img> src, etc.) must be prefixed manually. Next
+ * applies basePath automatically to <Link>, next/image and /_next assets, but
+ * NOT to plain string paths, so use `withBasePath` for those.
+ *
+ * `NEXT_PUBLIC_BASE_PATH` is inlined at build time (see next.config.js) and is
+ * therefore safe to read in both server and client/browser code.
+ */
+export const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH || "";
+
+/** Prefix an absolute (`/`-rooted) path with the deploy base path. */
+export function withBasePath(path: string): string {
+  if (!path.startsWith("/")) return path;
+  return `${BASE_PATH}${path}`;
+}

--- a/docs-site/next.config.js
+++ b/docs-site/next.config.js
@@ -1,6 +1,22 @@
 /** @type {import('next').NextConfig} */
+
+// When deploying to GitHub Pages the site is served from the `/continue/`
+// subpath (https://continuedev.github.io/continue/). GitHub Actions sets
+// GITHUB_ACTIONS=true, so we only apply the base path there — local dev
+// (localhost:3005) keeps serving from the root.
+const isGithubPages = process.env.GITHUB_ACTIONS === "true";
+const basePath = isGithubPages ? "/continue" : "";
+
 const nextConfig = {
   output: "export",
+  basePath,
+  assetPrefix: basePath || undefined,
+  // Expose the base path to client/runtime code so raw string asset paths
+  // (search index fetch, <img> src, etc.) can be prefixed manually — Next only
+  // applies basePath automatically to <Link>, next/image and /_next assets.
+  env: {
+    NEXT_PUBLIC_BASE_PATH: basePath,
+  },
   typescript: {
     ignoreBuildErrors: true,
   },


### PR DESCRIPTION
## Problem

The docs site deployed to GitHub Pages at https://continuedev.github.io/continue/ renders **unstyled**. It is served from the `/continue/` subpath, but `docs-site/next.config.js` set no `basePath`/`assetPrefix`, so `/_next/*` CSS/JS, the client-side search index, and images were requested from the domain root and 404'd.

## Fix

- Add `basePath`/`assetPrefix` of `/continue`, gated on `GITHUB_ACTIONS` so local dev (`localhost:3005`) still serves from root.
- Expose `NEXT_PUBLIC_BASE_PATH` and add a `withBasePath` helper (`docs-site/lib/basePath.ts`) for raw absolute asset paths that Next does **not** prefix automatically (it only prefixes `<Link>`, `next/image`, and `/_next` assets).
- Prefix the search-index `fetch`, the logo `<img>`, and MDX doc images with the base path.
- Guard against a pre-existing double `/images/docs/` rewrite in the MDX `img` component.

## Verification

Local build with `GITHUB_ACTIONS=true npm run build`:
- CSS hrefs -> `/continue/_next/static/.../*.css`
- Logo -> `/continue/images/continue-logo-light.png`
- Doc images -> `/continue/images/docs/...` (single `/docs/`)
- Search fetch -> `withBasePath("/search-index.json")` -> `/continue/search-index.json`

Normal `npm run build` (no env) -> root-relative paths, zero `/continue` refs, so local dev is unaffected.

Live site verification will follow the deploy.

Made with [Cursor](https://cursor.com)