### PR TITLE
docs: add API Token Sale Anthropic endpoint

### DIFF
--- a/docs/customize/model-providers/top-level/anthropic.mdx
+++ b/docs/customize/model-providers/top-level/anthropic.mdx
@@ -48,6 +48,44 @@ sidebarTitle: "Anthropic"
   **Check out a more advanced configuration [here](https://continue.dev/anthropic/claude-sonnet-4-6?view=config)**
 </Info>
 
+## Using an Anthropic-compatible endpoint
+
+Continue's Anthropic provider can also connect to third-party services that implement the Anthropic Messages API. For example, configure [API Token Sale](https://apitoken.sale/) with the API key issued by the provider:
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  name: My Config
+  version: 0.0.1
+  schema: v1
+
+  models:
+    - name: Claude Sonnet 4.6
+      provider: anthropic
+      model: claude-sonnet-4-6
+      apiBase: https://api.apitoken.sale/v1/
+      apiKey: <YOUR_PROVIDER_API_KEY>
+  ```
+  </Tab>
+  <Tab title="JSON (Deprecated)">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "Claude Sonnet 4.6",
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-6",
+        "apiBase": "https://api.apitoken.sale/v1/",
+        "apiKey": "<YOUR_PROVIDER_API_KEY>"
+      }
+    ]
+  }
+  ```
+  </Tab>
+</Tabs>
+
+Keep the trailing slash in `/v1/` so Continue resolves the Messages endpoint correctly. API Token Sale is an independent provider and is not affiliated with Anthropic or Continue. Third-party services have their own billing, privacy, and availability terms.
+
 ## How to Enable Prompt Caching with Claude
 
 Anthropic supports [prompt caching with Claude](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching), which allows Claude models to cache system messages and conversation history between requests to improve performance and reduce costs.


### PR DESCRIPTION
## Description

Closes #13048.

Documents Continue’s existing custom Anthropic `apiBase` support using API Token Sale as a concrete Anthropic-compatible example. The guide includes YAML and legacy JSON configurations, the required trailing `/v1/`, a provider-issued key placeholder, and an explicit third-party disclaimer.

This is documentation-only; no provider or runtime code changes are needed. The documentation was drafted with AI assistance and verified against Continue’s current Anthropic implementation and a live endpoint.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I’ve read the contributing guide
- [x] The relevant docs have been updated
- [x] The relevant existing tests were run

## Screen recording or screenshot

Not applicable — documentation-only change.

## Tests

- Prettier check for the changed MDX: passed
- `docs-site` production build: passed (342 static pages)
- Internal package build order from `scripts/build-packages.js`: passed
- `core/llm/llms/Anthropic.vitest.ts`: 8/8 passed
- Live Continue Anthropic handler: basic response, SSE/usage, and forced tool use passed with `claude-sonnet-4-6`
- Rendered page contains the heading, configuration tabs, API host, disclaimer, and homepage link

An additional `docs-site` `tsc:check` reports the pre-existing `MapIterator` target error in `app/[[...slug]]/page.tsx:42`; the documented GitHub Pages workflow runs the successful production build and does not run this extra command.