### PR TITLE
feat(llm): add Eden AI as an OpenAI-compatible provider

### DIFF
--- a/core/llm/llms/EdenAI.ts
+++ b/core/llm/llms/EdenAI.ts
@@ -1,0 +1,25 @@
+import { LLMOptions } from "../../index.js";
+import { osModelsEditPrompt } from "../templates/edit.js";
+
+import OpenAI from "./OpenAI.js";
+
+/**
+ * Eden AI (https://www.edenai.co) is an OpenAI-compatible aggregator that
+ * provides unified access to 100+ models from many providers (OpenAI,
+ * Anthropic, Google, Mistral, DeepSeek, and more) through a single EU-hosted
+ * endpoint and API key. Models use the `provider/model` naming scheme, e.g.
+ * `anthropic/claude-sonnet-4-5` or `mistral/codestral-latest`.
+ */
+class EdenAI extends OpenAI {
+  static providerName = "edenai";
+  static defaultOptions: Partial<LLMOptions> = {
+    apiBase: "https://api.edenai.run/v3/",
+    model: "anthropic/claude-sonnet-4-5",
+    promptTemplates: {
+      edit: osModelsEditPrompt,
+    },
+    useLegacyCompletionsEndpoint: false,
+  };
+}
+
+export default EdenAI;

--- a/core/llm/llms/OpenAI-compatible-core.vitest.ts
+++ b/core/llm/llms/OpenAI-compatible-core.vitest.ts
@@ -6,6 +6,7 @@ import Groq from "./Groq.js";
 import Fireworks from "./Fireworks.js";
 import Together from "./Together.js";
 import Deepseek from "./Deepseek.js";
+import EdenAI from "./EdenAI.js";
 import OpenRouter from "./OpenRouter.js";
 import xAI from "./xAI.js";
 import Mistral from "./Mistral.js";
@@ -224,6 +225,11 @@ createOpenAISubclassTests(Together, {
 createOpenAISubclassTests(Deepseek, {
   providerName: "deepseek",
   defaultApiBase: "https://api.deepseek.com/",
+});
+
+createOpenAISubclassTests(EdenAI, {
+  providerName: "edenai",
+  defaultApiBase: "https://api.edenai.run/v3/",
 });
 
 createOpenAISubclassTests(OpenRouter, {

--- a/core/llm/llms/index.ts
+++ b/core/llm/llms/index.ts
@@ -21,6 +21,7 @@ import CometAPI from "./CometAPI";
 import DeepInfra from "./DeepInfra";
 import Deepseek from "./Deepseek";
 import Docker from "./Docker";
+import EdenAI from "./EdenAI";
 import Fireworks from "./Fireworks";
 import Flowise from "./Flowise";
 import FunctionNetwork from "./FunctionNetwork";
@@ -106,6 +107,7 @@ export const LLMClasses = [
   Cloudflare,
   Deepseek,
   Docker,
+  EdenAI,
   Msty,
   Azure,
   WatsonX,

--- a/docs/customize/model-providers/more/edenai.mdx
+++ b/docs/customize/model-providers/more/edenai.mdx
@@ -1,0 +1,45 @@
+---
+title: "Eden AI"
+description: "Configure Eden AI with Continue — an OpenAI-compatible, EU-hosted API to 100+ models from many providers through a single API key"
+---
+
+[Eden AI](https://www.edenai.co) provides unified, OpenAI-compatible access to 100+ models from many providers (OpenAI, Anthropic, Google, Mistral, DeepSeek, and more) through a single EU-hosted endpoint and API key. Models use the `provider/model` naming scheme.
+
+1. Create an account and get an API key from the [Eden AI platform](https://app.edenai.run).
+2. Copy the API key for use in Continue.
+3. Update your Continue config file:
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  name: My Config
+  version: 0.0.1
+  schema: v1
+
+  models:
+    - name: Eden AI Claude Sonnet 4.5
+      provider: edenai
+      model: anthropic/claude-sonnet-4-5
+      apiKey: <YOUR_EDENAI_API_KEY>
+  ```
+  </Tab>
+  <Tab title="JSON">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "Eden AI Claude Sonnet 4.5",
+        "provider": "edenai",
+        "model": "anthropic/claude-sonnet-4-5",
+        "apiKey": "<YOUR_EDENAI_API_KEY>"
+      }
+    ]
+  }
+  ```
+  </Tab>
+</Tabs>
+
+<Info>
+  The default endpoint is `https://api.edenai.run/v3`. For EU-only data residency,
+  set `apiBase` to `https://api.eu.edenai.run/v3`.
+</Info>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -109,6 +109,7 @@
                       "customize/model-providers/more/clawrouter",
                       "customize/model-providers/more/deepseek",
                       "customize/model-providers/more/deepinfra",
+                      "customize/model-providers/more/edenai",
                       "customize/model-providers/more/groq",
                       "customize/model-providers/more/llamacpp",
                       "customize/model-providers/more/llamastack",

--- a/packages/openai-adapters/src/index.ts
+++ b/packages/openai-adapters/src/index.ts
@@ -149,6 +149,8 @@ export function constructLlmApi(config: LLMConfig): BaseLlmApi | undefined {
       return openAICompatible("http://127.0.0.1:5000/v1/", config);
     case "cerebras":
       return openAICompatible("https://api.cerebras.ai/v1/", config);
+    case "edenai":
+      return openAICompatible("https://api.edenai.run/v3/", config);
     case "kindo":
       return openAICompatible("https://llm.kindo.ai/v1/", config);
     case "msty":

--- a/packages/openai-adapters/src/types.ts
+++ b/packages/openai-adapters/src/types.ts
@@ -49,6 +49,7 @@ export const OpenAIConfigSchema = BasePlusConfig.extend({
     z.literal("lmstudio"),
     z.literal("ollama"),
     z.literal("cerebras"),
+    z.literal("edenai"),
     z.literal("kindo"),
     z.literal("msty"),
     z.literal("openrouter"),


### PR DESCRIPTION
## Description

Adds **Eden AI** (https://www.edenai.co) as an OpenAI-compatible LLM provider. Eden AI is an EU-hosted aggregator that exposes 100+ models from many providers (OpenAI, Anthropic, Google, Mistral, DeepSeek, xAI, …) through a single endpoint and API key. Models use the `provider/model` naming scheme (e.g. `anthropic/claude-sonnet-4-5`, `mistral/codestral-latest`).

Mirrors the existing OpenAI-compatible providers (Cerebras / Deepseek):

- `core/llm/llms/EdenAI.ts` — `EdenAI extends OpenAI` (`apiBase: https://api.edenai.run/v3/`)
- registered in `core/llm/llms/index.ts`
- `@continuedev/openai-adapters`: provider literal in the OpenAI-compatible union + `openAICompatible` case
- coverage entry in `OpenAI-compatible-core.vitest.ts`
- docs page + nav entry

## Example config

```yaml title="config.yaml"
models:
  - name: Eden AI Claude Sonnet 4.5
    provider: edenai
    model: anthropic/claude-sonnet-4-5
    apiKey: <YOUR_EDENAI_API_KEY>
```

## Testing

- `@continuedev/openai-adapters`: `tsc --noEmit` clean, `vitest` green (145 passed).
- The Eden AI endpoint was verified live (`/v3/chat/completions` and `/v3/models` both 200).
- API key is provided via config `apiKey` (or env), never hardcoded.
