### PR TITLE
Add file attachments to chat input box

### DIFF
--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -288,9 +288,16 @@ declare global {
   export type ChatMessageRole = "user" | "assistant" | "system" | "tool";
   
   export interface MessagePart {
-    type: "text" | "imageUrl";
+    type: "text" | "imageUrl" | "file";
     text?: string;
     imageUrl?: { url: string };
+    name?: string;
+    dataUrl?: string;
+    file?: {
+      file_data?: string;
+      file_id?: string;
+      filename?: string;
+    };
   }
   
   export type MessageContent = string | MessagePart[];

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -349,7 +349,20 @@ export type ImageMessagePart = {
   imageUrl: { url: string };
 };
 
-export type MessagePart = TextMessagePart | ImageMessagePart;
+export type FileMessagePart = {
+  type: "file";
+  name: string;
+  dataUrl: string;
+  // Providers that support file uploads (e.g. OpenAI Responses API) may consume
+  // this optional sub-object. See OpenAI.ts's input_file conversion.
+  file?: {
+    file_data?: string;
+    file_id?: string;
+    filename?: string;
+  };
+};
+
+export type MessagePart = TextMessagePart | ImageMessagePart | FileMessagePart;
 
 export type MessageContent = string | MessagePart[];
 

--- a/core/llm/countTokens.test.ts
+++ b/core/llm/countTokens.test.ts
@@ -26,6 +26,13 @@ describe.skip("countTokens", () => {
     const tokenCount = countTokens(content, "gpt-4");
     expect(tokenCount).toBeGreaterThan(0);
   });
+
+  it("should not throw when counting tokens for file attachment parts", () => {
+    const content: MessagePart[] = [
+      { type: "file", name: "report.pdf", dataUrl: "data:application/pdf;base64,xxxx" },
+    ];
+    expect(() => countTokens(content, "gpt-4")).not.toThrow();
+  });
 });
 
 describe("countTokensAsync", () => {
@@ -44,6 +51,14 @@ describe("countTokensAsync", () => {
     const content: MessagePart[] = [{ type: "text", text: "Hello world!" }];
     const tokenCount = await countTokensAsync(content, "gpt-4");
     expect(tokenCount).toBeGreaterThan(0);
+  });
+
+  it("should count tokens asynchronously for file attachment parts", async () => {
+    const content: MessagePart[] = [
+      { type: "file", name: "report.pdf", dataUrl: "data:application/pdf;base64,xxxx" },
+    ];
+    const tokenCount = await countTokensAsync(content, "gpt-4");
+    expect(tokenCount).toBeGreaterThanOrEqual(0);
   });
 });
 

--- a/core/llm/countTokens.ts
+++ b/core/llm/countTokens.ts
@@ -122,7 +122,9 @@ function countTokens(
         acc +
         (part.type === "text"
           ? encoding.encode(part.text ?? "", "all", []).length
-          : countImageTokens(part))
+          : part.type === "file"
+            ? encoding.encode(`[Attachment: ${part.name}]`, "all", []).length
+            : countImageTokens(part))
       );
     }, 0);
   } else {

--- a/core/llm/countTokens.ts
+++ b/core/llm/countTokens.ts
@@ -102,6 +102,9 @@ async function countTokensAsync(
       if (part.type === "imageUrl") {
         return countImageTokens(part);
       }
+      if (part.type === "file") {
+        return (await encoding.encode(`[Attachment: ${part.name}]`)).length;
+      }
       return (await encoding.encode(part.text ?? "")).length;
     });
     return (await Promise.all(promises)).reduce((sum, val) => sum + val, 0);

--- a/core/llm/llms/Anthropic.ts
+++ b/core/llm/llms/Anthropic.ts
@@ -105,7 +105,7 @@ class Anthropic extends BaseLLM {
               text: part.text,
             });
           }
-        } else {
+        } else if (part.type === "imageUrl") {
           const base64Data = extractBase64FromDataUrl(part.imageUrl.url);
           if (base64Data) {
             parts.push({
@@ -121,6 +121,14 @@ class Anthropic extends BaseLLM {
               "Anthropic: skipping image with invalid data URL format",
               part.imageUrl.url,
             );
+          }
+        } else if (part.type === "file") {
+          // File attachments aren't supported by Anthropic; render as text placeholder
+          if (part.name) {
+            parts.push({
+              type: "text",
+              text: `[Attachment: ${part.name}]`,
+            });
           }
         }
       }

--- a/core/llm/llms/Gemini.ts
+++ b/core/llm/llms/Gemini.ts
@@ -210,6 +210,12 @@ class Gemini extends BaseLLM {
       };
     }
 
