### PR TITLE
fix: sanitize malformed tool call arguments to prevent vLLM 400 errors

### DIFF
--- a/core/llm/openaiTypeConverters.ts
+++ b/core/llm/openaiTypeConverters.ts
@@ -155,14 +155,25 @@ export function toChatMessage(
 
     // Add tool calls if present
     if (message.toolCalls) {
-      msg.tool_calls = message.toolCalls.map((toolCall) => ({
-        id: toolCall.id!,
-        type: toolCall.type!,
-        function: {
-          name: toolCall.function?.name!,
-          arguments: toolCall.function?.arguments || "{}",
-        },
-      }));
+      msg.tool_calls = message.toolCalls.map((toolCall) => {
+        // Sanitize arguments — ensure valid JSON to prevent vLLM 400 errors
+        // when malformed tool arguments from previous turns are sent back in history
+        let args = toolCall.function?.arguments || "{}";
+        try {
+          JSON.parse(args);
+        } catch {
+          // If arguments are not valid JSON, wrap them to prevent server rejection
+          args = JSON.stringify({ _raw: args });
+        }
+        return {
+          id: toolCall.id!,
+          type: toolCall.type!,
+          function: {
+            name: toolCall.function?.name!,
+            arguments: args,
+          },
+        };
+      });
     }
 
     // Preserving reasoning blocks


### PR DESCRIPTION
## Problem

When LLMs generate malformed JSON in `tool_calls.function.arguments` (e.g., missing commas, truncated due to `max_tokens`), Continue stores this in conversation history and sends it back to the server on subsequent turns. vLLM validates JSON in tool_calls arguments during request preprocessing and rejects malformed input with a **400 error**, breaking the conversation.

## Solution

Validate JSON before sending tool_calls arguments back to server. If invalid, wrap in a valid JSON envelope (`{"_raw": original}`) to prevent server rejection while preserving the original content.

### Behavior

| Input arguments | Valid JSON? | Output |
|---|---|---|
| `{"path": "/tmp/x"}` | ✅ | Pass-through unchanged |
| `{"path": "/tmp/x" "content": "hi"}` | ❌ | `{"_raw": "..."}` |
| `""` (empty) | — | `"{}"` (fallback) |
| `null` / `undefined` | — | `"{}"` (fallback) |

## Root Causes of Malformed JSON

1. **max_tokens truncation** — cuts off mid-JSON
2. **Reasoning token leak** — thinking tokens leak into arguments field
3. **Model hallucination** — LLM occasionally produces invalid syntax
4. **Encoding issues** — special characters not properly escaped

## Trade-offs

- **Performance**: `JSON.parse()` on every tool_call argument — negligible cost (microseconds)
- **Semantics**: Wrapped `{"_raw": "..."}` may confuse model, but strictly better than 400 error
- **No data loss**: Original malformed string preserved in `_raw` field

## Related

- https://github.com/vllm-project/vllm/issues/43995