### PR TITLE
docs: add app.nz model provider page

### DIFF
--- a/docs/customize/model-providers/more/appnz.mdx
+++ b/docs/customize/model-providers/more/appnz.mdx
@@ -1,0 +1,119 @@
+---
+title: "app.nz"
+description: "Configure app.nz with Continue to access a hosted OpenAI-compatible LLM gateway with automatic model routing across multiple providers, including API setup instructions"
+---
+
+<Info>
+  app.nz is a hosted, OpenAI-compatible LLM gateway with an automatic router that selects the best model for each request across multiple providers.
+</Info>
+
+<Tip>
+  Get an API key from the [app.nz dashboard](https://app.nz/) and read the [docs](https://app.nz/docs).
+</Tip>
+
+## Configuration
+
+app.nz exposes an OpenAI-compatible API at `https://app.nz/v1`, so it is configured with the `openai` provider and a custom `apiBase`. Use the `app/auto` model to let the router pick the best model automatically.
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  name: My Config
+  version: 0.0.1
+  schema: v1
+
+  models:
+    - name: app.nz Auto
+      provider: openai
+      model: app/auto
+      apiBase: https://app.nz/v1
+      apiKey: <APP_NZ_API_KEY>
+  ```
+  </Tab>
+  <Tab title="JSON (Deprecated)">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "app.nz Auto",
+        "provider": "openai",
+        "model": "app/auto",
+        "apiBase": "https://app.nz/v1",
+        "apiKey": "<APP_NZ_API_KEY>"
+      }
+    ]
+  }
+  ```
+  </Tab>
+</Tabs>
+
+## Available Models
+
+`app/auto` routes each request to the best available model. You can also target a routing variant tuned for a specific workload, or address any upstream model directly with `provider/model`.
+
+| Model | Best For |
+|-------|----------|
+| `app/auto` | General use, balanced routing (recommended) |
+| `app/auto-code` | Coding and editing tasks |
+| `app/auto-reasoning` | Complex reasoning and planning |
+| `app/auto-fast` | Low-latency responses |
+| `app/auto-cheap` | Maximum cost savings |
+| `app/auto-vision` | Image and multimodal input |
+
+To use a specific upstream model instead of the router, pass it as `provider/model` (for example `anthropic/claude-sonnet-4` or `openai/gpt-4o`).
+
+## Using Multiple Roles
+
+You can configure app.nz routing variants for different Continue roles:
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  models:
+    - name: app.nz Code
+      provider: openai
+      model: app/auto-code
+      apiBase: https://app.nz/v1
+      apiKey: <APP_NZ_API_KEY>
+      roles:
+        - chat
+        - edit
+        - apply
+
+    - name: app.nz Fast
+      provider: openai
+      model: app/auto-fast
+      apiBase: https://app.nz/v1
+      apiKey: <APP_NZ_API_KEY>
+      roles:
+        - autocomplete
+  ```
+  </Tab>
+  <Tab title="JSON (Deprecated)">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "app.nz Code",
+        "provider": "openai",
+        "model": "app/auto-code",
+        "apiBase": "https://app.nz/v1",
+        "apiKey": "<APP_NZ_API_KEY>",
+        "roles": ["chat", "edit", "apply"]
+      }
+    ],
+    "tabAutocompleteModel": {
+      "title": "app.nz Fast",
+      "provider": "openai",
+      "model": "app/auto-fast",
+      "apiBase": "https://app.nz/v1",
+      "apiKey": "<APP_NZ_API_KEY>"
+    }
+  }
+  ```
+  </Tab>
+</Tabs>
+
+<Info>
+  app.nz also exposes an Anthropic-compatible endpoint at `https://app.nz/v1/messages` for clients that speak the Anthropic Messages API.
+</Info>

--- a/docs/customize/model-providers/overview.mdx
+++ b/docs/customize/model-providers/overview.mdx
@@ -35,6 +35,7 @@ Beyond the top-level providers, Continue supports many other options:
 | [DeepInfra](/customize/model-providers/more/deepinfra)                 | Hosting for various open source models                     |
 | [OpenRouter](/customize/model-providers/top-level/openrouter)          | Gateway to multiple model providers                        |
 | [ClawRouter](/customize/model-providers/more/clawrouter)               | Open-source LLM router with automatic cost-optimized model selection |
+| [app.nz](/customize/model-providers/more/appnz)                        | Hosted OpenAI-compatible gateway with automatic model routing |
 | [Tetrate Agent Router Service](/customize/model-providers/top-level/tetrate_agent_router_service) | Gateway with intelligent routing across multiple model providers |
 | [Cohere](/customize/model-providers/more/cohere)                       | Models specialized for semantic search and text generation |
 | [NVIDIA](/customize/model-providers/more/nvidia)                       | GPU-accelerated model hosting                              |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -105,6 +105,7 @@
                   {
                     "group": "More Providers",
                     "pages": [
+                      "customize/model-providers/more/appnz",
                       "customize/model-providers/more/asksage",
                       "customize/model-providers/more/clawrouter",
                       "customize/model-providers/more/deepseek",


### PR DESCRIPTION
## Description
Adds documentation for [app.nz](https://app.nz/), a hosted OpenAI-compatible (and Anthropic-compatible) LLM gateway with an automatic model router.

## Changes
- New page `docs/customize/model-providers/more/appnz.mdx` covering setup with `provider: openai`, `apiBase: https://app.nz/v1`, `model: app/auto`, and the `app/auto-code` / `app/auto-reasoning` / `app/auto-fast` / `app/auto-cheap` / `app/auto-vision` routing variants, plus `provider/model` direct addressing.
- Registered the page in the `docs.json` "More Providers" sidebar.
- Added an app.nz row to the providers overview table in `overview.mdx`.

The page mirrors the frontmatter and structure of existing `more/*.mdx` provider pages (e.g. ClawRouter, Morph).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add documentation for app.nz, an OpenAI-compatible LLM gateway with automatic model routing. The new page covers setup using `provider: openai`, `apiBase: https://app.nz/v1`, and `model: app/auto` (plus auto-* variants and `provider/model` direct addressing), and is linked in the “More Providers” sidebar and the providers overview.

<sup>Written for commit 8c0964e2c73e8a2ab5c825c33adcc7d660f45ea0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

