### PR TITLE
docs: add OpenZoo provider page under More Providers

### DIFF
--- a/docs/customize/model-providers/more/openzoo.mdx
+++ b/docs/customize/model-providers/more/openzoo.mdx
@@ -1,0 +1,84 @@
+---
+title: "How to Configure OpenZoo with Continue"
+sidebarTitle: "OpenZoo"
+---
+
+<Info>
+  OpenZoo is an OpenAI-compatible provider with no signup: any API key value is
+  accepted (for example `sk-openzoo`), and usage is paid per request — by card,
+  or automatically via the x402 protocol from a local burner wallet.
+</Info>
+
+<Tip>
+  Learn more at [openzoo.fun](https://openzoo.fun)
+</Tip>
+
+## Installation
+
+OpenZoo runs locally and provides an OpenAI-compatible API:
+
+```bash
+npx openzoo
+```
+
+This starts the gateway at `http://localhost:8402/v1`. A hosted endpoint is
+also available at `https://api.openzoo.fun/v1`.
+
+## Configuration
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  name: My Config
+  version: 0.0.1
+  schema: v1
+
+  models:
+    - name: GLM 5.3 Flash
+      provider: openai
+      model: z-ai/glm-5.3-flash
+      apiBase: http://localhost:8402/v1
+      apiKey: sk-openzoo
+  ```
+  </Tab>
+  <Tab title="JSON (Deprecated)">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "GLM 5.3 Flash",
+        "provider": "openai",
+        "model": "z-ai/glm-5.3-flash",
+        "apiBase": "http://localhost:8402/v1",
+        "apiKey": "sk-openzoo"
+      }
+    ]
+  }
+  ```
+  </Tab>
+</Tabs>
+
+To use the hosted endpoint instead, set `apiBase: https://api.openzoo.fun/v1`.
+
+## Available Models
+
+List every available model id with live pricing (free, no payment):
+
+```bash
+curl http://localhost:8402/v1/models
+```
+
+Model ids are provider-prefixed, for example `z-ai/glm-5.3-flash` or
+`qwen/qwen3.7-flash`. SSE streaming is supported for all models.
+
+## Troubleshooting
+
+If you see connection errors, make sure OpenZoo is running:
+
+```bash
+curl http://localhost:8402/v1/models
+npx openzoo
+```
+
+If a request returns HTTP 402, the local wallet is unfunded — the error body
+includes directions (`npx openzoo address` / `npx openzoo balance`).

--- a/docs/customize/model-providers/more/openzoo.mdx
+++ b/docs/customize/model-providers/more/openzoo.mdx
@@ -4,9 +4,10 @@ sidebarTitle: "OpenZoo"
 ---
 
 <Info>
-  OpenZoo is an OpenAI-compatible provider with no signup: any API key value is
-  accepted (for example `sk-openzoo`), and usage is paid per request — by card,
-  or automatically via the x402 protocol from a local burner wallet.
+  OpenZoo is an OpenAI-compatible provider with no account: a small local proxy
+  (`npx openzoo`) pays for each request via the x402 protocol from a local
+  burner wallet. The proxy ignores the API key, so any non-empty value works
+  (for example `sk-openzoo`).
 </Info>
 
 <Tip>
@@ -21,8 +22,9 @@ OpenZoo runs locally and provides an OpenAI-compatible API:
 npx openzoo
 ```
 
-This starts the gateway at `http://localhost:8402/v1`. A hosted endpoint is
-also available at `https://api.openzoo.fun/v1`.
+This starts the proxy at `http://localhost:8402/v1`. `npx openzoo address`
+prints its wallet — fund it with USDC on Solana or Base; `npx openzoo balance`
+shows what is left.
 
 ## Configuration
 
@@ -58,7 +60,9 @@ also available at `https://api.openzoo.fun/v1`.
   </Tab>
 </Tabs>
 
-To use the hosted endpoint instead, set `apiBase: https://api.openzoo.fun/v1`.
+The hosted endpoint `https://api.openzoo.fun/v1` answers HTTP 402 unless the
+caller pays x402 or presents an OpenZoo subscription key (`ozk_live_…`);
+Continue cannot pay x402 itself, so keep `apiBase` on the local proxy.
 
 ## Available Models
 
@@ -80,5 +84,6 @@ curl http://localhost:8402/v1/models
 npx openzoo
 ```
 
-If a request returns HTTP 402, the local wallet is unfunded — the error body
-includes directions (`npx openzoo address` / `npx openzoo balance`).
+If a request returns HTTP 402, the local wallet is unfunded — send USDC to
+the address from `npx openzoo address` (`npx openzoo balance` shows what is
+left).

--- a/docs/customize/model-providers/more/openzoo.mdx
+++ b/docs/customize/model-providers/more/openzoo.mdx
@@ -36,9 +36,9 @@ shows what is left.
   schema: v1
 
   models:
-    - name: GLM 5.3 Flash
+    - name: OpenZoo Auto
       provider: openai
-      model: z-ai/glm-5.3-flash
+      model: auto
       apiBase: http://localhost:8402/v1
       apiKey: sk-openzoo
   ```
@@ -48,9 +48,9 @@ shows what is left.
   {
     "models": [
       {
-        "title": "GLM 5.3 Flash",
+        "title": "OpenZoo Auto",
         "provider": "openai",
-        "model": "z-ai/glm-5.3-flash",
+        "model": "auto",
         "apiBase": "http://localhost:8402/v1",
         "apiKey": "sk-openzoo"
       }
@@ -72,8 +72,9 @@ List every available model id with live pricing (free, no payment):
 curl http://localhost:8402/v1/models
 ```
 
-Model ids are provider-prefixed, for example `z-ai/glm-5.3-flash` or
-`qwen/qwen3.7-flash`. SSE streaming is supported for all models.
+Model ids are bare model names, for example `claude-sonnet-5` or
+`gpt-4o-mini`; `auto` lets the proxy pick a model per request. SSE streaming is
+supported for all models.
 
 ## Troubleshooting
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -117,6 +117,7 @@
                       "customize/model-providers/more/moonshot",
                       "customize/model-providers/more/nous",
                       "customize/model-providers/more/nvidia",
+                      "customize/model-providers/more/openzoo",
                       "customize/model-providers/more/tensorix",
                       "customize/model-providers/more/together",
                       "customize/model-providers/more/xAI",


### PR DESCRIPTION
Updated 2026-09-02: corrected — the hosted `https://api.openzoo.fun/v1` endpoint answers HTTP 402 to a plain OpenAI client (it only serves calls that pay x402 or carry an OpenZoo subscription key, `ozk_live_…`). The page now sets up the local `npx openzoo` proxy (`http://localhost:8402/v1`), which pays x402 per call from a local burner wallet and ignores the API key.

## Description

Adds a docs page for [OpenZoo](https://openzoo.fun) under `customize/model-providers/more/`, plus the sidebar entry in `docs.json` (alphabetical, between nvidia and tensorix).

OpenZoo is an npx-launched, OpenAI-compatible gateway that pays per request via x402 — the same shape as the existing ClawRouter page (`more/clawrouter.mdx`), and the page follows that precedent's format. It works with Continue today via `provider: openai` + `apiBase`, so this is docs-only; no code change needed.

Disclosure: I operate OpenZoo.

## Verification

- `npx openzoo` then `curl http://localhost:8402/v1/models` — free, no key
- The config.yaml block on the page works verbatim against the proxy (the proxy ignores apiKey; any non-empty value)
- The page no longer offers the hosted `https://api.openzoo.fun/v1` as an alternative `apiBase`: it answers 402 unless the caller pays x402 or presents an `ozk_live_…` subscription key

## Checklist

- [x] Docs-only change, follows the deepinfra/clawrouter page format
- [x] Sidebar entry added to docs.json (Mintlify only shows listed pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
