### PR TITLE
fix: intersect ranges using only the boundary lines own characters

### DIFF
--- a/core/util/ranges.test.ts
+++ b/core/util/ranges.test.ts
@@ -301,8 +301,7 @@ describe("intersection", () => {
     expect(result).toBeNull();
   });
 
-  // TODO
-  test.skip("returns correct intersection for single line overlap", () => {
+  test("returns correct intersection for single line overlap", () => {
     rangeA = {
       start: { line: 1, character: 0 },
       end: { line: 1, character: 5 },
@@ -317,6 +316,42 @@ describe("intersection", () => {
     expect(result).toEqual({
       start: { line: 1, character: 3 },
       end: { line: 1, character: 5 },
+    });
+  });
+
+  test("returns correct intersection when both ranges start on the first line", () => {
+    rangeA = {
+      start: { line: 1, character: 0 },
+      end: { line: 5, character: 0 },
+    };
+
+    rangeB = {
+      start: { line: 1, character: 7 },
+      end: { line: 3, character: 2 },
+    };
+
+    const result = intersection(rangeA, rangeB);
+    expect(result).toEqual({
+      start: { line: 1, character: 7 },
+      end: { line: 3, character: 2 },
+    });
+  });
+
+  test("returns correct intersection when both ranges end on the last line", () => {
+    rangeA = {
+      start: { line: 1, character: 0 },
+      end: { line: 3, character: 8 },
+    };
+
+    rangeB = {
+      start: { line: 2, character: 0 },
+      end: { line: 3, character: 4 },
+    };
+
+    const result = intersection(rangeA, rangeB);
+    expect(result).toEqual({
+      start: { line: 2, character: 0 },
+      end: { line: 3, character: 4 },
     });
   });
 

--- a/core/util/ranges.ts
+++ b/core/util/ranges.ts
@@ -32,24 +32,22 @@ export function intersection(a: Range, b: Range): Range | null {
     return null;
   }
 
-  if (startLine === endLine) {
-    const startCharacter = Math.max(a.start.character, b.start.character);
-    const endCharacter = Math.min(a.end.character, b.end.character);
+  // A range only constrains the characters of the boundary line if it actually
+  // starts/ends there - otherwise it spans the whole line.
+  const startCharacter = Math.max(
+    ...[a.start, b.start]
+      .filter((position) => position.line === startLine)
+      .map((position) => position.character),
+  );
+  const endCharacter = Math.min(
+    ...[a.end, b.end]
+      .filter((position) => position.line === endLine)
+      .map((position) => position.character),
+  );
 
-    if (startCharacter > endCharacter) {
-      return null;
-    }
-
-    return {
-      start: { line: startLine, character: startCharacter },
-      end: { line: endLine, character: endCharacter },
-    };
+  if (startLine === endLine && startCharacter > endCharacter) {
+    return null;
   }
-
-  const startCharacter =
-    startLine === a.start.line ? a.start.character : b.start.character;
-  const endCharacter =
-    endLine === a.end.line ? a.end.character : b.end.character;
 
   return {
     start: { line: startLine, character: startCharacter },


### PR DESCRIPTION
## Description

`intersection()` in `core/util/ranges.ts` used the other range's character offsets even when that range did not start or end on the boundary line.

A same-line overlap such as `(1,0)-(1,5)` vs `(1,3)-(2,0)` returned `null` (`min(5, 0) = 0`). The repo already had a skipped test for this. Shared-start / shared-end multi-line cases were also too wide.

Only endpoints that actually lie on the boundary line now contribute. Used by VS Code autocomplete LSP crawl to drop duplicate type definitions.

Distinct from #13143/#13144/#13145.

## Checklist

- [x] I've read the contributing guide
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Tests

Un-skipped the existing single-line overlap case and added two shared-boundary cases. All three fail on main.

`cd core && npx cross-env NODE_OPTIONS=--experimental-vm-modules npx jest util/ranges.test.ts` → 24 passed, 10 skipped (unrelated `getRangeInString` block).