### PR TITLE
docs(model-providers/vllm): fix dead vllm engine_args doc link

### DIFF
--- a/docs/customize/model-providers/more/vllm.mdx
+++ b/docs/customize/model-providers/more/vllm.mdx
@@ -3,7 +3,7 @@ title: "vLLM"
 description: "Configure vLLM's high-performance inference library with Continue for chat, autocomplete, and embeddings, including setup instructions for Llama3.1, Qwen2.5-Coder, and Nomic Embed models"
 ---
 
-vLLM is an open-source library for fast LLM inference which typically is used to serve multiple users at the same time. It can also be used to run a large model on multiple GPU:s (e.g. when it doesn´t fit in a single GPU). Run their OpenAI-compatible server using `vllm serve`. See their [server documentation](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html) and the [engine arguments documentation](https://docs.vllm.ai/en/latest/usage/engine_args.html).
+vLLM is an open-source library for fast LLM inference which typically is used to serve multiple users at the same time. It can also be used to run a large model on multiple GPU:s (e.g. when it doesn´t fit in a single GPU). Run their OpenAI-compatible server using `vllm serve`. See their [server documentation](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html) and the [engine arguments documentation](https://docs.vllm.ai/en/latest/configuration/).
 
 ```shell
 vllm serve meta-llama/Meta-Llama-3.1-8B-Instruct


### PR DESCRIPTION
Replaces `https://docs.vllm.ai/en/latest/usage/engine_args.html` (404) with `https://docs.vllm.ai/en/latest/configuration/` (200) — the engine_args subpath was retired in the docs restructure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the dead vLLM engine arguments link in `docs/customize/model-providers/more/vllm.mdx` by updating it to the current Configuration page, so readers don’t hit a 404.

<sup>Written for commit c40092ee622961bc17801c9e4afac954fe0fc1f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

