### PR TITLE
docs(cli): refresh auth and MCP architecture paths

### DIFF
--- a/extensions/cli/AGENTS.md
+++ b/extensions/cli/AGENTS.md
@@ -18,37 +18,32 @@ This is a CLI tool for Continue Dev that provides an interactive AI-assisted dev
 ### Core Components
 
 1. **Entry Point** (`src/index.ts`): Main CLI logic with two modes:
-
    - **Headless mode**: Non-interactive mode for automation/CI
    - **TUI mode**: Terminal User Interface using Ink/React
    - **Standard mode**: Traditional readline-based chat interface
 
-2. **Authentication** (`src/auth/`): WorkOS-based authentication system
-
-   - `ensureAuth.ts`: Handles authentication flow
-   - `workos.ts`: WorkOS configuration and token management
+2. **Authentication** (`src/services/AuthService.ts`): Local authentication state after Hub authentication was removed
+   - `src/services/AuthService.ts`: Reports unauthenticated state and keeps login unavailable
+   - `src/auth/workos.ts`: No-op compatibility helpers retained for existing imports
 
 3. **Continue SDK Integration** (`src/continueSDK.ts`): Initializes the Continue SDK client with:
-
    - API key authentication
    - Assistant configuration (slug-based)
    - Organization support
 
 4. **Terminal UI** (`src/ui/`): React/Ink-based TUI components
-
    - `TUIChat.tsx`: Main chat interface component
    - `UserInput.tsx`: Input handling with multi-line support
    - `TextBuffer.ts`: Text display utilities
 
 5. **Tools System** (`src/tools/`): Built-in development tools including:
-
    - File operations (read, write, list)
    - Code search functionality
    - Terminal command execution
    - Diff viewing
    - Exit tool (headless mode only)
 
-6. **MCP Integration** (`src/mcp.ts`): Model Context Protocol service for extended tool capabilities
+6. **MCP Integration** (`src/services/MCPService.ts`): Model Context Protocol service, with transport and authentication helpers in `src/services/mcpTransports.ts` and `src/services/mcpUtils.ts`
 
 7. **Hooks System** (`src/hooks/`): Event interception system for extending CLI behavior
    - `HookService.ts`: Service container integration, loads config and fires events


### PR DESCRIPTION
## Description

Refresh the CLI architecture guide after Hub authentication removal and the MCP service split. The guide now points to `AuthService.ts`, the retained WorkOS compatibility helpers, `MCPService.ts`, `mcpTransports.ts`, and `mcpUtils.ts`. This docs-only correction was found with the attest static instruction-binding scan.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the contributing guide
- [x] The relevant docs have been updated
- [x] No test changes are required for this documentation-only update

## Screen recording or screenshot

N/A — documentation-only change.

## Tests

- `npm run lint` completes with zero errors (two pre-existing warnings).
- The edited file is formatter-clean.
- The modified CLI instructions report zero broken bindings under attest.