### PR TITLE
fix(autocomplete): cap reserved output tokens in pruneLength

### DIFF
--- a/core/autocomplete/templating/__tests__/renderPrompt.vitest.ts
+++ b/core/autocomplete/templating/__tests__/renderPrompt.vitest.ts
@@ -26,12 +26,14 @@ vi.mock("../../../llm/countTokens", () => {
   const pruneLinesFromBottom = (str: string, allowed: number) =>
     str.slice(0, allowed);
   const getTokenCountingBufferSafety = () => 0;
+  const MIN_RESPONSE_TOKENS = 1000;
 
   return {
     countTokens,
     pruneLinesFromTop,
     pruneLinesFromBottom,
     getTokenCountingBufferSafety,
+    MIN_RESPONSE_TOKENS,
   };
 });
 
@@ -253,6 +255,31 @@ describe("renderPromptWithTokenLimit parity & pruning", () => {
     });
 
     expect(compiledPrefix.length).toBeLessThan(120);
+  });
+
+  it("does not wipe a small prompt when default maxTokens exceeds a small context length", () => {
+    // Regression test: a model whose contextLength (e.g. Ollama's num_ctx) is smaller
+    // than the default maxTokens reservation (4096) used to compute a negative prompt
+    // budget, which caused every prefix/suffix to be pruned to nothing regardless of
+    // how small the actual prompt was.
+    const shortPrefix = "A".repeat(50);
+
+    const helper = makeHelper({ prunedPrefix: shortPrefix });
+
+    const llmStub = {
+      contextLength: 2048,
+      completionOptions: {},
+      model: "test-model",
+    } as any;
+
+    const { prefix: compiledPrefix } = renderPromptWithTokenLimit({
+      snippetPayload: emptySnippetPayload,
+      workspaceDirs: ["file:///workspace"],
+      helper,
+      llm: llmStub,
+    });
+
+    expect(compiledPrefix.includes(shortPrefix)).toBe(true);
   });
 });
 

--- a/core/autocomplete/templating/index.ts
+++ b/core/autocomplete/templating/index.ts
@@ -9,6 +9,7 @@ import { DEFAULT_MAX_TOKENS } from "../../llm/constants.js";
 import {
   countTokens,
   getTokenCountingBufferSafety,
+  MIN_RESPONSE_TOKENS,
   pruneLinesFromBottom,
   pruneLinesFromTop,
 } from "../../llm/countTokens";
@@ -204,7 +205,12 @@ function pruneLength(llm: ILLM, prompt: string): number {
   const contextLength = llm.contextLength;
   const reservedTokens = llm.completionOptions.maxTokens ?? DEFAULT_MAX_TOKENS;
   const safetyBuffer = getTokenCountingBufferSafety(contextLength);
-  const maxAllowedPromptTokens = contextLength - reservedTokens - safetyBuffer;
+  // Reserve at most MIN_RESPONSE_TOKENS for the completion, same as compileChatMessages.
+  // Otherwise a large maxTokens (the default is 4096) can consume the entire context
+  // window on small-context models, leaving no room for the prompt and silently
+  // pruning it to nothing on every request.
+  const minOutputTokens = Math.min(MIN_RESPONSE_TOKENS, reservedTokens);
+  const maxAllowedPromptTokens = contextLength - minOutputTokens - safetyBuffer;
   const promptTokenCount = countTokens(prompt, llm.model);
   return promptTokenCount - maxAllowedPromptTokens;
 }

--- a/core/llm/countTokens.ts
+++ b/core/llm/countTokens.ts
@@ -562,6 +562,7 @@ export {
   countTokens,
   countTokensAsync,
   extractToolSequence,
+  MIN_RESPONSE_TOKENS,
   pruneLinesFromBottom,
   pruneLinesFromTop,
   pruneRawPromptFromTop,


### PR DESCRIPTION
Fixes #13038

## What's broken

Tab autocomplete silently produces nothing, with no error and no log line, whenever the selected model's `contextLength` is smaller than the default `maxTokens` reservation (4096). This is common with Ollama, where a Modelfile pinning `PARAMETER num_ctx 4096` (a common move on small-VRAM GPUs) hits it directly, since Continue reads that value straight into `contextLength`.

`pruneLength` in `core/autocomplete/templating/index.ts` computes:

```ts
const maxAllowedPromptTokens = contextLength - reservedTokens - safetyBuffer;
```

with `reservedTokens` defaulting to 4096 whenever the user hasn't set `maxTokens` explicitly. If `contextLength` is anywhere near or below that, `maxAllowedPromptTokens` goes negative, and the prune amount ends up larger than the entire prefix plus suffix no matter how small the actual prompt is. `renderPromptWithTokenLimit` then prunes both down to nothing, sends an effectively empty prompt to the model, and `postprocessCompletion` drops the resulting blank completion. Nothing in that path surfaces an error.

## The fix

`compileChatMessages`, in the same file, already handles the equivalent chat-pruning case by capping the output reservation at `MIN_RESPONSE_TOKENS` (1000) instead of the full `maxTokens`:

```ts
const minOutputTokens = Math.min(MIN_RESPONSE_TOKENS, maxTokens);
```

`pruneLength` never got the same treatment. This applies the identical cap:

```ts
const minOutputTokens = Math.min(MIN_RESPONSE_TOKENS, reservedTokens);
const maxAllowedPromptTokens = contextLength - minOutputTokens - safetyBuffer;
```

`MIN_RESPONSE_TOKENS` wasn't exported from `countTokens.ts`, so I added it to the export list rather than duplicating the constant.

This only changes behavior when `reservedTokens` is larger than `MIN_RESPONSE_TOKENS` (1000), which is exactly the pathological case, small `contextLength` with a large default `maxTokens`. Models where `maxTokens` is already below 1000 see `Math.min` return the same value as before, so the existing pruning test (`contextLength: 120, maxTokens: 10`) is untouched.

## How I checked it

Reimplemented the exact arithmetic from `pruneLength` and the pruning branch in a standalone script to compare before/after against the reported repro's numbers (`contextLength=4096`, unset `maxTokens` defaulting to 4096):

```
before: pruned=true,  prefix='', suffix=''
after:  pruned=false, prefix='AAAAAAAAAAAAAAAAAAAA', suffix=''
```

Then applied the real fix and ran the actual suite. Added a test to `core/autocomplete/templating/__tests__/renderPrompt.vitest.ts` (`contextLength: 2048`, default `maxTokens`, a short prefix) asserting the prefix survives. It fails on `main` (`expected false to be true`, the prefix gets wiped) and passes with this change. Had to add `MIN_RESPONSE_TOKENS` to that file's existing `countTokens` mock too, since vitest's module mock doesn't auto-forward unmocked exports.

Full run: `npx vitest run autocomplete/` in `core/`, 178 passed, 1 pre-existing todo, the same as `main`. `tsc -p ./ --noEmit` and `eslint` are clean on all three changed files.

## Type

🐛 Bug Fix
