### PR TITLE
docs(contributing): fix stale tailwind and config references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,7 +213,7 @@ Guidelines for adding/updating theme colors:
 
 - Choose sensible VS Code variables to add/update in [gui/src/styles/theme.ts](gui/src/styles/theme.ts) (see [here](https://code.visualstudio.com/api/references/theme-color) and [here](https://www.notion.so/1fa1d55165f78097b551e3bc296fcf76?pvs=25) for inspiration)
 - Choose sensible JetBrains named colors to add/update in `GetTheme.kt` (flagship LLMs can give you good suggestions to try)
-- Update `tailwind.config.js` if needed
+- Update `tailwind.config.cjs` if needed
 - Use the Theme Test Page to check colors. This can be accessed by going to `Settings` -> `Help` -> `Theme Test Page` in dev/debug mode.
 
 ### Testing
@@ -258,7 +258,7 @@ add it with the following steps:
 ### Adding Models
 
 While any model that works with a supported provider can be used with Continue, we keep a list of recommended models
-that can be automatically configured from the UI or `config.json`. The following files should be updated when adding a
+that can be automatically configured from the UI or `config.yaml`. The following files should be updated when adding a
 model:
 
 - [AddNewModel page](./gui/src/pages/AddNewModel/configs/) - This directory defines which model options are shown in the


### PR DESCRIPTION
## Description

Updates `CONTRIBUTING.md` to use the current filenames for the Tailwind config (`tailwind.config.cjs`) and the user configuration file (`config.yaml`).

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A — documentation-only change.

## Tests

N/A — documentation-only change.

## Problem

`CONTRIBUTING.md` still points contributors to `tailwind.config.js` and `config.json`, but the repository now uses `tailwind.config.cjs` and `config.yaml` respectively.

## Triage / Root cause

Stale documentation references at lines 216 and 261 of `CONTRIBUTING.md`.

## Fix

- Line 216: `tailwind.config.js` → `tailwind.config.cjs`
- Line 261: `config.json` → `config.yaml`

## Verification

- Fetched `upstream/main` and confirmed the stale strings are still present and the corrected strings are absent using `scripts/preflight_ship.py`.
- `git show upstream/main:CONTRIBUTING.md` verified the stale references remain on the current default branch.

## Notes / Risks

No functional changes. This is a docs-only update.
