### PR TITLE
fix: declare JCEF plugin dependency required by JetBrains 2026.2

### DIFF
--- a/extensions/intellij/src/main/resources/META-INF/plugin.xml
+++ b/extensions/intellij/src/main/resources/META-INF/plugin.xml
@@ -8,6 +8,7 @@
 
     <depends>com.intellij.modules.platform</depends>
     <depends>org.jetbrains.plugins.terminal</depends>
+    <depends>com.intellij.modules.jcef</depends>
 
     <!-- See here for why this is optional:  https://github.com/continuedev/continue/issues/2775#issuecomment-2535620877-->
     <depends optional="true" config-file="continueintellijextension-withJSON.xml">


### PR DESCRIPTION
## Description

Starting with the 2026.2 platform release, JetBrains ships JCEF (the JetBrains Chromium Embedded Framework, which the Continue tool window renders in) as a separate bundled plugin with the id `com.intellij.modules.jcef`. Up to 2026.1 that id was a module alias of the core IDE, so plugins got the JCEF classes for free. On 2026.2 a plugin has to declare an explicit dependency on it, or its classloader can no longer resolve the JCEF classes.

The Continue plugin doesn't declare that dependency, so on any 2026.2 IDE it crashes during initialization with `java.lang.NoClassDefFoundError: com/intellij/ui/jcef/JBCefApp` and the tool window never loads.

This PR adds the missing `<depends>` entry to `plugin.xml`. Since the id was a core module alias before 2026.2, the change is backwards compatible with the older IDE versions the plugin supports. The AsciiDoc plugin fixed the same break the same way in [asciidoctor/asciidoctor-intellij-plugin#2081](https://github.com/asciidoctor/asciidoctor-intellij-plugin/pull/2081).

Fixes #13185

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created (none affected)
- [x] The relevant tests, if any, have been updated or created (none cover the plugin descriptor; verified manually in Rider 2026.2)
