### PR TITLE
fix: omit unset temperature from Responses API requests 🩷

### DIFF
--- a/core/llm/llms/OpenAI.test.ts
+++ b/core/llm/llms/OpenAI.test.ts
@@ -1,6 +1,26 @@
+import { ChatMessage, CompletionOptions } from "../../index.js";
 import OpenAI from "./OpenAI";
 
+class TestOpenAI extends OpenAI {
+  convertArgsResponses(options: CompletionOptions, messages: ChatMessage[]) {
+    return this._convertArgsResponses(options, messages);
+  }
+}
+
 describe("OpenAI", () => {
+  test("omits temperature from Responses API requests unless configured", () => {
+    const openai = new TestOpenAI({ model: "gpt-5" });
+    const messages: ChatMessage[] = [{ role: "user", content: "Hello" }];
+    const baseOptions = { model: "gpt-5" } as CompletionOptions;
+
+    expect(
+      openai.convertArgsResponses(baseOptions, messages),
+    ).not.toHaveProperty("temperature");
+    expect(
+      openai.convertArgsResponses({ ...baseOptions, temperature: 0 }, messages),
+    ).toHaveProperty("temperature", 0);
+  });
+
   test("should identify correct o-series models", () => {
     const openai = new OpenAI({
       model: "o3-mini",

--- a/core/llm/llms/OpenAI.ts
+++ b/core/llm/llms/OpenAI.ts
@@ -328,7 +328,9 @@ class OpenAI extends BaseLLM {
     const body: ResponseCreateParamsBase = {
       model,
       input,
-      temperature: options.temperature ?? null,
+      ...(options.temperature !== undefined && {
+        temperature: options.temperature,
+      }),
       top_p: options.topP ?? null,
       reasoning: {
         effort: "medium",


### PR DESCRIPTION
## Description

Responses API requests no longer include a `temperature` property when the option is unset. Explicit values, including `0`, are preserved. This avoids failures from OpenAI-compatible endpoints that reject the parameter.

Closes #12972

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I have read the contributing guide
- [x] No documentation update is needed for this request serialization fix
- [x] The relevant regression test was added

## Screen recording or screenshot

Not applicable; this change affects request serialization only.

## Tests

- `npm test -- --runInBand llm/llms/OpenAI.test.ts` (3 passed)
- `npm run tsc:check`
- Prettier check on both changed files