### PR TITLE
fix: write rule name into markdown frontmatter

### DIFF
--- a/core/tools/implementations/createRuleBlock.test.ts
+++ b/core/tools/implementations/createRuleBlock.test.ts
@@ -36,6 +36,7 @@ test("createRuleBlockImpl should create a rule with glob pattern", async () => {
   const { frontmatter, markdown } = parseMarkdownRule(fileContent);
 
   expect(frontmatter).toEqual({
+    name: "TypeScript Rule",
     alwaysApply: true,
     description: "Always use interfaces",
     globs: "**/*.{ts,tsx}",
@@ -73,6 +74,7 @@ test("createRuleBlockImpl should create a rule with description pattern", async 
   const { frontmatter, markdown } = parseMarkdownRule(fileContent);
 
   expect(frontmatter).toEqual({
+    name: "Description Test",
     alwaysApply: true,
     description: "This is a detailed explanation of the rule",
   });
@@ -96,6 +98,7 @@ test("createRuleBlockImpl should include both globs and description in frontmatt
   const { frontmatter, markdown } = parseMarkdownRule(fileContent);
 
   expect(frontmatter).toEqual({
+    name: "Complete Rule",
     alwaysApply: false,
     description: "This rule enforces our team standards",
     globs: "**/*.js",
@@ -119,6 +122,7 @@ test("createRuleBlockImpl should create a rule with alwaysApply set to false", a
   const { frontmatter } = parseMarkdownRule(fileContent);
 
   expect(frontmatter).toEqual({
+    name: "Conditional Rule",
     alwaysApply: false,
     description: "Optional rule",
   });

--- a/packages/config-yaml/src/markdown/createMarkdownRule.test.ts
+++ b/packages/config-yaml/src/markdown/createMarkdownRule.test.ts
@@ -101,6 +101,7 @@ describe("createRuleMarkdown", () => {
 
     const parsed = markdownToRule(result, mockPackageId);
 
+    expect(parsed.name).toBe("Test Rule");
     expect(parsed.description).toBe("Test description");
     expect(parsed.globs).toEqual(["*.ts", "*.js"]);
     expect(parsed.alwaysApply).toBe(true);
@@ -112,10 +113,18 @@ describe("createRuleMarkdown", () => {
 
     const parsed = markdownToRule(result, mockPackageId);
 
+    expect(parsed.name).toBe("Simple Rule");
     expect(parsed.description).toBeUndefined();
     expect(parsed.globs).toBeUndefined();
     expect(parsed.alwaysApply).toBeUndefined();
     expect(parsed.rule).toBe("Simple content");
+  });
+
+  it("should trim the name", () => {
+    const result = createRuleMarkdown("  Padded Name  ", "Content");
+
+    const parsed = markdownToRule(result, mockPackageId);
+    expect(parsed.name).toBe("Padded Name");
   });
 
   it("should handle string globs", () => {

--- a/packages/config-yaml/src/markdown/createMarkdownRule.ts
+++ b/packages/config-yaml/src/markdown/createMarkdownRule.ts
@@ -39,7 +39,9 @@ export function createRuleMarkdown(
     invokable?: boolean;
   } = {},
 ): string {
-  const frontmatter: RuleFrontmatter = {};
+  const frontmatter: RuleFrontmatter = {
+    name: name.trim(),
+  };
 
   if (options.globs) {
     frontmatter.globs =


### PR DESCRIPTION
createRuleMarkdown takes a name argument and never emits it. The name used to be an H1 in the rule body and was dropped without adding it to YAML frontmatter, so rules created via create_rule_block or New Rule had no name and markdownToRule fell back to the file path.

Frontmatter now includes name: name.trim(), matching createPromptMarkdown.

Tests: packages/config-yaml markdown jest 144 passed; core tools/config/markdown 15 passed; workspaceBlocks vitest 10 passed. Distinct from #13140-#13149.