### PR TITLE
fix: update broken docs.continue.dev customization links

### DIFF
--- a/core/config/createNewAssistantFile.ts
+++ b/core/config/createNewAssistantFile.ts
@@ -9,7 +9,7 @@ version: 1.0.0
 schema: v1
 
 # Define which models can be used
-# https://docs.continue.dev/customization/models
+# https://docs.continue.dev/customize/models
 models:
   - name: my gpt-5
     provider: openai

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -2792,8 +2792,8 @@
         },
         "slashCommands": {
           "title": "Slash Commands",
-          "markdownDescription": "An array of slash commands that let you take custom actions from the sidebar. Learn more in the [documentation](https://docs.continue.dev/customization/slash-commands).",
-          "x-intellij-html-description": "An array of slash commands that let you take custom actions from the sidebar. Learn more in the <a href='https://docs.continue.dev/customization/slash-commands'>documentation</a>.",
+          "markdownDescription": "An array of slash commands that let you take custom actions from the sidebar. Learn more in the [documentation](https://docs.continue.dev/customize/slash-commands).",
+          "x-intellij-html-description": "An array of slash commands that let you take custom actions from the sidebar. Learn more in the <a href='https://docs.continue.dev/customize/slash-commands'>documentation</a>.",
           "default": [],
           "type": "array",
           "items": {
@@ -2802,8 +2802,8 @@
         },
         "customCommands": {
           "title": "Custom Commands",
-          "markdownDescription": "An array of custom commands that allow you to reuse prompts. Each has name, description, and prompt properties. When you enter `/<name>` in the text input, it will act as a shortcut to the prompt. Learn more in the [documentation](https://docs.continue.dev/customization/slash-commands#custom-commands-use-natural-language).",
-          "x-intellij-html-description": "An array of custom commands that allow you to reuse prompts. Each has name, description, and prompt properties. When you enter <code>/<name></code> in the text input, it will act as a shortcut to the prompt. Learn more in the <a href='https://docs.continue.dev/customization/slash-commands#custom-commands-use-natural-language'>documentation</a>.",
+          "markdownDescription": "An array of custom commands that allow you to reuse prompts. Each has name, description, and prompt properties. When you enter `/<name>` in the text input, it will act as a shortcut to the prompt. Learn more in the [documentation](https://docs.continue.dev/customize/slash-commands#custom-commands-use-natural-language).",
+          "x-intellij-html-description": "An array of custom commands that allow you to reuse prompts. Each has name, description, and prompt properties. When you enter <code>/<name></code> in the text input, it will act as a shortcut to the prompt. Learn more in the <a href='https://docs.continue.dev/customize/slash-commands#custom-commands-use-natural-language'>documentation</a>.",
           "default": [
             {
               "name": "test",
@@ -2818,8 +2818,8 @@
         },
         "contextProviders": {
           "title": "Context Providers",
-          "markdownDescription": "A list of ContextProvider objects that can be used to provide context to the LLM by typing '@'. Read more about ContextProviders in [the documentation](https://docs.continue.dev/customization/context-providers).",
-          "x-intellij-html-description": "A list of ContextProvider objects that can be used to provide context to the LLM by typing '@'. Read more about ContextProviders in <a href='https://docs.continue.dev/customization/context-providers'>the documentation</a>.",
+          "markdownDescription": "A list of ContextProvider objects that can be used to provide context to the LLM by typing '@'. Read more about ContextProviders in [the documentation](https://docs.continue.dev/customize/deep-dives/custom-providers).",
+          "x-intellij-html-description": "A list of ContextProvider objects that can be used to provide context to the LLM by typing '@'. Read more about ContextProviders in <a href='https://docs.continue.dev/customize/deep-dives/custom-providers'>the documentation</a>.",
           "default": [],
           "type": "array",
           "items": {

--- a/gui/src/components/mainInput/TipTapEditor/utils/getSuggestion.ts
+++ b/gui/src/components/mainInput/TipTapEditor/utils/getSuggestion.ts
@@ -169,7 +169,7 @@ export function getContextProviderDropdownOptions(
         action: () => {
           ideMessenger.post(
             "openUrl",
-            "https://docs.continue.dev/customization/context-providers#built-in-context-providers",
+            "https://docs.continue.dev/customize/deep-dives/custom-providers#built-in-context-providers",
           );
         },
         description: "",


### PR DESCRIPTION
## Summary
- Updates example config.yaml comment: /customization/models → /customize/models
- Fixes "@ Add more context providers" URL to /customize/deep-dives/custom-providers
- Updates related VS Code config_schema.json doc links (context providers + slash commands)

Fixes #12669
Fixes #12507

## Test plan
- [ ] Open generated config.yaml comment link → models docs load
- [ ] In chat @ menu, "Add more context providers" opens a valid docs page