### PR TITLE
fix(core): correct range intersection when ranges share start/end lines

### DIFF
--- a/core/util/ranges.test.ts
+++ b/core/util/ranges.test.ts
@@ -353,6 +353,24 @@ describe("intersection", () => {
     });
   });
 
+  test("uses later start and earlier end when both ranges share the start and end lines", () => {
+    rangeA = {
+      start: { line: 0, character: 5 },
+      end: { line: 3, character: 4 },
+    };
+
+    rangeB = {
+      start: { line: 0, character: 10 },
+      end: { line: 3, character: 2 },
+    };
+
+    const result = intersection(rangeA, rangeB);
+    expect(result).toEqual({
+      start: { line: 0, character: 10 },
+      end: { line: 3, character: 2 },
+    });
+  });
+
   test("returns correct intersection when ranges touch at the edge", () => {
     rangeA = {
       start: { line: 1, character: 0 },

--- a/core/util/ranges.ts
+++ b/core/util/ranges.ts
@@ -46,10 +46,21 @@ export function intersection(a: Range, b: Range): Range | null {
     };
   }
 
+  // When both ranges begin on the shared start line, the intersection begins at
+  // the later of the two characters (and symmetrically ends at the earlier one).
+  // Picking whichever range's line matched first dropped that comparison.
   const startCharacter =
-    startLine === a.start.line ? a.start.character : b.start.character;
+    a.start.line === b.start.line
+      ? Math.max(a.start.character, b.start.character)
+      : startLine === a.start.line
+        ? a.start.character
+        : b.start.character;
   const endCharacter =
-    endLine === a.end.line ? a.end.character : b.end.character;
+    a.end.line === b.end.line
+      ? Math.min(a.end.character, b.end.character)
+      : endLine === a.end.line
+        ? a.end.character
+        : b.end.character;
 
   return {
     start: { line: startLine, character: startCharacter },


### PR DESCRIPTION
## Description

`intersection(a, b)` in `core/util/ranges.ts` computes the wrong start/end **character** in the multi-line branch when the two ranges begin (or end) on the same line.

It picked the character from whichever range's line matched `startLine`/`endLine` first:

```ts
const startCharacter = startLine === a.start.line ? a.start.character : b.start.character;
```

When both ranges start on that shared line, this returns `a`'s character instead of the later of the two — and symmetrically for the end. Example (both share start line 0 and end line 3):

```ts
intersection(
  { start: { line: 0, character: 5 },  end: { line: 3, character: 4 } },
  { start: { line: 0, character: 10 }, end: { line: 3, character: 2 } },
)
// before: { start: {0, 5},  end: {3, 4} }   ❌
// after:  { start: {0, 10}, end: {3, 2} }   ✔  (later start, earlier end)
```

The single-line branch already does this correctly (`Math.max` / `Math.min`); this makes the multi-line branch consistent.

## Fix

When the two ranges share the start line, take `Math.max` of the start characters; when they share the end line, take `Math.min` of the end characters. Otherwise the previous behavior is unchanged.

## Testing

Added a `ranges.test.ts` case for two ranges sharing both start and end lines (fails before, passes after). All existing `intersection` tests still pass (they use ranges on different start/end lines, so they don't touch the changed branch). Verified the logic directly against the existing test inputs plus the new case.