+    if (part.type === "file") {
+      return {
+        text: `[Attachment: ${part.name}]`,
+      };
+    }
+
     let data = "";
     if (part.imageUrl?.url) {
       const extracted = extractBase64FromDataUrl(part.imageUrl.url);

--- a/core/llm/logFormatter.ts
+++ b/core/llm/logFormatter.ts
@@ -276,8 +276,10 @@ export class LLMLogFormatter {
       for (const part of message.content) {
         if (part.type === "text") {
           this.logMessageText(item, part.text);
-        } else {
+        } else if (part.type === "imageUrl") {
           this.logLines(item, `Image: ${part.imageUrl.url}`);
+        } else if (part.type === "file") {
+          this.logLines(item, `Attachment: ${part.name}`);
         }
       }
     }

--- a/core/llm/openaiTypeConverters.ts
+++ b/core/llm/openaiTypeConverters.ts
@@ -198,6 +198,13 @@ export function toChatMessage(
                 },
               };
             }
+            if (part.type === "file") {
+              // File attachments aren't supported by providers; render as text placeholder
+              return {
+                type: "text" as const,
+                text: `[Attachment: ${part.name}]`,
+              };
+            }
             return part;
           })
         : message.content
@@ -806,6 +813,9 @@ function toResponseInputContentList(
         image_url: part.imageUrl.url,
         detail: "auto",
       });
+    } else if (part.type === "file") {
+      // File attachments aren't supported by the Responses API; render as text
+      list.push({ type: "input_text", text: `[Attachment: ${part.name}]` });
     }
   }
   return list;

--- a/core/util/messageContent.ts
+++ b/core/util/messageContent.ts
@@ -12,8 +12,12 @@ export function stripImages(messageContent: MessageContent): string {
   }
 
   return messageContent
-    .filter((part) => part.type === "text")
-    .map((part) => (part as TextMessagePart).text)
+    .filter((part) => part.type !== "imageUrl")
+    .map((part) =>
+      part.type === "file"
+        ? `[Attachment: ${part.name}]`
+        : (part as TextMessagePart).text ?? "",
+    )
     .join("\n");
 }
 

--- a/gui/src/components/console/Message.tsx
+++ b/gui/src/components/console/Message.tsx
@@ -33,9 +33,12 @@ function renderMessageContent(
     return message.content.map((part) => {
       if (part.type == "text") {
         return renderMessageText(part.text);
-      } else {
+      } else if (part.type == "imageUrl") {
         return <div>Image: {part.imageUrl.url}</div>;
+      } else if (part.type == "file") {
+        return <div>Attachment: {part.name}</div>;
       }
+      return null;
     });
   }
 }

--- a/gui/src/components/mainInput/InputToolbar.tsx
+++ b/gui/src/components/mainInput/InputToolbar.tsx
@@ -1,6 +1,7 @@
 import {
   AtSymbolIcon,
   LightBulbIcon as LightBulbIconOutline,
+  PaperClipIcon,
   PhotoIcon,
 } from "@heroicons/react/24/outline";
 import { LightBulbIcon as LightBulbIconSolid } from "@heroicons/react/24/solid";
@@ -39,6 +40,7 @@ interface InputToolbarProps {
   onAddContextItem?: () => void;
   onClick?: () => void;
   onImageFileSelected?: (file: File) => void;
+  onFileSelected?: (file: File) => void;
   hidden?: boolean;
   activeKey: string | null;
   toolbarOptions?: ToolbarOptions;
@@ -50,6 +52,7 @@ function InputToolbar(props: InputToolbarProps) {
   const dispatch = useAppDispatch();
   const ideMessenger = useContext(IdeMessengerContext);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const attachmentFileInputRef = useRef<HTMLInputElement | null>(null);
   const defaultModel = useAppSelector(selectSelectedChatModel);
   const useActiveFile = useAppSelector(selectUseActiveFile);
   const isInEdit = useAppSelector((store) => store.session.isInEdit);
@@ -128,6 +131,35 @@ function InputToolbar(props: InputToolbarProps) {
                   </ToolTip>
                 </>
               ))}
