### PR TITLE
perf(llm): avoid tokenizing discarded lines

### DIFF
--- a/core/llm/countTokens.test.ts
+++ b/core/llm/countTokens.test.ts
@@ -47,7 +47,7 @@ describe("countTokensAsync", () => {
   });
 });
 
-describe.skip("pruneLinesFromTop", () => {
+describe("pruneLinesFromTop", () => {
   it("should prune lines from the top to fit within max tokens", () => {
     const prompt = "Line 1\nLine 2\nLine 3\nLine 4";
     const pruned = pruneLinesFromTop(prompt, 5, "gpt-4");
@@ -88,7 +88,7 @@ describe.skip("pruneLinesFromTop", () => {
   });
 });
 
-describe.skip("pruneLinesFromBottom", () => {
+describe("pruneLinesFromBottom", () => {
   it("should prune lines from the bottom to fit within max tokens", () => {
     const prompt = "Line 1\nLine 2\nLine 3\nLine 4";
     const pruned = pruneLinesFromBottom(prompt, 5, "gpt-4");

--- a/core/llm/countTokens.ts
+++ b/core/llm/countTokens.ts
@@ -285,24 +285,19 @@ function pruneLinesFromTop(
   modelName: string,
 ): string {
   const lines = prompt.split("\n");
-  // Preprocess tokens for all lines and cache them.
-  const lineTokens = lines.map((line) => countTokens(line, modelName));
-  let totalTokens = lineTokens.reduce((sum, tokens) => sum + tokens, 0);
-  let start = 0;
-  let currentLines = lines.length;
+  let start = lines.length;
+  let totalTokens = 0;
 
-  // Calculate initial token count including newlines
-  totalTokens += Math.max(0, currentLines - 1); // Add tokens for joining newlines
-
-  // Using indexes instead of array modifications.
-  // Remove lines from the top until the token count is within the limit.
-  while (totalTokens > maxTokens && start < currentLines) {
-    totalTokens -= lineTokens[start];
-    // Decrement token count for the removed line and its preceding/joining newline (if not the last line)
-    if (currentLines - start > 1) {
-      totalTokens--;
+  // Build the retained suffix without tokenizing discarded leading lines.
+  while (start > 0) {
+    const next = start - 1;
+    const nextTokens = countTokens(lines[next], modelName);
+    const newlineTokens = start < lines.length ? 1 : 0;
+    if (totalTokens + nextTokens + newlineTokens > maxTokens) {
+      break;
     }
-    start++;
+    totalTokens += nextTokens + newlineTokens;
+    start = next;
   }
 
   return lines.slice(start).join("\n");
@@ -314,22 +309,18 @@ function pruneLinesFromBottom(
   modelName: string,
 ): string {
   const lines = prompt.split("\n");
-  const lineTokens = lines.map((line) => countTokens(line, modelName));
-  let totalTokens = lineTokens.reduce((sum, tokens) => sum + tokens, 0);
-  let end = lines.length;
+  let end = 0;
+  let totalTokens = 0;
 
-  // Calculate initial token count including newlines
-  totalTokens += Math.max(0, end - 1); // Add tokens for joining newlines
-
-  // Reverse traversal to avoid array modification
-  // Remove lines from the bottom until the token count is within the limit.
-  while (totalTokens > maxTokens && end > 0) {
-    end--;
-    totalTokens -= lineTokens[end];
-    // Decrement token count for the removed line and its following/joining newline (if not the first line)
-    if (end > 0) {
-      totalTokens--;
+  // Build the retained prefix without tokenizing discarded trailing lines.
+  while (end < lines.length) {
+    const nextTokens = countTokens(lines[end], modelName);
+    const newlineTokens = end > 0 ? 1 : 0;
+    if (totalTokens + nextTokens + newlineTokens > maxTokens) {
+      break;
     }
+    totalTokens += nextTokens + newlineTokens;
+    end++;
   }
 
   return lines.slice(0, end).join("\n");


### PR DESCRIPTION
## Description

Fixes #12980.

PR #5310 removed repeated array mutation from `pruneLinesFromTop` and `pruneLinesFromBottom`, but both functions still tokenize every line before discarding most of them. This change traverses from the side that will be retained and stops as soon as the next line would exceed the token budget.

The existing one-token newline accounting and returned strings are preserved. The production change is limited to the two pruning function bodies, and this PR enables their existing focused tests.

### Performance

The deterministic evaluator counts real `Tiktoken.encode` calls across top and bottom pruning of a 320-line prompt:

| Metric | `main` | This PR | Change |
| --- | ---: | ---: | ---: |
| median tokenizer calls | 641 | 88 | -86.3% |

All nine baseline and candidate samples were identical within each revision. A 580-case differential suite covering empty input, leading and trailing blank lines, newline boundaries, Unicode, oversized lines, random multiline prompts, and zero or negative limits produced byte-for-byte identical output.

On the 2,000-line scale described in #4947, the same metric is 4,001 calls on `main` and 86 on this branch (-97.9%).

### Autoresearch

The retained-side traversal was independently reproduced during a 10-step autoresearch run with Weco. The final patch was then reduced and validated in a clean worktree.

Public trajectory: https://dashboard.weco.ai/share/xWch5tqFM_tvJr2AZVT4lWugmaTnbu5b

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Not applicable; this changes token-pruning work without changing UI behavior.

## Tests

- `npm test -- --runInBand llm/countTokens.test.ts` (25 passed, 9 unrelated skipped)
- `npm run tsc:check`
- ESLint and Prettier on both changed files
- strict 580-case differential evaluator and positive/negative-control replay
- `git diff --check`
