### PR TITLE
fix(openai-adapters): allow disabling stream_options for strict OpenAI-compatible endpoints

### DIFF
--- a/packages/config-yaml/src/schemas/models.ts
+++ b/packages/config-yaml/src/schemas/models.ts
@@ -192,6 +192,7 @@ const baseModelFields = {
   promptTemplates: promptTemplatesSchema.optional(),
   useLegacyCompletionsEndpoint: z.boolean().optional(),
   useResponsesApi: z.boolean().optional(),
+  streamOptions: z.boolean().optional(),
   env: z
     .record(z.string(), z.union([z.string(), z.boolean(), z.number()]))
     .optional(),

--- a/packages/openai-adapters/src/apis/OpenAI.ts
+++ b/packages/openai-adapters/src/apis/OpenAI.ts
@@ -50,7 +50,7 @@ export class OpenAIApi implements BaseLlmApi {
   }
   modifyChatBody<T extends ChatCompletionCreateParams>(body: T): T {
     // Add stream_options to include usage in streaming responses
-    if (body.stream) {
+    if (body.stream && this.config.streamOptions !== false) {
       (body as any).stream_options = { include_usage: true };
     }
 

--- a/packages/openai-adapters/src/test/openai-adapter.vitest.ts
+++ b/packages/openai-adapters/src/test/openai-adapter.vitest.ts
@@ -1,4 +1,5 @@
-import { describe, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { OpenAIApi } from "../apis/OpenAI.js";
 import { createAdapterTests } from "./adapter-test-utils.js";
 
 // Mock the fetch package (not needed for OpenAI but required by the shared test utils)
@@ -24,5 +25,30 @@ describe("OpenAI Adapter Tests", () => {
       "content-type": "application/json",
       accept: "application/json",
     },
+  });
+
+  it("includes streaming usage by default unless stream options are disabled", () => {
+    const body = {
+      model: "gpt-4",
+      messages: [{ role: "user" as const, content: "hello" }],
+      stream: true as const,
+    };
+    const defaultApi = new OpenAIApi({
+      provider: "openai",
+      apiKey: "test-api-key",
+    });
+    const disabledApi = new OpenAIApi({
+      provider: "openai",
+      apiKey: "test-api-key",
+      streamOptions: false,
+    });
+
+    expect(defaultApi.modifyChatBody({ ...body })).toHaveProperty(
+      "stream_options.include_usage",
+      true,
+    );
+    expect(disabledApi.modifyChatBody({ ...body })).not.toHaveProperty(
+      "stream_options",
+    );
   });
 });

--- a/packages/openai-adapters/src/types.ts
+++ b/packages/openai-adapters/src/types.ts
@@ -31,6 +31,7 @@ export const BasePlusConfig = BaseConfig.extend({
 // OpenAI and compatible
 export const OpenAIConfigSchema = BasePlusConfig.extend({
   useResponsesApi: z.boolean().optional(),
+  streamOptions: z.boolean().optional(),
   provider: z.union([
     z.literal("openai"),
     z.literal("mistral"),


### PR DESCRIPTION
## Description

The OpenAI adapter always adds `stream_options: { include_usage: true }` to streaming requests. Strict OpenAI-compatible endpoints (for example Databricks serving endpoints) reject unknown fields and return `400 unknown field "stream_options"`, so Continue cannot talk to them even though the endpoint works when called directly.

This adds an optional `streamOptions` boolean to the model config, mirroring the existing `useResponsesApi` opt-out. Default behavior is unchanged: `stream_options` is still injected when streaming. Setting `streamOptions: false` skips it, letting strict endpoints work:

```yaml
models:
  - name: Databricks
    provider: openai
    model: <endpoint>
    apiBase: https://<workspace>/serving-endpoints
    apiKey: <token>
    streamOptions: false
```

The field is declared in both the openai-adapters schema and the config-yaml model schema, and gated in `modifyChatBody` (`body.stream && this.config.streamOptions !== false`).

Fixes #12936.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Not applicable. The change is a request-body field in `packages/openai-adapters` and has no UI surface. The observable result is whether `stream_options` is sent, which the test below asserts directly.

## Tests

Added a test asserting `stream_options.include_usage` is present by default and absent when `streamOptions: false`. `openai-adapter.vitest.ts` passes, 5 tests.
