### PR TITLE
docs: add DaoXE OpenAI-compatible provider guide

### DIFF
--- a/docs/customize/model-providers/more/daoxe.mdx
+++ b/docs/customize/model-providers/more/daoxe.mdx
@@ -1,0 +1,60 @@
+---
+title: "DaoXE"
+description: "Configure DaoXE with Continue as a multi-model multi-protocol AI API gateway using an OpenAI-compatible endpoint"
+---
+
+<Info>
+  Get an API key from [DaoXE](https://daoxe.com)
+</Info>
+
+[DaoXE](https://daoxe.com) is a multi-model multi-protocol AI API gateway for developers.
+Use it with Continue through the OpenAI-compatible provider by setting `apiBase` to
+`https://daoxe.com/v1`.
+
+DaoXE supports OpenAI Chat Completions, OpenAI Responses, Anthropic Messages, and
+image-compatible endpoints. Continue uses the OpenAI Chat Completions path below.
+
+> DaoXE is **not available in mainland China**.
+
+## Configuration
+
+Replace the placeholders with values from your own DaoXE account. Prefer an exact
+model ID currently available to your key.
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  name: My Config
+  version: 0.0.1
+  schema: v1
+
+  models:
+    - name: DaoXE
+      provider: openai
+      model: <DAOXE_MODEL_ID>
+      apiBase: https://daoxe.com/v1
+      apiKey: <YOUR_DAOXE_API_KEY>
+  ```
+  </Tab>
+  <Tab title="JSON (Deprecated)">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "DaoXE",
+        "provider": "openai",
+        "model": "<DAOXE_MODEL_ID>",
+        "apiBase": "https://daoxe.com/v1",
+        "apiKey": "<YOUR_DAOXE_API_KEY>"
+      }
+    ]
+  }
+  ```
+  </Tab>
+</Tabs>
+
+## Notes
+
+- Discover current models on the [DaoXE pricing/catalog page](https://daoxe.com/pricing) and confirm against your account.
+- Public examples and a low-cost smoke/compare benchmark: [DaoXE-AI](https://github.com/seven7763/DaoXE-AI).
+- Continue's OpenAI provider supports OpenAI-compatible endpoints via `apiBase`.

--- a/docs/customize/model-providers/overview.mdx
+++ b/docs/customize/model-providers/overview.mdx
@@ -33,6 +33,7 @@ Beyond the top-level providers, Continue supports many other options:
 | [Groq](/customize/model-providers/more/groq)                           | Ultra-fast inference for various open models               |
 | [Together AI](/customize/model-providers/more/together)                | Platform for running a variety of open models              |
 | [DeepInfra](/customize/model-providers/more/deepinfra)                 | Hosting for various open source models                     |
+| [DaoXE](/customize/model-providers/more/daoxe)                                   | Multi-model multi-protocol AI API gateway (OpenAI-compatible) |
 | [OpenRouter](/customize/model-providers/top-level/openrouter)          | Gateway to multiple model providers                        |
 | [ClawRouter](/customize/model-providers/more/clawrouter)               | Open-source LLM router with automatic cost-optimized model selection |
 | [Tetrate Agent Router Service](/customize/model-providers/top-level/tetrate_agent_router_service) | Gateway with intelligent routing across multiple model providers |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -109,7 +109,7 @@
                       "customize/model-providers/more/clawrouter",
                       "customize/model-providers/more/deepseek",
                       "customize/model-providers/more/deepinfra",
-        "customize/model-providers/more/daoxe",
+                      "customize/model-providers/more/daoxe",
                       "customize/model-providers/more/groq",
                       "customize/model-providers/more/llamacpp",
                       "customize/model-providers/more/llamastack",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -109,6 +109,7 @@
                       "customize/model-providers/more/clawrouter",
                       "customize/model-providers/more/deepseek",
                       "customize/model-providers/more/deepinfra",
+        "customize/model-providers/more/daoxe",
                       "customize/model-providers/more/groq",
                       "customize/model-providers/more/llamacpp",
                       "customize/model-providers/more/llamastack",


### PR DESCRIPTION
## Summary
- Add a **DaoXE** model-provider doc under `docs/customize/model-providers/more/`.
- Configure Continue with `provider: openai` + `apiBase: https://daoxe.com/v1` (no new native provider class required).
- Link from the providers overview and Mintlify nav (`docs.json`).
- Note multi-protocol scope and that DaoXE is not available in mainland China.
- Link public examples: https://github.com/seven7763/DaoXE-AI

## Disclosure
I am affiliated with DaoXE.

## Test plan
- [ ] Docs page renders
- [ ] Overview link and nav entry resolve
- [ ] Config YAML example is valid for Continue