### PR TITLE
fix(fetch): throw AbortError from streamResponse instead of swallowing

### DIFF
--- a/packages/fetch/src/stream.test.ts
+++ b/packages/fetch/src/stream.test.ts
@@ -21,6 +21,23 @@ function createMockResponse(sseLines: string[]): Response {
   } as unknown as Response;
 }
 
+function createMockResponseFromChunks(chunks: string[]): Response {
+  const stream = new Readable({
+    read() {
+      for (const chunk of chunks) {
+        this.push(chunk);
+      }
+      this.push(null);
+    },
+  }) as any;
+
+  return {
+    status: 200,
+    body: stream,
+    text: async () => "",
+  } as unknown as Response;
+}
+
 describe("streamSse", () => {
   it("yields parsed SSE data objects that ends with `data:[DONE]`", async () => {
     const sseLines = [
@@ -52,6 +69,44 @@ describe("streamSse", () => {
     }
 
     expect(results).toEqual([{ foo: "bar" }, { baz: 42 }]);
+  });
+
+  it("propogate AbortError when the stream is aborted with partial buffer", async () => {
+    // Simulate an abort mid-stream: the stream emits one complete SSE event,
+    // then a partial `data:` line (no trailing newline),
+    // then throws AbortError. The AbortError must propagate to the caller
+    // and not be swallowed, and the partial buffer must not be parsed.
+    async function* abortedStream() {
+      yield Buffer.from('data: {"foo": "bar"}\n\n');
+      yield Buffer.from('data: {"foo": "ba'); // partial - no newline
+      const abortError = new Error("The operation was aborted");
+      abortError.name = "AbortError";
+      throw abortError;
+    }
+
+    const stream = Readable.from(abortedStream()) as any;
+    const response = {
+      status: 200,
+      body: stream,
+      text: async () => "",
+    } as unknown as Response;
+
+    const results = [];
+    let caught: Error | undefined;
+    try {
+      for await (const data of streamSse(response)) {
+        results.push(data);
+      }
+    } catch (err) {
+      caught = err as Error;
+    }
+
+    // The first complete SSE event should be yielded before the abort occurs
+    expect(results).toEqual([{ foo: "bar" }]);
+
+    // The AbortError should be propagated to the caller, and not swallowed
+    expect(caught).toBeDefined();
+    expect(caught!.name).toBe("AbortError");
   });
 
   it("throws on malformed JSON", async () => {

--- a/packages/fetch/src/stream.ts
+++ b/packages/fetch/src/stream.ts
@@ -49,7 +49,10 @@ export async function* streamResponse(
   } catch (e) {
     if (e instanceof Error) {
       if (e.name.startsWith("AbortError")) {
-        return; // In case of client-side cancellation, just return
+        // Let callers know that the request was aborted, so they can handle it accordingly,
+        // especially not try parsing the left over buffers, which might be incomplete and
+        // cause a JSON parsing error.
+        throw e;
       }
       if (e.message.toLowerCase().includes("premature close")) {
         // Premature close can happen for various reasons, including:


### PR DESCRIPTION
## Description

### Problem

When using the OpenAI provider for autocomplete, moving the cursor during active streaming causes **"Malformed JSON sent from server"** errors (#7282).

Even though the original issue was closed, we still have a strong rationale for this fix: https://github.com/continuedev/continue/issues/7282#issuecomment-4943958622.

### Root cause

In `packages/fetch/src/stream.ts`, `streamResponse` catches `AbortError` and silently returns. This causes `streamSse` to fall through to its post-loop buffer flush, which tries to `JSON.parse` a partial JSON line that was mid-stream when the abort happened:

```js
// streamSse – post-loop code (lines 144-149)
if (buffer.length > 0) {
  const { done, data } = parseSseLine(buffer); // ← partial JSON!
  if (!done && data) yield data;
}
```

Fix

One-line change in `streamResponse` (line 52): throw the `AbortError` instead of swallowing it:

```diff
 if (e.name.startsWith("AbortError")) {
-    return; // In case of client-side cancellation, just return
+    throw e; // Let callers handle abort – they must not process partial buffers
 }
```

The exception propagates through `streamSse`'s `for await` loop, skipping the post-loop buffer flush entirely. The partial JSON is never parsed.

### Impact

- `streamSse` (29 call sites across providers): protected – post-loop buffer flush is skipped via exception.
- `streamJSON` (1 call site, Cohere.ts:118): safe – has no post-loop buffer flush to begin with.
- **7 direct** `streamResponse` **callers**: none have post-loop buffer processing.

Note: I know that changing the behavior from early returning to throwing an exception here has a huge blast radius, but I have checked that the AbortError exception will be properly handled in all direct/indirect call sites, so the change should be safe. I have also manually verified aborting all sorts of operations in Visual Studio Code extension to make sure that I'm not introducing any regression.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

No screen recording. This patch fixes a problem and made the annoying "Malformed JSON sent from server" popup going away.

## Tests

Added a test to verify that AbortError was propagated and buffered incomplete data won't be parsed.

We have also tested the built VSIX on Visual Studio Code manually to verify the fix.