### PR TITLE
feat(spark): add iFLYTEK Spark model provider

### DIFF
--- a/core/llm/autodetect.ts
+++ b/core/llm/autodetect.ts
@@ -68,6 +68,7 @@ const PROVIDER_HANDLES_TEMPLATING: string[] = [
   "deepseek",
   "xAI",
   "minimax",
+  "spark",
   "groq",
   "gemini",
   "docker",
@@ -252,6 +253,7 @@ const PARALLEL_PROVIDERS: string[] = [
   "function-network",
   "scaleway",
   "minimax",
+  "spark",
   "tensorix",
 ];
 

--- a/core/llm/llms/Spark.ts
+++ b/core/llm/llms/Spark.ts
@@ -1,0 +1,14 @@
+import { LLMOptions } from "../../index.js";
+
+import OpenAI from "./OpenAI.js";
+
+class Spark extends OpenAI {
+  static providerName = "spark";
+  static defaultOptions: Partial<LLMOptions> = {
+    apiBase: "https://spark-api-open.xf-yun.com/v1/",
+    model: "4.0Ultra",
+    useLegacyCompletionsEndpoint: false,
+  };
+}
+
+export default Spark;

--- a/core/llm/llms/index.ts
+++ b/core/llm/llms/index.ts
@@ -39,6 +39,7 @@ import LMStudio from "./LMStudio";
 import Mistral from "./Mistral";
 import Mimo from "./Mimo";
 import MiniMax from "./MiniMax";
+import Spark from "./Spark";
 import MockLLM from "./Mock";
 import Moonshot from "./Moonshot";
 import Msty from "./Msty";
@@ -95,6 +96,7 @@ export const LLMClasses = [
   Mistral,
   Mimo,
   MiniMax,
+  Spark,
   Bedrock,
   BedrockImport,
   SageMaker,

--- a/docs/customize/model-providers/more/spark.mdx
+++ b/docs/customize/model-providers/more/spark.mdx
@@ -1,0 +1,56 @@
+---
+title: "How to Configure iFLYTEK Spark with Continue"
+sidebarTitle: "iFLYTEK Spark"
+---
+
+<Info>
+  Get your API Password from the [iFLYTEK Spark console](https://console.xfyun.cn)
+</Info>
+
+## Configuration
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  name: My Config
+  version: 0.0.1
+  schema: v1
+
+  models:
+    - name: Spark 4.0 Ultra
+      provider: spark
+      model: 4.0Ultra
+      apiKey: <YOUR_SPARK_API_PASSWORD>
+  ```
+  </Tab>
+  <Tab title="JSON (Deprecated)">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "Spark 4.0 Ultra",
+        "provider": "spark",
+        "model": "4.0Ultra",
+        "apiKey": "<YOUR_SPARK_API_PASSWORD>"
+      }
+    ]
+  }
+  ```
+  </Tab>
+</Tabs>
+
+## Available Models
+
+| Model | Description |
+| :---- | :---------- |
+| `4.0Ultra` | Flagship Spark model with the strongest general capabilities. 32K context window. |
+| `generalv3.5` | Spark Max, high-capability model with function calling. 8K context window. |
+| `max-32k` | Spark Max with an extended 32K context window. |
+| `generalv3` | Spark Pro, cost-effective for everyday tasks. 8K context window. |
+| `pro-128k` | Spark Pro with a long 128K context window. |
+| `lite` | Lightweight, low-latency Spark model. 8K context window. |
+
+## Notes
+
+- Spark uses an OpenAI-compatible HTTP API at `https://spark-api-open.xf-yun.com/v1`
+- The `apiKey` is the **API Password** for the Spark HTTP service (`http服务接口认证信息` → `APIPassword` in the console). It is different from the APPID/APIKey/APISecret triple used by the legacy WebSocket API.

--- a/docs/customize/model-providers/overview.mdx
+++ b/docs/customize/model-providers/overview.mdx
@@ -40,6 +40,7 @@ Beyond the top-level providers, Continue supports many other options:
 | [NVIDIA](/customize/model-providers/more/nvidia)                       | GPU-accelerated model hosting                              |
 | [Cloudflare](/customize/model-providers/more/cloudflare)               | Edge-based AI inference services                           |
 | [MiniMax](/customize/model-providers/more/minimax)                     | High-performance models with 200K+ context window          |
+| [iFLYTEK Spark](/customize/model-providers/more/spark)                 | iFLYTEK's Spark models via an OpenAI-compatible API         |
 
 ### Local Model Options
 

--- a/gui/src/pages/AddNewModel/configs/models.ts
+++ b/gui/src/pages/AddNewModel/configs/models.ts
@@ -2788,6 +2788,52 @@ export const models: { [key: string]: ModelPackage } = {
     isOpenSource: true,
   },
 
+  spark40Ultra: {
+    title: "Spark 4.0 Ultra",
+    description:
+      "iFLYTEK's flagship Spark model with the strongest general capabilities. 32K context window.",
+    params: {
+      title: "Spark 4.0 Ultra",
+      model: "4.0Ultra",
+      contextLength: 32_768,
+    },
+    providerOptions: ["spark"],
+    isOpenSource: false,
+  },
+  sparkMax: {
+    title: "Spark Max",
+    description:
+      "High-capability Spark model with function calling support. 8K context window.",
+    params: {
+      title: "Spark Max",
+      model: "generalv3.5",
+      contextLength: 8_192,
+    },
+    providerOptions: ["spark"],
+    isOpenSource: false,
+  },
+  sparkMax32k: {
+    title: "Spark Max-32K",
+    description: "Spark Max with an extended 32K context window.",
+    params: {
+      title: "Spark Max-32K",
+      model: "max-32k",
+      contextLength: 32_768,
+    },
+    providerOptions: ["spark"],
+    isOpenSource: false,
+  },
+  sparkPro128k: {
+    title: "Spark Pro-128K",
+    description: "Spark Pro with a long 128K context window.",
+    params: {
+      title: "Spark Pro-128K",
+      model: "pro-128k",
+      contextLength: 131_072,
+    },
+    providerOptions: ["spark"],
+    isOpenSource: false,
+  },
   AUTODETECT: {
     title: "Autodetect",
     description:

--- a/gui/src/pages/AddNewModel/configs/providers.ts
+++ b/gui/src/pages/AddNewModel/configs/providers.ts
@@ -611,6 +611,38 @@ Select the \`GPT-4o\` model below to complete your provider configuration, but n
     packages: [models.mercury2],
     apiKeyUrl: "https://platform.inceptionlabs.ai/",
   },
+  spark: {
+    title: "iFLYTEK Spark",
+    provider: "spark",
+    description:
+      "Use iFLYTEK Spark (讯飞星火) models via an OpenAI-compatible API.",
+    longDescription:
+      "To get started with iFLYTEK Spark, obtain an API Password from the [iFLYTEK Spark console](https://console.xfyun.cn).",
+    tags: [ModelProviderTags.RequiresApiKey],
+    collectInputFor: [
+      {
+        inputType: "text",
+        key: "apiKey",
+        label: "API Key",
+        placeholder: "Enter your Spark API Password",
+        required: true,
+      },
+    ],
+    packages: [
+      models.spark40Ultra,
+      models.sparkMax,
+      models.sparkMax32k,
+      models.sparkPro128k,
+      {
+        ...models.AUTODETECT,
+        params: {
+          ...models.AUTODETECT.params,
+          title: "iFLYTEK Spark",
+        },
+      },
+    ],
+    apiKeyUrl: "https://console.xfyun.cn",
+  },
   deepseek: {
     title: "DeepSeek",
     provider: "deepseek",

--- a/packages/config-types/src/index.ts
+++ b/packages/config-types/src/index.ts
@@ -61,6 +61,7 @@ export const modelDescriptionSchema = z.object({
     "scaleway",
     "watsonx",
     "minimax",
+    "spark",
   ]),
   model: z.string(),
   apiKey: z.string().optional(),

--- a/packages/llm-info/src/index.ts
+++ b/packages/llm-info/src/index.ts
@@ -9,6 +9,7 @@ import { MiniMax } from "./providers/minimax.js";
 import { Mistral } from "./providers/mistral.js";
 import { Ollama } from "./providers/ollama.js";
 import { OpenAi } from "./providers/openai.js";
+import { Spark } from "./providers/spark.js";
 import { Vllm } from "./providers/vllm.js";
 import { Voyage } from "./providers/voyage.js";
 import { xAI } from "./providers/xAI.js";
@@ -29,6 +30,7 @@ export const allModelProviders: ModelProvider[] = [
   CometAPI,
   Inception,
   MiniMax,
+  Spark,
   xAI,
   zAI,
 ];

--- a/packages/llm-info/src/providers/spark.ts
+++ b/packages/llm-info/src/providers/spark.ts
@@ -1,0 +1,59 @@
+import { ModelProvider } from "../types.js";
+
+export const Spark: ModelProvider = {
+  models: [
+    {
+      model: "4.0Ultra",
+      displayName: "Spark 4.0 Ultra",
+      contextLength: 32768,
+      maxCompletionTokens: 8192,
+      description:
+        "iFLYTEK's flagship Spark model with the strongest general capabilities.",
+      regex: /4\.0Ultra/i,
+      recommendedFor: ["chat"],
+    },
+    {
+      model: "generalv3.5",
+      displayName: "Spark Max",
+      contextLength: 8192,
+      maxCompletionTokens: 8192,
+      description: "High-capability Spark model with function calling support.",
+      regex: /generalv3\.5/i,
+      recommendedFor: ["chat"],
+    },
+    {
+      model: "max-32k",
+      displayName: "Spark Max-32K",
+      contextLength: 32768,
+      maxCompletionTokens: 8192,
+      description: "Spark Max with an extended 32K context window.",
+      regex: /max-32k/i,
+    },
+    {
+      model: "generalv3",
+      displayName: "Spark Pro",
+      contextLength: 8192,
+      maxCompletionTokens: 8192,
+      description: "Cost-effective Spark model for everyday tasks.",
+      regex: /^generalv3$/i,
+    },
+    {
+      model: "pro-128k",
+      displayName: "Spark Pro-128K",
+      contextLength: 131072,
+      maxCompletionTokens: 8192,
+      description: "Spark Pro with a long 128K context window.",
+      regex: /pro-128k/i,
+    },
+    {
+      model: "lite",
+      displayName: "Spark Lite",
+      contextLength: 8192,
+      maxCompletionTokens: 4096,
+      description: "Lightweight, low-latency Spark model.",
+      regex: /^lite$/i,
+    },
+  ],
+  id: "spark",
+  displayName: "iFLYTEK Spark",
+};

--- a/packages/openai-adapters/src/apis/Spark.ts
+++ b/packages/openai-adapters/src/apis/Spark.ts
@@ -1,0 +1,14 @@
+import { SparkConfig } from "../types.js";
+import { OpenAIApi } from "./OpenAI.js";
+
+export const SPARK_API_BASE = "https://spark-api-open.xf-yun.com/v1/";
+
+export class SparkApi extends OpenAIApi {
+  constructor(config: SparkConfig) {
+    super({
+      ...config,
+      provider: "openai",
+      apiBase: config.apiBase ?? SPARK_API_BASE,
+    });
+  }
+}

--- a/packages/openai-adapters/src/index.ts
+++ b/packages/openai-adapters/src/index.ts
@@ -20,6 +20,7 @@ import { OpenAIApi } from "./apis/OpenAI.js";
 import { OpenRouterApi } from "./apis/OpenRouter.js";
 import { ClawRouterApi } from "./apis/ClawRouter.js";
 import { RelaceApi } from "./apis/Relace.js";
+import { SparkApi } from "./apis/Spark.js";
 import { VertexAIApi } from "./apis/VertexAI.js";
 import { WatsonXApi } from "./apis/WatsonX.js";
 import { BaseLlmApi } from "./apis/base.js";
@@ -143,6 +144,8 @@ export function constructLlmApi(config: LLMConfig): BaseLlmApi | undefined {
       return openAICompatible("https://api.groq.com/openai/v1/", config);
     case "minimax":
       return new MiniMaxApi(config);
+    case "spark":
+      return new SparkApi(config);
     case "sambanova":
       return openAICompatible("https://api.sambanova.ai/v1/", config);
     case "text-gen-webui":

--- a/packages/openai-adapters/src/types.ts
+++ b/packages/openai-adapters/src/types.ts
@@ -82,6 +82,11 @@ export const MiniMaxConfigSchema = OpenAIConfigSchema.extend({
 });
 export type MiniMaxConfig = z.infer<typeof MiniMaxConfigSchema>;
 
+export const SparkConfigSchema = OpenAIConfigSchema.extend({
+  provider: z.literal("spark"),
+});
+export type SparkConfig = z.infer<typeof SparkConfigSchema>;
+
 export const BedrockConfigSchema = OpenAIConfigSchema.extend({
   provider: z.literal("bedrock"),
   // cacheBehavior: z.object({
@@ -261,6 +266,7 @@ export const LLMConfigSchema = z.discriminatedUnion("provider", [
   MoonshotConfigSchema,
   DeepseekConfigSchema,
   MiniMaxConfigSchema,
+  SparkConfigSchema,
   CohereConfigSchema,
   AzureConfigSchema,
   GeminiConfigSchema,


### PR DESCRIPTION
## Description

Adds **iFLYTEK Spark (讯飞星火)** as a model provider. Spark is one of the major
Chinese foundation models still missing from Continue (DeepSeek, MiniMax,
Moonshot, MiMo, zAI and others are already supported), so this fills that gap.

Spark exposes an OpenAI-compatible HTTP endpoint at
`https://spark-api-open.xf-yun.com/v1` authenticated with a single Bearer **API
Password**, so the provider is a thin `OpenAI` wrapper — the same shape as the
recently merged MiniMax provider (#11367).

Wired up end to end, mirroring the MiniMax addition:

- `core/llm/llms/Spark.ts` + registration in `core/llm/llms/index.ts`
- `packages/openai-adapters/src/apis/Spark.ts` + `index.ts` case + `types.ts` config schema
- `packages/llm-info/src/providers/spark.ts` + `index.ts` (model metadata for the 6 public models)
- `packages/config-types` provider enum + `core/llm/autodetect.ts` (templating / parallel lists)
- GUI add-model config (`gui/src/pages/AddNewModel/configs/{models,providers}.ts`)
- Docs page + overview table row

Default model is `4.0Ultra`; `generalv3.5` (Max), `max-32k`, `generalv3` (Pro),
`pro-128k` and `lite` are also selectable.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [ ] The relevant tests, if any, have been updated or created

## Tests

No unit tests were added — this follows the same pattern as the existing MiniMax
provider (which ships as a config-only OpenAI-compatible wrapper). Happy to add
coverage under `packages/openai-adapters` if you'd prefer. I wasn't able to run
the full monorepo build/lint locally; flagging so CI can validate formatting.

## Notes

- The `apiKey` is the **API Password** for the Spark HTTP service
  (`http服务接口认证信息` → `APIPassword` in the console), distinct from the
  APPID/APIKey/APISecret triple used by Spark's legacy WebSocket API.
