### PR TITLE
Prevent margin from displacing content out of the viewport.

### DIFF
--- a/gui/src/pages/gui/Chat.tsx
+++ b/gui/src/pages/gui/Chat.tsx
@@ -78,7 +78,6 @@ const StepsDiv = styled.div`
 
   .thread-message {
     margin: 0 0 0 1px;
-    width: 100vw;
   }
 `;
 

--- a/gui/src/pages/gui/Chat.tsx
+++ b/gui/src/pages/gui/Chat.tsx
@@ -78,6 +78,7 @@ const StepsDiv = styled.div`
 
   .thread-message {
     margin: 0 0 0 1px;
+    width: 100vw;
   }
 `;
 

--- a/gui/src/pages/gui/index.tsx
+++ b/gui/src/pages/gui/index.tsx
@@ -7,7 +7,7 @@ export default function GUI() {
       <aside className="4xl:flex border-vsc-input-border no-scrollbar hidden min-h-0 w-96 overflow-y-auto border-0 border-r border-solid">
         <History />
       </aside>
-      <main className="no-scrollbar flex min-h-0 flex-1 flex-col">
+      <main className="no-scrollbar flex min-h-0 flex-1 flex-col w-screen">
         <Chat />
       </main>
     </div>


### PR DESCRIPTION
Prevent code block from expanding the chat webview beyond it's horizontal limits by setting thread message div width to 100vw.

Solves #13056 #13055 

## Description

Added a css property to force the thread message block to match the viewport witdth.

## AI Code Review

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [ ] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

After:

<img width="474" height="387" alt="image" src="https://github.com/user-attachments/assets/8b4df646-d988-4e95-9cb2-7f362d4e8b70" />

Before:

<img width="474" height="387" alt="image" src="https://github.com/user-attachments/assets/55a2aeeb-ea2e-49a0-b791-7f084f171b7c" />

## Tests

