### PR TITLE
docs: remove Sign in link (login flow retired)

### DIFF
--- a/docs-site/components/docs/DocsShell.tsx
+++ b/docs-site/components/docs/DocsShell.tsx
@@ -272,9 +272,6 @@ export function DocsShell({
                     {link.label}
                   </Link>
                 ))}
-                <Link href={resolveHref("/login")} className={NAV_LINK_CLASSES}>
-                  Sign in
-                </Link>
               </div>
               <ThemeToggle />
               {/* Mobile menu button */}
@@ -303,13 +300,6 @@ export function DocsShell({
                   {link.label}
                 </Link>
               ))}
-              <Link
-                href={resolveHref("/login")}
-                className={NAV_LINK_CLASSES}
-                onClick={() => setMobileMenuOpen(false)}
-              >
-                Sign in
-              </Link>
             </div>
           )}
         </nav>


### PR DESCRIPTION
The docs header and mobile menu linked to https://continue.dev/login, which now 404s — the app and its login flow were retired when continue.dev moved to the static GitHub Pages landing page. Removes the dead Sign in links from both navs. No other nav changes.

Made with [Cursor](https://cursor.com)