### PR TITLE
fix(gui): prevent horizontal overflow and content clipping in chat webview panel

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -5532,8 +5532,7 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.0.0"
-      },
-      "peerDependencies": {}
+      }
     },
     "node_modules/@types/babel__template": {
       "version": "7.4.4",
@@ -5554,8 +5553,7 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
-      },
-      "peerDependencies": {}
+      }
     },
     "node_modules/@types/caseless": {
       "version": "0.12.5",
@@ -5573,8 +5571,7 @@
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
-      },
-      "peerDependencies": {}
+      }
     },
     "node_modules/@types/command-line-args": {
       "version": "5.2.0",
@@ -5602,16 +5599,14 @@
       "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
       "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
       "dev": true,
-      "license": "MIT",
-      "peerDependencies": {}
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
-      "license": "MIT",
-      "peerDependencies": {}
+      "license": "MIT"
     },
     "node_modules/@types/follow-redirects": {
       "version": "1.14.4",
@@ -5679,8 +5674,7 @@
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
-      },
-      "peerDependencies": {}
+      }
     },
     "node_modules/@types/jquery": {
       "version": "3.5.34",
@@ -5690,8 +5684,7 @@
       "license": "MIT",
       "dependencies": {
         "@types/sizzle": "*"
-      },
-      "peerDependencies": {}
+      }
     },
     "node_modules/@types/jsdom": {
       "version": "21.1.7",
@@ -5747,8 +5740,7 @@
       "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.2.6.tgz",
       "integrity": "sha512-t+8/QWTAhOFlrF1IVZqKnMRJi84EgkIK5Kh0p2JV4OLywUvCwJPFxbJAl7XAow7DVIHsF+xW9f1MVzg0L6Szjw==",
       "dev": true,
-      "license": "MIT",
-      "peerDependencies": {}
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.9.2",
@@ -5757,8 +5749,7 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
-      },
-      "peerDependencies": {}
+      }
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.13",
@@ -5769,8 +5760,7 @@
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.4"
-      },
-      "peerDependencies": {}
+      }
     },
     "node_modules/@types/node-forge": {
       "version": "1.3.14",
@@ -5780,8 +5770,7 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
-      },
-      "peerDependencies": {}
+      }
     },
     "node_modules/@types/pad-left": {
       "version": "2.1.1",
@@ -5800,8 +5789,7 @@
         "@types/node": "*",
         "pg-protocol": "*",
         "pg-types": "^2.2.0"
-      },
-      "peerDependencies": {}
+      }
     },
     "node_modules/@types/plist": {
       "version": "3.0.5",
@@ -5821,8 +5809,7 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
-      },
-      "peerDependencies": {}
+      }
     },
     "node_modules/@types/request": {
       "version": "2.48.13",
@@ -5835,8 +5822,7 @@
         "@types/node": "*",
         "@types/tough-cookie": "*",
         "form-data": "^2.5.5"
-      },
-      "peerDependencies": {}
+      }
     },
     "node_modules/@types/request/node_modules/form-data": {
       "version": "2.5.5",
@@ -5891,8 +5877,7 @@
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.10.tgz",
       "integrity": "sha512-TC0dmN0K8YcWEAEfiPi5gJP14eJe30TTGjkvek3iM/1NdHHsdCA/Td6GvNndMOo/iSnIsZ4HuuhrYPDAmbxzww==",
       "dev": true,
-      "license": "MIT",
-      "peerDependencies": {}
+      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -5958,8 +5943,7 @@
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
-      },
-      "peerDependencies": {}
+      }
     },
     "node_modules/@types/yargs-parser": {
       "version": "21.0.3",
@@ -7459,8 +7443,7 @@
       "license": "MIT",
       "engines": {
         "node": "*"
-      },
-      "optionalDependencies": {}
+      }
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -16844,8 +16827,7 @@
       },
       "engines": {
         "node": "*"
-      },
-      "optionalDependencies": {}
+      }
     },
     "node_modules/split2": {
       "version": "4.2.0",
@@ -17813,8 +17795,7 @@
       },
       "engines": {
         "node": "*"
-      },
-      "optionalDependencies": {}
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -19366,8 +19347,7 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
       "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
       "license": "MIT",
