### PR TITLE
fix(docs): update 6 dead Snyk, Supabase, and Sanity links in MCP cookbooks

### DIFF
--- a/docs/guides/sanity-mcp-continue-cookbook.mdx
+++ b/docs/guides/sanity-mcp-continue-cookbook.mdx
@@ -175,7 +175,7 @@ After ensuring you meet the **Prerequisites** above, you have two paths to get s
   **Sanity MCP** provides comprehensive tools for content management:
   - Execute [GROQ queries](https://www.sanity.io/docs/groq) to fetch and analyze content
   - Explore and modify [document schemas](https://www.sanity.io/docs/schema-types)
-  - Manage [content releases](https://www.sanity.io/docs/release-schedules) and versions
+  - Manage [content releases](https://www.sanity.io/docs/studio/scheduled-publishing) and versions
   - Handle content [migrations](https://www.sanity.io/docs/migrating-data) between environments
   - Automate documentation generation
   - Perform bulk content operations

--- a/docs/guides/snyk-mcp-continue-cookbook.mdx
+++ b/docs/guides/snyk-mcp-continue-cookbook.mdx
@@ -161,7 +161,7 @@ After ensuring you meet the **Prerequisites** above, you have two paths to get s
     3. Rules apply globally to all your Continue sessions
 
     These rules configure your agent to:
-    - **Run [SAST](https://snyk.io/learn/application-security/sast/) scans** on newly generated or modified code
+    - **Run [SAST](https://snyk.io/articles/application-security/static-application-security-testing/) scans** on newly generated or modified code
     - **Check dependencies** when adding or updating packages
     - **Auto-fix issues** using Snyk's recommendations, then rescan
 
@@ -211,7 +211,7 @@ You can add prompts to your agent's configuration for easy access in future sess
   Snyk Code scan and fix the top 3 issues"`
 </Info>
 
-### Code Vulnerability Scanning ([SAST](https://snyk.io/learn/application-security/sast/))
+### Code Vulnerability Scanning ([SAST](https://snyk.io/articles/application-security/static-application-security-testing/))
 
 <Card title="Static Application Security Testing" icon="code">
   Scan your source code for security vulnerabilities and code quality issues.
@@ -230,7 +230,7 @@ cn -p "Run a Snyk Code scan on this repo with severity threshold medium. Summari
 
 </Card>
 
-### Dependency Scanning ([SCA](https://snyk.io/learn/software-composition-analysis-sca/))
+### Dependency Scanning ([SCA](https://snyk.io/articles/open-source-security/))
 
 <Card title="Software Composition Analysis" icon="cube">
   Check open source dependencies for known vulnerabilities.
@@ -249,7 +249,7 @@ cn -p "Run Snyk Open Source on this repo (include dev deps). Summarize vulnerabl
 
 </Card>
 
-### Infrastructure as Code ([IaC](https://snyk.io/learn/infrastructure-as-code-iac/))
+### Infrastructure as Code ([IaC](https://snyk.io/articles/infrastructure-as-code-iac/))
 
 <Card title="IaC Security" icon="cloud">
   Scan Terraform, CloudFormation, and Kubernetes configs for misconfigurations.
@@ -696,11 +696,11 @@ After completing this guide, you have a complete **AI-powered security system** 
 
 ## Next Steps
 
-1. **Run your first scan** - Try the [SAST](https://snyk.io/learn/application-security/sast/) prompt on your current project
+1. **Run your first scan** - Try the [SAST](https://snyk.io/articles/application-security/static-application-security-testing/) prompt on your current project
 2. **Review findings** - Analyze the security report and implement fixes
 3. **Set up CI pipeline** - Add the GitHub Actions workflow to your repo
 4. **Customize rules** - Add project-specific security policies
-5. **Monitor trends** - Track [vulnerability](https://snyk.io/learn/security-vulnerability/) reduction over time
+5. **Monitor trends** - Track [vulnerability](https://snyk.io/articles/enterprise-security/enterprise-vulnerability-management/) reduction over time
 
 ## Additional Resources
 

--- a/docs/guides/supabase-mcp-database-workflow.mdx
+++ b/docs/guides/supabase-mcp-database-workflow.mdx
@@ -509,7 +509,7 @@ If you encounter connection issues:
 
 - [Supabase MCP Documentation](https://supabase.com/docs/guides/getting-started/mcp)
 - [Supabase Database Guide](https://supabase.com/docs/guides/database)
-- [Supabase Security Best Practices](https://supabase.com/docs/guides/database/security)
+- [Supabase Security Best Practices](https://supabase.com/docs/guides/database/postgres/row-level-security)
 - [Model Context Protocol Docs](https://modelcontextprotocol.io/introduction)
 - [Continue CLI Guide](https://docs.continue.dev/guides/cli)
 - [Continuous AI Best Practices](https://blog.continue.dev/what-is-continuous-ai-a-developers-guide/)


### PR DESCRIPTION
Six dead external link fixes across three MCP cookbook docs. The Snyk learn/* paths were all migrated to a new articles/* structure; the Supabase database/security path was replaced with the RLS-equivalent in the Postgres guide; the Sanity release-schedules page moved to scheduled-publishing under the Studio subpath.

**Snyk MCP cookbook** (4 links, all in `docs/guides/snyk-mcp-continue-cookbook.mdx`):
- `snyk.io/learn/application-security/sast/` (×3) → `snyk.io/articles/application-security/static-application-security-testing/` (200)
- `snyk.io/learn/software-composition-analysis-sca/` → `snyk.io/articles/open-source-security/` (200)
- `snyk.io/learn/infrastructure-as-code-iac/` → `snyk.io/articles/infrastructure-as-code-iac/` (200)
- `snyk.io/learn/security-vulnerability/` → `snyk.io/articles/enterprise-security/enterprise-vulnerability-management/` (200)

**Supabase MCP workflow** (1 link in `docs/guides/supabase-mcp-database-workflow.mdx`):
- `supabase.com/docs/guides/database/security` → `supabase.com/docs/guides/database/postgres/row-level-security` (200)

**Sanity MCP cookbook** (1 link in `docs/guides/sanity-mcp-continue-cookbook.mdx`):
- `sanity.io/docs/release-schedules` → `sanity.io/docs/studio/scheduled-publishing` (200)

All replacement URLs verified with HEAD requests. No semantic content change beyond updating link targets. No em-dashes introduced.