### PR TITLE
fix: resolve YAML env placeholders for API keys and remote shell env

### DIFF
--- a/core/config/yaml/LocalPlatformClient.ts
+++ b/core/config/yaml/LocalPlatformClient.ts
@@ -7,6 +7,7 @@ import {
 import * as dotenv from "dotenv";
 import { IDE } from "../..";
 import { getContinueDotEnv } from "../../util/paths";
+import { getEnvVarsFromUserShell } from "../../util/shellPath";
 import { joinPathsToUri } from "../../util/uri";
 
 export class LocalPlatformClient implements PlatformClient {
@@ -93,6 +94,7 @@ export class LocalPlatformClient implements PlatformClient {
     }
 
     const results: (SecretResult | undefined)[] = [];
+    let shellEnvVars: Record<string, string> | undefined;
 
     for (let i = 0; i < fqsns.length; i++) {
       let secretResult = await this.findSecretInEnvFiles(fqsns[i]);
@@ -105,6 +107,25 @@ export class LocalPlatformClient implements PlatformClient {
             found: true,
             fqsn: fqsns[i],
             value: secretValueFromProcessEnv,
+            secretLocation: {
+              secretName: fqsns[i].secretName,
+              secretType: SecretType.ProcessEnv as SecretType.ProcessEnv,
+            },
+          };
+        }
+      }
+
+      if (!secretResult?.found) {
+        shellEnvVars ??= await getEnvVarsFromUserShell(
+          (await this.ide.getIdeInfo()).remoteName,
+        );
+
+        const secretValueFromShellEnv = shellEnvVars?.[fqsns[i].secretName];
+        if (secretValueFromShellEnv !== undefined) {
+          secretResult = {
+            found: true,
+            fqsn: fqsns[i],
+            value: secretValueFromShellEnv,
             secretLocation: {
               secretName: fqsns[i].secretName,
               secretType: SecretType.ProcessEnv as SecretType.ProcessEnv,

--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -276,13 +276,15 @@ export async function configYamlToContinueConfig(options: {
       subagent: null,
     },
     rules: [],
-    requestOptions: { ...unrolledAssistant.requestOptions },
+    requestOptions: {},
   };
 
   const config = await resolveConfigEnvPlaceholders(
     nonNullifyConfigYaml(unrolledAssistant),
     ideInfo.remoteName,
   );
+
+  continueConfig.requestOptions = { ...config.requestOptions };
 
   for (const rule of config.rules ?? []) {
     const convertedRule = convertYamlRuleToContinueRule(rule);

--- a/core/config/yaml/loadYaml.ts
+++ b/core/config/yaml/loadYaml.ts
@@ -32,6 +32,7 @@ import { convertPromptBlockToSlashCommand } from "../../commands/slash/promptBlo
 import { slashCommandFromPromptFile } from "../../commands/slash/promptFileSlashCommand";
 import { loadJsonMcpConfigs } from "../../context/mcp/json/loadJsonMcpConfigs";
 import { getBaseToolDefinitions } from "../../tools";
+import { getEnvVarsFromUserShell } from "../../util/shellPath";
 import { getCleanUriPath } from "../../util/uri";
 import { loadConfigContextProviders } from "../loadContextProviders";
 import { getAllDotContinueDefinitionFiles } from "../loadLocalAssistants";
@@ -153,6 +154,91 @@ function nonNullifyConfigYaml(
   };
 }
 
+const ENV_PLACEHOLDER_REGEX = /\$\{env:([A-Za-z_][A-Za-z0-9_]*)\}/g;
+
+function collectEnvPlaceholderNames(value: unknown, envVarNames: Set<string>) {
+  if (typeof value === "string") {
+    for (const match of value.matchAll(ENV_PLACEHOLDER_REGEX)) {
+      envVarNames.add(match[1]);
+    }
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectEnvPlaceholderNames(item, envVarNames));
+    return;
+  }
+
+  if (value && typeof value === "object") {
+    Object.values(value).forEach((item) =>
+      collectEnvPlaceholderNames(item, envVarNames),
+    );
+  }
+}
+
+function replaceEnvPlaceholders<T>(
+  value: T,
+  envValues: Record<string, string>,
+): T {
+  if (typeof value === "string") {
+    return value.replace(
+      ENV_PLACEHOLDER_REGEX,
+      (fullMatch, envVarName) => envValues[envVarName] ?? fullMatch,
+    ) as T;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => replaceEnvPlaceholders(item, envValues)) as T;
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        key,
+        replaceEnvPlaceholders(item, envValues),
+      ]),
+    ) as T;
+  }
+
+  return value;
+}
+
+async function resolveConfigEnvPlaceholders<T>(
+  value: T,
+  remoteName?: string,
+): Promise<T> {
+  const envVarNames = new Set<string>();
+  collectEnvPlaceholderNames(value, envVarNames);
+
+  if (envVarNames.size === 0) {
+    return value;
+  }
+
+  const envValues: Record<string, string> = {};
+  for (const envVarName of envVarNames) {
+    const envValue = process.env[envVarName];
+    if (envValue !== undefined) {
+      envValues[envVarName] = envValue;
+    }
+  }
+
+  const missingEnvVarNames = [...envVarNames].filter(
+    (envVarName) => envValues[envVarName] === undefined,
+  );
+
+  if (missingEnvVarNames.length > 0) {
+    const shellEnvVars = await getEnvVarsFromUserShell(remoteName);
+    for (const envVarName of missingEnvVarNames) {
+      const envValue = shellEnvVars?.[envVarName];
+      if (envValue !== undefined) {
+        envValues[envVarName] = envValue;
+      }
+    }
+  }
+
+  return replaceEnvPlaceholders(value, envValues);
+}
+
 export async function configYamlToContinueConfig(options: {
   unrolledAssistant: AssistantUnrolled;
   ide: IDE;
@@ -193,7 +279,10 @@ export async function configYamlToContinueConfig(options: {
     requestOptions: { ...unrolledAssistant.requestOptions },
   };
 
-  const config = nonNullifyConfigYaml(unrolledAssistant);
+  const config = await resolveConfigEnvPlaceholders(
+    nonNullifyConfigYaml(unrolledAssistant),
+    ideInfo.remoteName,
+  );
 
   for (const rule of config.rules ?? []) {
     const convertedRule = convertYamlRuleToContinueRule(rule);

--- a/core/util/shellPath.ts
+++ b/core/util/shellPath.ts
@@ -2,9 +2,10 @@ import { exec } from "child_process";
 import { promisify } from "util";
 
 const execAsync = promisify(exec);
-export async function getEnvPathFromUserShell(
+
+async function getUserShellEnvironment(
   remoteName?: string,
-): Promise<string | undefined> {
+): Promise<Record<string, string> | undefined> {
   const isWindowsHostWithWslRemote =
     process.platform === "win32" && remoteName === "wsl";
   if (process.platform === "win32" && !isWindowsHostWithWslRemote) {
@@ -17,14 +18,45 @@ export async function getEnvPathFromUserShell(
 
   try {
     // Source common profile files
-    const command = `${process.env.SHELL} -l -c 'for f in ~/.zprofile ~/.zshrc ~/.bash_profile ~/.bashrc; do [ -f "$f" ] && source "$f" 2>/dev/null; done; echo $PATH'`;
+    const command = `${process.env.SHELL} -l -c 'for f in ~/.zprofile ~/.zshrc ~/.bash_profile ~/.bashrc; do [ -f "$f" ] && . "$f" 2>/dev/null; done; env'`;
 
     const { stdout } = await execAsync(command, {
       encoding: "utf8",
     });
 
-    return stdout.trim();
+    return Object.fromEntries(
+      stdout
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .map((line) => {
+          const separatorIndex = line.indexOf("=");
+          if (separatorIndex === -1) {
+            return undefined;
+          }
+
+          return [
+            line.slice(0, separatorIndex),
+            line.slice(separatorIndex + 1),
+          ] as const;
+        })
+        .filter(
+          (entry): entry is readonly [string, string] => entry !== undefined,
+        ),
+    );
   } catch (error) {
-    return process.env.PATH; // Fallback to current PATH
+    return undefined;
   }
+}
+
+export async function getEnvVarsFromUserShell(
+  remoteName?: string,
+): Promise<Record<string, string> | undefined> {
+  return getUserShellEnvironment(remoteName);
+}
+
+export async function getEnvPathFromUserShell(
+  remoteName?: string,
+): Promise<string | undefined> {
+  const shellEnvironment = await getUserShellEnvironment(remoteName);
+  return shellEnvironment?.PATH ?? process.env.PATH;
 }

--- a/core/util/shellPath.ts
+++ b/core/util/shellPath.ts
@@ -3,6 +3,27 @@ import { promisify } from "util";
 
 const execAsync = promisify(exec);
 
+function parseEnvEntries(entries: string[]): Record<string, string> {
+  return Object.fromEntries(
+    entries
+      .filter(Boolean)
+      .map((entry) => {
+        const separatorIndex = entry.indexOf("=");
+        if (separatorIndex === -1) {
+          return undefined;
+        }
+
+        return [
+          entry.slice(0, separatorIndex),
+          entry.slice(separatorIndex + 1),
+        ] as const;
+      })
+      .filter(
+        (entry): entry is readonly [string, string] => entry !== undefined,
+      ),
+  );
+}
+
 async function getUserShellEnvironment(
   remoteName?: string,
 ): Promise<Record<string, string> | undefined> {
@@ -18,31 +39,15 @@ async function getUserShellEnvironment(
 
   try {
     // Source common profile files
-    const command = `${process.env.SHELL} -l -c 'for f in ~/.zprofile ~/.zshrc ~/.bash_profile ~/.bashrc; do [ -f "$f" ] && . "$f" 2>/dev/null; done; env'`;
+    const command = `${process.env.SHELL} -l -c 'for f in ~/.zprofile ~/.zshrc ~/.bash_profile ~/.bashrc; do [ -f "$f" ] && . "$f" 2>/dev/null; done; if env -0 >/dev/null 2>&1; then env -0; elif printenv -0 >/dev/null 2>&1; then printenv -0; else env; fi'`;
 
     const { stdout } = await execAsync(command, {
       encoding: "utf8",
     });
 
-    return Object.fromEntries(
-      stdout
-        .split(/\r?\n/)
-        .filter(Boolean)
-        .map((line) => {
-          const separatorIndex = line.indexOf("=");
-          if (separatorIndex === -1) {
-            return undefined;
-          }
-
-          return [
-            line.slice(0, separatorIndex),
-            line.slice(separatorIndex + 1),
-          ] as const;
-        })
-        .filter(
-          (entry): entry is readonly [string, string] => entry !== undefined,
-        ),
-    );
+    return stdout.includes("\0")
+      ? parseEnvEntries(stdout.split("\0"))
+      : parseEnvEntries(stdout.split(/\r?\n/));
   } catch (error) {
     return undefined;
   }


### PR DESCRIPTION
Fixes #12842

## Description

Fixes config YAML env placeholder resolution for API keys such as `${env:OPENROUTER_API_KEY}`.

Previously, hardcoding an API key in YAML worked, but using `${env:VAR}` could fail to resolve in some environments, leading to missing API keys and `401` errors.

This PR makes two focused fixes:
- resolves `${env:VAR}` placeholders while converting YAML config into runtime config
- adds the same shell-environment fallback for `LocalPlatformClient` secret resolution, which helps in Remote-SSH / remote shell scenarios where `process.env` may not contain the expected variable

This is a minimal fix scoped to config/env resolution behavior.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Not included, since this change affects config/env resolution rather than a visible UI flow.

If helpful for review, I can add a short repro note instead:
- hardcoded `apiKey` in YAML works
- `${env:OPENROUTER_API_KEY}` now also works
- Remote-SSH/remote shell resolution is covered by the same fallback path

## Tests

No automated tests were added in this change.

Manual validation suggested:
- confirm hardcoded `apiKey` in YAML works
- confirm `${env:OPENROUTER_API_KEY}` works in local setup
- confirm `${env:OPENROUTER_API_KEY}` works in Remote-SSH / remote shell setup where the variable is available from the user shell

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes YAML `${env:VAR}` resolution across the config (including request options) and adds a shell-environment fallback that preserves multiline values to prevent missing API keys and 401s in local and Remote-SSH setups. Fixes #12842.

- **Bug Fixes**
  - Resolve env placeholders during YAML-to-runtime conversion across all fields, including `requestOptions`.
  - Fallback to the user's login shell when `process.env` is missing vars, preserving multiline values and working in Remote-SSH.

<sup>Written for commit 1bcea8676f07cfbdc5f46111571fe4a541a64fff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

