### PR TITLE
fix(gui): correct the Codestral API key note in the Add Model form

### DIFF
--- a/gui/src/forms/AddModelForm.tsx
+++ b/gui/src/forms/AddModelForm.tsx
@@ -315,8 +315,9 @@ export function AddModelForm({ onDone }: AddModelFormProps) {
                 <Alert>
                   <p className="m-0 text-sm font-bold">Codestral API key</p>
                   <p className="m-0 mt-1">
-                    Note that codestral requires a different API key from other
-                    Mistral models
+                    Codestral accepts either a Mistral API key or a
+                    Codestral-specific key. Continue detects which one you've
+                    entered and uses the matching endpoint.
                   </p>
                 </Alert>
               </div>


### PR DESCRIPTION
## Description

Fixes #13049.

The Add Model form shows this note whenever the selected model starts with `codestral`:

> Note that codestral requires a different API key from other Mistral models

That claim doesn't match what Continue does. The Mistral provider autodetects which kind of key it was given and selects the endpoint to match — `core/llm/llms/Mistral.ts`:

```ts
private async autodetectApiKeyType(): Promise<MistralApiKeyType> {
  const mistralResp = await fetch("https://api.mistral.ai/v1/models", { ... });
  if (mistralResp.status === 401) {
    return "codestral";
  }
  return "mistral";
}
```

and then rewrites `apiBase` to either `codestral.mistral.ai/v1/` or `api.mistral.ai/v1/`. That branch runs whenever no explicit `apiBase` was configured — which is exactly the case for a model added through this form, since `models.codestral` in `gui/src/pages/AddNewModel/configs/models.ts` sets only `title`, `model` and `contextLength`.

So a standard Mistral key does work for Codestral, which is what the reporter observed. This PR rewords the note to describe the actual behaviour instead of asserting a requirement that isn't enforced.

### What I verified, and what I didn't

Verified in this repo: the autodetect path above, and that the form-created config carries no `apiBase`, so that path is reached.

**Not** verified: whether Mistral still issues a separate Codestral key at all. The reporter mentions the "Codestral" section is gone from `console.mistral.ai`, but that console is behind auth (`/codestral`, `/api-keys` and `/` all 303 to the login flow identically), so I couldn't confirm it either way. I've therefore kept the note and corrected it, rather than deleting it or asserting that Mistral changed their policy. Happy to just remove the block instead if you'd prefer.

Two related spots that still assume a dedicated Codestral key, left alone here to keep the diff focused — tell me if you'd like them in scope:

- `AddModelForm.tsx:30,105-108` — the API-key link switches to `https://console.mistral.ai/codestral` for codestral models
- `gui/src/pages/AddNewModel/configs/providers.ts:418,446` — same URL in the Mistral provider's `longDescription` and `apiKeyUrl`

### Unrelated observation

While reading `Mistral.ts` I noticed `autodetectApiKeyType()` is called fire-and-forget in the constructor (`.then(...)` with an empty `.catch(() => {})`). The constructor returns with `apiBase` still set to `codestral.mistral.ai/v1/`, so a request issued before the probe resolves can go to the wrong endpoint. Not touched here since it's a separate concern — happy to open an issue if that's useful.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created — none describe this note
- [x] The relevant tests, if any, have been updated or created — see below

## Screen recording or screenshot

Copy-only change inside the existing `Alert`; no layout or behaviour change. The note renders in **Add Chat model → provider Mistral → model Codestral**, immediately above the API key field.

Before:

> **Codestral API key**
> Note that codestral requires a different API key from other Mistral models

After:

> **Codestral API key**
> Codestral accepts either a Mistral API key or a Codestral-specific key. Continue detects which one you've entered and uses the matching endpoint.

## Tests

No tests added: this changes static copy inside a conditional that has no existing test coverage (there is no `AddModelForm` test file, and no test file for `Mistral.ts`), and asserting on exact wording would be brittle. The full `gui` suite still passes — 38 files / 376 tests — with `tsc --noEmit` and Prettier clean.
