### PR TITLE
docs: update Node.js requirement to 20.20.1+

### DIFF
--- a/docs/cli/quickstart.mdx
+++ b/docs/cli/quickstart.mdx
@@ -25,7 +25,7 @@ cn --version
 
 ### Requirements
 
-- **Node.js 20+** — needed for the npm install path. The shell installer bundles its own runtime.
+- **Node.js 20.20.1+** — needed for the npm install path. The shell installer bundles its own runtime.
 - A [Continue](https://continue.dev) account, or an Anthropic API key.
 
 ## First run

--- a/docs/guides/chrome-devtools-mcp-performance.mdx
+++ b/docs/guides/chrome-devtools-mcp-performance.mdx
@@ -40,7 +40,7 @@ This cookbook teaches you to:
 
 - Chrome browser installed
 - Web project with a running development server (or deployed URL)
-- Node.js 20+ installed
+- Node.js 20.20.1+ installed
 - [Continue CLI](https://docs.continue.dev/guides/cli)
 - [Chrome DevTools MCP](https://continue.dev) configured
 
@@ -145,7 +145,7 @@ After completing **Quick Setup** above, you have two paths to get started:
       - **Continue CLI Pro Plan** with the models add-on, OR
       - **Your own API keys** configured as environment variables
       - **Chrome browser** installed on your system
-      - **Node.js 20+** to run the MCP via npx
+      - **Node.js 20.20.1+** to run the MCP via npx
 
     The agent will automatically detect and use your configuration.
 </Accordion>

--- a/docs/guides/continue-docs-mcp-cookbook.mdx
+++ b/docs/guides/continue-docs-mcp-cookbook.mdx
@@ -14,7 +14,7 @@ Before starting, ensure you have:
 
 - Read: [Contributing to Continue Documentation](/CONTRIBUTING) for setup instructions
 - Forked the [continuedev/continue](https://github.com/continuedev/continue) repository
-- Node.js 20+ and Continue CLI installed
+- Node.js 20.20.1+ and Continue CLI installed
 
 <Warning>
   This cookbook assumes you've read the setup in the [CONTRIBUTING guide](/CONTRIBUTING). If you haven't, start there first.

--- a/docs/guides/github-pr-review-bot.mdx
+++ b/docs/guides/github-pr-review-bot.mdx
@@ -405,7 +405,7 @@ The workflow will respond with a targeted review based on your request.
 ## Troubleshooting
 <AccordionGroup>
 <Accordion title="Continue CLI not found">
-- The workflow installs the CLI automatically, but ensure Node.js 20+ is available
+- The workflow installs the CLI automatically, but ensure Node.js 20.20.1+ is available
 - Check the "Install Continue CLI" step logs for errors
 </Accordion>
 <Accordion title="Authentication failed">

--- a/docs/guides/sanity-mcp-continue-cookbook.mdx
+++ b/docs/guides/sanity-mcp-continue-cookbook.mdx
@@ -18,7 +18,7 @@ import CLIInstall from '/snippets/cli-install.mdx'
 
 Before starting, ensure you have:
 
-- Node.js 20+ installed locally
+- Node.js 20.20.1+ installed locally
 - A [Sanity account](https://www.sanity.io/) and project (free tier works)
 - Basic understanding of content management systems
 

--- a/docs/snippets/cli-install.mdx
+++ b/docs/snippets/cli-install.mdx
@@ -10,7 +10,7 @@
     ```
   </Tab>
   <Tab title="npm (cross-platform)">
-    If you already have Node.js 20+:
+    If you already have Node.js 20.20.1+:
     ```bash
     npm i -g @continuedev/cli
     ```


### PR DESCRIPTION
Updates CLI docs to match the 20.20.1 minimum required by install scripts and package engines.