### PR TITLE
fix(vscode): stop autocomplete firing in non-code input boxes (#12933)

### DIFF
--- a/extensions/vscode/src/autocomplete/__tests__/ContinueCompletionProvider.vitest.ts
+++ b/extensions/vscode/src/autocomplete/__tests__/ContinueCompletionProvider.vitest.ts
@@ -2,7 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import * as vscode from "vscode";
 
-import { ContinueCompletionProvider } from "../completionProvider";
+import {
+  ContinueCompletionProvider,
+  isNonCodeInputScheme,
+} from "../completionProvider";
 
 import * as NextEditLoggingServiceModule from "core/nextEdit/NextEditLoggingService";
 import * as PrefetchQueueModule from "core/nextEdit/NextEditPrefetchQueue";
@@ -158,6 +161,90 @@ describe("ContinueCompletionProvider triggering logic", () => {
   });
 });
 
+describe("isNonCodeInputScheme", () => {
+  it("returns true for non-code input surfaces", () => {
+    const deniedSchemes = [
+      "vscode-scm",
+      "comment",
+      "chatSessionInput",
+      "vscode-interactive-input",
+      "vscode-chat-editor",
+      "chat-editing-text-model",
+      "output",
+      "vscode-settings",
+    ];
+    for (const scheme of deniedSchemes) {
+      expect(isNonCodeInputScheme(scheme)).toBe(true);
+    }
+  });
+
+  it("returns false for real editable document schemes", () => {
+    const allowedSchemes = [
+      "file",
+      "vscode-remote",
+      "untitled",
+      "vscode-notebook-cell",
+      "vscode-vfs",
+    ];
+    for (const scheme of allowedSchemes) {
+      expect(isNonCodeInputScheme(scheme)).toBe(false);
+    }
+  });
+});
+
+describe("ContinueCompletionProvider non-code input schemes", () => {
+  const deniedSchemes = [
+    "vscode-scm",
+    "comment",
+    "chatSessionInput",
+    "vscode-interactive-input",
+    "vscode-chat-editor",
+    "chat-editing-text-model",
+    "output",
+    "vscode-settings",
+  ];
+
+  it.each(deniedSchemes)(
+    "returns null and does not start a chain for the %s scheme",
+    async (scheme) => {
+      const document = createDocument(undefined, `${scheme}:input-0`);
+      setActiveEditor(document);
+
+      const provider = buildProvider();
+
+      const result = await provider.provideInlineCompletionItems(
+        document,
+        createPosition(),
+        createContext(),
+        createToken(),
+      );
+
+      expect(result).toBeNull();
+      expect(mockNextEditProvider.startChain).not.toHaveBeenCalled();
+      expect(
+        mockNextEditProvider.provideInlineCompletionItems,
+      ).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not autocomplete inside the Copilot Chat input (chatSessionInput)", async () => {
+    const document = createDocument(undefined, "chatSessionInput:input-0");
+    setActiveEditor(document);
+
+    const provider = buildProvider();
+
+    const result = await provider.provideInlineCompletionItems(
+      document,
+      createPosition(),
+      createContext(),
+      createToken(),
+    );
+
+    expect(result).toBeNull();
+    expect(mockNextEditProvider.startChain).not.toHaveBeenCalled();
+  });
+});
+
 function buildProvider(options: { usingFullFileDiff?: boolean } = {}) {
   const usingFullFileDiff = options.usingFullFileDiff ?? true;
   const configHandler = {
@@ -181,10 +268,11 @@ function buildProvider(options: { usingFullFileDiff?: boolean } = {}) {
 
 function createDocument(
   text = "function example() {\n  return true;\n}",
+  uri = "file:///test",
 ): vscode.TextDocument {
   const lines = text.split("\n");
   return {
-    uri: vscode.Uri.parse("file:///test"),
+    uri: { scheme: uri.split(":")[0], toString: () => uri },
     isUntitled: false,
     getText: (range?: any) => {
       if (!range) {

--- a/extensions/vscode/src/autocomplete/completionProvider.ts
+++ b/extensions/vscode/src/autocomplete/completionProvider.ts
@@ -31,6 +31,24 @@ import {
   stopStatusBarLoading,
 } from "./statusBar";
 
+// Schemes belonging to non-code input surfaces (other extensions' chat / comment /
+// output boxes) where inline completions must not fire. See issue #12933.
+// Ref: VS Code scheme registry (Schemas) in src/vs/base/common/network.ts.
+const NON_CODE_INPUT_SCHEMES: Set<string> = new Set([
+  "vscode-scm", // SCM commit-message input (was the only prior guard)
+  "comment", // SCM / review comment input
+  "chatSessionInput", // Copilot Chat input (current builds) — the #12933 repro
+  "vscode-interactive-input", // chat / interactive input (older builds — version drift)
+  "vscode-chat-editor", // chat editor surface (older builds)
+  "chat-editing-text-model", // chat editing working-copy model
+  "output", // Output panel (never a code input)
+  "vscode-settings", // Settings editor input fields
+]);
+
+export function isNonCodeInputScheme(scheme: string): boolean {
+  return NON_CODE_INPUT_SCHEMES.has(scheme);
+}
+
 interface VsCodeCompletionInput {
   document: vscode.TextDocument;
   position: vscode.Position;
@@ -171,7 +189,7 @@ export class ContinueCompletionProvider
       return null;
     }
 
-    if (document.uri.scheme === "vscode-scm") {
+    if (isNonCodeInputScheme(document.uri.scheme)) {
       return null;
     }
 


### PR DESCRIPTION
## Description

Continue's VS Code inline autocomplete was firing inside other extensions' text input boxes - the reporter saw it autocomplete into the GitHub Copilot Chat input (#12933).

**Root cause:** the inline completion provider is registered with a catch-all document selector `[{ pattern: "**" }]` (`extensions/vscode/src/extension/VsCodeExtension.ts`), so VS Code invokes it for every document, including foreign chat/comment/output input boxes. The handler `provideInlineCompletionItems` only returned early for the `vscode-scm` scheme, so it had no general guard against non-code input surfaces. The Copilot Chat input is a real TextDocument with URI scheme `chatSessionInput`, which slipped through and received completions.

**Fix:** add a small handler-side guard that returns early for known non-code input schemes, extracted into a testable `isNonCodeInputScheme()` helper. The existing `vscode-scm` bail is folded into the same denylist (behavior-preserving).

I kept this as a scheme denylist rather than narrowing the registration selector to an allowlist, because an allowlist would risk silently regressing document types that work today - `vscode-remote` (SSH/WSL/Codespaces), `vscode-vfs` (github.dev), `untitled` buffers, and notebook cells. This also mirrors how VS Code's own Copilot completions guard their chat input by scheme, and matches existing scheme-guarding precedent in this repo (InlineTipManager, NextEditWindowManager, ideUtils)

## Checklist
- [x] I've read the contributing guide

- [x] The relevant docs, if any, have been updated or created (n/a — internal behavior fix)

- [x] The relevant tests, if any, have been updated or created.

## Tests

Added unit tests in `ContinueCompletionProvider.vitest.ts`:

- `isNonCodeInputScheme` returns true for each denied scheme (vscode-scm, comment, chatSessionInput, vscode-interactive-input, vscode-chat-editor, chat-editing-text-model, output, vscode-settings) and false for real editable schemes (file, vscode-remote, untitled, vscode-notebook-cell, vscode-vfs).

- The provider returns null and does not start a completion chain for each denied scheme (parametrized), with a named case for the chatSessionInput scheme that reproduces #12933.

- The existing "starts a new chain" test on a file:// document acts as the positive control, confirming real code files are unaffected.

Manual repro (autocomplete leaking into the Copilot Chat input) requires a build of the extension with Copilot installed; the behavior is otherwise fully covered by the unit tests above.
