### PR TITLE
fix: preserve Windows drive letter colons in URI path segments

### DIFF
--- a/core/util/uri.test.ts
+++ b/core/util/uri.test.ts
@@ -13,6 +13,19 @@ import {
 
 describe("uri utils", () => {
   describe("pathToUriPathSegment", () => {
+    it("should not percent-encode Windows drive letter colon (RFC 3986 pchar)", () => {
+      // encodeURIComponent over-encodes ":" → "%3A", breaking Windows drive
+      // letters. ":" is a valid pchar in URI path segments per RFC 3986.
+      expect(pathToUriPathSegment("C:/Users/foo")).toBe("C:/Users/foo");
+      expect(pathToUriPathSegment("C:\\Users\\foo")).toBe("C:/Users/foo");
+    });
+
+    it("should still encode characters invalid in URI path segments", () => {
+      expect(pathToUriPathSegment("hello world.ts")).toBe("hello%20world.ts");
+      expect(pathToUriPathSegment("file<name>.ts")).toBe("file%3Cname%3E.ts");
+      expect(pathToUriPathSegment("dir#sub")).toBe("dir%23sub");
+    });
+
     it("should convert Windows paths to URI segments", () => {
       expect(pathToUriPathSegment("\\path\\to\\folder\\")).toBe(
         "path/to/folder",

--- a/core/util/uri.ts
+++ b/core/util/uri.ts
@@ -11,7 +11,19 @@ export function pathToUriPathSegment(path: string) {
   clean = clean.replace(/\/$/, ""); // remove end slash
   return clean
     .split("/")
-    .map((part) => encodeURIComponent(part))
+    .map((part) =>
+      // RFC 3986 allows ":" in path segments (pchar); encodeURIComponent
+      // over-encodes it, breaking Windows drive letters ("C:" → "C%3A").
+      // Restore characters that are valid unencoded in a URI path segment.
+      encodeURIComponent(part)
+        .replace(/%3A/gi, ":")
+        .replace(/%40/gi, "@")
+        .replace(/%21/gi, "!")
+        .replace(/%27/gi, "'")
+        .replace(/%28/gi, "(")
+        .replace(/%29/gi, ")")
+        .replace(/%2A/gi, "*"),
+    )
     .join("/");
 }
 


### PR DESCRIPTION
## Issue

Fixes #13231

On Windows, `@file` references showed paths like `c%3A/Users/...` instead of `C:/Users/...`, and the model could not read the file because the URI was over-encoded.

## Root cause

`pathToUriPathSegment` in `core/util/uri.ts` runs `encodeURIComponent` on each path segment. On Windows, the drive-letter segment `C:` gets its colon encoded to `%3A` because `encodeURIComponent` treats `:` as a reserved character. But RFC 3986 explicitly allows `:` in URI path segments (it's part of the `pchar` grammar), along with `@`, `!`, `'`, `(`, `)`, and `*`.

## Fix

After `encodeURIComponent`, restore the RFC 3986-valid pchar characters that it needlessly encodes:

```typescript
encodeURIComponent(part)
  .replace(/%3A/gi, ":")
  .replace(/%40/gi, "@")
  .replace(/%21/gi, "!")
  .replace(/%27/gi, "'")
  .replace(/%28/gi, "(")
  .replace(/%29/gi, ")")
  .replace(/%2A/gi, "*")
```

Genuinely unsafe characters (spaces, `<`, `>`, `#`, etc.) are still encoded.

## Testing

Two new regression tests:
- `should not percent-encode Windows drive letter colon` — verifies `C:/Users/foo` and `C:\Users\foo` produce `C:/Users/foo`
- `should still encode characters invalid in URI path segments` — verifies `hello world.ts` → `hello%20world.ts`, `file<name>.ts` → `file%3Cname%3E.ts`, `dir#sub` → `dir%23sub`

Existing tests (POSIX paths, backslash conversion, trailing slash stripping) are unchanged and verified passing.