### PR TITLE
docs: fix dead model links on Ollama provider page

### DIFF
--- a/docs/customize/model-providers/top-level/ollama.mdx
+++ b/docs/customize/model-providers/top-level/ollama.mdx
@@ -5,7 +5,7 @@ sidebarTitle: "Ollama"
 ---
 
 <Tip>
-  **Discover Ollama models [here](https://continue.dev/lmstudio)**
+  **Discover Ollama models [here](https://docs.continue.dev/customize/models)**
 </Tip>
 
 <Info>
@@ -45,7 +45,7 @@ sidebarTitle: "Ollama"
 </Tabs>
 
 <Info>
-  **Check out a more advanced configuration [here](https://continue.dev/ollama/qwen3-coder-30b?view=config)**
+  **Check out a more advanced configuration [here](https://docs.continue.dev/guides/ollama-guide)**
 </Info>
 
 ## How to Configure Model Capabilities in Ollama


### PR DESCRIPTION
## Description

Both links on the Ollama provider page point at URLs that no longer resolve. The model catalog moved to the docs site after the hub was retired, so readers clicking "Discover Ollama models" or "Check out a more advanced configuration" land on 404 pages instead of the content they're after.

Pointed both links at the live docs pages: the model recommendations page and the full Ollama setup guide.

Fixes #13130.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Docs-only change, nothing to capture.

## Tests

Docs-only change. Both replacement URLs were confirmed to return 200 before submitting; the old ones both return 404.
