### PR TITLE
docs: document .continue/configs/ directory structure

### DIFF
--- a/docs/customize/deep-dives/configuration.mdx
+++ b/docs/customize/deep-dives/configuration.mdx
@@ -24,6 +24,41 @@ When editing this file, you can see the available options suggested as you type,
 
 See the full reference for `config.yaml` [here](/reference).
 
+## `.continue` Directory Structure
+
+Continue scans several subdirectories inside your `.continue/` folder (both the global `~/.continue/` and any workspace-level `.continue/`) to automatically discover and load local config profiles. Each YAML file found in these directories appears as a selectable profile in the config dropdown, and Continue watches for file changes to reload automatically.
+
+| Directory | Purpose |
+|---|---|
+| `.continue/configs/` | Config profiles — the recommended location for local YAML config files |
+| `.continue/agents/` | Agent definitions (also loaded as profiles) |
+| `.continue/assistants/` | Legacy name for `.continue/agents/` — still supported |
+
+### Using `.continue/configs/`
+
+Place any `config.yaml` (or other `.yaml` files) in `.continue/configs/` at the workspace or global level:
+
+```
+~/.continue/
+  configs/
+    frontend.yaml      # global profile: "frontend"
+    backend.yaml       # global profile: "backend"
+
+<your-project>/
+  .continue/
+    configs/
+      project.yaml     # workspace profile: "project"
+```
+
+Each file becomes its own selectable profile. Creating, deleting, or editing a file in this directory triggers an automatic config reload — no restart required.
+
+### Global vs. Workspace
+
+| Location | Scope |
+|---|---|
+| `~/.continue/configs/` (macOS/Linux) or `%USERPROFILE%\.continue\configs\` (Windows) | Available in all workspaces |
+| `<workspace-root>/.continue/configs/` | Available only in that workspace |
+
 ## Legacy Configuration Methods (Deprecated)
 
 <Info>

--- a/docs/customize/model-providers/top-level/inception.mdx
+++ b/docs/customize/model-providers/top-level/inception.mdx
@@ -22,9 +22,9 @@ sidebarTitle: "Inception"
   schema: v1
 
   models:
-    - name: <MODEL_NAME>
+    - name: Mercury 2
       provider: inception
-      model: <MODEL_ID>
+      model: mercury-2
       apiKey: <INCEPTION_API_KEY>
   ```
   </Tab>
@@ -33,9 +33,9 @@ sidebarTitle: "Inception"
   {
     "models": [
       {
-        "title": "<MODEL_NAME>",
+        "title": "Mercury 2",
         "provider": "inception",
-        "model": "<MODEL_ID>",
+        "model": "mercury-2",
         "apiKey": "<INCEPTION_API_KEY>"
       }
     ]
@@ -47,3 +47,50 @@ sidebarTitle: "Inception"
 <Info>
   **Check out a more advanced configuration [here](https://continue.dev/inceptionlabs/mercury-coder?view=config)**
 </Info>
+
+## Available Models
+
+| Model | Description | Context | Tool calling |
+|---|---|---|---|
+| `mercury-2` | Fastest reasoning diffusion model; most capable | 128k | ✓ |
+| `mercury-edit-2` | Code editing model for autocomplete, apply, and next-edit | 32k | — |
+| `mercury-coder-small` | Lightweight coding model | 32k | — |
+
+## Tool Calling with mercury-2
+
+`mercury-2` supports tool calling, enabling agent workflows in Continue. No extra configuration is required — Continue detects tool support automatically for models whose ID starts with `mercury-2`.
+
+To use `mercury-2` as both a chat and agent model:
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  name: My Config
+  version: 0.0.1
+  schema: v1
+
+  models:
+    - name: Mercury 2
+      provider: inception
+      model: mercury-2
+      apiKey: <INCEPTION_API_KEY>
+      roles:
+        - chat
+        - agent
+  ```
+  </Tab>
+  <Tab title="JSON (Deprecated)">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "Mercury 2",
+        "provider": "inception",
+        "model": "mercury-2",
+        "apiKey": "<INCEPTION_API_KEY>"
+      }
+    ]
+  }
+  ```
+  </Tab>
+</Tabs>


### PR DESCRIPTION
## Description

Closes #12484

Adds a `.continue Directory Structure` section to the configuration deep-dive page documenting the `.continue/configs/` directory introduced in #11935.

- Added a table listing all three supported profile directories: `configs/`, `agents/`, and `assistants/` (legacy)
- Added a directory tree example showing global vs workspace placement
- Documented auto-discovery, file watching, and no-restart reload behavior
- Added a Global vs. Workspace scope table with OS-specific paths

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A — documentation-only change.

## Tests

No tests required for a documentation update.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Docs update: added `.continue/configs/` directory guidance and refreshed Inception provider docs with `mercury-2` models and tool-calling setup. This clarifies how to organize profiles and configure `mercury-2` for chat and agent workflows.

- **Documentation**
  - Added a ".continue Directory Structure" section covering `configs/`, `agents/`, and `assistants/` (legacy), with global vs workspace scope and OS-specific paths.
  - Documented auto-discovery, file watching, and no-restart reload behavior for profile YAMLs in `.continue/configs/`.
  - Updated Inception examples to use `mercury-2`, added an Available Models table (`mercury-2`, `mercury-edit-2`, `mercury-coder-small`).
  - Added tool-calling notes and chat/agent role configuration for `mercury-2`.

<sup>Written for commit ea4a7e691e10d52677e642bfe5cbf804108fc5cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

