### PR TITLE
fix(gui): prevent Accept/Reject buttons from being clipped in narrow sidebar

### DIFF
--- a/gui/src/components/StyledMarkdownPreview/index.tsx
+++ b/gui/src/components/StyledMarkdownPreview/index.tsx
@@ -66,8 +66,8 @@ const StyledMarkdown = styled.div<{
     background-color: ${vscEditorBackground};
     border-radius: ${defaultBorderRadius};
 
-    max-width: calc(100vw - 24px);
-    overflow-x: scroll;
+    max-width: 100%;
+    overflow-x: auto;
     overflow-y: hidden;
 
     padding: 8px;

--- a/gui/src/components/UnifiedTerminal/UnifiedTerminal.tsx
+++ b/gui/src/components/UnifiedTerminal/UnifiedTerminal.tsx
@@ -88,8 +88,8 @@ const StyledTerminalContainer = styled.div<{
 const TerminalContent = styled.div`
   pre {
     white-space: pre-wrap;
-    max-width: calc(100vw - 24px);
-    overflow-x: scroll;
+    max-width: 100%;
+    overflow-x: auto;
     overflow-y: hidden;
     padding: 8px;
     margin: 0;

--- a/gui/src/components/mainInput/Lump/LumpToolbar/PendingToolCallToolbar.tsx
+++ b/gui/src/components/mainInput/Lump/LumpToolbar/PendingToolCallToolbar.tsx
@@ -36,17 +36,17 @@ export function PendingToolCallToolbar() {
   };
 
   return (
-    <div className="flex w-full flex-col pb-0.5">
+    <div className="flex w-full min-w-0 flex-col pb-0.5">
       {pendingToolCalls.map((toolCall, index) => (
         <div
           key={toolCall.toolCallId}
-          className="border-input bg-input flex items-center gap-2 rounded border"
+          className="border-input bg-input grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center rounded border"
         >
-          <span className="text-description flex-1 truncate text-xs italic">
+          <span className="text-description truncate px-1 text-xs italic">
             {toolCall.tool?.displayTitle ?? toolCall.toolCall.function.name}
           </span>
 
-          <div className="flex items-center gap-1">
+          <div className="flex items-center gap-1 pr-1">
             <Button
               variant="ghost"
               size="sm"

--- a/gui/src/components/mainInput/Lump/index.tsx
+++ b/gui/src/components/mainInput/Lump/index.tsx
@@ -5,8 +5,8 @@ import { LumpToolbar } from "./LumpToolbar/LumpToolbar";
  */
 export function Lump() {
   return (
-    <div className="bg-input rounded-t-default border-command-border mx-1.5 border-l border-r border-t">
-      <div className="xs:px-2 px-1 py-0.5">
+    <div className="bg-input rounded-t-default border-command-border mx-1 min-w-0 overflow-hidden border-l border-r border-t">
+      <div className="min-w-0 px-1 py-0.5">
         <LumpToolbar />
       </div>
     </div>

--- a/gui/src/pages/gui/Chat.tsx
+++ b/gui/src/pages/gui/Chat.tsx
@@ -46,10 +46,9 @@ import { ToolCallDiv } from "./ToolCallDiv";
 import { useStore } from "react-redux";
 import FeedbackDialog from "../../components/dialogs/FeedbackDialog";
 
-import { DeprecationBanner } from "../../components/DeprecationBanner";
 import { FatalErrorIndicator } from "../../components/config/FatalErrorNotice";
+import { DeprecationBanner } from "../../components/DeprecationBanner";
 import InlineErrorMessage from "../../components/mainInput/InlineErrorMessage";
-import { resolveEditorContent } from "../../components/mainInput/TipTapEditor/utils/resolveEditorContent";
 import { setDialogMessage, setShowDialog } from "../../redux/slices/uiSlice";
 import { RootState } from "../../redux/store";
 import { cancelStream } from "../../redux/thunks/cancelStream";
@@ -71,6 +70,7 @@ function findLatestSummaryIndex(history: ChatHistoryItem[]): number {
 const StepsDiv = styled.div`
   position: relative;
   background-color: transparent;
+  overflow-x: hidden;
 
   & > * {
     position: relative;

--- a/gui/src/pages/gui/index.tsx
+++ b/gui/src/pages/gui/index.tsx
@@ -7,7 +7,7 @@ export default function GUI() {
       <aside className="4xl:flex border-vsc-input-border no-scrollbar hidden min-h-0 w-96 overflow-y-auto border-0 border-r border-solid">
         <History />
       </aside>
-      <main className="no-scrollbar flex min-h-0 flex-1 flex-col">
+      <main className="no-scrollbar flex min-h-0 min-w-0 flex-1 flex-col">
         <Chat />
       </main>
     </div>


### PR DESCRIPTION
## Summary

The PendingToolCallToolbar buttons (Accept/Reject) are clipped when the sidebar panel is narrow or after extended chat sessions with many code blocks/terminal outputs.

## Root Causes

1. Toolbar used flexbox with `shrink-0` on buttons container, causing overflow when panel width was insufficient
2. Pre elements used `max-width: calc(100vw - 24px)` which could expand content beyond the sidebar container width, pushing the entire layout outside the `overflow-x: hidden` boundary

## Fix

- Switch toolbar row from flexbox to CSS Grid (`grid-cols-[minmax(0,1fr)_auto]`) ensuring buttons always receive their intrinsic width
- Replace viewport-relative max-width with container-relative (`100%`) for pre elements in both StyledMarkdownPreview and UnifiedTerminal
- Add `overflow-x: hidden` on StepsDiv to contain chat content
- Add `min-w-0` on flex containers to allow proper shrinking

## Testing

- Tested with narrow sidebar (~300px) — buttons always visible
- Extended chat sessions with multiple terminal outputs — no overflow
- Code blocks render with horizontal scroll inside their container (no layout push)

## Changed Files

| File | Change |
|------|--------|
| `PendingToolCallToolbar.tsx` | flex → grid layout |
| `Lump/index.tsx` | Add `min-w-0`, `overflow-hidden` |
| `StyledMarkdownPreview/index.tsx` | `calc(100vw-24px)` → `100%` |
| `UnifiedTerminal.tsx` | `calc(100vw-24px)` → `100%` |
| `Chat.tsx` | StepsDiv `overflow-x: hidden` |
| `gui/index.tsx` | Main `min-w-0` |