### PR TITLE
fix(gui): correct Windows chat history storage path

### DIFF
--- a/gui/src/components/History/index.tsx
+++ b/gui/src/components/History/index.tsx
@@ -220,7 +220,7 @@ export function History() {
           Chat history is saved to{" "}
           <span className="italic">
             {platform === "windows"
-              ? "%USERPROFILE%/.continue"
+              ? "%USERPROFILE%/.continue/sessions"
               : "~/.continue/sessions"}
           </span>
         </span>


### PR DESCRIPTION
## Description

On Windows, the History footer points to `%USERPROFILE%/.continue`, but session files are stored in its `sessions` subdirectory. Add the missing `/sessions` suffix so the displayed path points to the chat history folder.

## Validation

Checked the path against `getSessionsFolderPath()` and `getSessionFilePath()` in `core/util/paths.ts`. One display string changed in one file; `git diff --check` passes. The full test suite was not run for this text-only change.