### PR TITLE
docs: add Pilot Protocol MCP guide

### DIFF
--- a/docs/guides/overview.mdx
+++ b/docs/guides/overview.mdx
@@ -28,6 +28,10 @@ Step-by-step guides for integrating Model Context Protocol (MCP) servers with Co
     Use GitHub MCP to list, filter, and summarize open issues and merged PRs, and post AI-generated comments
   </Card>
 
+  <Card title="Pilot Protocol Agent Networking" icon="network-wired" href="/guides/pilot-protocol-mcp-agent-networking">
+    Discover specialist agents and exchange messages with trusted peers from Continue
+  </Card>
+
   <Card title="Atlassian MCP Cookbook" icon="atlassian" href="/guides/atlassian-mcp-continue-cookbook">
     Use Atlassian Rovo MCP to search and manage Jira issues, Confluence pages, and Compass components with natural language
   </Card>

--- a/docs/guides/pilot-protocol-mcp-agent-networking.mdx
+++ b/docs/guides/pilot-protocol-mcp-agent-networking.mdx
@@ -1,0 +1,57 @@
+---
+title: "Connect Continue to Other Agents with Pilot Protocol"
+description: "Add Pilot Protocol to Continue for specialist discovery, encrypted peer messaging, and agent-to-agent workflows."
+sidebarTitle: "Pilot Protocol with Continue"
+---
+
+## What this adds
+
+Pilot Protocol gives Continue tools for discovering specialist agents, querying
+their live data, and exchanging messages with trusted peers. It runs locally as
+an MCP server and does not require an API key.
+
+## Prerequisites
+
+- Continue installed and configured
+- Node.js 18 or newer
+
+## Install
+
+Run the harness-specific setup command:
+
+```bash
+npx -y pilotprotocol-mcp setup --continue
+```
+
+The setup command preserves your existing Continue configuration and adds this
+entry to `~/.continue/config.yaml`:
+
+```yaml
+mcpServers:
+  - name: Pilot
+    command: npx
+    args:
+      - "-y"
+      - "pilotprotocol-mcp"
+```
+
+Restart Continue after setup. The first tool call initializes the local Pilot
+runtime and identity, which can take about a minute.
+
+## Verify the connection
+
+Ask Continue to use one of the Pilot tools:
+
+```text
+Use pilot_search to find agents related to weather.
+```
+
+For peer connectivity, try:
+
+```text
+Use pilot_peers to show connected Pilot peers and their routes.
+```
+
+Pilot also exposes tools for specialist queries, handshakes, direct messages,
+and inbox access. See the [source and tool reference](https://github.com/pilot-protocol/pilot-mcp)
+for the complete list.


### PR DESCRIPTION
## Summary
- add a concise Continue setup guide for the Pilot Protocol MCP server
- document the generated `config.yaml` entry and two verification prompts
- link the guide from the MCP cookbook index

## Validation
- checked the setup command and YAML against the current Pilot Continue adapter
- `git diff --check`

Disclosure: I contribute to Pilot Protocol.