### PR TITLE
fix(core): honor config requestOptions in ContinueServerClient

### DIFF
--- a/core/continueServer/stubs/client.ts
+++ b/core/continueServer/stubs/client.ts
@@ -1,3 +1,6 @@
+import { fetchwithRequestOptions } from "@continuedev/fetch";
+
+import type { RequestOptions } from "../../index.js";
 import type {
   ArtifactType,
   EmbeddingsCacheResponse,
@@ -10,6 +13,7 @@ export class ContinueServerClient implements IContinueServerClient {
   constructor(
     serverUrl: string | undefined,
     private readonly userToken: string | undefined,
+    private readonly requestOptions?: RequestOptions,
   ) {
     try {
       this.url =
@@ -32,18 +36,22 @@ export class ContinueServerClient implements IContinueServerClient {
 
   public async getConfig(): Promise<{ configJson: string }> {
     const userToken = await this.userToken;
-    const response = await fetch(new URL("sync", this.url).href, {
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${userToken}`,
+    const response = await fetchwithRequestOptions(
+      new URL("sync", this.url),
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${userToken}`,
+        },
       },
-    });
+      this.requestOptions,
+    );
     if (!response.ok) {
       throw new Error(
         `Failed to sync remote config (HTTP ${response.status}): ${response.statusText}`,
       );
     }
-    const data = await response.json();
+    const data = (await response.json()) as { configJson: string };
     return data;
   }
 
@@ -66,17 +74,21 @@ export class ContinueServerClient implements IContinueServerClient {
     const url = new URL("indexing/cache", this.url);
 
     try {
-      const response = await fetch(url, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${await this.userToken}`,
+      const response = await fetchwithRequestOptions(
+        url,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${await this.userToken}`,
+          },
+          body: JSON.stringify({
+            keys,
+            artifactId,
+            repo: repoName ?? "NONE",
+          }),
         },
-        body: JSON.stringify({
-          keys,
-          artifactId,
-          repo: repoName ?? "NONE",
-        }),
-      });
+        this.requestOptions,
+      );
 
       if (!response.ok) {
         const text = await response.text();
@@ -88,7 +100,7 @@ export class ContinueServerClient implements IContinueServerClient {
         };
       }
 
-      const data = await response.json();
+      const data = (await response.json()) as EmbeddingsCacheResponse<T>;
       return data;
     } catch (e) {
       console.warn("Failed to retrieve from remote cache", e);
@@ -105,15 +117,19 @@ export class ContinueServerClient implements IContinueServerClient {
 
     const url = new URL("feedback", this.url);
 
-    const response = await fetch(url, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${await this.userToken}`,
+    const response = await fetchwithRequestOptions(
+      url,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${await this.userToken}`,
+        },
+        body: JSON.stringify({
+          feedback,
+          data,
+        }),
       },
-      body: JSON.stringify({
-        feedback,
-        data,
-      }),
-    });
+      this.requestOptions,
+    );
   }
 }

--- a/core/continueServer/stubs/client.vitest.ts
+++ b/core/continueServer/stubs/client.vitest.ts
@@ -1,0 +1,55 @@
+import { fetchwithRequestOptions } from "@continuedev/fetch";
+import { beforeEach, expect, test, vi } from "vitest";
+import type { RequestOptions } from "../../index.js";
+import { ContinueServerClient } from "./client.js";
+
+vi.mock("@continuedev/fetch");
+
+const requestOptions: RequestOptions = {
+  proxy: "http://proxy.example.com:8080",
+  verifySsl: false,
+};
+
+beforeEach(() => {
+  vi.mocked(fetchwithRequestOptions).mockResolvedValue({
+    ok: true,
+    json: async () => ({ configJson: "{}" }),
+  } as any);
+});
+
+test("getConfig forwards requestOptions to the fetch layer", async () => {
+  const client = new ContinueServerClient(
+    "https://server.example.com",
+    "token",
+    requestOptions,
+  );
+
+  await client.getConfig();
+
+  expect(fetchwithRequestOptions).toHaveBeenCalledWith(
+    expect.any(URL),
+    expect.objectContaining({ method: "GET" }),
+    requestOptions,
+  );
+});
+
+test("getFromIndexCache forwards requestOptions to the fetch layer", async () => {
+  vi.mocked(fetchwithRequestOptions).mockResolvedValue({
+    ok: true,
+    json: async () => ({ files: {} }),
+  } as any);
+
+  const client = new ContinueServerClient(
+    "https://server.example.com",
+    "token",
+    requestOptions,
+  );
+
+  await client.getFromIndexCache(["key"], "embeddings" as any, "repo");
+
+  expect(fetchwithRequestOptions).toHaveBeenCalledWith(
+    expect.any(URL),
+    expect.objectContaining({ method: "POST" }),
+    requestOptions,
+  );
+});

--- a/core/indexing/CodebaseIndexer.ts
+++ b/core/indexing/CodebaseIndexer.ts
@@ -161,6 +161,7 @@ export class CodebaseIndexer {
     const continueServerClient = new ContinueServerClient(
       ideSettings.remoteConfigServerUrl,
       ideSettings.userToken,
+      config.requestOptions,
     );
     if (!continueServerClient) {
       return [];


### PR DESCRIPTION
## Description

Config-sync and index-cache requests in `ContinueServerClient` used the global `fetch()`, so `config.yaml` `requestOptions` (`proxy`, `verifySsl`, `caBundlePath`) were ignored on those paths. Behind an HTTPS-intercepting corporate proxy with a custom CA, this surfaces as a startup "Connection error" in core.log even though LLM requests work fine (they already go through `fetchwithRequestOptions`).

This routes the client's requests through `fetchwithRequestOptions` and passes `config.requestOptions` in from `CodebaseIndexer`, so the same proxy/TLS settings apply to config sync and index caching.

Fixes #12956

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A — network-path change with no UI. Any request made by `ContinueServerClient` previously bypassed `config.yaml` `requestOptions`; after this change it uses them.

## Tests

Added `core/continueServer/stubs/client.vitest.ts` — verifies `getConfig` and `getFromIndexCache` forward the constructor's `requestOptions` to `fetchwithRequestOptions`.