### PR TITLE
Add Denizen Blu as an LLM provider

### DIFF
--- a/core/llm/autodetect.ts
+++ b/core/llm/autodetect.ts
@@ -133,6 +133,7 @@ const PROVIDER_SUPPORTS_IMAGES: string[] = [
   "watsonx",
   "zAI",
   "tensorix",
+  "denizenblu",
 ];
 
 const MODEL_SUPPORTS_IMAGES: RegExp[] = [

--- a/core/llm/llms/DenizenBlu.ts
+++ b/core/llm/llms/DenizenBlu.ts
@@ -1,0 +1,12 @@
+import { LLMOptions } from "../../index.js";
+
+import OpenAI from "./OpenAI.js";
+
+class DenizenBlu extends OpenAI {
+  static providerName = "denizenblu";
+  static defaultOptions: Partial<LLMOptions> = {
+    apiBase: "https://bluroute.denizenblu.com/v1",
+  };
+}
+
+export default DenizenBlu;

--- a/core/llm/llms/index.ts
+++ b/core/llm/llms/index.ts
@@ -20,6 +20,7 @@ import Cohere from "./Cohere";
 import CometAPI from "./CometAPI";
 import DeepInfra from "./DeepInfra";
 import Deepseek from "./Deepseek";
+import DenizenBlu from "./DenizenBlu";
 import Docker from "./Docker";
 import Fireworks from "./Fireworks";
 import Flowise from "./Flowise";
@@ -105,6 +106,7 @@ export const LLMClasses = [
   NCompass,
   Cloudflare,
   Deepseek,
+  DenizenBlu,
   Docker,
   Msty,
   Azure,

--- a/docs/customize/model-providers/more/denizenblu.mdx
+++ b/docs/customize/model-providers/more/denizenblu.mdx
@@ -1,0 +1,51 @@
+---
+title: "How to Configure Denizen Blu with Continue"
+sidebarTitle: "Denizen Blu"
+---
+
+<Info>
+  Denizen Blu is an OpenAI-compatible model gateway. Get an API key from your
+  Denizen Blu administrator.
+</Info>
+
+## Configuration
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  name: My Config
+  version: 0.0.1
+  schema: v1
+
+  models:
+    - name: Qwen2.5 Coder 1.5B
+      provider: denizenblu
+      model: qwen2.5-coder-1.5b-instruct
+      apiKey: <YOUR_DENIZENBLU_API_KEY>
+    - name: Qwen3 0.6B
+      provider: denizenblu
+      model: qwen3-0.6b
+      apiKey: <YOUR_DENIZENBLU_API_KEY>
+  ```
+  </Tab>
+  <Tab title="JSON (Deprecated)">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "Qwen2.5 Coder 1.5B",
+        "provider": "denizenblu",
+        "model": "qwen2.5-coder-1.5b-instruct",
+        "apiKey": "<YOUR_DENIZENBLU_API_KEY>"
+      },
+      {
+        "title": "Qwen3 0.6B",
+        "provider": "denizenblu",
+        "model": "qwen3-0.6b",
+        "apiKey": "<YOUR_DENIZENBLU_API_KEY>"
+      }
+    ]
+  }
+  ```
+  </Tab>
+</Tabs>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -109,6 +109,7 @@
                       "customize/model-providers/more/clawrouter",
                       "customize/model-providers/more/deepseek",
                       "customize/model-providers/more/deepinfra",
+                      "customize/model-providers/more/denizenblu",
                       "customize/model-providers/more/groq",
                       "customize/model-providers/more/llamacpp",
                       "customize/model-providers/more/llamastack",


### PR DESCRIPTION

## Summary
Adds support for [Denizen Blu](https://bluroute.denizenblu.com/v1), an OpenAI-compatible model gateway, as a new default provider.

- `core/llm/llms/DenizenBlu.ts` — subclasses `OpenAI` (fixed-endpoint OpenAI-compatible provider, same pattern as `Groq`/`DeepInfra`)
- Registered in `core/llm/llms/index.ts`
- Added to `PROVIDER_SUPPORTS_IMAGES` in `core/llm/autodetect.ts`
- Docs page at `docs/customize/model-providers/more/denizenblu.mdx` with `config.yaml` examples

## Test plan
- [x] `tsc --noEmit` passes clean across `core/`
- [x] Prettier formatting passes on all changed/new files
- [x] Manually tested in the VS Code extension debug host with a live Denizen Blu API key — confirmed chat + streaming work end-to-end with both `qwen2.5-coder-1.5b-instruct` and `qwen3-0.6b`

Screen recording of it working attached below.

https://github.com/user-attachments/assets/96606b66-11d9-4949-8879-3c0cee775ad9