### PR TITLE
docs(model-providers/huggingface): fix dead endpoints.huggingface.co subpath

### DIFF
--- a/docs/customize/model-providers/more/morph.mdx
+++ b/docs/customize/model-providers/more/morph.mdx
@@ -3,7 +3,7 @@ title: "Morph"
 description: "Configure Morph with Continue to access their optimized models for code application, embeddings, and reranking, designed for fast and accurate integration of AI-generated code changes"
 ---
 
-Morph provides a fast apply model that helps you quickly and accurately apply code changes from chat suggestions to your files. It's optimized for speed and precision when integrating generated code into your existing codebase. You can sign up for Morph's generous free tier [here](https://morphllm.com/dashboard). Then, update your configuration file as follows:
+Morph provides a fast apply model that helps you quickly and accurately apply code changes from chat suggestions to your files. It's optimized for speed and precision when integrating generated code into your existing codebase. You can sign up for Morph's generous free tier [here](https://morphllm.com/sign-up) (the old `/dashboard` URL was retired). Then, update your configuration file as follows:
 
 <Tabs>
    <Tab title="YAML">

--- a/docs/customize/model-providers/top-level/huggingfaceinference.mdx
+++ b/docs/customize/model-providers/top-level/huggingfaceinference.mdx
@@ -52,7 +52,7 @@ Inference Endpoints is a dedicated service that allows you to run your open mode
 
 <Info>
 
-Before you can use Inference Endpoints, you need to create an endpoint. You can do this by going to [Inference Endpoints](https://endpoints.huggingface.co/burtenshaw/endpoints/dedicated) and clicking on "Create Endpoint".
+Before you can use Inference Endpoints, you need to create an endpoint. You can do this by going to [Inference Endpoints](https://endpoints.huggingface.co) and clicking on "Create Endpoint". (The old `/burtenshaw/endpoints/dedicated` user-scoped subpath was retired; the root `/` is the current canonical entry.)
 
 </Info>
 


### PR DESCRIPTION
Replaces `https://endpoints.huggingface.co/burtenshaw/endpoints/dedicated` (404) with `https://endpoints.huggingface.co` (200) — the user-scoped subpath was retired.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken links in model provider docs by updating Hugging Face Inference Endpoints and Morph sign-up URLs to their current pages.

- **Bug Fixes**
  - Replaced `https://endpoints.huggingface.co/burtenshaw/endpoints/dedicated` (404) with `https://endpoints.huggingface.co`.
  - Updated Morph sign-up link from `https://morphllm.com/dashboard` to `https://morphllm.com/sign-up`.

<sup>Written for commit 9b7430d9536c509fce38bd901ff0a1c2123d5a65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

