### PR TITLE
fix(fetch): ignore SSE comment lines instead of ending the stream

### DIFF
--- a/packages/fetch/src/stream.test.ts
+++ b/packages/fetch/src/stream.test.ts
@@ -54,6 +54,32 @@ describe("streamSse", () => {
     expect(results).toEqual([{ foo: "bar" }, { baz: 42 }]);
   });
 
+  it("ignores SSE comment lines that share a chunk with data events", async () => {
+    // Servers and proxies send SSE comments (e.g. `: ping`) as keep-alives.
+    // When one arrives in the same chunk as the following data events, those
+    // events must still be yielded rather than silently dropped.
+    const stream = new Readable({
+      read() {
+        this.push(
+          ': ping\n\ndata: {"foo": "bar"}\n\ndata: {"baz": 42}\n\ndata: [DONE]\n\n',
+        );
+        this.push(null); // End of stream
+      },
+    }) as any;
+    const response = {
+      status: 200,
+      body: stream,
+      text: async () => "",
+    } as unknown as Response;
+
+    const results = [];
+    for await (const data of streamSse(response)) {
+      results.push(data);
+    }
+
+    expect(results).toEqual([{ foo: "bar" }, { baz: 42 }]);
+  });
+
   it("throws on malformed JSON", async () => {
     const sseLines = ['data: {"foo": "bar"', "data:[DONE]"];
     const response = createMockResponse(sseLines);

--- a/packages/fetch/src/stream.ts
+++ b/packages/fetch/src/stream.ts
@@ -115,8 +115,9 @@ function parseSseLine(line: string): { done: boolean; data: any } {
   if (line.startsWith("data:")) {
     return { done: false, data: parseDataLine(line) };
   }
-  if (line.startsWith(": ping")) {
-    return { done: true, data: undefined };
+  if (line.startsWith(":")) {
+    // Comment line (e.g. the `: ping` keep-alive), ignored per the SSE spec
+    return { done: false, data: undefined };
   }
   return { done: false, data: undefined };
 }


### PR DESCRIPTION
## Description

`parseSseLine` returned `{ done: true }` for the `: ping` keep-alive comment, and `streamSse` uses that flag to `break` out of the loop that drains the line buffer.

When a server or proxy flushes the comment in the same chunk as the `data:` events that follow (common with TCP/TLS coalescing and gateways such as LiteLLM or nginx), those events stay in the buffer. If the stream ends at that point, the trailing-buffer fallback sees a value starting with `\n`, does not match the `data:` prefix, and yields nothing — so the remainder of the model response is silently dropped, with no error and no log.

Per the SSE spec, any line starting with a colon is a comment and must be ignored. This changes the branch to match any `:`-prefixed line and return `{ done: false }`, so the buffer keeps draining.

`streamSse` is the shared helper behind most providers (OpenAI, Anthropic, Deepseek, Moonshot, VertexAI, LlamaStack, Inception, SiliconFlow, HuggingFace, Cohere), so this affects any of them talking to a server that sends SSE comments.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Not applicable — no user-facing UI change. The behaviour is covered by the unit test below.

## Tests

Added `ignores SSE comment lines that share a chunk with data events` to `packages/fetch/src/stream.test.ts`. It pushes a single chunk containing `: ping` followed by two `data:` events and `data: [DONE]`.

Before the fix the test fails with `expected [] to deeply equal [ { foo: 'bar' }, { baz: 42 } ]` — the entire response is lost. After the fix both events are yielded.

`npx vitest run` in `packages/fetch`: 6 files, 83 tests passing.
