### PR TITLE
docs: update config yaml models link

### DIFF
--- a/core/config/createNewAssistantFile.ts
+++ b/core/config/createNewAssistantFile.ts
@@ -9,7 +9,7 @@ version: 1.0.0
 schema: v1
 
 # Define which models can be used
-# https://docs.continue.dev/customization/models
+# https://docs.continue.dev/customize/models
 models:
   - name: my gpt-5
     provider: openai


### PR DESCRIPTION
## Summary
Update the generated `config.yaml` example comment to point to the current models customization docs URL.

## Motivation
The starter config currently links to `/customization/models`, while the current docs path is `/customize/models`. This can send new users to a stale URL from the generated config template.

Fixes #12669

## Changes
- Replace the stale models documentation URL in `core/config/createNewAssistantFile.ts`.

## Testing
- Verified the old URL no longer appears in the file and the new URL does.
- `git diff --check`
- Prettier check on the touched file with an equivalent temporary config excluding unavailable local plugins.
- Secret scan on diff: clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the models docs link in the generated config.yaml comment so new configs point to the current docs. Replaces /customization/models with /customize/models in `core/config/createNewAssistantFile.ts`.

<sup>Written for commit 15a520c69a333248f6105f7bf609a52c27345831. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

