### PR TITLE
Add session trace markdown renderer

### DIFF
--- a/core/util/sessionTrace.test.ts
+++ b/core/util/sessionTrace.test.ts
@@ -1,0 +1,215 @@
+import { Session } from "../index.js";
+import { sessionToTraceMarkdown } from "./sessionTrace.js";
+
+const createdAt = new Date("2026-06-18T12:00:00.000Z");
+
+function render(history: Session["history"]) {
+  return sessionToTraceMarkdown(
+    {
+      sessionId: "session-123",
+      title: "Trace Test",
+      workspaceDirectory: "/workspace",
+      history,
+    },
+    { createdAt },
+  );
+}
+
+describe("sessionToTraceMarkdown", () => {
+  it("renders deterministic session frontmatter and basic message events", () => {
+    const trace = render([
+      {
+        message: {
+          role: "user",
+          content: "Fix the auth tests",
+        },
+        contextItems: [
+          {
+            id: { providerTitle: "file", itemId: "auth.ts" },
+            name: "auth.ts",
+            description: "src/auth.ts",
+            content: "export function auth() {}",
+          },
+        ],
+      },
+      {
+        message: {
+          role: "assistant",
+          content: "I'll inspect the failing tests.",
+        },
+        contextItems: [],
+      },
+    ]);
+
+    expect(trace).toContain("traceVersion: 1");
+    expect(trace).toContain('sessionId: "session-123"');
+    expect(trace).toContain('createdAt: "2026-06-18T12:00:00.000Z"');
+    expect(trace).toContain("messageCount: 2");
+    expect(trace).toContain("## 001 user_message");
+    expect(trace).toContain("Fix the auth tests");
+    expect(trace).toContain("Context:\n- auth.ts - src/auth.ts");
+    expect(trace).toContain("## 002 assistant_message");
+    expect(trace).toContain("I'll inspect the failing tests.");
+  });
+
+  it("renders reasoning and redacted thinking events", () => {
+    const trace = render([
+      {
+        message: {
+          role: "assistant",
+          content: "Answer after thinking",
+        },
+        contextItems: [],
+        reasoning: {
+          active: false,
+          text: "Private chain of thought",
+          startAt: 1,
+          endAt: 2,
+        },
+      },
+      {
+        message: {
+          role: "thinking",
+          content: "",
+          redactedThinking: "encrypted",
+        },
+        contextItems: [],
+      },
+    ]);
+
+    expect(trace).toContain("## 002 reasoning\n\nPrivate chain of thought");
+    expect(trace).toContain("## 003 reasoning\n\n[redacted]");
+  });
+
+  it("renders conversation summaries as summary events", () => {
+    const trace = render([
+      {
+        message: {
+          role: "assistant",
+          content: "Compacted previous work.",
+        },
+        contextItems: [],
+        conversationSummary: "The previous conversation fixed auth setup.",
+      },
+    ]);
+
+    expect(trace).toContain("## 001 assistant_message");
+    expect(trace).toContain(
+      "## 002 summary\n\nThe previous conversation fixed auth setup.",
+    );
+  });
+
+  it("separates tool calls from successful tool results", () => {
+    const trace = render([
+      {
+        message: {
+          role: "assistant",
+          content: "",
+          toolCalls: [
+            {
+              id: "tool-1",
+              type: "function",
+              function: {
+                name: "runTerminalCommand",
+                arguments: '{"cmd":"npm test"}',
+              },
+            },
+          ],
+        },
+        contextItems: [],
+        toolCallStates: [
+          {
+            toolCallId: "tool-1",
+            toolCall: {
+              id: "tool-1",
+              type: "function",
+              function: {
+                name: "runTerminalCommand",
+                arguments: '{"cmd":"npm test"}',
+              },
+            },
+            status: "done",
+            parsedArgs: { cmd: "npm test" },
+          },
+        ],
+      },
+      {
+        message: {
+          role: "tool",
+          toolCallId: "tool-1",
+          content: "Tests passed",
+        },
+        contextItems: [],
+      },
+    ]);
+
+    expect(trace).toContain("## 001 tool_call: runTerminalCommand");
+    expect(trace).toContain('"cmd": "npm test"');
+    expect(trace).toContain("## 002 tool_result: runTerminalCommand");
+    expect(trace).toContain("Success: true");
+    expect(trace).toContain("Output:\nTests passed");
+    expect(trace).not.toContain("Status: done");
+  });
+
+  it("puts failed tool output only in tool_result", () => {
+    const trace = render([
+      {
+        message: {
+          role: "assistant",
+          content: "",
+        },
+        contextItems: [],
+        toolCallStates: [
+          {
+            toolCallId: "tool-1",
+            toolCall: {
+              id: "tool-1",
+              type: "function",
+              function: {
+                name: "runTerminalCommand",
+                arguments: '{"cmd":"npm test"}',
+              },
+            },
+            status: "errored",
+            parsedArgs: { cmd: "npm test" },
+            output: [
+              {
+                name: "Tool Call Error",
+                description: "Tool Call Failed",
+                content: "runTerminalCommand failed with exit code 1",
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    const toolCallSection = trace.slice(
+      trace.indexOf("## 001 tool_call"),
+      trace.indexOf("## 002 tool_result"),
+    );
+    expect(toolCallSection).not.toContain("Success:");
+    expect(toolCallSection).not.toContain("failed with exit code 1");
+    expect(trace).toContain("## 002 tool_result: runTerminalCommand");
+    expect(trace).toContain("Success: false");
+    expect(trace).toContain("runTerminalCommand failed with exit code 1");
+  });
+
+  it("renders unknown success for tool results without matching tool call state", () => {
+    const trace = render([
+      {
+        message: {
+          role: "tool",
+          toolCallId: "missing-tool-state",
+          content: "Detached tool output",
+        },
+        contextItems: [],
+      },
+    ]);
+
+    expect(trace).toContain("## 001 tool_result: unknownTool");
+    expect(trace).toContain("Tool Call ID: missing-tool-state");
+    expect(trace).toContain("Success: unknown");
+    expect(trace).toContain("Detached tool output");
+  });
+});

--- a/core/util/sessionTrace.test.ts
+++ b/core/util/sessionTrace.test.ts
@@ -11,7 +11,7 @@ function render(history: Session["history"]) {
       workspaceDirectory: "/workspace",
       history,
     },
-    { createdAt },
+    { traceCreatedAt: createdAt },
   );
 }
 
@@ -43,7 +43,7 @@ describe("sessionToTraceMarkdown", () => {
 
     expect(trace).toContain("traceVersion: 1");
     expect(trace).toContain('sessionId: "session-123"');
-    expect(trace).toContain('createdAt: "2026-06-18T12:00:00.000Z"');
+    expect(trace).toContain('traceCreatedAt: "2026-06-18T12:00:00.000Z"');
     expect(trace).toContain("messageCount: 2");
     expect(trace).toContain("## 001 user_message");
     expect(trace).toContain("Fix the auth tests");
@@ -211,5 +211,68 @@ describe("sessionToTraceMarkdown", () => {
     expect(trace).toContain("Tool Call ID: missing-tool-state");
     expect(trace).toContain("Success: unknown");
     expect(trace).toContain("Detached tool output");
+  });
+
+  it("renders unknown success for incomplete tool call states", () => {
+    const trace = render([
+      {
+        message: {
+          role: "assistant",
+          content: "",
+        },
+        contextItems: [],
+        toolCallStates: [
+          {
+            toolCallId: "tool-1",
+            toolCall: {
+              id: "tool-1",
+              type: "function",
+              function: {
+                name: "runTerminalCommand",
+                arguments: '{"cmd":"npm test"}',
+              },
+            },
+            status: "calling",
+            parsedArgs: { cmd: "npm test" },
+            output: [
+              {
+                name: "Partial output",
+                description: "Still running",
+                content: "Command started",
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    expect(trace).toContain("## 002 tool_result: runTerminalCommand");
+    expect(trace).toContain("Success: unknown");
+    expect(trace).toContain("Command started");
+  });
+
+  it("does not label non-json tool args as json", () => {
+    const trace = render([
+      {
+        message: {
+          role: "assistant",
+          content: "",
+          toolCalls: [
+            {
+              id: "tool-1",
+              type: "function",
+              function: {
+                name: "legacyTool",
+                arguments: "not json",
+              },
+            },
+          ],
+        },
+        contextItems: [],
+      },
+    ]);
+
+    expect(trace).toContain("Args:\n\n```\nnot json\n```");
+    expect(trace).not.toContain("```json\nnot json");
   });
 });

--- a/core/util/sessionTrace.ts
+++ b/core/util/sessionTrace.ts
@@ -19,7 +19,12 @@ export type SessionTraceEventType =
 type ToolCallState = NonNullable<ChatHistoryItem["toolCallStates"]>[number];
 
 export interface SessionTraceOptions {
-  createdAt?: Date;
+  traceCreatedAt?: Date;
+}
+
+interface FormattedToolArgs {
+  content: string;
+  language?: "json";
 }
 
 function formatDate(date: Date): string {
@@ -36,14 +41,14 @@ function countMessages(session: Session): number {
   ).length;
 }
 
-function frontmatter(session: Session, createdAt: Date): string {
+function frontmatter(session: Session, traceCreatedAt: Date): string {
   return [
     "---",
     `traceVersion: ${SESSION_TRACE_VERSION}`,
     `sessionId: ${yamlString(session.sessionId)}`,
     `title: ${yamlString(session.title)}`,
     `workspaceDirectory: ${yamlString(session.workspaceDirectory)}`,
-    `createdAt: ${yamlString(formatDate(createdAt))}`,
+    `traceCreatedAt: ${yamlString(formatDate(traceCreatedAt))}`,
     `messageCount: ${countMessages(session)}`,
     "---",
   ].join("\n");
@@ -72,20 +77,26 @@ function formatContextItems(contextItems: ContextItem[]): string {
   ].join("\n");
 }
 
-function formatJsonBlock(value: unknown): string {
+function formatToolArgs(value: unknown): FormattedToolArgs | undefined {
   if (value === undefined) {
-    return "";
+    return undefined;
   }
 
   if (typeof value === "string") {
     try {
-      return JSON.stringify(JSON.parse(value), undefined, 2);
+      return {
+        content: JSON.stringify(JSON.parse(value), undefined, 2),
+        language: "json",
+      };
     } catch {
-      return value;
+      return { content: value };
     }
   }
 
-  return JSON.stringify(value, undefined, 2);
+  return {
+    content: JSON.stringify(value, undefined, 2),
+    language: "json",
+  };
 }
 
 function getToolCallName(toolCallState?: ToolCallState, delta?: ToolCallDelta) {
@@ -113,7 +124,15 @@ function isSuccessfulToolCall(toolCallState?: ToolCallState): string {
     return "unknown";
   }
 
-  return toolCallState.status === "done" ? "true" : "false";
+  if (toolCallState.status === "done") {
+    return "true";
+  }
+
+  if (["errored", "canceled"].includes(toolCallState.status)) {
+    return "false";
+  }
+
+  return "unknown";
 }
 
 function toolOutputFromContextItems(contextItems: ContextItem[] | undefined) {
@@ -158,7 +177,7 @@ export function sessionToTraceMarkdown(
   session: Session,
   options: SessionTraceOptions = {},
 ): string {
-  const createdAt = options.createdAt ?? new Date();
+  const traceCreatedAt = options.traceCreatedAt ?? new Date();
   const toolCallStates = collectToolCallStates(session.history);
   const toolMessageIds = collectToolMessageIds(session.history);
   const events: string[] = [];
@@ -209,14 +228,14 @@ export function sessionToTraceMarkdown(
       for (const [toolCallState, delta] of toolCallEntries) {
         const toolName = getToolCallName(toolCallState, delta);
         const toolCallId = getToolCallId(toolCallState, delta);
-        const args = formatJsonBlock(getToolCallArgs(toolCallState, delta));
+        const args = formatToolArgs(getToolCallArgs(toolCallState, delta));
+        const argsFence = args
+          ? `Args:\n\n\`\`\`${args.language ?? ""}\n${args.content}\n\`\`\``
+          : "";
 
         addEvent(
           "tool_call",
-          [
-            toolCallId ? `Tool Call ID: ${toolCallId}` : "",
-            args ? `Args:\n\n\`\`\`json\n${args}\n\`\`\`` : "",
-          ]
+          [toolCallId ? `Tool Call ID: ${toolCallId}` : "", argsFence]
             .filter(Boolean)
             .join("\n\n"),
           toolName,
@@ -261,7 +280,7 @@ export function sessionToTraceMarkdown(
   }
 
   return [
-    frontmatter(session, createdAt),
+    frontmatter(session, traceCreatedAt),
     "",
     `# Session: ${session.title}`,
     "",

--- a/core/util/sessionTrace.ts
+++ b/core/util/sessionTrace.ts
@@ -1,0 +1,272 @@
+import {
+  ChatHistoryItem,
+  ContextItem,
+  Session,
+  ToolCallDelta,
+} from "../index.js";
+import { renderChatMessage, renderContextItems } from "./messageContent.js";
+
+export const SESSION_TRACE_VERSION = 1;
+
+export type SessionTraceEventType =
+  | "user_message"
+  | "assistant_message"
+  | "reasoning"
+  | "tool_call"
+  | "tool_result"
+  | "summary";
+
+type ToolCallState = NonNullable<ChatHistoryItem["toolCallStates"]>[number];
+
+export interface SessionTraceOptions {
+  createdAt?: Date;
+}
+
+function formatDate(date: Date): string {
+  return date.toISOString();
+}
+
+function yamlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function countMessages(session: Session): number {
+  return session.history.filter((item) =>
+    ["user", "assistant", "thinking", "tool"].includes(item.message.role),
+  ).length;
+}
+
+function frontmatter(session: Session, createdAt: Date): string {
+  return [
+    "---",
+    `traceVersion: ${SESSION_TRACE_VERSION}`,
+    `sessionId: ${yamlString(session.sessionId)}`,
+    `title: ${yamlString(session.title)}`,
+    `workspaceDirectory: ${yamlString(session.workspaceDirectory)}`,
+    `createdAt: ${yamlString(formatDate(createdAt))}`,
+    `messageCount: ${countMessages(session)}`,
+    "---",
+  ].join("\n");
+}
+
+function heading(
+  eventNumber: number,
+  eventType: SessionTraceEventType,
+  label?: string,
+): string {
+  const index = String(eventNumber).padStart(3, "0");
+  return `## ${index} ${eventType}${label ? `: ${label}` : ""}`;
+}
+
+function formatContextItems(contextItems: ContextItem[]): string {
+  if (!contextItems.length) {
+    return "";
+  }
+
+  return [
+    "Context:",
+    ...contextItems.map((item) => {
+      const description = item.description ? ` - ${item.description}` : "";
+      return `- ${item.name}${description}`;
+    }),
+  ].join("\n");
+}
+
+function formatJsonBlock(value: unknown): string {
+  if (value === undefined) {
+    return "";
+  }
+
+  if (typeof value === "string") {
+    try {
+      return JSON.stringify(JSON.parse(value), undefined, 2);
+    } catch {
+      return value;
+    }
+  }
+
+  return JSON.stringify(value, undefined, 2);
+}
+
+function getToolCallName(toolCallState?: ToolCallState, delta?: ToolCallDelta) {
+  return (
+    toolCallState?.toolCall.function.name ??
+    delta?.function?.name ??
+    "unknownTool"
+  );
+}
+
+function getToolCallId(toolCallState?: ToolCallState, delta?: ToolCallDelta) {
+  return toolCallState?.toolCallId ?? delta?.id;
+}
+
+function getToolCallArgs(toolCallState?: ToolCallState, delta?: ToolCallDelta) {
+  return (
+    toolCallState?.processedArgs ??
+    toolCallState?.parsedArgs ??
+    delta?.function?.arguments
+  );
+}
+
+function isSuccessfulToolCall(toolCallState?: ToolCallState): string {
+  if (!toolCallState) {
+    return "unknown";
+  }
+
+  return toolCallState.status === "done" ? "true" : "false";
+}
+
+function toolOutputFromContextItems(contextItems: ContextItem[] | undefined) {
+  if (!contextItems?.length) {
+    return "";
+  }
+
+  return renderContextItems(contextItems);
+}
+
+function createEvent(
+  eventNumber: number,
+  eventType: SessionTraceEventType,
+  body: string,
+  label?: string,
+): string {
+  const trimmedBody = body.trim();
+  return `${heading(eventNumber, eventType, label)}\n\n${trimmedBody}`;
+}
+
+function collectToolCallStates(history: ChatHistoryItem[]) {
+  const toolCallStates = new Map<string, ToolCallState>();
+  for (const item of history) {
+    for (const toolCallState of item.toolCallStates ?? []) {
+      toolCallStates.set(toolCallState.toolCallId, toolCallState);
+    }
+  }
+  return toolCallStates;
+}
+
+function collectToolMessageIds(history: ChatHistoryItem[]) {
+  const toolMessageIds = new Set<string>();
+  for (const item of history) {
+    if (item.message.role === "tool") {
+      toolMessageIds.add(item.message.toolCallId);
+    }
+  }
+  return toolMessageIds;
+}
+
+export function sessionToTraceMarkdown(
+  session: Session,
+  options: SessionTraceOptions = {},
+): string {
+  const createdAt = options.createdAt ?? new Date();
+  const toolCallStates = collectToolCallStates(session.history);
+  const toolMessageIds = collectToolMessageIds(session.history);
+  const events: string[] = [];
+  let eventNumber = 1;
+
+  const addEvent = (
+    eventType: SessionTraceEventType,
+    body: string,
+    label?: string,
+  ) => {
+    events.push(createEvent(eventNumber, eventType, body, label));
+    eventNumber += 1;
+  };
+
+  for (const item of session.history) {
+    const messageText = renderChatMessage(item.message);
+
+    if (item.message.role === "user") {
+      const context = formatContextItems(item.contextItems);
+      addEvent(
+        "user_message",
+        [messageText, context].filter(Boolean).join("\n\n"),
+      );
+    } else if (item.message.role === "assistant") {
+      if (messageText.trim()) {
+        addEvent("assistant_message", messageText);
+      }
+
+      if (item.reasoning?.text.trim()) {
+        addEvent("reasoning", item.reasoning.text);
+      }
+
+      const toolCallDeltasById = new Map<string, ToolCallDelta>();
+      for (const delta of item.message.toolCalls ?? []) {
+        if (delta.id) {
+          toolCallDeltasById.set(delta.id, delta);
+        }
+      }
+
+      const toolCallEntries: [ToolCallState | undefined, ToolCallDelta?][] =
+        item.toolCallStates?.length
+          ? item.toolCallStates.map((state) => [
+              state,
+              toolCallDeltasById.get(state.toolCallId),
+            ])
+          : (item.message.toolCalls ?? []).map((delta) => [undefined, delta]);
+
+      for (const [toolCallState, delta] of toolCallEntries) {
+        const toolName = getToolCallName(toolCallState, delta);
+        const toolCallId = getToolCallId(toolCallState, delta);
+        const args = formatJsonBlock(getToolCallArgs(toolCallState, delta));
+
+        addEvent(
+          "tool_call",
+          [
+            toolCallId ? `Tool Call ID: ${toolCallId}` : "",
+            args ? `Args:\n\n\`\`\`json\n${args}\n\`\`\`` : "",
+          ]
+            .filter(Boolean)
+            .join("\n\n"),
+          toolName,
+        );
+
+        const output = toolOutputFromContextItems(toolCallState?.output);
+        if (toolCallId && output && !toolMessageIds.has(toolCallId)) {
+          addEvent(
+            "tool_result",
+            [
+              `Success: ${isSuccessfulToolCall(toolCallState)}`,
+              `Output:\n${output}`,
+            ]
+              .filter(Boolean)
+              .join("\n\n"),
+            toolName,
+          );
+        }
+      }
+    } else if (item.message.role === "thinking") {
+      addEvent(
+        "reasoning",
+        item.message.redactedThinking ? "[redacted]" : messageText,
+      );
+    } else if (item.message.role === "tool") {
+      const toolCallState = toolCallStates.get(item.message.toolCallId);
+      const toolName = getToolCallName(toolCallState);
+      addEvent(
+        "tool_result",
+        [
+          `Tool Call ID: ${item.message.toolCallId}`,
+          `Success: ${isSuccessfulToolCall(toolCallState)}`,
+          `Output:\n${messageText}`,
+        ].join("\n\n"),
+        toolName,
+      );
+    }
+
+    if (item.conversationSummary?.trim()) {
+      addEvent("summary", item.conversationSummary);
+    }
+  }
+
+  return [
+    frontmatter(session, createdAt),
+    "",
+    `# Session: ${session.title}`,
+    "",
+    ...events.flatMap((event) => [event, ""]),
+  ]
+    .join("\n")
+    .trimEnd();
+}


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Markdown renderer for session traces that outputs a deterministic document with frontmatter and numbered events. This makes sessions easy to export, read, and debug.

- **New Features**
  - Introduces `sessionToTraceMarkdown(session, { traceCreatedAt })` in `core/util/sessionTrace.ts`.
  - Emits frontmatter with `traceVersion`, `sessionId`, `title`, `workspaceDirectory`, `traceCreatedAt`, `messageCount`.
  - Renders events: `user_message`, `assistant_message`, `reasoning` (redacts thinking), `tool_call` (fenced args; JSON when parseable), `tool_result` with `Success: true|false|unknown`, plus `summary`.
  - Associates tool results via `toolCallStates`/`toolCallId`, includes context-based output when no tool message exists, and handles unknown tool names/ids.
  - Adds tests in `core/util/sessionTrace.test.ts` for frontmatter determinism, redaction, tool call/result mapping, failures, and non-JSON args.

<sup>Written for commit 0da8a4cb0ee157ceb45a642888fc2d411102bf31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

