### PR TITLE
docs: fix broken link for chat model role in reference.mdx

### DIFF
--- a/docs/reference.mdx
+++ b/docs/reference.mdx
@@ -87,7 +87,7 @@ The `models` section defines the language models used in your configuration. Mod
 
 - `maxStopWords`: Maximum number of stop words allowed, to avoid API errors with extensive lists.
 
-- `promptTemplates`: Can be used to override the default prompt templates for different model roles. Valid values are [`chat`](), [`edit`](/customize/model-roles/edit#prompt-templating), [`apply`](/customize/model-roles/apply#prompt-templating) and [`autocomplete`](/customize/model-roles/autocomplete#prompt-templating). The `chat` property must be a valid template name, such as `llama3` or `anthropic`.
+- `promptTemplates`: Can be used to override the default prompt templates for different model roles. Valid values are [`chat`](/customize/model-roles/chat), [`edit`](/customize/model-roles/edit#prompt-templating), [`apply`](/customize/model-roles/apply#prompt-templating) and [`autocomplete`](/customize/model-roles/autocomplete#prompt-templating). The `chat` property must be a valid template name, such as `llama3` or `anthropic`.
 
 - `chatOptions`: If the model includes role `chat`, these settings apply for Agent and Chat mode:
 


### PR DESCRIPTION
## Description

Fixes a broken markdown link in `docs/reference.mdx`. The `promptTemplates`
bullet listed `[chat]()` with an empty URL, while the sibling links (`edit`,
`apply`, `autocomplete`) all pointed to their respective docs pages. This
corrects the dead link.

`[chat]()` → `[chat](/customize/model-roles/chat)`

Note: the sibling links use a `#prompt-templating` anchor, but `chat.mdx` has
no such heading, so this links to the page root instead of a non-existent
anchor.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A — documentation-only change (single link fix), no UI or behavior affected.

## Tests

N/A — documentation-only change. MDX files are excluded from Prettier via
`.prettierignore`, and no code paths or tests are affected.