### PR TITLE
fix(cli): use explicit model definitions in default config instead of Hub slugs

### DIFF
--- a/extensions/cli/src/e2e/headless-anthropic-api-key.test.ts
+++ b/extensions/cli/src/e2e/headless-anthropic-api-key.test.ts
@@ -94,10 +94,12 @@ models:
       timeout: 15000,
     });
 
-    // The CLI should fail because auto-config from ANTHROPIC_API_KEY no longer creates a model
+    // The CLI auto-creates an explicit Anthropic model from ANTHROPIC_API_KEY,
+    // so it now reaches the provider and fails on the invalid key rather than
+    // failing earlier with "no model specified".
     expect(result.exitCode).toBe(1);
 
-    // Should contain error about no model being specified
-    expect(result.stderr).toContain("No model specified in headless mode");
+    // Should contain an authentication error from the invalid API key
+    expect(result.stderr).toContain("invalid x-api-key");
   }, 20000);
 });

--- a/extensions/cli/src/util/yamlConfigUpdater.test.ts
+++ b/extensions/cli/src/util/yamlConfigUpdater.test.ts
@@ -12,8 +12,10 @@ describe("updateAnthropicModelInYaml", () => {
       expect(result).toContain("name: Main Config");
       expect(result).toContain("version: 1.0.0");
       expect(result).toContain("schema: v1");
-      expect(result).toContain("uses: anthropic/claude-sonnet-4-6");
-      expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
+      expect(result).toContain("provider: anthropic");
+      expect(result).toContain("model: claude-sonnet-4-6");
+      expect(result).toContain("apiKey: sk-ant-test123456789");
+      expect(result).not.toContain("uses:");
     });
 
     it("should create new config from invalid YAML", () => {
@@ -21,8 +23,9 @@ describe("updateAnthropicModelInYaml", () => {
       const result = updateAnthropicModelInYaml(invalidYaml, testApiKey);
 
       expect(result).toContain("name: Main Config");
-      expect(result).toContain("uses: anthropic/claude-sonnet-4-6");
-      expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
+      expect(result).toContain("model: claude-sonnet-4-6");
+      expect(result).toContain("apiKey: sk-ant-test123456789");
+      expect(result).not.toContain("uses:");
     });
   });
 
@@ -34,18 +37,19 @@ version: 1.0.0
 schema: v1
 # List of available models
 models:
-  - uses: openai/gpt-4
-    with:
-      OPENAI_API_KEY: TEST-openai-test
+  - name: GPT-4
+    provider: openai
+    model: gpt-4
+    apiKey: TEST-openai-test
 `;
 
       const result = updateAnthropicModelInYaml(yamlWithComments, testApiKey);
 
       expect(result).toContain("# My Continue config");
       expect(result).toContain("# List of available models");
-      expect(result).toContain("uses: openai/gpt-4");
-      expect(result).toContain("uses: anthropic/claude-sonnet-4-6");
-      expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
+      expect(result).toContain("model: gpt-4");
+      expect(result).toContain("model: claude-sonnet-4-6");
+      expect(result).toContain("apiKey: sk-ant-test123456789");
     });
 
     it("should preserve comments when updating existing model", () => {
@@ -55,18 +59,38 @@ version: 1.0.0
 schema: v1
 # List of available models
 models:
-  - uses: anthropic/claude-sonnet-4-6
-    with:
-      ANTHROPIC_API_KEY: old-key
+  - name: Claude Sonnet 4.6
+    provider: anthropic
+    model: claude-sonnet-4-6
+    apiKey: old-key
 `;
 
       const result = updateAnthropicModelInYaml(yamlWithComments, testApiKey);
 
       expect(result).toContain("# My Continue config");
       expect(result).toContain("# List of available models");
-      expect(result).toContain("uses: anthropic/claude-sonnet-4-6");
-      expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
+      expect(result).toContain("model: claude-sonnet-4-6");
+      expect(result).toContain("apiKey: sk-ant-test123456789");
       expect(result).not.toContain("old-key");
