### PR TITLE
docs(guides): fix dead snyk.io/learn/security-vulnerability link

### DIFF
--- a/docs/guides/snyk-mcp-continue-cookbook.mdx
+++ b/docs/guides/snyk-mcp-continue-cookbook.mdx
@@ -700,7 +700,7 @@ After completing this guide, you have a complete **AI-powered security system** 
 2. **Review findings** - Analyze the security report and implement fixes
 3. **Set up CI pipeline** - Add the GitHub Actions workflow to your repo
 4. **Customize rules** - Add project-specific security policies
-5. **Monitor trends** - Track [vulnerability](https://snyk.io/learn/security-vulnerability/) reduction over time
+5. **Monitor trends** - Track [vulnerability](https://snyk.io/learn/) reduction over time
 
 ## Additional Resources
 


### PR DESCRIPTION
Follow-up to #12871 which fixed the adjacent \`snyk.io/learn/software-composition-analysis-sca/\` link in the same file. The specific \`/security-vulnerability/\` page returns 404; the \`/learn/\` root is the canonical hub.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix a broken link in `docs/guides/snyk-mcp-continue-cookbook.mdx` by updating the Snyk “security vulnerability” reference to the canonical https://snyk.io/learn/ hub. This removes a 404 and keeps readers on the correct resource.

<sup>Written for commit 3b29e897ee6f83638ef58a33169d41b4094dd568. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

