### PR TITLE
docs: fix 'extention' typo in chat how-to guide

### DIFF
--- a/docs/chat/how-to-use-it.mdx
+++ b/docs/chat/how-to-use-it.mdx
@@ -17,7 +17,7 @@ Chat is best used to understand and iterate on code or as a replacement for sear
 
 ## Send a Coding Question or Task to AI Chat
 
-To send a question, add it to the input box in the extention and press enter. You send it a question, and it replies with an answer. You tell it to solve a problem, and it provides you a solution. You ask for some code, and it generates it.
+To send a question, add it to the input box in the extension and press enter. You send it a question, and it replies with an answer. You tell it to solve a problem, and it provides you a solution. You ask for some code, and it generates it.
 
 ## Add Code Context to AI Chat by Highlighting Code
 


### PR DESCRIPTION
Tiny docs fix: correct `extention` to `extension` in the chat how-to guide.