### PR TITLE
docs(model-providers/morph): fix dead morphllm.com/dashboard link

### DIFF
--- a/docs/customize/model-providers/more/morph.mdx
+++ b/docs/customize/model-providers/more/morph.mdx
@@ -3,7 +3,7 @@ title: "Morph"
 description: "Configure Morph with Continue to access their optimized models for code application, embeddings, and reranking, designed for fast and accurate integration of AI-generated code changes"
 ---
 
-Morph provides a fast apply model that helps you quickly and accurately apply code changes from chat suggestions to your files. It's optimized for speed and precision when integrating generated code into your existing codebase. You can sign up for Morph's generous free tier [here](https://morphllm.com/dashboard). Then, update your configuration file as follows:
+Morph provides a fast apply model that helps you quickly and accurately apply code changes from chat suggestions to your files. It's optimized for speed and precision when integrating generated code into your existing codebase. You can sign up for Morph's generous free tier [here](https://morphllm.com/sign-up) (the old `/dashboard` URL was retired). Then, update your configuration file as follows:
 
 <Tabs>
    <Tab title="YAML">


### PR DESCRIPTION
Replaces `https://morphllm.com/dashboard` (404) with `https://morphllm.com/sign-up` (200) — the old dashboard URL was retired.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Morph provider docs to replace the dead dashboard link with the working sign-up page. This prevents 404s and keeps the setup flow smooth for new users.

<sup>Written for commit c1a28f1f6e3117f3d92b38fdd3004e8d505aded1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

