### PR TITLE
docs: add Router One model provider guide

### DIFF
--- a/docs/customize/model-providers/more/router-one.mdx
+++ b/docs/customize/model-providers/more/router-one.mdx
@@ -1,0 +1,94 @@
+---
+title: "Router One"
+description: "Configure Router One with Continue through its OpenAI-compatible API, using a pinned model or server-managed routing"
+---
+
+<Info>
+  [Router One](https://router.one) is an LLM API gateway that exposes multiple
+  model providers through one OpenAI-compatible endpoint. Configure it with
+  Continue's existing `openai` provider and a custom `apiBase`; no dedicated
+  provider implementation is required.
+</Info>
+
+<Tip>
+  Create a key in [Dashboard → API Keys](https://router.one/dashboard/api-keys)
+  and choose an exact model ID from the [model catalog](https://router.one/models).
+</Tip>
+
+## Configuration
+
+The following example pins a tool-capable model for chat, edit, and apply roles:
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  name: My Config
+  version: 0.0.1
+  schema: v1
+
+  models:
+    - name: Router One GPT-5.4 Mini
+      provider: openai
+      model: openai/gpt-5.4-mini
+      apiBase: https://api.router.one/v1
+      apiKey: <YOUR_ROUTER_ONE_API_KEY>
+      capabilities:
+        - tool_use
+      roles:
+        - chat
+        - edit
+        - apply
+  ```
+  </Tab>
+  <Tab title="JSON (Deprecated)">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "Router One GPT-5.4 Mini",
+        "provider": "openai",
+        "model": "openai/gpt-5.4-mini",
+        "apiBase": "https://api.router.one/v1",
+        "apiKey": "<YOUR_ROUTER_ONE_API_KEY>",
+        "capabilities": ["tool_use"]
+      }
+    ]
+  }
+  ```
+  </Tab>
+</Tabs>
+
+`provider: openai` selects Continue's OpenAI-compatible client. The `model`
+value is still sent unchanged to Router One, so it may reference a model from
+any upstream provider in the Router One catalog.
+
+## Server-managed routing
+
+Set `model` to `auto` when you want Router One to select from its server-managed
+candidate set. For predictable Agent mode capability detection, pin an exact
+tool-capable model as shown above.
+
+```yaml title="config.yaml"
+models:
+  - name: Router One Auto
+    provider: openai
+    model: auto
+    apiBase: https://api.router.one/v1
+    apiKey: <YOUR_ROUTER_ONE_API_KEY>
+    roles:
+      - chat
+```
+
+With an exact model ID, Router One keeps the requested model fixed while it may
+retry another eligible provider route serving that same model. With `auto`,
+candidate selection is managed by Router One.
+
+## Troubleshooting
+
+- Keep `/v1` in `apiBase`; Continue appends the OpenAI-compatible endpoint path.
+- A `401` response usually means the API key is missing or invalid.
+- A `402` response means the wallet balance or API-key spend limit is exhausted.
+- A `429` response means the API key's configured rate limit was reached.
+
+See the [Router One API documentation](https://router.one/docs) for endpoint and
+error details.

--- a/docs/customize/model-providers/overview.mdx
+++ b/docs/customize/model-providers/overview.mdx
@@ -34,6 +34,7 @@ Beyond the top-level providers, Continue supports many other options:
 | [Together AI](/customize/model-providers/more/together)                | Platform for running a variety of open models              |
 | [DeepInfra](/customize/model-providers/more/deepinfra)                 | Hosting for various open source models                     |
 | [OpenRouter](/customize/model-providers/top-level/openrouter)          | Gateway to multiple model providers                        |
+| [Router One](/customize/model-providers/more/router-one)               | OpenAI-compatible multi-model gateway with exact-model and server-managed routing |
 | [ClawRouter](/customize/model-providers/more/clawrouter)               | Open-source LLM router with automatic cost-optimized model selection |
 | [Tetrate Agent Router Service](/customize/model-providers/top-level/tetrate_agent_router_service) | Gateway with intelligent routing across multiple model providers |
 | [Cohere](/customize/model-providers/more/cohere)                       | Models specialized for semantic search and text generation |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -117,6 +117,7 @@
                       "customize/model-providers/more/moonshot",
                       "customize/model-providers/more/nous",
                       "customize/model-providers/more/nvidia",
+                      "customize/model-providers/more/router-one",
                       "customize/model-providers/more/tensorix",
                       "customize/model-providers/more/together",
                       "customize/model-providers/more/xAI",


### PR DESCRIPTION
## Description

Adds documentation for configuring Router One with Continue through Continue's existing OpenAI-compatible provider path.

## Changes

- add a Router One provider page with YAML and deprecated JSON examples
- document pinned model configuration and optional `model: auto` routing
- add Router One to the model providers overview and More Providers sidebar
- include API key, model catalog, and troubleshooting links

No new provider implementation is required because Router One uses Continue's existing `provider: openai` client with `apiBase: https://api.router.one/v1`.

## Validation

- `npx --yes mintlify@4.2.454 validate`
- parsed the YAML and JSON config examples
- verified `openai/gpt-5.4-mini` is present in the live Router One catalog with tool-calling support
- verified all added Router One links return HTTP 200
- `git diff --check`

Mintlify validation passed. The repository's broken-link check still reports six existing `/CONTRIBUTING` links in `guides/continue-docs-mcp-cookbook.mdx`; this PR adds no broken links.

## Screen recording or screenshot

N/A — documentation-only change.

## Checklist

- [x] I've read the contributing guide
- [x] The relevant docs have been updated
- [x] This is a documentation-only change
