### PR TITLE
fix: tell models the workspace root so filesystem tools work on remote setups

### DIFF
--- a/gui/src/redux/thunks/streamNormalInput.ts
+++ b/gui/src/redux/thunks/streamNormalInput.ts
@@ -137,6 +137,7 @@ export const streamNormalInput = createAsyncThunk<
       state.session.mode,
       selectedChatModel,
       activeTools,
+      window.workspacePaths?.[0],
     );
 
     const systemMessage = systemToolsFramework

--- a/gui/src/redux/util/getBaseSystemMessage.test.ts
+++ b/gui/src/redux/util/getBaseSystemMessage.test.ts
@@ -4,7 +4,11 @@ import {
   DEFAULT_CHAT_SYSTEM_MESSAGE,
   DEFAULT_PLAN_SYSTEM_MESSAGE,
 } from "core/llm/defaultSystemMessages";
-import { getBaseSystemMessage, NO_TOOL_WARNING } from "./getBaseSystemMessage";
+import {
+  getBaseSystemMessage,
+  getWorkspaceDisplayPath,
+  NO_TOOL_WARNING,
+} from "./getBaseSystemMessage";
 
 test("getBaseSystemMessage should return the correct system message based on mode", () => {
   const mockModel = {
@@ -83,4 +87,96 @@ test("getBaseSystemMessage should append no-tools warning for agent/plan modes w
   expect(getBaseSystemMessage("plan", mockModel)).toBe(
     "Custom Plan System Message" + NO_TOOL_WARNING,
   );
+});
+
+test("getBaseSystemMessage should inject the workspace root for agent and plan modes", () => {
+  const mockModel = {
+    baseChatSystemMessage: "Custom Chat System Message",
+    basePlanSystemMessage: "Custom Plan System Message",
+    baseAgentSystemMessage: "Custom Agent System Message",
+  } as ModelDescription;
+
+  const mockTool = {
+    function: {
+      name: "testTool",
+      description: "Test tool",
+      parameters: {},
+    },
+  } as Tool;
+
+  const workspaceDirectory = "vscode-remote://ssh-remote+debian/opt/billing";
+
+  // Agent mode: workspace root appended after the base message
+  const agentMessage = getBaseSystemMessage(
+    "agent",
+    mockModel,
+    [mockTool],
+    workspaceDirectory,
+  );
+  expect(agentMessage).toContain("Custom Agent System Message");
+  expect(agentMessage).toContain("Your workspace root is: /opt/billing");
+
+  // Plan mode: workspace root appended after the base message
+  const planMessage = getBaseSystemMessage(
+    "plan",
+    mockModel,
+    [mockTool],
+    workspaceDirectory,
+  );
+  expect(planMessage).toContain("Custom Plan System Message");
+  expect(planMessage).toContain("Your workspace root is: /opt/billing");
+
+  // Chat mode: workspace root is not injected
+  const chatMessage = getBaseSystemMessage(
+    "chat",
+    mockModel,
+    [mockTool],
+    workspaceDirectory,
+  );
+  expect(chatMessage).toBe("Custom Chat System Message");
+
+  // No workspace: no injection
+  expect(getBaseSystemMessage("agent", mockModel, [mockTool], "")).toBe(
+    "Custom Agent System Message",
+  );
+  expect(getBaseSystemMessage("agent", mockModel, [mockTool], undefined)).toBe(
+    "Custom Agent System Message",
+  );
+
+  // No tools: no injection (avoids contradicting NO_TOOL_WARNING)
+  expect(getBaseSystemMessage("agent", mockModel, [], workspaceDirectory)).toBe(
+    "Custom Agent System Message" + NO_TOOL_WARNING,
+  );
+});
+
+test("getWorkspaceDisplayPath should convert workspace URIs to display paths", () => {
+  // Remote-SSH (the reported bug: model invented C:\workspace)
+  expect(
+    getWorkspaceDisplayPath("vscode-remote://ssh-remote+debian/opt/billing"),
+  ).toBe("/opt/billing");
+
+  // Dev Containers
+  expect(
+    getWorkspaceDisplayPath("vscode-remote://dev-container+abc123/workspace"),
+  ).toBe("/workspace");
+
+  // vscode-vfs
+  expect(getWorkspaceDisplayPath("vscode-vfs://github/continue/continue")).toBe(
+    "/continue/continue",
+  );
+
+  // Local POSIX
+  expect(getWorkspaceDisplayPath("file:///home/user/proj")).toBe(
+    "/home/user/proj",
+  );
+
+  // Local Windows
+  expect(getWorkspaceDisplayPath("file:///C:/Users/bob/my%20project")).toBe(
+    "C:/Users/bob/my project",
+  );
+
+  // Unsupported / missing
+  expect(getWorkspaceDisplayPath("untitled:Untitled-1")).toBeNull();
+  expect(getWorkspaceDisplayPath("")).toBeNull();
+  expect(getWorkspaceDisplayPath("not a uri")).toBeNull();
 });

--- a/gui/src/redux/util/getBaseSystemMessage.ts
+++ b/gui/src/redux/util/getBaseSystemMessage.ts
@@ -8,10 +8,55 @@ import {
 export const NO_TOOL_WARNING =
   "\n\nTHE USER HAS NOT PROVIDED ANY TOOLS, DO NOT ATTEMPT TO USE ANY TOOLS. STOP AND LET THE USER KNOW THAT THERE ARE NO TOOLS AVAILABLE. The user can provide tools by enabling them in the Tool Policies section of the notch (wrench icon)";
 
+/**
+ * Converts a workspace directory (URI or raw path) into an LLM-friendly
+ * absolute path that the filesystem tools can be pointed at.
+ *
+ * - file:///C:/Users/me/proj           -> C:/Users/me/proj (Windows local)
+ * - file:///home/me/proj               -> /home/me/proj (POSIX local)
+ * - vscode-remote://ssh-remote+host/opt -> /opt (Remote-SSH / Dev Containers)
+ * - vscode-vfs://github/repo            -> /repo
+ * - anything else (untitled:, empty)    -> null
+ */
+export function getWorkspaceDisplayPath(
+  workspaceDirectory: string,
+): string | null {
+  if (!workspaceDirectory) {
+    return null;
+  }
+
+  try {
+    if (workspaceDirectory.startsWith("file://")) {
+      const { pathname } = new URL(workspaceDirectory);
+      const decoded = decodeURIComponent(pathname);
+      // On Windows, file:///C:/... has a leading slash before the drive letter
+      return /^\/[a-zA-Z]:/.test(decoded) ? decoded.slice(1) : decoded;
+    }
+
+    // Remote IDE schemes embed the remote path after the authority:
+    // vscode-remote://ssh-remote+host/opt/billing -> /opt/billing
+    const remotePath = /^[a-z][a-z0-9+.-]*:\/\/[^/]*(\/.*)$/.exec(
+      workspaceDirectory,
+    );
+    if (remotePath) {
+      return decodeURIComponent(remotePath[1]);
+    }
+  } catch {
+    // Ignore malformed URIs and fall through to null
+  }
+
+  return null;
+}
+
+function workspaceInfoBlock(displayPath: string): string {
+  return `\n\n<workspace_info>\nYour workspace root is: ${displayPath}\nWhen using filesystem tools, pass paths relative to this root (e.g. "src/main.ts" for ${displayPath}/src/main.ts) or absolute paths. Explore the workspace with the viewSubdirectory or ls tools instead of guessing paths.\n</workspace_info>`;
+}
+
 export function getBaseSystemMessage(
   messageMode: string,
   model: ModelDescription,
   activeTools?: Tool[],
+  workspaceDirectory?: string,
 ): string {
   let baseMessage: string;
 
@@ -26,6 +71,17 @@ export function getBaseSystemMessage(
   // Add no-tools warning for agent/plan modes when no tools are available
   if (messageMode !== "chat" && (!activeTools || activeTools.length === 0)) {
     baseMessage += NO_TOOL_WARNING;
+  }
+
+  // Tell the model where the workspace root actually is. Without this, models
+  // guess a workspace path (e.g. `C:\workspace`), which breaks filesystem tools
+  // on remote setups like Remote-SSH or Dev Containers where the workspace is a
+  // non-file:// URI. Only relevant when tools are available to use.
+  if (messageMode !== "chat" && activeTools && activeTools.length > 0) {
+    const displayPath = getWorkspaceDisplayPath(workspaceDirectory ?? "");
+    if (displayPath) {
+      baseMessage += workspaceInfoBlock(displayPath);
+    }
   }
 
   return baseMessage;


### PR DESCRIPTION
## Description

Fixes #13082 — Continue Agent filesystem tools resolve `C:\workspace` instead of the actual workspace, breaking all filesystem tools on **Remote-SSH** (and Dev Containers / any `vscode-remote://` setup).

**Root cause:** the agent/plan system message instructs models to use filesystem tools with paths "relative to the root of the workspace" — but never tells the model what that root *is*. On local workspaces the model can infer it from `file://` context URIs, but on Remote-SSH the workspace is a `vscode-remote://ssh-remote+host/opt` URI, so no context ever reveals the real path. The model then guesses (`C:\workspace`), and every `readFile`/`ls`/`viewSubdirectory` call fails with "The directory c:\workspace does not exist."

**Fix:** when the session has filesystem tools available, inject a `<workspace_info>` block into the agent/plan system message stating the resolved workspace root:

```xml
<workspace_info>
Your workspace root is: /opt/billing
When using filesystem tools, pass paths relative to this root (e.g. "src/main.ts" for /opt/billing/src/main.ts) or absolute paths. Explore the workspace with the viewSubdirectory or ls tools instead of guessing paths.
</workspace_info>
```

The root is derived from `window.workspacePaths[0]` (the same source the session metadata already uses) via a new `getWorkspaceDisplayPath()` helper that handles:
- `file:///C:/Users/...` → `C:/Users/...` (Windows local)
- `file:///home/user/proj` → `/home/user/proj` (POSIX local)
- `vscode-remote://ssh-remote+host/opt` → `/opt` (Remote-SSH / Dev Containers)
- `vscode-vfs://...` → remote path
- `untitled:`/empty → skipped (no injection)

Chat mode is untouched; the injection only happens in agent/plan modes **when tools are actually enabled**, so it never contradicts the no-tools warning.

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](https://github.com/continuedev/continue/blob/main/CODE_OF_CONDUCT.md)
- [x] I have read and agree to the [Contributor License Agreement](https://github.com/continuedev/continue/blob/main/CLA.md)
- [x] I have tested the changes locally
- [x] I have added tests covering the changes (`getWorkspaceDisplayPath` unit tests + system-message injection tests)

## Testing

- `vitest run src/redux/util/` — **46/46 tests pass** (3 new test cases covering the helper and the injection)
- `tsc --noEmit` — clean on all changed files (pre-existing workspace-package errors in `core/` are unrelated)
- Manually verified the helper output for Remote-SSH, Dev Containers, vscode-vfs, local POSIX, local Windows, and unsupported schemes
