### PR TITLE
fix: remove overly conservative context length check for @file (#12165)

### DIFF
--- a/gui/src/components/mainInput/AtMentionDropdown/index.tsx
+++ b/gui/src/components/mainInput/AtMentionDropdown/index.tsx
@@ -5,7 +5,7 @@ import {
   PlusIcon,
 } from "@heroicons/react/24/outline";
 import type { Editor } from "@tiptap/react";
-import type { RangeInFile } from "core";
+
 import {
   forwardRef,
   useContext,
@@ -25,7 +25,7 @@ import {
   vscQuickInputBackground,
 } from "../..";
 import { IdeMessengerContext } from "../../../context/IdeMessenger";
-import { useAppSelector } from "../../../redux/hooks";
+
 import { setDialogMessage, setShowDialog } from "../../../redux/slices/uiSlice";
 import { fontSize } from "../../../util";
 import FileIcon from "../../FileIcon";
@@ -142,29 +142,10 @@ interface AtMentionDropdownProps {
   onClose: () => void;
 }
 
-const formatFileSize = (fileSize: number) => {
-  const KB = 1000;
-  const MB = 1000_000;
-  const GB = 1000_000_000;
-
-  if (fileSize > GB) {
-    return `${(fileSize / GB).toFixed(1)} GB`;
-  } else if (fileSize > MB) {
-    return `${(fileSize / MB).toFixed(1)} MB`;
-  } else if (fileSize > KB) {
-    return `${(fileSize / KB).toFixed(1)} KB`;
-  }
-
-  return `${fileSize} byte${fileSize > 1 ? "s" : ""}`;
-};
-
 const AtMentionDropdown = forwardRef((props: AtMentionDropdownProps, ref) => {
   const dispatch = useDispatch();
 
   const ideMessenger = useContext(IdeMessengerContext);
-  const isInAgentMode = useAppSelector(
-    (store) => store.session.mode === "agent",
-  );
 
   const [selectedIndex, setSelectedIndex] = useState(0);
 
@@ -179,89 +160,6 @@ const AtMentionDropdown = forwardRef((props: AtMentionDropdownProps, ref) => {
   >(undefined);
 
   const [allItems, setAllItems] = useState<ComboBoxItem[]>([]);
-
-  async function isItemTooBig(
-    name: string,
-    query: string,
-  ): Promise<[boolean, number]> {
-    const selectedCode: RangeInFile[] = [];
-    // Get context item from core
-    const contextResult = await ideMessenger.request(
-      "context/getContextItems",
-      {
-        name,
-        query,
-        fullInput: "",
-        selectedCode,
-        isInAgentMode,
-      },
-    );
-
-    if (contextResult.status === "error") {
-      return [false, -1];
-    }
-
-    const item = contextResult.content[0];
-
-    // Check if the context item exceeds the context length of the selected model
-    const result = await ideMessenger.request("isItemTooBig", {
-      item,
-    });
-
-    if (result.status === "error") {
-      return [false, -1];
-    }
-
-    const size = new Blob([item.content]).size;
-
-    return [result.content, size];
-  }
-
-  function handleItemTooBig(
-    fileExceeds: boolean,
-    fileSize: number,
-    item: ComboBoxItem,
-  ) {
-    if (fileExceeds) {
-      props.editor
-        .chain()
-        .focus()
-        .command(({ tr, state }) => {
-          const text = state.doc.textBetween(
-            0,
-            state.selection.from,
-            "\n",
-            "\n",
-          ); // Get the text before the cursor
-          const lastAtIndex = text.lastIndexOf("@");
-
-          if (lastAtIndex !== -1) {
-            // Delete text after the last "@"
-            tr.delete(lastAtIndex + 1, state.selection.from);
-            return true;
-          }
-          return false;
-        })
-        .run();
-
-      // Trigger warning message
-      void ideMessenger.ide.showToast(
-        "warning",
-        fileSize > 0
-          ? "File exceeds model's context length"
-          : "Error loading file",
-        {
-          modal: true,
-          detail:
-            fileSize > 0
-              ? `'${item.title}' cannot be added because it exceeds the model's allowed context length. File size: ${formatFileSize(fileSize)}`
-              : `'${item.title}' could not be loaded. Please check if the file exists and has the correct permissions.`,
-        },
-      );
-    } else {
-      props.command({ ...item, itemType: item.type });
-    }
-  }
 
   useEffect(() => {
     const items = [...props.items];
@@ -369,14 +267,7 @@ const AtMentionDropdown = forwardRef((props: AtMentionDropdownProps, ref) => {
     }
 
     if (item) {
-      if (item.type === "file" && item.query) {
-        void isItemTooBig(item.type, item.query).then(
-          ([fileExceeds, fileSize]) =>
-            handleItemTooBig(fileExceeds, fileSize, item),
-        );
-      } else {
-        props.command({ ...item, itemType: item.type });
-      }
+      props.command({ ...item, itemType: item.type });
     }
   };
 


### PR DESCRIPTION
## Description

Fixes #12165

The \@file\ context provider had an \isItemTooBig\ check that incorrectly rejected files larger than ~16kB when using Ollama with \model: AUTODETECT\. This happened because AUTODETECT skips \ensureModelInfo()\ (see \core/llm/llms/Ollama.ts:178\), so \contextLength\ defaults to 8192 tokens instead of the actual model context size.

The formula used: \	okens > contextLength - maxTokens\ → \	okens > 8192 - 4096 = 4096\ rejected files that produce >4096 tokens (~16kB of text).

## Fix

Removed the frontend-side \isItemTooBig\ check entirely, making \@file\ consistent with \@CurrentFile\ and all other context providers. The core \compileChatMessages\ function already handles context overflow gracefully.

## Changes

- \gui/src/components/mainInput/AtMentionDropdown/index.tsx\: Removed \isItemTooBig\, \handleItemTooBig\, \ormatFileSize\ dead code (~107 lines) and unused imports. All non-action/non-submenu/non-query items now go through \props.command()\ uniformly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the overly conservative context-length check for `@file` mentions that blocked valid files (notably with Ollama `model: AUTODETECT`). `@file` now behaves like `@CurrentFile`, with overflow handled by core logic.

- **Bug Fixes**
  - Removed the frontend `isItemTooBig` check in `AtMentionDropdown`; all non-action items now go through `props.command(...)`.
  - Cleaned up dead code and unused imports.

<sup>Written for commit fff283d08e616e6aae386eb867487f3f0a2df48a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

