### PR TITLE
Route Mistral API key autodetection through this.fetch

### DIFF
--- a/core/llm/llms/Mistral.ts
+++ b/core/llm/llms/Mistral.ts
@@ -17,7 +17,7 @@ class Mistral extends OpenAI {
   };
 
   private async autodetectApiKeyType(): Promise<MistralApiKeyType> {
-    const mistralResp = await fetch("https://api.mistral.ai/v1/models", {
+    const mistralResp = await this.fetch("https://api.mistral.ai/v1/models", {
       method: "GET",
       headers: this._getHeaders(),
     });

--- a/core/llm/llms/Mistral.ts
+++ b/core/llm/llms/Mistral.ts
@@ -1,3 +1,5 @@
+import { fetchwithRequestOptions } from "@continuedev/fetch";
+
 import { ChatMessage, LLMOptions } from "../../index.js";
 import { codestralEditPrompt } from "../templates/edit/codestral.js";
 
@@ -17,10 +19,16 @@ class Mistral extends OpenAI {
   };
 
   private async autodetectApiKeyType(): Promise<MistralApiKeyType> {
-    const mistralResp = await this.fetch("https://api.mistral.ai/v1/models", {
-      method: "GET",
-      headers: this._getHeaders(),
-    });
+    // Not this.fetch: that throws on a non-ok response, and this request
+    // detects a Codestral key precisely by inspecting a 401.
+    const mistralResp = await fetchwithRequestOptions(
+      "https://api.mistral.ai/v1/models",
+      {
+        method: "GET",
+        headers: this._getHeaders(),
+      },
+      this.requestOptions,
+    );
     if (mistralResp.status === 401) {
       return "codestral";
     }


### PR DESCRIPTION
## Description

`Mistral.autodetectApiKeyType()` calls the global `fetch` directly:

```ts
const mistralResp = await fetch("https://api.mistral.ai/v1/models", {
```

That bypasses `fetchwithRequestOptions`, so this one request ignores the user's configured `proxy`, `caBundlePath`, `verifySsl` and custom headers. Every other request in this provider goes through the wrapper that `BaseLLM` wires to `fetchwithRequestOptions` with `this.requestOptions` (`core/llm/index.ts`). The inherited call sites in `OpenAI.ts` all use `this.fetch(...)` already.

The call is reachable in the common case: the constructor invokes it whenever `apiBase` is not set explicitly, in order to decide between the codestral and mistral endpoints. Its rejection is swallowed by an empty `.catch((err: any) => {})`, so behind an intercepting corporate proxy or with a custom CA the request fails silently, no error surfaces, and the provider is left with an incorrectly autodetected `apiBase`.

The fix calls `fetchwithRequestOptions` with `this.requestOptions` rather than `this.fetch`. `this.fetch` throws on a non-ok response, and this request detects a Codestral key precisely by reading a 401, so it must see the response instead of an exception. Only `.status` is read, so there is no typing change.

This is a sibling of #12993 and #12999, which fixed the same class of bypass elsewhere in the codebase.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Not applicable. Reproducing the failure needs an intercepting proxy or a custom CA in front of the client, which a recording cannot show. The observable result is whether the autodetected `apiBase` is correct under those conditions.

## Tests

No new tests. The change moves one call onto the same request wrapper every sibling method already uses, and the behaviour it restores (honouring `requestOptions`) needs a proxy or custom CA to observe, which the existing suite does not set up.

I ran a typecheck over `core` before and after the change: 115 pre-existing errors both times, none in `Mistral.ts`. The pre-existing errors are unrelated module resolution failures for unbuilt `@continuedev/*` workspace packages.
