### PR TITLE
Fix image input in Chat UI and silence extension console errors

### DIFF
--- a/core/nextEdit/DocumentHistoryTracker.ts
+++ b/core/nextEdit/DocumentHistoryTracker.ts
@@ -61,7 +61,9 @@ export class DocumentHistoryTracker {
     const documentHistory = this.documentContentHistoryMap.get(documentPath);
 
     if (!astHistory || !documentHistory) {
-      console.error(`Document ${documentPath} not found in AST tracker`);
+      if (!documentPath.endsWith(".yaml") && !documentPath.endsWith(".json") && !documentPath.endsWith(".md")) {
+        console.error(`Document ${documentPath} not found in AST tracker`);
+      }
       this.addDocument(documentPath, documentContent, ast);
       return; // Early return - document was added with initial state
     }
@@ -82,7 +84,9 @@ export class DocumentHistoryTracker {
     const astHistory = this.documentAstMap.get(documentPath);
 
     if (!astHistory) {
-      console.error(`Document ${documentPath} not found in AST tracker`);
+      if (!documentPath.endsWith(".yaml") && !documentPath.endsWith(".json") && !documentPath.endsWith(".md")) {
+        console.error(`Document ${documentPath} not found in AST tracker`);
+      }
       return null;
     }
     if (astHistory.length === 0) {
@@ -105,7 +109,9 @@ export class DocumentHistoryTracker {
     const documentHistory = this.documentContentHistoryMap.get(documentPath);
 
     if (!documentHistory) {
-      console.error(`Document ${documentPath} not found in AST tracker`);
+      if (!documentPath.endsWith(".yaml") && !documentPath.endsWith(".json") && !documentPath.endsWith(".md")) {
+        console.error(`Document ${documentPath} not found in AST tracker`);
+      }
       return null;
     }
     if (documentHistory.length === 0) {

--- a/core/nextEdit/DocumentHistoryTracker.ts
+++ b/core/nextEdit/DocumentHistoryTracker.ts
@@ -61,10 +61,12 @@ export class DocumentHistoryTracker {
     const documentHistory = this.documentContentHistoryMap.get(documentPath);
 
     if (!astHistory || !documentHistory) {
+      const lowerPath = documentPath.toLowerCase();
       if (
-        !documentPath.endsWith(".yaml") &&
-        !documentPath.endsWith(".json") &&
-        !documentPath.endsWith(".md")
+        !lowerPath.endsWith(".yaml") &&
+        !lowerPath.endsWith(".yml") &&
+        !lowerPath.endsWith(".json") &&
+        !lowerPath.endsWith(".md")
       ) {
         console.error(`Document ${documentPath} not found in AST tracker`);
       }
@@ -88,10 +90,12 @@ export class DocumentHistoryTracker {
     const astHistory = this.documentAstMap.get(documentPath);
 
     if (!astHistory) {
+      const lowerPath = documentPath.toLowerCase();
       if (
-        !documentPath.endsWith(".yaml") &&
-        !documentPath.endsWith(".json") &&
-        !documentPath.endsWith(".md")
+        !lowerPath.endsWith(".yaml") &&
+        !lowerPath.endsWith(".yml") &&
+        !lowerPath.endsWith(".json") &&
+        !lowerPath.endsWith(".md")
       ) {
         console.error(`Document ${documentPath} not found in AST tracker`);
       }
@@ -117,10 +121,12 @@ export class DocumentHistoryTracker {
     const documentHistory = this.documentContentHistoryMap.get(documentPath);
 
     if (!documentHistory) {
+      const lowerPath = documentPath.toLowerCase();
       if (
-        !documentPath.endsWith(".yaml") &&
-        !documentPath.endsWith(".json") &&
-        !documentPath.endsWith(".md")
+        !lowerPath.endsWith(".yaml") &&
+        !lowerPath.endsWith(".yml") &&
+        !lowerPath.endsWith(".json") &&
+        !lowerPath.endsWith(".md")
       ) {
         console.error(`Document ${documentPath} not found in AST tracker`);
       }

--- a/core/nextEdit/DocumentHistoryTracker.ts
+++ b/core/nextEdit/DocumentHistoryTracker.ts
@@ -61,7 +61,11 @@ export class DocumentHistoryTracker {
     const documentHistory = this.documentContentHistoryMap.get(documentPath);
 
     if (!astHistory || !documentHistory) {
-      if (!documentPath.endsWith(".yaml") && !documentPath.endsWith(".json") && !documentPath.endsWith(".md")) {
+      if (
+        !documentPath.endsWith(".yaml") &&
+        !documentPath.endsWith(".json") &&
+        !documentPath.endsWith(".md")
+      ) {
         console.error(`Document ${documentPath} not found in AST tracker`);
       }
       this.addDocument(documentPath, documentContent, ast);
@@ -84,7 +88,11 @@ export class DocumentHistoryTracker {
     const astHistory = this.documentAstMap.get(documentPath);
 
     if (!astHistory) {
-      if (!documentPath.endsWith(".yaml") && !documentPath.endsWith(".json") && !documentPath.endsWith(".md")) {
+      if (
+        !documentPath.endsWith(".yaml") &&
+        !documentPath.endsWith(".json") &&
+        !documentPath.endsWith(".md")
+      ) {
         console.error(`Document ${documentPath} not found in AST tracker`);
       }
       return null;
@@ -109,7 +117,11 @@ export class DocumentHistoryTracker {
     const documentHistory = this.documentContentHistoryMap.get(documentPath);
 
     if (!documentHistory) {
-      if (!documentPath.endsWith(".yaml") && !documentPath.endsWith(".json") && !documentPath.endsWith(".md")) {
+      if (
+        !documentPath.endsWith(".yaml") &&
+        !documentPath.endsWith(".json") &&
+        !documentPath.endsWith(".md")
+      ) {
         console.error(`Document ${documentPath} not found in AST tracker`);
       }
       return null;

--- a/extensions/intellij/src/testIntegration/kotlin/com/github/continuedev/continueintellijextension/Autocomplete.kt
+++ b/extensions/intellij/src/testIntegration/kotlin/com/github/continuedev/continueintellijextension/Autocomplete.kt
@@ -31,6 +31,13 @@ class Autocomplete {
                     clickTab("Main.java")
                 }
                 codeEditor {
+                    keyboard {
+                        escape() // close any popups
+                        pageDown()
+                        pageDown()
+                        end()
+                        enter()
+                    }
                     var success = false
                     for (i in 1..10) {
                         keyboard {
@@ -49,8 +56,8 @@ class Autocomplete {
                             enter()
                         }
                     }
-                    assertTrue(success) {
-                        "Autocomplete mismatch.\nEditor=${text.take(500)}"
+                    if (!success) {
+                        throw Exception("DEBUG_TEXT: ${text.take(500)}")
                     }
                 }
             }

--- a/extensions/intellij/src/testIntegration/kotlin/com/github/continuedev/continueintellijextension/Autocomplete.kt
+++ b/extensions/intellij/src/testIntegration/kotlin/com/github/continuedev/continueintellijextension/Autocomplete.kt
@@ -10,7 +10,6 @@ import com.intellij.ide.starter.plugins.PluginConfigurator
 import com.intellij.ide.starter.project.NoProject
 import com.intellij.ide.starter.runner.Starter
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.Assertions.assertTrue
 import java.io.File
 import kotlin.time.Duration.Companion.seconds
 

--- a/extensions/intellij/src/testIntegration/kotlin/com/github/continuedev/continueintellijextension/Autocomplete.kt
+++ b/extensions/intellij/src/testIntegration/kotlin/com/github/continuedev/continueintellijextension/Autocomplete.kt
@@ -31,20 +31,25 @@ class Autocomplete {
                     clickTab("Main.java")
                 }
                 codeEditor {
-                    keyboard {
-                        enterText("TEST_USER_MESSAGE_0")
-                        space()
+                    var success = false
+                    for (i in 1..10) {
+                        keyboard {
+                            enterText("TEST_USER_MESSAGE_0")
+                            space()
+                        }
+                        wait(2.seconds)
+                        keyboard {
+                            tab()
+                        }
+                        if (text.contains("TEST_LLM_RESPONSE_0")) {
+                            success = true
+                            break
+                        }
+                        keyboard {
+                            enter()
+                        }
                     }
-                    wait(5.seconds)
-                    keyboard {
-                        tab()
-                    }
-                    var attempts = 0
-                    while (!text.contains("TEST_LLM_RESPONSE_0") && attempts < 10) {
-                        wait(1.seconds)
-                        attempts++
-                    }
-                    assertTrue(text.contains("TEST_LLM_RESPONSE_0")) {
+                    assertTrue(success) {
                         "Autocomplete mismatch.\nEditor=${text.take(500)}"
                     }
                 }

--- a/extensions/intellij/src/testIntegration/kotlin/com/github/continuedev/continueintellijextension/Autocomplete.kt
+++ b/extensions/intellij/src/testIntegration/kotlin/com/github/continuedev/continueintellijextension/Autocomplete.kt
@@ -35,11 +35,18 @@ class Autocomplete {
                         enterText("TEST_USER_MESSAGE_0")
                         space()
                     }
-                    wait(2.seconds)
+                    wait(5.seconds)
                     keyboard {
                         tab()
                     }
-                    assertTrue(text.contains("TEST_LLM_RESPONSE_0"))
+                    var attempts = 0
+                    while (!text.contains("TEST_LLM_RESPONSE_0") && attempts < 10) {
+                        wait(1.seconds)
+                        attempts++
+                    }
+                    assertTrue(text.contains("TEST_LLM_RESPONSE_0")) {
+                        "Autocomplete mismatch.\nEditor=${text.take(500)}"
+                    }
                 }
             }
         }

--- a/extensions/intellij/src/testIntegration/kotlin/com/github/continuedev/continueintellijextension/Autocomplete.kt
+++ b/extensions/intellij/src/testIntegration/kotlin/com/github/continuedev/continueintellijextension/Autocomplete.kt
@@ -32,9 +32,8 @@ class Autocomplete {
                 codeEditor {
                     keyboard {
                         escape() // close any popups
-                        pageDown()
-                        pageDown()
-                        end()
+                        enter()
+                        enter()
                         enter()
                     }
                     var success = false

--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -48,20 +48,23 @@ export async function activateExtension(context: vscode.ExtensionContext) {
     "config-yaml-schema.json",
   ).toString();
 
-  try {
-    await yamlConfig.update(
-      "schemas",
-      {
-        ...yamlSchemas,
-        [newPath]: [yamlMatcher],
-      },
-      vscode.ConfigurationTarget.Global,
-    );
-  } catch (error) {
-    console.error(
-      "Failed to register Continue config.yaml schema, most likely, YAML extension is not installed",
-      error,
-    );
+  const yamlExtension = vscode.extensions.getExtension("redhat.vscode-yaml");
+  if (yamlExtension) {
+    try {
+      await yamlConfig.update(
+        "schemas",
+        {
+          ...yamlSchemas,
+          [newPath]: [yamlMatcher],
+        },
+        vscode.ConfigurationTarget.Global,
+      );
+    } catch (error) {
+      console.error(
+        "Failed to register Continue config.yaml schema",
+        error,
+      );
+    }
   }
 
   const api = new VsCodeContinueApi(vscodeExtension);

--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -60,10 +60,7 @@ export async function activateExtension(context: vscode.ExtensionContext) {
         vscode.ConfigurationTarget.Global,
       );
     } catch (error) {
-      console.error(
-        "Failed to register Continue config.yaml schema",
-        error,
-      );
+      console.error("Failed to register Continue config.yaml schema", error);
     }
   }
 

--- a/gui/src/components/mainInput/TipTapEditor/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor/TipTapEditor.tsx
@@ -255,10 +255,14 @@ function TipTapEditorInner(props: TipTapEditorProps) {
           }
           if (result) {
             const [_, dataUrl] = result;
-            editor.commands.insertContent({
-              type: "image",
-              attrs: { src: dataUrl },
-            });
+            editor
+              .chain()
+              .focus()
+              .insertContent({
+                type: "image",
+                attrs: { src: dataUrl },
+              })
+              .run();
           }
         });
         event.preventDefault();
@@ -287,10 +291,14 @@ function TipTapEditorInner(props: TipTapEditorProps) {
               }
               if (result) {
                 const [_, dataUrl] = result;
-                editor.commands.insertContent({
-                  type: "image",
-                  attrs: { src: dataUrl },
-                });
+                editor
+                  .chain()
+                  .focus()
+                  .insertContent({
+                    type: "image",
+                    attrs: { src: dataUrl },
+                  })
+                  .run();
               }
             });
           }}

--- a/gui/src/components/mainInput/TipTapEditor/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor/TipTapEditor.tsx
@@ -255,10 +255,10 @@ function TipTapEditorInner(props: TipTapEditorProps) {
           }
           if (result) {
             const [_, dataUrl] = result;
-            const { schema } = editor.state;
-            const node = schema.nodes.image.create({ src: dataUrl });
-            const tr = editor.state.tr.insert(0, node);
-            editor.view.dispatch(tr);
+            editor.commands.insertContent({
+              type: "image",
+              attrs: { src: dataUrl }
+            });
           }
         });
         event.preventDefault();
@@ -287,11 +287,9 @@ function TipTapEditorInner(props: TipTapEditorProps) {
               }
               if (result) {
                 const [_, dataUrl] = result;
-                const { schema } = editor.state;
-                const node = schema.nodes.image.create({ src: dataUrl });
-                editor.commands.command(({ tr }) => {
-                  tr.insert(0, node);
-                  return true;
+                editor.commands.insertContent({
+                  type: "image",
+                  attrs: { src: dataUrl }
                 });
               }
             });

--- a/gui/src/components/mainInput/TipTapEditor/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor/TipTapEditor.tsx
@@ -257,7 +257,7 @@ function TipTapEditorInner(props: TipTapEditorProps) {
             const [_, dataUrl] = result;
             editor.commands.insertContent({
               type: "image",
-              attrs: { src: dataUrl }
+              attrs: { src: dataUrl },
             });
           }
         });
@@ -289,7 +289,7 @@ function TipTapEditorInner(props: TipTapEditorProps) {
                 const [_, dataUrl] = result;
                 editor.commands.insertContent({
                   type: "image",
-                  attrs: { src: dataUrl }
+                  attrs: { src: dataUrl },
                 });
               }
             });

--- a/gui/src/components/mainInput/TipTapEditor/utils/editorConfig.ts
+++ b/gui/src/components/mainInput/TipTapEditor/utils/editorConfig.ts
@@ -161,7 +161,8 @@ export function createEditorConfig(options: {
                   if (!model) return;
                   const items = event.clipboardData?.items;
                   if (items) {
-                    for (const item of items) {
+                    for (let i = 0; i < items.length; i++) {
+                      const item = items[i];
                       const file = item.getAsFile();
                       file &&
                         modelSupportsImages(
@@ -178,7 +179,7 @@ export function createEditorConfig(options: {
                             const node = schema.nodes.image.create({
                               src: dataUrl,
                             });
-                            const tr = view.state.tr.insert(0, node);
+                            const tr = view.state.tr.replaceSelectionWith(node);
                             view.dispatch(tr);
                           },
                         );


### PR DESCRIPTION
### Problem
The image attachment mechanism was completely broken on Windows because it tried to insert an inline image node at position 0 in the editor. This violates TipTap's schema and is silently dropped by ProseMirror. Additionally, there were harmless but alarming YAML schema and AST Tracker errors spamming the developer console.

### Solution
- Modifies the image paste and upload mechanism to insert the image at the active selection/cursor using `editor.commands.insertContent`, properly delegating schema resolution to TipTap.
- Wraps the `yaml.schemas` registration with an extension availability check so it doesn't throw a `CodeExpectedError`.
- Suppresses the AST Tracker error log for non-AST files like `.yaml` and `.json`.

Fixes #12845

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken image attachments in the Chat UI by inserting images at the cursor using TipTap chain/focus, and silences noisy console errors from YAML schema registration and the AST tracker.

- **Bug Fixes**
  - Insert images at the active selection via chain().focus().insertContent() for paste and upload; clipboard paste replaces the current selection.
  - Register YAML schemas only if `redhat.vscode-yaml` is installed.
  - Suppress "Document not found in AST tracker" logs for .yaml, .yml, .json, .md.
  - Stabilize IntelliJ Autocomplete test: start on a clean line with Esc + Enter x3, retry up to 10; Tab to accept, Enter to retry; throw an exception with debug text; avoid unresolved SDK commands.
  - Remove unused JUnit import to fix Kotlin test compilation.

- **Refactors**
  - Applied Prettier formatting to satisfy CI checks.

<sup>Written for commit 813b5d7375e01e0535445685fde2cd1117841806. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

