### PR TITLE
fix(vscode): remove duplicate command contribution

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -191,7 +191,7 @@
       {
         "command": "continue.focusContinueInput",
         "category": "Continue",
-        "title": "Add Highlighted Code to Context and Clear Chat",
+        "title": "Focus Continue Chat",
         "group": "Continue"
       },
       {
@@ -327,12 +327,6 @@
         "command": "continue.docsReIndex",
         "category": "Continue",
         "title": "Docs Force Re-Index",
-        "group": "Continue"
-      },
-      {
-        "command": "continue.focusContinueInput",
-        "category": "Continue",
-        "title": "Focus Continue Chat",
         "group": "Continue"
       },
       {

--- a/extensions/vscode/src/packageManifest.vitest.ts
+++ b/extensions/vscode/src/packageManifest.vitest.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import packageJson from "../package.json";
+
+describe("VS Code package manifest", () => {
+  it("contributes each command identifier once", () => {
+    const commandIds = packageJson.contributes.commands.map(
+      ({ command }) => command,
+    );
+    const duplicateCommandIds = [
+      ...new Set(
+        commandIds.filter(
+          (command, index) => commandIds.indexOf(command) !== index,
+        ),
+      ),
+    ];
+
+    expect(duplicateCommandIds).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #13158.

The VS Code manifest contributed `continue.focusContinueInput` twice, giving it 38 command entries but only 37 unique command IDs. This removes the duplicate contribution, keeps the canonical **Focus Continue Chat** title, and adds a manifest regression test that rejects duplicate command identifiers.

This prevents VS Code from receiving two registrations for the same Continue command during extension startup, including in WSL extension hosts.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created (not applicable; no user-facing workflow or configuration changed)
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Not applicable — this fixes extension manifest metadata and does not change the UI.

## Tests

- `npm test` (7 files, 87 tests passed)
- `npm run tsc:check`
- `npm run lint` (0 errors)
- `../../node_modules/.bin/prettier --check package.json src/packageManifest.vitest.ts`
- `git diff --check`
