### PR TITLE
fix: handle Windows backslash path separator in grep_search tool

### DIFF
--- a/core/util/grepSearch.ts
+++ b/core/util/grepSearch.ts
@@ -57,7 +57,7 @@ export function formatGrepSearchResults(
 
   let resultLines: string[] = [];
   for (const line of results.split("\n").filter((l) => !!l)) {
-    if (line.startsWith("./") || line === "--") {
+    if (line.startsWith("./") || line.startsWith(".\\") || line === "--") {
       processResult(resultLines); // process previous result
       resultLines = [line];
       numResults++;


### PR DESCRIPTION
## Problem

On Windows, ripgrep outputs file paths prefixed with a backslash separator (e.g. `.\path\to\file.ts`) instead of the Unix-style forward slash (e.g. `./path/to/file.ts`).

The `formatGrepSearchResults` function in `core/util/grepSearch.ts` only checked for `line.startsWith("./")` when identifying file header lines, so on Windows **none of the lines were detected as file paths**, and the `grep_search` tool silently returned zero results for every query.

## Root Cause

```ts
// Before — only matches Unix paths
if (line.startsWith("./") || line === "--") {
```

## Fix

Added a second check for the Windows backslash prefix:

```ts
// After — matches both Unix and Windows paths
if (line.startsWith("./") || line.startsWith(".\\") || line === "--") {
```

This is a one-line surgical fix with no risk of affecting Unix behaviour.

## Testing

- On Unix: existing behaviour preserved — `./` prefix still matched correctly
- On Windows: `.\` prefix now detected, file headers correctly identified, results returned

Fixes #13027

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)