### PR TITLE
fix(edit): correct case-insensitive search/replace offsets for non-length-preserving lowercasing

### DIFF
--- a/core/edit/searchAndReplace/executeFindAndReplace.vitest.ts
+++ b/core/edit/searchAndReplace/executeFindAndReplace.vitest.ts
@@ -326,5 +326,20 @@ describe("executeFindAndReplace", () => {
 
       expect(result).toBe("new content");
     });
+
+    it("should not corrupt the file when an earlier character changes length on lowercase", () => {
+      // "İ" (U+0130) lowercases to "i" + combining dot (2 UTF-16 units). The
+      // case-insensitive match must report indices into the original content,
+      // otherwise the replacement lands at the wrong offset and corrupts the file.
+      const content = "// İ marker comment\nconst value = 1;";
+      const result = executeFindAndReplace(
+        content,
+        "CONST VALUE = 1;",
+        "const value = 2;",
+        false,
+      );
+
+      expect(result).toBe("// İ marker comment\nconst value = 2;");
+    });
   });
 });

--- a/core/edit/searchAndReplace/findSearchMatch.ts
+++ b/core/edit/searchAndReplace/findSearchMatch.ts
@@ -61,20 +61,50 @@ function trimmedMatch(
 
 /**
  * Case-insensitive matching strategy
+ *
+ * The match must be located in terms of the ORIGINAL file content. Searching
+ * the lowercased file directly is unsafe because `String.prototype.toLowerCase`
+ * is not guaranteed to be length-preserving (e.g. "İ" lowercases to "i̇", two
+ * UTF-16 units). A single such character before or within the match would shift
+ * every subsequent index, producing a misaligned slice and a corrupted edit.
+ *
+ * Instead we scan the original content and, for each candidate start position,
+ * lowercase only the slice that lines up with the lowercased search string. The
+ * matched region in the original may be longer or shorter than the search, so
+ * the end index is derived from that slice rather than from `searchContent.length`.
  */
 function caseInsensitiveMatch(
   fileContent: string,
   searchContent: string,
 ): BasicMatchResult | null {
-  const lowerFileContent = fileContent.toLowerCase();
   const lowerSearchContent = searchContent.toLowerCase();
-  const index = lowerFileContent.indexOf(lowerSearchContent);
-  if (index !== -1) {
-    return {
-      startIndex: index,
-      endIndex: index + searchContent.length,
-    };
+  if (lowerSearchContent.length === 0) {
+    return null;
   }
+
+  for (let startIndex = 0; startIndex < fileContent.length; startIndex++) {
+    // Grow the candidate slice until its lowercased form is at least as long as
+    // the search, then check for equality. This keeps indices anchored to the
+    // original string even when lowercasing changes length.
+    for (
+      let endIndex = startIndex + 1;
+      endIndex <= fileContent.length;
+      endIndex++
+    ) {
+      const lowerCandidate = fileContent
+        .slice(startIndex, endIndex)
+        .toLowerCase();
+      if (lowerCandidate.length < lowerSearchContent.length) {
+        continue;
+      }
+      if (lowerCandidate === lowerSearchContent) {
+        return { startIndex, endIndex };
+      }
+      // Once the candidate is long enough but doesn't match, advance the start.
+      break;
+    }
+  }
+
   return null;
 }
 

--- a/core/edit/searchAndReplace/findSearchMatch.vitest.ts
+++ b/core/edit/searchAndReplace/findSearchMatch.vitest.ts
@@ -179,6 +179,36 @@ describe("findSearchMatch", () => {
         strategyName: "caseInsensitiveMatch",
       });
     });
