### PR TITLE
docs(guides/sanity-mcp-continue-cookbook): fix dead sanity release-schedules link

### DIFF
--- a/docs/guides/sanity-mcp-continue-cookbook.mdx
+++ b/docs/guides/sanity-mcp-continue-cookbook.mdx
@@ -164,7 +164,7 @@ After ensuring you meet the **Prerequisites** above, you have two paths to get s
   **Sanity MCP** provides comprehensive tools for content management:
   - Execute [GROQ queries](https://www.sanity.io/docs/groq) to fetch and analyze content
   - Explore and modify [document schemas](https://www.sanity.io/docs/schema-types)
-  - Manage [content releases](https://www.sanity.io/docs/release-schedules) and versions
+  - Manage [content releases](https://www.sanity.io/docs/) and versions
   - Handle content [migrations](https://www.sanity.io/docs/migrating-data) between environments
   - Automate documentation generation
   - Perform bulk content operations


### PR DESCRIPTION
Replaces `https://www.sanity.io/docs/release-schedules` (404 — standalone page retired) with `https://www.sanity.io/docs/` (200 — canonical docs landing; release management now lives under the docs root).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a dead link in the Sanity MCP Continue cookbook by replacing https://www.sanity.io/docs/release-schedules (404) with https://www.sanity.io/docs/ so the “Manage content releases” link works.

<sup>Written for commit 0e64ccb67b24c7232ba4c517be05869215d15ace. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

