### PR TITLE
docs(model-roles/embeddings): fix dead www.voyageai.com link

### DIFF
--- a/docs/customize/model-roles/embeddings.mdx
+++ b/docs/customize/model-roles/embeddings.mdx
@@ -29,7 +29,7 @@ If you want to generate embeddings locally, we recommend using `nomic-embed-text
 
 ### Voyage AI
 
-After obtaining an API key from [here](https://www.voyageai.com/), you can configure like this:
+After obtaining an API key from [here](https://voyageai.com/dashboard), you can configure like this:
 
 <Tabs>
     <Tab title="YAML">


### PR DESCRIPTION
Replaces `https://www.voyageai.com/` (404 via www subdomain) with `https://voyageai.com/dashboard` (200).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a dead Voyage AI link in the embeddings docs by replacing https://www.voyageai.com/ with https://voyageai.com/dashboard. This points users directly to the API key page.

<sup>Written for commit 4863138a68a4cb2341f5570924a37efd6a5275ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

