### PR TITLE
fix(vscode): load webview stylesheets through CORS

### DIFF
--- a/extensions/vscode/src/ContinueConsoleWebviewViewProvider.ts
+++ b/extensions/vscode/src/ContinueConsoleWebviewViewProvider.ts
@@ -3,6 +3,7 @@ import { EXTENSION_NAME } from "core/util/constants";
 import { LLMLogger } from "core/llm/logger";
 import * as vscode from "vscode";
 
+import { getStylesheetLink } from "./util/util";
 import { getExtensionUri, getNonce } from "./util/vscode";
 
 interface FromConsoleView {
@@ -196,7 +197,7 @@ export class ContinueConsoleWebviewViewProvider
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <script>const vscode = acquireVsCodeApi();</script>
-        <link href="${styleMainUri}" rel="stylesheet">
+        ${getStylesheetLink(styleMainUri)}
 
         <title>Continue</title>
       </head>

--- a/extensions/vscode/src/ContinueGUIWebviewViewProvider.ts
+++ b/extensions/vscode/src/ContinueGUIWebviewViewProvider.ts
@@ -1,7 +1,11 @@
 import * as vscode from "vscode";
 
 import { getTheme } from "./util/getTheme";
-import { getExtensionVersion, getvsCodeUriScheme } from "./util/util";
+import {
+  getExtensionVersion,
+  getStylesheetLink,
+  getvsCodeUriScheme,
+} from "./util/util";
 import { getExtensionUri, getNonce, getUniqueId } from "./util/vscode";
 import { VsCodeWebviewProtocol } from "./webviewProtocol";
 
@@ -133,7 +137,7 @@ export class ContinueGUIWebviewViewProvider
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <script>const vscode = acquireVsCodeApi();</script>
-        <link href="${styleMainUri}" rel="stylesheet">
+        ${getStylesheetLink(styleMainUri)}
 
         <title>Continue</title>
       </head>

--- a/extensions/vscode/src/util/util.ts
+++ b/extensions/vscode/src/util/util.ts
@@ -160,6 +160,10 @@ export function getExtensionVersion(): string {
   return extension?.packageJSON.version || "0.1.0";
 }
 
+export function getStylesheetLink(styleUri: string): string {
+  return `<link href="${styleUri}" rel="stylesheet" crossorigin="anonymous">`;
+}
+
 export function getvsCodeUriScheme(): string {
   return vscode.env.uriScheme;
 }

--- a/extensions/vscode/src/util/util.vitest.ts
+++ b/extensions/vscode/src/util/util.vitest.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { getStylesheetLink } from "./util";
+
 vi.mock("node:os", () => ({
   platform: vi.fn(),
   arch: vi.fn(),
@@ -75,5 +77,13 @@ describe("isExtensionPrerelease", () => {
     } as any);
 
     expect(isExtensionPrerelease()).toBe(true);
+  });
+});
+
+describe("getStylesheetLink", () => {
+  it("requests webview stylesheets with CORS", () => {
+    expect(getStylesheetLink("vscode-webview://continue/gui/index.css")).toBe(
+      '<link href="vscode-webview://continue/gui/index.css" rel="stylesheet" crossorigin="anonymous">',
+    );
   });
 });


### PR DESCRIPTION
## Description

Fixes #12135.

Firefox 149 sends the stylesheet request from Continue's VS Code webview with `Sec-Fetch-Mode: no-cors`. In code-server, that request skips the service worker and the generated `vscode-resource` host cannot be resolved. The script request already uses CORS and continues to load.

This adds `crossorigin="anonymous"` to the stylesheet link generated for both the main and console webviews. The link markup is shared through a small helper so both providers keep the same behavior.

This change was developed with AI assistance and reviewed manually against the webview code path and the issue's request details.

## AI Code Review

Not requested; this PR is from an external contributor.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Not applicable for this focused webview markup fix.

## Tests

- `pnpm exec vitest run src/util/util.vitest.ts` (4 tests passed)
- `pnpm exec eslint src/ContinueGUIWebviewViewProvider.ts src/ContinueConsoleWebviewViewProvider.ts src/util/util.ts src/util/util.vitest.ts --ext ts` (0 errors; two pre-existing warnings remain)
- `git diff --check`
- `pnpm exec tsc -p ./ --noEmit` was attempted but is currently blocked by missing generated/local workspace package outputs such as `@continuedev/config-yaml` and `@continuedev/fetch`, producing existing repository-wide errors unrelated to this change.
