### PR TITLE
docs: add minirouter provider guide

### DIFF
--- a/docs/customize/model-providers/more/minirouter.mdx
+++ b/docs/customize/model-providers/more/minirouter.mdx
@@ -1,0 +1,56 @@
+---
+title: "How to Configure minirouter with Continue"
+sidebarTitle: "minirouter"
+---
+
+<Info>
+  Get a prepaid, accountless API key at [minirouter](https://minirouter.sh/key).
+</Info>
+
+minirouter is an OpenAI-compatible gateway with one key for the Vercel AI
+Gateway catalog.
+
+## Configuration
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  name: My Config
+  version: 0.0.1
+  schema: v1
+
+  models:
+    - name: Llama 3.3 70B (minirouter)
+      provider: openai
+      model: meta/llama-3.3-70b
+      apiBase: https://api.minirouter.sh/v1
+      apiKey: <MINIROUTER_API_KEY>
+      roles:
+        - chat
+        - edit
+        - apply
+  ```
+  </Tab>
+  <Tab title="JSON (Deprecated)">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "Llama 3.3 70B (minirouter)",
+        "provider": "openai",
+        "model": "meta/llama-3.3-70b",
+        "apiBase": "https://api.minirouter.sh/v1",
+        "apiKey": "<MINIROUTER_API_KEY>",
+        "roles": ["chat", "edit", "apply"]
+      }
+    ]
+  }
+  ```
+  </Tab>
+</Tabs>
+
+Model IDs use `<lab>/<model>`. See the [full model list and
+prices](https://minirouter.sh/docs/models), or send `GET https://api.minirouter.sh/v1/models`.
+
+Streaming, tool calling, and `max_completion_tokens` are supported on every
+model that advertises them.

--- a/docs/customize/model-providers/overview.mdx
+++ b/docs/customize/model-providers/overview.mdx
@@ -34,6 +34,7 @@ Beyond the top-level providers, Continue supports many other options:
 | [Together AI](/customize/model-providers/more/together)                | Platform for running a variety of open models              |
 | [DeepInfra](/customize/model-providers/more/deepinfra)                 | Hosting for various open source models                     |
 | [OpenRouter](/customize/model-providers/top-level/openrouter)          | Gateway to multiple model providers                        |
+| [minirouter](/customize/model-providers/more/minirouter)               | OpenAI-compatible gateway with prepaid, accountless keys   |
 | [ClawRouter](/customize/model-providers/more/clawrouter)               | Open-source LLM router with automatic cost-optimized model selection |
 | [Tetrate Agent Router Service](/customize/model-providers/top-level/tetrate_agent_router_service) | Gateway with intelligent routing across multiple model providers |
 | [Cohere](/customize/model-providers/more/cohere)                       | Models specialized for semantic search and text generation |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -113,6 +113,7 @@
                       "customize/model-providers/more/llamacpp",
                       "customize/model-providers/more/llamastack",
                       "customize/model-providers/more/mimo",
+                      "customize/model-providers/more/minirouter",
                       "customize/model-providers/more/mistral",
                       "customize/model-providers/more/moonshot",
                       "customize/model-providers/more/nous",


### PR DESCRIPTION
## Description

Adds a minirouter provider guide using Continue's generic `openai` provider with `https://api.minirouter.sh/v1` and `MINIROUTER_API_KEY`

Also adds minirouter to the model-provider overview and sidebar navigation

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Not applicable, this is a documentation-only change

## Tests

- New page compiles with `@mdx-js/mdx` under Node 20.20.1
- `docs/docs.json` parses as valid JSON
- `git diff --check` passes
- Full Mintlify build is blocked before reading docs by the existing `tar` default-export incompatibility under Node 20.20.1 and Node 25