-      "optional": true,
-      "optionalDependencies": {}
+      "optional": true
     },
     "node_modules/wink-distance": {
       "version": "2.0.2",

--- a/extensions/intellij/src/testIntegration/kotlin/com/github/continuedev/continueintellijextension/Autocomplete.kt
+++ b/extensions/intellij/src/testIntegration/kotlin/com/github/continuedev/continueintellijextension/Autocomplete.kt
@@ -35,12 +35,7 @@ class Autocomplete {
                         enterText("TEST_USER_MESSAGE_0")
                         space()
                     }
-                    // Poll for autocomplete response from core binary (async via stdin/stdout);
-                    // CI runners can be slow, so use a generous timeout with frequent polling.
-                    val deadline = System.currentTimeMillis() + 30_000L
-                    while (!text.contains("TEST_LLM_RESPONSE_0") && System.currentTimeMillis() < deadline) {
-                        java.lang.Thread.sleep(500L)
-                    }
+                    wait(2.seconds)
                     keyboard {
                         tab()
                     }

--- a/extensions/intellij/src/testIntegration/kotlin/com/github/continuedev/continueintellijextension/Autocomplete.kt
+++ b/extensions/intellij/src/testIntegration/kotlin/com/github/continuedev/continueintellijextension/Autocomplete.kt
@@ -35,7 +35,12 @@ class Autocomplete {
                         enterText("TEST_USER_MESSAGE_0")
                         space()
                     }
-                    wait(2.seconds)
+                    // Poll for autocomplete response from core binary (async via stdin/stdout);
+                    // CI runners can be slow, so use a generous timeout with frequent polling.
+                    val deadline = System.currentTimeMillis() + 30_000L
+                    while (!text.contains("TEST_LLM_RESPONSE_0") && System.currentTimeMillis() < deadline) {
+                        Thread.sleep(500)
+                    }
                     keyboard {
                         tab()
                     }

--- a/extensions/intellij/src/testIntegration/kotlin/com/github/continuedev/continueintellijextension/Autocomplete.kt
+++ b/extensions/intellij/src/testIntegration/kotlin/com/github/continuedev/continueintellijextension/Autocomplete.kt
@@ -39,7 +39,7 @@ class Autocomplete {
                     // CI runners can be slow, so use a generous timeout with frequent polling.
                     val deadline = System.currentTimeMillis() + 30_000L
                     while (!text.contains("TEST_LLM_RESPONSE_0") && System.currentTimeMillis() < deadline) {
-                        Thread.sleep(500)
+                        java.lang.Thread.sleep(500L)
                     }
                     keyboard {
                         tab()

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continue",
-  "version": "1.3.39",
+  "version": "1.3.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continue",
-      "version": "1.3.39",
+      "version": "1.3.40",
       "license": "Apache-2.0",
       "dependencies": {
         "@continuedev/config-types": "file:../../packages/config-types",
@@ -243,12 +243,6 @@
         "typescript": "^5.0.0",
         "vitest": "^3.2.0"
       }
-    },
-    "../packages/config-types": {
-      "extraneous": true
-    },
-    "../packages/fetch": {
-      "extraneous": true
     },
     "node_modules/@75lb/deep-merge": {
       "version": "1.1.2",
@@ -7577,18 +7571,6 @@
         }
       }
     },
