### PR TITLE
fix(openai): limit stream_options to official API

### DIFF
--- a/packages/openai-adapters/src/apis/OpenAI.test.ts
+++ b/packages/openai-adapters/src/apis/OpenAI.test.ts
@@ -1,0 +1,32 @@
+import { ChatCompletionCreateParams } from "openai/resources/index";
+import { describe, expect, it } from "vitest";
+
+import { OpenAIApi } from "./OpenAI.js";
+
+const streamingBody = (): ChatCompletionCreateParams => ({
+  model: "gpt-4.1",
+  messages: [{ role: "user", content: "hello" }],
+  stream: true,
+});
+
+describe("OpenAIApi modifyChatBody stream_options", () => {
+  it("adds stream_options for official OpenAI streaming requests", () => {
+    const api = new OpenAIApi({ provider: "openai", apiKey: "test-key" });
+
+    const modifiedBody = api.modifyChatBody(streamingBody());
+
+    expect((modifiedBody as any).stream_options).toEqual({ include_usage: true });
+  });
+
+  it("does not add OpenAI-only stream_options for compatible endpoints", () => {
+    const api = new OpenAIApi({
+      provider: "openai",
+      apiKey: "test-key",
+      apiBase: "https://example.cloud.databricks.com/serving-endpoints/chat/invocations",
+    });
+
+    const modifiedBody = api.modifyChatBody(streamingBody());
+
+    expect((modifiedBody as any).stream_options).toBeUndefined();
+  });
+});

--- a/packages/openai-adapters/src/apis/OpenAI.ts
+++ b/packages/openai-adapters/src/apis/OpenAI.ts
@@ -49,8 +49,10 @@ export class OpenAIApi implements BaseLlmApi {
     });
   }
   modifyChatBody<T extends ChatCompletionCreateParams>(body: T): T {
-    // Add stream_options to include usage in streaming responses
-    if (body.stream) {
+    const isOfficialOpenAIAPI = this.apiBase === "https://api.openai.com/v1/";
+
+    // Add stream_options to include usage in official OpenAI streaming responses
+    if (body.stream && isOfficialOpenAIAPI) {
       (body as any).stream_options = { include_usage: true };
     }
 
@@ -65,7 +67,6 @@ export class OpenAIApi implements BaseLlmApi {
     }
 
     // o-series models - only apply for official OpenAI API
-    const isOfficialOpenAIAPI = this.apiBase === "https://api.openai.com/v1/";
     if (isOfficialOpenAIAPI) {
       if (body.model.startsWith("o") || body.model.includes("gpt-5")) {
         // a) use max_completion_tokens instead of max_tokens


### PR DESCRIPTION
## Summary
- only send OpenAI `stream_options: { include_usage: true }` to the official OpenAI API
- avoid sending the OpenAI-only field to OpenAI-compatible endpoints such as Databricks
- add regression tests for official and compatible API bases

Fixes #12936.

## Verification
- `npm --prefix packages/openai-adapters test -- --run src/apis/OpenAI.test.ts`
- `npm --prefix packages/openai-adapters run build`
