### PR TITLE
feat(cli): auto-discover MCP servers in .continue/mcpServers

### DIFF
--- a/extensions/cli/src/services/ConfigService.ts
+++ b/extensions/cli/src/services/ConfigService.ts
@@ -19,6 +19,7 @@ import {
 import { logger } from "../util/logger.js";
 
 import { BaseService, ServiceWithDependencies } from "./BaseService.js";
+import { loadJsonMcpServers } from "./loadJsonMcpServers.js";
 import { serviceContainer } from "./ServiceContainer.js";
 import { ToolPermissionServiceState } from "./ToolPermissionService.js";
 import {
@@ -96,6 +97,7 @@ export class ConfigService
       packageIdentifiers,
       additional,
     );
+    this.processJsonMcpServers(additional);
     this.processAgentFileRules(agentFileState, packageIdentifiers);
     this.processRulesAndPrompts(
       options.rule || [],
@@ -154,6 +156,12 @@ export class ConfigService
       } catch (e) {
         logger.warn(`Failed to add MCP server "${mcp}": ${getErrorString(e)}`);
       }
+    }
+  }
+
+  private processJsonMcpServers(additional: AssistantUnrolled): void {
+    for (const server of loadJsonMcpServers()) {
+      additional.mcpServers!.push(server);
     }
   }
 

--- a/extensions/cli/src/services/loadJsonMcpServers.test.ts
+++ b/extensions/cli/src/services/loadJsonMcpServers.test.ts
@@ -1,0 +1,91 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { loadJsonMcpServers } from "./loadJsonMcpServers.js";
+
+describe("loadJsonMcpServers", () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = fs.mkdtempSync(path.join(os.tmpdir(), "cn-mcp-json-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  });
+
+  function writeWorkspaceMcpFile(fileName: string, content: unknown): void {
+    const dir = path.join(cwd, ".continue", "mcpServers");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, fileName), JSON.stringify(content));
+  }
+
+  it("returns an empty array when there is no mcpServers directory", () => {
+    expect(loadJsonMcpServers(cwd)).toEqual([]);
+  });
+
+  it("discovers a single-server stdio file, named after the file", () => {
+    writeWorkspaceMcpFile("playwright.json", {
+      command: "npx",
+      args: ["-y", "@playwright/mcp"],
+    });
+
+    const servers = loadJsonMcpServers(cwd);
+
+    expect(servers).toHaveLength(1);
+    expect(servers[0]).toMatchObject({
+      name: "playwright",
+      type: "stdio",
+      command: "npx",
+      args: ["-y", "@playwright/mcp"],
+    });
+  });
+
+  it("discovers servers from a Claude-desktop-style mcpServers map", () => {
+    writeWorkspaceMcpFile("config.json", {
+      mcpServers: { weather: { command: "uvx", args: ["weather-mcp"] } },
+    });
+
+    const servers = loadJsonMcpServers(cwd);
+
+    expect(servers.map((s) => s.name)).toEqual(["weather"]);
+  });
+
+  it("discovers an http server and maps the transport type", () => {
+    writeWorkspaceMcpFile("remote.json", {
+      url: "https://example.com/mcp",
+      type: "http",
+    });
+
+    const servers = loadJsonMcpServers(cwd);
+
+    expect(servers[0]).toMatchObject({
+      name: "remote",
+      url: "https://example.com/mcp",
+      type: "streamable-http",
+    });
+  });
+
+  it("skips files that do not match a supported MCP config format", () => {
+    writeWorkspaceMcpFile("notes.json", { hello: "world" });
+
+    expect(loadJsonMcpServers(cwd)).toEqual([]);
+  });
+
+  it("de-duplicates servers by name, keeping the first encountered", () => {
+    writeWorkspaceMcpFile("a.json", {
+      mcpServers: { dup: { command: "first" } },
+    });
+    writeWorkspaceMcpFile("b.json", {
+      mcpServers: { dup: { command: "second" } },
+    });
+
+    const servers = loadJsonMcpServers(cwd);
+
+    expect(servers).toHaveLength(1);
+    expect(servers[0]).toMatchObject({ name: "dup", command: "first" });
+  });
+});

