### PR TITLE
feat: add NeuronPool OpenAI-compatible provider + Add Model wizard

### DIFF
--- a/docs/customize/model-providers/more/neuronpool.mdx
+++ b/docs/customize/model-providers/more/neuronpool.mdx
@@ -9,6 +9,8 @@ sidebarTitle: "NeuronPool"
 
 NeuronPool is an OpenAI-compatible inference API (pool machines plus public buyers). Use `provider: openai` and set `apiBase`. Model ids come from `GET /v1/models` (`gpt-oss-20b`, `llama-3.1-8b-instruct`, …).
 
+Add Model → **NeuronPool** pre-fills the live Worker base URL and AUTODETECT models. Paste a `sk-neuronpool-…` key.
+
 ## Configuration
 
 <Tabs>

--- a/docs/customize/model-providers/more/neuronpool.mdx
+++ b/docs/customize/model-providers/more/neuronpool.mdx
@@ -1,0 +1,49 @@
+---
+title: "NeuronPool"
+sidebarTitle: "NeuronPool"
+---
+
+<Info>
+  Mint a buyer key on the [NeuronPool dashboard](https://neuronpool.damnknee.workers.dev/dashboard).
+</Info>
+
+NeuronPool is an OpenAI-compatible inference API (pool machines plus public buyers). Use `provider: openai` and set `apiBase`. Model ids come from `GET /v1/models` (`gpt-oss-20b`, `llama-3.1-8b-instruct`, …).
+
+## Configuration
+
+<Tabs>
+  <Tab title="YAML">
+  ```yaml title="config.yaml"
+  name: My Config
+  version: 0.0.1
+  schema: v1
+
+  models:
+    - name: NeuronPool gpt-oss-20b
+      provider: openai
+      model: gpt-oss-20b
+      apiBase: https://neuronpool.damnknee.workers.dev/v1
+      apiKey: ${{ secrets.NEURONPOOL_API_KEY }}
+      roles: [chat, edit, apply]
+  ```
+  </Tab>
+  <Tab title="JSON (Deprecated)">
+  ```json title="config.json"
+  {
+    "models": [
+      {
+        "title": "NeuronPool gpt-oss-20b",
+        "provider": "openai",
+        "model": "gpt-oss-20b",
+        "apiBase": "https://neuronpool.damnknee.workers.dev/v1",
+        "apiKey": "<YOUR_NEURONPOOL_API_KEY>"
+      }
+    ]
+  }
+  ```
+  </Tab>
+</Tabs>
+
+`apiBase` **must** include `/v1`. Continue appends `/chat/completions` and `/models`. Store the key in Continue secrets, not in the file.
+
+Until `api.neuronpool.dev` resolves, use the live Worker URL above. After the custom-domain cutover, swap `apiBase` to `https://api.neuronpool.dev/v1`.

--- a/gui/src/pages/AddNewModel/configs/providers.ts
+++ b/gui/src/pages/AddNewModel/configs/providers.ts
@@ -224,6 +224,44 @@ export const providers: Partial<Record<string, ProviderInfo>> = {
     ],
   },
 
+  neuronpool: {
+    title: "NeuronPool",
+    provider: "openai",
+    description:
+      "OpenAI-compatible social compute — pool machines plus public buyers.",
+    longDescription: `Mint a buyer key on the [NeuronPool dashboard](https://neuronpool.damnknee.workers.dev/dashboard). Continue talks to the OpenAI-compatible API at the live Worker until api.neuronpool.dev resolves.`,
+    icon: "openai.png",
+    tags: [ModelProviderTags.RequiresApiKey],
+    refPage: "neuronpool",
+    apiKeyUrl: "https://neuronpool.damnknee.workers.dev/dashboard",
+    params: {
+      apiBase: "https://neuronpool.damnknee.workers.dev/v1",
+    },
+    collectInputFor: [
+      {
+        inputType: "text",
+        key: "apiKey",
+        label: "API Key",
+        placeholder: "sk-neuronpool-…",
+        required: true,
+      },
+      {
+        ...apiBaseInput,
+        defaultValue: "https://neuronpool.damnknee.workers.dev/v1",
+      },
+      ...completionParamsInputsConfigs,
+    ],
+    packages: [
+      {
+        ...models.AUTODETECT,
+        params: {
+          ...models.AUTODETECT.params,
+          title: "NeuronPool",
+        },
+      },
+    ],
+  },
+
   moonshot: {
     title: "Moonshot",
     provider: "moonshot",


### PR DESCRIPTION
Adds NeuronPool as an OpenAI-compatible provider for Continue.

## Changes
- Docs page at `docs/customize/model-providers/more/neuronpool.mdx`
- Add Model wizard row in `gui/src/pages/AddNewModel/configs/providers.ts` (`provider: openai`, live Worker `apiBase`, AUTODETECT models)

Until `api.neuronpool.dev` resolves, recipes use the live Worker:

- Base: `https://neuronpool.damnknee.workers.dev/v1`
- Key: `sk-neuronpool-…` from https://neuronpool.damnknee.workers.dev/dashboard
- Default model: `gpt-oss-20b` (`GET /v1/models` for the catalog)

The wizard file is ~47.9KB. The NeuronPool row was inserted via a fork Action (commit `6a1e496835f5b3e16348c27f02469cc432d37d4f`, blob `8870eb275dfb9690f29f27c3df30ea2d248242b6`) so the rest of `providers.ts` was not rewritten.

Verification:
- [x] `GET /v1/models` returns catalog ids with a live buyer key
- [x] Streaming chat completion replies (Continue CLI against a local pool)
- [x] Tool-call at the NeuronPool API: local `POST /v1/responses` + `tool_choice` function → 200 `function_call` + `X-NeuronPool-Pool` (2026-09-04). Continue CLI + `llama-3.2-1b-instruct` still hallucinates file contents instead of calling tools — that is the 1B model, not a missing wizard row.
- [x] No key committed; env var / password field only