### PR TITLE
feat: add Modelsell provider

### DIFF
--- a/core/llm/llms/Modelsell.ts
+++ b/core/llm/llms/Modelsell.ts
@@ -1,0 +1,13 @@
+import { LLMOptions } from "../../index.js";
+
+import OpenAI from "./OpenAI.js";
+
+class Modelsell extends OpenAI {
+  static providerName = "modelsell";
+  static defaultOptions: Partial<LLMOptions> = {
+    apiBase: "https://modelsell.com/v1/",
+    useLegacyCompletionsEndpoint: false,
+  };
+}
+
+export default Modelsell;

--- a/core/llm/llms/Modelsell.vitest.ts
+++ b/core/llm/llms/Modelsell.vitest.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test, vi } from "vitest";
+
+import Modelsell from "./Modelsell.js";
+import { LLMClasses } from "./index.js";
+
+describe("Modelsell", () => {
+  test("registers the provider with the Modelsell API base", () => {
+    expect(Modelsell.providerName).toBe("modelsell");
+    expect(Modelsell.defaultOptions).toMatchObject({
+      apiBase: "https://modelsell.com/v1/",
+      useLegacyCompletionsEndpoint: false,
+    });
+    expect(LLMClasses).toContain(Modelsell);
+  });
+
+  test("discovers model IDs from the Modelsell models endpoint", async () => {
+    const modelsell = new Modelsell({
+      apiKey: "test-api-key",
+      model: "",
+    });
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [{ id: "provider/model-a" }, { id: "model-b" }],
+        }),
+        { headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    (modelsell as any).fetch = mockFetch;
+
+    await expect(modelsell.listModels()).resolves.toEqual([
+      "provider/model-a",
+      "model-b",
+    ]);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url.toString()).toBe("https://modelsell.com/v1/models");
+    expect(options).toMatchObject({
+      method: "GET",
+      headers: {
+        Authorization: "Bearer test-api-key",
+      },
+    });
+  });
+});

--- a/core/llm/llms/index.ts
+++ b/core/llm/llms/index.ts
@@ -39,6 +39,7 @@ import LMStudio from "./LMStudio";
 import Mistral from "./Mistral";
 import Mimo from "./Mimo";
 import MiniMax from "./MiniMax";
+import Modelsell from "./Modelsell";
 import MockLLM from "./Mock";
 import Moonshot from "./Moonshot";
 import Msty from "./Msty";
@@ -95,6 +96,7 @@ export const LLMClasses = [
   Mistral,
   Mimo,
   MiniMax,
+  Modelsell,
   Bedrock,
   BedrockImport,
   SageMaker,

--- a/docs/customize/model-providers/more/modelsell.mdx
+++ b/docs/customize/model-providers/more/modelsell.mdx
@@ -1,0 +1,55 @@
+---
+title: "Modelsell"
+description: "Configure Modelsell with Continue through its OpenAI-compatible Chat Completions API and dynamic model discovery."
+---
+
+Modelsell provides a unified OpenAI-compatible endpoint for using multiple AI model providers in Continue.
+
+- **API base:** `https://modelsell.com/v1`
+- **API keys:** [modelsell.com/console/token](https://modelsell.com/console/token)
+- **API documentation:** [modelsell.com/docs/api-reference](https://modelsell.com/docs/api-reference)
+
+## Discover available models
+
+Modelsell's model catalog is dynamic. Fetch the model IDs available to your API key from `GET /v1/models` rather than relying on a static list:
+
+```bash
+curl https://modelsell.com/v1/models \
+  -H "Authorization: Bearer $MODELSELL_API_KEY"
+```
+
+Use an `id` from the response as the `model` value in your Continue configuration.
+
+## Configuration
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  name: My Config
+  version: 0.0.1
+  schema: v1
+
+  models:
+    - name: Modelsell
+      provider: modelsell
+      model: <MODEL_ID_FROM_GET_V1_MODELS>
+      apiKey: ${{ secrets.MODELSELL_API_KEY }}
+  ```
+  </Tab>
+  <Tab title="JSON (Deprecated)">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "Modelsell",
+        "provider": "modelsell",
+        "model": "<MODEL_ID_FROM_GET_V1_MODELS>",
+        "apiKey": "<YOUR_MODELSELL_API_KEY>"
+      }
+    ]
+  }
+  ```
+  </Tab>
+</Tabs>
+
+The initial integration uses Modelsell's OpenAI-compatible Chat Completions endpoint. It does not maintain a hardcoded model catalog in Continue.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -114,6 +114,7 @@
                       "customize/model-providers/more/llamastack",
                       "customize/model-providers/more/mimo",
                       "customize/model-providers/more/mistral",
+                      "customize/model-providers/more/modelsell",
                       "customize/model-providers/more/moonshot",
                       "customize/model-providers/more/nous",
                       "customize/model-providers/more/nvidia",


### PR DESCRIPTION
## Description

Adds Modelsell as a named OpenAI-compatible model provider with the fixed API base `https://modelsell.com/v1/`.

The provider reuses Continue’s existing OpenAI Chat Completions implementation and discovers the model catalog dynamically from `GET /v1/models`, so no model IDs are hardcoded. This also adds provider documentation and exposes the page in the documentation navigation.

Fixes #13040

Disclosure: I represent Modelsell.

No live authenticated Modelsell API call was performed.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I’ve read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Not applicable; this change adds a provider integration and documentation without changing the UI.

## Tests

- `npm run vitest -- llm/llms/Modelsell.vitest.ts`
- `npm run tsc:check`
- `npx eslint llm/llms/Modelsell.ts llm/llms/Modelsell.vitest.ts llm/llms/index.ts`
- `npx prettier --check core/llm/llms/Modelsell.ts core/llm/llms/Modelsell.vitest.ts core/llm/llms/index.ts docs/customize/model-providers/more/modelsell.mdx docs/docs.json`
- JSON parse check for `docs/docs.json`
- `git diff --check`