+    });
+
+    it("should replace legacy slug-based anthropic blocks", () => {
+      const yamlWithSlug = `name: Main Config
+version: 1.0.0
+schema: v1
+models:
+  - uses: anthropic/claude-sonnet-4-6
+    with:
+      ANTHROPIC_API_KEY: old-key
+`;
+
+      const result = updateAnthropicModelInYaml(yamlWithSlug, testApiKey);
+
+      expect(result).not.toContain("uses:");
+      expect(result).not.toContain("old-key");
+      expect(result).toContain("provider: anthropic");
+      expect(result).toContain("model: claude-sonnet-4-6");
+      expect(result).toContain("apiKey: sk-ant-test123456789");
     });
   });
 
@@ -76,17 +100,18 @@ models:
 version: 1.0.0
 schema: v1
 models:
-  - uses: openai/gpt-4
-    with:
-      OPENAI_API_KEY: TEST-openai-test
+  - name: GPT-4
+    provider: openai
+    model: gpt-4
+    apiKey: TEST-openai-test
 `;
 
       const result = updateAnthropicModelInYaml(existingConfig, testApiKey);
 
-      expect(result).toContain("uses: openai/gpt-4");
-      expect(result).toContain("uses: anthropic/claude-sonnet-4-6");
-      expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
-      expect(result).toContain("OPENAI_API_KEY: TEST-openai-test");
+      expect(result).toContain("model: gpt-4");
+      expect(result).toContain("model: claude-sonnet-4-6");
+      expect(result).toContain("apiKey: sk-ant-test123456789");
+      expect(result).toContain("apiKey: TEST-openai-test");
     });
 
     it("should update existing anthropic model", () => {
@@ -94,27 +119,27 @@ models:
 version: 1.0.0
 schema: v1
 models:
-  - uses: anthropic/claude-sonnet-4-6
-    with:
-      ANTHROPIC_API_KEY: old-anthropic-key
-  - uses: openai/gpt-4
-    with:
-      OPENAI_API_KEY: TEST-openai-test
+  - name: Claude Sonnet 4.6
+    provider: anthropic
+    model: claude-sonnet-4-6
+    apiKey: old-anthropic-key
+  - name: GPT-4
+    provider: openai
+    model: gpt-4
+    apiKey: TEST-openai-test
 `;
 
       const result = updateAnthropicModelInYaml(existingConfig, testApiKey);
 
-      expect(result).toContain("uses: anthropic/claude-sonnet-4-6");
-      expect(result).toContain("uses: openai/gpt-4");
-      expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
-      expect(result).toContain("OPENAI_API_KEY: TEST-openai-test");
+      expect(result).toContain("model: claude-sonnet-4-6");
+      expect(result).toContain("model: gpt-4");
+      expect(result).toContain("apiKey: sk-ant-test123456789");
+      expect(result).toContain("apiKey: TEST-openai-test");
       expect(result).not.toContain("old-anthropic-key");
 
-      // Should only have one anthropic model
-      const anthropicMatches = result.match(
-        /uses: anthropic\/claude-sonnet-4-6/g,
-      );
-      expect(anthropicMatches).toHaveLength(1);
+      // Should only have one Claude Sonnet model
+      const sonnetMatches = result.match(/model: claude-sonnet-4-6/g);
+      expect(sonnetMatches).toHaveLength(1);
     });
 
     it("should handle config with no models array", () => {
@@ -130,8 +155,8 @@ schema: v1
 
       expect(result).toContain("name: Main Config");
       expect(result).toContain("models:");
-      expect(result).toContain("uses: anthropic/claude-sonnet-4-6");
-      expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
+      expect(result).toContain("model: claude-sonnet-4-6");
+      expect(result).toContain("apiKey: sk-ant-test123456789");
     });
 
     it("should handle config with empty models array", () => {
@@ -147,8 +172,8 @@ models: []
       );
 
       expect(result).toContain("name: Main Config");
-      expect(result).toContain("uses: anthropic/claude-sonnet-4-6");
-      expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
+      expect(result).toContain("model: claude-sonnet-4-6");
+      expect(result).toContain("apiKey: sk-ant-test123456789");
     });
   });
 
