### PR TITLE
fix(core): recognise Windows backslash paths in grep_search output

### DIFF
--- a/core/util/grepSearch.ts
+++ b/core/util/grepSearch.ts
@@ -57,7 +57,9 @@ export function formatGrepSearchResults(
 
   let resultLines: string[] = [];
   for (const line of results.split("\n").filter((l) => !!l)) {
-    if (line.startsWith("./") || line === "--") {
+    // ripgrep headings start with the relative path: "./" on POSIX, ".\" on Windows.
+    // Only checking "./" silently discarded every match on Windows (#13027).
+    if (line.startsWith("./") || line.startsWith(".\\") || line === "--") {
       processResult(resultLines); // process previous result
       resultLines = [line];
       numResults++;

--- a/core/util/grepSearch.vitest.ts
+++ b/core/util/grepSearch.vitest.ts
@@ -215,3 +215,21 @@ test("decreases indentation when original is more than 2 spaces", () => {
   expect(result.formatted).toContain("    tooMuchIndent();");
   expect(result.formatted).toContain("  }");
 });
+
+test("parses Windows ripgrep output with backslash path separators", () => {
+  // On Windows, ripgrep emits headings like `.\dir\file.ext` instead of `./dir/file.ext`.
+  // The parser must recognise those as file headers, otherwise every match is discarded (#13027).
+  const windowsOutput = [
+    ".\\src\\program.cs",
+    '        Console.WriteLine("Hello World!");',
+    "--",
+    ".\\test\\calc.kt",
+    "    fun subtract(number: Double): Test {",
+  ].join("\n");
+
+  const result = formatGrepSearchResults(windowsOutput);
+
+  expect(result.numResults).toBeGreaterThan(0);
+  expect(result.formatted).toContain("program.cs");
+  expect(result.formatted).toContain("calc.kt");
+});


### PR DESCRIPTION
## Problem

Fixes #13027.

`grep_search` always returns "The search returned no results" on Windows, even when ripgrep finds matches (verified by the reporter with Process Monitor: `rg.exe` runs and returns results, but the tool reports none).

## Root cause

`formatGrepSearchResults` in `core/util/grepSearch.ts` detects ripgrep file-heading lines with:

```ts
if (line.startsWith("./") || line === "--") {
```

ripgrep emits headings as the relative path — `./dir/file` on POSIX, but `.\dir\file` on Windows. The `startsWith("./")` check never matches the Windows form, so no line is counted as a heading, `numResults` stays `0`, and every match is silently discarded. Diagnosed precisely in the issue by @SpikedCola.

## Fix

Also accept the `.\` prefix:

```ts
if (line.startsWith("./") || line.startsWith(".\\") || line === "--") {
```

POSIX `./` headings and the `--` context separator are unchanged.

## Tests

Added a unit test in `core/util/grepSearch.vitest.ts` that feeds backslash-separated ripgrep output and asserts `numResults > 0` and the filenames are present — it fails before the change (0 results) and passes after.

I verified the header-detection logic in isolation (the Windows heading goes from unrecognised → recognised, POSIX and `--` still recognised). I don't have a Windows machine to run the full agent end-to-end, but the parser is pure and the added test covers the regression in CI.
