### PR TITLE
docs(model-providers/asksage): fix dead /api-documentation/ subpath

### DIFF
--- a/docs/customize/model-providers/more/asksage.mdx
+++ b/docs/customize/model-providers/more/asksage.mdx
@@ -18,7 +18,7 @@ Ask Sage provides secure, government-compliant access to LLMs. This guide explai
   Sign up or log in at [Ask Sage Platform](https://chat.asksage.ai/).
 
 - **API Key:**  
-  Follow the [API Key Documentation](https://docs.asksage.ai/docs/api-documentation/api-documentation.html) to generate your key.
+  Follow the [API Key Documentation](https://docs.asksage.ai/) to generate your key. (The old `/docs/api-documentation/api-documentation.html` subpath was retired; the Ask Sage homepage is the current canonical entry.)
 
 
 ## 2. Configuration
@@ -120,7 +120,7 @@ Supported features:
 
 ## 6. Support
 
-- Refer to [Ask Sage Docs](https://docs.asksage.ai/docs/api-documentation/api-documentation.html) for more details.
+- Refer to [Ask Sage Docs](https://docs.asksage.ai/) for more details. (The old `/docs/api-documentation/api-documentation.html` subpath was retired; the Ask Sage homepage is the current canonical entry.)
 - Email the Ask Sage support team for assistance at support@asksage.ai.
 
 ---


### PR DESCRIPTION
Replaces two `https://docs.asksage.ai/docs/api-documentation/api-documentation.html` (404) URLs with the docs root `/` (200 via redirect) — the subpath was retired.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed two broken Ask Sage docs links in `docs/customize/model-providers/more/asksage.mdx` by replacing `/docs/api-documentation/api-documentation.html` with `https://docs.asksage.ai/` to restore working references. The retired subpath returned 404; the homepage is now the canonical entry.

<sup>Written for commit 2c726d5903856318d2dc5e76d92631d674c3ca13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