+
+    it("should return original-cased indices when an earlier character changes length on lowercase", () => {
+      // "İ" (U+0130) lowercases to "i" + combining dot (2 UTF-16 units), so an
+      // index found in the lowercased file would be shifted relative to the original.
+      const fileContent = "İ test";
+      const result = findSearchMatch(fileContent, "TEST");
+
+      expect(result).toEqual({
+        startIndex: 2,
+        endIndex: 6,
+        strategyName: "caseInsensitiveMatch",
+      });
+      expect(fileContent.slice(result!.startIndex, result!.endIndex)).toBe(
+        "test",
+      );
+    });
+
+    it("should return original-cased indices when the match itself changes length on lowercase", () => {
+      // The matched region in the file is a single code unit ("İ") that lowercases
+      // to two units, so endIndex must come from the original slice, not the search length.
+      const fileContent = "x İ y";
+      const result = findSearchMatch(fileContent, "i̇");
+
+      expect(result).toEqual({
+        startIndex: 2,
+        endIndex: 3,
+        strategyName: "caseInsensitiveMatch",
+      });
+      expect(fileContent.slice(result!.startIndex, result!.endIndex)).toBe("İ");
+    });
   });
 
   describe("Whitespace ignored strategy fallback", () => {


### PR DESCRIPTION
## Description

`caseInsensitiveMatch` (the fallback strategy used by `findSearchMatch` / `findSearchMatches`, which back `edit_existing_file` and the multi-edit tool) located the match by running `indexOf` on the **fully lowercased** file content, then returned that index — plus `searchContent.length` — as a position into the **original** content:

```ts
const lowerFileContent = fileContent.toLowerCase();
const index = lowerFileContent.indexOf(searchContent.toLowerCase());
return { startIndex: index, endIndex: index + searchContent.length };
```

`String.prototype.toLowerCase()` is **not length-preserving** for every character. For example `"İ"` (U+0130, LATIN CAPITAL LETTER I WITH DOT ABOVE) lowercases to `"i"` + a combining dot (two UTF-16 units). When such a character appears **before** the match, every subsequent index in the lowercased string is shifted relative to the original, so the returned `startIndex`/`endIndex` point at the wrong characters. When the character is **inside** the match, `endIndex` is wrong too because it is derived from the search length rather than the matched region's actual length.

Because these indices feed directly into `fileContent.substring(0, start) + new + fileContent.substring(end)` in `executeFindAndReplace`, the replacement lands at the wrong offset and **corrupts the file**. Concrete example (file has a leading `İ` in a comment):

```
// İ marker comment        oldString: "CONST VALUE = 1;"   (case-insensitive)
const value = 1;           newString: "const value = 2;"
```

produces `cconst value = 2;` on `main` (a duplicated `c`, original `t` dropped) instead of `const value = 2;`.

### Fix

Scan the original content and, for each candidate start position, lowercase only the slice that lines up with the lowercased search string, comparing for equality. This keeps both indices anchored to the original string, and the end index comes from the matched slice rather than `searchContent.length`. Behaviour for ASCII / length-preserving input is unchanged (all 128 existing tests still pass).

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created (n/a — internal logic fix)
- [x] The relevant tests, if any, have been updated or created

## Tests

Verified RED-on-`main`, GREEN-with-fix by reverting the implementation while keeping the new tests.

- `core/edit/searchAndReplace/findSearchMatch.vitest.ts` — two cases: an earlier character that changes length on lowercase, and the matched region itself changing length. Both assert the returned indices slice the correctly-cased original text.
- `core/edit/searchAndReplace/executeFindAndReplace.vitest.ts` — end-to-end test asserting the file is not corrupted.

```
edit/searchAndReplace/findSearchMatch.vitest.ts          (50 tests) ✓
edit/searchAndReplace/executeFindAndReplace.vitest.ts    (30 tests) ✓
edit/searchAndReplace/findAndReplaceUtils.vitest.ts      (25 tests) ✓
edit/searchAndReplace/multiEdit.vitest.ts                (23 tests) ✓
edit/searchAndReplace/findSearchMatches.test.ts          (32 tests, jest) ✓
```

`prettier` clean on the changed files; `tsc` reports no errors in any changed file.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes case-insensitive search/replace offsets when lowercasing changes string length, preventing misaligned edits and file corruption. Updates `caseInsensitiveMatch` to anchor indices to the original content and adds regression tests.

- **Bug Fixes**
  - Scan the original string and lowercase only the candidate slice to compare with the lowercased search.
  - Derive `endIndex` from the matched slice, not `searchContent.length`, covering cases like `"İ"` → `"i̇"`.
  - Added unit tests for pre-match and in-match length changes, plus an end-to-end test in `executeFindAndReplace`.

<sup>Written for commit 91d67a4ff61ffe1dcdff4792b5e6aa89cb91ed8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

