### PR TITLE
docs(model-providers/function-network): fix 3 dead function.network doc links

### DIFF
--- a/docs/customize/model-providers/more/function-network.mdx
+++ b/docs/customize/model-providers/more/function-network.mdx
@@ -7,7 +7,7 @@ description: "Configure Function Network with Continue to access private and aff
 
 <Info>
 
-To get an API key, login to the Function Network Developer Platform. If you don't have an account, you can create one [here](https://www.function.network/join-waitlist).
+To get an API key, login to the Function Network Developer Platform. If you don't have an account, you can create one [here](https://www.function.network/).
 
 </Info>
 
@@ -47,7 +47,7 @@ Function Network supports a number of models for chat. We recommend using LLama 
   </Tab>
 </Tabs>
 
-[Click here](https://docs.function.network/models-supported/chat-and-code-completion) to see a list of chat model providers.
+[Click here](https://docs.function.network/) to see a list of chat model providers.
 
 ## Autocomplete Model
 
@@ -116,7 +116,7 @@ Function Network supports a number of models for embeddings. We recommend using 
   </Tab>
 </Tabs>
 
-[Click here](https://docs.function.network/models-supported/embeddings) to see a list of embeddings model providers.
+[Click here](https://docs.function.network/) to see a list of embeddings model providers.
 
 ## Reranking Model
 


### PR DESCRIPTION
Three broken URLs: `/join-waitlist` (404), `/models-supported/chat-and-code-completion` (404), `/models-supported/embeddings` (404). All replaced with the canonical homepage `/` or docs root `/` which return 200.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed three dead Function Network links in `docs/customize/model-providers/more/function-network.mdx`. Updated them to the canonical homepage/docs index to avoid 404s and keep readers on the right pages.

<sup>Written for commit ad81eeaf1e41e7555844429db8413ddbdc14ffcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

