### PR TITLE
fix: prevent layout shift when pasting long unbroken strings in composer input

### DIFF
--- a/gui/src/components/mainInput/ContinueInputBox.tsx
+++ b/gui/src/components/mainInput/ContinueInputBox.tsx
@@ -112,7 +112,7 @@ function ContinueInputBox(props: ContinueInputBoxProps) {
       className={`${props.hidden ? "hidden" : ""}`}
       data-testid={`continue-input-box-${props.inputId}`}
     >
-      <div className={`relative flex flex-col px-2`}>
+      <div className={`relative flex min-w-0 flex-col px-2`}>
         {props.isMainInput && <Lump />}
         <GradientBorder
           loading={isStreaming && (props.isLastUserInput || isInEdit) ? 1 : 0}

--- a/gui/src/components/mainInput/TipTapEditor/TipTapEditor.css
+++ b/gui/src/components/mainInput/TipTapEditor/TipTapEditor.css
@@ -16,6 +16,12 @@
   transition: background-color 0.2s ease-in-out;
 }
 
+.tiptap {
+  overflow-wrap: break-word;
+  word-break: break-word;
+  min-width: 0;
+}
+
 .tiptap p.is-editor-empty:first-child::before {
   color: #646464; /* lightGray */
   content: attr(data-placeholder);


### PR DESCRIPTION
## Problem

Pasting a long unbroken string (e.g. a base64 token, a minified JS bundle, a long URL with no spaces) into the composer input box caused the TipTap editor content to overflow its flex container. This pushed the send button out of view and broke the overall input layout.

## Root Cause

Two missing CSS properties:

1. **No `overflow-wrap`/`word-break` on `.tiptap`** — without these, the browser treats the unbroken string as a single unbreakable word and renders it at full width, overflowing the container.

2. **No `min-width: 0` on the flex container** — flex items default to `min-width: auto`, which means they will never shrink below their content width. This prevents `overflow-wrap` from working inside a flex layout.

## Fix

**`TipTapEditor.css`** — add a `.tiptap` rule:
```css
.tiptap {
  overflow-wrap: break-word;
  word-break: break-word;
  min-width: 0;
}
```

**`ContinueInputBox.tsx`** — add `min-w-0` to the outer flex container:
```tsx
<div className={`relative flex flex-col px-2 min-w-0`}>
```

## Testing

- Paste a long base64 string or a URL with no spaces into the input box
- Before: editor overflows, send button disappears off-screen
- After: text wraps correctly, layout stays intact

Fixes #13016

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)