### PR TITLE
fix(gui): extract nested messages from structured API errors

### DIFF
--- a/gui/src/util/errorAnalysis.test.ts
+++ b/gui/src/util/errorAnalysis.test.ts
@@ -130,7 +130,7 @@ describe("errorAnalysis", () => {
         expect(result.parsedError).toBe("");
       });
 
-      it("should handle complex nested JSON", () => {
+      it("should handle complex nested JSON by returning the nested message string", () => {
         const complexJson = {
           error: {
             code: 400,
@@ -141,7 +141,59 @@ describe("errorAnalysis", () => {
         const error = new Error(`Header\n\n${JSON.stringify(complexJson)}`);
         const result = analyzeError(error, null);
 
-        expect(result.parsedError).toBe(JSON.stringify(complexJson.error));
+        expect(result.parsedError).toBe("Bad Request");
+      });
+
+      it("should extract nested message from structured error object", () => {
+        const errorJson = {
+          error: {
+            message: "Quota exceeded",
+            status: "RESOURCE_EXHAUSTED",
+          },
+        };
+        const error = new Error(`Header\n\n${JSON.stringify(errorJson)}`);
+        const result = analyzeError(error, null);
+
+        expect(result.parsedError).toBe("Quota exceeded");
+      });
+
+      it("should preserve fallback behavior for nested error object without message", () => {
+        const errorJson = {
+          error: {
+            status: "RESOURCE_EXHAUSTED",
+          },
+        };
+        const error = new Error(`Header\n\n${JSON.stringify(errorJson)}`);
+        const result = analyzeError(error, null);
+
+        expect(result.parsedError).toBe('{"status":"RESOURCE_EXHAUSTED"}');
+      });
+
+      it("should handle primitive string error with no regression", () => {
+        const errorJson = {
+          error: "Invalid API key",
+        };
+        const error = new Error(`Header\n\n${JSON.stringify(errorJson)}`);
+        const result = analyzeError(error, null);
+
+        expect(result.parsedError).toBe('"Invalid API key"');
+      });
+
+      it("should handle top-level message with no regression", () => {
+        const errorJson = {
+          message: "Simple message",
+        };
+        const error = new Error(`Header\n\n${JSON.stringify(errorJson)}`);
+        const result = analyzeError(error, null);
+
+        expect(result.parsedError).toBe('"Simple message"');
+      });
+
+      it("should handle malformed JSON with no regression", () => {
+        const error = new Error("Header\n\n{invalid json}");
+        const result = analyzeError(error, null);
+
+        expect(result.parsedError).toBe("{invalid json}");
       });
     });
 
@@ -386,7 +438,7 @@ describe("errorAnalysis", () => {
         };
         const result = analyzeError(error, selectedModel);
 
-        expect(result.parsedError).toBe(JSON.stringify(errorObj.error));
+        expect(result.parsedError).toBe("Invalid request");
         expect(result.statusCode).toBe(400);
       });
 

--- a/gui/src/util/errorAnalysis.ts
+++ b/gui/src/util/errorAnalysis.ts
@@ -24,6 +24,13 @@ function parseErrorMessage(fullErrMsg: string): string {
   try {
     const parsed = JSON.parse(msg);
     if (parsed.error !== undefined && parsed.error !== null) {
+      if (
+        typeof parsed.error === "object" &&
+        parsed.error !== null &&
+        typeof (parsed.error as any).message === "string"
+      ) {
+        return (parsed.error as any).message;
+      }
       return JSON.stringify(parsed.error);
     }
     if (parsed.message !== undefined && parsed.message !== null) {


### PR DESCRIPTION
## Description

Fixes #12945.

This PR improves structured API error parsing in the GUI by extracting nested `error.message` values instead of displaying the entire stringified error object.

Previously, when providers returned structured error payloads (such as Gemini's HTTP 429 quota-exceeded response), the **View error output** section displayed raw JSON (for example, `{"message":"...","status":"RESOURCE_EXHAUSTED"}`) rather than the provider's human-readable error message.

This change updates the error parser to:
- Extract and display the nested `error.message` when present.
- Preserve the existing behavior for primitive error values, malformed JSON, top-level `message` fields, and structured error objects without a `message` field.
- Keep the existing HTTP status code extraction and provider-specific error handling unchanged.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [ ] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Since reproducing the original issue requires exceeding the Gemini API quota, I wasn't able to capture a runtime screenshot.

Instead, I verified the fix by simulating the original error payload reported in the issue.

**Before**

```text
{"message":"You exceeded your current quota for Gemini API in your project. Please check your plan and billing details.","status":"RESOURCE_EXHAUSTED"}
```

**After**

```text
You exceeded your current quota for Gemini API in your project. Please check your plan and billing details.
```

## Tests

- Updated the existing tests for structured nested error parsing.
- Added regression tests covering:
  - Structured error objects with a nested `message`
  - Structured error objects without a `message`
  - Primitive string errors
  - Top-level `message` fields
  - Malformed JSON
- Simulated the original Gemini quota-exceeded payload from Issue #12945 and verified that:
  - The parser extracts the human-readable error message.
  - HTTP status code extraction (`429`) remains unchanged.
- Verified that all `errorAnalysis` tests pass successfully.