### PR TITLE
docs: serve docs site at docs.continue.dev (custom domain)

### DIFF
--- a/docs-site/next.config.js
+++ b/docs-site/next.config.js
@@ -1,11 +1,8 @@
 /** @type {import('next').NextConfig} */
 
-// When deploying to GitHub Pages the site is served from the `/continue/`
-// subpath (https://continuedev.github.io/continue/). GitHub Actions sets
-// GITHUB_ACTIONS=true, so we only apply the base path there — local dev
-// (localhost:3005) keeps serving from the root.
-const isGithubPages = process.env.GITHUB_ACTIONS === "true";
-const basePath = isGithubPages ? "/continue" : "";
+// Served at the root of the custom domain docs.continue.dev (via GitHub Pages),
+// so there is no base path. (public/CNAME sets the custom domain.)
+const basePath = "";
 
 const nextConfig = {
   output: "export",

--- a/docs-site/public/CNAME
+++ b/docs-site/public/CNAME
@@ -1,0 +1,1 @@
+docs.continue.dev


### PR DESCRIPTION
Repoints the docs GitHub Pages deployment from the project-page subpath (`continuedev.github.io/continue/`) to the custom domain **docs.continue.dev**, served at the domain root. This replaces the current Vercel deployment.

## Changes
- `docs-site/next.config.js`: `basePath` `/continue` → `""` (root domain, no subpath).
- `docs-site/public/CNAME`: `docs.continue.dev` (persists the custom domain across Actions deploys).

The existing `.github/workflows/docs-gh-pages.yml` builds/deploys `docs-site/out` unchanged.

## Required steps to complete the cutover (after merge)
1. **Settings → Pages → Custom domain** → `docs.continue.dev`, then enable **Enforce HTTPS**.
2. **DNS**: `CNAME  docs → continuedev.github.io` (replaces the current Vercel record).

## Note
`basePath=""` and the custom domain go together: after merge, the old `continuedev.github.io/continue/` URL will render unstyled (assets resolve at root). The site renders correctly at `docs.continue.dev` once the custom domain + DNS are in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)