--- a/extensions/cli/src/services/loadJsonMcpServers.ts
+++ b/extensions/cli/src/services/loadJsonMcpServers.ts
@@ -1,0 +1,134 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import {
+  claudeCodeLikeConfigFileSchema,
+  claudeDesktopLikeConfigFileSchema,
+  convertJsonMcpConfigToYamlMcpConfig,
+  type McpJsonConfig,
+  mcpServersJsonSchema,
+} from "@continuedev/config-yaml";
+
+import { env } from "../env.js";
+import { getErrorString } from "../util/error.js";
+import { logger } from "../util/logger.js";
+
+import { MCPServerConfig } from "./types.js";
+
+const MCP_SERVERS_DIRNAME = "mcpServers";
+
+interface NamedMcpJsonConfig {
+  name: string;
+  mcpJson: McpJsonConfig;
+}
+
+// Workspace `.continue/mcpServers` and the global `~/.continue/mcpServers`,
+// matching where the IDE extensions look for standalone MCP server files.
+function getMcpServerDirs(cwd: string): string[] {
+  return [
+    path.join(cwd, ".continue", MCP_SERVERS_DIRNAME),
+    path.join(env.continueHome, MCP_SERVERS_DIRNAME),
+  ];
+}
+
+// A file may hold a single server, a Claude-desktop-style `{ mcpServers: {...} }`
+// map, or a Claude-code-style file with top-level and per-project servers.
+function parseMcpServerFile(
+  content: string,
+  fileName: string,
+): NamedMcpJsonConfig[] {
+  const json = JSON.parse(content);
+
+  const claudeCode = claudeCodeLikeConfigFileSchema.safeParse(json);
+  if (claudeCode.success) {
+    const records = [
+      claudeCode.data.mcpServers,
+      ...Object.values(claudeCode.data.projects).map((p) => p.mcpServers),
+    ];
+    return records
+      .filter((record): record is NonNullable<typeof record> => !!record)
+      .flatMap((record) =>
+        Object.entries(record).map(([name, mcpJson]) => ({ name, mcpJson })),
+      );
+  }
+
+  const claudeDesktop = claudeDesktopLikeConfigFileSchema.safeParse(json);
+  if (claudeDesktop.success) {
+    return Object.entries(claudeDesktop.data.mcpServers).map(
+      ([name, mcpJson]) => ({ name, mcpJson }),
+    );
+  }
+
+  const single = mcpServersJsonSchema.safeParse(json);
+  if (single.success) {
+    return [{ name: fileName.replace(/\.json$/, ""), mcpJson: single.data }];
+  }
+
+  throw new Error("file does not match a supported MCP JSON config format");
+}
+
+/**
+ * Discover MCP servers defined as standalone JSON files in `.continue/mcpServers`
+ * (workspace and global), bringing the CLI to parity with the IDE extensions.
+ * Returns configs in the same shape as the rest of the assistant's mcpServers.
+ */
+export function loadJsonMcpServers(
+  cwd: string = process.cwd(),
+): MCPServerConfig[] {
+  const servers: MCPServerConfig[] = [];
+  const seenNames = new Set<string>();
+
+  for (const dir of getMcpServerDirs(cwd)) {
+    let fileNames: string[];
+    try {
+      if (!fs.existsSync(dir)) {
+        continue;
+      }
+      fileNames = fs
+        .readdirSync(dir)
+        .filter((fileName) => fileName.endsWith(".json"))
+        .sort();
+    } catch (e) {
+      logger.warn(
+        `Failed to read MCP servers directory ${dir}: ${getErrorString(e)}`,
+      );
+      continue;
+    }
+
+    for (const fileName of fileNames) {
+      const filePath = path.join(dir, fileName);
+      let parsed: NamedMcpJsonConfig[];
+      try {
+        parsed = parseMcpServerFile(
+          fs.readFileSync(filePath, "utf-8"),
+          fileName,
+        );
+      } catch (e) {
+        logger.warn(
+          `Skipping invalid MCP server file ${filePath}: ${getErrorString(e)}`,
+        );
+        continue;
+      }
+
+      for (const { name, mcpJson } of parsed) {
+        if (seenNames.has(name)) {
+          continue;
+        }
+        try {
+          const { yamlConfig } = convertJsonMcpConfigToYamlMcpConfig(
+            name,
+            mcpJson,
+          );
+          servers.push(yamlConfig as MCPServerConfig);
+          seenNames.add(name);
+        } catch (e) {
+          logger.warn(
+            `Failed to load MCP server "${name}" from ${filePath}: ${getErrorString(e)}`,
+          );
+        }
+      }
+    }
+  }
+
+  return servers;
+}


