### PR TITLE
docs(guides/custom-code-rag): fix dead voyageai dash.api-keys link

### DIFF
--- a/docs/guides/custom-code-rag.mdx
+++ b/docs/guides/custom-code-rag.mdx
@@ -6,7 +6,7 @@ keywords: [RAG, vector database, embeddings, code search, MCP]
 
 ## Step 1: How to Choose an Embeddings Model
 
-If possible, we recommend using [`voyage-code-3`](https://docs.voyageai.com/docs/embeddings), which will give the most accurate answers of any existing embeddings model for code. You can obtain an API key [here](https://dash.voyageai.com/api-keys). Because their API is [OpenAI-compatible](https://docs.voyageai.com/reference/embeddings-api), you can use any OpenAI client by swapping out the URL.
+If possible, we recommend using [`voyage-code-3`](https://docs.voyageai.com/docs/embeddings), which will give the most accurate answers of any existing embeddings model for code. You can obtain an API key from the [Voyage AI dashboard](https://voyageai.com/dashboard) (the old `dash.voyageai.com/api-keys` URL is no longer live). Because their API is [OpenAI-compatible](https://docs.voyageai.com/reference/embeddings-api), you can use any OpenAI client by swapping out the URL.
 
 ## Step 2: How to Choose a Vector Database
 


### PR DESCRIPTION
Replaces `https://dash.voyageai.com/api-keys` (404) with `https://voyageai.com/dashboard` (200 via 308) — the old `dash.voyageai.com/api-keys` URL is no longer live.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a dead link to the Voyage AI API key page in the Custom Code RAG guide. Replaces dash.voyageai.com/api-keys (404) with voyageai.com/dashboard so readers can access the API key dashboard.

<sup>Written for commit 550825fe86de18056ae181d7e68236516864c2ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

