### PR TITLE
docs(intellij): fix stale config.json reference

### DIFF
--- a/extensions/intellij/CONTRIBUTING.md
+++ b/extensions/intellij/CONTRIBUTING.md
@@ -95,7 +95,7 @@ This should open a new instance on IntelliJ with the extension installed.
 
 When running the `Start Core Dev Server` task, we set the location of your Continue directory to
 `./extensions/.continue-debug`. This is to
-allow for changes to your `config.json` and other files during development, without affecting your actual configuration.
+allow for changes to your `config.yaml` and other files during development, without affecting your actual configuration.
 
 ### Viewing logs
 


### PR DESCRIPTION
## Description

Updates `extensions/intellij/CONTRIBUTING.md` to reference `config.yaml` instead of the stale `config.json` for the Continue directory used during development.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A — documentation-only change.

## Tests

N/A — documentation-only change.

## Problem

`extensions/intellij/CONTRIBUTING.md` still refers to `config.json` for development-time Continue directory files, but the project now uses `config.yaml`.

## Triage / Root cause

Stale documentation reference at line 98 of `extensions/intellij/CONTRIBUTING.md`.

## Fix

- Line 98: `config.json` → `config.yaml`

## Verification

- Fetched `upstream/main` and confirmed the stale string is still present and the corrected string is absent using `scripts/preflight_ship.py`.
- `git show upstream/main:extensions/intellij/CONTRIBUTING.md` verified the stale reference remains on the current default branch.

## Notes / Risks

No functional changes. This is a docs-only update.
