### PR TITLE
fix(gui): prevent composer overflow with long unbroken strings

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor/TipTapEditor.css
+++ b/gui/src/components/mainInput/TipTapEditor/TipTapEditor.css
@@ -1,3 +1,8 @@
+.tiptap {
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
 .mention {
   background-color: var(--vscode-badge-background, #bfe2b6);
   color: var(--vscode-badge-foreground, --vscode-foreground, #000);

--- a/gui/src/components/mainInput/TipTapEditor/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor/TipTapEditor.tsx
@@ -342,7 +342,7 @@ const MemoInner = memo(
 
 export function TipTapEditor(props: TipTapEditorProps) {
   return (
-    <div className="relative w-full">
+    <div className="relative w-full min-w-0">
       <MemoInner {...props} />
     </div>
   );


### PR DESCRIPTION
## Summary

Fixes composer layout overflow when typing or pasting long unbroken strings.

### Changes

- Allow long unbroken strings to wrap inside the TipTap editor.
- Prevent the editor flex item from expanding beyond its container by applying `min-w-0`.

### Verification

- Manually verified long unbroken strings wrap correctly.
- Composer width remains stable.
- Send button remains aligned.
- Normal text input behavior is unchanged.
- Responsive sidebar layout behaves correctly.

### Notes

Automated tests could not be fully executed because the local environment did not have all required project dependencies installed.