### PR TITLE
fix(cli): restrict stdio MCP environment inheritance

### DIFF
--- a/extensions/cli/src/services/MCPService.test.ts
+++ b/extensions/cli/src/services/MCPService.test.ts
@@ -57,6 +57,7 @@ describe("MCPService", () => {
 
   afterEach(async () => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
     await mcpService.cleanup();
   });
 
@@ -216,6 +217,39 @@ describe("MCPService", () => {
       await expect(
         mcpService.initialize(defaultAssistant),
       ).resolves.not.toThrow();
+    });
+
+    it("should not forward ambient environment variables to stdio servers", async () => {
+      vi.stubEnv("CONTINUE_MCP_TEST_SECRET", "must-not-be-inherited");
+      const { StdioClientTransport } = await import(
+        "@modelcontextprotocol/sdk/client/stdio.js"
+      );
+      const stdioAssistant: AssistantConfig = {
+        name: "stdio-assistant",
+        version: "1.0.0",
+        mcpServers: [
+          {
+            name: "stdio-server",
+            command: "node",
+            env: { EXPLICIT_MCP_VALUE: "allowed" },
+          },
+        ],
+      } as AssistantConfig;
+
+      await mcpService.initialize(stdioAssistant);
+
+      expect(StdioClientTransport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          env: { EXPLICIT_MCP_VALUE: "allowed" },
+        }),
+      );
+      expect(StdioClientTransport).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          env: expect.objectContaining({
+            CONTINUE_MCP_TEST_SECRET: "must-not-be-inherited",
+          }),
+        }),
+      );
     });
 
     it("should create HttpsAgent when verifySsl is false for SSE transport", async () => {

--- a/extensions/cli/src/services/mcpTransports.ts
+++ b/extensions/cli/src/services/mcpTransports.ts
@@ -74,19 +74,14 @@ export function constructStdioTransport(
   serverConfig: StdioMcpServer,
   connection: MCPConnectionInfo,
 ): StdioClientTransport {
-  const env: Record<string, string> = serverConfig.env || {};
-  if (process.env) {
-    for (const [key, value] of Object.entries(process.env)) {
-      if (!(key in env) && !!value) {
-        env[key] = value;
-      }
-    }
-  }
-
   const transport = new StdioClientTransport({
     command: serverConfig.command,
     args: serverConfig.args || [],
-    env,
+    // The MCP SDK adds its platform-safe default environment (for example
+    // PATH and HOME). Only add variables the user explicitly configured;
+    // forwarding process.env would expose unrelated credentials to every
+    // stdio MCP server.
+    env: serverConfig.env,
     cwd: serverConfig.cwd,
     stderr: "pipe",
   });


### PR DESCRIPTION
## Description

Stdio MCP servers currently receive every variable from `process.env`, including unrelated cloud credentials, database secrets, and API tokens. This change stops copying the ambient environment into each server configuration and lets the MCP SDK apply its platform-safe default environment, while preserving variables explicitly configured for that server.

This also avoids mutating `serverConfig.env` while constructing the transport.

Fixes #13010.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

This contribution was prepared with AI assistance under the contributor's authorization and review.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Not applicable; this changes the stdio MCP subprocess environment and has no UI surface.

## Tests

- Added a regression test that places a sentinel secret in `process.env`, initializes an stdio MCP server with one explicit variable, and verifies only the explicit variable is passed to `StdioClientTransport`.
- `npm test -- --run src/services/MCPService.test.ts` — 21 passed
- targeted Prettier and ESLint checks passed
- CLI bundle build passed
- `git diff --check` passed

The standalone CLI `tsc --noEmit` command still reports existing NodeNext import-extension errors in `core/` files outside this diff; the production esbuild bundle completes successfully.
