### PR TITLE
docs: add mercury-2 model documentation to Inception provider page

### DIFF
--- a/docs/customize/model-providers/top-level/inception.mdx
+++ b/docs/customize/model-providers/top-level/inception.mdx
@@ -22,9 +22,9 @@ sidebarTitle: "Inception"
   schema: v1
 
   models:
-    - name: <MODEL_NAME>
+    - name: Mercury 2
       provider: inception
-      model: <MODEL_ID>
+      model: mercury-2
       apiKey: <INCEPTION_API_KEY>
   ```
   </Tab>
@@ -33,9 +33,9 @@ sidebarTitle: "Inception"
   {
     "models": [
       {
-        "title": "<MODEL_NAME>",
+        "title": "Mercury 2",
         "provider": "inception",
-        "model": "<MODEL_ID>",
+        "model": "mercury-2",
         "apiKey": "<INCEPTION_API_KEY>"
       }
     ]
@@ -47,3 +47,50 @@ sidebarTitle: "Inception"
 <Info>
   **Check out a more advanced configuration [here](https://continue.dev/inceptionlabs/mercury-coder?view=config)**
 </Info>
+
+## Available Models
+
+| Model | Description | Context | Tool calling |
+|---|---|---|---|
+| `mercury-2` | Fastest reasoning diffusion model; most capable | 128k | ✓ |
+| `mercury-edit-2` | Code editing model for autocomplete, apply, and next-edit | 32k | — |
+| `mercury-coder-small` | Lightweight coding model | 32k | — |
+
+## Tool Calling with mercury-2
+
+`mercury-2` supports tool calling, enabling agent workflows in Continue. No extra configuration is required — Continue detects tool support automatically for models whose ID starts with `mercury-2`.
+
+To use `mercury-2` as both a chat and agent model:
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  name: My Config
+  version: 0.0.1
+  schema: v1
+
+  models:
+    - name: Mercury 2
+      provider: inception
+      model: mercury-2
+      apiKey: <INCEPTION_API_KEY>
+      roles:
+        - chat
+        - agent
+  ```
+  </Tab>
+  <Tab title="JSON (Deprecated)">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "Mercury 2",
+        "provider": "inception",
+        "model": "mercury-2",
+        "apiKey": "<INCEPTION_API_KEY>"
+      }
+    ]
+  }
+  ```
+  </Tab>
+</Tabs>


### PR DESCRIPTION
## Description

Adds model documentation to the Inception provider page, addressing #12482.

- Updated config examples to use `mercury-2` instead of generic placeholders
- Added an Available Models table covering all three models from PR #12156 (`mercury-2`, `mercury-edit-2`, `mercury-coder-small`) with context lengths and capabilities
- Added a Tool Calling section documenting that `mercury-2` supports agent workflows and showing the `roles: [chat, agent]` config pattern

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A — documentation-only change.

## Tests

No tests required for a documentation update.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `mercury-2` documentation to the Inception provider page, including clear config examples, an available models table, and tool-calling guidance. Closes #12482.

- **New Features**
  - Updated config examples to use `mercury-2` with clear names.
  - Added Available Models table for `mercury-2`, `mercury-edit-2`, and `mercury-coder-small` with context/tool-calling info.
  - Documented tool calling for `mercury-2` and showed `roles: [chat, agent]` configuration.

<sup>Written for commit 5a2f251b50e5183a867bfc2ea6ba226cec43e4c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