### PR DESCRIPTION
## Description

Closes #12254.

The CLI (`cn`) only discovers MCP servers from four sources: the active config's `mcpServers:` block, `uses:` references resolved by the unroller, `--mcp`, and `--agent` files. Unlike the IDE extensions, it ignores standalone server files placed in `.continue/mcpServers/` — even though the [docs](https://docs.continue.dev/customize/deep-dives/mcp#quick-start-how-to-set-up-your-first-mcp-server) describe that directory as the quick-start path.

## Change

Adds `loadJsonMcpServers` (`extensions/cli/src/services/loadJsonMcpServers.ts`), which mirrors the IDE's `core/context/mcp/json/loadJsonMcpConfigs.ts`:

- Scans the **workspace** `.continue/mcpServers/` and the **global** `~/.continue/mcpServers/` (via `env.continueHome`, matching the existing skills loader).
- Parses `.json` files in all three formats the IDE supports — single-server, Claude-desktop (`{ "mcpServers": { … } }`), and Claude-code (top-level + per-project) — reusing `@continuedev/config-yaml`'s schemas and `convertJsonMcpConfigToYamlMcpConfig` so the output matches the assistant's `mcpServers` shape.
- De-duplicates by server name and skips invalid files with a warning rather than throwing.

`ConfigService.getAdditionalBlocksFromOptions` merges the discovered servers into the unrolled assistant, so `cn` now reaches parity with the IDE.

## Tests

`loadJsonMcpServers.test.ts` — 6 vitest cases against the real `@continuedev/config-yaml` (empty dir, single stdio file named after the file, Claude-desktop map, http transport mapping, invalid-file skip, name de-duplication). `npm run lint` + `tsc --noEmit` pass; existing `ConfigService`/`MCPService` suites unaffected.

## Notes

- Scoped to `.json` to match the IDE's loader (which filters to `.json`); YAML discovery could be a follow-up.
- Uses `JSON.parse` (no new dependency); switching to JSONC for comment support is a possible follow-up.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CLI auto-discovery of MCP servers from `.continue/mcpServers` (workspace and global) and merge them into the assistant config, bringing `cn` to parity with the IDE. Supports single-server, Claude Desktop, and Claude Code JSON formats with name de-dupe and safe skips.

- **New Features**
  - Added `loadJsonMcpServers` to scan workspace and `env.continueHome` `.continue/mcpServers/`.
  - Parses `.json` files in supported formats using `@continuedev/config-yaml` schemas and `convertJsonMcpConfigToYamlMcpConfig`.
  - Merged discovered servers in `ConfigService.getAdditionalBlocksFromOptions`.
  - De-duplicates by server name, warns on invalid files, and maps `http` to `streamable-http`.

<sup>Written for commit a129774372ccd035020a192b8483f74dcb9941f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

