### PR TITLE
fix(cli): abort headless streams on SIGINT

### DIFF
--- a/extensions/cli/src/commands/chat.ts
+++ b/extensions/cli/src/commands/chat.ts
@@ -33,6 +33,7 @@ import {
   calculateContextUsagePercentage,
   countChatHistoryTokens,
 } from "../util/tokenizer.js";
+import { withSigintAbort } from "../util/withSigintAbort.js";
 
 import { ExtendedCommandOptions } from "./BaseCommandOptions.js";
 
@@ -169,28 +170,14 @@ async function getStreamingResponse(
   model: ModelConfig,
   llmApi: BaseLlmApi,
 ): Promise<string> {
-  const abortController = new AbortController();
+  return withSigintAbort(async (abortController) => {
+    const history =
+      compactionIndex !== null && compactionIndex !== undefined
+        ? services.chatHistory.getHistoryForLLM(compactionIndex)
+        : services.chatHistory.getHistory();
 
-  if (compactionIndex !== null && compactionIndex !== undefined) {
-    // Use service to compute history for LLM
-    const historyForLLM =
-      services.chatHistory.getHistoryForLLM(compactionIndex);
-
-    return await streamChatResponse(
-      historyForLLM,
-      model,
-      llmApi,
-      abortController,
-    );
-  } else {
-    // No compaction - get full history from service
-    return await streamChatResponse(
-      services.chatHistory.getHistory(),
-      model,
-      llmApi,
-      abortController,
-    );
-  }
+    return await streamChatResponse(history, model, llmApi, abortController);
+  });
 }
 
 // Helper function to process and output response in headless mode

--- a/extensions/cli/src/util/withSigintAbort.test.ts
+++ b/extensions/cli/src/util/withSigintAbort.test.ts
@@ -1,0 +1,51 @@
+import { vi } from "vitest";
+
+import { withSigintAbort } from "./withSigintAbort.js";
+
+describe("withSigintAbort", () => {
+  it("aborts the active operation on SIGINT and prevents its late effect", async () => {
+    const listenersBefore = process.listeners("SIGINT");
+    const lateEffect = vi.fn();
+    let finishOperation: (() => void) | undefined;
+    let operationSignal: AbortSignal | undefined;
+
+    const operation = withSigintAbort(async (abortController) => {
+      operationSignal = abortController.signal;
+      await new Promise<void>((resolve) => {
+        finishOperation = resolve;
+      });
+
+      if (!abortController.signal.aborted) {
+        lateEffect();
+      }
+
+      return "finished";
+    });
+
+    const addedListeners = process
+      .listeners("SIGINT")
+      .filter((listener) => !listenersBefore.includes(listener));
+
+    expect(addedListeners).toHaveLength(1);
+    addedListeners[0]("SIGINT");
+    finishOperation?.();
+
+    await expect(operation).resolves.toBe("finished");
+    expect(operationSignal?.aborted).toBe(true);
+    expect(lateEffect).not.toHaveBeenCalled();
+    expect(process.listeners("SIGINT")).toEqual(listenersBefore);
+  });
+
+  it("removes its SIGINT listener when the operation rejects", async () => {
+    const listenersBefore = process.listeners("SIGINT");
+    const expectedError = new Error("stream failed");
+
+    await expect(
+      withSigintAbort(async () => {
+        throw expectedError;
+      }),
+    ).rejects.toBe(expectedError);
+
+    expect(process.listeners("SIGINT")).toEqual(listenersBefore);
+  });
+});

--- a/extensions/cli/src/util/withSigintAbort.ts
+++ b/extensions/cli/src/util/withSigintAbort.ts
@@ -1,0 +1,14 @@
+export async function withSigintAbort<T>(
+  operation: (abortController: AbortController) => Promise<T>,
+): Promise<T> {
+  const abortController = new AbortController();
+  const abortOnSigint = () => abortController.abort();
+
+  process.once("SIGINT", abortOnSigint);
+
+  try {
+    return await operation(abortController);
+  } finally {
+    process.off("SIGINT", abortOnSigint);
+  }
+}


### PR DESCRIPTION
## Description

Fixes the headless CLI cancellation gap reported in #12701.

The active provider stream now receives an abort signal synchronously when the process receives `SIGINT`. This prevents delayed provider chunks from reaching tool-call handling while the process-level shutdown handler is still awaiting cleanup. The temporary signal listener is removed after both successful and failed requests.

The TUI signal path is unchanged.

Closes #12701.

AI assistance disclosure: I used an AI coding assistant to help trace the cancellation flow and prepare the patch. I reviewed the changes and ran the validation below.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Not applicable; this fixes headless process cancellation behavior.

## Tests

- `npm test -- --run src/util/withSigintAbort.test.ts src/stream/streamChatResponse.test.ts` — 10 passed, 6 skipped
- Full CLI suite — 1,673 passed, 49 skipped; one unrelated TUI timing assertion failed once and then passed 27/27 on an isolated rerun
- `npm run build`
- ESLint and Prettier checks on all changed files
- `git diff --check`
