### PR TITLE
feat: add Aivene as an OpenAI-compatible LLM provider

### DIFF
--- a/core/llm/autodetect.ts
+++ b/core/llm/autodetect.ts
@@ -74,6 +74,7 @@ const PROVIDER_HANDLES_TEMPLATING: string[] = [
   "nous",
   "zAI",
   "tensorix",
+  "aivene",
   // TODO add these, change to inverted logic so only the ones that need templating are hardcoded
   // Asksage.ts
   // Azure.ts
@@ -133,6 +134,7 @@ const PROVIDER_SUPPORTS_IMAGES: string[] = [
   "watsonx",
   "zAI",
   "tensorix",
+  "aivene",
 ];
 
 const MODEL_SUPPORTS_IMAGES: RegExp[] = [
@@ -253,6 +255,7 @@ const PARALLEL_PROVIDERS: string[] = [
   "scaleway",
   "minimax",
   "tensorix",
+  "aivene",
 ];
 
 function llmCanGenerateInParallel(provider: string, model: string): boolean {
@@ -533,5 +536,5 @@ export {
   llmCanGenerateInParallel,
   modelSupportsImages,
   modelSupportsNextEdit,
-  modelSupportsReasoning,
+  modelSupportsReasoning
 };

--- a/core/llm/llms/Aivene.ts
+++ b/core/llm/llms/Aivene.ts
@@ -1,0 +1,14 @@
+import OpenAI from "./OpenAI.js";
+
+import type { LLMOptions } from "../../index.js";
+
+class Aivene extends OpenAI {
+  static providerName = "aivene";
+  protected supportsReasoningContentField = true;
+  static defaultOptions: Partial<LLMOptions> = {
+    apiBase: "https://api.aivene.com/v1/",
+    useLegacyCompletionsEndpoint: false,
+  };
+}
+
+export default Aivene;

--- a/core/llm/llms/index.ts
+++ b/core/llm/llms/index.ts
@@ -9,12 +9,14 @@ import {
 } from "../..";
 import { renderTemplatedString } from "../../util/handlebars/renderTemplatedString";
 import { BaseLLM } from "../index";
+import Aivene from "./Aivene";
 import Anthropic from "./Anthropic";
 import Asksage from "./Asksage";
 import Azure from "./Azure";
 import Bedrock from "./Bedrock";
 import BedrockImport from "./BedrockImport";
 import Cerebras from "./Cerebras";
+import ClawRouter from "./ClawRouter";
 import Cloudflare from "./Cloudflare";
 import Cohere from "./Cohere";
 import CometAPI from "./CometAPI";
@@ -31,14 +33,14 @@ import HuggingFaceTEIEmbeddingsProvider from "./HuggingFaceTEI";
 import HuggingFaceTGI from "./HuggingFaceTGI";
 import Inception from "./Inception";
 import Kindo from "./Kindo";
+import Lemonade from "./Lemonade";
 import LlamaCpp from "./LlamaCpp";
 import Llamafile from "./Llamafile";
 import LlamaStack from "./LlamaStack";
-import Lemonade from "./Lemonade";
 import LMStudio from "./LMStudio";
-import Mistral from "./Mistral";
 import Mimo from "./Mimo";
 import MiniMax from "./MiniMax";
+import Mistral from "./Mistral";
 import MockLLM from "./Mock";
 import Moonshot from "./Moonshot";
 import Msty from "./Msty";
@@ -50,7 +52,6 @@ import Nvidia from "./Nvidia";
 import Ollama from "./Ollama";
 import OpenAI from "./OpenAI";
 import OpenRouter from "./OpenRouter";
-import ClawRouter from "./ClawRouter";
 import OVHcloud from "./OVHcloud";
 import { Relace } from "./Relace";
 import Replicate from "./Replicate";
@@ -58,8 +59,8 @@ import SageMaker from "./SageMaker";
 import SambaNova from "./SambaNova";
 import Scaleway from "./Scaleway";
 import SiliconFlow from "./SiliconFlow";
-import Tensorix from "./Tensorix";
 import TARS from "./TARS";
+import Tensorix from "./Tensorix";
 import TestLLM from "./Test";
 import TextGenWebUI from "./TextGenWebUI";
 import Together from "./Together";
@@ -71,6 +72,7 @@ import WatsonX from "./WatsonX";
 import xAI from "./xAI";
 import zAI from "./zAI";
 export const LLMClasses = [
+  Aivene,
   Anthropic,
   Cohere,
   CometAPI,

--- a/docs/customize/model-providers/more/aivene.mdx
+++ b/docs/customize/model-providers/more/aivene.mdx
@@ -1,0 +1,124 @@
+---
+title: "Aivene"
+description: "Configure Aivene with Continue to access various LLM models through a unified AI gateway"
+---
+
+[Aivene](https://aivene.com) is an AI gateway that provides access to various LLM models including GPT-4o, Claude, DeepSeek, Gemini, Llama, and many more through a single unified OpenAI-compatible API. Browse all available models at [platform.aivene.com/models](https://platform.aivene.com/models).
+
+<Info>
+  You can get an API key from
+  [platform.aivene.com](https://platform.aivene.com).
+</Info>
+
+## Chat Model
+
+We recommend configuring **deepseek-v4-pro** as your chat model for complex reasoning and coding tasks.
+
+<Tabs>
+    <Tab title="YAML">
+    ```yaml title="config.yaml"
+    name: My Config
+    version: 0.0.1
+    schema: v1
+
+    models:
+      - name: DeepSeek V4 Pro
+        provider: aivene
+        model: deepseek-v4-pro
+        apiKey: <YOUR_AIVENE_API_KEY>
+        roles:
+          - chat
+    ```
+    </Tab>
+    <Tab title="JSON">
+    ```json title="config.json"
+    {
+      "models": [
+        {
+          "title": "DeepSeek V4 Pro",
+          "provider": "aivene",
+          "model": "deepseek-v4-pro",
+          "apiKey": "<YOUR_AIVENE_API_KEY>"
+        }
+      ]
+    }
+    ```
+    </Tab>
+</Tabs>
+
+## Autocomplete Model
+
+<Tabs>
+    <Tab title="YAML">
+    ```yaml title="config.yaml"
+    name: My Config
+    version: 0.0.1
+    schema: v1
+
+    models:
+      - name: GPT-4o Mini
+        provider: aivene
+        model: gpt-4o-mini
+        apiKey: <YOUR_AIVENE_API_KEY>
+        roles:
+          - autocomplete
+    ```
+    </Tab>
+    <Tab title="JSON">
+    ```json title="config.json"
+    {
+      "models": [
+        {
+          "title": "GPT-4o Mini",
+          "provider": "aivene",
+          "model": "gpt-4o-mini",
+          "apiKey": "<YOUR_AIVENE_API_KEY>"
+        }
+      ],
+      "tabAutocompleteModel": {
+        "title": "GPT-4o Mini",
+        "provider": "aivene",
+        "model": "gpt-4o-mini",
+        "apiKey": "<YOUR_AIVENE_API_KEY>"
+      }
+    }
+    ```
+    </Tab>
+</Tabs>
+
+## Embeddings Model
+
+Aivene provides access to various embedding models for semantic search, clustering, and RAG pipelines.
+
+<Tabs>
+    <Tab title="YAML">
+    ```yaml title="config.yaml"
+    name: My Config
+    version: 0.0.1
+    schema: v1
+
+    models:
+      - name: Text Embedding 3 Small
+        provider: aivene
+        model: text-embedding-3-small
+        apiKey: <YOUR_AIVENE_API_KEY>
+        roles:
+          - embed
+    ```
+    </Tab>
+    <Tab title="JSON">
+    ```json title="config.json"
+    {
+      "embeddingsProvider": {
+        "provider": "aivene",
+        "model": "text-embedding-3-small",
+        "apiKey": "<YOUR_AIVENE_API_KEY>"
+      }
+    }
+    ```
+    </Tab>
+</Tabs>
+
+Browse all available embedding models at [platform.aivene.com/models](https://platform.aivene.com/models) under the Embeddings tab.
+
+[View the source](https://github.com/continuedev/continue/blob/main/core/llm/llms/Aivene.ts)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -105,6 +105,7 @@
                   {
                     "group": "More Providers",
                     "pages": [
+                      "customize/model-providers/more/aivene",
                       "customize/model-providers/more/asksage",
                       "customize/model-providers/more/clawrouter",
                       "customize/model-providers/more/deepseek",

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -229,6 +229,7 @@
             "moonshot",
             "siliconflow",
             "tensorix",
+            "aivene",
             "function-network",
             "scaleway",
             "relace",
@@ -282,6 +283,7 @@
             "### Moonshot\nTo get started with Moonshot AI, obtain your API key from [Moonshot AI](https://platform.moonshot.cn/). Moonshot AI provides high-quality large language models with competitive pricing.\n> [Reference](https://platform.moonshot.cn/docs/api)",
             "### SiliconFlow\nTo get started with SiliconFlow, obtain your API key from [SiliconCloud](https://cloud.siliconflow.cn/account/ak). SiliconCloud provides cost-effective GenAI services based on excellent open source basic models.\n> [Models](https://siliconflow.cn/zh-cn/models)",
             "### Tensorix\nTensorix is an OpenAI-compatible API gateway with access to DeepSeek, Llama, Qwen, GLM, and other models. Pay-as-you-go with no subscription required.\nTo get started, create an account and get an API key at [app.tensorix.ai](https://app.tensorix.ai).\n> [Models](https://tensorix.ai/models)",
+            "### Aivene\nAivene is an AI gateway that provides access to various LLM models through a unified OpenAI-compatible API.\nTo get started, create an account and get an API key at [platform.aivene.com](https://platform.aivene.com).",
             "### Function Network offers private, affordable user-owned AI\nTo get started with Function Network, obtain your API key from [Function Network](https://www.function.network/join-waitlist). Function Network provides a variety of models for chat, completion, and embeddings.",
             "### Scaleway\n Generative APIs are serverless endpoints for the most popular AI models.\nHosted in European data centers and priced competitively per million tokens used, models served by Scaleway are ideal for users requiring low latency, full data privacy, and 100% compliance with EU AI Act. To get access to the Scaleway Generative APIs, read the [Quickstart guide](https://www.scaleway.com/en/docs/ai-data/generative-apis/quickstart/) and get a [valid API key](https://www.scaleway.com/en/docs/identity-and-access-management/iam/how-to/create-api-keys/).",
             "### Relace\n Relace provides a fast apply model. To get started, obtain an API key from [here](https://app.relace.ai/settings/api-keys).",
@@ -2871,6 +2873,7 @@
                 "lmstudio",
                 "siliconflow",
                 "tensorix",
+                "aivene",
                 "function-network",
                 "scaleway",
                 "ovhcloud"
@@ -2937,7 +2940,8 @@
                       "nvidia",
                       "gemini",
                       "siliconflow",
-                      "tensorix"
+                      "tensorix",
+                      "aivene"
                     ]
                   }
                 },
@@ -3006,7 +3010,8 @@
                 "llm",
                 "huggingface-tei",
                 "siliconflow",
-                "tensorix"
+                "tensorix",
+                "aivene"
               ]
             },
             "params": {

--- a/gui/src/pages/AddNewModel/configs/providers.ts
+++ b/gui/src/pages/AddNewModel/configs/providers.ts
@@ -1270,6 +1270,26 @@ To get started, [register](https://dataplatform.cloud.ibm.com/registration/stepo
     packages: [{ ...models.AUTODETECT }],
     apiKeyUrl: "https://app.tensorix.ai",
   },
+  aivene: {
+    title: "Aivene",
+    provider: "aivene",
+    description:
+      "Aivene is an AI gateway that provides access to various LLM models through a unified OpenAI-compatible API.",
+    longDescription:
+      "To get started with Aivene, create an account and get an API key at [platform.aivene.com](https://platform.aivene.com).",
+    tags: [ModelProviderTags.RequiresApiKey, ModelProviderTags.OpenSource],
+    collectInputFor: [
+      {
+        inputType: "text",
+        key: "apiKey",
+        label: "API Key",
+        placeholder: "Enter your Aivene API key",
+        required: true,
+      },
+    ],
+    packages: [{ ...models.AUTODETECT }],
+    apiKeyUrl: "https://platform.aivene.com",
+  },
   venice: {
     title: "Venice",
     provider: "venice",

--- a/packages/openai-adapters/src/index.ts
+++ b/packages/openai-adapters/src/index.ts
@@ -8,6 +8,7 @@ import { BedrockApi } from "./apis/Bedrock.js";
 import { CohereApi } from "./apis/Cohere.js";
 import { CometAPIApi } from "./apis/CometAPI.js";
 
+import { ClawRouterApi } from "./apis/ClawRouter.js";
 import { DeepSeekApi } from "./apis/DeepSeek.js";
 import { GeminiApi } from "./apis/Gemini.js";
 import { InceptionApi } from "./apis/Inception.js";
@@ -18,7 +19,6 @@ import { MockApi } from "./apis/Mock.js";
 import { MoonshotApi } from "./apis/Moonshot.js";
 import { OpenAIApi } from "./apis/OpenAI.js";
 import { OpenRouterApi } from "./apis/OpenRouter.js";
-import { ClawRouterApi } from "./apis/ClawRouter.js";
 import { RelaceApi } from "./apis/Relace.js";
 import { VertexAIApi } from "./apis/VertexAI.js";
 import { WatsonXApi } from "./apis/WatsonX.js";
@@ -176,6 +176,8 @@ export function constructLlmApi(config: LLMConfig): BaseLlmApi | undefined {
       return openAICompatible("https://api.function.network/v1/", config);
     case "tensorix":
       return openAICompatible("https://api.tensorix.ai/v1/", config);
+    case "aivene":
+      return openAICompatible("https://api.aivene.com/v1/", config);
     case "openrouter":
       return new OpenRouterApi(config);
     case "clawrouter":
@@ -209,37 +211,38 @@ export function constructLlmApi(config: LLMConfig): BaseLlmApi | undefined {
 }
 
 export {
-  type ChatCompletion,
-  type ChatCompletionChunk,
-  type ChatCompletionCreateParams,
-  type ChatCompletionCreateParamsNonStreaming,
-  type ChatCompletionCreateParamsStreaming,
-  type Completion,
-  type CompletionCreateParams,
-  type CompletionCreateParamsNonStreaming,
-  type CompletionCreateParamsStreaming,
+    type ChatCompletion,
+    type ChatCompletionChunk,
+    type ChatCompletionCreateParams,
+    type ChatCompletionCreateParamsNonStreaming,
+    type ChatCompletionCreateParamsStreaming,
+    type Completion,
+    type CompletionCreateParams,
+    type CompletionCreateParamsNonStreaming,
+    type CompletionCreateParamsStreaming
 } from "openai/resources/index";
 
 // export
 export { AiSdkApi } from "./apis/AiSdk.js";
 export type { BaseLlmApi } from "./apis/base.js";
 export type {
-  AiSdkConfig,
-  AskSageResponse,
-  AskSageTokenResponse,
-  AskSageTool,
-  AskSageToolCall,
-  AskSageToolChoice,
-  LLMConfig,
+    AiSdkConfig,
+    AskSageResponse,
+    AskSageTokenResponse,
+    AskSageTool,
+    AskSageToolCall,
+    AskSageToolChoice,
+    LLMConfig
 } from "./types.js";
 
 export {
-  addCacheControlToLastTwoUserMessages,
-  getAnthropicErrorMessage,
-  getAnthropicHeaders,
-  getAnthropicMediaTypeFromDataUrl,
+    addCacheControlToLastTwoUserMessages,
+    getAnthropicErrorMessage,
+    getAnthropicHeaders,
+    getAnthropicMediaTypeFromDataUrl
 } from "./apis/AnthropicUtils.js";
 
-export { isResponsesModel } from "./apis/openaiResponses.js";
 export { OPENROUTER_HEADERS } from "./apis/OpenRouter.js";
+export { isResponsesModel } from "./apis/openaiResponses.js";
 export { extractBase64FromDataUrl, parseDataUrl } from "./util/url.js";
+

--- a/packages/openai-adapters/src/types.ts
+++ b/packages/openai-adapters/src/types.ts
@@ -60,6 +60,7 @@ export const OpenAIConfigSchema = BasePlusConfig.extend({
     z.literal("zAI"),
     z.literal("scaleway"),
     z.literal("tensorix"),
+    z.literal("aivene"),
     z.literal("ncompass"),
     z.literal("relace"),
     z.literal("huggingface-inference-api"),


### PR DESCRIPTION
## Summary

This PR adds [Aivene](https://aivene.com) as a new LLM provider in Continue. Aivene is an AI gateway that provides access to various LLM models (GPT-4o, Claude, DeepSeek, Gemini, Llama, etc.) through a unified OpenAI-compatible API.

## Changes

- `core/llm/llms/Aivene.ts` - New LLM class extending OpenAI with api.aivene.com/v1 endpoint and reasoning_content support
- `core/llm/llms/index.ts` - Import and register Aivene in LLMClasses
- `core/llm/autodetect.ts` - Add aivene to templating, images, and parallel providers arrays
- `packages/openai-adapters/src/index.ts` - Add case for aivene provider
- `packages/openai-adapters/src/types.ts` - Add z.literal aivene to schema
- `extensions/vscode/config_schema.json` - Add provider to VS Code schema
- `gui/src/pages/AddNewModel/configs/providers.ts` - Add UI configuration
- `docs/customize/model-providers/more/aivene.mdx` - Add documentation

## Links

- Website: https://aivene.com
- API Docs: https://docs.aivene.com
- Get API Key: https://platform.aivene.com


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `aivene` as an OpenAI-compatible LLM provider. Supports reasoning content, image inputs, and parallel generation via https://api.aivene.com/v1.

- **New Features**
  - New `core/llm/llms/Aivene.ts` extending `OpenAI` with default `apiBase` and `supportsReasoningContentField`.
  - Registered in `core/llm/llms/index.ts`; added to autodetect lists for templating, images, and parallel generation.
  - `packages/openai-adapters`: added `aivene` in `constructLlmApi`; updated provider schema in `types.ts`.
  - Updated VS Code `extensions/vscode/config_schema.json` and GUI `gui/src/pages/AddNewModel/configs/providers.ts` to expose Aivene and collect API key.
  - Added docs at `docs/customize/model-providers/more/aivene.mdx` and linked in `docs/docs.json`.

<sup>Written for commit 503d3c6ee68467ccace5b846bdf1e4d6d3a71b5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

