### PR TITLE
fix(core): add pricing for current Claude models

### DIFF
--- a/core/llm/utils/calculateRequestCost.ts
+++ b/core/llm/utils/calculateRequestCost.ts
@@ -17,12 +17,68 @@ function calculateAnthropicCost(
     string,
     { input: number; output: number; cacheWrite: number; cacheRead: number }
   > = {
+    // Claude Fable 5
+    "claude-fable-5": {
+      input: 10,
+      output: 50,
+      cacheWrite: 12.5,
+      cacheRead: 1,
+    },
+
+    // Claude Opus 5
+    "claude-opus-5": {
+      input: 5,
+      output: 25,
+      cacheWrite: 6.25,
+      cacheRead: 0.5,
+    },
+
+    // Claude Opus 4.8
+    "claude-opus-4-8": {
+      input: 5,
+      output: 25,
+      cacheWrite: 6.25,
+      cacheRead: 0.5,
+    },
+
+    // Claude Opus 4.7
+    "claude-opus-4-7": {
+      input: 5,
+      output: 25,
+      cacheWrite: 6.25,
+      cacheRead: 0.5,
+    },
+
+    // Claude Sonnet 5
+    "claude-sonnet-5": {
+      input: 3,
+      output: 15,
+      cacheWrite: 3.75,
+      cacheRead: 0.3,
+    },
+
     // Claude Sonnet 4.6
     "claude-sonnet-4-6": {
       input: 3,
       output: 15,
       cacheWrite: 3.75,
       cacheRead: 0.3,
+    },
+
+    // Claude Sonnet 4.5
+    "claude-sonnet-4-5": {
+      input: 3,
+      output: 15,
+      cacheWrite: 3.75,
+      cacheRead: 0.3,
+    },
+
+    // Claude Haiku 4.5
+    "claude-haiku-4-5": {
+      input: 1,
+      output: 5,
+      cacheWrite: 1.25,
+      cacheRead: 0.1,
     },
 
     // Claude Opus 4.6
@@ -41,7 +97,7 @@ function calculateAnthropicCost(
       cacheRead: 0.5,
     },
 
-    // Claude Opus 4 (legacy)
+    // Claude 3 Opus (legacy)
     "claude-3-opus": {
       input: 15,
       output: 75,
@@ -49,7 +105,7 @@ function calculateAnthropicCost(
       cacheRead: 1.5,
     },
 
-    // Claude Sonnet 4 (optimal balance)
+    // Claude 3.5 Sonnet (legacy)
     "claude-3-5-sonnet": {
       input: 3,
       output: 15,
@@ -57,7 +113,7 @@ function calculateAnthropicCost(
       cacheRead: 0.3,
     },
 
-    // Claude Haiku 3.5 (fastest, most cost-effective)
+    // Claude 3.5 Haiku (legacy)
     "claude-3-5-haiku": {
       input: 0.8,
       output: 4,

--- a/core/llm/utils/calculateRequestCost.vitest.ts
+++ b/core/llm/utils/calculateRequestCost.vitest.ts
@@ -199,6 +199,86 @@ describe("calculateRequestCost", () => {
       description: "Provider name case insensitive",
     },
 
+    // Anthropic Claude Opus 5
+    {
+      provider: "anthropic",
+      model: "claude-opus-5",
+      promptTokens: 1000,
+      completionTokens: 500,
+      expectedCost: 0.0175,
+      description: "Claude Opus 5 basic usage",
+    },
+    {
+      provider: "anthropic",
+      model: "claude-opus-5",
+      promptTokens: 1000,
+      completionTokens: 500,
+      cachedTokens: 2000,
+      cacheWriteTokens: 300,
+      expectedCost: 0.020375,
+      description: "Claude Opus 5 with cache reads and writes",
+    },
+
+    // Anthropic Claude Opus 4.8
+    {
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      promptTokens: 1000,
+      completionTokens: 500,
+      expectedCost: 0.0175,
+      description: "Claude Opus 4.8",
+    },
+
+    // Anthropic Claude Opus 4.7
+    {
+      provider: "anthropic",
+      model: "claude-opus-4-7",
+      promptTokens: 1000,
+      completionTokens: 500,
+      expectedCost: 0.0175,
+      description: "Claude Opus 4.7",
+    },
+
+    // Anthropic Claude Sonnet 5
+    {
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+      promptTokens: 1000,
+      completionTokens: 500,
+      expectedCost: 0.0105,
+      description: "Claude Sonnet 5",
+    },
+
+    // Anthropic Claude Sonnet 4.5
+    {
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      promptTokens: 1000,
+      completionTokens: 500,
+      expectedCost: 0.0105,
+      description: "Claude Sonnet 4.5",
+    },
+
+    // Anthropic Claude Haiku 4.5
+    {
+      provider: "anthropic",
+      model: "claude-haiku-4-5",
+      promptTokens: 1000,
+      completionTokens: 500,
+      expectedCost: 0.0035,
+      description: "Claude Haiku 4.5",
+    },
+
+    // Anthropic Claude Fable 5
+    {
+      provider: "anthropic",
+      model: "claude-fable-5",
+      promptTokens: 1000,
+      completionTokens: 500,
+      expectedCost: 0.035,
+      description: "Claude Fable 5",
+    },
+
     // Unknown models/providers
     {
       provider: "anthropic",


### PR DESCRIPTION
## Description

`calculateAnthropicCost` matches the model against a prefix table and returns `null` when
nothing matches, so any model missing from the table shows no cost at all in the Console's
usage panel and in the CLI's per-request summary.

The table stops at Opus 4.6 / Sonnet 4.6, so most of the Claude models people are actually
running today fall through it:

| Model | Before | After |
|---|---|---|
| `claude-opus-5` | no cost shown | $5 / $25 |
| `claude-opus-4-8` | no cost shown | $5 / $25 |
| `claude-opus-4-7` | no cost shown | $5 / $25 |
| `claude-sonnet-5` | no cost shown | $3 / $15 |
| `claude-sonnet-4-5` | no cost shown | $3 / $15 |
| `claude-haiku-4-5` | no cost shown | $1 / $5 |
| `claude-fable-5` | no cost shown | $10 / $50 |

Sonnet 4.5 and Haiku 4.5 are the ones I'd expect to bite people most — Opus 4.5 is in the
table but the two Claude 4.5 models next to it never were.

Cache-write and cache-read rates follow the same 1.25x / 0.1x relationship to input price
that every existing row uses.

Also relabelled three comments that named the wrong model (`claude-3-opus` was commented
"Claude Opus 4 (legacy)", `claude-3-5-sonnet` was "Claude Sonnet 4"). Comments only, no
behaviour change.

Prices are Anthropic's list prices. Sonnet 5 currently has promotional input/output pricing
running to 2026-08-31; I used the list price rather than the promo, since the table has no
way to express a time-boxed rate and the promo expires shortly.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Not applicable — no UI change. The affected surfaces (`TotalUsage.tsx`, `useLLMSummary`,
`useTotalUsage`, and the CLI's `streamChatResponse.helpers`) all just consume the return
value of `calculateRequestCost`, which was previously `null` for these models.

## Tests

Added 8 cases to `calculateRequestCost.vitest.ts` covering each newly-priced model, plus a
combined cache-read + cache-write case for Opus 5.

```
core/llm/utils/calculateRequestCost.vitest.ts   30 passed
```

With the test file kept and the change to `calculateRequestCost.ts` stashed, exactly the 8
new cases fail (`8 failed | 22 passed`), so they're pinning the fix rather than passing
either way.

The existing `claude-unknown-model` -> `null` case still passes; none of the added prefixes
match it.

---

Written with AI assistance (Claude Code); I reviewed the change and ran the tests above.
