### PR TITLE
docs(guides): fix dead klavis.ai/integrations link

### DIFF
--- a/docs/guides/klavis-mcp-continue-cookbook.mdx
+++ b/docs/guides/klavis-mcp-continue-cookbook.mdx
@@ -19,7 +19,7 @@ Before starting, ensure you have:
 
 - [Continue CLI](https://docs.continue.dev/guides/cli) with **active credits** (required for API usage)
 - A Klavis [AI account](https://www.klavis.ai/) with access to your Strata URL
-- OAuth authentication completed in Klavis dashboard for Slack and Gmail (see [Klavis integrations guide](https://www.klavis.ai/integrations))
+- OAuth authentication completed in Klavis dashboard for Slack and Gmail (see [Klavis docs](https://www.klavis.ai/docs))
 
 <Warning>
   To use agents in headless mode, you need a [Continue API key](https://continue.dev/settings/api-keys).


### PR DESCRIPTION
\`www.klavis.ai/integrations\` returns 404. The Klavis docs home at \`/docs\` is the canonical replacement for setup guidance.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a dead link in the Klavis MCP + Continue cookbook, replacing `https://www.klavis.ai/integrations` (404) with `https://www.klavis.ai/docs` so users reach the current setup guidance. This prevents confusion when completing OAuth setup for Slack and Gmail.

<sup>Written for commit 82aa99572339552e4d5d5bdd3ce079b6c2535189. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

