### PR TITLE
fix(core): send Gemini API key as header, not URL query param

### DIFF
--- a/core/llm/fetchModels.ts
+++ b/core/llm/fetchModels.ts
@@ -179,8 +179,14 @@ async function fetchGeminiModels(
 ): Promise<FetchedModel[]> {
   const base = apiBase || "https://generativelanguage.googleapis.com/v1beta/";
   const url = new URL("models", base);
-  url.searchParams.set("key", apiKey ?? "");
-  const response = await fetch(url);
+  // Send the key as a header, never a query param — URLs leak into server
+  // logs, proxies, and referer headers. Same auth method the Gemini adapter
+  // uses (x-goog-api-key).
+  const response = await fetch(url, {
+    headers: {
+      "x-goog-api-key": apiKey ?? "",
+    },
+  });
   if (!response.ok) {
     throw new Error(`Failed to fetch Gemini models: ${response.status}`);
   }

--- a/core/llm/fetchModels.vitest.ts
+++ b/core/llm/fetchModels.vitest.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fetchModels } from "./fetchModels";
+
+describe("fetchModels gemini", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function stubGeminiListResponse() {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        models: [
+          {
+            name: "models/gemini-2.5-pro",
+            displayName: "Gemini 2.5 Pro",
+            inputTokenLimit: 1048576,
+            outputTokenLimit: 65536,
+            supportedGenerationMethods: ["generateContent"],
+          },
+        ],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  it("sends the API key as an x-goog-api-key header, never in the URL", async () => {
+    const fetchMock = stubGeminiListResponse();
+
+    const models = await fetchModels("gemini", "test-api-key");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    const parsed = new URL(url.toString());
+    expect(parsed.searchParams.get("key")).toBeNull();
+    expect(parsed.search).toBe("");
+    expect(init.headers["x-goog-api-key"]).toBe("test-api-key");
+    expect(parsed.toString()).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/models",
+    );
+
+    expect(models).toEqual([
+      {
+        name: "Gemini 2.5 Pro",
+        modelId: "gemini-2.5-pro",
+        icon: "gemini.png",
+        contextLength: 1048576,
+        maxTokens: 65536,
+        supportsTools: true,
+      },
+    ]);
+  });
+
+  it("sends an empty x-goog-api-key header when no key is configured", async () => {
+    const fetchMock = stubGeminiListResponse();
+
+    await fetchModels("gemini", undefined);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(new URL(url.toString()).search).toBe("");
+    expect(init.headers["x-goog-api-key"]).toBe("");
+  });
+
+  it("honors a custom apiBase without leaking the key", async () => {
+    const fetchMock = stubGeminiListResponse();
+
+    await fetchModels(
+      "gemini",
+      "test-api-key",
+      "https://gateway.example.com/v1beta/",
+    );
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url.toString()).toBe("https://gateway.example.com/v1beta/models");
+  });
+});


### PR DESCRIPTION
## Description

Part 2 of 4 of #13052 (tracking issue with full root-cause analysis and the PR split plan).

`fetchModels` listed Gemini models by putting the API key in a `?key=` query parameter. Keys in URLs leak through server logs, proxies, and referer headers. This sends the key as the `x-goog-api-key` header instead, matching how the rest of the Gemini integration authenticates.

Same fix as #12190 (credit to its author) — glad to coordinate; this version adds tests.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created — no user-facing docs describe this internal call; the Gemini docs PR (part 4 of #13052) covers user-facing config
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A — internal HTTP call change in `core/llm/fetchModels.ts` (no UI).

## Tests

New `core/llm/fetchModels.vitest.ts` (3 tests): asserts the key is sent via `x-goog-api-key`, asserts the key never appears in the request URL, and covers the undefined-key case. Verified manually against the live Google API (real key, outside CI): model listing returns real models with the key absent from the URL.
