### PR TITLE
fix(cli): resume selected session in `cn ls` instead of the latest

### DIFF
--- a/extensions/cli/src/session.test.ts
+++ b/extensions/cli/src/session.test.ts
@@ -357,6 +357,31 @@ describe("SessionManager", () => {
       expect(result).toEqual(mockSession);
       expect(getCurrentSession()).toEqual(mockSession);
     });
+
+    it("should load the selected session when CONTINUE_CLI_TEST_SESSION_ID is set", () => {
+      const selectedSession: Session = {
+        sessionId: "selected-session-id",
+        title: "Selected Session",
+        workspaceDirectory: "/test/workspace",
+        history: [],
+      };
+      mockHistoryManager.load.mockReturnValue(selectedSession);
+      process.env.CONTINUE_CLI_TEST_SESSION_ID = "selected-session-id";
+
+      try {
+        const result = loadSession();
+
+        expect(result).toEqual(selectedSession);
+        // It must resolve the session by id, not by most-recent mtime
+        expect(mockHistoryManager.load).toHaveBeenCalledWith(
+          "selected-session-id",
+        );
+        expect(mockFs.readdirSync).not.toHaveBeenCalled();
+        expect(getCurrentSession()).toEqual(selectedSession);
+      } finally {
+        delete process.env.CONTINUE_CLI_TEST_SESSION_ID;
+      }
+    });
   });
 
   describe("clearSession", () => {

--- a/extensions/cli/src/session.ts
+++ b/extensions/cli/src/session.ts
@@ -300,6 +300,18 @@ export function saveSession(): void {
  */
 export function loadSession(): Session | null {
   try {
+    // If a specific session has been selected (e.g. via `cn ls`), resume that
+    // one instead of the most recent. The selection is communicated through the
+    // same env var that SessionManager uses to pin the current session id.
+    const selectedSessionId = process.env.CONTINUE_CLI_TEST_SESSION_ID;
+    if (selectedSessionId) {
+      const selectedSession = loadSessionById(selectedSessionId);
+      if (selectedSession) {
+        SessionManager.getInstance().setSession(selectedSession);
+        return selectedSession;
+      }
+    }
+
     // For resume, we need to find the most recent session
     const sessionDir = getSessionDir();
     if (!fs.existsSync(sessionDir)) {


### PR DESCRIPTION
## Description

Fixes #12927.

`cn ls` lets you pick a past session from the TUI, but resuming always reopened the **most recent** session regardless of which one you selected.

Root cause is in `extensions/cli/src/session.ts`. `loadSession()` sorts the session files by mtime and unconditionally loads `files[0]`:

```ts
// Load the most recent session
const session: Session = JSON.parse(fs.readFileSync(files[0].path, "utf8"));
```

The `cn ls` flow (`commands/ls.ts`) already communicates the chosen session by setting `CONTINUE_CLI_TEST_SESSION_ID` — the same env var `SessionManager.getCurrentSession()` uses to pin the current session id — before calling `chat({ resume: true })`. But `loadSession()` never read that var, so the selection was silently dropped and `--resume` always fell back to the latest session.

This PR makes `loadSession()` honor `CONTINUE_CLI_TEST_SESSION_ID` first (loading that session by id via the existing `loadSessionById()`), falling back to the most-recent session when the var is absent or the id can't be loaded. Plain `cn --resume` is unchanged.

The fix is intentionally minimal — one guard at the top of `loadSession()`, no signature or caller changes.

> Note: the env var name (`CONTINUE_CLI_TEST_SESSION_ID`) reads as test-only, but it is already used on the production `cn ls` path today. I kept the existing name to stay minimal; happy to rename it in a follow-up if maintainers prefer a non-`TEST` name for this now-user-facing mechanism.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created (no user-facing docs affected)
- [x] The relevant tests, if any, have been updated or created

## Tests

Added a unit test in `extensions/cli/src/session.test.ts` under `loadSession`:

- **`should load the selected session when CONTINUE_CLI_TEST_SESSION_ID is set`** — sets the env var and asserts `loadSession()` resolves the session by id (`historyManager.load` called with the selected id), does **not** fall back to scanning the directory by mtime (`readdirSync` not called), and sets it as the current session.

I verified the test fails on `main` (without the fix) and passes with it. Existing `loadSession` tests (including "should load the most recent session" for the no-selection path) still pass — full `session.test.ts` is green (32/32).

 I have read the CLA Document and I hereby sign the CLA