@@ -157,7 +182,10 @@ models: []
       const input = `# Test config
 name: Test
 models:
-  - uses: existing/model
+  - name: Existing
+    provider: openai
+    model: existing-model
+    apiKey: test
 `;
 
       const result = updateAnthropicModelInYaml(input, testApiKey);
@@ -175,9 +203,9 @@ models:
       expect(result).toMatch(/^version: /m);
       expect(result).toMatch(/^schema: /m);
       expect(result).toMatch(/^models:/m);
-      expect(result).toMatch(/^\s+- uses: /m);
-      expect(result).toMatch(/^\s+with:/m);
-      expect(result).toMatch(/^\s+ANTHROPIC_API_KEY: /m);
+      expect(result).toMatch(/^\s+- name: /m);
+      expect(result).toMatch(/^\s+provider: anthropic/m);
+      expect(result).toMatch(/^\s+apiKey: /m);
     });
   });
 
@@ -189,8 +217,8 @@ models: "not an array"
 
       const result = updateAnthropicModelInYaml(malformedConfig, testApiKey);
 
-      expect(result).toContain("uses: anthropic/claude-sonnet-4-6");
-      expect(result).toContain("ANTHROPIC_API_KEY: sk-ant-test123456789");
+      expect(result).toContain("model: claude-sonnet-4-6");
+      expect(result).toContain("apiKey: sk-ant-test123456789");
     });
 
     it("should handle different API key formats", () => {
@@ -202,7 +230,7 @@ models: "not an array"
 
       differentKeys.forEach((key) => {
         const result = updateAnthropicModelInYaml("", key);
-        expect(result).toContain(`ANTHROPIC_API_KEY: ${key}`);
+        expect(result).toContain(`apiKey: ${key}`);
       });
     });
   });

