### PR TITLE
fix(gui): preserve filepath in apply error state

### DIFF
--- a/gui/src/redux/thunks/handleApplyStateUpdate.ts
+++ b/gui/src/redux/thunks/handleApplyStateUpdate.ts
@@ -210,6 +210,7 @@ export const applyForEditTool = createAsyncThunk<
           status: "closed",
           streamId: applyState.streamId,
           toolCallId,
+          filepath: payload.filepath,
         }),
       );
     }


### PR DESCRIPTION
## Description

Fixes https://github.com/continuedev/continue/issues/12641

Preserve the original `filepath` when an edit/apply operation fails in the GUI apply flow.

Previously, the failure path in `handleApplyStateUpdate` could close the apply state without carrying the file path forward, which caused the UI to show `Failed to edit undefined`.

This change keeps the file context in the error flow so the failure message references the correct file.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Not applicable for this change, since this is a minimal error-state handling fix.

## Tests

No tests were added as part of this minimal fix.

The change is limited to preserving `filepath` in the failed apply-state update so the existing error message uses the correct file path instead of `undefined`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserve the original `filepath` in the GUI apply error flow so failure messages show the correct file. Fixes "Failed to edit undefined" by carrying `filepath` through the failed apply-state update.

<sup>Written for commit fd245dce0a3d1d04de501964997dab52768f4524. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

