### PR TITLE
Add AIgateway as LLM provider

### DIFF
--- a/core/llm/autodetect.ts
+++ b/core/llm/autodetect.ts
@@ -74,6 +74,7 @@ const PROVIDER_HANDLES_TEMPLATING: string[] = [
   "nous",
   "zAI",
   "tensorix",
+  "aigateway",
   // TODO add these, change to inverted logic so only the ones that need templating are hardcoded
   // Asksage.ts
   // Azure.ts
@@ -133,6 +134,7 @@ const PROVIDER_SUPPORTS_IMAGES: string[] = [
   "watsonx",
   "zAI",
   "tensorix",
+  "aigateway",
 ];
 
 const MODEL_SUPPORTS_IMAGES: RegExp[] = [
@@ -253,6 +255,7 @@ const PARALLEL_PROVIDERS: string[] = [
   "scaleway",
   "minimax",
   "tensorix",
+  "aigateway",
 ];
 
 function llmCanGenerateInParallel(provider: string, model: string): boolean {

--- a/core/llm/llms/AIgateway.ts
+++ b/core/llm/llms/AIgateway.ts
@@ -1,0 +1,13 @@
+import OpenAI from "./OpenAI.js";
+
+import type { LLMOptions } from "../../index.js";
+
+class AIgateway extends OpenAI {
+  static providerName = "aigateway";
+  static defaultOptions: Partial<LLMOptions> = {
+    apiBase: "https://api.aigateway.sh/v1",
+    model: "zai-org/glm-5.3-flash",
+  };
+}
+
+export default AIgateway;

--- a/core/llm/llms/index.ts
+++ b/core/llm/llms/index.ts
@@ -58,6 +58,7 @@ import SageMaker from "./SageMaker";
 import SambaNova from "./SambaNova";
 import Scaleway from "./Scaleway";
 import SiliconFlow from "./SiliconFlow";
+import AIgateway from "./AIgateway";
 import Tensorix from "./Tensorix";
 import TARS from "./TARS";
 import TestLLM from "./Test";
@@ -125,6 +126,7 @@ export const LLMClasses = [
   xAI,
   SiliconFlow,
   Tensorix,
+  AIgateway,
   Scaleway,
   Relace,
   Inception,

--- a/docs/customize/model-providers/more/aigateway.mdx
+++ b/docs/customize/model-providers/more/aigateway.mdx
@@ -1,0 +1,93 @@
+---
+title: "AIgateway"
+description: "Configure AIgateway with Continue to access 1,000+ models from 85+ labs through a single OpenAI-compatible API"
+---
+
+[AIgateway](https://aigateway.sh) is an OpenAI-compatible model aggregator that provides access to 1,000+ models from 85+ labs — Claude, GPT, Gemini, Kimi, GLM, Llama, and more — with pass-through pricing plus a flat 5% platform fee on top-ups.
+
+<Info>
+  You can get an API key from
+  [aigateway.sh/dashboard/keys](https://aigateway.sh/dashboard/keys).
+</Info>
+
+## Chat Model
+
+We recommend configuring **zai-org/glm-5.3-flash** as your chat model.
+
+<Tabs>
+    <Tab title="YAML">
+    ```yaml title="config.yaml"
+    name: My Config
+    version: 0.0.1
+    schema: v1
+
+    models:
+      - name: GLM-5.3 Flash
+        provider: aigateway
+        model: zai-org/glm-5.3-flash
+        apiKey: <YOUR_AIGATEWAY_API_KEY>
+        roles:
+          - chat
+    ```
+    </Tab>
+    <Tab title="JSON">
+    ```json title="config.json"
+    {
+      "models": [
+        {
+          "title": "GLM-5.3 Flash",
+          "provider": "aigateway",
+          "model": "zai-org/glm-5.3-flash",
+          "apiKey": "<YOUR_AIGATEWAY_API_KEY>"
+        }
+      ]
+    }
+    ```
+    </Tab>
+</Tabs>
+
+## Autocomplete Model
+
+<Tabs>
+    <Tab title="YAML">
+    ```yaml title="config.yaml"
+    name: My Config
+    version: 0.0.1
+    schema: v1
+
+    models:
+      - name: GLM-5.3 Flash
+        provider: aigateway
+        model: zai-org/glm-5.3-flash
+        apiKey: <YOUR_AIGATEWAY_API_KEY>
+        roles:
+          - autocomplete
+    ```
+    </Tab>
+    <Tab title="JSON">
+    ```json title="config.json"
+    {
+      "models": [
+        {
+          "title": "GLM-5.3 Flash",
+          "provider": "aigateway",
+          "model": "zai-org/glm-5.3-flash",
+          "apiKey": "<YOUR_AIGATEWAY_API_KEY>"
+        }
+      ],
+      "tabAutocompleteModel": {
+        "title": "GLM-5.3 Flash",
+        "provider": "aigateway",
+        "model": "zai-org/glm-5.3-flash",
+        "apiKey": "<YOUR_AIGATEWAY_API_KEY>"
+      }
+    }
+    ```
+    </Tab>
+</Tabs>
+
+## Embeddings Model
+
+AIgateway provides access to various embedding models. [Click here](https://aigateway.sh/models?modality=embed) to see a list of available models.
+
+[View the source](https://github.com/continuedev/continue/blob/main/core/llm/llms/AIgateway.ts)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -107,6 +107,7 @@
                     "pages": [
                       "customize/model-providers/more/asksage",
                       "customize/model-providers/more/clawrouter",
+                      "customize/model-providers/more/aigateway",
                       "customize/model-providers/more/deepseek",
                       "customize/model-providers/more/deepinfra",
                       "customize/model-providers/more/groq",

--- a/extensions/vscode/config_schema.json
+++ b/extensions/vscode/config_schema.json
@@ -229,6 +229,7 @@
             "moonshot",
             "siliconflow",
             "tensorix",
+            "aigateway",
             "function-network",
             "scaleway",
             "relace",
@@ -282,6 +283,7 @@
             "### Moonshot\nTo get started with Moonshot AI, obtain your API key from [Moonshot AI](https://platform.moonshot.cn/). Moonshot AI provides high-quality large language models with competitive pricing.\n> [Reference](https://platform.moonshot.cn/docs/api)",
             "### SiliconFlow\nTo get started with SiliconFlow, obtain your API key from [SiliconCloud](https://cloud.siliconflow.cn/account/ak). SiliconCloud provides cost-effective GenAI services based on excellent open source basic models.\n> [Models](https://siliconflow.cn/zh-cn/models)",
             "### Tensorix\nTensorix is an OpenAI-compatible API gateway with access to DeepSeek, Llama, Qwen, GLM, and other models. Pay-as-you-go with no subscription required.\nTo get started, create an account and get an API key at [app.tensorix.ai](https://app.tensorix.ai).\n> [Models](https://tensorix.ai/models)",
+            "### AIgateway\nAIgateway is an OpenAI-compatible model aggregator with 1,000+ models from 85+ labs at pass-through pricing plus a flat 5% platform fee on top-ups.\nTo get started, create an account and get an API key at [aigateway.sh](https://aigateway.sh/dashboard/keys).\n> [Models](https://aigateway.sh/models)",
             "### Function Network offers private, affordable user-owned AI\nTo get started with Function Network, obtain your API key from [Function Network](https://www.function.network/join-waitlist). Function Network provides a variety of models for chat, completion, and embeddings.",
             "### Scaleway\n Generative APIs are serverless endpoints for the most popular AI models.\nHosted in European data centers and priced competitively per million tokens used, models served by Scaleway are ideal for users requiring low latency, full data privacy, and 100% compliance with EU AI Act. To get access to the Scaleway Generative APIs, read the [Quickstart guide](https://www.scaleway.com/en/docs/ai-data/generative-apis/quickstart/) and get a [valid API key](https://www.scaleway.com/en/docs/identity-and-access-management/iam/how-to/create-api-keys/).",
             "### Relace\n Relace provides a fast apply model. To get started, obtain an API key from [here](https://app.relace.ai/settings/api-keys).",
@@ -2871,6 +2873,7 @@
                 "lmstudio",
                 "siliconflow",
                 "tensorix",
+                "aigateway",
                 "function-network",
                 "scaleway",
                 "ovhcloud"
@@ -2937,7 +2940,8 @@
                       "nvidia",
                       "gemini",
                       "siliconflow",
-                      "tensorix"
+                      "tensorix",
+                      "aigateway"
                     ]
                   }
                 },
@@ -3006,7 +3010,8 @@
                 "llm",
                 "huggingface-tei",
                 "siliconflow",
-                "tensorix"
+                "tensorix",
+                "aigateway"
               ]
             },
             "params": {

--- a/gui/src/pages/AddNewModel/configs/providers.ts
+++ b/gui/src/pages/AddNewModel/configs/providers.ts
@@ -1270,6 +1270,26 @@ To get started, [register](https://dataplatform.cloud.ibm.com/registration/stepo
     packages: [{ ...models.AUTODETECT }],
     apiKeyUrl: "https://app.tensorix.ai",
   },
+  aigateway: {
+    title: "AIgateway",
+    provider: "aigateway",
+    description:
+      "AIgateway is an OpenAI-compatible aggregator with 1,000+ models from 85+ labs at pass-through pricing.",
+    longDescription:
+      "To get started with AIgateway, create an account and get an API key at [aigateway.sh](https://aigateway.sh/dashboard/keys).",
+    tags: [ModelProviderTags.RequiresApiKey],
+    collectInputFor: [
+      {
+        inputType: "text",
+        key: "apiKey",
+        label: "API Key",
+        placeholder: "Enter your AIgateway API key",
+        required: true,
+      },
+    ],
+    packages: [{ ...models.AUTODETECT }],
+    apiKeyUrl: "https://aigateway.sh/dashboard/keys",
+  },
   venice: {
     title: "Venice",
     provider: "venice",

--- a/packages/openai-adapters/src/index.ts
+++ b/packages/openai-adapters/src/index.ts
@@ -176,6 +176,8 @@ export function constructLlmApi(config: LLMConfig): BaseLlmApi | undefined {
       return openAICompatible("https://api.function.network/v1/", config);
     case "tensorix":
       return openAICompatible("https://api.tensorix.ai/v1/", config);
+    case "aigateway":
+      return openAICompatible("https://api.aigateway.sh/v1", config);
     case "openrouter":
       return new OpenRouterApi(config);
     case "clawrouter":

--- a/packages/openai-adapters/src/types.ts
+++ b/packages/openai-adapters/src/types.ts
@@ -60,6 +60,7 @@ export const OpenAIConfigSchema = BasePlusConfig.extend({
     z.literal("zAI"),
     z.literal("scaleway"),
     z.literal("tensorix"),
+    z.literal("aigateway"),
     z.literal("ncompass"),
     z.literal("relace"),
     z.literal("huggingface-inference-api"),


### PR DESCRIPTION
## Description

Adds [AIgateway](https://aigateway.sh) as a first-class LLM provider, following the existing Tensorix pattern (an OpenAI-compatible aggregator):

- `core/llm/llms/AIgateway.ts` — provider class extending `OpenAI` with `apiBase: https://api.aigateway.sh/v1`
- Registered in `core/llm/llms/index.ts`, `core/llm/autodetect.ts` (templating / images / parallel lists)
- `packages/openai-adapters` — OpenAI-compatible adapter mapping + schema literal
- `gui/src/pages/AddNewModel/configs/providers.ts` — Add New Model entry
- `extensions/vscode/config_schema.json` — provider enum, description, apiKey-required condition, embeddings enums
- `docs/customize/model-providers/more/aigateway.mdx` + sidebar entry in `docs/docs.json`

AIgateway aggregates 1,000+ models from 85+ labs (Claude, GPT, Gemini, Kimi, GLM, Llama, ...) behind one OpenAI-compatible endpoint, with model IDs as `provider/slug` pairs. Default model is `zai-org/glm-5.3-flash` (1.3M context, tool use, vision).

Happy to adjust anything — naming conventions, default model, docs wording.