### PR TITLE
feat: always-on context usage display with sub-1% precision

### DIFF
--- a/gui/src/components/StepContainer/ResponseActions.tsx
+++ b/gui/src/components/StepContainer/ResponseActions.tsx
@@ -38,9 +38,7 @@ export default function ResponseActions({
   const hasContextData = contextPercentage !== undefined;
 
   // Format: show 1 decimal place when < 1%, integer otherwise
-  const displayPercent = hasContextData
-    ? contextPercentage * 100
-    : 0;
+  const displayPercent = hasContextData ? contextPercentage * 100 : 0;
   const percentFormatted = hasContextData
     ? displayPercent < 1
       ? displayPercent.toFixed(1)

--- a/gui/src/components/StepContainer/ResponseActions.tsx
+++ b/gui/src/components/StepContainer/ResponseActions.tsx
@@ -32,14 +32,28 @@ export default function ResponseActions({
     (state) => state.session.contextPercentage,
   );
   const isPruned = useAppSelector((state) => state.session.isPruned);
+  const history = useAppSelector((state) => state.session.history);
 
-  const percent = Math.round((contextPercentage ?? 0) * 100);
+  // contextPercentage is undefined until first message is sent
+  const hasContextData = contextPercentage !== undefined;
+
+  // Format: show 1 decimal place when < 1%, integer otherwise
+  const displayPercent = hasContextData
+    ? contextPercentage * 100
+    : 0;
+  const percentFormatted = hasContextData
+    ? displayPercent < 1
+      ? displayPercent.toFixed(1)
+      : Math.round(displayPercent).toString()
+    : "";
+  const percent = hasContextData ? Math.round(displayPercent) : 0;
   const buttonColorClass =
     isLast && (isPruned || percent > 80)
       ? "text-warning"
       : "text-description-muted";
 
-  const showLabel = isLast && (isPruned || percent >= 60);
+  // Always show label on last message when there's history
+  const showLabel = isLast && history.length > 0;
 
   const compactConversation = useCompactConversation();
 
@@ -63,7 +77,7 @@ export default function ResponseActions({
             <span
               className={`text-xs ${buttonColorClass || "text-description-muted"}`}
             >
-              Compact conversation
+              {hasContextData ? `${percentFormatted}% · ` : ""}Compact
             </span>
           )}
         </div>

--- a/gui/src/components/mainInput/ContextStatus.tsx
+++ b/gui/src/components/mainInput/ContextStatus.tsx
@@ -15,8 +15,22 @@ const ContextStatus = () => {
   const previousHistoryLength = useRef<number | null>(null);
   const previousSelectedChatModel = useRef<string | null>(null);
   const history = useAppSelector((state) => state.session.history);
-  const percent = Math.round((contextPercentage ?? 0) * 100);
   const isPruned = useAppSelector((state) => state.session.isPruned);
+
+  // contextPercentage is undefined until the first message is sent
+  // (it's only computed in compileChatMessages during streamNormalInput)
+  const hasContextData = contextPercentage !== undefined;
+
+  // Format: show 1 decimal place when < 1%, integer otherwise
+  const displayPercent = hasContextData
+    ? contextPercentage * 100
+    : 0;
+  const percentFormatted = hasContextData
+    ? displayPercent < 1
+      ? displayPercent.toFixed(1)
+      : Math.round(displayPercent).toString()
+    : "—";
+  const percent = hasContextData ? Math.round(displayPercent) : 0;
 
   const isDifferentModelAndSameHistory = useMemo(() => {
     if (!selectedChatModel) return false;
@@ -30,7 +44,10 @@ const ContextStatus = () => {
   }, [history.length, selectedChatModel]);
 
   const compactConversation = useCompactConversation();
-  if (!isPruned && percent < 60) {
+
+  // Always show context usage when there's history, regardless of percentage
+  // Previously: if (!isPruned && percent < 60) return null;
+  if (history.length === 0) {
     return null;
   }
 
@@ -39,13 +56,18 @@ const ContextStatus = () => {
     return null;
   }
 
-  const barColorClass = isPruned ? "bg-error" : "bg-description";
+  const barColorClass = isPruned
+    ? "bg-error"
+    : percent >= 80
+      ? "bg-warning"
+      : percent >= 60
+        ? "bg-description"
+        : "bg-description-muted";
 
   return (
-    <div>
+    <div className="flex items-center gap-1">
       <ToolTip
         closeEvents={{
-          // blur: false,
           mouseleave: true,
           click: true,
           mouseup: false,
@@ -54,7 +76,9 @@ const ContextStatus = () => {
         content={
           <div className="flex flex-col gap-0 text-left text-xs">
             <span className="inline-block">
-              {`${percent}% of context filled.`}
+              {hasContextData
+                ? `${percentFormatted}% of context filled.`
+                : `Context usage will be shown after sending a message.`}
             </span>
             {isPruned && (
               <span className="inline-block">
@@ -93,10 +117,15 @@ const ContextStatus = () => {
         <div className="border-command-border relative h-[14px] w-[7px] rounded-[1px] border-[0.5px] border-solid md:h-[10px] md:w-[5px]">
           <div
             className={`transition-height absolute bottom-0 left-0 w-full duration-300 ease-in-out ${barColorClass}`}
-            style={{ height: `${percent}%` }}
+            style={{ height: `${hasContextData ? Math.max(percent, 2) : 0}%` }}
           />
         </div>
       </ToolTip>
+      <span
+        className={`text-description-muted hidden select-none text-[10px] leading-none xs:inline ${percent >= 80 ? "text-warning" : percent >= 60 ? "text-description" : "text-description-muted"}`}
+      >
+        {hasContextData ? `${percentFormatted}%` : "—"}
+      </span>
     </div>
   );
 };

--- a/gui/src/components/mainInput/ContextStatus.tsx
+++ b/gui/src/components/mainInput/ContextStatus.tsx
@@ -22,9 +22,7 @@ const ContextStatus = () => {
   const hasContextData = contextPercentage !== undefined;
 
   // Format: show 1 decimal place when < 1%, integer otherwise
-  const displayPercent = hasContextData
-    ? contextPercentage * 100
-    : 0;
+  const displayPercent = hasContextData ? contextPercentage * 100 : 0;
   const percentFormatted = hasContextData
     ? displayPercent < 1
       ? displayPercent.toFixed(1)
@@ -122,7 +120,7 @@ const ContextStatus = () => {
         </div>
       </ToolTip>
       <span
-        className={`text-description-muted hidden select-none text-[10px] leading-none xs:inline ${percent >= 80 ? "text-warning" : percent >= 60 ? "text-description" : "text-description-muted"}`}
+        className={`text-description-muted xs:inline hidden select-none text-[10px] leading-none ${percent >= 80 ? "text-warning" : percent >= 60 ? "text-description" : "text-description-muted"}`}
       >
         {hasContextData ? `${percentFormatted}%` : "—"}
       </span>


### PR DESCRIPTION
## Problem

Currently, the context usage indicator in Continue is only shown when:
- The conversation is pruned (context exceeded)
- OR context usage is >= 60%

This means users have **no visibility** into context consumption during normal usage. They only discover context limits when it is too late — after pruning has already occurred and information has been lost.

## Solution

Make the context usage indicator **always visible** when there is conversation history, with enhanced precision and visual feedback.

### Changes

#### ContextStatus.tsx
- **Always visible** when `history.length > 0` (removed 60% threshold)
- **Sub-1% precision**: shows `0.3%` instead of rounding to `0%`
- **Color-coded bar**:
  - `< 60%`: muted (subtle, non-intrusive)
  - `>= 60%`: description (noticeable)
  - `>= 80%`: warning (attention needed)
  - `pruned`: error (action required)
- **Percentage number** displayed next to the bar
- **Graceful handling**: shows `—` before first message (when `contextPercentage` is undefined)

#### ResponseActions.tsx
- **Always show** `Compact` label on the last message
- **Percentage prefix**: `0.3% · Compact`
- **Hide prefix** when no context data yet

### Screenshots

_Context usage at 4% — always visible, subtle when low_
_Context usage at 80%+ — warning color, clearly visible_

### Inspiration

This UX pattern is inspired by **Kiro IDE**, which always shows context usage to help users proactively manage their context budget.

### Backward Compatibility

- No breaking changes
- No new dependencies
- Purely additive UI enhancement
- Existing behavior preserved when `history.length === 0`