### PR TITLE
fix(vscode): guard theme colors lookup so a non-standard palette can't crash activation

### DIFF
--- a/extensions/vscode/src/activation/InlineTipManager.ts
+++ b/extensions/vscode/src/activation/InlineTipManager.ts
@@ -236,7 +236,7 @@ export class InlineTipManager {
 
   private createSvgTooltipDecoration() {
     var backgroundColour = "#333333";
-    if (this.theme) {
+    if (this.theme?.colors?.["editor.background"]) {
       backgroundColour = this.theme.colors["editor.background"];
     }
     return vscode.window.createTextEditorDecorationType({
@@ -274,7 +274,7 @@ export class InlineTipManager {
           {
             ...baseTextConfig,
             x: SVG_CONFIG.chatLabelX,
-            fill: this.theme?.colors["editor.foreground"] ?? SVG_CONFIG.stroke,
+            fill: this.theme?.colors?.["editor.foreground"] ?? SVG_CONFIG.stroke,
           },
           SVG_CONFIG.chatLabel,
         )
@@ -291,7 +291,7 @@ export class InlineTipManager {
           {
             ...baseTextConfig,
             x: SVG_CONFIG.editLabelX,
-            fill: this.theme?.colors["editor.foreground"] ?? SVG_CONFIG.stroke,
+            fill: this.theme?.colors?.["editor.foreground"] ?? SVG_CONFIG.stroke,
           },
           SVG_CONFIG.editLabel,
         )

--- a/extensions/vscode/src/activation/InlineTipManager.ts
+++ b/extensions/vscode/src/activation/InlineTipManager.ts
@@ -274,7 +274,8 @@ export class InlineTipManager {
           {
             ...baseTextConfig,
             x: SVG_CONFIG.chatLabelX,
-            fill: this.theme?.colors?.["editor.foreground"] ?? SVG_CONFIG.stroke,
+            fill:
+              this.theme?.colors?.["editor.foreground"] ?? SVG_CONFIG.stroke,
           },
           SVG_CONFIG.chatLabel,
         )
@@ -291,7 +292,8 @@ export class InlineTipManager {
           {
             ...baseTextConfig,
             x: SVG_CONFIG.editLabelX,
-            fill: this.theme?.colors?.["editor.foreground"] ?? SVG_CONFIG.stroke,
+            fill:
+              this.theme?.colors?.["editor.foreground"] ?? SVG_CONFIG.stroke,
           },
           SVG_CONFIG.editLabel,
         )

--- a/extensions/vscode/src/activation/InlineTipManager.vitest.ts
+++ b/extensions/vscode/src/activation/InlineTipManager.vitest.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+
+// createSvgTooltipDecoration only calls window.createTextEditorDecorationType,
+// but importing the module pulls in helpers that read the workspace config, so
+// the mock covers that surface too.
+vi.mock("vscode", () => ({
+  window: {
+    createTextEditorDecorationType: vi
+      .fn()
+      .mockReturnValue({ dispose: vi.fn() }),
+  },
+  workspace: {
+    getConfiguration: vi.fn().mockReturnValue({ get: vi.fn() }),
+    onDidChangeConfiguration: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+  },
+  ThemeColor: class {
+    constructor(public id: string) {}
+  },
+  Uri: { file: vi.fn(), parse: vi.fn() },
+}));
+vi.mock("core/control-plane/env", () => ({ EXTENSION_NAME: "continue" }));
+vi.mock("../util/util", () => ({
+  getMetaKeyLabel: () => "Cmd",
+  getMetaKeyName: () => "metaKey",
+}));
+vi.mock("../util/getTheme", () => ({
+  getTheme: vi.fn().mockReturnValue({ colors: {} }),
+}));
+vi.mock("svg-builder", () => ({
+  default: { newInstance: () => ({ width: () => ({ height: () => ({}) }) }) },
+}));
+
+import { InlineTipManager } from "./InlineTipManager";
+
+describe("InlineTipManager.createSvgTooltipDecoration", () => {
+  it("does not throw when the active theme exposes no colors map", () => {
+    // A non-standard color theme can produce a Monaco theme whose `colors` is
+    // undefined. Previously the guard only checked `this.theme` was truthy and
+    // then read `this.theme.colors["editor.background"]`, throwing a TypeError
+    // that killed extension activation (issue #12947).
+    const instance = Object.create(
+      InlineTipManager.prototype,
+    ) as { createSvgTooltipDecoration: () => unknown; theme: unknown };
+    instance.theme = { colors: undefined };
+
+    expect(() => instance.createSvgTooltipDecoration()).not.toThrow();
+  });
+
+  it("uses the theme background when the colors map is present", () => {
+    const instance = Object.create(
+      InlineTipManager.prototype,
+    ) as { createSvgTooltipDecoration: () => unknown; theme: unknown };
+    instance.theme = { colors: { "editor.background": "#101010" } };
+
+    expect(() => instance.createSvgTooltipDecoration()).not.toThrow();
+  });
+});

--- a/extensions/vscode/src/activation/InlineTipManager.vitest.ts
+++ b/extensions/vscode/src/activation/InlineTipManager.vitest.ts
@@ -38,18 +38,20 @@ describe("InlineTipManager.createSvgTooltipDecoration", () => {
     // undefined. Previously the guard only checked `this.theme` was truthy and
     // then read `this.theme.colors["editor.background"]`, throwing a TypeError
     // that killed extension activation (issue #12947).
-    const instance = Object.create(
-      InlineTipManager.prototype,
-    ) as { createSvgTooltipDecoration: () => unknown; theme: unknown };
+    const instance = Object.create(InlineTipManager.prototype) as {
+      createSvgTooltipDecoration: () => unknown;
+      theme: unknown;
+    };
     instance.theme = { colors: undefined };
 
     expect(() => instance.createSvgTooltipDecoration()).not.toThrow();
   });
 
   it("uses the theme background when the colors map is present", () => {
-    const instance = Object.create(
-      InlineTipManager.prototype,
-    ) as { createSvgTooltipDecoration: () => unknown; theme: unknown };
+    const instance = Object.create(InlineTipManager.prototype) as {
+      createSvgTooltipDecoration: () => unknown;
+      theme: unknown;
+    };
     instance.theme = { colors: { "editor.background": "#101010" } };
 
     expect(() => instance.createSvgTooltipDecoration()).not.toThrow();


### PR DESCRIPTION
## Description

Fixes #12947. Extension activation crashes with a non-standard color theme.

`InlineTipManager.createSvgTooltipDecoration` guarded only `if (this.theme)` and then read `this.theme.colors["editor.background"]`. When the active theme produces a Monaco theme whose `colors` map is `undefined`, that read throws `TypeError: Cannot read properties of undefined (reading 'editor.background')`, which propagates out of the field initializer and kills activation. The two `this.theme?.colors["editor.foreground"]` reads in `createSvgTooltip` have the same latent unsafe access.

This makes all three reads null-safe (`this.theme?.colors?.[...]`), so a theme without the standard colors falls back to the existing default instead of crashing.

## Checklist

- [x] I've read the contributing guide
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

![before: TypeError on undefined colors / after: 2 passed](https://github.com/user-attachments/assets/9ca10b75-4986-4f12-952d-e86b335a2d59)

## Tests

Added `extensions/vscode/src/activation/InlineTipManager.vitest.ts`, which exercises `createSvgTooltipDecoration` with a theme whose `colors` is `undefined`. Before the change it throws the `editor.background` TypeError; after, it does not throw (and the colors-present case still works). `npx vitest run src/activation/InlineTipManager.vitest.ts`: before = 1 failed, after = 2 passed.
