### PR TITLE
docs: update stale models docs link in generated config

### DIFF
--- a/core/config/createNewAssistantFile.ts
+++ b/core/config/createNewAssistantFile.ts
@@ -9,7 +9,7 @@ version: 1.0.0
 schema: v1
 
 # Define which models can be used
-# https://docs.continue.dev/customization/models
+# https://docs.continue.dev/customize/models
 models:
   - name: my gpt-5
     provider: openai


### PR DESCRIPTION
## What

Updates the docs link in the generated example config from `https://docs.continue.dev/customization/models` to
`https://docs.continue.dev/customize/models`

## Why

The "create new assistant" flow (`core/config/createNewAssistantFile.ts`)
writes an example `config.yaml` for new users. Its "Define which models can
be used" comment links to `/customization/models`, which is no longer a
canonical page. It only resolves through the redirect defined in
`docs/docs.json` (`/customization/models` → `/customize/models`). New users
following the link are bounced through a redirect. This points them straight
at the live page.

## How

One-line change to the `DEFAULT_ASSISTANT_FILE` template comment.

## Testing

No tests. This is a comment-only string change inside a config template;
there's no behavioral assertion tied to the URL, and the file's formatting is
unchanged (comment text only). Verified locally: `git diff --check` clean,
Prettier-neutral (only the URL text changed, no structural edits).

Fixes #12669