### PR TITLE
fix(cli): expand AUTODETECT model entries before sending API requests

### DIFF
--- a/extensions/cli/src/services/ModelService.test.ts
+++ b/extensions/cli/src/services/ModelService.test.ts
@@ -9,7 +9,7 @@ import * as workos from "../auth/workos.js";
 import { AuthConfig } from "../auth/workos.js";
 import * as config from "../config.js";
 
-import { ModelService } from "./ModelService.js";
+import { ModelService, expandAutodetectModels } from "./ModelService.js";
 
 describe("ModelService", () => {
   let service: ModelService;
@@ -364,6 +364,196 @@ describe("ModelService", () => {
         "Failed to initialize LLM",
       );
       expect(errorListener).toHaveBeenCalledWith(expect.any(Error));
+    });
+  });
+
+  describe("expandAutodetectModels()", () => {
+    test("expands AUTODETECT into concrete models", async () => {
+      const autodetectModel: ModelConfig = {
+        provider: "ollama",
+        model: "AUTODETECT",
+        apiBase: "http://localhost:11434",
+        roles: ["chat"],
+      } as ModelConfig;
+
+      const mockLlmApi = {
+        list: vi.fn().mockResolvedValue([
+          { id: "llama3", object: "model", owned_by: "ollama" },
+          { id: "mistral", object: "model", owned_by: "ollama" },
+        ]),
+      };
+
+      vi.mocked(config.createLlmApi).mockReturnValue(mockLlmApi as any);
+
+      const result = await expandAutodetectModels(
+        [autodetectModel],
+        mockAuthConfig,
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        ...autodetectModel,
+        model: "llama3",
+        name: "llama3",
+      });
+      expect(result[1]).toEqual({
+        ...autodetectModel,
+        model: "mistral",
+        name: "mistral",
+      });
+    });
+
+    test("passes through non-AUTODETECT models unchanged", async () => {
+      const gpt4Model: ModelConfig = {
+        provider: "openai",
+        model: "gpt-4",
+        name: "GPT-4",
+        apiKey: "test-key",
+        roles: ["chat"],
+      } as ModelConfig;
+
+      vi.mocked(config.createLlmApi).mockReturnValue(mockLlmApi as any);
+
+      const result = await expandAutodetectModels([gpt4Model], mockAuthConfig);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(gpt4Model);
+    });
+
+    test("handles list() failure gracefully", async () => {
+      const autodetectModel: ModelConfig = {
+        provider: "ollama",
+        model: "AUTODETECT",
+        apiBase: "http://localhost:11434",
+        roles: ["chat"],
+      } as ModelConfig;
+
+      const mockLlmApi = {
+        list: vi.fn().mockRejectedValue(new Error("Connection failed")),
+      };
+
+      vi.mocked(config.createLlmApi).mockReturnValue(mockLlmApi as any);
+
+      const result = await expandAutodetectModels(
+        [autodetectModel],
+        mockAuthConfig,
+      );
+
+      // AUTODETECT entry should be skipped when list() fails
+      expect(result).toHaveLength(0);
+    });
+
+    test("handles empty list() results", async () => {
+      const autodetectModel: ModelConfig = {
+        provider: "ollama",
+        model: "AUTODETECT",
+        apiBase: "http://localhost:11434",
+        roles: ["chat"],
+      } as ModelConfig;
+
+      const mockLlmApi = {
+        list: vi.fn().mockResolvedValue([]),
+      };
+
+      vi.mocked(config.createLlmApi).mockReturnValue(mockLlmApi as any);
+
+      const result = await expandAutodetectModels(
+        [autodetectModel],
+        mockAuthConfig,
+      );
+
+      // AUTODETECT entry should be skipped when no models are returned
+      expect(result).toHaveLength(0);
+    });
+
+    test("filters out AUTODETECT from list results", async () => {
+      const autodetectModel: ModelConfig = {
+        provider: "ollama",
+        model: "AUTODETECT",
+        apiBase: "http://localhost:11434",
+        roles: ["chat"],
+      } as ModelConfig;
+
+      const mockLlmApi = {
+        list: vi.fn().mockResolvedValue([
+          { id: "AUTODETECT", object: "model", owned_by: "ollama" },
+          { id: "real-model", object: "model", owned_by: "ollama" },
+        ]),
+      };
+
+      vi.mocked(config.createLlmApi).mockReturnValue(mockLlmApi as any);
+
+      const result = await expandAutodetectModels(
+        [autodetectModel],
+        mockAuthConfig,
+      );
+
+      // Only real-model should appear, AUTODETECT should be filtered
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        ...autodetectModel,
+        model: "real-model",
+        name: "real-model",
+      });
+    });
+
+    test("handles mixed AUTODETECT and non-AUTODETECT models", async () => {
+      const autodetectModel: ModelConfig = {
+        provider: "ollama",
+        model: "AUTODETECT",
+        apiBase: "http://localhost:11434",
+        roles: ["chat"],
+      } as ModelConfig;
+
+      const gpt4Model: ModelConfig = {
+        provider: "openai",
+        model: "gpt-4",
+        name: "GPT-4",
+        apiKey: "test-key",
+        roles: ["chat"],
+      } as ModelConfig;
+
+      const mockLlmApi = {
+        list: vi
+          .fn()
+          .mockResolvedValue([
+            { id: "llama3", object: "model", owned_by: "ollama" },
+          ]),
+      };
+
+      vi.mocked(config.createLlmApi).mockReturnValue(mockLlmApi as any);
+
+      const result = await expandAutodetectModels(
+        [autodetectModel, gpt4Model],
+        mockAuthConfig,
+      );
+
+      // Should have the expanded llama3 and the unchanged gpt-4
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        ...autodetectModel,
+        model: "llama3",
+        name: "llama3",
+      });
+      expect(result[1]).toBe(gpt4Model);
+    });
+
+    test("handles createLlmApi returning null", async () => {
+      const autodetectModel: ModelConfig = {
+        provider: "invalid-provider",
+        model: "AUTODETECT",
+        roles: ["chat"],
+      } as ModelConfig;
+
+      vi.mocked(config.createLlmApi).mockReturnValue(null as any);
+
+      const result = await expandAutodetectModels(
+        [autodetectModel],
+        mockAuthConfig,
+      );
+
+      // AUTODETECT entry should be skipped when createLlmApi returns null
+      expect(result).toHaveLength(0);
     });
   });
 });

