### PR TITLE
test(fetch): add unit tests for getProxy precedence

### DIFF
--- a/packages/fetch/src/util.test.ts
+++ b/packages/fetch/src/util.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, expect, test, vi } from "vitest";
 import {
+  getProxy,
   getProxyFromEnv,
   patternMatchesHostname,
   shouldBypassProxy,
@@ -54,6 +55,41 @@ test("getProxyFromEnv prefers HTTPS_PROXY over other env vars for https protocol
   process.env.HTTP_PROXY = "http://notused2.example.com";
   process.env.http_proxy = "http://notused3.example.com";
   expect(getProxyFromEnv("https:")).toBe("https://preferred.example.com");
+});
+
+// Tests for getProxy
+test("getProxy returns undefined when neither request options nor env proxy are set", () => {
+  expect(getProxy("http:", undefined)).toBeUndefined();
+  expect(getProxy("https:", undefined)).toBeUndefined();
+  expect(getProxy("http:", {})).toBeUndefined();
+});
+
+test("getProxy returns the request options proxy when set", () => {
+  expect(getProxy("https:", { proxy: "http://request.example.com" })).toBe(
+    "http://request.example.com",
+  );
+});
+
+test("getProxy prefers the request options proxy over environment variables", () => {
+  process.env.HTTPS_PROXY = "https://env.example.com";
+  expect(getProxy("https:", { proxy: "http://request.example.com" })).toBe(
+    "http://request.example.com",
+  );
+});
+
+test("getProxy falls back to the environment proxy when request options has no proxy", () => {
+  process.env.HTTP_PROXY = "http://env.example.com";
+  expect(getProxy("http:", {})).toBe("http://env.example.com");
+  expect(getProxy("http:", { noProxy: ["example.com"] })).toBe(
+    "http://env.example.com",
+  );
+});
+
+test("getProxy respects protocol when falling back to the environment proxy", () => {
+  process.env.HTTPS_PROXY = "https://secure.example.com";
+  process.env.HTTP_PROXY = "http://insecure.example.com";
+  expect(getProxy("https:", undefined)).toBe("https://secure.example.com");
+  expect(getProxy("http:", undefined)).toBe("http://insecure.example.com");
 });
 
 // Tests for patternMatchesHostname


### PR DESCRIPTION
## Description

Adds unit-test coverage for the `getProxy` helper in `@continuedev/fetch` (`packages/fetch/src/util.ts`), which previously had none. `getProxy` implements the documented contract that a per-model `requestOptions.proxy` takes precedence over the `HTTP(S)_PROXY` environment variables, then falls back to the protocol-aware environment proxy. The surrounding helpers (`getProxyFromEnv`, `patternMatchesHostname`, `shouldBypassProxy`) were already tested; `getProxy` itself was the gap.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A. Test-only change with no user-facing or runtime behavior change.

## Tests

Added 5 cases to `packages/fetch/src/util.test.ts` covering `getProxy`:

- returns `undefined` when neither request options nor an env proxy are set
- returns the request-options proxy when present
- request-options proxy takes precedence over `HTTP(S)_PROXY`
- falls back to the env proxy when request options has no `proxy`
- protocol-aware env fallback (`https:` vs `http:`)

`npx vitest run` passes (87/87 in the package), Prettier-formatted, and `tsc --noEmit` is clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `getProxy` in `@continuedev/fetch` to verify proxy precedence and protocol-aware env fallback. Covers per-request `proxy` over `HTTP(S)_PROXY`, env fallback when absent, and undefined when none; tests only, no runtime changes.

<sup>Written for commit 52c01a8a56855cac3f525e166737779d2a397599. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

