### PR TITLE
fix(ci): update FFmpeg 7.1 → 8.1 for jetbrains-tests

### DIFF
--- a/.github/actions/run-jetbrains-tests/action.yml
+++ b/.github/actions/run-jetbrains-tests/action.yml
@@ -44,7 +44,7 @@ runs:
     - name: Setup FFmpeg
       uses: AnimMouse/setup-ffmpeg@v1
       with:
-        version: 7.1
+        version: 8.1
         token: ${{ inputs.github-token }}
 
     - name: Setup Gradle


### PR DESCRIPTION
## Summary

Fixes broken `jetbrains-tests` CI job that has been failing for **all PRs** since 19/08/2026.

## Root Cause

`AnimMouse/setup-ffmpeg@v1` is pinned to FFmpeg **7.1**, but [BtbN/FFmpeg-Builds](https://github.com/BtbN/FFmpeg-Builds/releases/tag/latest) **no longer publishes 7.1 artifacts**. The download returns an HTML 404 page, which `tar` cannot parse:

```
xz: (stdin): File format not recognized
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

This is **not a flaky test** — it fails 100% of the time for every PR.

## Fix

Bump FFmpeg version from `7.1` to `8.1` (latest stable still published by BtbN).

## Evidence

| PR | jetbrains-tests | Error |
|---|---|---|
| #13131 (GUI CSS fix) | ❌ FAILURE | FFmpeg tar error |
| #13227 (docs) | ❌ FAILURE | FFmpeg tar error |
| #13226 (GUI fix) | ❌ FAILURE | FFmpeg tar error |

All unrelated to code changes — pure CI infrastructure breakage.

## Related

- Closes #13164
- See also #13173 (latent Autocomplete test bug masked by this FFmpeg failure)