### PR TITLE
docs(model-roles/reranking): fix dead www.voyageai.com link

### DIFF
--- a/docs/customize/model-roles/reranking.mdx
+++ b/docs/customize/model-roles/reranking.mdx
@@ -19,7 +19,7 @@ If you have the ability to use any model, we recommend `rerank-2` by Voyage AI, 
 
 ### Voyage AI
 
-Voyage AI offers the best reranking model for code with their `rerank-2` model. After obtaining an API key from [here](https://www.voyageai.com/), you can configure a reranker as follows:
+Voyage AI offers the best reranking model for code with their `rerank-2` model. After obtaining an API key from [here](https://voyageai.com/dashboard), you can configure a reranker as follows:
 
 <Tabs>
   <Tab title="YAML">


### PR DESCRIPTION
Replaces `https://www.voyageai.com/` (404) with `https://voyageai.com/dashboard` (200).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a dead Voyage AI link in the reranking docs by updating the API key reference to https://voyageai.com/dashboard. This removes the 404 and directs users to the correct dashboard page.

<sup>Written for commit f056d7007509321bb10d3bbc12556bf767926c4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

