### PR TITLE
fix(cli): dedupe userRules from config and markdown rule sources

### DIFF
--- a/extensions/cli/src/services/ConfigService.ts
+++ b/extensions/cli/src/services/ConfigService.ts
@@ -281,9 +281,13 @@ export class ConfigService
       const existingRuleContents = new Set(
         (merged.rules ?? []).map((r) => (typeof r === "string" ? r : r?.rule)),
       );
-      const newRules = markdownRules.filter(
-        (r) => !existingRuleContents.has(r.rule),
-      );
+      const newRules = markdownRules.filter((r) => {
+        if (existingRuleContents.has(r.rule)) {
+          return false;
+        }
+        existingRuleContents.add(r.rule);
+        return true;
+      });
       merged.rules = [...(merged.rules ?? []), ...newRules];
     }
 

--- a/extensions/cli/src/systemMessage.test.ts
+++ b/extensions/cli/src/systemMessage.test.ts
@@ -1,8 +1,17 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
 import { describe, expect, it, vi } from "vitest";
+
+import { serviceContainer } from "./services/ServiceContainer.js";
 
 // Use the actual implementation instead of the mocked one
 vi.unmock("./systemMessage.js");
-const { constructSystemMessage } = await import("./systemMessage.js");
+import * as systemMessageModule from "./systemMessage.js";
+
+const { constructSystemMessage, loadMarkdownRulesWithMetadata } =
+  systemMessageModule;
 
 // Mock the service container to avoid "No factory registered for service 'config'" error
 vi.mock("./services/ServiceContainer.js", () => ({
@@ -258,5 +267,82 @@ Rule 3: Third rule`;
     expect(result).toContain(
       "which means that your goal is to help the user investigate their ideas",
     );
+  });
+
+  it("should not duplicate markdown rules already loaded via config", async () => {
+    const dbRule = "Use PostgreSQL for all database queries.";
+    const globalRule = "Always write tests for new features.";
+
+    vi.mocked(serviceContainer.get).mockResolvedValueOnce({
+      config: {
+        rules: [
+          { name: "db", rule: dbRule },
+          { name: "global", rule: globalRule },
+        ],
+      },
+    });
+
+    vi.spyOn(
+      systemMessageModule,
+      "loadMarkdownRulesWithMetadata",
+    ).mockReturnValue([
+      { name: "db", rule: dbRule, alwaysApply: true },
+      { name: "global", rule: globalRule, alwaysApply: true },
+    ]);
+
+    const result = await constructSystemMessage("normal");
+
+    const userRulesMatch = result.match(
+      /<context name="userRules">([\s\S]*?)<\/context>/,
+    );
+    expect(userRulesMatch).toBeTruthy();
+    const userRulesBody = userRulesMatch![1];
+
+    expect(userRulesBody.match(new RegExp(dbRule, "g"))?.length).toBe(1);
+    expect(userRulesBody.match(new RegExp(globalRule, "g"))?.length).toBe(1);
+  });
+
+  it("should dedupe identical markdown rules from multiple rule directories", () => {
+    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "continue-home-"));
+    const tmpProject = fs.mkdtempSync(
+      path.join(os.tmpdir(), "continue-project-"),
+    );
+    const sharedRule = "Never commit secrets to the repository.";
+
+    const writeRule = (dir: string, name: string, content: string) => {
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, name), content);
+    };
+
+    writeRule(
+      path.join(tmpHome, "rules"),
+      "security.md",
+      `---\nalwaysApply: true\n---\n${sharedRule}`,
+    );
+    writeRule(
+      path.join(tmpProject, ".continue", "rules"),
+      "security.md",
+      `---\nalwaysApply: true\n---\n${sharedRule}`,
+    );
+
+    const originalCwd = process.cwd();
+    const originalHome = process.env.CONTINUE_GLOBAL_DIR;
+    process.chdir(tmpProject);
+    process.env.CONTINUE_GLOBAL_DIR = tmpHome;
+
+    try {
+      const rules = loadMarkdownRulesWithMetadata();
+      expect(rules).toHaveLength(1);
+      expect(rules[0]?.rule).toBe(sharedRule);
+    } finally {
+      process.chdir(originalCwd);
+      if (originalHome === undefined) {
+        delete process.env.CONTINUE_GLOBAL_DIR;
+      } else {
+        process.env.CONTINUE_GLOBAL_DIR = originalHome;
+      }
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+      fs.rmSync(tmpProject, { recursive: true, force: true });
+    }
   });
 });

--- a/extensions/cli/src/systemMessage.test.ts
+++ b/extensions/cli/src/systemMessage.test.ts
@@ -5,10 +5,10 @@ import * as path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 import { serviceContainer } from "./services/ServiceContainer.js";
+import * as systemMessageModule from "./systemMessage.js";
 
 // Use the actual implementation instead of the mocked one
 vi.unmock("./systemMessage.js");
-import * as systemMessageModule from "./systemMessage.js";
 
 const { constructSystemMessage, loadMarkdownRulesWithMetadata } =
   systemMessageModule;

--- a/extensions/cli/src/systemMessage.ts
+++ b/extensions/cli/src/systemMessage.ts
@@ -83,15 +83,47 @@ function getRuleNameFromPath(filePath: string): string {
   return lastTwoParts.filter(Boolean).join("/").replace(/\.md$/, "");
 }
 
-function appendUniqueRuleContents(
-  target: string[],
-  incoming: string[],
-): void {
+function appendUniqueRuleContents(target: string[], incoming: string[]): void {
   const seen = new Set(target);
   for (const rule of incoming) {
     if (seen.has(rule)) continue;
     seen.add(rule);
     target.push(rule);
+  }
+}
+
+function parseAlwaysApplyMarkdownRule(
+  filePath: string,
+  file: string,
+  seenRuleContents: Set<string>,
+): RuleObject | null {
+  try {
+    const content = fs.readFileSync(filePath, "utf-8");
+    const { frontmatter, markdown } = parseMarkdownRule(content);
+
+    if (frontmatter.invokable) return null;
+
+    const isAlwaysApply =
+      frontmatter.alwaysApply === true ||
+      (frontmatter.alwaysApply === undefined &&
+        !frontmatter.globs &&
+        !frontmatter.regex);
+
+    if (!isAlwaysApply || !markdown.trim()) return null;
+    if (seenRuleContents.has(markdown)) return null;
+
+    seenRuleContents.add(markdown);
+    return {
+      name: frontmatter.name || getRuleNameFromPath(String(file)),
+      rule: markdown,
+      description: frontmatter.description,
+      globs: frontmatter.globs,
+      regex: frontmatter.regex,
+      alwaysApply: true,
+      sourceFile: filePath,
+    };
+  } catch {
+    return null;
   }
 }
 
@@ -129,37 +161,12 @@ export function loadMarkdownRulesWithMetadata(): RuleObject[] {
         continue;
       }
 
-      try {
-        const content = fs.readFileSync(filePath, "utf-8");
-        const { frontmatter, markdown } = parseMarkdownRule(content);
-
-        if (frontmatter.invokable) continue;
-
-        const isAlwaysApply =
-          frontmatter.alwaysApply === true ||
-          (frontmatter.alwaysApply === undefined &&
-            !frontmatter.globs &&
-            !frontmatter.regex);
-
-        if (isAlwaysApply && markdown.trim()) {
-          if (seenRuleContents.has(markdown)) continue;
-          seenRuleContents.add(markdown);
-
-          const ruleName =
-            frontmatter.name || getRuleNameFromPath(String(file));
-          rules.push({
-            name: ruleName,
-            rule: markdown,
-            description: frontmatter.description,
-            globs: frontmatter.globs,
-            regex: frontmatter.regex,
-            alwaysApply: true,
-            sourceFile: filePath,
-          });
-        }
-      } catch {
-        // Skip files that can't be read or parsed
-      }
+      const rule = parseAlwaysApplyMarkdownRule(
+        filePath,
+        String(file),
+        seenRuleContents,
+      );
+      if (rule) rules.push(rule);
     }
   }
 

--- a/extensions/cli/src/systemMessage.ts
+++ b/extensions/cli/src/systemMessage.ts
@@ -83,6 +83,18 @@ function getRuleNameFromPath(filePath: string): string {
   return lastTwoParts.filter(Boolean).join("/").replace(/\.md$/, "");
 }
 
+function appendUniqueRuleContents(
+  target: string[],
+  incoming: string[],
+): void {
+  const seen = new Set(target);
+  for (const rule of incoming) {
+    if (seen.has(rule)) continue;
+    seen.add(rule);
+    target.push(rule);
+  }
+}
+
 /**
  * Scan .continue/rules/ directories for markdown rule files and return the rules with metadata that should be always-applied
  */
@@ -94,6 +106,7 @@ export function loadMarkdownRulesWithMetadata(): RuleObject[] {
   ];
 
   const rules: RuleObject[] = [];
+  const seenRuleContents = new Set<string>();
 
   for (const dir of rulesDirs) {
     if (!fs.existsSync(dir)) continue;
@@ -129,6 +142,9 @@ export function loadMarkdownRulesWithMetadata(): RuleObject[] {
             !frontmatter.regex);
 
         if (isAlwaysApply && markdown.trim()) {
+          if (seenRuleContents.has(markdown)) continue;
+          seenRuleContents.add(markdown);
+
           const ruleName =
             frontmatter.name || getRuleNameFromPath(String(file));
           rules.push({
@@ -198,18 +214,14 @@ export async function constructSystemMessage(
   }
 
   const configYamlRules = await getConfigYamlRules();
-  processedRules.push(...configYamlRules);
+  appendUniqueRuleContents(processedRules, configYamlRules);
 
-  // Load markdown rules from .continue/rules/ directories
+  // Fallback for callers without ConfigService markdown merge (e.g. tests)
   const markdownRules = loadMarkdownRulesWithMetadata();
-  // Deduplicate against already-loaded rules
-  const existingRulesSet = new Set(processedRules);
-  for (const rule of markdownRules) {
-    if (!existingRulesSet.has(rule.rule)) {
-      processedRules.push(rule.rule);
-      existingRulesSet.add(rule.rule);
-    }
-  }
+  appendUniqueRuleContents(
+    processedRules,
+    markdownRules.map((rule) => rule.rule),
+  );
 
   // Construct the comprehensive system message
   let systemMessage = baseSystemMessage;


### PR DESCRIPTION
## Summary

Fixes duplicate `.continue/rules` content in the Continue CLI system prompt `userRules` block.

## Motivation

Fixes #12925. When using the Continue CLI, markdown rules from `.continue/rules/` were rendered twice in the model context. This happened because markdown rules were merged into `config.rules` in `ConfigService`, then loaded again in `constructSystemMessage()`, and deduplication did not cover duplicate entries already present in config or identical rules found in both project and global rule directories.

## Changes

- Add `appendUniqueRuleContents()` and use it when merging config rules and markdown fallback rules in `constructSystemMessage()`
- Deduplicate rule bodies while scanning project and global `.continue/rules` directories in `loadMarkdownRulesWithMetadata()`
- Skip duplicate markdown entries when `ConfigService` merges rules into config
- Add regression tests for config+markdown dedupe and project/global directory dedupe

## Tests

- `npx vitest run src/systemMessage.test.ts` — 24 passed
- `npx vitest run src/services/ConfigService.test.ts` — 24 passed

## Notes

Composer-2.5 review: APPROVE. Minimal, focused CLI-only change; no behavior change for distinct rule bodies.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates CLI `userRules` so markdown rules from `.continue/rules` aren’t repeated in the system prompt. Fixes #12925 by removing duplicates across config, project, and global rule sources.

- **Bug Fixes**
  - Deduplicate at merge time in both `ConfigService` and `constructSystemMessage()` using `appendUniqueRuleContents()`.
  - Remove identical markdown rule bodies across rule directories in `loadMarkdownRulesWithMetadata()`; extract `parseAlwaysApplyMarkdownRule()` to reduce nesting and satisfy ESLint max-depth.
  - Add regression tests for config + markdown and project + global dedupe; fix ESLint import order in tests.

<sup>Written for commit 9279b894a2e4f83a0f32c65b8f4a0a252ab96b74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

