### PR TITLE
docs(model-roles/apply): fix dead morphllm.com/dashboard link

### DIFF
--- a/docs/customize/model-roles/apply.mdx
+++ b/docs/customize/model-roles/apply.mdx
@@ -13,7 +13,7 @@ When editing code, Chat and Edit model output often doesn't clearly align with e
   For the latest Apply model recommendations, see our [comprehensive model recommendations](/customize/models#recommended-models).
 </Info>
 
-We recommend [Morph Fast Apply](https://morphllm.com) or [Relace's Instant Apply model](https://continue.dev/relace/instant-apply) for the fastest Apply experience. You can sign up for Morph's free tier [here](https://morphllm.com/dashboard) or get a Relace API key [here](https://app.relace.ai/settings/api-keys).
+We recommend [Morph Fast Apply](https://morphllm.com) or [Relace's Instant Apply model](https://continue.dev/relace/instant-apply) for the fastest Apply experience. You can sign up for Morph's free tier [here](https://morphllm.com/sign-up) (the old `/dashboard` URL was retired) or get a Relace API key [here](https://app.relace.ai/settings/api-keys).
 
 However, most Chat models can also be used for applying code changes. We recommend smaller/cheaper models for the task, such as Claude 3.5 Haiku.
 


### PR DESCRIPTION
Replaces `https://morphllm.com/dashboard` (404) with `https://morphllm.com/sign-up` (200) — the old dashboard URL was retired.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a dead link in the Apply model docs by replacing Morph’s retired /dashboard URL with the working /sign-up page. This removes a 404 and sends users to the correct sign-up flow.

<sup>Written for commit dbeaea090769dcd4b2dfc541c60e48f853a5417c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

