### PR TITLE
fix(gui): prevent opening a chat when clicking its rename input

### DIFF
--- a/gui/src/components/History/HistoryTableRow.tsx
+++ b/gui/src/components/History/HistoryTableRow.tsx
@@ -104,6 +104,7 @@ export function HistoryTableRow({
               className="w-full"
               ref={(titleInput) => titleInput && titleInput.focus()}
               value={sessionTitleEditValue}
+              onClick={(e) => e.stopPropagation()}
               onChange={(e) => setSessionTitleEditValue(e.target.value)}
               onKeyUp={(e) => handleKeyUp(e)}
               onBlur={() => setEditing(false)}


### PR DESCRIPTION
## Description

Clicking inside the title input while renaming a chat in History also triggers the row's click handler, opening the chat. Stop click propagation on the input so the title remains editable.

One line added in one file.

## Validation

Verified before and after in an isolated browser preview of HistoryTableRow with IDE calls stubbed: clicking the input no longer opens the chat; Enter still dispatches the title update, Escape cancels editing, and clicking the row still opens the chat. The full extension test suite was not run. `git diff --check` passes.