### PR TITLE
fix(gui): prevent sidebar panel content clipping at narrow widths

### DIFF
--- a/gui/src/components/Layout.tsx
+++ b/gui/src/components/Layout.tsx
@@ -201,7 +201,7 @@ const Layout = () => {
           <OSRContextMenu />
           <div
             style={{
-              scrollbarGutter: "stable both-edges",
+              scrollbarGutter: "stable",
               minHeight: "100%",
               display: "grid",
               gridTemplateRows: "1fr auto",

--- a/gui/src/components/StyledMarkdownPreview/index.tsx
+++ b/gui/src/components/StyledMarkdownPreview/index.tsx
@@ -66,7 +66,7 @@ const StyledMarkdown = styled.div<{
     background-color: ${vscEditorBackground};
     border-radius: ${defaultBorderRadius};
 
-    max-width: calc(100vw - 24px);
+    max-width: 100%;
     overflow-x: scroll;
     overflow-y: hidden;
 

--- a/gui/src/pages/gui/index.test.tsx
+++ b/gui/src/pages/gui/index.test.tsx
@@ -1,0 +1,13 @@
+import { readFileSync } from "fs";
+import { describe, expect, it } from "vitest";
+
+describe("GUI sidebar shell layout", () => {
+  it("uses panel-relative width and allows flex children to shrink", () => {
+    const source = readFileSync("src/pages/gui/index.tsx", "utf8");
+
+    expect(source).toMatch(/className="[^"]*\bw-full\b[^"]*"/);
+    expect(source).not.toMatch(/className="[^"]*\bw-screen\b[^"]*"/);
+    expect(source).toMatch(/<div className="[^"]*\bmin-w-0\b[^"]*">/);
+    expect(source).toMatch(/<main className="[^"]*\bmin-w-0\b[^"]*">/);
+  });
+});

--- a/gui/src/pages/gui/index.tsx
+++ b/gui/src/pages/gui/index.tsx
@@ -3,11 +3,11 @@ import { Chat } from "./Chat";
 
 export default function GUI() {
   return (
-    <div className="flex min-h-0 w-screen flex-row overflow-x-hidden">
+    <div className="flex min-h-0 w-full min-w-0 flex-row overflow-x-hidden">
       <aside className="4xl:flex border-vsc-input-border no-scrollbar hidden min-h-0 w-96 overflow-y-auto border-0 border-r border-solid">
         <History />
       </aside>
-      <main className="no-scrollbar flex min-h-0 flex-1 flex-col">
+      <main className="no-scrollbar flex min-h-0 min-w-0 flex-1 flex-col">
         <Chat />
       </main>
     </div>


### PR DESCRIPTION
## Problem

Fixes #13055.

In VS Code and VSCodium, when the Continue side panel is narrow, chat and onboarding content is cropped on the right edge instead of adapting to the available width. A commenter confirmed via DevTools that stacked layout padding (`scrollbarGutter: stable both-edges` plus horizontal padding) contributes to the clipping.

## Triage / Root cause

Three layout rules sized content against the full viewport or reserved phantom gutter space instead of the sidebar webview panel:

1. `gui/src/pages/gui/index.tsx` used `w-screen` (100vw) for the chat shell, which can exceed the webview panel width.
2. `gui/src/components/Layout.tsx` set `scrollbarGutter: "stable both-edges"`, reserving gutter space on both sides and eating horizontal space even when no scrollbar is visible.
3. `gui/src/components/StyledMarkdownPreview/index.tsx` capped `<pre>` blocks at `calc(100vw - 24px)`, again using viewport width instead of the panel container.

## Fix

- Replace `w-screen` with `w-full` and add `min-w-0` on the shell and `<main>` so flex children can shrink within a narrow panel.
- Change `scrollbarGutter` from `"stable both-edges"` to `"stable"`.
- Change markdown `<pre>` `max-width` from `calc(100vw - 24px)` to `100%`.
- Add a small layout regression test in `gui/src/pages/gui/index.test.tsx`.

## Verification

- Added `gui/src/pages/gui/index.test.tsx` (static source assertions for the layout contract).
- `npx vitest run src/pages/gui/index.test.tsx` passes.
- `npx eslint src/pages/gui/index.tsx src/pages/gui/index.test.tsx src/components/Layout.tsx src/components/StyledMarkdownPreview/index.tsx` passes.
- `npm run tsc:check` and `npx vite build` in `gui/` are blocked on this host unless the full `core` workspace dependencies are installed, which require a large install including `puppeteer`. The changes are CSS/layout only with no logic changes.

## Model Disclosure

This pull request contains AI-generated code changes produced by Cognition Devin (an AI coding assistant) and reviewed before submission.

## Notes / Risks

- Related open PR #13068 addresses overlapping overflow issues for #12910 but does not reference #13055 and keeps `w-screen` on the shell. This PR is scoped specifically to #13055 with `w-full` as the width fix.
- After merge, first-time contributors need to sign the CLA via PR comment: `I have read the CLA Document and I hereby sign the CLA`.
