### PR TITLE
fix: treat Windows del flags as case-insensitive

### DIFF
--- a/packages/terminal-security/src/evaluateTerminalCommandSecurity.ts
+++ b/packages/terminal-security/src/evaluateTerminalCommandSecurity.ts
@@ -465,9 +465,12 @@ function isCriticalCommand(baseCommand: string, args: string[]): boolean {
 
   // Windows destructive commands
   if (baseCommand === "del") {
-    const hasRecursive = args.includes("/s") && args.includes("/q");
-    const hasSystemDrive = args.some(
-      (arg) => arg.toLowerCase().includes("c:\\") || arg.includes("c:/"),
+    // Windows switches and drive letters are case-insensitive, so `/S /Q C:\`
+    // has to be treated exactly like `/s /q c:\`
+    const lowerArgs = args.map((arg) => arg.toLowerCase());
+    const hasRecursive = lowerArgs.includes("/s") && lowerArgs.includes("/q");
+    const hasSystemDrive = lowerArgs.some(
+      (arg) => arg.includes("c:\\") || arg.includes("c:/"),
     );
     if (hasRecursive || hasSystemDrive) {
       return true;

--- a/packages/terminal-security/test/terminalCommandSecurity.test.ts
+++ b/packages/terminal-security/test/terminalCommandSecurity.test.ts
@@ -60,6 +60,22 @@ describe("evaluateTerminalCommandSecurity", () => {
         expect(result).toBe("disabled");
       });
 
+      it("should disable Windows del with uppercase recursive flags", () => {
+        const result = evaluateTerminalCommandSecurity(
+          "allowedWithoutPermission",
+          "DEL /S /Q C:\\",
+        );
+        expect(result).toBe("disabled");
+      });
+
+      it("should disable Windows del on the system drive regardless of case", () => {
+        const result = evaluateTerminalCommandSecurity(
+          "allowedWithoutPermission",
+          "del /Q C:/Windows",
+        );
+        expect(result).toBe("disabled");
+      });
+
       it("should disable dd commands that could overwrite disk", () => {
         const result = evaluateTerminalCommandSecurity(
           "allowedWithoutPermission",


### PR DESCRIPTION
## Description

`isCriticalCommand` already blocks recursive/quiet `del` on the system drive, but it compared `/s`, `/q`, and `c:/` case-sensitively. Windows switches and drive letters are not case-sensitive, so `DEL /S /Q C:\` and `del /Q C:/Windows` were downgraded from always-blocked to ask-the-user.

The argument list is now lowercased once before both checks. Existing lowercase matches are unchanged.

Distinct from #13143 (tar create-flag) and #13008 (blocklist expansion). #12429 does not touch the `del` block.

## Checklist

- [x] I've read the contributing guide
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Tests

`cd packages/terminal-security && npx vitest run` → 226 passed. Two new cases cover the uppercase switch/drive forms; they fail on unmodified source.