### PR TITLE
fix(core): price gpt-4.1 family at OpenAI list rates instead of legacy gpt-4

### DIFF
--- a/core/llm/utils/calculateRequestCost.ts
+++ b/core/llm/utils/calculateRequestCost.ts
@@ -161,6 +161,11 @@ function calculateOpenAICost(
     "gpt-4o-mini": { input: 0.15, output: 0.6 },
     "gpt-4o": { input: 2.5, output: 10 },
 
+    // GPT-4.1 models
+    "gpt-4.1-mini": { input: 0.4, output: 1.6 },
+    "gpt-4.1-nano": { input: 0.1, output: 0.4 },
+    "gpt-4.1": { input: 2, output: 8 },
+
     // GPT-4 Turbo models
     "gpt-4-turbo": { input: 10, output: 30 },
 

--- a/core/llm/utils/calculateRequestCost.vitest.ts
+++ b/core/llm/utils/calculateRequestCost.vitest.ts
@@ -153,6 +153,40 @@ describe("calculateRequestCost", () => {
       description: "GPT-4o-mini",
     },
 
+    // OpenAI GPT-4.1 family
+    {
+      provider: "openai",
+      model: "gpt-4.1",
+      promptTokens: 1000,
+      completionTokens: 500,
+      expectedCost: 0.006,
+      description: "GPT-4.1",
+    },
+    {
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      promptTokens: 1000,
+      completionTokens: 500,
+      expectedCost: 0.0012,
+      description: "GPT-4.1-mini",
+    },
+    {
+      provider: "openai",
+      model: "gpt-4.1-nano",
+      promptTokens: 1000,
+      completionTokens: 500,
+      expectedCost: 0.0003,
+      description: "GPT-4.1-nano",
+    },
+    {
+      provider: "openai",
+      model: "gpt-4.1-2025-04-14",
+      promptTokens: 1000,
+      completionTokens: 500,
+      expectedCost: 0.006,
+      description: "GPT-4.1 date-stamped snapshot",
+    },
+
     // OpenAI GPT-3.5
     {
       provider: "openai",


### PR DESCRIPTION
Fixes #13184

## Summary

`calculateOpenAICost` matches pricing rows by longest-prefix `startsWith`. The table had no `gpt-4.1*` rows, so every `gpt-4.1` id (including date-stamped snapshots like `gpt-4.1-2025-04-14`) fell through to the legacy `gpt-4` row (input $30 / output $60 per MTok) — **15x–300x over OpenAI list price**.

## What this does

Adds the three missing pricing rows:

| model | input | output |
|---|---|---|
| `gpt-4.1-mini` | 0.40 | 1.60 |
| `gpt-4.1-nano` | 0.10 | 0.40 |
| `gpt-4.1` | 2.00 | 8.00 |

(per million tokens, USD)

No matcher change needed: `sortedKeys` is longest-first, so `gpt-4.1-mini`/`gpt-4.1-nano` (12 chars) are checked before `gpt-4.1` (7), which is checked before legacy `gpt-4` (5).

## Verification

Regression cases added to `core/llm/utils/calculateRequestCost.vitest.ts` (1000 in / 500 out tokens):

- Before the fix, all four new cases fail — every `gpt-4.1*` model cost 0.06 USD (legacy gpt-4 rates).
- After the fix, all pass:
  - `gpt-4.1`: 0.006, `gpt-4.1-mini`: 0.0012, `gpt-4.1-nano`: 0.0003, `gpt-4.1-2025-04-14`: 0.006
  - control `gpt-4o` unchanged at 0.0075

Prettier check clean on both files.