### PR TITLE
docs: add Vestige to example MCP servers

### DIFF
--- a/docs/customize/deep-dives/mcp-examples.mdx
+++ b/docs/customize/deep-dives/mcp-examples.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Example MCP Servers"
-keywords: [mcp, integrations, sentry, slack, linear, posthog, supabase, netlify, atlassian, github, sanity, snyk, dlt, chrome-devtools]
+keywords: [mcp, integrations, sentry, slack, linear, posthog, supabase, netlify, atlassian, github, sanity, snyk, dlt, chrome-devtools, vestige, memory]
 ---
 
 Ready-to-use MCP server configurations for popular tools and services. Copy these into your `config.yaml` to get started.
@@ -182,6 +182,21 @@ mcpServers:
 ```
 
 See also: [Chrome DevTools MCP guide](/guides/chrome-devtools-mcp-performance)
+
+## Vestige
+
+Vestige gives the agent persistent memory across sessions. It runs locally and stores decisions, preferences, and past fixes on your own machine, so Continue can recall project context instead of starting cold each time.
+
+```yaml
+mcpServers:
+  - name: Vestige
+    command: npx
+    args:
+      - "-y"
+      - "-p"
+      - "vestige-mcp-server@latest"
+      - "vestige-mcp"
+```
 
 ## Other guides
 


### PR DESCRIPTION
## Description

Adds Vestige to the example MCP servers page. It's a local stdio MCP server that gives the agent memory across sessions, so Continue can recall project decisions and past fixes instead of starting cold every time. None of the current examples cover memory, and it comes up a lot, so it earns a spot on the list.

Config uses the same `mcpServers` shape as the other entries. I ran the exact snippet before submitting: `npx -y -p vestige-mcp-server@latest vestige-mcp` boots the server and returns a valid response to an MCP `initialize` call over stdio, so it's copy-paste ready. Also added `vestige` and `memory` to the page keywords. Docs only, nothing else touched.

## Checklist

- [x] I've read the contributing guide
- [x] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created

## Tests

Docs only, no tests. Verified the config snippet starts the server and answers an MCP `initialize` request locally.
