### PR TITLE
feat: add Abliteration.ai as an LLM provider

### DIFF
--- a/core/llm/autodetect.ts
+++ b/core/llm/autodetect.ts
@@ -74,6 +74,7 @@ const PROVIDER_HANDLES_TEMPLATING: string[] = [
   "nous",
   "zAI",
   "tensorix",
+  "abliteration",
   // TODO add these, change to inverted logic so only the ones that need templating are hardcoded
   // Asksage.ts
   // Azure.ts
@@ -133,6 +134,7 @@ const PROVIDER_SUPPORTS_IMAGES: string[] = [
   "watsonx",
   "zAI",
   "tensorix",
+  "abliteration",
 ];
 
 const MODEL_SUPPORTS_IMAGES: RegExp[] = [
@@ -253,6 +255,7 @@ const PARALLEL_PROVIDERS: string[] = [
   "scaleway",
   "minimax",
   "tensorix",
+  "abliteration",
 ];
 
 function llmCanGenerateInParallel(provider: string, model: string): boolean {

--- a/core/llm/llms/Abliteration.ts
+++ b/core/llm/llms/Abliteration.ts
@@ -1,0 +1,14 @@
+import OpenAI from "./OpenAI.js";
+
+import type { LLMOptions } from "../../index.js";
+
+class Abliteration extends OpenAI {
+  static providerName = "abliteration";
+  static defaultOptions: Partial<LLMOptions> = {
+    apiBase: "https://api.abliteration.ai/v1/",
+    model: "abliterated-model",
+    useLegacyCompletionsEndpoint: false,
+  };
+}
+
+export default Abliteration;

--- a/core/llm/llms/index.ts
+++ b/core/llm/llms/index.ts
@@ -9,6 +9,7 @@ import {
 } from "../..";
 import { renderTemplatedString } from "../../util/handlebars/renderTemplatedString";
 import { BaseLLM } from "../index";
+import Abliteration from "./Abliteration";
 import Anthropic from "./Anthropic";
 import Asksage from "./Asksage";
 import Azure from "./Azure";
@@ -71,6 +72,7 @@ import WatsonX from "./WatsonX";
 import xAI from "./xAI";
 import zAI from "./zAI";
 export const LLMClasses = [
+  Abliteration,
   Anthropic,
   Cohere,
   CometAPI,

--- a/docs/customize/model-providers/more/abliteration.mdx
+++ b/docs/customize/model-providers/more/abliteration.mdx
@@ -1,0 +1,93 @@
+---
+title: "Abliteration.ai"
+description: "Configure Abliteration.ai with Continue to access less-restrictive, uncensored models through an OpenAI-compatible API"
+---
+
+[Abliteration.ai](https://abliteration.ai) is an inference API for unrestricted, uncensored models behind an OpenAI-compatible API. Drop in by changing the base URL — same code, fewer refusals, with an optional policy gateway for governance.
+
+<Info>
+  You can get an API key from the
+  [Abliteration.ai console](https://abliteration.ai).
+</Info>
+
+## Chat Model
+
+We recommend configuring **abliterated-model** as your chat model.
+
+<Tabs>
+    <Tab title="YAML">
+    ```yaml title="config.yaml"
+    name: My Config
+    version: 0.0.1
+    schema: v1
+
+    models:
+      - name: Abliterated Model
+        provider: abliteration
+        model: abliterated-model
+        apiKey: <YOUR_ABLITERATION_API_KEY>
+        roles:
+          - chat
+    ```
+    </Tab>
+    <Tab title="JSON">
+    ```json title="config.json"
+    {
+      "models": [
+        {
+          "title": "Abliterated Model",
+          "provider": "abliteration",
+          "model": "abliterated-model",
+          "apiKey": "<YOUR_ABLITERATION_API_KEY>"
+        }
+      ]
+    }
+    ```
+    </Tab>
+</Tabs>
+
+## Autocomplete Model
+
+<Tabs>
+    <Tab title="YAML">
+    ```yaml title="config.yaml"
+    name: My Config
+    version: 0.0.1
+    schema: v1
+
+    models:
+      - name: Abliterated Model
+        provider: abliteration
+        model: abliterated-model
+        apiKey: <YOUR_ABLITERATION_API_KEY>
+        roles:
+          - autocomplete
+    ```
+    </Tab>
+    <Tab title="JSON">
+    ```json title="config.json"
+    {
+      "models": [
+        {
+          "title": "Abliterated Model",
+          "provider": "abliteration",
+          "model": "abliterated-model",
+          "apiKey": "<YOUR_ABLITERATION_API_KEY>"
+        }
+      ],
+      "tabAutocompleteModel": {
+        "title": "Abliterated Model",
+        "provider": "abliteration",
+        "model": "abliterated-model",
+        "apiKey": "<YOUR_ABLITERATION_API_KEY>"
+      }
+    }
+    ```
+    </Tab>
+</Tabs>
+
+## Available Models
+
+Abliteration.ai currently hosts two models: **abliterated-model** (general-purpose default, multimodal, 256K context) and **abliterated-model-large** (text-only, 1M context, for harder reasoning workloads). The live list is returned by `GET https://api.abliteration.ai/v1/models`. See the [Abliteration.ai docs](https://docs.abliteration.ai) for details.
+
+[View the source](https://github.com/continuedev/continue/blob/main/core/llm/llms/Abliteration.ts)

--- a/docs/customize/model-providers/overview.mdx
+++ b/docs/customize/model-providers/overview.mdx
@@ -40,6 +40,7 @@ Beyond the top-level providers, Continue supports many other options:
 | [NVIDIA](/customize/model-providers/more/nvidia)                       | GPU-accelerated model hosting                              |
 | [Cloudflare](/customize/model-providers/more/cloudflare)               | Edge-based AI inference services                           |
 | [MiniMax](/customize/model-providers/more/minimax)                     | High-performance models with 200K+ context window          |
+| [Abliteration.ai](/customize/model-providers/more/abliteration)        | Inference API for unrestricted, uncensored models          |
 
 ### Local Model Options
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -106,6 +106,7 @@
                     "group": "More Providers",
                     "pages": [
                       "customize/model-providers/more/asksage",
+                      "customize/model-providers/more/abliteration",
                       "customize/model-providers/more/clawrouter",
                       "customize/model-providers/more/deepseek",
                       "customize/model-providers/more/deepinfra",

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -229,6 +229,7 @@
             "moonshot",
             "siliconflow",
             "tensorix",
+            "abliteration",
             "function-network",
             "scaleway",
             "relace",
@@ -282,6 +283,7 @@
             "### Moonshot\nTo get started with Moonshot AI, obtain your API key from [Moonshot AI](https://platform.moonshot.cn/). Moonshot AI provides high-quality large language models with competitive pricing.\n> [Reference](https://platform.moonshot.cn/docs/api)",
             "### SiliconFlow\nTo get started with SiliconFlow, obtain your API key from [SiliconCloud](https://cloud.siliconflow.cn/account/ak). SiliconCloud provides cost-effective GenAI services based on excellent open source basic models.\n> [Models](https://siliconflow.cn/zh-cn/models)",
             "### Tensorix\nTensorix is an OpenAI-compatible API gateway with access to DeepSeek, Llama, Qwen, GLM, and other models. Pay-as-you-go with no subscription required.\nTo get started, create an account and get an API key at [app.tensorix.ai](https://app.tensorix.ai).\n> [Models](https://tensorix.ai/models)",
+            "### Abliteration.ai\nAbliteration.ai is an inference API for unrestricted, uncensored models behind an OpenAI-compatible API. To get started, create an account and get an API key at [abliteration.ai](https://abliteration.ai).\n> [Docs](https://docs.abliteration.ai)",
             "### Function Network offers private, affordable user-owned AI\nTo get started with Function Network, obtain your API key from [Function Network](https://www.function.network/join-waitlist). Function Network provides a variety of models for chat, completion, and embeddings.",
             "### Scaleway\n Generative APIs are serverless endpoints for the most popular AI models.\nHosted in European data centers and priced competitively per million tokens used, models served by Scaleway are ideal for users requiring low latency, full data privacy, and 100% compliance with EU AI Act. To get access to the Scaleway Generative APIs, read the [Quickstart guide](https://www.scaleway.com/en/docs/ai-data/generative-apis/quickstart/) and get a [valid API key](https://www.scaleway.com/en/docs/identity-and-access-management/iam/how-to/create-api-keys/).",
             "### Relace\n Relace provides a fast apply model. To get started, obtain an API key from [here](https://app.relace.ai/settings/api-keys).",
@@ -2871,6 +2873,7 @@
                 "lmstudio",
                 "siliconflow",
                 "tensorix",
+                "abliteration",
                 "function-network",
                 "scaleway",
                 "ovhcloud"
@@ -2937,7 +2940,8 @@
                       "nvidia",
                       "gemini",
                       "siliconflow",
-                      "tensorix"
+                      "tensorix",
+                      "abliteration"
                     ]
                   }
                 },
@@ -3006,7 +3010,8 @@
                 "llm",
                 "huggingface-tei",
                 "siliconflow",
-                "tensorix"
+                "tensorix",
+                "abliteration"
               ]
             },
             "params": {

--- a/gui/src/pages/AddNewModel/configs/providers.ts
+++ b/gui/src/pages/AddNewModel/configs/providers.ts
@@ -1270,6 +1270,26 @@ To get started, [register](https://dataplatform.cloud.ibm.com/registration/stepo
     packages: [{ ...models.AUTODETECT }],
     apiKeyUrl: "https://app.tensorix.ai",
   },
+  abliteration: {
+    title: "Abliteration.ai",
+    provider: "abliteration",
+    description:
+      "Abliteration.ai is an inference API for unrestricted, uncensored models behind an OpenAI-compatible API.",
+    longDescription:
+      "To get started with Abliteration.ai, create an account and get an API key at [abliteration.ai](https://abliteration.ai).",
+    tags: [ModelProviderTags.RequiresApiKey, ModelProviderTags.OpenSource],
+    collectInputFor: [
+      {
+        inputType: "text",
+        key: "apiKey",
+        label: "API Key",
+        placeholder: "Enter your Abliteration.ai API key",
+        required: true,
+      },
+    ],
+    packages: [{ ...models.AUTODETECT }],
+    apiKeyUrl: "https://abliteration.ai",
+  },
   venice: {
     title: "Venice",
     provider: "venice",

--- a/packages/config-types/src/index.ts
+++ b/packages/config-types/src/index.ts
@@ -61,6 +61,7 @@ export const modelDescriptionSchema = z.object({
     "scaleway",
     "watsonx",
     "minimax",
+    "abliteration",
   ]),
   model: z.string(),
   apiKey: z.string().optional(),

--- a/packages/openai-adapters/src/index.ts
+++ b/packages/openai-adapters/src/index.ts
@@ -176,6 +176,8 @@ export function constructLlmApi(config: LLMConfig): BaseLlmApi | undefined {
       return openAICompatible("https://api.function.network/v1/", config);
     case "tensorix":
       return openAICompatible("https://api.tensorix.ai/v1/", config);
+    case "abliteration":
+      return openAICompatible("https://api.abliteration.ai/v1/", config);
     case "openrouter":
       return new OpenRouterApi(config);
     case "clawrouter":

--- a/packages/openai-adapters/src/types.ts
+++ b/packages/openai-adapters/src/types.ts
@@ -60,6 +60,7 @@ export const OpenAIConfigSchema = BasePlusConfig.extend({
     z.literal("zAI"),
     z.literal("scaleway"),
     z.literal("tensorix"),
+    z.literal("abliteration"),
     z.literal("ncompass"),
     z.literal("relace"),
     z.literal("huggingface-inference-api"),


### PR DESCRIPTION
## Description

Adds [Abliteration.ai](https://abliteration.ai) as a first-class provider. Abliteration.ai is an inference API for less-restrictive, uncensored models behind an OpenAI-compatible API (`https://api.abliteration.ai/v1`), currently hosting `abliterated-model` (multimodal, 256K context) and `abliterated-model-large` (1M context).

Changes:
- New LLM class `core/llm/llms/Abliteration.ts` (extends `OpenAI`, sets `apiBase` and default model)
- Registered in `core/llm/llms/index.ts`, `packages/openai-adapters` (types + `constructLlmApi`), and `packages/config-types`
- Added to `PROVIDER_HANDLES_TEMPLATING`, `PROVIDER_SUPPORTS_IMAGES`, and `PARALLEL_PROVIDERS` in `core/llm/autodetect.ts`
- Added to the VS Code extension `config_schema.json`
- Added to the GUI provider selection with `AUTODETECT`
- New docs page `docs/customize/model-providers/more/abliteration.mdx` with YAML/JSON config examples, plus `docs.json` nav and overview table entries

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

N/A — configuration-only provider addition, mirroring the recent Tensorix provider PR (#11184).

## Tests

No new tests added (provider is a thin `OpenAI` subclass, same as Tensorix and other OpenAI-compatible providers). Verified locally:
- `npm run tsc:check` in `core` — clean
- `tsc` build in `packages/openai-adapters` and `packages/config-types` — clean
- `tsc --noEmit` in `gui` — clean
- `npx vitest run llm` in `core` — 465 tests passed
- `npx vitest run` in `packages/openai-adapters` — 145 tests passed
- `jest llm/llms/OpenAI.test.ts llm/toolSupport.test.ts` in `core` — 75 tests passed