### PR TITLE
fix(vscode): execute runCommand so the terminal actually runs the command

### DIFF
--- a/extensions/vscode/src/VsCodeIde.ts
+++ b/extensions/vscode/src/VsCodeIde.ts
@@ -352,7 +352,7 @@ class VsCodeIde implements IDE {
       terminal = vscode.window.createTerminal(options?.terminalName);
     }
     terminal.show();
-    terminal.sendText(command, false);
+    terminal.sendText(command);
   }
 
   async saveFile(fileUri: string): Promise<void> {


### PR DESCRIPTION
`sendText(command, false)` types the command and never hits enter.

Fixes #10542