### PR TITLE
Check if YAML extension is installed before registering config schema

### DIFF
--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -60,10 +60,7 @@ export async function activateExtension(context: vscode.ExtensionContext) {
         vscode.ConfigurationTarget.Global,
       );
     } catch (error) {
-      console.error(
-        "Failed to register Continue config.yaml schema",
-        error,
-      );
+      console.error("Failed to register Continue config.yaml schema", error);
     }
   }
 

--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -39,29 +39,32 @@ export async function activateExtension(context: vscode.ExtensionContext) {
   }
 
   // Register config.yaml schema by removing old entries and adding new one (uri.fsPath changes with each version)
-  const yamlMatcher = ".continue/**/*.yaml";
-  const yamlConfig = vscode.workspace.getConfiguration("yaml");
-  const yamlSchemas = yamlConfig.get<object>("schemas", {});
+  const yamlExtension = vscode.extensions.getExtension("redhat.vscode-yaml");
+  if (yamlExtension) {
+    const yamlMatcher = ".continue/**/*.yaml";
+    const yamlConfig = vscode.workspace.getConfiguration("yaml");
+    const yamlSchemas = yamlConfig.get<object>("schemas", {});
 
-  const newPath = vscode.Uri.joinPath(
-    context.extension.extensionUri,
-    "config-yaml-schema.json",
-  ).toString();
+    const newPath = vscode.Uri.joinPath(
+      context.extension.extensionUri,
+      "config-yaml-schema.json",
+    ).toString();
 
-  try {
-    await yamlConfig.update(
-      "schemas",
-      {
-        ...yamlSchemas,
-        [newPath]: [yamlMatcher],
-      },
-      vscode.ConfigurationTarget.Global,
-    );
-  } catch (error) {
-    console.error(
-      "Failed to register Continue config.yaml schema, most likely, YAML extension is not installed",
-      error,
-    );
+    try {
+      await yamlConfig.update(
+        "schemas",
+        {
+          ...yamlSchemas,
+          [newPath]: [yamlMatcher],
+        },
+        vscode.ConfigurationTarget.Global,
+      );
+    } catch (error) {
+      console.error(
+        "Failed to register Continue config.yaml schema",
+        error,
+      );
+    }
   }
 
   const api = new VsCodeContinueApi(vscodeExtension);


### PR DESCRIPTION
### Description
This PR resolves issue #12948 where extension activation fails when the Red Hat YAML extension (`redhat.vscode-yaml`) is not installed.

Writing to `yaml.schemas` user settings when the configuration is not registered throws `CodeExpectedError: Unable to write to User Settings because yaml.schemas is not a registered configuration.`.

This is resolved by checking if the `redhat.vscode-yaml` extension is installed using `vscode.extensions.getExtension` before reading or updating the `yaml.schemas` settings configuration.

### Test Plan
1. Uninstall the Red Hat YAML extension.
2. Start VS Code with the Continue extension enabled.
3. Verify that the extension activates successfully without throwing a `CodeExpectedError` on `yaml.schemas`.
