### PR TITLE
feat(context): add Dakera Memory context provider

### DIFF
--- a/core/context/providers/DakeraContextProvider.ts
+++ b/core/context/providers/DakeraContextProvider.ts
@@ -16,7 +16,7 @@ import { BaseContextProvider } from "../index.js";
  *     {
  *       "name": "dakera",
  *       "params": {
- *         "baseUrl": "http://localhost:3000",
+ *         "baseUrl": "http://localhost:3300",
  *         "apiKey": "your-api-key",
  *         "topK": 10
  *       }
@@ -42,7 +42,7 @@ class DakeraContextProvider extends BaseContextProvider {
   ): Promise<ContextItem[]> {
     const baseUrl: string =
       (this.options.baseUrl as string | undefined)?.replace(/\/$/, "") ??
-      "http://localhost:3000";
+      "http://localhost:3300";
     const apiKey: string | undefined = this.options.apiKey as
       | string
       | undefined;

--- a/core/context/providers/DakeraContextProvider.ts
+++ b/core/context/providers/DakeraContextProvider.ts
@@ -1,0 +1,129 @@
+import {
+  ContextItem,
+  ContextProviderDescription,
+  ContextProviderExtras,
+} from "../../index.js";
+import { BaseContextProvider } from "../index.js";
+
+/**
+ * DakeraContextProvider retrieves semantically relevant memories from a
+ * self-hosted Dakera memory server (https://dakera.ai).
+ *
+ * Usage in config.json:
+ * ```json
+ * {
+ *   "contextProviders": [
+ *     {
+ *       "name": "dakera",
+ *       "params": {
+ *         "baseUrl": "http://localhost:3000",
+ *         "apiKey": "your-api-key",
+ *         "topK": 10
+ *       }
+ *     }
+ *   ]
+ * }
+ * ```
+ *
+ * Then in the chat: `@dakera what did I implement last week in the auth module?`
+ */
+class DakeraContextProvider extends BaseContextProvider {
+  static description: ContextProviderDescription = {
+    title: "dakera",
+    displayTitle: "Dakera Memory",
+    description:
+      "Recall relevant memories from your self-hosted Dakera memory server",
+    type: "normal",
+  };
+
+  async getContextItems(
+    query: string,
+    extras: ContextProviderExtras,
+  ): Promise<ContextItem[]> {
+    const baseUrl: string =
+      (this.options.baseUrl as string | undefined)?.replace(/\/$/, "") ??
+      "http://localhost:3000";
+    const apiKey: string | undefined = this.options.apiKey as
+      | string
+      | undefined;
+    const topK: number = (this.options.topK as number | undefined) ?? 10;
+    const sessionId: string | undefined = this.options.sessionId as
+      | string
+      | undefined;
+
+    const searchUrl = `${baseUrl}/v1/memories/search`;
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (apiKey) {
+      headers["Authorization"] = `Bearer ${apiKey}`;
+    }
+
+    const body: Record<string, unknown> = {
+      query: query || extras.fullInput || "",
+      top_k: topK,
+    };
+    if (sessionId) {
+      body["session_id"] = sessionId;
+    }
+
+    try {
+      // Use extras.fetch when available so Continue can handle proxying/auth;
+      // fall back to global fetch for environments where extras.fetch is absent.
+      const fetchFn: typeof fetch =
+        typeof extras.fetch === "function" ? (extras.fetch as any) : fetch;
+
+      const response = await fetchFn(searchUrl, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        console.warn(
+          `[DakeraContextProvider] Search request failed: ${response.status} ${response.statusText}`,
+        );
+        return [];
+      }
+
+      const json = await response.json();
+
+      // Dakera returns { memories: MemoryRecord[] } or a bare array.
+      const records: any[] = Array.isArray(json)
+        ? json
+        : Array.isArray(json?.memories)
+          ? json.memories
+          : [];
+
+      return records.map((record: any, index: number) => {
+        const text: string =
+          record.content ??
+          record.text ??
+          record.value ??
+          JSON.stringify(record);
+        const id: string = record.id ?? record.memory_id ?? String(index);
+        const importance: number | undefined =
+          record.importance ?? record.score;
+        const importanceLabel =
+          importance !== undefined
+            ? ` (relevance: ${(importance * 100).toFixed(0)}%)`
+            : "";
+
+        return {
+          name: `Memory ${id}${importanceLabel}`,
+          description: `Dakera memory retrieved for: ${query || extras.fullInput}`,
+          content: text,
+        } satisfies ContextItem;
+      });
+    } catch (e) {
+      console.warn(
+        `[DakeraContextProvider] Failed to retrieve memories from ${searchUrl}:`,
+        e,
+      );
+      return [];
+    }
+  }
+}
+
+export default DakeraContextProvider;

--- a/core/context/providers/index.ts
+++ b/core/context/providers/index.ts
@@ -4,6 +4,7 @@ import { ContextProviderName } from "../../";
 import ClipboardContextProvider from "./ClipboardContextProvider";
 import CodebaseContextProvider from "./CodebaseContextProvider";
 import CodeContextProvider from "./CodeContextProvider";
+import DakeraContextProvider from "./DakeraContextProvider";
 
 import CurrentFileContextProvider from "./CurrentFileContextProvider";
 import DatabaseContextProvider from "./DatabaseContextProvider";
@@ -71,6 +72,7 @@ export const Providers: (typeof BaseContextProvider)[] = [
   GitCommitContextProvider,
   ClipboardContextProvider,
   RulesContextProvider,
+  DakeraContextProvider,
 ];
 
 export function contextProviderClassFromName(


### PR DESCRIPTION
## Summary

Adds `DakeraContextProvider`, a new context provider that semantically searches a self-hosted [Dakera](https://dakera.ai) memory server and injects relevant memories into Continue chat as context items.

Closes #12929

## What this does

- New file: `core/context/providers/DakeraContextProvider.ts`
- Registered in `core/context/providers/index.ts` `Providers` array
- Uses `extras.fetch` (Continue-native) when available, falls back to global `fetch`
- Graceful error handling — returns `[]` on any network/parse failure, never throws

## Usage

In `config.json`:

```json
{
  "contextProviders": [
    {
      "name": "dakera",
      "params": {
        "baseUrl": "http://localhost:3000",
        "apiKey": "your-api-key",
        "topK": 10,
        "sessionId": "optional-session-filter"
      }
    }
  ]
}
```

Then in Continue chat:

```
@dakera what did I implement last week in the auth module?
@dakera how did we handle rate limiting?
```

## Config options

| Option | Default | Description |
|--------|---------|-------------|
| `baseUrl` | `http://localhost:3000` | URL of your Dakera instance |
| `apiKey` | _(none)_ | Bearer token if your instance requires auth |
| `topK` | `10` | Max number of memories to return |
| `sessionId` | _(none)_ | Filter results to a specific session |

## API contract

The provider calls `POST /v1/memories/search` with:

```json
{ "query": "<user query>", "top_k": 10 }
```

And maps the response (`{ memories: [...] }` or bare array) to `ContextItem[]`. Each memory's `content`, `text`, or `value` field becomes the context item content. Relevance score is shown in the item name when present.

## Pattern followed

Modeled after `HttpContextProvider` — same `BaseContextProvider` extension, same `extras.fetch` usage, same error-handling approach.

## Testing

- Self-hosted Dakera instance: spin up with `docker run -p 3000:3000 dakera/dakera` (or via the [dakera-deploy](https://github.com/dakera-ai/dakera-deploy) repo)
- Set `baseUrl` in config, type `@dakera <any question>` in Continue chat
- Verified provider is correctly registered and appears via `contextProviderClassFromName("dakera")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `DakeraContextProvider` to search a self-hosted Dakera memory server and inject relevant memories as context items in Continue chat via `@dakera`. Queries `POST /v1/memories/search` and defaults to port 3300.

- **New Features**
  - New `core/context/providers/DakeraContextProvider.ts`; registered in `Providers`.
  - Config: `baseUrl` (default `http://localhost:3300`), `apiKey`, `topK` (default 10), `sessionId`.
  - Uses `extras.fetch` when available; otherwise global `fetch`. Fails gracefully by returning `[]`.
  - Maps results to `ContextItem[]` and includes relevance in the item name when available.

<sup>Written for commit 7ddbbae4a455f0a92f88149129445028bbe3d617. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/continuedev/continue/pull/12930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

