### PR TITLE
feat: add Scalattice OpenAI-compatible provider

### DIFF
--- a/core/llm/llms/OpenAI-compatible.vitest.ts
+++ b/core/llm/llms/OpenAI-compatible.vitest.ts
@@ -15,6 +15,7 @@ import Cerebras from "./Cerebras.js";
 import DeepInfra from "./DeepInfra.js";
 import Nvidia from "./Nvidia.js";
 import SambaNova from "./SambaNova.js";
+import Scalattice from "./Scalattice.js";
 import Scaleway from "./Scaleway.js";
 import Venice from "./Venice.js";
 import Moonshot from "./Moonshot.js";
@@ -353,6 +354,11 @@ createOpenAISubclassTests(Nvidia, {
 createOpenAISubclassTests(SambaNova, {
   providerName: "sambanova",
   defaultApiBase: "https://api.sambanova.ai/v1/",
+});
+
+createOpenAISubclassTests(Scalattice, {
+  providerName: "scalattice",
+  defaultApiBase: "https://api.scalattice.cloud/v1/",
 });
 
 createOpenAISubclassTests(Scaleway, {

--- a/core/llm/llms/Scalattice.ts
+++ b/core/llm/llms/Scalattice.ts
@@ -1,0 +1,12 @@
+import OpenAI from "./OpenAI.js";
+
+import type { LLMOptions } from "../../index.js";
+
+class Scalattice extends OpenAI {
+  static providerName = "scalattice";
+  static defaultOptions: Partial<LLMOptions> = {
+    apiBase: "https://api.scalattice.cloud/v1/",
+  };
+}
+
+export default Scalattice;

--- a/core/llm/llms/index.ts
+++ b/core/llm/llms/index.ts
@@ -56,6 +56,7 @@ import { Relace } from "./Relace";
 import Replicate from "./Replicate";
 import SageMaker from "./SageMaker";
 import SambaNova from "./SambaNova";
+import Scalattice from "./Scalattice";
 import Scaleway from "./Scaleway";
 import SiliconFlow from "./SiliconFlow";
 import Tensorix from "./Tensorix";
@@ -125,6 +126,7 @@ export const LLMClasses = [
   xAI,
   SiliconFlow,
   Tensorix,
+  Scalattice,
   Scaleway,
   Relace,
   Inception,

--- a/docs/customize/model-providers/more/scalattice.mdx
+++ b/docs/customize/model-providers/more/scalattice.mdx
@@ -1,0 +1,42 @@
+---
+title: "How to Configure Scalattice with Continue"
+sidebarTitle: "Scalattice"
+---
+
+<Info>
+  Get an API key from the [Scalattice developer docs](https://scalattice.cloud/docs/developers).
+</Info>
+
+Scalattice is an OpenAI-compatible inference marketplace. Use `provider: scalattice` and a catalog model ID such as `qwen-3-14b`.
+
+## Configuration
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  name: My Config
+  version: 0.0.1
+  schema: v1
+
+  models:
+    - name: Qwen3 14B
+      provider: scalattice
+      model: qwen-3-14b
+      apiKey: <YOUR_SCALATTICE_API_KEY>
+  ```
+  </Tab>
+  <Tab title="JSON (Deprecated)">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "Qwen3 14B",
+        "provider": "scalattice",
+        "model": "qwen-3-14b",
+        "apiKey": "<YOUR_SCALATTICE_API_KEY>"
+      }
+    ]
+  }
+  ```
+  </Tab>
+</Tabs>

--- a/docs/customize/model-providers/overview.mdx
+++ b/docs/customize/model-providers/overview.mdx
@@ -33,6 +33,7 @@ Beyond the top-level providers, Continue supports many other options:
 | [Groq](/customize/model-providers/more/groq)                           | Ultra-fast inference for various open models               |
 | [Together AI](/customize/model-providers/more/together)                | Platform for running a variety of open models              |
 | [DeepInfra](/customize/model-providers/more/deepinfra)                 | Hosting for various open source models                     |
+| [Scalattice](/customize/model-providers/more/scalattice)               | OpenAI-compatible marketplace for open-weight models      |
 | [OpenRouter](/customize/model-providers/top-level/openrouter)          | Gateway to multiple model providers                        |
 | [ClawRouter](/customize/model-providers/more/clawrouter)               | Open-source LLM router with automatic cost-optimized model selection |
 | [Tetrate Agent Router Service](/customize/model-providers/top-level/tetrate_agent_router_service) | Gateway with intelligent routing across multiple model providers |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -117,6 +117,7 @@
                       "customize/model-providers/more/moonshot",
                       "customize/model-providers/more/nous",
                       "customize/model-providers/more/nvidia",
+                      "customize/model-providers/more/scalattice",
                       "customize/model-providers/more/tensorix",
                       "customize/model-providers/more/together",
                       "customize/model-providers/more/xAI",

--- a/gui/src/pages/AddNewModel/configs/providers.ts
+++ b/gui/src/pages/AddNewModel/configs/providers.ts
@@ -331,6 +331,39 @@ export const providers: Partial<Record<string, ProviderInfo>> = {
     ],
     apiKeyUrl: "https://endpoints.ai.cloud.ovh.net/",
   },
+  scalattice: {
+    title: "Scalattice",
+    provider: "scalattice",
+    refPage: "scalattice",
+    description:
+      "OpenAI-compatible marketplace for open-weight models on a GPU fleet",
+    longDescription:
+      "Get an API key from the [Scalattice developer docs](https://scalattice.cloud/docs/developers), then pick a catalog model ID such as qwen-3-14b.",
+    params: {
+      apiKey: "",
+    },
+    collectInputFor: [
+      {
+        inputType: "text",
+        key: "apiKey",
+        label: "API key",
+        placeholder: "Enter your Scalattice API key",
+        required: true,
+      },
+      ...completionParamsInputsConfigs,
+    ],
+    tags: [ModelProviderTags.RequiresApiKey, ModelProviderTags.OpenSource],
+    packages: [
+      {
+        ...models.AUTODETECT,
+        params: {
+          ...models.AUTODETECT.params,
+          title: "Scalattice",
+        },
+      },
+    ],
+    apiKeyUrl: "https://scalattice.cloud/docs/developers",
+  },
   scaleway: {
     title: "Scaleway",
     provider: "scaleway",

--- a/packages/openai-adapters/src/index.ts
+++ b/packages/openai-adapters/src/index.ts
@@ -162,6 +162,8 @@ export function constructLlmApi(config: LLMConfig): BaseLlmApi | undefined {
       );
     case "scaleway":
       return openAICompatible("https://api.scaleway.ai/v1/", config);
+    case "scalattice":
+      return openAICompatible("https://api.scalattice.cloud/v1/", config);
     case "fireworks":
       return openAICompatible("https://api.fireworks.ai/inference/v1/", config);
     case "together":

--- a/packages/openai-adapters/src/types.ts
+++ b/packages/openai-adapters/src/types.ts
@@ -59,6 +59,7 @@ export const OpenAIConfigSchema = BasePlusConfig.extend({
     z.literal("xAI"),
     z.literal("zAI"),
     z.literal("scaleway"),
+    z.literal("scalattice"),
     z.literal("tensorix"),
     z.literal("ncompass"),
     z.literal("relace"),


### PR DESCRIPTION
## Summary

Add Scalattice as an OpenAI-compatible provider (`https://api.scalattice.cloud/v1`, `SCALATTICE_API_KEY`).

- `core/llm/llms/Scalattice.ts` plus registration in `core/llm/llms/index.ts`
- `packages/openai-adapters` route for `provider: scalattice`
- Docs page under Additional / Hosted Services
- Add New Model entry that autodetects the live catalog

Keys: https://scalattice.cloud/docs/developers