### PR TITLE
fix(fetch): route dynamic model-list fetches through request options

### DIFF
--- a/core/core.ts
+++ b/core/core.ts
@@ -1135,10 +1135,12 @@ export class Core {
 
     on("models/fetch", async (msg) => {
       try {
+        const { config } = await this.configHandler.loadConfig();
         return await fetchModels(
           msg.data.provider,
           msg.data.apiKey,
           msg.data.apiBase,
+          config?.requestOptions,
         );
       } catch (error: any) {
         void this.ide.showToast("error", error.message);

--- a/core/llm/fetchModels.ts
+++ b/core/llm/fetchModels.ts
@@ -143,7 +143,7 @@ async function fetchOpenRouterModels(
       throw new Error(`Failed to fetch OpenRouter models: ${response.status}`);
     }
 
-    const data = await response.json();
+    const data: any = await response.json();
     if (!data.data || !Array.isArray(data.data)) {
       return [];
     }
@@ -181,7 +181,7 @@ async function fetchAnthropicModels(
   if (!response.ok) {
     throw new Error(`Failed to fetch Anthropic models: ${response.status}`);
   }
-  const data = await response.json();
+  const data: any = await response.json();
   return (data.data ?? []).map((m: any) => ({
     name: m.display_name ?? m.id,
     modelId: m.id,
@@ -200,11 +200,15 @@ async function fetchGeminiModels(
   const base = apiBase || "https://generativelanguage.googleapis.com/v1beta/";
   const url = new URL("models", base);
   url.searchParams.set("key", apiKey ?? "");
-  const response = await fetchwithRequestOptions(url, undefined, requestOptions);
+  const response = await fetchwithRequestOptions(
+    url,
+    undefined,
+    requestOptions,
+  );
   if (!response.ok) {
     throw new Error(`Failed to fetch Gemini models: ${response.status}`);
   }
-  const data = await response.json();
+  const data: any = await response.json();
   return (data.models ?? [])
     .filter((m: any) => {
       const id: string = m.name?.replace("models/", "") ?? "";

--- a/core/llm/fetchModels.ts
+++ b/core/llm/fetchModels.ts
@@ -1,3 +1,6 @@
+import { fetchwithRequestOptions } from "@continuedev/fetch";
+
+import type { RequestOptions } from "../index.js";
 import { LLMClasses, llmFromProviderAndOptions } from "./llms/index.js";
 
 export interface FetchedModel {
@@ -61,9 +64,15 @@ function getOllamaIcon(modelName: string): string {
   return bestMatch ? OLLAMA_ICON_MAP[bestMatch] : "ollama.png";
 }
 
-async function fetchOllamaModels(): Promise<FetchedModel[]> {
+async function fetchOllamaModels(
+  requestOptions?: RequestOptions,
+): Promise<FetchedModel[]> {
   try {
-    const response = await fetch("https://ollama.com/library");
+    const response = await fetchwithRequestOptions(
+      "https://ollama.com/library",
+      undefined,
+      requestOptions,
+    );
     if (!response.ok) {
       throw new Error(`Failed to fetch Ollama library: ${response.status}`);
     }
@@ -121,9 +130,15 @@ async function fetchOllamaModels(): Promise<FetchedModel[]> {
   }
 }
 
-async function fetchOpenRouterModels(): Promise<FetchedModel[]> {
+async function fetchOpenRouterModels(
+  requestOptions?: RequestOptions,
+): Promise<FetchedModel[]> {
   try {
-    const response = await fetch("https://openrouter.ai/api/v1/models");
+    const response = await fetchwithRequestOptions(
+      "https://openrouter.ai/api/v1/models",
+      undefined,
+      requestOptions,
+    );
     if (!response.ok) {
       throw new Error(`Failed to fetch OpenRouter models: ${response.status}`);
     }
@@ -149,8 +164,11 @@ async function fetchOpenRouterModels(): Promise<FetchedModel[]> {
   }
 }
 
-async function fetchAnthropicModels(apiKey?: string): Promise<FetchedModel[]> {
-  const response = await fetch(
+async function fetchAnthropicModels(
+  apiKey?: string,
+  requestOptions?: RequestOptions,
+): Promise<FetchedModel[]> {
+  const response = await fetchwithRequestOptions(
     "https://api.anthropic.com/v1/models?limit=100",
     {
       headers: {
@@ -158,6 +176,7 @@ async function fetchAnthropicModels(apiKey?: string): Promise<FetchedModel[]> {
         "anthropic-version": "2023-06-01",
       },
     },
+    requestOptions,
   );
   if (!response.ok) {
     throw new Error(`Failed to fetch Anthropic models: ${response.status}`);
@@ -176,11 +195,12 @@ async function fetchAnthropicModels(apiKey?: string): Promise<FetchedModel[]> {
 async function fetchGeminiModels(
   apiKey?: string,
   apiBase?: string,
+  requestOptions?: RequestOptions,
 ): Promise<FetchedModel[]> {
   const base = apiBase || "https://generativelanguage.googleapis.com/v1beta/";
   const url = new URL("models", base);
   url.searchParams.set("key", apiKey ?? "");
-  const response = await fetch(url);
+  const response = await fetchwithRequestOptions(url, undefined, requestOptions);
   if (!response.ok) {
     throw new Error(`Failed to fetch Gemini models: ${response.status}`);
   }
@@ -242,16 +262,17 @@ export async function fetchModels(
   provider: string,
   apiKey?: string,
   apiBase?: string,
+  requestOptions?: RequestOptions,
 ): Promise<FetchedModel[]> {
   switch (provider) {
     case "ollama":
-      return fetchOllamaModels();
+      return fetchOllamaModels(requestOptions);
     case "openrouter":
-      return fetchOpenRouterModels();
+      return fetchOpenRouterModels(requestOptions);
     case "anthropic":
-      return fetchAnthropicModels(apiKey);
+      return fetchAnthropicModels(apiKey, requestOptions);
     case "gemini":
-      return fetchGeminiModels(apiKey, apiBase);
+      return fetchGeminiModels(apiKey, apiBase, requestOptions);
     default:
       return fetchProviderModelsViaListModels(provider, apiKey, apiBase);
   }

--- a/core/llm/fetchModels.ts
+++ b/core/llm/fetchModels.ts
@@ -243,6 +243,7 @@ async function fetchProviderModelsViaListModels(
   provider: string,
   apiKey?: string,
   apiBase?: string,
+  requestOptions?: RequestOptions,
 ): Promise<FetchedModel[]> {
   try {
     const cls = LLMClasses.find((llm) => llm.providerName === provider);
@@ -252,6 +253,7 @@ async function fetchProviderModelsViaListModels(
       apiKey,
       apiBase: apiBase || defaultApiBase,
       model: "",
+      requestOptions,
     });
     const modelIds = await llm.listModels();
     return modelIds.map((id) => ({ name: id }));
@@ -278,6 +280,11 @@ export async function fetchModels(
     case "gemini":
       return fetchGeminiModels(apiKey, apiBase, requestOptions);
     default:
-      return fetchProviderModelsViaListModels(provider, apiKey, apiBase);
+      return fetchProviderModelsViaListModels(
+        provider,
+        apiKey,
+        apiBase,
+        requestOptions,
+      );
   }
 }


### PR DESCRIPTION
## Description

The dynamic model-list fetchers in `core/llm/fetchModels.ts` (Ollama, OpenRouter, Anthropic, Gemini) call the global `fetch()` directly. They never go through `fetchwithRequestOptions`, so they ignore the user's `requestOptions` (proxy, custom CA / `verifySsl`, custom headers).

Behind an SSL-intercepting corporate proxy, or with a custom CA configured, the "Add model" dropdown fails to load these provider model lists even though normal chat requests succeed, because chat already routes through `fetchwithRequestOptions` while these fetchers do not.

This threads `requestOptions` through the four fetchers and uses `fetchwithRequestOptions` instead of the raw `fetch()`. The `models/fetch` handler in `core.ts` now loads the config and passes `config.requestOptions` down.

There is no behavior change for users without `requestOptions` configured; it stays a no-op for them. The change follows the existing `fetchwithRequestOptions(url, init, requestOptions)` call pattern already used elsewhere in `core.ts`.

This mirrors the earlier `ContinueServerClient` fix in #12993, which deliberately left `fetchModels.ts` untouched.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Not applicable. Reproducing the failure needs an SSL-intercepting proxy or a custom CA in front of the client, which a recording cannot show. The observable result is whether the "Add model" dropdown populates under those conditions.

## Tests

No new tests. The four fetchers move onto the same wrapper the chat path already uses, and the behaviour restored (honouring `requestOptions`) needs a proxy or custom CA to observe, which the existing suite does not set up.
