### PR TITLE
fix(gui): contain sidebar markdown overflow

### DIFF
--- a/gui/src/components/StepContainer/StepContainer.tsx
+++ b/gui/src/components/StepContainer/StepContainer.tsx
@@ -75,9 +75,9 @@ export default function StepContainer(props: StepContainerProps) {
   }
 
   return (
-    <div>
+    <div className="min-w-0">
       <div
-        className={`bg-background p-1 px-1.5 ${isBeforeLatestSummary ? "opacity-35" : ""}`}
+        className={`bg-background min-w-0 p-1 px-1.5 ${isBeforeLatestSummary ? "opacity-35" : ""}`}
       >
         {uiConfig?.displayRawMarkdown ? (
           <pre className="text-2xs max-w-full overflow-x-auto whitespace-pre-wrap break-words p-4">

--- a/gui/src/components/StyledMarkdownPreview/index.tsx
+++ b/gui/src/components/StyledMarkdownPreview/index.tsx
@@ -37,6 +37,8 @@ const StyledMarkdown = styled.div<{
   whiteSpace: string;
   bgColor: string;
 }>`
+  min-width: 0;
+  max-width: 100%;
   h1 {
     font-size: 1.25em;
   }
@@ -66,7 +68,9 @@ const StyledMarkdown = styled.div<{
     background-color: ${vscEditorBackground};
     border-radius: ${defaultBorderRadius};
 
-    max-width: calc(100vw - 24px);
+    box-sizing: border-box;
+    min-width: 0;
+    max-width: 100%;
     overflow-x: scroll;
     overflow-y: hidden;
 
@@ -77,6 +81,8 @@ const StyledMarkdown = styled.div<{
     span.line:empty {
       display: none;
     }
+    overflow-wrap: anywhere;
+    word-break: break-word;
     word-wrap: break-word;
     border-radius: 0.3125rem;
     background-color: ${vscEditorBackground};

--- a/gui/src/pages/gui/Chat.tsx
+++ b/gui/src/pages/gui/Chat.tsx
@@ -355,7 +355,7 @@ export function Chat() {
 
       // Default case - regular assistant message
       return (
-        <div className="thread-message">
+        <div className="thread-message min-w-0">
           <TimelineItem
             item={item}
             iconElement={<ChatBubbleOvalLeftIcon width="16px" height="16px" />}
@@ -386,7 +386,7 @@ export function Chat() {
 
       <StepsDiv
         ref={stepsDivRef}
-        className={`pt-[8px] ${showScrollbar ? "thin-scrollbar" : "no-scrollbar"} ${history.length > 0 ? "min-h-0 flex-1 overflow-y-scroll" : "shrink-0"}`}
+        className={`min-w-0 pt-[8px] ${showScrollbar ? "thin-scrollbar" : "no-scrollbar"} ${history.length > 0 ? "min-h-0 flex-1 overflow-x-hidden overflow-y-scroll" : "shrink-0"}`}
       >
         <DeprecationBanner dismissable={true} />
         {highlights}

--- a/gui/src/pages/gui/index.tsx
+++ b/gui/src/pages/gui/index.tsx
@@ -7,7 +7,7 @@ export default function GUI() {
       <aside className="4xl:flex border-vsc-input-border no-scrollbar hidden min-h-0 w-96 overflow-y-auto border-0 border-r border-solid">
         <History />
       </aside>
-      <main className="no-scrollbar flex min-h-0 flex-1 flex-col">
+      <main className="no-scrollbar flex min-h-0 min-w-0 flex-1 flex-col">
         <Chat />
       </main>
     </div>


### PR DESCRIPTION
## Summary\n- allow the GUI main pane and chat step wrappers to shrink with min-w-0\n- hide horizontal overflow at the chat-scroll container while keeping code blocks horizontally scrollable\n- cap markdown/code blocks to their parent width instead of viewport width\n\nFixes #12910.\n\n## Verification\n- npx prettier --check gui/src/pages/gui/index.tsx gui/src/pages/gui/Chat.tsx gui/src/components/StepContainer/StepContainer.tsx gui/src/components/StyledMarkdownPreview/index.tsx\n- npm --prefix gui run lint -- src/pages/gui/index.tsx src/pages/gui/Chat.tsx src/components/StepContainer/StepContainer.tsx src/components/StyledMarkdownPreview/index.tsx\n- Chromium layout smoke: 420px sidebar with 5000-character unbroken code token kept document scrollWidth at 420px, Enter button right edge at 412px, and overflow inside the code block\n\n## Notes\n- npm --prefix gui run tsc:check was not usable in this checkout after package install because it reports existing core dependency/type errors outside these files.\n- npm --prefix gui test -- src/pages/gui/chat-tests/Chat.test.tsx was not usable because the existing test setup fails before collection with localStorage.getItem is not a function.