### PR TITLE
docs: correct response spelling in Gemini comments

### DIFF
--- a/core/llm/llms/gemini-types.ts
+++ b/core/llm/llms/gemini-types.ts
@@ -141,7 +141,7 @@ function convertJsonSchemaToGeminiSchema(jsonSchema: any): GeminiObjectSchema {
 }
 
 // https://ai.google.dev/api/caching#FunctionDeclaration
-// Note "reponse" field (schema showing function output structure) is not supported at the moment
+// Note "response" field (schema showing function output structure) is not supported at the moment
 export function convertContinueToolToGeminiFunction(
   tool: Tool,
 ): GeminiToolFunctionDeclaration {

--- a/packages/openai-adapters/src/util/gemini-types.ts
+++ b/packages/openai-adapters/src/util/gemini-types.ts
@@ -141,7 +141,7 @@ function convertJsonSchemaToGeminiSchema(jsonSchema: any): GeminiObjectSchema {
 }
 
 // https://ai.google.dev/api/caching#FunctionDeclaration
-// Note "reponse" field (schema showing function output structure) is not supported at the moment
+// Note "response" field (schema showing function output structure) is not supported at the moment
 export function convertOpenAIToolToGeminiFunction(
   tool: ChatCompletionTool,
 ): GeminiToolFunctionDeclaration {


### PR DESCRIPTION
The same comment in the Gemini type helpers refers to the "response" field but currently contains a spelling error. Correct the spelling in both comments. No runtime behavior changes.