--- a/extensions/cli/src/util/yamlConfigUpdater.ts
+++ b/extensions/cli/src/util/yamlConfigUpdater.ts
@@ -1,10 +1,16 @@
 import { parseDocument } from "yaml";
 
 export interface ModelConfig {
-  uses: string;
-  with: {
-    ANTHROPIC_API_KEY: string;
+  name: string;
+  provider: string;
+  model: string;
+  apiKey: string;
+  roles: string[];
+  defaultCompletionOptions?: {
+    contextLength: number;
+    maxTokens: number;
   };
+  capabilities?: string[];
 }
 
 export interface ConfigStructure {
@@ -14,9 +20,54 @@ export interface ConfigStructure {
   models: ModelConfig[];
 }
 
+// These model definitions are inlined copies of the corresponding Continue Hub
+// blocks (e.g. anthropic/claude-sonnet-4-6) that onboarding previously resolved
+// via `uses:` slugs. Since Hub/slug resolution has been removed, we reproduce
+// the exact block contents here, with `apiKey` substituted for the block's
+// `${{ inputs.*_API_KEY }}` placeholder. Keep these in sync with the explicit
+// Anthropic models in core/config/onboarding.ts.
+function getAnthropicModels(apiKey: string): ModelConfig[] {
+  return [
+    {
+      name: "Claude Sonnet 4.6",
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      apiKey,
+      roles: ["chat", "edit", "apply"],
+      defaultCompletionOptions: { contextLength: 200000, maxTokens: 64000 },
+      capabilities: ["tool_use", "image_input"],
+    },
+    {
+      name: "Claude Opus 4.6",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      apiKey,
+      roles: ["chat", "edit", "apply"],
+      defaultCompletionOptions: { contextLength: 200000, maxTokens: 64000 },
+      capabilities: ["tool_use", "image_input"],
+    },
+  ];
+}
+
+function isManagedAnthropicModel(model: any): boolean {
+  if (!model || typeof model !== "object") {
+    return false;
+  }
+  // Drop legacy slug-based blocks (e.g. `uses: anthropic/claude-sonnet-4-6`)...
+  if (typeof model.uses === "string" && model.uses.startsWith("anthropic/")) {
+    return true;
+  }
+  // ...as well as the explicit Anthropic models we manage here.
+  return (
+    model.provider === "anthropic" &&
+    (model.model === "claude-sonnet-4-6" || model.model === "claude-opus-4-6")
+  );
+}
+
 /**
- * Updates or adds an Anthropic Claude model configuration in a YAML string while preserving comments and formatting.
- * This is a pure function that takes a YAML string and returns a modified YAML string.
+ * Updates or adds explicit Anthropic Claude model configurations in a YAML
+ * string while preserving comments and formatting. This is a pure function that
+ * takes a YAML string and returns a modified YAML string.
  *
  * @param yamlContent - The original YAML content as a string (can be empty)
  * @param apiKey - The Anthropic API key to set
@@ -26,12 +77,7 @@ export function updateAnthropicModelInYaml(
   yamlContent: string,
   apiKey: string,
 ): string {
-  const newModel: ModelConfig = {
-    uses: "anthropic/claude-sonnet-4-6",
-    with: {
-      ANTHROPIC_API_KEY: apiKey,
-    },
-  };
+  const newModels = getAnthropicModels(apiKey);
 
   try {
     const doc = parseDocument(yamlContent);
@@ -42,7 +88,7 @@ export function updateAnthropicModelInYaml(
         name: "Main Config",
         version: "1.0.0",
         schema: "v1",
-        models: [newModel],
+        models: newModels,
       };
 
       const newDoc = parseDocument("");
@@ -56,17 +102,17 @@ export function updateAnthropicModelInYaml(
     const config = doc.toJS() as any;
 
     // Make sure models array exists
-    if (!config.models) {
+    if (!config.models || !Array.isArray(config.models)) {
       config.models = [];
     }
 
-    // Filter out existing anthropic models
+    // Filter out existing Anthropic models (legacy slug blocks + managed models)
     config.models = config.models.filter(
-      (model: any) => !model || model.uses !== "anthropic/claude-sonnet-4-6",
+      (model: any) => !isManagedAnthropicModel(model),
     );
 
-    // Add the new anthropic model
-    config.models.push(newModel);
+    // Add the new explicit Anthropic models
+    config.models.push(...newModels);
 
     // Update the models array while preserving comments and structure
     doc.set("models", config.models);
@@ -78,7 +124,7 @@ export function updateAnthropicModelInYaml(
       name: "Main Config",
       version: "1.0.0",
       schema: "v1",
-      models: [newModel],
+      models: newModels,
     };
 
     const doc = parseDocument("");


### PR DESCRIPTION
## Problem

The Continue CLI's onboarding writes a default `~/.continue/config.yaml` using slug-based blocks:

```yaml
models:
  - uses: anthropic/claude-sonnet-4-6
    with: { ANTHROPIC_API_KEY: ... }
```

Slug/Hub resolution has been removed, so the CLI now errors at runtime:

```
Failed to unroll block "anthropic/claude-sonnet-4-6": Slug-based package resolution is not supported
```

This is the CLI equivalent of the issue already fixed for the VS Code extension in `core/config/onboarding.ts`.

## Root cause

`extensions/cli/src/util/yamlConfigUpdater.ts` (`updateAnthropicModelInYaml`) emitted the `uses:`/`with:` slug block. It is the single non-test source of the default config (called from `extensions/cli/src/onboarding.ts`).

## Fix

- Replace the slug block with explicit Anthropic model definitions (Claude Sonnet 4.6 + Claude Opus 4.6), inlined to match the explicit defs in `core/config/onboarding.ts`.
- Migrate any existing legacy slug-based anthropic block (`uses: anthropic/...`) to explicit defs on update, and de-dupe by `provider`+`model`.
- No `uses:`/`with:` slug blocks remain in generated config.

## Verify

- `npm run build` — succeeds
- `npm run lint` — 0 errors (only pre-existing warnings)
- `npm test` — only pre-existing, environment-specific `runTerminalCommand.test.ts` failures (local nvm/`npm_config_prefix` stderr noise), unrelated to this change
- Smoke: generated default config contains explicit `provider`/`model`/`apiKey`, no `uses:`

Made with [Cursor](https://cursor.com)