### PR TITLE
fix: retry without tools when OpenAI-compatible server returns empty response

### DIFF
--- a/packages/openai-adapters/src/apis/OpenAI.ts
+++ b/packages/openai-adapters/src/apis/OpenAI.ts
@@ -134,12 +134,34 @@ export class OpenAIApi implements BaseLlmApi {
       const response = await this.responsesNonStream(body, signal);
       return responseToChatCompletion(response);
     }
-    const response = await this.openai.chat.completions.create(
+    let response = await this.openai.chat.completions.create(
       this.modifyChatBody(body),
       {
         signal,
       },
     );
+
+    // Some OpenAI-compatible servers (e.g. NIM, vLLM) return content: null
+    // with an empty tool_calls array when tools are provided but the model
+    // decides not to call any. This is effectively an empty response that
+    // the GUI renders as blank. Retry without tools so the model responds
+    // with text content instead.
+    const msg = response.choices?.[0]?.message;
+    if (
+      msg &&
+      !msg.content &&
+      (!msg.tool_calls || msg.tool_calls.length === 0) &&
+      body.tools?.length
+    ) {
+      const { tools, tool_choice, ...bodyWithoutTools } = body;
+      response = await this.openai.chat.completions.create(
+        this.modifyChatBody(
+          bodyWithoutTools as ChatCompletionCreateParamsNonStreaming,
+        ),
+        { signal },
+      );
+    }
+
     return response;
   }
 


### PR DESCRIPTION
## Problem

Some OpenAI-compatible servers (NIM, vLLM, TGI) return `content: null` with an empty `tool_calls: []` array when tools are provided in the request but the model decides not to call any tool. This results in blank responses rendered in the Continue GUI.

## Solution

Detect empty response (`content: null` + `tool_calls: []`) and retry the same request **without** the `tools` parameter. The model then responds with text content normally.

### Behavior Matrix

| Model Response | tools in request | Retry? | Result |
|---|---|---|---|
| `content: "Hello"`, `tool_calls: []` | Yes | ❌ No | Text shown normally |
| `content: null`, `tool_calls: [{...}]` | Yes | ❌ No | Tool call executed |
| `content: null`, `tool_calls: []` | Yes | ✅ Yes | Retry → text shown |
| `content: null`, `tool_calls: []` | No | ❌ No | Empty (no tools to remove) |

## Affected Models

- **nvidia/nemotron-ultra-253b** (NIM) — frequently
- **deepseek-ai/DeepSeek-V4-Flash** (vLLM) — occasionally
- Any OpenAI-compatible server with tool support

## Trade-offs

- **Latency**: Adds one extra API call when empty response is detected (~2-5s)
- **Correctness**: Model genuinely wants to say nothing → forced to respond (acceptable for coding assistant)
- **Scope**: Only affects `chatCompletionNonStream` (non-streaming path)

## Related

- https://github.com/continuedev/continue/issues/5508