### PR TITLE
docs(guides/netlify-mcp): fix 4 more dead netlify docs subpaths

### DIFF
--- a/docs/customize/model-providers/more/vllm.mdx
+++ b/docs/customize/model-providers/more/vllm.mdx
@@ -3,7 +3,7 @@ title: "vLLM"
 description: "Configure vLLM's high-performance inference library with Continue for chat, autocomplete, and embeddings, including setup instructions for Llama3.1, Qwen2.5-Coder, and Nomic Embed models"
 ---
 
-vLLM is an open-source library for fast LLM inference which typically is used to serve multiple users at the same time. It can also be used to run a large model on multiple GPU:s (e.g. when it doesn´t fit in a single GPU). Run their OpenAI-compatible server using `vllm serve`. See their [server documentation](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html) and the [engine arguments documentation](https://docs.vllm.ai/en/latest/usage/engine_args.html).
+vLLM is an open-source library for fast LLM inference which typically is used to serve multiple users at the same time. It can also be used to run a large model on multiple GPU:s (e.g. when it doesn´t fit in a single GPU). Run their OpenAI-compatible server using `vllm serve`. See their [server documentation](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html) and the [engine arguments documentation](https://docs.vllm.ai/en/latest/configuration/engine_args.html).
 
 ```shell
 vllm serve meta-llama/Meta-Llama-3.1-8B-Instruct

--- a/docs/guides/netlify-mcp-continuous-deployment.mdx
+++ b/docs/guides/netlify-mcp-continuous-deployment.mdx
@@ -252,7 +252,7 @@ Show me the netlify.toml configuration and explain each optimization"
 
 <Info>
   **Netlify Build Features You're Getting**:
-  - [Build Caching](https://docs.netlify.com/configure-builds/build-caching/) - Persist dependencies between builds
+  - [Build Caching](https://docs.netlify.com/) - Persist dependencies between builds (the old `/configure-builds/build-caching/` URL was retired in the Netlify docs restructure)
   - [Build Plugins](https://docs.netlify.com/integrations/build-plugins/) - Extend build process with 100+ plugins
   - [Conditional Builds](https://docs.netlify.com/configure-builds/ignore-builds/) - Skip unnecessary builds
   - [Monorepo Support](https://docs.netlify.com/configure-builds/monorepos/) - Optimize multi-package repos
@@ -311,13 +311,13 @@ Generate a full report with before/after bundle sizes"
 
     **Features Available Through Netlify MCP**: 
     - [Bundle
-    Analyzer](https://docs.netlify.com/configure-builds/build-plugins/bundle-analyzer/): Visualize your JavaScript bundles 
+    Analyzer](https://docs.netlify.com/): Visualize your JavaScript bundles (the old `/configure-builds/build-plugins/bundle-analyzer/` URL was retired in the Netlify docs restructure)
     - [Asset
-    Optimization](https://docs.netlify.com/configure-builds/post-processing/):
-    Automatic minification and compression 
+    Optimization](https://docs.netlify.com/):
+    Automatic minification and compression (the old `/configure-builds/post-processing/` URL was retired in the Netlify docs restructure)
     - [Edge
-    Network](https://docs.netlify.com/platform/edge-network/): Global CDN with
-    smart caching 
+    Network](https://docs.netlify.com/): Global CDN with
+    smart caching (the old `/platform/edge-network/` URL was retired in the Netlify docs restructure) 
     - [Deploy
     Previews](https://docs.netlify.com/site-deploys/deploy-previews/): Test
     optimizations before production


### PR DESCRIPTION
Replaces 4 more `docs.netlify.com` 404 URLs (`/configure-builds/build-caching/`, `/configure-builds/build-plugins/bundle-analyzer/`, `/configure-builds/post-processing/`, `/platform/edge-network/`) with the docs root `/` (200). Follows up on #12860 which only addressed the analytics links.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dead links in the Netlify MCP guide and vLLM docs to remove 404s. Replaces four retired Netlify URLs with the docs root and updates the vLLM engine arguments link to its new location.

- **Bug Fixes**
  - Netlify MCP guide: replaced 404s for Build Caching, Bundle Analyzer, Asset Optimization, and Edge Network with https://docs.netlify.com/ and noted the paths were retired.
  - vLLM docs: updated the engine arguments link to https://docs.vllm.ai/en/latest/configuration/engine_args.html.

<sup>Written for commit f674b66037cd96a6e2cc11d98e5f74d573d0571e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

