### PR TITLE
docs: add Lynkr to model providers (more)

### DIFF
--- a/docs/customize/model-providers/more/lynkr.mdx
+++ b/docs/customize/model-providers/more/lynkr.mdx
@@ -1,0 +1,43 @@
+---
+title: "How to Configure Lynkr with Continue"
+sidebarTitle: "Lynkr"
+---
+
+<Info>
+  Lynkr is an open-source, self-hosted LLM gateway that routes each request by
+  complexity: simple requests go to local models (Ollama, llama.cpp, LM Studio),
+  complex ones to a configured cloud provider (AWS Bedrock, Azure OpenAI,
+  Databricks, OpenRouter, and others). It also strips unused tool schemas and
+  compresses large JSON tool results to reduce token usage.
+</Info>
+
+<Tip>
+  Get started with [Lynkr on GitHub](https://github.com/Fast-Editor/Lynkr)
+</Tip>
+
+## Installation
+
+Lynkr runs locally and provides an OpenAI-compatible API:
+
+```bash
+npm install -g lynkr
+lynkr init   # interactive wizard: choose tier models and provider credentials
+lynkr start
+```
+
+This starts the gateway at `http://localhost:8081`.
+
+## Configuration
+
+```yaml title="config.yaml"
+models:
+  - name: Lynkr
+    provider: openai
+    model: lynkr-auto
+    apiBase: http://localhost:8081/v1
+    apiKey: none
+```
+
+The `model` value is a placeholder — Lynkr's tier routing selects the actual
+model per request based on the tiers configured in `lynkr init`, so a single
+entry covers the local-to-cloud range.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -112,6 +112,7 @@
                       "customize/model-providers/more/groq",
                       "customize/model-providers/more/llamacpp",
                       "customize/model-providers/more/llamastack",
+                      "customize/model-providers/more/lynkr",
                       "customize/model-providers/more/mimo",
                       "customize/model-providers/more/mistral",
                       "customize/model-providers/more/moonshot",


### PR DESCRIPTION
Adds a docs page for Lynkr, a self-hosted Apache-2.0 gateway usable with Continue through the OpenAI-compatible provider, plus the docs.json nav entry under More Providers (alphabetical placement).

Lynkr routes each request by complexity — simple requests to local models (Ollama/llama.cpp/LM Studio), complex ones to a configured cloud provider — and reduces token usage via tool-schema stripping and JSON tool-result compression. Repo: https://github.com/Fast-Editor/Lynkr

Page modeled on the existing more/ provider pages (clawrouter.mdx). Happy to adjust format to current conventions if needed.