+            {props.toolbarOptions?.hideImageUpload || (
+              <>
+                <input
+                  type="file"
+                  ref={attachmentFileInputRef}
+                  style={{ display: "none" }}
+                  onChange={(e) => {
+                    const files = e.target?.files ?? [];
+                    for (const file of files) {
+                      props.onFileSelected?.(file);
+                    }
+                    if (attachmentFileInputRef.current) {
+                      attachmentFileInputRef.current.value = "";
+                    }
+                  }}
+                />
+
+                <ToolTip place="top" content="Attach File">
+                  <HoverItem className="">
+                    <PaperClipIcon
+                      className="h-3 w-3 hover:brightness-125"
+                      onClick={(e) => {
+                        attachmentFileInputRef.current?.click();
+                      }}
+                    />
+                  </HoverItem>
+                </ToolTip>
+              </>
+            )}
             {props.toolbarOptions?.hideAddContext || (
               <ToolTip place="top" content="Attach Context">
                 <HoverItem onClick={props.onAddContextItem}>

--- a/gui/src/components/mainInput/TipTapEditor/TipTapEditor.css
+++ b/gui/src/components/mainInput/TipTapEditor/TipTapEditor.css
@@ -43,3 +43,39 @@
 .tiptap img.selected-image {
   outline: 3px solid var(--vscode-badge-background, #bfe2b6);
 }
+
+.file-attachment {
+  display: inline-flex;
+  vertical-align: middle;
+  margin: 0 0.15em;
+}
+
+.file-attachment a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+  padding: 0.1em 0.4em;
+  border-radius: 3px;
+  background-color: var(--vscode-badge-background, #bfe2b6);
+  color: var(--vscode-badge-foreground, --vscode-foreground, #000);
+  font-size: 0.9em;
+  text-decoration: none;
+  white-space: nowrap;
+  max-width: 20em;
+  overflow: hidden;
+}
+
+.file-attachment a:hover {
+  filter: brightness(1.1);
+}
+
+.file-attachment .file-attachment-icon {
+  width: 0.85em;
+  height: 0.85em;
+  flex-shrink: 0;
+}
+
+.file-attachment span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/gui/src/components/mainInput/TipTapEditor/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor/TipTapEditor.tsx
@@ -21,7 +21,7 @@ import { InputBoxDiv } from "./components/StyledComponents";
 import { useMainEditor } from "./MainEditorProvider";
 import "./TipTapEditor.css";
 import { createEditorConfig, getPlaceholderText } from "./utils/editorConfig";
-import { handleImageFile } from "./utils/imageUtils";
+import { handleFile, handleImageFile } from "./utils/imageUtils";
 import { useEditorEventHandlers } from "./utils/keyHandlers";
 
 export interface TipTapEditorProps {
@@ -237,30 +237,56 @@ function TipTapEditorInner(props: TipTapEditorProps) {
       }}
       onDrop={(event) => {
         setShowDragOverMsg(false);
-        if (
-          !defaultModel ||
-          !modelSupportsImages(
+        const files = Array.from(event.dataTransfer.files);
+        if (files.length === 0) {
+          return;
+        }
+        const modelSupportsImage =
+          !!defaultModel &&
+          modelSupportsImages(
             defaultModel.provider,
             defaultModel.model,
             defaultModel.title,
             defaultModel.capabilities,
-          )
-        ) {
-          return;
+          );
+        for (const file of files) {
+          if (file.type.startsWith("image/")) {
+            if (!modelSupportsImage) {
+              continue;
+            }
+            void handleImageFile(ideMessenger, file).then((result) => {
+              if (!editor) {
+                return;
+              }
+              if (result) {
+                const [_, dataUrl] = result;
+                const { schema } = editor.state;
+                const node = schema.nodes.image.create({ src: dataUrl });
+                const tr = editor.state.tr.insert(0, node);
+                editor.view.dispatch(tr);
+              }
+            });
+          } else {
+            void handleFile(ideMessenger, file).then((result) => {
+              if (!editor) {
+                return;
+              }
+              if (result) {
+                const [name, dataUrl] = result;
+                const { schema } = editor.state;
+                const node = schema.nodes["file-attachment"].create({
+                  name,
+                  dataUrl,
+                });
+                const tr = editor.state.tr.insert(
+                  editor.state.selection.from,
+                  node,
+                );
+                editor.view.dispatch(tr);
+              }
+            });
+          }
         }
-        let file = event.dataTransfer.files[0];
-        void handleImageFile(ideMessenger, file).then((result) => {
-          if (!editor) {
-            return;
-          }
-          if (result) {
-            const [_, dataUrl] = result;
-            const { schema } = editor.state;
-            const node = schema.nodes.image.create({ src: dataUrl });
-            const tr = editor.state.tr.insert(0, node);
-            editor.view.dispatch(tr);
-          }
-        });
         event.preventDefault();
       }}
     >
@@ -289,6 +315,25 @@ function TipTapEditorInner(props: TipTapEditorProps) {
                 const [_, dataUrl] = result;
                 const { schema } = editor.state;
                 const node = schema.nodes.image.create({ src: dataUrl });
+                editor.commands.command(({ tr }) => {
+                  tr.insert(0, node);
+                  return true;
+                });
+              }
+            });
+          }}
+          onFileSelected={(file) => {
+            void handleFile(ideMessenger, file).then((result) => {
+              if (!editor) {
+                return;
+              }
+              if (result) {
+                const [name, dataUrl] = result;
+                const { schema } = editor.state;
+                const node = schema.nodes["file-attachment"].create({
+                  name,
+                  dataUrl,
+                });
                 editor.commands.command(({ tr }) => {
                   tr.insert(0, node);
                   return true;

--- a/gui/src/components/mainInput/TipTapEditor/extensions/FileAttachment/FileAttachment.tsx
+++ b/gui/src/components/mainInput/TipTapEditor/extensions/FileAttachment/FileAttachment.tsx
@@ -1,0 +1,64 @@
+import { mergeAttributes, Node } from "@tiptap/core";
+import {
+  NodeViewProps,
+  NodeViewWrapper,
+  ReactNodeViewRenderer,
+} from "@tiptap/react";
+import { PaperClipIcon } from "@heroicons/react/24/outline";
+
+export const FileAttachment = Node.create({
+  name: "file-attachment",
+
+  inline: true,
+  group: "inline",
+  atom: true,
+  selectable: true,
+
+  addAttributes() {
+    return {
+      name: {
+        default: null,
+      },
+      dataUrl: {
+        default: null,
+      },
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: "span[data-file-attachment]",
+      },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "span",
+      mergeAttributes(HTMLAttributes, { "data-file-attachment": "" }),
+    ];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(FileAttachmentView);
+  },
+});
+
+function FileAttachmentView(props: NodeViewProps) {
+  const { name, dataUrl } = props.node.attrs;
+
+  return (
+    <NodeViewWrapper
+      as="span"
+      className="file-attachment"
+      contentEditable={false}
+      data-file-attachment
+    >
+      <a href={dataUrl} download={name} title={name} onClick={(e) => e.stopPropagation()}>
+        <PaperClipIcon className="file-attachment-icon" />
+        <span>{name}</span>
+      </a>
+    </NodeViewWrapper>
+  );
+}

--- a/gui/src/components/mainInput/TipTapEditor/extensions/index.ts
+++ b/gui/src/components/mainInput/TipTapEditor/extensions/index.ts
@@ -1,4 +1,5 @@
 export { CodeBlock } from "./CodeBlock/CodeBlock";
+export { FileAttachment } from "./FileAttachment/FileAttachment";
 export { Mention } from "./Mention";
 export { PromptBlock } from "./Prompt/PromptBlock";
 export { SlashCommand } from "./SlashCommand";

--- a/gui/src/components/mainInput/TipTapEditor/utils/editorConfig.ts
+++ b/gui/src/components/mainInput/TipTapEditor/utils/editorConfig.ts
@@ -22,13 +22,13 @@ import { selectSelectedChatModel } from "../../../../redux/slices/configSlice";
 import { AppDispatch } from "../../../../redux/store";
 import { exitEdit } from "../../../../redux/thunks/edit";
 import { getFontSize, isJetBrains } from "../../../../util";
-import { CodeBlock, Mention, PromptBlock, SlashCommand } from "../extensions";
+import { CodeBlock, FileAttachment, Mention, PromptBlock, SlashCommand } from "../extensions";
 import { TipTapEditorProps } from "../TipTapEditor";
 import {
   getContextProviderDropdownOptions,
   getSlashCommandDropdownOptions,
 } from "./getSuggestion";
-import { handleImageFile } from "./imageUtils";
+import { handleFile, handleImageFile } from "./imageUtils";
 
 export function getPlaceholderText(
   placeholder: TipTapEditorProps["placeholder"],
@@ -56,6 +56,13 @@ export function hasValidEditorContent(json: JSONContent): boolean {
     (c) => c.type === PromptBlock.name || c.type === CodeBlock.name,
   );
 
+  // File attachments (top-level or nested inside a paragraph) count as content
+  const hasFileAttachment = json.content?.some(
+    (c) =>
+      c.type === FileAttachment.name ||
+      c.content?.some((child) => child.type === FileAttachment.name),
+  );
+
   // Check for non-whitespace text content
   const hasNonWhitespaceText = json.content?.some((c) =>
     c.content?.some((child) => {
@@ -71,7 +78,7 @@ export function hasValidEditorContent(json: JSONContent): boolean {
   );
 
   // Content is valid if it has either non-whitespace text or special blocks
-  return hasNonWhitespaceText || hasPromptOrCodeBlock || false;
+  return hasNonWhitespaceText || hasPromptOrCodeBlock || hasFileAttachment || false;
 }
 
 /**
@@ -230,6 +237,51 @@ export function createEditorConfig(options: {
           props.placeholder,
           historyLengthRef.current,
         ),
+      }),
+      FileAttachment.extend({
+        addProseMirrorPlugins() {
+          const filePastePlugin = new Plugin({
+            props: {
+              handleDOMEvents: {
+                paste(view, event) {
+                  const items = event.clipboardData?.items;
+                  if (!items) {
+                    return;
+                  }
+                  const fileItems = [...items]
+                    .map((item) => item.getAsFile())
+                    .filter(
+                      (file): file is File =>
+                        !!file && !file.type.startsWith("image/"),
+                    );
+                  if (fileItems.length === 0) {
+                    return;
+                  }
+                  for (const file of fileItems) {
+                    void handleFile(ideMessenger, file).then((result) => {
+                      if (!result) {
+                        return;
+                      }
+                      const [name, dataUrl] = result;
+                      const { schema } = view.state;
+                      const node = schema.nodes["file-attachment"].create({
+                        name,
+                        dataUrl,
+                      });
+                      const tr = view.state.tr.insert(
+                        view.state.selection.from,
+                        node,
+                      );
+                      view.dispatch(tr);
+                    });
+                  }
+                  event.preventDefault();
+                },
+              },
+            },
+          });
+          return [filePastePlugin];
+        },
       }),
       Paragraph.extend({
         addKeyboardShortcuts() {

--- a/gui/src/components/mainInput/TipTapEditor/utils/imageUtils.ts
+++ b/gui/src/components/mainInput/TipTapEditor/utils/imageUtils.ts
@@ -1,6 +1,7 @@
 import { IIdeMessenger } from "../../../../context/IdeMessenger";
 
 const IMAGE_RESOLUTION = 1024;
+const MAX_FILE_SIZE_MB = 10;
 
 export function getDataUrlForFile(
   file: File,
@@ -70,4 +71,31 @@ export async function handleImageFile(
       "Images need to be in jpg or png format and less than 10MB in size.",
     ]);
   }
+}
+
+/**
+ * Reads a non-image file as a data URL so it can be embedded in the editor and
+ * history as a download-able attachment. Returns [name, dataUrl] or undefined.
+ */
+export async function handleFile(
+  ideMessenger: IIdeMessenger,
+  file: File,
+): Promise<[string, string] | undefined> {
+  const filesize = file.size / 1024 / 1024; // filesize in MB
+  if (filesize > MAX_FILE_SIZE_MB) {
+    ideMessenger.post("showToast", [
+      "error",
+      `File "${file.name}" is too large. Maximum size is ${MAX_FILE_SIZE_MB}MB.`,
+    ]);
+    return undefined;
+  }
+
+  const dataUrl = await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+
+  return [file.name, dataUrl];
 }

--- a/gui/src/components/mainInput/TipTapEditor/utils/processEditorContent.ts
+++ b/gui/src/components/mainInput/TipTapEditor/utils/processEditorContent.ts
@@ -4,13 +4,14 @@ import { Text } from "@tiptap/extension-text";
 import { JSONContent } from "@tiptap/react";
 import {
   ContextItemWithId,
+  FileMessagePart,
   MessagePart,
   RangeInFile,
   TextMessagePart,
 } from "core";
 import { ctxItemToRifWithContents } from "core/commands/util";
 import { getUriDescription } from "core/util/uri";
-import { CodeBlock, Mention, PromptBlock } from "../extensions";
+import { CodeBlock, FileAttachment, Mention, PromptBlock } from "../extensions";
 import { GetContextRequest } from "./types";
 
 interface MentionAttrs {
@@ -24,8 +25,13 @@ function resolvePromptBlock(p: JSONContent): string | undefined {
   return p.attrs?.item.name;
 }
 
-function resolveParagraph(p: JSONContent): [string, GetContextRequest[]] {
+function resolveParagraph(p: JSONContent): {
+  text: string;
+  contextRequests: GetContextRequest[];
+  fileParts: FileMessagePart[];
+} {
   const contextRequests: GetContextRequest[] = [];
+  const fileParts: FileMessagePart[] = [];
 
   const text = (p.content || [])
     .map((child) => {
@@ -40,7 +46,16 @@ function resolveParagraph(p: JSONContent): [string, GetContextRequest[]] {
             query: attrs.query,
           });
           return child.attrs?.renderInlineAs ?? child.attrs?.label;
-
+        case FileAttachment.name:
+          const name = child.attrs?.name as string | undefined;
+          if (name) {
+            fileParts.push({
+              type: "file",
+              name,
+              dataUrl: (child.attrs?.dataUrl as string) ?? "",
+            });
+          }
+          return name ? `[Attachment: ${name}]` : "";
         default:
           console.warn("Unexpected child type", child.type);
           return "";
@@ -49,7 +64,7 @@ function resolveParagraph(p: JSONContent): [string, GetContextRequest[]] {
     .join("")
     .trimStart();
 
-  return [text, contextRequests];
+  return { text, contextRequests, fileParts };
 }
 
 export function processEditorContent(editorState: JSONContent) {
@@ -64,9 +79,10 @@ export function processEditorContent(editorState: JSONContent) {
         slashCommandName = resolvePromptBlock(p);
         break;
       case Paragraph.name:
-        const [text, ctxItems] = resolveParagraph(p);
+        const { text, contextRequests: paraCtxRequests, fileParts } =
+          resolveParagraph(p);
 
-        contextRequests.push(...ctxItems);
+        contextRequests.push(...paraCtxRequests);
 
         if (text) {
           // Merge with previous text part if possible
@@ -76,6 +92,8 @@ export function processEditorContent(editorState: JSONContent) {
             parts.push({ type: "text", text });
           }
         }
+
+        parts.push(...fileParts);
         break;
       case CodeBlock.name:
         if (!p.attrs?.item) {

--- a/gui/src/redux/util/constructMessages.test.ts
+++ b/gui/src/redux/util/constructMessages.test.ts
@@ -1063,4 +1063,69 @@ describe("constructMessages", () => {
       );
     });
   });
+
+  test("should convert file attachment parts to text placeholders for the LLM", () => {
+    mockHistory = [
+      {
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "Please review this" },
+            {
+              type: "file",
+              name: "report.pdf",
+              dataUrl: "data:application/pdf;base64,xxxx",
+            },
+          ],
+        } as ChatMessage,
+        contextItems: [],
+      },
+    ];
+
+    const { messages } = constructMessages(
+      mockHistory,
+      "Base System Message",
+      [],
+      {},
+    );
+
+    const userMessage = messages[1] as UserChatMessage;
+    expect(Array.isArray(userMessage.content)).toBe(true);
+    const content = userMessage.content as any[];
+
+    // The text part is preserved as-is
+    expect(content[0]).toEqual({ type: "text", text: "Please review this" });
+    // The file part is converted to a text placeholder (no dataUrl leak)
+    expect(content[1]).toEqual({
+      type: "text",
+      text: "[Attachment: report.pdf]",
+    });
+    // No file part should ever reach the LLM
+    expect(content.some((part) => part.type === "file")).toBe(false);
+  });
+
+  test("should not alter messages without file parts", () => {
+    mockHistory = [
+      {
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "Just text" }],
+        } as ChatMessage,
+        contextItems: [],
+      },
+    ];
+
+    const { messages } = constructMessages(
+      mockHistory,
+      "Base System Message",
+      [],
+      {},
+    );
+
+    const userMessage = messages[1] as UserChatMessage;
+    expect(Array.isArray(userMessage.content)).toBe(true);
+    expect(userMessage.content).toEqual([
+      { type: "text", text: "Just text" },
+    ]);
+  });
 });

--- a/gui/src/redux/util/constructMessages.ts
+++ b/gui/src/redux/util/constructMessages.ts
@@ -34,6 +34,25 @@ interface MessageWithContextItems {
   ctxItems: ContextItemWithId[];
   message: ChatMessage;
 }
+
+/**
+ * File attachments are rendered in the UI (via editorState) but are not sent
+ * to LLM providers, which do not understand the `file` part type. Convert them
+ * to a text placeholder so every provider receives a safe, valid message.
+ */
+function sanitizeFilePartsForLLM(content: ChatMessage["content"]): ChatMessage["content"] {
+  if (!Array.isArray(content)) {
+    return content;
+  }
+  if (!content.some((part) => part.type === "file")) {
+    return content;
+  }
+  return content.map((part) =>
+    part.type === "file"
+      ? { type: "text" as const, text: `[Attachment: ${part.name}]` }
+      : part,
+  );
+}
 export function constructMessages(
   history: ChatHistoryItem[],
   baseSystemMessage: string | undefined,
@@ -221,7 +240,10 @@ export function constructMessages(
     });
   }
 
-  const messages = msgs.map((m) => m.message);
+  const messages = msgs.map((m) => ({
+    ...m.message,
+    content: sanitizeFilePartsForLLM(m.message.content),
+  }));
   return {
     messages,
     appliedRules,

--- a/gui/src/redux/util/constructMessages.ts
+++ b/gui/src/redux/util/constructMessages.ts
@@ -34,25 +34,6 @@ interface MessageWithContextItems {
   ctxItems: ContextItemWithId[];
   message: ChatMessage;
 }
-
-/**
- * File attachments are rendered in the UI (via editorState) but are not sent
- * to LLM providers, which do not understand the `file` part type. Convert them
- * to a text placeholder so every provider receives a safe, valid message.
- */
-function sanitizeFilePartsForLLM(content: ChatMessage["content"]): ChatMessage["content"] {
-  if (!Array.isArray(content)) {
-    return content;
-  }
-  if (!content.some((part) => part.type === "file")) {
-    return content;
-  }
-  return content.map((part) =>
-    part.type === "file"
-      ? { type: "text" as const, text: `[Attachment: ${part.name}]` }
-      : part,
-  );
-}
 export function constructMessages(
   history: ChatHistoryItem[],
   baseSystemMessage: string | undefined,
@@ -240,10 +221,31 @@ export function constructMessages(
     });
   }
 
-  const messages = msgs.map((m) => ({
-    ...m.message,
-    content: sanitizeFilePartsForLLM(m.message.content),
-  }));
+  // File attachments are rendered in the UI (via editorState) but are not sent
+  // to LLM providers, which do not understand the `file` part type. Convert them
+  // to a text placeholder so every provider receives a safe, valid message.
+  const messages = msgs.map((m) => {
+    const { message } = m;
+    if (
+      message.role !== "user" &&
+      message.role !== "assistant" &&
+      message.role !== "thinking"
+    ) {
+      return message;
+    }
+    if (
+      typeof message.content === "string" ||
+      !message.content.some((part) => part.type === "file")
+    ) {
+      return message;
+    }
+    const content = message.content.map((part) =>
+      part.type === "file"
+        ? { type: "text" as const, text: `[Attachment: ${part.name}]` }
+        : part,
+    );
+    return { ...message, content };
+  });
   return {
     messages,
     appliedRules,


### PR DESCRIPTION
## Summary

Adds the ability to attach non-image files (e.g. PDFs, text, archives) to the chat input box.

## Changes

- **New \FileMessagePart\ type** in core (\core/index.d.ts\ + \core/config/types.ts\) carrying \
ame\ and \dataUrl\.
- **Choke point**: \constructMessages\ converts file parts to a text placeholder (\[Attachment: name]\) before messages reach any LLM provider, so providers never receive an unsupported part type.
- **Defense in depth** for file parts in: \countTokens\, \openaiTypeConverters\ (Chat Completions + Responses paths), \Anthropic\, \Gemini\, \stripImages\, and console \Message\ rendering.
- **Editor**: new TipTap \FileAttachment\ inline node with a NodeView chip (name + download via dataUrl), paste/drop handling for non-image files, and a paperclip toolbar button.

## Tests

- \constructMessages.test.ts\: file parts are converted to \[Attachment: name]\ without leaking the dataUrl; messages without file parts are unchanged.
- \countTokens.test.ts\: counting tokens for file parts does not throw.