### PR TITLE
fix: keep code-block toolbar within panel bounds when sidebar is narrowed

### DIFF
--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/index.test.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/index.test.tsx
@@ -1,0 +1,79 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { StepContainerPreToolbar } from "./index";
+
+vi.mock("../../../context/IdeMessenger", () => {
+  const { createContext } = require("react");
+  return {
+    IdeMessengerContext: createContext({
+      ide: {
+        getCurrentFile: vi.fn().mockResolvedValue(undefined),
+        showToast: vi.fn(),
+        showLines: vi.fn(),
+      },
+      post: vi.fn(),
+    }),
+  };
+});
+
+vi.mock("../../../redux/hooks", () => ({
+  useAppSelector: () => ({}),
+}));
+
+vi.mock("../../../hooks/useWebviewListener", () => ({
+  useWebviewListener: () => {},
+}));
+
+vi.mock("../../../hooks/useIdeMessengerRequest", () => ({
+  useIdeMessengerRequest: () => ({
+    result: undefined,
+    refresh: vi.fn(),
+    isLoading: false,
+  }),
+}));
+
+vi.mock("../../../redux/selectors/selectToolCalls", () => ({
+  selectToolCallById: () => undefined,
+}));
+
+vi.mock("../../../redux/slices/sessionSlice", () => ({
+  selectApplyStateByStreamId: () => undefined,
+  selectApplyStateByToolCallId: () => undefined,
+}));
+
+describe("StepContainerPreToolbar", () => {
+  const baseProps = {
+    codeBlockContent: "console.log('hello')",
+    language: "javascript",
+    codeBlockIndex: 0,
+    isLastCodeblock: true,
+    codeBlockStreamId: "stream-1",
+  };
+
+  it("renders the code block", () => {
+    const { container } = render(
+      <StepContainerPreToolbar {...baseProps}>
+        <pre>console.log(&#39;hello&#39;)</pre>
+      </StepContainerPreToolbar>,
+    );
+    expect(container).toBeTruthy();
+  });
+
+  it("lets the title side shrink and pins the action buttons so the toolbar never overflows the panel", () => {
+    const { container } = render(
+      <StepContainerPreToolbar {...baseProps}>
+        <pre>console.log(&#39;hello&#39;)</pre>
+      </StepContainerPreToolbar>,
+    );
+
+    const titleContainer = [...container.querySelectorAll("div")].find((el) =>
+      el.classList.contains("min-w-0"),
+    );
+    expect(titleContainer).toBeTruthy();
+
+    const actionsContainer = [...container.querySelectorAll("div")].find((el) =>
+      el.classList.contains("shrink-0"),
+    );
+    expect(actionsContainer).toBeTruthy();
+  });
+});

--- a/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/index.tsx
+++ b/gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/index.tsx
@@ -294,10 +294,10 @@ export function StepContainerPreToolbar({
   return (
     <div className="outline-command-border -outline-offset-0.5 rounded-default bg-editor !my-2 flex min-w-0 flex-col outline outline-1">
       <div
-        className={`find-widget-skip bg-editor sticky -top-2 z-10 m-0 flex items-center justify-between gap-3 px-1.5 py-1 ${isExpanded ? "rounded-t-default border-command-border border-b" : "rounded-default"}`}
+        className={`find-widget-skip bg-editor sticky -top-2 z-10 m-0 flex flex-wrap items-center justify-between gap-x-3 gap-y-1 px-1.5 py-1 ${isExpanded ? "rounded-t-default border-command-border border-b" : "rounded-default"}`}
         style={{ fontSize: `${getFontSize() - 2}px` }}
       >
-        <div className="flex max-w-[50%] flex-row items-center">
+        <div className="flex min-w-0 max-w-[50%] flex-row items-center">
           {toolCallStatusIcon}
           <ChevronDownIcon
             data-testid="toggle-codeblock"
@@ -319,7 +319,7 @@ export function StepContainerPreToolbar({
           )}
         </div>
 
-        <div className="flex items-center gap-2.5">
+        <div className="flex shrink-0 items-center gap-2.5">
           {!isGeneratingCodeBlock && (
             <div className="xs:flex hidden items-center gap-2.5">
               <InsertButton onInsert={onClickInsertAtCursor} />


### PR DESCRIPTION
## Description

Fixes #13085 — when the Continue sidebar/panel is narrowed, the code-block header bar (Copy/Run/Enter buttons) does not resize and the action buttons get hidden under the sidebar edge. Explanation text between code blocks could also overflow.

**Root cause:** the toolbar header is a flex row whose children have flexbox's default `min-width: auto`, which prevents them from shrinking. The root container has `overflow-x: hidden`, so when the panel narrows, the button row is pushed past the visible area and clipped.

**Fix (in `StepContainerPreToolbar`):**
- Title side (filepath/language + chevron): added `min-w-0` so it can shrink; the filepath already truncates via `line-clamp-1 break-all`.
- Action-button side: added `shrink-0` so Copy/Run/Apply buttons are never clipped.
- Header row: added `flex-wrap` + `gap-x-3 gap-y-1` so on very narrow widths the buttons wrap to a second line instead of overflowing.

This targets the code-block header specifically (the issue's primary symptom). Explanation-text reflow stems from the same overflow root and is also relieved once the block no longer forces itself wider than the panel.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [ ] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

When the sidebar is narrower than the code-block toolbar, the buttons now stay visible (title truncates / buttons wrap) instead of being clipped at the panel edge.

## Tests

Added `gui/src/components/StyledMarkdownPreview/StepContainerPreToolbar/index.test.tsx`:
- smoke test (component renders)
- regression test asserting the title container has `min-w-0` (shrinkable) and the action-button container has `shrink-0` (never clipped)

All 44 tests in `StyledMarkdownPreview/` pass (`npx vitest run src/components/StyledMarkdownPreview/`). `tsc --noEmit` shows only pre-existing workspace-package resolution errors in `core/` (unbuilt `@continuedev/config-yaml`), none in the changed files.
