### PR TITLE
docs: fix typos in readme and spec files

### DIFF
--- a/binary/README.md
+++ b/binary/README.md
@@ -2,7 +2,7 @@
 
 The purpose of this folder is to package Typescript code in a way that can be run from any IDE or platform. We first bundle with `esbuild` and then package into binaries with `pkg`.
 
-The `pkgJson/package.json` contains instructions for building with pkg, and needs to be in a separte folder because there is no CLI flag for the assets option (it must be in a package.json), and pkg doesn't recognize any name other than package.json, but if we use the same package.json with dependencies in it, pkg will automatically include these, significantly increasing the binary size.
+The `pkgJson/package.json` contains instructions for building with pkg, and needs to be in a separate folder because there is no CLI flag for the assets option (it must be in a package.json), and pkg doesn't recognize any name other than package.json, but if we use the same package.json with dependencies in it, pkg will automatically include these, significantly increasing the binary size.
 
 The build process is otherwise defined entirely in `build.js`.
 

--- a/core/diff/test-examples/README.md
+++ b/core/diff/test-examples/README.md
@@ -14,7 +14,7 @@ Tests are specified as
 <EXPECTED DIFF>
 ```
 
-`---` is the delimeter, and surrounding whitespace will be trimmed.
+`---` is the delimiter, and surrounding whitespace will be trimmed.
 
 The expected diff can be generated with the `displayDiff` function.
 

--- a/extensions/cli/spec/permissions.md
+++ b/extensions/cli/spec/permissions.md
@@ -10,7 +10,7 @@ To make sure that users can oversee the actions of the LLM, we implement a permi
 
 ## Rule precedence
 
-There is a default set of permissions for the builtin tools in [`src/permissions/defaultPolicies.ts`](../src/permissions/defaultPolicies.ts). But these policies can be overriden by multiple layers. The order of precedence is as follows, which the earlier items taking precedence:
+There is a default set of permissions for the builtin tools in [`src/permissions/defaultPolicies.ts`](../src/permissions/defaultPolicies.ts). But these policies can be overridden by multiple layers. The order of precedence is as follows, which the earlier items taking precedence:
 
 1. **Mode policies** (highest priority - see [modes.md](./modes.md))
 2. Command line flags (`--allow`, `--ask`, `--exclude`)

--- a/sync/src/README.md
+++ b/sync/src/README.md
@@ -53,4 +53,4 @@ Several files are stored and updated on disk in the ~/.continue/index folder to 
 ### Current limitations:
 
 - Only handles local files, so is not currently being used in situations where the Continue server is on a different machine from the IDE or the workspace (Remote SSH, WSL, or a Continue server being run for a team).
-- Currently not using stat to check for recent changes to files, is instaed re-calculating the entire Merkle tree on every IDE reload. This is fine for now since it only takes 0.2 seconds on the Continue codebase, but is a quick improvement we can make later.
+- Currently not using stat to check for recent changes to files, is instead re-calculating the entire Merkle tree on every IDE reload. This is fine for now since it only takes 0.2 seconds on the Continue codebase, but is a quick improvement we can make later.


### PR DESCRIPTION
Four spelling mistakes in documentation:

- `separte` -> `separate` (`binary/README.md`)
- `delimeter` -> `delimiter` (`core/diff/test-examples/README.md`)
- `overriden` -> `overridden` (`extensions/cli/spec/permissions.md`)
- `instaed` -> `instead` (`sync/src/README.md`)

Found with codespell, then each one read in context so nothing inside a code block or an identifier was touched. Docs only -- no code, no build input

I left two categories alone on purpose: anything under `core/vendor/` (third-party code, not ours to correct) & the `CHANGELOG.md` files (a historical record of what was written at the time)

AI usage disclosure: I used Claude to run the spell check & prepare the diff. I checked every change myself and I am responsible for what is here