### PR TITLE
fix: treat null and arrays as non-mergeable in mergeJson

### DIFF
--- a/core/util/merge.test.ts
+++ b/core/util/merge.test.ts
@@ -71,6 +71,27 @@ describe("mergeJson", () => {
     expect(result).toEqual({ a: 1, b: 2, c: undefined });
   });
 
+  it("should let null in the second object replace an object", () => {
+    const first = { a: { b: 1 } };
+    const second = { a: null };
+    const result = mergeJson(first, second);
+    expect(result).toEqual({ a: null });
+  });
+
+  it("should let an object in the second object replace null", () => {
+    const first = { a: null };
+    const second = { a: { b: 1 } };
+    const result = mergeJson(first, second);
+    expect(result).toEqual({ a: { b: 1 } });
+  });
+
+  it("should replace rather than merge when only one value is an array", () => {
+    expect(mergeJson({ a: [1, 2] }, { a: { b: 1 } })).toEqual({
+      a: { b: 1 },
+    });
+    expect(mergeJson({ a: { b: 1 } }, { a: [1, 2] })).toEqual({ a: [1, 2] });
+  });
+
   it("should handle empty objects", () => {
     const first = {};
     const second = { a: 1 };

--- a/core/util/merge.ts
+++ b/core/util/merge.ts
@@ -2,6 +2,10 @@ import { ConfigMergeType } from "../index.js";
 
 type JsonObject = { [key: string]: any };
 
+function isMergeableObject(value: any): boolean {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 export function mergeJson(
   first: JsonObject,
   second: JsonObject,
@@ -38,13 +42,13 @@ export function mergeJson(
           copyOfFirst[key] = [...firstValue, ...secondValue];
         }
       } else if (
-        typeof secondValue === "object" &&
-        typeof firstValue === "object"
+        isMergeableObject(secondValue) &&
+        isMergeableObject(firstValue)
       ) {
         // Object
         copyOfFirst[key] = mergeJson(firstValue, secondValue, mergeBehavior);
       } else {
-        // Other (boolean, number, string)
+        // Other (boolean, number, string, null, or mismatched types)
         copyOfFirst[key] = secondValue;
       }
     }


### PR DESCRIPTION
## Description

mergeJson used typeof value === "object" so null and arrays were treated as mergeable objects.

That produced three incorrect results:

- mergeJson({a: {b: 1}}, {a: null}) kept the object instead of clearing it
- mergeJson({a: null}, {a: {b: 1}}) threw internally
- mergeJson({a: {b: 1}}, {a: [1, 2]}) produced a hybrid object

isMergeableObject now gates recursion. On a type mismatch, the second value wins.

Distinct from #13143, #13144, #13145, and #13146.

## Checklist

- [x] I have read the contributing guide
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Tests

core/util/merge.test.ts: 14 passed
