### PR TITLE
fix: use Promise.allSettled for parallel config directory loading

### DIFF
--- a/core/config/ConfigHandler.ts
+++ b/core/config/ConfigHandler.ts
@@ -171,12 +171,18 @@ export class ConfigHandler {
     if (options.includeWorkspace) {
       const yamlOptions = { ...options, fileExtType: "yaml" } as const;
       const allFiles = (
-        await Promise.all([
+        await Promise.allSettled([
           getAllDotContinueDefinitionFiles(this.ide, yamlOptions, "assistants"),
           getAllDotContinueDefinitionFiles(this.ide, yamlOptions, "agents"),
           getAllDotContinueDefinitionFiles(this.ide, yamlOptions, "configs"),
         ])
-      ).flat();
+      ).flatMap((result) => {
+        if (result.status === "rejected") {
+          console.warn("Failed to load local config profiles:", result.reason);
+          return [];
+        }
+        return result.value;
+      });
       const profiles = allFiles.map((assistant) => {
         return new LocalProfileLoader(this.ide, this.llmLogger, assistant);
       });

--- a/docs/customize/model-providers/top-level/inception.mdx
+++ b/docs/customize/model-providers/top-level/inception.mdx
@@ -22,9 +22,9 @@ sidebarTitle: "Inception"
   schema: v1
 
   models:
-    - name: <MODEL_NAME>
+    - name: Mercury 2
       provider: inception
-      model: <MODEL_ID>
+      model: mercury-2
       apiKey: <INCEPTION_API_KEY>
   ```
   </Tab>
@@ -33,9 +33,9 @@ sidebarTitle: "Inception"
   {
     "models": [
       {
-        "title": "<MODEL_NAME>",
+        "title": "Mercury 2",
         "provider": "inception",
-        "model": "<MODEL_ID>",
+        "model": "mercury-2",
         "apiKey": "<INCEPTION_API_KEY>"
       }
     ]
@@ -47,3 +47,50 @@ sidebarTitle: "Inception"
 <Info>
   **Check out a more advanced configuration [here](https://continue.dev/inceptionlabs/mercury-coder?view=config)**
 </Info>
+
+## Available Models
+
+| Model | Description | Context | Tool calling |
+|---|---|---|---|
+| `mercury-2` | Fastest reasoning diffusion model; most capable | 128k | ✓ |
+| `mercury-edit-2` | Code editing model for autocomplete, apply, and next-edit | 32k | — |
+| `mercury-coder-small` | Lightweight coding model | 32k | — |
+
+## Tool Calling with mercury-2
+
+`mercury-2` supports tool calling, enabling agent workflows in Continue. No extra configuration is required — Continue detects tool support automatically for models whose ID starts with `mercury-2`.
+
+To use `mercury-2` as both a chat and agent model:
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  name: My Config
+  version: 0.0.1
+  schema: v1
+
+  models:
+    - name: Mercury 2
+      provider: inception
+      model: mercury-2
+      apiKey: <INCEPTION_API_KEY>
+      roles:
+        - chat
+        - agent
+  ```
+  </Tab>
+  <Tab title="JSON (Deprecated)">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "Mercury 2",
+        "provider": "inception",
+        "model": "mercury-2",
+        "apiKey": "<INCEPTION_API_KEY>"
+      }
+    ]
+  }
+  ```
+  </Tab>
+</Tabs>


### PR DESCRIPTION
## Description

Follows up on #11935.

Replaces `Promise.all` with `Promise.allSettled` when loading local profile directories (`assistants`, `agents`, `configs`) in `getLocalProfiles`. With `Promise.all`, a failure reading any single directory causes all profiles to fail loading. This fix preserves partial results — if one directory fails, profiles from the other two are still returned. Rejected promises are explicitly logged as warnings so errors are visible rather than silently swallowed.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A — error handling change with no UI impact.

## Tests

No new tests added. The fix only affects the failure path — the happy path behaviour is unchanged. Manual test plan: place an invalid/unreadable directory at `.continue/configs/` and verify that `.continue/agents/` profiles still load correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `Promise.allSettled` in `getLocalProfiles` to load local profile directories (`assistants`, `agents`, `configs`) in parallel without failing everything on a single read error; rejected results are logged as warnings and partial profiles are returned. Also updates Inception provider docs to use `mercury-2` examples, add an Available Models table, and document tool-calling support and agent/chat role configuration.

<sup>Written for commit 4d77af3948ee3ffd1d2e87a464aab4084859ffc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

