### PR TITLE
Guard theme colors to prevent activation crash

### DIFF
--- a/extensions/vscode/src/activation/InlineTipManager.ts
+++ b/extensions/vscode/src/activation/InlineTipManager.ts
@@ -236,7 +236,7 @@ export class InlineTipManager {
 
   private createSvgTooltipDecoration() {
     var backgroundColour = "#333333";
-    if (this.theme) {
+    if (this.theme?.colors?.["editor.background"]) {
       backgroundColour = this.theme.colors["editor.background"];
     }
     return vscode.window.createTextEditorDecorationType({
@@ -274,7 +274,7 @@ export class InlineTipManager {
           {
             ...baseTextConfig,
             x: SVG_CONFIG.chatLabelX,
-            fill: this.theme?.colors["editor.foreground"] ?? SVG_CONFIG.stroke,
+            fill: this.theme?.colors?.["editor.foreground"] ?? SVG_CONFIG.stroke,
           },
           SVG_CONFIG.chatLabel,
         )
@@ -291,7 +291,7 @@ export class InlineTipManager {
           {
             ...baseTextConfig,
             x: SVG_CONFIG.editLabelX,
-            fill: this.theme?.colors["editor.foreground"] ?? SVG_CONFIG.stroke,
+            fill: this.theme?.colors?.["editor.foreground"] ?? SVG_CONFIG.stroke,
           },
           SVG_CONFIG.editLabel,
         )

--- a/extensions/vscode/src/activation/InlineTipManager.ts
+++ b/extensions/vscode/src/activation/InlineTipManager.ts
@@ -274,7 +274,8 @@ export class InlineTipManager {
           {
             ...baseTextConfig,
             x: SVG_CONFIG.chatLabelX,
-            fill: this.theme?.colors?.["editor.foreground"] ?? SVG_CONFIG.stroke,
+            fill:
+              this.theme?.colors?.["editor.foreground"] ?? SVG_CONFIG.stroke,
           },
           SVG_CONFIG.chatLabel,
         )
@@ -291,7 +292,8 @@ export class InlineTipManager {
           {
             ...baseTextConfig,
             x: SVG_CONFIG.editLabelX,
-            fill: this.theme?.colors?.["editor.foreground"] ?? SVG_CONFIG.stroke,
+            fill:
+              this.theme?.colors?.["editor.foreground"] ?? SVG_CONFIG.stroke,
           },
           SVG_CONFIG.editLabel,
         )

--- a/extensions/vscode/src/activation/JumpManager.ts
+++ b/extensions/vscode/src/activation/JumpManager.ts
@@ -145,7 +145,8 @@ export class JumpManager {
           {
             ...baseTextConfig,
             x: 4,
-            fill: this._theme?.colors?.["editor.foreground"] ?? SVG_CONFIG.stroke,
+            fill:
+              this._theme?.colors?.["editor.foreground"] ?? SVG_CONFIG.stroke,
           },
           SVG_CONFIG.label,
         )

--- a/extensions/vscode/src/activation/JumpManager.ts
+++ b/extensions/vscode/src/activation/JumpManager.ts
@@ -145,7 +145,7 @@ export class JumpManager {
           {
             ...baseTextConfig,
             x: 4,
-            fill: this._theme?.colors["editor.foreground"] ?? SVG_CONFIG.stroke,
+            fill: this._theme?.colors?.["editor.foreground"] ?? SVG_CONFIG.stroke,
           },
           SVG_CONFIG.label,
         )
@@ -168,7 +168,7 @@ export class JumpManager {
 
   private _createSvgJumpDecoration(): vscode.TextEditorDecorationType {
     const backgroundColour =
-      this._theme?.colors["editor.background"] ?? "#333333";
+      this._theme?.colors?.["editor.background"] ?? "#333333";
 
     return vscode.window.createTextEditorDecorationType({
       after: {


### PR DESCRIPTION
### Description
This PR resolves issue #12947 where the extension fails to activate when using non-standard or custom color palettes. 

Specifically, accessing `this.theme.colors["editor.background"]` or `this.theme.colors["editor.foreground"]` throws `TypeError: Cannot read properties of undefined (reading 'editor.background')` if `this.theme.colors` is `undefined`.

Optional chaining (`?.`) has been added to guard these theme property lookups in both `InlineTipManager.ts` and `JumpManager.ts`, falling back safely to default stroke/background colors when theme colors are unavailable.

### Test Plan
1. Switch to a custom/non-standard theme that does not declare VS Code token colors in the usual format.
2. Activate the Continue extension.
3. Observe that the extension starts up successfully without crashing during tooltip generation.
