### PR TITLE
fix(cli): distinguish unavailable permission prompts

### DIFF
--- a/extensions/cli/src/stream/streamChatResponse.helpers.ts
+++ b/extensions/cli/src/stream/streamChatResponse.helpers.ts
@@ -28,6 +28,12 @@ import { PreprocessedToolCall, ToolCall } from "../tools/types.js";
 import { logger } from "../util/logger.js";
 
 import { StreamCallbacks } from "./streamChatResponse.types.js";
+import {
+  getPermissionDeniedMessage,
+  resolveUserPermissionResult,
+  type ToolPermissionApprovalResult,
+  type ToolPermissionDenialReason,
+} from "./toolPermissionResult.js";
 
 export interface ToolResultWithStatus extends ChatCompletionToolMessageParam {
   status: ToolStatus;
@@ -38,12 +44,9 @@ export function handlePermissionDenied(
   toolCall: PreprocessedToolCall,
   chatHistoryEntries: ChatCompletionToolMessageParam[],
   callbacks?: StreamCallbacks,
-  reason: "user" | "policy" = "user",
+  reason: ToolPermissionDenialReason = "user",
 ): void {
-  const deniedMessage =
-    reason === "policy"
-      ? `Command blocked by security policy`
-      : `Permission denied by user`;
+  const deniedMessage = getPermissionDeniedMessage(reason);
 
   logger.info("Tool call denied", {
     name: toolCall.name,
@@ -65,9 +68,13 @@ export function handlePermissionDenied(
 export async function requestUserPermission(
   toolCall: PreprocessedToolCall,
   callbacks?: StreamCallbacks,
-): Promise<boolean> {
+): Promise<boolean | undefined> {
   if (!callbacks?.onToolPermissionRequest) {
-    return false;
+    logger.error("Cannot request interactive tool permission", {
+      name: toolCall.name,
+      reason: "onToolPermissionRequest callback is missing",
+    });
+    return undefined;
   }
 
   const toolCallRequest: ToolCallRequest = {
@@ -115,7 +122,7 @@ export async function checkToolPermissionApproval(
   toolCall: PreprocessedToolCall,
   callbacks?: StreamCallbacks,
   isHeadless?: boolean,
-): Promise<{ approved: boolean; denialReason?: "user" | "policy" }> {
+): Promise<ToolPermissionApprovalResult> {
   const permissionCheck = checkToolPermission(toolCall, permissions);
 
   if (permissionCheck.permission === "allow") {
@@ -126,9 +133,7 @@ export async function checkToolPermissionApproval(
       return { approved: false, denialReason: "policy" };
     }
     const userApproved = await requestUserPermission(toolCall, callbacks);
-    return userApproved
-      ? { approved: true }
-      : { approved: false, denialReason: "user" };
+    return resolveUserPermissionResult(userApproved);
   } else if (permissionCheck.permission === "exclude") {
     // Tool blocked by security policy
     return { approved: false, denialReason: "policy" };
@@ -520,10 +525,7 @@ export async function executeStreamedToolCalls(
       if (!permissionResult.approved) {
         // Permission denied: create entry with canceled status
         const denialReason = permissionResult.denialReason || "user";
-        const deniedMessage =
-          denialReason === "policy"
-            ? `Command blocked by security policy`
-            : `Permission denied by user`;
+        const deniedMessage = getPermissionDeniedMessage(denialReason);
 
         const deniedEntry: ToolResultWithStatus = {
           role: "tool",

--- a/extensions/cli/src/stream/streamChatResponse.permissions.test.ts
+++ b/extensions/cli/src/stream/streamChatResponse.permissions.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getPermissionDeniedMessage,
+  resolveUserPermissionResult,
+} from "./toolPermissionResult.js";
+
+describe("tool permission result", () => {
+  it("reports a missing interactive callback instead of a user denial", () => {
+    const result = resolveUserPermissionResult(undefined);
+
+    expect(result).toEqual({
+      approved: false,
+      denialReason: "callback_missing",
+    });
+    expect(getPermissionDeniedMessage(result.denialReason!)).toBe(
+      "Interactive permission prompt unavailable",
+    );
+  });
+});

--- a/extensions/cli/src/stream/toolPermissionResult.ts
+++ b/extensions/cli/src/stream/toolPermissionResult.ts
@@ -1,0 +1,29 @@
+export type ToolPermissionDenialReason = "user" | "policy" | "callback_missing";
+
+export interface ToolPermissionApprovalResult {
+  approved: boolean;
+  denialReason?: ToolPermissionDenialReason;
+}
+
+export function resolveUserPermissionResult(
+  userApproved: boolean | undefined,
+): ToolPermissionApprovalResult {
+  if (userApproved === undefined) {
+    return { approved: false, denialReason: "callback_missing" };
+  }
+  return userApproved
+    ? { approved: true }
+    : { approved: false, denialReason: "user" };
+}
+
+export function getPermissionDeniedMessage(
+  reason: ToolPermissionDenialReason,
+): string {
+  if (reason === "policy") {
+    return "Command blocked by security policy";
+  }
+  if (reason === "callback_missing") {
+    return "Interactive permission prompt unavailable";
+  }
+  return "Permission denied by user";
+}


### PR DESCRIPTION
## Description

Fixes #13178.

When an `ask`-tier tool call reaches the CLI without an `onToolPermissionRequest` callback, the CLI now distinguishes the unavailable interactive prompt from an explicit user rejection.

- represent the missing callback as a dedicated `callback_missing` denial reason
- surface `Interactive permission prompt unavailable` instead of `Permission denied by user`
- preserve the existing user-denial and policy-denial behavior

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Not applicable; this corrects the CLI's permission result and message when no interactive callback is available.

## Tests

- `npm test -- src/stream/streamChatResponse.permissions.test.ts`
- `prettier --check src/stream/streamChatResponse.helpers.ts src/stream/streamChatResponse.permissions.test.ts src/stream/toolPermissionResult.ts`
- `eslint src/stream/streamChatResponse.helpers.ts src/stream/streamChatResponse.permissions.test.ts src/stream/toolPermissionResult.ts`
