### PR TITLE
docs: add Standard Compute OpenAI-compatible setup

### DIFF
--- a/docs/customize/model-providers/more/standardcompute.mdx
+++ b/docs/customize/model-providers/more/standardcompute.mdx
@@ -1,0 +1,43 @@
+---
+title: "Standard Compute"
+description: "Use Standard Compute's routed model through Continue's OpenAI-compatible provider."
+---
+
+Use [Standard Compute](https://standardcompute.com/) to keep working in Continue
+while the service selects models and providers for your requests. Connect it
+through Continue's existing `openai` provider with a custom API base.
+
+## Configuration
+
+1. Get an API key from the [Standard Compute dashboard](https://standardcompute.com/dashboard).
+2. Add the model below to your `~/.continue/config.yaml`. If you already have
+   models configured, append this entry to your existing `models` list.
+3. Replace `<YOUR_STANDARD_COMPUTE_API_KEY>` with your key and select
+   **Standard Compute** in Continue's model selector.
+
+```yaml title="config.yaml"
+name: My Config
+version: 0.0.1
+schema: v1
+
+models:
+  - name: Standard Compute
+    provider: openai
+    model: standardcompute
+    apiBase: https://api.stdcmpt.com/v1
+    apiKey: <YOUR_STANDARD_COMPUTE_API_KEY>
+    roles:
+      - chat
+    capabilities:
+      - tool_use
+```
+
+Keep `provider: openai`: it selects the compatible connection, while `apiBase`
+directs requests to Standard Compute. This example uses Chat Completions and
+declares tool use explicitly because `standardcompute` is a routing alias that
+Continue cannot identify as a specific upstream model.
+
+The example configures the chat role, including Agent mode. Keep your existing
+autocomplete and embedding models if you use those features. Check
+[Standard Compute's current plans](https://standardcompute.com/pricing) for the
+subscription and usage allowance; these are separate from Continue.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -117,6 +117,7 @@
                       "customize/model-providers/more/moonshot",
                       "customize/model-providers/more/nous",
                       "customize/model-providers/more/nvidia",
+                      "customize/model-providers/more/standardcompute",
                       "customize/model-providers/more/tensorix",
                       "customize/model-providers/more/together",
                       "customize/model-providers/more/xAI",


### PR DESCRIPTION
## Description

Adds a Standard Compute page under More Providers with the exact YAML needed for Continue's existing OpenAI-compatible connection. The example declares tool use for the routing alias, so readers can configure Agent mode without guessing a model-specific capability. Existing autocomplete and embedding configuration stays separate.

Disclosure: I run Standard Compute. This is a docs-only addition with one navigation entry; it adds no provider implementation.

## AI Code Review

Prepared and checked with AI assistance. No team-only review trigger requested.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs have been created
- [x] The configuration and documentation checks below passed; no application behavior changed

## Screen recording or screenshot

No application UI change. This adds a documentation page and its navigation entry.

## Tests

- The new MDX compiles with `@mdx-js/mdx` 3.
- The embedded YAML parses and passes `@continuedev/config-yaml` 1.23.0's `configYamlSchema`; the provider, endpoint, model alias and `tool_use` capability are preserved.
- The updated navigation is valid JSON and includes the new document.
- `git diff --check` passes.

Checks were run by the coding agent on macOS. These verify documentation/configuration, not an end-to-end coding-quality benchmark. The full Mintlify site was not built locally.

### CI follow-up

The docs-related formatting/lint checks and package checks passed. The [JetBrains job](https://github.com/continuedev/continue/actions/runs/34094880728/job/101656139597) failed while downloading FFmpeg 7.1: `xz: (stdin): File format not recognized`, before tests ran. The aggregate check consequently failed too. A job rerun request from this contributor account returned “job cannot be rerun”; a maintainer rerun or upstream download fix is needed. The CLA signature is tracked separately.
