### PR TITLE
fix(openai-adapters): suppress org/project headers that break under Turkish locales

### DIFF
--- a/packages/openai-adapters/src/apis/Azure.ts
+++ b/packages/openai-adapters/src/apis/Azure.ts
@@ -23,6 +23,13 @@ export class AzureApi extends OpenAIApi {
       baseURL,
       fetch: customFetch(azureConfig.requestOptions),
       defaultQuery,
+      // Same Turkish-locale header guard as OpenAIApi — see #12568.
+      organization: null,
+      project: null,
+      defaultHeaders: {
+        "openai-organization": null,
+        "openai-project": null,
+      },
     });
   }
 

--- a/packages/openai-adapters/src/apis/OpenAI.ts
+++ b/packages/openai-adapters/src/apis/OpenAI.ts
@@ -46,6 +46,15 @@ export class OpenAIApi implements BaseLlmApi {
       baseURL: this.apiBase,
       fetch: customFetch(config.requestOptions),
       timeout: config?.requestOptions?.timeout || undefined,
+      // Avoid injecting OpenAI-Organization / OpenAI-Project from env. Under
+      // Turkish locales those PascalCase names lowercase to invalid tokens
+      // (openaı-organization) and crash fetch. See #12568.
+      organization: null,
+      project: null,
+      defaultHeaders: {
+        "openai-organization": null,
+        "openai-project": null,
+      },
     });
   }
   modifyChatBody<T extends ChatCompletionCreateParams>(body: T): T {

--- a/packages/openai-adapters/src/test/main.test.ts
+++ b/packages/openai-adapters/src/test/main.test.ts
@@ -235,6 +235,43 @@ describe("Configuration", () => {
     );
   });
 
+  it("should suppress OpenAI org/project headers that break under Turkish locales", () => {
+    // Demonstrates the locale bug: mixed-case OpenAI-* headers lowercase to
+    // invalid HTTP tokens under tr-TR (dotless ı).
+    expect("OpenAI-Organization".toLocaleLowerCase("tr-TR")).toBe(
+      "openaı-organization",
+    );
+    expect(() => {
+      new Headers({ "openaı-organization": "org" });
+    }).toThrow();
+
+    const prevOrg = process.env.OPENAI_ORG_ID;
+    const prevProject = process.env.OPENAI_PROJECT_ID;
+    process.env.OPENAI_ORG_ID = "org_should_not_leak";
+    process.env.OPENAI_PROJECT_ID = "proj_should_not_leak";
+    try {
+      const openai = constructLlmApi({
+        provider: "openai",
+        apiKey: "sk-xxx",
+        apiBase: "https://openrouter.ai/api/v1/",
+      }) as OpenAIApi;
+
+      // Client must not pick up org/project from the environment — that is what
+      // injects the PascalCase headers the SDK then lowercases unsafely.
+      expect(openai.openai.organization).toBeNull();
+      expect(openai.openai.project).toBeNull();
+      expect((openai.openai as any)._options.defaultHeaders).toMatchObject({
+        "openai-organization": null,
+        "openai-project": null,
+      });
+    } finally {
+      if (prevOrg === undefined) delete process.env.OPENAI_ORG_ID;
+      else process.env.OPENAI_ORG_ID = prevOrg;
+      if (prevProject === undefined) delete process.env.OPENAI_PROJECT_ID;
+      else process.env.OPENAI_PROJECT_ID = prevProject;
+    }
+  });
+
   it("should configure Inception OpenAI client with correct apiBase and apiKey", () => {
     const inception = constructLlmApi({
       provider: "inception",


### PR DESCRIPTION
## Summary
- Under Turkish locales, the OpenAI SDK's `OpenAI-Organization` / `OpenAI-Project` headers lowercase to invalid HTTP tokens (`openaı-organization`) and crash requests.
- Explicitly set `organization`/`project` to `null` and null out those headers with ASCII-safe lowercase keys so `OPENAI_ORG_ID` / `OPENAI_PROJECT_ID` from the environment cannot inject the PascalCase headers.
- Applied in both `OpenAIApi` and `AzureApi` client construction.

Fixes #12568

## Test plan
- [x] Regression test asserts `OpenAI-Organization`.toLocaleLowerCase(`tr-TR`) produces the invalid token, and that our client does not pick up org/project from env
- [x] A/B: without the fix, `openai.organization` leaks `OPENAI_ORG_ID`; with the fix it stays `null`
- [x] `vitest --run src/test/main.test.ts` passes


Made with [Cursor](https://cursor.com)