### PR TITLE
fix: only treat tar as create when the mode flag is actually c

### DIFF
--- a/packages/terminal-security/src/evaluateTerminalCommandSecurity.ts
+++ b/packages/terminal-security/src/evaluateTerminalCommandSecurity.ts
@@ -974,6 +974,25 @@ function isHighRiskCommand(
 }
 
 /**
+ * Checks if tar arguments ask for archive creation.
+ *
+ * Only mode flags may be inspected: file operands such as `archive.tar.gz` also
+ * contain a "c", which would make extraction look like creation.
+ */
+function isTarCreation(args: string[]): boolean {
+  return args.some((arg, idx) => {
+    if (arg.startsWith("--")) {
+      return arg === "--create";
+    }
+    if (arg.startsWith("-")) {
+      return arg.includes("c");
+    }
+    // tar also accepts the flag bundle without a leading dash, e.g. `tar czf`
+    return idx === 0 && /^[a-z]+$/i.test(arg) && arg.includes("c");
+  });
+}
+
+/**
  * Checks if a command is safe and can be auto-approved
  */
 function isSafeCommand(baseCommand: string, args: string[]): boolean {
@@ -1074,7 +1093,7 @@ function isSafeCommand(baseCommand: string, args: string[]): boolean {
   if (baseCommand === "tar") {
     // Check for create flag
     if (
-      args.some((arg) => arg.includes("c")) &&
+      isTarCreation(args) &&
       !args.some(
         (arg, idx) =>
           (arg === "-C" &&

--- a/packages/terminal-security/test/terminalCommandSecurity.test.ts
+++ b/packages/terminal-security/test/terminalCommandSecurity.test.ts
@@ -1521,6 +1521,38 @@ describe("evaluateTerminalCommandSecurity", () => {
       expect(result).toBe("allowedWithPermission");
     });
 
+    it("should auto-approve tar creation", () => {
+      const result = evaluateTerminalCommandSecurity(
+        "allowedWithoutPermission",
+        "tar -czf backup.tar.gz ./data",
+      );
+      expect(result).toBe("allowedWithoutPermission");
+    });
+
+    it("should auto-approve tar creation with old-style flags", () => {
+      const result = evaluateTerminalCommandSecurity(
+        "allowedWithoutPermission",
+        "tar czf backup.tar.gz ./data",
+      );
+      expect(result).toBe("allowedWithoutPermission");
+    });
+
+    it("should require permission for tar extraction", () => {
+      const result = evaluateTerminalCommandSecurity(
+        "allowedWithoutPermission",
+        "tar -xzf archive.tar.gz",
+      );
+      expect(result).toBe("allowedWithPermission");
+    });
+
+    it("should require permission for tar extraction with old-style flags", () => {
+      const result = evaluateTerminalCommandSecurity(
+        "allowedWithoutPermission",
+        "tar xzf archive.tar.gz",
+      );
+      expect(result).toBe("allowedWithPermission");
+    });
+
     it("should allow safe zip creation", () => {
       const result = evaluateTerminalCommandSecurity(
         "allowedWithPermission",


### PR DESCRIPTION
Safe-create check matched any argument containing the letter c. Mode flags only. 228 tests passed in packages/terminal-security.