### PR TITLE
docs(guides/supabase-mcp-database-workflow): fix dead supabase database/security link

### DIFF
--- a/docs/guides/supabase-mcp-database-workflow.mdx
+++ b/docs/guides/supabase-mcp-database-workflow.mdx
@@ -509,7 +509,7 @@ If you encounter connection issues:
 
 - [Supabase MCP Documentation](https://supabase.com/docs/guides/getting-started/mcp)
 - [Supabase Database Guide](https://supabase.com/docs/guides/database)
-- [Supabase Security Best Practices](https://supabase.com/docs/guides/database/security)
+- [Supabase Security Best Practices](https://supabase.com/docs/guides/database)
 - [Model Context Protocol Docs](https://modelcontextprotocol.io/introduction)
 - [Continue CLI Guide](https://docs.continue.dev/guides/cli)
 - [Continuous AI Best Practices](https://blog.continue.dev/what-is-continuous-ai-a-developers-guide/)


### PR DESCRIPTION
Replaces `https://supabase.com/docs/guides/database/security` (404 — `database/security` subpage retired) with `https://supabase.com/docs/guides/database` (200 — database guide landing now includes security).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a dead Supabase security link in the Supabase MCP database workflow guide. Replaces `https://supabase.com/docs/guides/database/security` with `https://supabase.com/docs/guides/database` so readers reach the current security guidance.

<sup>Written for commit 1a408414070f3a6a2b2476fa43ad2ad964162d51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

