### PR TITLE
fix(gui): allow the onboarding card to be reopened after dismissal

### DIFF
--- a/gui/src/components/OnboardingCard/hooks/useOnboardingCard.test.tsx
+++ b/gui/src/components/OnboardingCard/hooks/useOnboardingCard.test.tsx
@@ -1,0 +1,74 @@
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { getLocalStorage, setLocalStorage } from "../../../util/localStorage";
+import { renderWithProviders } from "../../../util/test/render";
+import { useOnboardingCard } from "./useOnboardingCard";
+
+/**
+ * Minimal probe that surfaces the hook's state and actions to the DOM, so the
+ * hook can be exercised through the same providers the real card renders in.
+ */
+function OnboardingCardProbe() {
+  const { show, open, close } = useOnboardingCard();
+
+  return (
+    <div>
+      <span data-testid="show">{String(show)}</span>
+      <button data-testid="open" onClick={() => void open()}>
+        open
+      </button>
+      <button data-testid="close" onClick={() => close()}>
+        close
+      </button>
+    </div>
+  );
+}
+
+describe("useOnboardingCard", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("shows the card by default for a user who has not onboarded", async () => {
+    await renderWithProviders(<OnboardingCardProbe />);
+
+    expect(screen.getByTestId("show").textContent).toBe("true");
+  });
+
+  it("persists the dismissal when the card is closed", async () => {
+    const { user } = await renderWithProviders(<OnboardingCardProbe />);
+
+    await user.click(screen.getByTestId("close"));
+
+    expect(screen.getByTestId("show").textContent).toBe("false");
+    expect(getLocalStorage("hasDismissedOnboardingCard")).toBe(true);
+  });
+
+  // Regression test for https://github.com/continuedev/continue/issues/12582
+  it("clears the persisted dismissal when the card is reopened", async () => {
+    setLocalStorage("hasDismissedOnboardingCard", true);
+
+    const { user } = await renderWithProviders(<OnboardingCardProbe />);
+    expect(screen.getByTestId("show").textContent).toBe("false");
+
+    await user.click(screen.getByTestId("open"));
+
+    expect(screen.getByTestId("show").textContent).toBe("true");
+    expect(getLocalStorage("hasDismissedOnboardingCard")).toBe(false);
+  });
+
+  // The redux `show` flag is not persisted by redux-persist, so reopening has
+  // to clear the localStorage flag or the card vanishes again on next load.
+  it("keeps the card visible after a reload once it has been reopened", async () => {
+    setLocalStorage("hasDismissedOnboardingCard", true);
+
+    const first = await renderWithProviders(<OnboardingCardProbe />);
+    await first.user.click(screen.getByTestId("open"));
+    first.unmount();
+
+    // A fresh store stands in for a webview reload: only localStorage carries over.
+    await renderWithProviders(<OnboardingCardProbe />);
+
+    expect(screen.getByTestId("show").textContent).toBe("true");
+  });
+});

--- a/gui/src/components/OnboardingCard/hooks/useOnboardingCard.ts
+++ b/gui/src/components/OnboardingCard/hooks/useOnboardingCard.ts
@@ -38,6 +38,9 @@ export function useOnboardingCard(): UseOnboardingCard {
   }
 
   async function open(tab?: OnboardingModes) {
+    // Clear the dismissal flag set by `close`. The redux `show` flag is not
+    // persisted, so without this the card disappears again on the next reload.
+    setLocalStorage("hasDismissedOnboardingCard", false);
     navigate("/");
     dispatch(
       setOnboardingCard({

--- a/gui/src/pages/config/sections/HelpSection.tsx
+++ b/gui/src/pages/config/sections/HelpSection.tsx
@@ -8,10 +8,10 @@ import {
 import { useContext, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import Shortcut from "../../../components/gui/Shortcut";
+import { useOnboardingCard } from "../../../components/OnboardingCard/hooks/useOnboardingCard";
 import { Card } from "../../../components/ui";
 import { IdeMessengerContext } from "../../../context/IdeMessenger";
 import { useAppDispatch, useAppSelector } from "../../../redux/hooks";
-import { setOnboardingCard } from "../../../redux/slices/uiSlice";
 import { saveCurrentSession } from "../../../redux/thunks/session";
 import { isJetBrains } from "../../../util";
 import { ROUTES } from "../../../util/navigation";
@@ -150,6 +150,7 @@ export function HelpSection() {
   const ideMessenger = useContext(IdeMessengerContext);
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
+  const onboardingCard = useOnboardingCard();
 
   const currentSession = useAppSelector((state) => state.session);
 
@@ -226,12 +227,7 @@ export function HelpSection() {
                       generateTitle: true,
                     }),
                   );
-                  dispatch(
-                    setOnboardingCard({
-                      show: true,
-                      activeTab: undefined,
-                    }),
-                  );
+                  void onboardingCard.open();
                   ideMessenger.post("showTutorial", undefined);
                 }}
               />


### PR DESCRIPTION
## Description

Fixes #12582 — once the onboarding card is closed, there is no way to get it back.

`close` writes `hasDismissedOnboardingCard: true` to localStorage, but nothing in the codebase ever clears it. The redux `onboardingCard.show` flag isn't persisted (the `ui` slice only persists `toolSettings`, `toolGroupSettings`, `ruleSettings` and `reasoningSettings`), so the existing **Help → Quickstart** row re-showed the card for the current session only — after a webview reload, `show` was recomputed from localStorage and the card was suppressed again:

```ts
show = onboardingStatus !== "Completed" && !hasDismissedOnboardingCard;
```

The only escape was opening webview devtools and running `localStorage.removeItem("hasDismissedOnboardingCard")`.

**Change:** `open` now clears the flag, mirroring `close` which sets it. Every call site of `open` (`Layout.tsx` `setupLocalConfig`/`setupApiKey`, the new-user auto-open, and the Quickstart row) is an explicit request to show the card, so clearing the dismissal there is safe.

The Quickstart row now calls `onboardingCard.open()` instead of dispatching `setOnboardingCard` directly, so it goes through that same path. This is behaviour-preserving: it previously passed `activeTab: undefined`, and the card already defaults to `API_KEY` when `activeTab` is unset (`OnboardingCard.tsx`).

### Scope note

This intentionally leaves one case alone: a user whose `onboardingStatus` is `"Completed"` is still suppressed after a reload by the first half of the condition above. Quickstart re-shows the card for that session, which seems like the intended behaviour for someone who has finished onboarding — happy to widen this if you'd prefer `open` to reset the status too.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created — no user-facing docs describe this flag
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Not included — this is a state-persistence fix with no visual change to the card itself. It reproduces as follows:

1. Configure a chat model (the close button only renders once `config.modelsByRole.chat.length > 0`).
2. Open the chat panel and dismiss the onboarding card with the **x**.
3. **Help → Quickstart** — card reappears.
4. Reload the webview.

On `main` the card is gone again at step 4 with no way to restore it; with this change it persists.

## Tests

Added `gui/src/components/OnboardingCard/hooks/useOnboardingCard.test.tsx` (4 cases):

- shows by default for a user who hasn't onboarded
- `close` persists the dismissal and hides the card
- `open` clears the persisted dismissal — regression test for #12582
- the card is still visible after a simulated reload (fresh store, localStorage carried over)

Both regression cases fail on `main` (`expected true to be false`, `expected 'false' to be 'true'`) and pass with this change. Full `gui` suite: **38 files / 376 tests passing**; `tsc --noEmit` and Prettier clean.
