### PR TITLE
docs(model-providers/llamastack): fix dead llama-stack RTD link + typo

### DIFF
--- a/docs/customize/model-providers/more/llamastack.mdx
+++ b/docs/customize/model-providers/more/llamastack.mdx
@@ -4,7 +4,7 @@ keywords: [llama, stack, local, api, inference]
 ---
 
 <Info>
-  Get started with [Lllama Stack](https://llama-stack.readthedocs.io/en/latest/getting_started/index.html)
+  Get started with [Llama Stack](https://github.com/meta-llama/llama-stack) (the readthedocs.io docs site was retired; the GitHub repo is the canonical home)
 </Info>
 
 <Tabs>


### PR DESCRIPTION
Replaces `https://llama-stack.readthedocs.io/en/latest/getting_started/index.html` (404 — readthedocs.io docs site retired) with `https://github.com/meta-llama/llama-stack` (200). Also fixes typo `Lllama` → `Llama`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the dead Llama Stack Read the Docs URL with the canonical GitHub repo in `docs/customize/model-providers/more/llamastack.mdx`. Also fix the "Lllama" → "Llama" typo.

<sup>Written for commit 1256a94484dfe74b24f6f1e6fe822abf5b84e753. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

