### PR TITLE
docs(guides/snyk-mcp-continue-cookbook): fix dead snyk.io/learn/software-composition-analysis-sca link

### DIFF
--- a/docs/guides/snyk-mcp-continue-cookbook.mdx
+++ b/docs/guides/snyk-mcp-continue-cookbook.mdx
@@ -230,7 +230,7 @@ cn -p "Run a Snyk Code scan on this repo with severity threshold medium. Summari
 
 </Card>
 
-### Dependency Scanning ([SCA](https://snyk.io/learn/software-composition-analysis-sca/))
+### Dependency Scanning ([SCA](https://snyk.io/learn/))
 
 <Card title="Software Composition Analysis" icon="cube">
   Check open source dependencies for known vulnerabilities.


### PR DESCRIPTION
Replaces `https://snyk.io/learn/software-composition-analysis-sca/` (404 — deep `/learn/<topic>` paths retired) with `https://snyk.io/learn/` (200 — canonical Snyk learning hub landing).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix broken Snyk SCA link in the cookbook. Replace `https://snyk.io/learn/software-composition-analysis-sca/` with `https://snyk.io/learn/` so the docs point to the live learning hub.

<sup>Written for commit 83e36f22f28aee7af697d1f5ca39b446b1596b8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

