### PR TITLE
fix(cli): keep Ollama tool calls when stream deltas omit id

### DIFF
--- a/extensions/cli/src/stream/processToolCallDelta.test.ts
+++ b/extensions/cli/src/stream/processToolCallDelta.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { processToolCallDelta } from "./streamChatResponse.helpers.js";
+import { ToolCall } from "../tools/types.js";
+
+describe("processToolCallDelta", () => {
+  it("synthesizes a stable id when the first delta has index but no id", () => {
+    const toolCallsMap = new Map<string, ToolCall>();
+    const indexToIdMap = new Map<number, string>();
+
+    processToolCallDelta(
+      {
+        index: 0,
+        function: { name: "Read", arguments: '{"filepath":' },
+      },
+      toolCallsMap,
+      indexToIdMap,
+    );
+
+    expect(indexToIdMap.get(0)).toBe("call_0");
+    expect(toolCallsMap.has("call_0")).toBe(true);
+    expect(toolCallsMap.get("call_0")?.name).toBe("Read");
+    expect(toolCallsMap.get("call_0")?.argumentsStr).toBe('{"filepath":');
+
+    processToolCallDelta(
+      {
+        index: 0,
+        function: { arguments: '"convex/schema.ts"}' },
+      },
+      toolCallsMap,
+      indexToIdMap,
+    );
+
+    expect(toolCallsMap.size).toBe(1);
+    expect(toolCallsMap.get("call_0")?.arguments).toEqual({
+      filepath: "convex/schema.ts",
+    });
+  });
+
+  it("still prefers a real id when provided", () => {
+    const toolCallsMap = new Map<string, ToolCall>();
+    const indexToIdMap = new Map<number, string>();
+
+    processToolCallDelta(
+      {
+        index: 1,
+        id: "toolu_real",
+        function: { name: "Write", arguments: "{}" },
+      },
+      toolCallsMap,
+      indexToIdMap,
+    );
+
+    expect(indexToIdMap.get(1)).toBe("toolu_real");
+    expect(toolCallsMap.has("toolu_real")).toBe(true);
+    expect(toolCallsMap.has("call_1")).toBe(false);
+  });
+});

--- a/extensions/cli/src/stream/streamChatResponse.helpers.ts
+++ b/extensions/cli/src/stream/streamChatResponse.helpers.ts
@@ -196,8 +196,14 @@ export function processToolCallDelta(
       indexToIdMap.set(toolCallDelta.index, toolCallId);
     }
   } else if (toolCallDelta.index !== undefined) {
-    // No ID, but we have an index - look up the ID from our map
+    // No ID, but we have an index - look up the ID from our map.
+    // Some providers (e.g. Ollama) send the first delta with index only.
+    // Synthesize a stable id so the call is not dropped before later fragments.
     toolCallId = indexToIdMap.get(toolCallDelta.index);
+    if (!toolCallId) {
+      toolCallId = `call_${toolCallDelta.index}`;
+      indexToIdMap.set(toolCallDelta.index, toolCallId);
+    }
   }
 
   if (!toolCallId) {


### PR DESCRIPTION
Fixes #13225

## Summary
Some providers (notably Ollama with models like `gpt-oss`) send the first streaming `tool_calls` delta with an `index` but no `id`. `processToolCallDelta()` only created an index→id mapping when `id` was present, so the first delta was dropped and later argument fragments never accumulated. Tool args then appeared as plain assistant text and the tool never ran.

## Change
When a delta has `index` but no `id` and no mapping yet, synthesize a stable `call_<index>` id and store it in `indexToIdMap` so subsequent fragments attach correctly. Real provider ids are still preferred when present.

## Test plan
- [x] Unit tests for synthetic-id and real-id paths
- [ ] CLI agent turn with Ollama tool use: tool calls with index-only first deltas execute