### PR TITLE
docs: fix typo unkown -> unknown

### DIFF
--- a/core/config/types.ts
+++ b/core/config/types.ts
@@ -649,7 +649,7 @@ declare global {
   }
   
   export enum FileType {
-    Unkown = 0,
+    Unknown = 0,
     File = 1,
     Directory = 2,
     SymbolicLink = 64,


### PR DESCRIPTION
Corrects the misspelling `unkown` -> `unknown` in `core/config/types.ts`.

Documentation only, no behaviour change.