### PR TITLE
feat: add TokenLab provider

### DIFF
--- a/core/llm/llms/OpenAI-compatible-core.vitest.ts
+++ b/core/llm/llms/OpenAI-compatible-core.vitest.ts
@@ -14,6 +14,7 @@ import Cerebras from "./Cerebras.js";
 import DeepInfra from "./DeepInfra.js";
 import Nvidia from "./Nvidia.js";
 import CometAPI from "./CometAPI.js";
+import TokenLab from "./TokenLab.js";
 
 // Base OpenAI tests
 import { afterEach, describe, expect, test, vi } from "vitest";
@@ -238,6 +239,11 @@ createOpenAISubclassTests(xAI, {
     "grok-beta": "grok-beta",
   },
   modelConversionContent: "hello",
+});
+
+createOpenAISubclassTests(TokenLab, {
+  providerName: "tokenlab",
+  defaultApiBase: "https://api.tokenlab.sh/v1/",
 });
 
 createOpenAISubclassTests(Mistral, {

--- a/core/llm/llms/TokenLab.ts
+++ b/core/llm/llms/TokenLab.ts
@@ -1,0 +1,18 @@
+import { LLMOptions } from "../../index.js";
+
+import OpenAI from "./OpenAI.js";
+
+class TokenLab extends OpenAI {
+  static providerName = "tokenlab";
+  static defaultOptions: Partial<LLMOptions> = {
+    apiBase: "https://api.tokenlab.sh/v1/",
+    model: "gpt-5.5",
+    useLegacyCompletionsEndpoint: false,
+  };
+
+  supportsCompletions(): boolean {
+    return false;
+  }
+}
+
+export default TokenLab;

--- a/core/llm/llms/index.ts
+++ b/core/llm/llms/index.ts
@@ -59,6 +59,7 @@ import SambaNova from "./SambaNova";
 import Scaleway from "./Scaleway";
 import SiliconFlow from "./SiliconFlow";
 import Tensorix from "./Tensorix";
+import TokenLab from "./TokenLab";
 import TARS from "./TARS";
 import TestLLM from "./Test";
 import TextGenWebUI from "./TextGenWebUI";
@@ -125,6 +126,7 @@ export const LLMClasses = [
   xAI,
   SiliconFlow,
   Tensorix,
+  TokenLab,
   Scaleway,
   Relace,
   Inception,

--- a/docs/customize/model-providers/more/tokenlab.mdx
+++ b/docs/customize/model-providers/more/tokenlab.mdx
@@ -1,0 +1,67 @@
+---
+title: TokenLab
+slug: ../tokenlab
+---
+
+TokenLab provides a unified AI gateway for GPT, Claude, Gemini, Grok, DeepSeek, GLM, Qwen, Kimi, MiniMax, and other model families.
+
+<Info>
+  Get an API key from [TokenLab](https://tokenlab.sh/) and see API details in the [TokenLab docs](https://docs.tokenlab.sh/introduction).
+</Info>
+
+## Configuration
+
+Continue uses TokenLab's OpenAI-compatible chat endpoint. TokenLab also exposes native endpoints for Responses, Anthropic Messages, Gemini generateContent, embeddings, images, videos, audio, realtime, and translations for applications that call those APIs directly.
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  name: My Config
+  version: 0.0.1
+  schema: v1
+
+  models:
+    - name: GPT-5.5
+      provider: tokenlab
+      model: gpt-5.5
+      apiKey: <YOUR_TOKENLAB_API_KEY>
+  ```
+  </Tab>
+  <Tab title="JSON (Deprecated)">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "GPT-5.5",
+        "provider": "tokenlab",
+        "model": "gpt-5.5",
+        "apiKey": "<YOUR_TOKENLAB_API_KEY>"
+      }
+    ]
+  }
+  ```
+  </Tab>
+</Tabs>
+
+## Example Models
+
+Common TokenLab model IDs include:
+
+- `gpt-5.5`
+- `gpt-5.4`
+- `gpt-5.4-mini`
+- `claude-sonnet-5`
+- `claude-opus-4-8`
+- `claude-fable-5`
+- `gemini-3.5-flash`
+- `gemini-3.1-flash-lite`
+- `grok-4.3`
+- `grok-4-fast`
+- `deepseek-v4-pro`
+- `deepseek-v4-flash`
+- `glm-5.2`
+- `qwen3.7-max`
+- `kimi-k2.7-code`
+- `minimax-m3`
+
+TokenLab's full model catalog is available from `https://api.tokenlab.sh/v1/models`.

--- a/docs/customize/model-providers/overview.mdx
+++ b/docs/customize/model-providers/overview.mdx
@@ -35,6 +35,7 @@ Beyond the top-level providers, Continue supports many other options:
 | [DeepInfra](/customize/model-providers/more/deepinfra)                 | Hosting for various open source models                     |
 | [OpenRouter](/customize/model-providers/top-level/openrouter)          | Gateway to multiple model providers                        |
 | [ClawRouter](/customize/model-providers/more/clawrouter)               | Open-source LLM router with automatic cost-optimized model selection |
+| [TokenLab](/customize/model-providers/more/tokenlab)                   | Unified gateway for GPT, Claude, Gemini, Grok, DeepSeek, Qwen, Kimi, MiniMax, and more |
 | [Tetrate Agent Router Service](/customize/model-providers/top-level/tetrate_agent_router_service) | Gateway with intelligent routing across multiple model providers |
 | [Cohere](/customize/model-providers/more/cohere)                       | Models specialized for semantic search and text generation |
 | [NVIDIA](/customize/model-providers/more/nvidia)                       | GPU-accelerated model hosting                              |


### PR DESCRIPTION
## Summary

- Add `tokenlab` as a Continue LLM provider backed by the OpenAI-compatible chat endpoint at `https://api.tokenlab.sh/v1/`.
- Register the provider in the core LLM class list and add it to the shared OpenAI-compatible provider test suite.
- Add TokenLab docs with YAML/JSON examples, example model IDs, and a note that TokenLab also exposes native Responses, Anthropic Messages, Gemini generateContent, embeddings, images, videos, audio, realtime, and translation endpoints for direct API callers.

## Validation

- `cd core && npm run vitest -- llm/llms/OpenAI-compatible-core.vitest.ts`
- `cd core && npm run tsc:check`
- `npx prettier --check core/llm/llms/TokenLab.ts core/llm/llms/index.ts core/llm/llms/OpenAI-compatible-core.vitest.ts docs/customize/model-providers/more/tokenlab.mdx docs/customize/model-providers/overview.mdx`
- `node -e "fetch('https://api.tokenlab.sh/v1/models').then(r=>r.json().then(j=>{const ids=(j.data||[]).map(m=>m.id); console.log(r.status, ['gpt-5.5','claude-sonnet-5','gemini-3.5-flash','qwen3.7-max'].every(id=>ids.includes(id)), ids.length);}))"`



---

Supersedes #12959. The previous PR was closed while fixing contributor commit metadata; this replacement branch preserves the same scoped diff with commits authored by `hedging8563 <45883076+hedging8563@users.noreply.github.com>`.
