### PR TITLE
fix(core): match nested and Windows paths in isSecurityConcern

### DIFF
--- a/core/indexing/ignore.ts
+++ b/core/indexing/ignore.ts
@@ -1,6 +1,5 @@
 import ignore from "ignore";
 
-import path from "path";
 import { fileURLToPath } from "url";
 import { ContinueError, ContinueErrorReason } from "../util/errors";
 
@@ -235,19 +234,34 @@ export const defaultIgnoreFileAndDir = ignore()
   .add(defaultIgnoreFile)
   .add(defaultIgnoreDir);
 
+/**
+ * Convert a filepath or file URI into a gitignore-style relative path for the
+ * `ignore` library. Keep the full path (not just parent/basename) so nested
+ * security directories still match, and normalize Windows separators/drives.
+ */
+export function normalizePathForSecurityIgnore(filePathOrUri: string): string {
+  let filepath = filePathOrUri;
+  try {
+    filepath = fileURLToPath(filePathOrUri);
+  } catch {
+    // Not a file URL; use the original string.
+  }
+
+  filepath = filepath.replace(/\\/g, "/");
+  // POSIX fileURLToPath of file:///C:/... yields /C:/...
+  filepath = filepath.replace(/^\/+([a-zA-Z]:)/, "$1");
+  filepath = filepath.replace(/^[a-zA-Z]:/, "");
+  filepath = filepath.replace(/^\/+/, "");
+  filepath = filepath.replace(/^\.\/+/, "");
+
+  return filepath;
+}
+
 export function isSecurityConcern(filePathOrUri: string) {
   if (!filePathOrUri) {
     return false;
   }
-  let filepath = filePathOrUri;
-  try {
-    filepath = fileURLToPath(filePathOrUri);
-  } catch {}
-  if (path.isAbsolute(filepath)) {
-    const dir = path.dirname(filepath).split(/\/|\\/).at(-1) ?? "";
-    const basename = path.basename(filepath);
-    filepath = `${dir ? dir + "/" : ""}${basename}`;
-  }
+  const filepath = normalizePathForSecurityIgnore(filePathOrUri);
   if (!filepath) {
     return false;
   }

--- a/core/indexing/ignore.vitest.ts
+++ b/core/indexing/ignore.vitest.ts
@@ -136,10 +136,27 @@ describe("isSecurityConcern", () => {
       expect(isSecurityConcern("backend/certs/server.key")).toBe(true);
     });
 
-    // it("should handle Windows-style paths", () => {
-    //   expect(isSecurityConcern("C:\\Users\\user\\.env")).toBe(true);
-    //   expect(isSecurityConcern("D:\\projects\\app\\secrets\\")).toBe(true);
-    // });
+    it("should detect nested files inside security directories for absolute paths", () => {
+      expect(isSecurityConcern("/home/user/.aws/prod/credentials")).toBe(true);
+      expect(isSecurityConcern("/home/user/.ssh/config.d/host")).toBe(true);
+      expect(isSecurityConcern("/var/www/.secrets/api/token")).toBe(true);
+      expect(isSecurityConcern("file:///home/user/.kube/cache/config")).toBe(
+        true,
+      );
+    });
+
+    it("should handle Windows-style paths", () => {
+      expect(isSecurityConcern("C:\\Users\\user\\.env")).toBe(true);
+      expect(isSecurityConcern("D:\\projects\\app\\secrets\\")).toBe(true);
+      expect(isSecurityConcern("C:\\Users\\user\\.aws\\prod\\credentials")).toBe(
+        true,
+      );
+      expect(isSecurityConcern("project\\config\\.env")).toBe(true);
+      expect(isSecurityConcern("file:///C:/Users/user/.env")).toBe(true);
+      expect(
+        isSecurityConcern("file:///C:/Users/user/.ssh/id_rsa"),
+      ).toBe(true);
+    });
   });
 
   describe("Non-security files", () => {
@@ -149,6 +166,8 @@ describe("isSecurityConcern", () => {
       expect(isSecurityConcern("utils/helper.py")).toBe(false);
       expect(isSecurityConcern("models/User.java")).toBe(false);
       expect(isSecurityConcern("styles/main.css")).toBe(false);
+      expect(isSecurityConcern("C:\\Users\\user\\src\\main.js")).toBe(false);
+      expect(isSecurityConcern("/home/user/project/src/main.js")).toBe(false);
     });
 
     it("should not flag regular configuration files", () => {


### PR DESCRIPTION
## Summary

`isSecurityConcern()` is the gate that blocks tools, autocomplete, and next-edit from reading secrets (`.env`, `.aws/credentials`, `.ssh/id_rsa`, etc.). Two path-handling bugs let those files through.

1. **Nested security directories on absolute paths.** Absolute paths were truncated to `parent/basename` before gitignore matching. `/home/user/.aws/prod/credentials` became `prod/credentials`, which does not match `.aws/`, so the agent could read it.
2. **Windows backslash paths.** The `ignore` library treats `\` as a gitignore escape. Relative paths like `project\config\.env` and drive-letter paths that were not rewritten never matched. The existing Windows-path test in `ignore.vitest.ts` was commented out rather than fixed.

Both show up in real call sites: `throwIfFileIsSecurityConcern(resolvedPath.displayPath)` (Windows `fileURLToPath` / `fsPath`) and autocomplete `isSecurityConcern(input.filepath)`.

## Root cause

Absolute paths were reduced to only the immediate parent directory plus basename so `ignore()` would receive a relative path. That dropped every ancestor except the last folder, so nested files under `.aws/`, `.ssh/`, `.kube/`, `secrets/`, and similar directories were not blocked. Un-normalized backslashes made Windows paths fail independently.

## Fix

Normalize to a full gitignore-style relative path: convert `file://` URIs, replace `\` with `/`, strip a Windows drive letter, strip a leading `/`. Keep the entire remaining path so `.aws/prod/credentials` still matches `.aws/`.

## Test plan

- [x] `npx vitest run indexing/ignore.vitest.ts` — 31/31 passed
- [x] New cases: nested absolute POSIX paths, Windows drive/backslash paths, `file:///C:/...` URIs
- [x] Regular source files with Windows/POSIX absolute paths still return `false`

## Reproduction (before this change)

```ts
isSecurityConcern("/home/user/.aws/prod/credentials") // false, should be true
isSecurityConcern("C:\\Users\\user\\.env")            // false, should be true
isSecurityConcern("project\\config\\.env")            // false, should be true
```
