### PR TITLE
fix(ci): bump pinned FFmpeg to a version BtbN still publishes

### DIFF
--- a/.github/actions/run-jetbrains-tests/action.yml
+++ b/.github/actions/run-jetbrains-tests/action.yml
@@ -8,6 +8,10 @@ inputs:
   ci-github-token:
     description: "CI GitHub token for vscode extension build"
     required: true
+  ffmpeg-version:
+    description: "FFmpeg release branch to install, must be one still published by BtbN/FFmpeg-Builds under its rolling 'latest' tag"
+    required: false
+    default: "8.1"
 
 runs:
   using: "composite"
@@ -41,10 +45,35 @@ runs:
         distribution: zulu
         java-version: 17
 
+    - name: Check FFmpeg artifact is available
+      shell: bash
+      env:
+        FFMPEG_VERSION: ${{ inputs.ffmpeg-version }}
+      run: |
+        asset="ffmpeg-n$FFMPEG_VERSION-latest-linux64-gpl-$FFMPEG_VERSION.tar.xz"
+        url="$GITHUB_SERVER_URL/BtbN/FFmpeg-Builds/releases/download/latest/$asset"
+        status=$(curl -sSIL --retry 3 --retry-connrefused --connect-timeout 10 \
+          --max-time 60 -o /dev/null -w '%{http_code}' "$url") || status=""
+        case "$status" in
+          2*) ;;
+          404)
+            echo "::error::FFmpeg $FFMPEG_VERSION is no longer published by BtbN/FFmpeg-Builds. Bump ffmpeg-version. Missing: $url"
+            exit 1
+            ;;
+          ""|000)
+            echo "::error::Could not reach $url to verify the FFmpeg artifact (network or DNS failure), so the pinned version was not checked."
+            exit 1
+            ;;
+          *)
+            echo "::error::Unexpected HTTP $status when verifying the FFmpeg artifact at $url."
+            exit 1
+            ;;
+        esac
+
     - name: Setup FFmpeg
       uses: AnimMouse/setup-ffmpeg@v1
       with:
-        version: 7.1
+        version: ${{ inputs.ffmpeg-version }}
         token: ${{ inputs.github-token }}
 
     - name: Setup Gradle


### PR DESCRIPTION
## Description

Closes https://github.com/continuedev/continue/issues/13164

The JetBrains test job pins `AnimMouse/setup-ffmpeg` to `version: 7.1`. `BtbN/FFmpeg-Builds` keeps only the most recent release branches under its rolling `latest` tag, and the 7.1 artifacts have since been dropped, so the asset URL the action constructs now 404s:

```
https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n7.1-latest-linux64-gpl-7.1.tar.xz
```

The action pipes `wget -qO-` directly into `tar -xJ`. Because of `-q` the 404 is silent and its response body is written to stdout, so tar receives non-xz bytes and the failure surfaces one stage downstream as:

```
xz: (stdin): File format not recognized
tar: Child returned status 1
##[error]Process completed with exit code 2.
```

No change in this repository caused this — an external artifact was removed out from under a valid pin, which is why it started failing on every PR at once, including ones touching no JetBrains code.

`Setup FFmpeg` runs early in the composite action, so the job dies before Gradle, prepackage, the binary build and `Run tests` (all reported `outcome=skipped`). No JetBrains tests run at all, and since the recordings are uploaded as required artifacts this blocks `prcheck` rather than merely degrading it.

This bumps the pin to 8.1, and because the underlying breakage is silent by design, adds a preflight check that verifies the artifact exists before the action runs and fails with an explicit annotation naming the missing URL. The next time BtbN rotates a branch out, the log will say so directly instead of surfacing as a tar format error. The version is a single action input with a default, so the pin lives in exactly one place rather than being duplicated across the check and the setup step.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Not applicable — a CI configuration fix.

## Tests

Verified against the live BtbN release assets, which currently are:

```
ffmpeg-master-latest-linux64-gpl.tar.xz
ffmpeg-n8.1-latest-linux64-gpl-8.1.tar.xz
ffmpeg-n9.0-latest-linux64-gpl-9.0.tar.xz
```

- Ran the action's exact `wget -qO- … | tar -xJC FFmpeg --strip-components 2 --no-anchored ffmpeg ffprobe` pipeline for 8.1: extracts cleanly and both binaries execute (`ffmpeg version n8.1.2-44-g7c533d0f86`).
- Ran the preflight check both ways: passes for 8.1, and for 7.1 exits non-zero with the intended annotation instead of the tar error.
- `action.yml` parses as valid YAML and passes `prettier --check`.
