### PR TITLE
Fix startup logs by registering continue.viewLogs command early

### DIFF
--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -14,6 +14,15 @@ async function dynamicImportAndActivate(context: vscode.ExtensionContext) {
 }
 
 export function activate(context: vscode.ExtensionContext) {
+  // Register the viewLogs command early so it's available even if activation fails.
+  const viewLogsDisposable = vscode.commands.registerCommand(
+    "continue.viewLogs",
+    () => {
+      vscode.commands.executeCommand("workbench.action.toggleDevTools");
+    },
+  );
+  context.subscriptions.push(viewLogsDisposable);
+
   return dynamicImportAndActivate(context).catch((e) => {
     console.log("Error activating extension: ", e);
     vscode.window


### PR DESCRIPTION
### Description
This PR resolves issue #12946 where clicking the "Show Logs" button during extension startup failures does nothing and throws an error in the console: command 'continue.viewLogs' not found.

The command continue.viewLogs was registered too late (after full extension activation). When activation crashes early, the command is never registered, rendering the troubleshooting option useless. 

By registering continue.viewLogs immediately in the main ctivate entry point in extension.ts, we ensure that the command is available to VS Code even if subsequent activation fails.

### Test Plan
1. Induce an early activation crash (e.g., throwing a dummy error in ctivateExtension).
2. Click the "View Logs" (or "Show Logs") button on the warning pop-up.
3. DevTools console should toggle open successfully instead of throwing a command-not-found error.