### PR TITLE
fix: resolve ignored image attachment due to invalid schema insertion

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor/TipTapEditor.tsx
@@ -255,10 +255,10 @@ function TipTapEditorInner(props: TipTapEditorProps) {
           }
           if (result) {
             const [_, dataUrl] = result;
-            const { schema } = editor.state;
-            const node = schema.nodes.image.create({ src: dataUrl });
-            const tr = editor.state.tr.insert(0, node);
-            editor.view.dispatch(tr);
+            editor.commands.insertContentAt(0, {
+              type: "image",
+              attrs: { src: dataUrl },
+            });
           }
         });
         event.preventDefault();
@@ -287,11 +287,9 @@ function TipTapEditorInner(props: TipTapEditorProps) {
               }
               if (result) {
                 const [_, dataUrl] = result;
-                const { schema } = editor.state;
-                const node = schema.nodes.image.create({ src: dataUrl });
-                editor.commands.command(({ tr }) => {
-                  tr.insert(0, node);
-                  return true;
+                editor.commands.insertContentAt(0, {
+                  type: "image",
+                  attrs: { src: dataUrl },
                 });
               }
             });

--- a/gui/src/components/mainInput/TipTapEditor/utils/editorConfig.ts
+++ b/gui/src/components/mainInput/TipTapEditor/utils/editorConfig.ts
@@ -69,8 +69,13 @@ export function hasValidEditorContent(json: JSONContent): boolean {
     }),
   );
 
+  // Check for images
+  const hasImage = json.content?.some(
+    (c) => c.type === "image" || c.content?.some((child) => child.type === "image")
+  );
+
   // Content is valid if it has either non-whitespace text or special blocks
-  return hasNonWhitespaceText || hasPromptOrCodeBlock || false;
+  return hasNonWhitespaceText || hasPromptOrCodeBlock || hasImage || false;
 }
 
 /**

--- a/gui/src/components/mainInput/TipTapEditor/utils/editorConfig.ts
+++ b/gui/src/components/mainInput/TipTapEditor/utils/editorConfig.ts
@@ -156,34 +156,40 @@ export function createEditorConfig(options: {
           const pastePlugin = new Plugin({
             props: {
               handleDOMEvents: {
-                paste(view, event) {
+                paste: (view, event) => {
                   const model = defaultModelRef.current;
-                  if (!model) return;
+                  if (!model) return false;
                   const items = event.clipboardData?.items;
                   if (items) {
+                    let handled = false;
                     for (const item of items) {
+                      if (item.type.indexOf("image/") !== 0) continue;
                       const file = item.getAsFile();
-                      file &&
+                      if (
+                        file &&
                         modelSupportsImages(
                           model.provider,
                           model.model,
                           model.title,
                           model.capabilities,
-                        ) &&
+                        )
+                      ) {
                         void handleImageFile(ideMessenger, file).then(
                           (resp) => {
                             if (!resp) return;
                             const [img, dataUrl] = resp;
-                            const { schema } = view.state;
-                            const node = schema.nodes.image.create({
-                              src: dataUrl,
+                            this.editor.commands.insertContentAt(0, {
+                              type: "image",
+                              attrs: { src: dataUrl },
                             });
-                            const tr = view.state.tr.insert(0, node);
-                            view.dispatch(tr);
                           },
                         );
+                        handled = true;
+                      }
                     }
+                    if (handled) return true;
                   }
+                  return false;
                 },
               },
             },


### PR DESCRIPTION
## Description

[ What changed? Feel free to be brief. ]

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

[ When applicable, please include a short screen recording or screenshot - this makes it much easier for us as contributors to review and understand your changes. See [this PR](https://github.com/continuedev/continue/pull/6455) as a good example. ]

## Tests

[ What tests were added or updated to ensure the changes work as expected? ]
  

Fixes #12845

**Description:**
This PR fixes a bug in the TipTap editor where attempting to attach an image via the upload icon, drag-and-drop, or `Ctrl + V` paste was completely ignored by the UI.

The root cause was that `image` nodes are defined as inline content, but the editor was using a low-level ProseMirror transaction (`tr.insert(0, node)`) to insert the node directly into the absolute root of the document (position 0). Since the `doc` root only accepts block nodes, this violated the document schema and the transaction was silently discarded by ProseMirror without throwing a visible error.

**Changes:**
- Replaced the low-level ProseMirror `tr.insert` transaction with TipTap's schema-aware `editor.commands.insertContentAt(0, ...)` method in both `editorConfig.ts` and `TipTapEditor.tsx`, which correctly handles wrapping the inline image inside a block element (like a paragraph).
- Updated the custom `pastePlugin` handler to explicitly `return true` upon successfully matching and handling an image file to properly signal to ProseMirror that the paste event was consumed, preventing potential interference from default paste behaviors.

**Testing:**
- Verified that compiling via TypeScript returns no errors.
- Checked that image node insertion properly cascades and behaves correctly according to the TipTap extension specifications.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ignored image attachments in the `TipTap` editor by switching to schema-aware insertion and properly consuming paste events. Images added via upload, drag-and-drop, or paste now insert reliably and are treated as valid content. Fixes #12845.

- **Bug Fixes**
  - Replaced `ProseMirror` `tr.insert` with `editor.commands.insertContentAt(0, { type: "image", attrs: { src } })` to respect the schema.
  - Paste handler now processes only when the model supports images and returns `true` when handled.
  - Updated `hasValidEditorContent` to treat image nodes as valid so image-only inputs are accepted.

<sup>Written for commit 6582b402332f1b90115a59c4acaf8550367dc791. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

