### PR TITLE
docs: fix broken vLLM engine arguments docs link in vllm.mdx

### DIFF
--- a/docs/customize/model-providers/more/vllm.mdx
+++ b/docs/customize/model-providers/more/vllm.mdx
@@ -3,7 +3,7 @@ title: "vLLM"
 description: "Configure vLLM's high-performance inference library with Continue for chat, autocomplete, and embeddings, including setup instructions for Llama3.1, Qwen2.5-Coder, and Nomic Embed models"
 ---
 
-vLLM is an open-source library for fast LLM inference which typically is used to serve multiple users at the same time. It can also be used to run a large model on multiple GPU:s (e.g. when it doesn´t fit in a single GPU). Run their OpenAI-compatible server using `vllm serve`. See their [server documentation](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html) and the [engine arguments documentation](https://docs.vllm.ai/en/latest/usage/engine_args.html).
+vLLM is an open-source library for fast LLM inference which typically is used to serve multiple users at the same time. It can also be used to run a large model on multiple GPU:s (e.g. when it doesn´t fit in a single GPU). Run their OpenAI-compatible server using `vllm serve`. See their [server documentation](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html) and the [engine arguments documentation](https://docs.vllm.ai/en/latest/configuration/engine_args.html).
 
 ```shell
 vllm serve meta-llama/Meta-Llama-3.1-8B-Instruct


### PR DESCRIPTION
## Summary

Single link fix in `docs/customize/model-providers/more/vllm.mdx:6`.

The vLLM provider documentation references the vLLM engine arguments page at a URL that returns 404:
```
https://docs.vllm.ai/en/latest/usage/engine_args.html
```

vLLM reorganized their docs and moved the engine arguments page under `/configuration/`:
```
https://docs.vllm.ai/en/latest/configuration/engine_args.html
```

## Verification

- Old URL: HTTP 404 (curl HEAD + GET)
- New URL: HTTP 200, page renders vLLM's engine arguments reference

The 'server documentation' link above this line (`/serving/openai_compatible_server.html`) still returns 200 and was not changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the vLLM provider docs to point the “engine arguments” link to the new /configuration/engine_args.html path. This fixes the 404 and sends readers to the correct reference page.

<sup>Written for commit 277c059985e97dfe48780466f9cc9c6c4bf7a8aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

