### PR TITLE
fix(openai): don't auto-use Responses API on compatible apiBase

### DIFF
--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -1021,9 +1021,23 @@ export abstract class BaseLLM implements ILLM {
   }
 
   private canUseOpenAIResponses(options: CompletionOptions): boolean {
+    // Only auto-route gpt-5 / o-series traffic to /responses on the official
+    // OpenAI API. Compatible proxies (custom apiBase) typically only implement
+    // /chat/completions — see #12995. Explicit useResponsesApi: true still
+    // opts in; useResponsesApi: false always opts out.
+    const useResponsesApi = this._llmOptions.useResponsesApi;
+    if (useResponsesApi === false) {
+      return false;
+    }
+    const apiBase = (this.apiBase ?? "").replace(/\/?$/, "/");
+    const isOfficialOpenAIAPI =
+      useResponsesApi === true ||
+      apiBase === "https://api.openai.com/v1/" ||
+      // empty / default base is treated as official OpenAI
+      !this.apiBase;
     return (
       this.providerName === "openai" &&
-      this._llmOptions.useResponsesApi !== false &&
+      isOfficialOpenAIAPI &&
       typeof (this as any)._streamResponses === "function" &&
       (this as any).isOSeriesOrGpt5PlusModel(options.model)
     );


### PR DESCRIPTION
## Summary
Fixes #12995: using `provider: openai` with a **custom** `apiBase` and a gpt-5-like model name was still auto-routed to `POST /responses`, which many OpenAI-compatible proxies do not implement (they only have `/chat/completions`).

## Change
- `BaseLLM.canUseOpenAIResponses` now only auto-enables Responses for the official OpenAI API base (matching `packages/openai-adapters` `shouldUseResponsesEndpoint`)
- `useResponsesApi: false` still hard-opts out
- `useResponsesApi: true` still hard-opts in even on a custom base
- Document the flag + custom-base behavior in the OpenAI provider docs

## Test plan
- [ ] Official OpenAI + `gpt-5*` still uses `/responses` by default
- [ ] Custom `apiBase` + `gpt-5.5` uses `/chat/completions` by default
- [ ] Custom `apiBase` + `useResponsesApi: true` forces `/responses`
- [ ] Any base + `useResponsesApi: false` forces `/chat/completions`

Fixes #12995.
