### PR TITLE
docs(guides/netlify-mcp): fix dead /analytics/get-started/ link

### DIFF
--- a/docs/guides/netlify-mcp-continuous-deployment.mdx
+++ b/docs/guides/netlify-mcp-continuous-deployment.mdx
@@ -19,7 +19,7 @@ import CLIInstall from '/snippets/cli-install.mdx'
 <Info>
   **Did You Know?** Netlify is more than just static hosting! It offers:
   - [Split Testing](https://docs.netlify.com/site-deploys/split-testing/) for A/B testing branches
-  - [Analytics](https://docs.netlify.com/analytics/get-started/) with Core Web Vitals tracking
+  - [Analytics](https://docs.netlify.com/manage/monitoring/overview/) with Core Web Vitals tracking (the old `/analytics/get-started/` path was retired in the Netlify docs restructure)
   - [Edge Functions](https://docs.netlify.com/edge-functions/overview/) for personalization at the edge
   - [Build Plugins](https://docs.netlify.com/integrations/build-plugins/) ecosystem with 100+ integrations
   - [Forms](https://docs.netlify.com/forms/setup/) with built-in spam protection
@@ -35,7 +35,7 @@ This guide shows you how to leverage these features through natural language wit
 This cookbook teaches you to:
 
 - Run [A/B tests](https://docs.netlify.com/site-deploys/split-testing/) between branches to measure performance impact
-- Monitor [Core Web Vitals](https://docs.netlify.com/analytics/get-started/#core-web-vitals) and build performance metrics
+- Monitor [Core Web Vitals](https://docs.netlify.com/manage/monitoring/overview/) and build performance metrics
 - Automatically block deploys that degrade performance using [Deploy Contexts](https://docs.netlify.com/site-deploys/overview/#deploy-contexts)
 - Optimize build times with [Build Plugins](https://docs.netlify.com/integrations/build-plugins/) and bundle sizes with AI assistance
 


### PR DESCRIPTION
Replaces two `https://docs.netlify.com/analytics/get-started/` (404) URLs with `https://docs.netlify.com/manage/monitoring/overview/` (200) — the /analytics/ subpath was retired in the Netlify docs restructure; monitoring is now under /manage/.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced two dead Netlify Analytics links in `docs/guides/netlify-mcp-continuous-deployment.mdx` with `https://docs.netlify.com/manage/monitoring/overview/`. This fixes 404s and keeps Core Web Vitals references accurate.

<sup>Written for commit d9cb5e51fe710eaa559d8335dfcfc3bef161fdc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

