### PR TITLE
docs: add ZvenoAI OpenAI-compatible config

### DIFF
--- a/docs/customize/model-providers/top-level/openai.mdx
+++ b/docs/customize/model-providers/top-level/openai.mdx
@@ -118,7 +118,8 @@ models:
       - tool_use
 ```
 
-Use the [ZvenoAI model catalog](https://zveno.ai/models) to replace the model ID.
+When replacing the model ID from the [ZvenoAI model catalog](https://zveno.ai/models),
+keep `tool_use` only for models that support tool calling.
 
 ### How to Force Legacy Completions Endpoint Usage
 

--- a/docs/customize/model-providers/top-level/openai.mdx
+++ b/docs/customize/model-providers/top-level/openai.mdx
@@ -97,7 +97,7 @@ If you are using an OpenAI API compatible providers, you can change the `apiBase
   </Tab>
 </Tabs>
 
-#### ZvenoAI
+### ZvenoAI
 
 Create a [ZvenoAI API key](https://zveno.ai/api-keys), save it as the
 `ZVENOAI_API_KEY` [Continue secret](/faqs#managing-local-secrets-and-environment-variables),
@@ -118,8 +118,8 @@ models:
       - tool_use
 ```
 
-When replacing the model ID from the [ZvenoAI model catalog](https://zveno.ai/models),
-keep `tool_use` only for models that support tool calling.
+When choosing another model from the [ZvenoAI model catalog](https://zveno.ai/models),
+include `tool_use` only if the model supports tool calling.
 
 ### How to Force Legacy Completions Endpoint Usage
 

--- a/docs/customize/model-providers/top-level/openai.mdx
+++ b/docs/customize/model-providers/top-level/openai.mdx
@@ -61,6 +61,7 @@ OpenAI API compatible providers include
 - [vLLM](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html)
 - [BerriAI/litellm](https://github.com/BerriAI/litellm)
 - [Tetrate Agent Router Service](https://router.tetrate.ai)
+- [ZvenoAI](https://zveno.ai/models)
 
 If you are using an OpenAI API compatible providers, you can change the `apiBase` like this:
 
@@ -95,6 +96,29 @@ If you are using an OpenAI API compatible providers, you can change the `apiBase
   ```
   </Tab>
 </Tabs>
+
+#### ZvenoAI
+
+Create a [ZvenoAI API key](https://zveno.ai/api-keys), save it as the
+`ZVENOAI_API_KEY` [Continue secret](/faqs#managing-local-secrets-and-environment-variables),
+and add this model to `config.yaml`:
+
+```yaml title="config.yaml"
+name: My Config
+version: 0.0.1
+schema: v1
+
+models:
+  - name: ZvenoAI GPT-OSS 20B
+    provider: openai
+    model: openai/gpt-oss-20b:free
+    apiBase: https://api.zveno.ai/v1
+    apiKey: ${{ secrets.ZVENOAI_API_KEY }}
+    capabilities:
+      - tool_use
+```
+
+Use the [ZvenoAI model catalog](https://zveno.ai/models) to replace the model ID.
 
 ### How to Force Legacy Completions Endpoint Usage
 


### PR DESCRIPTION
## Description

Adds ZvenoAI to the OpenAI-compatible providers list and includes a minimal `config.yaml` example using the production endpoint, a current tool-capable model, and Continue's secret syntax. The guide links to the ZvenoAI model catalog for other model IDs.

Refs #13156.

## Checklist

- [x] I have read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md).
- [x] The relevant documentation has been updated.
- [x] Tests are not applicable to this documentation-only change.

## Screen recording or screenshot

Not applicable for a configuration example.

## Tests

- `npx --yes prettier@3.3.3 --check docs/customize/model-providers/top-level/openai.mdx`
- Compiled the MDX with `@mdx-js/mdx` and parsed all five YAML examples with `js-yaml`.
- `git diff --check`
- Confirmed that `openai/gpt-oss-20b:free` lists `tools` and `tool_choice` in the production `/v1/models` response.
