### PR TITLE
fix(gui): prevent sidebar overflow from long code blocks

### DIFF
--- a/gui/src/components/StyledMarkdownPreview/SyntaxHighlightedPre.tsx
+++ b/gui/src/components/StyledMarkdownPreview/SyntaxHighlightedPre.tsx
@@ -24,6 +24,8 @@ const StyledPre = styled.pre<{ theme: any }>`
   margin-bottom: 0;
   border-radius: 0 0 ${defaultBorderRadius} ${defaultBorderRadius} !important;
   max-height: 40vh;
+  max-width: 100%;
+  min-width: 0;
   overflow-y: scroll !important;
 
   ${(props) => generateThemeStyles(props.theme)}

--- a/gui/src/components/StyledMarkdownPreview/index.tsx
+++ b/gui/src/components/StyledMarkdownPreview/index.tsx
@@ -66,7 +66,9 @@ const StyledMarkdown = styled.div<{
     background-color: ${vscEditorBackground};
     border-radius: ${defaultBorderRadius};
 
-    max-width: calc(100vw - 24px);
+    box-sizing: border-box;
+    max-width: 100%;
+    min-width: 0;
     overflow-x: scroll;
     overflow-y: hidden;
 
@@ -77,6 +79,8 @@ const StyledMarkdown = styled.div<{
     span.line:empty {
       display: none;
     }
+    overflow-wrap: anywhere;
+    word-break: break-word;
     word-wrap: break-word;
     border-radius: 0.3125rem;
     background-color: ${vscEditorBackground};

--- a/gui/src/components/mainInput/ContinueInputBox.tsx
+++ b/gui/src/components/mainInput/ContinueInputBox.tsx
@@ -109,10 +109,10 @@ function ContinueInputBox(props: ContinueInputBoxProps) {
 
   return (
     <div
-      className={`${props.hidden ? "hidden" : ""}`}
+      className={`${props.hidden ? "hidden" : ""} min-w-0`}
       data-testid={`continue-input-box-${props.inputId}`}
     >
-      <div className={`relative flex flex-col px-2`}>
+      <div className={`relative flex min-w-0 flex-col px-2`}>
         {props.isMainInput && <Lump />}
         <GradientBorder
           loading={isStreaming && (props.isLastUserInput || isInEdit) ? 1 : 0}

--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -78,12 +78,12 @@ function InputToolbar(props: InputToolbarProps) {
     <>
       <div
         onClick={props.onClick}
-        className={`find-widget-skip bg-vsc-input-background flex select-none flex-row items-center justify-between gap-1 pt-1 ${props.hidden ? "pointer-events-none h-0 cursor-default opacity-0" : "pointer-events-auto mt-2 cursor-text opacity-100"}`}
+        className={`find-widget-skip bg-vsc-input-background flex min-w-0 select-none flex-row items-center justify-between gap-1 pt-1 ${props.hidden ? "pointer-events-none h-0 cursor-default opacity-0" : "pointer-events-auto mt-2 cursor-text opacity-100"}`}
         style={{
           fontSize: smallFont,
         }}
       >
-        <div className="xs:gap-1.5 flex flex-row items-center gap-1">
+        <div className="xs:gap-1.5 flex min-w-0 flex-row items-center gap-1 overflow-hidden">
           {!isInEdit && (
             <ToolTip place="top" content="Select Mode">
               <HoverItem className="!p-0">
@@ -169,7 +169,7 @@ function InputToolbar(props: InputToolbarProps) {
         </div>
 
         <div
-          className="text-description flex items-center gap-2 whitespace-nowrap"
+          className="text-description flex flex-shrink-0 items-center gap-2 whitespace-nowrap"
           style={{
             fontSize: tinyFont,
           }}

--- a/gui/src/pages/gui/Chat.tsx
+++ b/gui/src/pages/gui/Chat.tsx
@@ -386,7 +386,7 @@ export function Chat() {
 
       <StepsDiv
         ref={stepsDivRef}
-        className={`pt-[8px] ${showScrollbar ? "thin-scrollbar" : "no-scrollbar"} ${history.length > 0 ? "min-h-0 flex-1 overflow-y-scroll" : "shrink-0"}`}
+        className={`min-w-0 pt-[8px] ${showScrollbar ? "thin-scrollbar" : "no-scrollbar"} ${history.length > 0 ? "min-h-0 flex-1 overflow-y-scroll" : "shrink-0"}`}
       >
         <DeprecationBanner dismissable={true} />
         {highlights}
@@ -411,7 +411,7 @@ export function Chat() {
             </div>
           ))}
       </StepsDiv>
-      <div className={"relative shrink-0"}>
+      <div className={"relative min-w-0 shrink-0"}>
         <ContinueInputBox
           isMainInput
           isLastUserInput={false}

--- a/gui/src/pages/gui/index.test.tsx
+++ b/gui/src/pages/gui/index.test.tsx
@@ -1,0 +1,8 @@
+import { readFileSync } from "node:fs";
+
+test("sidebar shell allows flex children to shrink horizontally", () => {
+  const source = readFileSync("src/pages/gui/index.tsx", "utf8");
+
+  expect(source).toMatch(/<div className="[^"]*\bmin-w-0\b[^"]*">/);
+  expect(source).toMatch(/<main className="[^"]*\bmin-w-0\b[^"]*">/);
+});

--- a/gui/src/pages/gui/index.tsx
+++ b/gui/src/pages/gui/index.tsx
@@ -3,11 +3,11 @@ import { Chat } from "./Chat";
 
 export default function GUI() {
   return (
-    <div className="flex min-h-0 w-screen flex-row overflow-x-hidden">
+    <div className="flex min-h-0 w-screen min-w-0 flex-row overflow-x-hidden">
       <aside className="4xl:flex border-vsc-input-border no-scrollbar hidden min-h-0 w-96 overflow-y-auto border-0 border-r border-solid">
         <History />
       </aside>
-      <main className="no-scrollbar flex min-h-0 flex-1 flex-col">
+      <main className="no-scrollbar flex min-h-0 min-w-0 flex-1 flex-col">
         <Chat />
       </main>
     </div>


### PR DESCRIPTION
## Summary
- Add `min-w-0` to the sidebar chat flex containers so long generated content cannot widen the webview shell
- Keep code blocks constrained to the available message width while preserving horizontal scrolling
- Keep the input toolbar's send/action buttons from shrinking off-screen when the left side overflows

Closes #12910

## Test plan
- `npm test -- --run src/pages/gui/index.test.tsx`
- `NODE_OPTIONS=--max-old-space-size=4096 npm run tsc:check`
- `npm exec -- prettier --check gui/src/pages/gui/index.tsx gui/src/pages/gui/index.test.tsx gui/src/pages/gui/Chat.tsx gui/src/components/mainInput/ContinueInputBox.tsx gui/src/components/mainInput/InputToolbar.tsx gui/src/components/StyledMarkdownPreview/index.tsx gui/src/components/StyledMarkdownPreview/SyntaxHighlightedPre.tsx`