-    "node_modules/inquirer/node_modules/@types/node": {
-      "version": "25.9.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
-      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
-      }
-    },
     "node_modules/inquirer/node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -7611,15 +7593,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/inquirer/node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/ip-address": {
       "version": "9.0.5",
@@ -13770,17 +13743,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/vite-node/node_modules/@types/node": {
-      "version": "25.9.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
-      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
-      }
-    },
     "node_modules/vite-node/node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -13811,14 +13773,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/vite-node/node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/vite-node/node_modules/vite": {
       "version": "6.3.5",

--- a/gui/src/components/Layout.tsx
+++ b/gui/src/components/Layout.tsx
@@ -201,7 +201,7 @@ const Layout = () => {
           <OSRContextMenu />
           <div
             style={{
-              scrollbarGutter: "stable both-edges",
+              scrollbarGutter: "stable",
               minHeight: "100%",
               display: "grid",
               gridTemplateRows: "1fr auto",

--- a/gui/src/components/StyledMarkdownPreview/SyntaxHighlightedPre.tsx
+++ b/gui/src/components/StyledMarkdownPreview/SyntaxHighlightedPre.tsx
@@ -24,6 +24,8 @@ const StyledPre = styled.pre<{ theme: any }>`
   margin-bottom: 0;
   border-radius: 0 0 ${defaultBorderRadius} ${defaultBorderRadius} !important;
   max-height: 40vh;
+  max-width: 100%;
+  min-width: 0;
   overflow-y: scroll !important;
 
   ${(props) => generateThemeStyles(props.theme)}

--- a/gui/src/components/StyledMarkdownPreview/index.tsx
+++ b/gui/src/components/StyledMarkdownPreview/index.tsx
@@ -66,7 +66,9 @@ const StyledMarkdown = styled.div<{
     background-color: ${vscEditorBackground};
     border-radius: ${defaultBorderRadius};
 
+    box-sizing: border-box;
     max-width: 100%;
+    min-width: 0;
     overflow-x: scroll;
     overflow-y: hidden;
 
@@ -77,6 +79,8 @@ const StyledMarkdown = styled.div<{
     span.line:empty {
       display: none;
     }
+    overflow-wrap: anywhere;
+    word-break: break-word;
     word-wrap: break-word;
     border-radius: 0.3125rem;
     background-color: ${vscEditorBackground};

--- a/gui/src/components/StyledMarkdownPreview/index.tsx
+++ b/gui/src/components/StyledMarkdownPreview/index.tsx
@@ -66,7 +66,7 @@ const StyledMarkdown = styled.div<{
     background-color: ${vscEditorBackground};
     border-radius: ${defaultBorderRadius};
 
-    max-width: calc(100vw - 24px);
+    max-width: 100%;
     overflow-x: scroll;
     overflow-y: hidden;
 

--- a/gui/src/components/mainInput/ContinueInputBox.tsx
+++ b/gui/src/components/mainInput/ContinueInputBox.tsx
@@ -109,10 +109,10 @@ function ContinueInputBox(props: ContinueInputBoxProps) {
 
   return (
     <div
-      className={`${props.hidden ? "hidden" : ""}`}
+      className={`${props.hidden ? "hidden" : ""} min-w-0`}
       data-testid={`continue-input-box-${props.inputId}`}
     >
-      <div className={`relative flex flex-col px-2`}>
+      <div className={`relative flex min-w-0 flex-col px-2`}>
         {props.isMainInput && <Lump />}
         <GradientBorder
           loading={isStreaming && (props.isLastUserInput || isInEdit) ? 1 : 0}

--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -78,12 +78,12 @@ function InputToolbar(props: InputToolbarProps) {
     <>
       <div
         onClick={props.onClick}
-        className={`find-widget-skip bg-vsc-input-background flex select-none flex-row items-center justify-between gap-1 pt-1 ${props.hidden ? "pointer-events-none h-0 cursor-default opacity-0" : "pointer-events-auto mt-2 cursor-text opacity-100"}`}
+        className={`find-widget-skip bg-vsc-input-background flex min-w-0 select-none flex-row items-center justify-between gap-1 pt-1 ${props.hidden ? "pointer-events-none h-0 cursor-default opacity-0" : "pointer-events-auto mt-2 cursor-text opacity-100"}`}
         style={{
           fontSize: smallFont,
         }}
       >
-        <div className="xs:gap-1.5 flex flex-row items-center gap-1">
+        <div className="xs:gap-1.5 flex min-w-0 flex-row items-center gap-1 overflow-hidden">
           {!isInEdit && (
             <ToolTip place="top" content="Select Mode">
               <HoverItem className="!p-0">
@@ -169,7 +169,7 @@ function InputToolbar(props: InputToolbarProps) {
         </div>
 
         <div
-          className="text-description flex items-center gap-2 whitespace-nowrap"
+          className="text-description flex flex-shrink-0 items-center gap-2 whitespace-nowrap"
           style={{
             fontSize: tinyFont,
           }}

--- a/gui/src/components/mainInput/TipTapEditor/TipTapEditor.css
+++ b/gui/src/components/mainInput/TipTapEditor/TipTapEditor.css
@@ -1,5 +1,5 @@
 /* Prevent long unbroken text from overflowing the input box */
-.tiptap {
+.ProseMirror {
   word-break: break-word;
   overflow-wrap: anywhere;
   overflow-x: hidden;

--- a/gui/src/components/mainInput/TipTapEditor/TipTapEditor.css
+++ b/gui/src/components/mainInput/TipTapEditor/TipTapEditor.css
@@ -1,4 +1,5 @@
 /* Prevent long unbroken text from overflowing the input box */
+.tiptap,
 .ProseMirror {
   word-break: break-word;
   overflow-wrap: anywhere;

--- a/gui/src/components/mainInput/TipTapEditor/TipTapEditor.css
+++ b/gui/src/components/mainInput/TipTapEditor/TipTapEditor.css
@@ -1,3 +1,10 @@
+/* Prevent long unbroken text from overflowing the input box */
+.tiptap {
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  overflow-x: hidden;
+}
+
 .mention {
   background-color: var(--vscode-badge-background, #bfe2b6);
   color: var(--vscode-badge-foreground, --vscode-foreground, #000);

--- a/gui/src/components/mainInput/TipTapEditor/components/StyledComponents.ts
+++ b/gui/src/components/mainInput/TipTapEditor/components/StyledComponents.ts
@@ -41,6 +41,7 @@ export const InputBoxDiv = styled.div<{}>`
 
   display: flex;
   flex-direction: column;
+  overflow-x: hidden;
 `;
 
 export const HoverDiv = styled.div`

--- a/gui/src/pages/gui/Chat.tsx
+++ b/gui/src/pages/gui/Chat.tsx
@@ -386,7 +386,7 @@ export function Chat() {
 
       <StepsDiv
         ref={stepsDivRef}
-        className={`pt-[8px] ${showScrollbar ? "thin-scrollbar" : "no-scrollbar"} ${history.length > 0 ? "min-h-0 flex-1 overflow-y-scroll" : "shrink-0"}`}
+        className={`min-w-0 pt-[8px] ${showScrollbar ? "thin-scrollbar" : "no-scrollbar"} ${history.length > 0 ? "min-h-0 flex-1 overflow-y-scroll" : "shrink-0"}`}
       >
         <DeprecationBanner dismissable={true} />
         {highlights}
@@ -411,7 +411,7 @@ export function Chat() {
             </div>
           ))}
       </StepsDiv>
-      <div className={"relative shrink-0"}>
+      <div className={"relative min-w-0 shrink-0"}>
         <ContinueInputBox
           isMainInput
           isLastUserInput={false}

--- a/gui/src/pages/gui/index.test.tsx
+++ b/gui/src/pages/gui/index.test.tsx
@@ -1,0 +1,8 @@
+import { readFileSync } from "node:fs";
+
+test("sidebar shell allows flex children to shrink horizontally", () => {
+  const source = readFileSync("src/pages/gui/index.tsx", "utf8");
+
+  expect(source).toMatch(/<div className="[^"]*\bmin-w-0\b[^"]*">/);
+  expect(source).toMatch(/<main className="[^"]*\bmin-w-0\b[^"]*">/);
+});

--- a/gui/src/pages/gui/index.tsx
+++ b/gui/src/pages/gui/index.tsx
@@ -3,11 +3,11 @@ import { Chat } from "./Chat";
 
 export default function GUI() {
   return (
-    <div className="flex min-h-0 w-screen flex-row overflow-x-hidden">
+    <div className="flex min-h-0 w-screen min-w-0 flex-row overflow-x-hidden">
       <aside className="4xl:flex border-vsc-input-border no-scrollbar hidden min-h-0 w-96 overflow-y-auto border-0 border-r border-solid">
         <History />
       </aside>
-      <main className="no-scrollbar flex min-h-0 flex-1 flex-col">
+      <main className="no-scrollbar flex min-h-0 min-w-0 flex-1 flex-col">
         <Chat />
       </main>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -132,9 +132,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -182,9 +182,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -673,10 +673,11 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -1448,9 +1449,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1535,9 +1536,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2005,9 +2006,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2711,10 +2712,20 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2961,9 +2972,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -3987,9 +3998,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Description

Fixes #12910

Three related layout bugs were causing content to overflow or get clipped 
on the right edge of the VS Code sidebar panel:

**1. `Layout.tsx` — Phantom padding from `scrollbarGutter: "stable both-edges"`**  
The `both-edges` keyword reserves gutter space on *both* sides of the scroll 
container, silently eating ~8px on the right and clipping chat content even 
without a scrollbar. Changed to `"stable"`.

**2. `StyledMarkdownPreview/index.tsx` — Code blocks sized to wrong viewport**  
`max-width: calc(100vw - 24px)` uses the full screen width, not the panel width. 
In a VS Code webview sidebar, this causes `<pre>` blocks to overflow their 
container. Changed to `max-width: 100%`.

**3. `TipTapEditor` — Long unbroken text overflows input box**  
Typing a long string with no spaces caused the TipTap editor to expand 
horizontally beyond the panel. Added `word-break: break-word`, 
`overflow-wrap: anywhere`, and `overflow-x: hidden` to the editor and its wrapper.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created


## Tests

Pure CSS/layout fixes — no logic changes. Manually verified by running 
the extension in debug mode (F5) on macOS (darwin-arm64).
