### PR TITLE
fix(core): handle Windows separators in the remaining grep_search parsers

### DIFF
--- a/core/tools/implementations/grepSearch.ts
+++ b/core/tools/implementations/grepSearch.ts
@@ -1,7 +1,10 @@
 import { ToolImpl } from ".";
 import { ContextItem } from "../..";
 import { ContinueError, ContinueErrorReason } from "../../util/errors";
-import { formatGrepSearchResults } from "../../util/grepSearch";
+import {
+  formatGrepSearchResults,
+  GREP_RESULT_PATH_PREFIX_SOURCE,
+} from "../../util/grepSearch";
 import { prepareQueryForRipgrep } from "../../util/regexValidator";
 import { getStringArg } from "../parseArgs";
 
@@ -9,13 +12,21 @@ const DEFAULT_GREP_SEARCH_RESULTS_LIMIT = 100;
 const DEFAULT_GREP_SEARCH_CHAR_LIMIT = 7500; // ~1500 tokens, will keep truncation simply for now
 
 function splitGrepResultsByFile(content: string): ContextItem[] {
-  const matches = [...content.matchAll(/^\.\/([^\n]+)$/gm)];
+  // `.\path` on Windows, `./path` elsewhere — see isGrepResultPathLine.
+  const headingRegex = new RegExp(
+    `^${GREP_RESULT_PATH_PREFIX_SOURCE}([^\\n]+)$`,
+    "gm",
+  );
+  const matches = [...content.matchAll(headingRegex)];
 
   const contextItems: ContextItem[] = [];
 
   for (let i = 0; i < matches.length; i++) {
     const match = matches[i];
-    const filepath = match[1];
+    // Normalise separators: this becomes a `file` context-item URI, and those
+    // are glob-matched for rule application, where a backslash is an escape
+    // character rather than a separator.
+    const filepath = match[1].replace(/\\/g, "/");
     const startIndex = match.index!;
     const endIndex =
       i < matches.length - 1 ? matches[i + 1].index! : content.length;
@@ -23,7 +34,7 @@ function splitGrepResultsByFile(content: string): ContextItem[] {
     // Extract grepped content for this file
     const fileContent = content
       .substring(startIndex, endIndex)
-      .replace(/^\.\/[^\n]+\n/, "") // remove the line with file path
+      .replace(new RegExp(`^${GREP_RESULT_PATH_PREFIX_SOURCE}[^\\n]+\\n`), "") // remove the line with file path
       .trim();
 
     if (fileContent) {

--- a/core/tools/implementations/grepSearch.vitest.ts
+++ b/core/tools/implementations/grepSearch.vitest.ts
@@ -1,0 +1,86 @@
+import { expect, test, vi } from "vitest";
+
+import { ToolExtras } from "../..";
+
+import { grepSearchImpl } from "./grepSearch";
+
+function extrasReturning(results: string) {
+  return {
+    fetch: vi.fn() as any,
+    ide: {
+      getSearchResults: vi.fn().mockResolvedValue(results),
+    } as any,
+  } as unknown as ToolExtras;
+}
+
+// ripgrep is run with `.` as the search root, so `--heading` echoes that root
+// back using the platform separator: `./path` on POSIX, `.\path` on Windows.
+const posixResults = "./src/calc.ts\n  subtract(n) {\n    return this;";
+const windowsResults = ".\\src\\calc.ts\n  subtract(n) {\n    return this;";
+
+test("returns results for POSIX-style headings", async () => {
+  const result = await grepSearchImpl(
+    { query: "subtract" },
+    extrasReturning(posixResults),
+  );
+
+  expect(result).toHaveLength(1);
+  expect(result[0].content).toContain("subtract(n) {");
+});
+
+test("returns results for Windows-style headings", async () => {
+  // The reported bug: ripgrep found the match, but no heading was recognised,
+  // so numResults stayed 0 and the tool answered "no results" with the content
+  // sitting right there in its hand.
+  const result = await grepSearchImpl(
+    { query: "subtract" },
+    extrasReturning(windowsResults),
+  );
+
+  expect(result).toHaveLength(1);
+  expect(result[0].content).not.toBe("The search returned no results.");
+  expect(result[0].content).toContain("subtract(n) {");
+});
+
+test("splits Windows results per file and normalises the URI separators", async () => {
+  const result = await grepSearchImpl(
+    { query: "subtract", splitByFile: true },
+    extrasReturning(
+      `${windowsResults}\n.\\test.py\n  def subtract(self):\n    pass`,
+    ),
+  );
+
+  expect(result).toHaveLength(2);
+  // Forward slashes, even though ripgrep reported backslashes: this value is a
+  // `file` context-item URI, and those get glob-matched to decide which rules
+  // apply — and in a glob a backslash escapes the next character rather than
+  // separating path segments, so `src\calc.ts` would match nothing.
+  expect(result[0].uri).toEqual({ type: "file", value: "src/calc.ts" });
+  expect(result[1].uri).toEqual({ type: "file", value: "test.py" });
+  // The heading line itself is stripped from each chunk's content.
+  expect(result[0].content).toBe("subtract(n) {\n    return this;");
+  expect(result[1].content).toBe("def subtract(self):\n    pass");
+});
+
+test("splits POSIX results per file", async () => {
+  const result = await grepSearchImpl(
+    { query: "subtract", splitByFile: true },
+    extrasReturning(
+      `${posixResults}\n./test.py\n  def subtract(self):\n    pass`,
+    ),
+  );
+
+  expect(result).toHaveLength(2);
+  expect(result[0].uri).toEqual({ type: "file", value: "src/calc.ts" });
+  expect(result[1].uri).toEqual({ type: "file", value: "test.py" });
+});
+
+test("still reports genuinely empty searches as empty", async () => {
+  const result = await grepSearchImpl(
+    { query: "nothing" },
+    extrasReturning(""),
+  );
+
+  expect(result).toHaveLength(1);
+  expect(result[0].content).toBe("The search returned no results.");
+});

--- a/core/util/grepSearch.ts
+++ b/core/util/grepSearch.ts
@@ -1,8 +1,26 @@
 /*
+  ripgrep is invoked with `.` as the search root, and with `--heading` it echoes
+  that root back on the file-heading line using the platform separator: `./path`
+  on POSIX, but `.\path` on Windows. Every parser of this output has to accept
+  both, or Windows results are silently discarded — the content is all there,
+  but no heading is ever recognised, so the result count stays 0.
+*/
+export function isGrepResultPathLine(line: string): boolean {
+  return line.startsWith("./") || line.startsWith(".\\");
+}
+
+/**
+ * Regex source for the same heading prefix, for callers that need it inside a
+ * larger pattern. Kept next to {@link isGrepResultPathLine} so the two cannot
+ * drift apart.
+ */
+export const GREP_RESULT_PATH_PREFIX_SOURCE = "\\.[\\\\/]";
+
+/*
   Formats the output of a grep search to reduce unnecessary indentation, lines, etc
   Assumes a command with these params
     ripgrep -i --ignore-file .continueignore --ignore-file .gitignore -C 2 --heading -m 100 -e <query> .
-  
+
   Also can truncate the output to a specified number of characters
 */
 export function formatGrepSearchResults(
@@ -57,7 +75,7 @@ export function formatGrepSearchResults(
 
   let resultLines: string[] = [];
   for (const line of results.split("\n").filter((l) => !!l)) {
-    if (line.startsWith("./") || line === "--") {
+    if (isGrepResultPathLine(line) || line === "--") {
       processResult(resultLines); // process previous result
       resultLines = [line];
       numResults++;

--- a/core/util/grepSearch.vitest.ts
+++ b/core/util/grepSearch.vitest.ts
@@ -215,3 +215,57 @@ test("decreases indentation when original is more than 2 spaces", () => {
   expect(result.formatted).toContain("    tooMuchIndent();");
   expect(result.formatted).toContain("  }");
 });
+
+// ripgrep echoes the `.` search root back with the platform separator, so on
+// Windows every heading arrives as `.\path\file` rather than `./path/file`.
+// Headings that go unrecognised are not just mis-titled: processResult() only
+// keeps lines that follow a heading, so the whole result set is dropped and
+// numResults stays 0 — the caller reports "no results" with the matches in hand.
+const sampleWindowsGrepOutput = `.\\program.cs
+        Console.WriteLine("Hello World!");
+--
+        }
+
+.\\src\\test.kt
+    fun subtract(number: Double): Test {
+        result -= number`;
+
+test("formats Windows-style backslash headings", () => {
+  const result = formatGrepSearchResults(sampleWindowsGrepOutput);
+
+  expect(result.numResults).toBe(3);
+  expect(result.formatted).toContain(".\\program.cs");
+  expect(result.formatted).toContain(".\\src\\test.kt");
+  expect(result.formatted).toContain('Console.WriteLine("Hello World!");');
+  expect(result.formatted).toContain("fun subtract(number: Double): Test {");
+});
+
+test("counts Windows headings so results are not reported as empty", () => {
+  // The reported symptom: content present, numResults 0, caller says
+  // "The search returned no results."
+  const result = formatGrepSearchResults(".\\file.ts\n  const x = 1;");
+
+  expect(result.numResults).toBe(1);
+  expect(result.formatted).toBe(".\\file.ts\n  const x = 1;");
+});
+
+test("handles mixed separators in a single result set", () => {
+  // Multi-root workspaces concatenate one ripgrep run per directory, so a
+  // single string can carry both forms.
+  const input = "./posix.ts\n  a();\n.\\windows.ts\n  b();";
+  const result = formatGrepSearchResults(input);
+
+  expect(result.numResults).toBe(2);
+  expect(result.formatted).toContain("./posix.ts");
+  expect(result.formatted).toContain(".\\windows.ts");
+});
+
+test("does not treat a bare relative path as a heading", () => {
+  // Only `./` and `.\` are headings. A content line that merely starts with a
+  // dot must not open a new result.
+  const result = formatGrepSearchResults("./file.ts\n  ...spread\n  .method()");
+
+  expect(result.numResults).toBe(1);
+  expect(result.formatted).toContain("  ...spread");
+  expect(result.formatted).toContain("  .method()");
+});

--- a/extensions/vscode/src/VsCodeIde.ts
+++ b/extensions/vscode/src/VsCodeIde.ts
@@ -4,6 +4,7 @@ import { exec } from "node:child_process";
 import { Range } from "core";
 import { EXTENSION_NAME } from "core/util/constants";
 import { DEFAULT_IGNORES, defaultIgnoresGlob } from "core/indexing/ignore";
+import { GREP_RESULT_PATH_PREFIX_SOURCE } from "core/util/grepSearch";
 import * as URI from "uri-js";
 import * as vscode from "vscode";
 
@@ -616,8 +617,12 @@ class VsCodeIde implements IDE {
     if (maxResults) {
       // In case of multiple workspaces, do max results per workspace and then truncate to maxResults
       // Will prioritize first workspace results, fine for now
-      // Results are separated by either ./ or --
-      const matches = Array.from(allResults.matchAll(/(\n--|\n\.\/)/g));
+      // Results are separated by either ./ or -- (.\ on Windows)
+      const matches = Array.from(
+        allResults.matchAll(
+          new RegExp(`(\\n--|\\n${GREP_RESULT_PATH_PREFIX_SOURCE})`, "g"),
+        ),
+      );
       if (matches.length > maxResults) {
         return allResults.substring(0, matches[maxResults].index);
       } else {


### PR DESCRIPTION
## Description

Follow-up to #13027. **This is complementary to @guillaume-flambard's #13037, not a replacement** — that PR fixes the one site the issue named, this one covers the three that were left, including a worse variant of the same bug.

ripgrep is invoked with `.` as the search root, so with `--heading` it echoes that root back on every file-heading line using the platform separator: `./path` on POSIX, `.\path` on Windows. **Four** independent parsers of that output assumed `./`:

| # | Site | Effect on Windows | Covered by |
|---|------|-------------------|------------|
| 1 | `core/util/grepSearch.ts:60` — `formatGrepSearchResults` heading check | `numResults` stays 0 → "The search returned no results." | #13037 (and here, refactored into a shared helper) |
| 2 | `core/tools/implementations/grepSearch.ts` — `splitGrepResultsByFile` heading regex + strip regex | With `splitByFile: true`, returns an **empty array** of context items — not even the "no results" message | **this PR** |
| 3 | Same function — captured path becomes a `type: "file"` ContextItem URI | Backslash path breaks glob rule-matching | **this PR** |
| 4 | `extensions/vscode/src/VsCodeIde.ts:620` — `maxResults` truncation `matchAll` | No boundaries found → the result limit cannot be honoured | **this PR** |

Site 2 is the one worth flagging: fixing only site 1 makes `splitByFile: true` go from "no results" to *silently returning zero context items*, which reads as success to the caller. Verified by control experiment below.

Site 3 is a consequence of fixing site 2 rather than extra scope. That captured path is consumed as a `file` ContextItem URI, which `core/llm/rules/getSystemMessageWithRules.ts:288-290` glob-matches to decide which rules apply — and in a glob a backslash **escapes** the next character rather than separating segments, so `src\calc.ts` would match no rule pattern. It is normalised to forward slashes.

Both IDE integrations pass `.` as the ripgrep root (`extensions/vscode/src/VsCodeIde.ts:609`, `extensions/intellij/.../IntelliJIde.kt:488`), so both feed `.\` into the shared core parser on Windows — this is not VS Code-specific.

To stop the four sites from drifting apart again, the predicate and its regex equivalent now live together in `core/util/grepSearch.ts`:

```ts
export function isGrepResultPathLine(line: string): boolean {
  return line.startsWith("./") || line.startsWith(".\\");
}

/** Regex source for the same prefix, for callers that need it inside a larger pattern. */
export const GREP_RESULT_PATH_PREFIX_SOURCE = "\\.[\\\\/]";
```

If #13037 lands first, site 1 here is a trivial conflict — happy to rebase onto it and drop that hunk, or to have this rebased however you prefer.

## Tests

`core/util/grepSearch.vitest.ts` — 4 added (9 → 13):

- `formats Windows-style backslash headings` — nested `.\src\test.kt` alongside `--` separators
- `counts Windows headings so results are not reported as empty` — asserts the reported symptom directly
- `handles mixed separators in a single result set` — multi-root workspaces concatenate one ripgrep run per directory
- `does not treat a bare relative path as a heading` — negative case: a content line starting with `.` (`.method()`, `...spread`) must not open a new result

`core/tools/implementations/grepSearch.vitest.ts` — **new file, 5 tests**. `grepSearchImpl` had no test file at all, which is why sites 2–4 went unnoticed. Covers POSIX and Windows for both `splitByFile` modes, the URI normalisation, and that a genuinely empty search still reports empty.

### Reviewer test plan

```bash
cd core
npx vitest run util/grepSearch.vitest.ts tools/implementations/grepSearch.vitest.ts
```

→ **18 passed** (13 + 5).

### Control experiment — do the tests actually catch the bug?

Reverting each source file in isolation, leaving the tests in place:

```bash
git stash push -- core/util/grepSearch.ts
cd core && npx vitest run util/grepSearch.vitest.ts
```
→ 3 fail (`expected 1 to be 3`, `expected +0 to be 1`, `expected 1 to be 2`); the 4th is the negative case, which correctly still passes.

```bash
git stash push -- core/tools/implementations/grepSearch.ts
cd core && npx vitest run tools/implementations/grepSearch.vitest.ts
```
→ 1 fail: `expected [] to have a length of 2 but got +0` — the empty-array symptom, reproduced.

### Regression / lint

- `npx vitest run tools/ util/` — **356 passed, 16 failed**. Clean `main` baseline on the same machine: **347 passed, 16 failed**. Identical failure set (pre-existing POSIX path assumptions in `resolveWorkingDirectory.vitest.ts` and 3 other files, unrelated to grep); my change adds +9 passing and 0 failures.
- `npx tsc --noEmit -p core` — 151 errors, and clean-`main` baseline is also **151** (unbuilt `@continuedev/*` workspace packages). No new errors; `grep -c grepSearch` on the output → 0.
- `npx eslint --max-warnings 0` on all changed files — clean. `npx prettier --check` — "All matched files use Prettier code style!"

### Tested on

| Platform | Unit tests | Real ripgrep end-to-end |
|---|---|---|
| Windows 11 | ✅ | ⚠️ not run |
| macOS / Linux | ⚠️ not run | ⚠️ not run |

**Not validated:** the extension end-to-end with a live `rg.exe`, and the IntelliJ path. The parsers are pure functions and the tests feed them the exact byte sequences ripgrep emits, but I have not watched a real search return results in the UI. Worth a maintainer sanity-check on a Windows box before merge.

## Screen recording or screenshot

N/A — no UI change; this is parser behaviour covered by unit tests.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created — none apply
- [x] The relevant tests, if any, have been updated or created

Credit to @SpikedCola for pinpointing the root cause in #13027 with Process Monitor, and to @guillaume-flambard for #13037.
