### PR TITLE
fix(indexing): escape apostrophes in LanceDB SQL path predicates

### DIFF
--- a/core/indexing/LanceDbIndex.ts
+++ b/core/indexing/LanceDbIndex.ts
@@ -25,6 +25,7 @@ import {
 
 import type * as LanceType from "vectordb";
 import { tagToString } from "./utils";
+import { escapeLanceSqlString } from "./escapeLanceSqlString";
 
 interface LanceDbRow {
   uuid: string;
@@ -37,6 +38,7 @@ interface LanceDbRow {
 type ItemWithChunks = { item: PathAndCacheKey; chunks: Chunk[] };
 
 type ChunkMap = Map<string, ItemWithChunks>;
+
 
 export class LanceDbIndex implements CodebaseIndex {
   private static lance: typeof LanceType | null = null;
@@ -364,7 +366,7 @@ export class LanceDbIndex implements CodebaseIndex {
 
       for (const { path, cacheKey } of toDel) {
         await lanceTable.delete(
-          `cachekey = '${cacheKey}' AND path = '${path}'`,
+          `cachekey = '${escapeLanceSqlString(cacheKey)}' AND path = '${escapeLanceSqlString(path)}'`,
         );
 
         accumulatedProgress += 1 / toDel.length / 3;
@@ -419,7 +421,7 @@ export class LanceDbIndex implements CodebaseIndex {
     const table = await db.openTable(tableName);
     let query = table.search(vector);
     if (directory) {
-      query = query.where(`path LIKE '${directory}%'`).limit(300);
+      query = query.where(`path LIKE '${escapeLanceSqlString(directory)}%'`).limit(300);
     } else {
       query = query.limit(n);
     }
@@ -477,7 +479,7 @@ export class LanceDbIndex implements CodebaseIndex {
     const sqliteDb = await SqliteDb.get();
     const data = await sqliteDb.all(
       `SELECT * FROM lance_db_cache WHERE uuid in (${allResults
-        .map((r) => `'${r.uuid}'`)
+        .map((r) => `'${escapeLanceSqlString(r.uuid)}'`)
         .join(",")})`,
     );
 

--- a/core/indexing/escapeLanceSqlString.test.ts
+++ b/core/indexing/escapeLanceSqlString.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { escapeLanceSqlString } from "./escapeLanceSqlString";
+
+describe("escapeLanceSqlString", () => {
+  it("leaves strings without quotes unchanged", () => {
+    expect(escapeLanceSqlString("src/normal.ts")).toBe("src/normal.ts");
+  });
+
+  it("doubles single quotes so LanceDB predicates stay valid", () => {
+    expect(escapeLanceSqlString("src/don't.ts")).toBe("src/don''t.ts");
+    expect(escapeLanceSqlString("it's a test/")).toBe("it''s a test/");
+  });
+
+  it("escapes multiple apostrophes", () => {
+    expect(escapeLanceSqlString("a'b'c")).toBe("a''b''c");
+  });
+});

--- a/core/indexing/escapeLanceSqlString.ts
+++ b/core/indexing/escapeLanceSqlString.ts
@@ -1,0 +1,7 @@
+/**
+ * Escape a value for use inside a single-quoted LanceDB SQL string literal.
+ * LanceDB / SQL standard escaping doubles single quotes.
+ */
+export function escapeLanceSqlString(value: string): string {
+  return value.replace(/'/g, "''");
+}


### PR DESCRIPTION
Fixes #13233

## Summary
`LanceDbIndex` built LanceDB delete/retrieve predicates by interpolating filesystem paths and cache keys into single-quoted SQL. Paths with apostrophes (`don't.ts`, `it's a test/…`) produced `Unterminated string literal`, so deletes failed (stale chunks stayed retrievable) and directory-filtered retrieval broke for whole workspaces.

## Change
- Add `escapeLanceSqlString()` (SQL-standard `'` → `''`)
- Use it for `cachekey`/`path` deletes, `path LIKE` retrieval filters, and UUID `IN` lookups
- Unit tests for the escape helper

## Test plan
- [x] Unit tests for `escapeLanceSqlString`
- [ ] Index a file whose path contains an apostrophe, delete/rename it, confirm chunks are removed
- [ ] Retrieve with a workspace directory that contains an apostrophe