### PR TITLE
fix: fall back to cmd.exe when PowerShell unavailable on Windows (#11960)

### DIFF
--- a/core/tools/implementations/runTerminalCommand.ts
+++ b/core/tools/implementations/runTerminalCommand.ts
@@ -22,17 +22,28 @@ function getDecodedOutput(data: Buffer): string {
     return data.toString();
   }
 }
-// Try to detect if PowerShell is available on Windows
+// Cached result of PowerShell availability check
+let _powerShellAvailable: boolean | undefined;
+
+// Try to detect if PowerShell is available on Windows (result is cached)
 function isPowerShellAvailable(): boolean {
-  try {
-    childProcess.execFileSync("powershell.exe", ["-NoProfile", "-Command", "exit"], {
-      timeout: 3000,
-      windowsHide: true,
-    });
-    return true;
-  } catch {
-    return false;
+  if (_powerShellAvailable !== undefined) {
+    return _powerShellAvailable;
   }
+  try {
+    childProcess.execFileSync(
+      "powershell.exe",
+      ["-NoProfile", "-Command", "exit"],
+      {
+        timeout: 3000,
+        windowsHide: true,
+      },
+    );
+    _powerShellAvailable = true;
+  } catch {
+    _powerShellAvailable = false;
+  }
+  return _powerShellAvailable;
 }
 
 // Helper function to use login shell on Unix/macOS and PowerShell on Windows

--- a/core/tools/implementations/runTerminalCommand.ts
+++ b/core/tools/implementations/runTerminalCommand.ts
@@ -21,13 +21,34 @@ function getDecodedOutput(data: Buffer): string {
   } else {
     return data.toString();
   }
-} // Simple helper function to use login shell on Unix/macOS and PowerShell on Windows
+}
+// Try to detect if PowerShell is available on Windows
+function isPowerShellAvailable(): boolean {
+  try {
+    childProcess.execFileSync("powershell.exe", ["-NoProfile", "-Command", "exit"], {
+      timeout: 3000,
+      windowsHide: true,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Helper function to use login shell on Unix/macOS and PowerShell on Windows
+// Falls back to cmd.exe when PowerShell is unavailable (e.g., corporate policy)
 function getShellCommand(command: string): { shell: string; args: string[] } {
   if (process.platform === "win32") {
-    // Windows: Use PowerShell
+    if (isPowerShellAvailable()) {
+      return {
+        shell: "powershell.exe",
+        args: ["-NoLogo", "-ExecutionPolicy", "Bypass", "-Command", command],
+      };
+    }
+    const cmd = process.env.COMSPEC || "cmd.exe";
     return {
-      shell: "powershell.exe",
-      args: ["-NoLogo", "-ExecutionPolicy", "Bypass", "-Command", command],
+      shell: cmd,
+      args: ["/C", command],
     };
   } else {
     // Unix/macOS: Use login shell to source .bashrc/.zshrc etc.


### PR DESCRIPTION
## Description

Fixes #11960

On Windows, \un_terminal_command\ always uses \child_process.spawn('powershell.exe', ...)\ to run terminal commands. When PowerShell is unavailable due to corporate security policy (or any other reason), this fails with \spawn UNKNOWN\.

## Changes

- \core/tools/implementations/runTerminalCommand.ts\: Added \isPowerShellAvailable()\ check that probes for \powershell.exe\ using \execFileSync\. When not found, falls back to \%COMSPEC%\ (typically \cmd.exe\) with \/C\ argument, which is always available on Windows.

All three spawn paths (streaming, non-streaming, background/detached) benefit from this fix since they all go through \getShellCommand()\.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
On Windows, fall back to `cmd.exe` when PowerShell is unavailable to avoid “spawn UNKNOWN” and keep terminal commands working in restricted environments.

- **Bug Fixes**
  - Added cached `isPowerShellAvailable()` using `execFileSync` to probe `powershell.exe` once, avoiding repeated 3s checks.
  - Updated `getShellCommand()` to use `%COMSPEC%` (defaults to `cmd.exe`) with `/C` when PowerShell is missing; affects streaming, non-streaming, and detached spawns.

<sup>Written for commit 89d3d31f990522fae752f9a3403e0b9fda2d5a73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