--- a/extensions/cli/src/services/ModelService.ts
+++ b/extensions/cli/src/services/ModelService.ts
@@ -111,7 +111,7 @@ export class ModelService
     this.authConfig = authConfig;
 
     // Expand AUTODETECT model entries into concrete models
-    if (assistant.models) {
+    if (assistant.models?.some((m) => m?.model === AUTODETECT)) {
       assistant = {
         ...assistant,
         models: await expandAutodetectModels(

--- a/extensions/cli/src/services/ModelService.ts
+++ b/extensions/cli/src/services/ModelService.ts
@@ -7,6 +7,65 @@ import { logger } from "../util/logger.js";
 import { BaseService, ServiceWithDependencies } from "./BaseService.js";
 import { AgentFileServiceState, ModelServiceState } from "./types.js";
 
+const AUTODETECT = "AUTODETECT";
+
+/**
+ * Expands AUTODETECT model entries into concrete models
+ * For each model with model === "AUTODETECT", calls llm.list() to get available models
+ * and replaces the AUTODETECT entry with one ModelConfig per available model.
+ * Handles errors gracefully by skipping failed expansions with a warning.
+ */
+export async function expandAutodetectModels(
+  models: ModelConfig[],
+  authConfig: AuthConfig,
+): Promise<ModelConfig[]> {
+  const expanded: ModelConfig[] = [];
+
+  for (const model of models) {
+    if (model.model !== AUTODETECT) {
+      expanded.push(model);
+      continue;
+    }
+
+    const llmApi = createLlmApi(model, authConfig);
+    if (!llmApi) {
+      logger.warn(
+        `Cannot create API client for AUTODETECT model with provider ${model.provider}, skipping`,
+      );
+      continue;
+    }
+
+    try {
+      const availableModels = await llmApi.list();
+      if (!availableModels || availableModels.length === 0) {
+        logger.warn(
+          `No models returned from ${model.provider} for AUTODETECT, skipping`,
+        );
+        continue;
+      }
+
+      for (const available of availableModels) {
+        if (available.id === AUTODETECT) continue;
+        expanded.push({
+          ...model,
+          model: available.id,
+          name: available.id,
+        });
+      }
+
+      logger.debug(
+        `Expanded AUTODETECT for ${model.provider}: ${availableModels.map((m) => m.id).join(", ")}`,
+      );
+    } catch (e) {
+      logger.warn(
+        `Error listing models for AUTODETECT expansion (${model.provider}): ${e}`,
+      );
+    }
+  }
+
+  return expanded;
+}
+
 /**
  * Service for managing LLM and model state
  * Depends on auth config and assistant config
@@ -49,8 +108,20 @@ export class ModelService
       assistantModelsCount: assistant?.models?.length || 0,
     });
 
-    this.assistant = assistant;
     this.authConfig = authConfig;
+
+    // Expand AUTODETECT model entries into concrete models
+    if (assistant.models) {
+      assistant = {
+        ...assistant,
+        models: await expandAutodetectModels(
+          assistant.models.filter((m): m is ModelConfig => !!m),
+          authConfig,
+        ),
+      };
+    }
+
+    this.assistant = assistant;
     this.availableModels = (assistant.models?.filter(
       (model) =>
         model && (model.roles?.includes("chat") || model.roles === undefined),


### PR DESCRIPTION
## Summary

Fixes #12633

The CLI does not expand `AUTODETECT` model entries into actual model names before sending API requests. When a user configures Ollama (or any provider) with `model: AUTODETECT` in their config, the VS Code and JetBrains extensions call `listModels()` to discover available models and replace the placeholder. The CLI skips this step entirely, sending literal `"AUTODETECT"` as the model name in chat completion requests, which causes 400 errors from the provider.

## Root cause

The CLI has its own config loading pipeline (`configLoader.ts` -> `ModelService.ts`) that is separate from the extension path (`core/config/load.ts`, `core/config/yaml/models.ts`). The extension path checks for `model === "AUTODETECT"` and calls `listModels()` to expand it into real model entries. The CLI's `ModelService.doInitialize()` passes the raw `ModelConfig[]` from the unrolled assistant config directly to `createLlmApi()` without checking for or expanding AUTODETECT entries.

## Changes

- Add `expandAutodetectModels()` to `ModelService.ts` that iterates model configs, detects entries with `model: "AUTODETECT"`, creates a temporary LLM API client, calls `list()` to discover available models, and replaces each AUTODETECT entry with concrete model configs
- Call expansion during `doInitialize()` before model filtering and selection
- Match the extension behavior: log a warning and skip gracefully if model listing fails
- Add unit tests covering successful expansion, failed listing, empty results, and non-AUTODETECT passthrough

## What this doesn't change

- The extension path AUTODETECT logic in `core/config/load.ts` and `core/config/yaml/models.ts` is untouched
- No changes to the config YAML schema or config loading pipeline
- No changes to the openai-adapters package
- Tab autocomplete model handling is unaffected

## Checklist

- [ ] Code follows project conventions
- [ ] Tests pass locally
- [ ] Prettier formatting verified
- [ ] No unrelated changes included

## Tests

- `extensions/cli/src/services/ModelService.test.ts` - new test cases for AUTODETECT expansion
- Manual test: configure Ollama with `model: AUTODETECT` in `~/.continue/config.yaml`, run `continue chat`, verify models are listed and requests succeed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The CLI now expands `AUTODETECT` model entries into real model names before calling providers, matching extension behavior and preventing 400 errors when using sources like Ollama.

- **Bug Fixes**
  - Added `expandAutodetectModels()` in `ModelService.ts` to resolve `AUTODETECT` via `list()` and replace with concrete model configs.
  - Hooked into `doInitialize()` before model filtering/selection; skips work if no `AUTODETECT` entries.
  - Logs a warning and skips on failures or empty results; filters out `AUTODETECT` from provider responses.
  - Added unit tests for success, passthrough, failures, empty results, and mixed configs.

<sup>Written for commit 30511791dd42d9d236fc5ba593aba17277778f0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

