### PR TITLE
fix(anthropic): honor adaptive thinking config for newer Claude models

### DIFF
--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -1214,6 +1214,13 @@ export interface BaseCompletionOptions {
   toolChoice?: ToolChoice;
   reasoning?: boolean;
   reasoningBudgetTokens?: number;
+  thinking?: {
+    type?: "enabled" | "adaptive" | "disabled";
+    budget_tokens?: number;
+  };
+  output_config?: {
+    effort?: "low" | "medium" | "high";
+  };
   promptCaching?: boolean;
 }
 

--- a/core/llm/llms/Anthropic.ts
+++ b/core/llm/llms/Anthropic.ts
@@ -55,9 +55,43 @@ class Anthropic extends BaseLLM {
   }
 
   // Public for use within VertexAI
+  private buildThinkingParams(
+    options: CompletionOptions,
+  ): Record<string, unknown> {
+    if (options.thinking?.type) {
+      const thinking: Record<string, unknown> = {
+        type: options.thinking.type,
+      };
+      if (options.thinking.type === "enabled") {
+        thinking.budget_tokens =
+          options.thinking.budget_tokens ??
+          options.reasoningBudgetTokens ??
+          DEFAULT_REASONING_TOKENS;
+      }
+      const params: Record<string, unknown> = { thinking };
+      if (options.output_config) {
+        params.output_config = options.output_config;
+      }
+      return params;
+    }
+
+    if (options.reasoning) {
+      return {
+        thinking: {
+          type: "enabled",
+          budget_tokens:
+            options.reasoningBudgetTokens ?? DEFAULT_REASONING_TOKENS,
+        },
+      };
+    }
+
+    return {};
+  }
+
   public convertArgs(
     options: CompletionOptions,
   ): Omit<MessageCreateParams, "messages"> {
+    const thinkingParams = this.buildThinkingParams(options);
     const finalOptions = {
       top_k: options.topK,
       top_p: options.topP,
@@ -67,13 +101,7 @@ class Anthropic extends BaseLLM {
       stop_sequences: options.stop?.filter((x) => x.trim() !== ""),
       stream: options.stream ?? true,
       tools: options.tools?.map(this.convertToolToAnthropicTool),
-      thinking: options.reasoning
-        ? {
-            type: "enabled" as const,
-            budget_tokens:
-              options.reasoningBudgetTokens ?? DEFAULT_REASONING_TOKENS,
-          }
-        : undefined,
+      ...thinkingParams,
       tool_choice: options.toolChoice
         ? {
             type: "tool" as const,
@@ -82,7 +110,7 @@ class Anthropic extends BaseLLM {
         : undefined,
     };
 
-    return finalOptions;
+    return finalOptions as Omit<MessageCreateParams, "messages">;
   }
 
   private convertMessageContentToBlocks(

--- a/core/llm/llms/Anthropic.ts
+++ b/core/llm/llms/Anthropic.ts
@@ -58,6 +58,8 @@ class Anthropic extends BaseLLM {
   private buildThinkingParams(
     options: CompletionOptions,
   ): Record<string, unknown> {
+    const params: Record<string, unknown> = {};
+
     if (options.thinking?.type) {
       const thinking: Record<string, unknown> = {
         type: options.thinking.type,
@@ -68,24 +70,20 @@ class Anthropic extends BaseLLM {
           options.reasoningBudgetTokens ??
           DEFAULT_REASONING_TOKENS;
       }
-      const params: Record<string, unknown> = { thinking };
-      if (options.output_config) {
-        params.output_config = options.output_config;
-      }
-      return params;
-    }
-
-    if (options.reasoning) {
-      return {
-        thinking: {
-          type: "enabled",
-          budget_tokens:
-            options.reasoningBudgetTokens ?? DEFAULT_REASONING_TOKENS,
-        },
+      params.thinking = thinking;
+    } else if (options.reasoning) {
+      params.thinking = {
+        type: "enabled",
+        budget_tokens:
+          options.reasoningBudgetTokens ?? DEFAULT_REASONING_TOKENS,
       };
     }
 
-    return {};
+    if (options.output_config) {
+      params.output_config = options.output_config;
+    }
+
+    return params;
   }
 
   public convertArgs(

--- a/core/llm/llms/Anthropic.vitest.ts
+++ b/core/llm/llms/Anthropic.vitest.ts
@@ -519,6 +519,56 @@ describe("Anthropic", () => {
       });
     });
 
+    test("should forward output_config on legacy reasoning path", async () => {
+      const anthropic = new Anthropic({
+        apiKey: "test-api-key",
+        model: "claude-opus-4-8",
+        apiBase: "https://api.anthropic.com/v1/",
+      });
+
+      await runLlmTest({
+        llm: anthropic,
+        methodToTest: "streamChat",
+        params: [
+          [{ role: "user", content: "hello" }],
+          new AbortController().signal,
+          {
+            model: "claude-opus-4-8",
+            reasoning: true,
+            output_config: { effort: "high" },
+          },
+        ],
+        expectedRequest: {
+          url: "https://api.anthropic.com/v1/messages",
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+            "anthropic-version": "2023-06-01",
+            "x-api-key": "test-api-key",
+          },
+          body: {
+            model: "claude-opus-4-8",
+            max_tokens: 8192,
+            stream: true,
+            messages: [
+              {
+                role: "user",
+                content: [{ type: "text", text: "hello" }],
+              },
+            ],
+            thinking: { type: "enabled", budget_tokens: 2048 },
+            output_config: { effort: "high" },
+            system: "",
+          },
+        },
+        mockStream: [
+          '{"type": "content_block_delta", "delta": {"type": "text_delta", "text": "Hello!"}}',
+          '{"type": "content_block_stop"}',
+        ],
+      });
+    });
+
     test("should prefer configured thinking over legacy reasoning toggle", async () => {
       const anthropic = new Anthropic({
         apiKey: "test-api-key",

--- a/core/llm/llms/Anthropic.vitest.ts
+++ b/core/llm/llms/Anthropic.vitest.ts
@@ -471,6 +471,54 @@ describe("Anthropic", () => {
       });
     });
 
+    test("should forward output_config without explicit thinking.type", async () => {
+      const anthropic = new Anthropic({
+        apiKey: "test-api-key",
+        model: "claude-opus-4-8",
+        apiBase: "https://api.anthropic.com/v1/",
+      });
+
+      await runLlmTest({
+        llm: anthropic,
+        methodToTest: "streamChat",
+        params: [
+          [{ role: "user", content: "hello" }],
+          new AbortController().signal,
+          {
+            model: "claude-opus-4-8",
+            output_config: { effort: "high" },
+          },
+        ],
+        expectedRequest: {
+          url: "https://api.anthropic.com/v1/messages",
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+            "anthropic-version": "2023-06-01",
+            "x-api-key": "test-api-key",
+          },
+          body: {
+            model: "claude-opus-4-8",
+            max_tokens: 8192,
+            stream: true,
+            messages: [
+              {
+                role: "user",
+                content: [{ type: "text", text: "hello" }],
+              },
+            ],
+            output_config: { effort: "high" },
+            system: "",
+          },
+        },
+        mockStream: [
+          '{"type": "content_block_delta", "delta": {"type": "text_delta", "text": "Hello!"}}',
+          '{"type": "content_block_stop"}',
+        ],
+      });
+    });
+
     test("should prefer configured thinking over legacy reasoning toggle", async () => {
       const anthropic = new Anthropic({
         apiKey: "test-api-key",

--- a/core/llm/llms/Anthropic.vitest.ts
+++ b/core/llm/llms/Anthropic.vitest.ts
@@ -421,6 +421,107 @@ describe("Anthropic", () => {
       });
     });
 
+    test("should forward adaptive thinking and output_config from completion options", async () => {
+      const anthropic = new Anthropic({
+        apiKey: "test-api-key",
+        model: "claude-opus-4-8",
+        apiBase: "https://api.anthropic.com/v1/",
+      });
+
+      await runLlmTest({
+        llm: anthropic,
+        methodToTest: "streamChat",
+        params: [
+          [{ role: "user", content: "hello" }],
+          new AbortController().signal,
+          {
+            model: "claude-opus-4-8",
+            thinking: { type: "adaptive" },
+            output_config: { effort: "high" },
+          },
+        ],
+        expectedRequest: {
+          url: "https://api.anthropic.com/v1/messages",
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+            "anthropic-version": "2023-06-01",
+            "x-api-key": "test-api-key",
+          },
+          body: {
+            model: "claude-opus-4-8",
+            max_tokens: 8192,
+            stream: true,
+            messages: [
+              {
+                role: "user",
+                content: [{ type: "text", text: "hello" }],
+              },
+            ],
+            thinking: { type: "adaptive" },
+            output_config: { effort: "high" },
+            system: "",
+          },
+        },
+        mockStream: [
+          '{"type": "content_block_delta", "delta": {"type": "text_delta", "text": "Hello!"}}',
+          '{"type": "content_block_stop"}',
+        ],
+      });
+    });
+
+    test("should prefer configured thinking over legacy reasoning toggle", async () => {
+      const anthropic = new Anthropic({
+        apiKey: "test-api-key",
+        model: "claude-opus-4-8",
+        apiBase: "https://api.anthropic.com/v1/",
+        completionOptions: {
+          model: "claude-opus-4-8",
+          thinking: { type: "adaptive" },
+          output_config: { effort: "high" },
+        },
+      });
+
+      await runLlmTest({
+        llm: anthropic,
+        methodToTest: "streamChat",
+        params: [
+          [{ role: "user", content: "hello" }],
+          new AbortController().signal,
+          { reasoning: true },
+        ],
+        expectedRequest: {
+          url: "https://api.anthropic.com/v1/messages",
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+            "anthropic-version": "2023-06-01",
+            "x-api-key": "test-api-key",
+          },
+          body: {
+            model: "claude-opus-4-8",
+            max_tokens: 8192,
+            stream: true,
+            messages: [
+              {
+                role: "user",
+                content: [{ type: "text", text: "hello" }],
+              },
+            ],
+            thinking: { type: "adaptive" },
+            output_config: { effort: "high" },
+            system: "",
+          },
+        },
+        mockStream: [
+          '{"type": "content_block_delta", "delta": {"type": "text_delta", "text": "Hello!"}}',
+          '{"type": "content_block_stop"}',
+        ],
+      });
+    });
+
     test("should handle custom max tokens", async () => {
       const anthropic = new Anthropic({
         apiKey: "test-api-key",

--- a/gui/src/redux/thunks/streamNormalInput.ts
+++ b/gui/src/redux/thunks/streamNormalInput.ts
@@ -54,6 +54,10 @@ function buildReasoningCompletionOptions(
     return baseOptions;
   }
 
+  if (model.completionOptions?.thinking?.type) {
+    return baseOptions;
+  }
+
   const reasoningOptions: LLMFullCompletionOptions = {
     ...baseOptions,
     reasoning: !!hasReasoningEnabled,

--- a/packages/config-yaml/src/schemas/models.ts
+++ b/packages/config-yaml/src/schemas/models.ts
@@ -44,6 +44,17 @@ export const modelCapabilitySchema = z.union([
 // not ideal but lose type suggestions if use z.infer because of the string fallback
 export type ModelCapability = "tool_use" | "image_input" | "next_edit";
 
+export const thinkingConfigSchema = z.object({
+  type: z.enum(["enabled", "adaptive", "disabled"]).optional(),
+  budget_tokens: z.number().optional(),
+});
+export type ThinkingConfig = z.infer<typeof thinkingConfigSchema>;
+
+export const outputConfigSchema = z.object({
+  effort: z.enum(["low", "medium", "high"]).optional(),
+});
+export type OutputConfig = z.infer<typeof outputConfigSchema>;
+
 export const completionOptionsSchema = z.object({
   contextLength: z.number().optional(),
   maxTokens: z.number().optional(),
@@ -57,6 +68,8 @@ export const completionOptionsSchema = z.object({
   n: z.number().optional(),
   reasoning: z.boolean().optional(),
   reasoningBudgetTokens: z.number().optional(),
+  thinking: thinkingConfigSchema.optional(),
+  output_config: outputConfigSchema.optional(),
   promptCaching: z.boolean().optional(),
   stream: z.boolean().optional(),
   keepAlive: z.number().optional(),


### PR DESCRIPTION
## Summary

Parse and forward Anthropic `thinking` / `output_config` completion options from config.yaml instead of always mapping the legacy reasoning toggle to `thinking.type: enabled`.

## Motivation

Claude Opus 4.x models reject `thinking.type.enabled` and require `thinking.type.adaptive` with `output_config.effort`. Users who configured adaptive thinking in YAML still got API errors because Continue stripped unknown completion-option fields and the chat UI forced `reasoning: true`.

Fixes #12908

## Changes

| File | Change |
|------|--------|
| `packages/config-yaml/src/schemas/models.ts` | Add `thinking` and `output_config` to completion options schema |
| `core/index.d.ts` | Extend `BaseCompletionOptions` types |
| `core/llm/llms/Anthropic.ts` | Prefer explicit thinking config over legacy `reasoning` boolean |
| `gui/src/redux/thunks/streamNormalInput.ts` | Skip legacy reasoning toggle when model config already sets `thinking.type` |
| `core/llm/llms/Anthropic.vitest.ts` | Regression tests for adaptive thinking request bodies |

## Tests

- Added `Anthropic.vitest.ts` cases for adaptive thinking + `output_config`, and for config precedence over legacy `reasoning: true`
- Full vitest suite could not be executed locally due to monorepo workspace package resolution in this environment; CI should run project tests

## Notes

- Legacy `reasoning: true` behavior is unchanged when no `thinking` block is configured
- `output_config.effort` enum currently covers low/medium/high; API may add more values later
- Bedrock provider may need a similar follow-up for Opus 4.x on Bedrock

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor Anthropic `thinking` and `output_config` from YAML and per-request options, preferring them over the legacy `reasoning` flag. Fixes Claude Opus 4.x errors by supporting `thinking.type: adaptive` with `output_config.effort`, and forwards `output_config` even when set without `thinking` (fixes #12908).

- **Bug Fixes**
  - Parse `thinking` and `output_config` in `packages/config-yaml`; add types in `core/index.d.ts`.
  - Build Anthropic requests with explicit `thinking` (budget_tokens for `enabled`) and always include `output_config`; fall back to legacy `reasoning` only if `thinking` isn’t set.
  - In `gui`, skip adding the legacy `reasoning` toggle when `thinking.type` is configured.
  - Add tests for adaptive `thinking`/`output_config`, `output_config`-only, `output_config` on the legacy `reasoning` path, and config precedence over legacy `reasoning`; include required `model` in `completionOptions`.

<sup>Written for commit 69f7f0f73ffcc7f4d894cfacf70ba541c2264651. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

