### PR TITLE
feat: add llmman as an LLM provider

### DIFF
--- a/core/llm/llms/Llmman.ts
+++ b/core/llm/llms/Llmman.ts
@@ -1,0 +1,18 @@
+import Ollama from "./Ollama";
+
+import type { LLMOptions } from "../../index.js";
+
+/**
+ * llmman (https://github.com/llmmanorg/llmman) is a local model runner that
+ * serves the Ollama API, so it reuses that implementation wholesale and only
+ * changes the provider name and the default port it listens on.
+ */
+class Llmman extends Ollama {
+  static providerName = "llmman";
+  static defaultOptions: Partial<LLMOptions> = {
+    ...Ollama.defaultOptions,
+    apiBase: "http://localhost:17434/",
+  };
+}
+
+export default Llmman;

--- a/core/llm/llms/index.ts
+++ b/core/llm/llms/index.ts
@@ -47,6 +47,7 @@ import Nebius from "./Nebius";
 import Nous from "./Nous";
 import Novita from "./Novita";
 import Nvidia from "./Nvidia";
+import Llmman from "./Llmman";
 import Ollama from "./Ollama";
 import OpenAI from "./OpenAI";
 import OpenRouter from "./OpenRouter";
@@ -78,6 +79,7 @@ export const LLMClasses = [
   Gemini,
   Llamafile,
   Moonshot,
+  Llmman,
   Ollama,
   Replicate,
   TextGenWebUI,

--- a/core/llm/toolSupport.ts
+++ b/core/llm/toolSupport.ts
@@ -199,6 +199,9 @@ export const PROVIDER_TOOL_SUPPORT: Record<string, (model: string) => boolean> =
 
       return false;
     },
+    // llmman serves the same local models over the Ollama API, so the same
+    // name-based heuristic applies.
+    llmman: (model) => PROVIDER_TOOL_SUPPORT["ollama"](model),
     lmstudio: (model) => {
       // LM Studio uses hyphenated model IDs (e.g., "Meta-Llama-3.1-8B-Instruct-GGUF")
       // that don't match Ollama's substring patterns (e.g., "llama3.1").

--- a/packages/config-types/src/index.ts
+++ b/packages/config-types/src/index.ts
@@ -47,6 +47,7 @@ export const modelDescriptionSchema = z.object({
     "anthropic",
     "cohere",
     "ollama",
+    "llmman",
     "huggingface-tgi",
     "huggingface-inference-api",
     "replicate",
@@ -107,6 +108,7 @@ export const embeddingsProviderSchema = z.object({
   provider: z.enum([
     "transformers.js",
     "ollama",
+    "llmman",
     "openai",
     "cohere",
     "gemini",


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman), a local model runner that serves the **Ollama API** (alongside OpenAI- and Anthropic-compatible ones) on port 17434.

Because the wire protocol is the same, the provider subclasses the existing Ollama implementation and overrides only the provider name and default `apiBase` — 18 lines instead of duplicating 833. Model listing, FIM, embeddings and streaming all carry over.

Two other touchpoints:
- `toolSupport` delegates to the same name-based heuristic, since llmman serves the same local models.
- `fetchModels` needs **no** case of its own — the `default` branch goes through `listModels`, which the inherited implementation answers from the running server rather than scraping a remote catalog. That's the correct behaviour here, not an omission.

**Testing:** `tsc --noEmit -p core/tsconfig.json` reports 157 errors both before and after this change (all pre-existing "cannot find module" for unbuilt workspace packages like `@continuedev/config-yaml`), so nothing new is introduced. I couldn't run the extension end-to-end against a live server, so that part is unverified.

> AI-assisted, reviewed before submitting.
