### PR TITLE
fix(ollama): preserve tools across agent loop turns

### DIFF
--- a/core/llm/llms/Ollama.test.ts
+++ b/core/llm/llms/Ollama.test.ts
@@ -127,6 +127,68 @@ describe("Ollama", () => {
     });
   });
 
+  describe("_streamChat", () => {
+    const tool = {
+      type: "function",
+      function: {
+        name: "read_file",
+        description: "Read a file",
+        parameters: {
+          type: "object",
+          required: ["filepath"],
+          properties: { filepath: { type: "string" } },
+        },
+      },
+    };
+
+    async function requestBody(messages: ChatMessage[]) {
+      const ollama = createOllama();
+      (ollama as any).ensureModelInfo = jest.fn();
+      (ollama as any).getEndpoint = jest.fn(() => "http://localhost/api/chat");
+      (ollama as any)._getModel = jest.fn(() => "test-model");
+      (ollama.fetch as jest.Mock).mockResolvedValue({
+        json: async () => ({
+          message: { role: "assistant", content: "done" },
+        }),
+      });
+
+      const stream = (ollama as any)._streamChat(
+        messages,
+        new AbortController().signal,
+        { stream: false, tools: [tool] },
+      );
+      for await (const _ of stream) {
+        // Drain the response so the request completes.
+      }
+
+      const [, init] = (ollama.fetch as jest.Mock).mock.calls[0];
+      return JSON.parse(init.body);
+    }
+
+    it("should attach tools after a tool result for multi-step agent loops", async () => {
+      const body = await requestBody([
+        { role: "user", content: "Read file A, then file B" },
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [
+            {
+              id: "tc_1",
+              type: "function",
+              function: {
+                name: "read_file",
+                arguments: '{"filepath":"fileA"}',
+              },
+            },
+          ],
+        },
+        { role: "tool", content: "file A", toolCallId: "tc_1" },
+      ]);
+
+      expect(body.tools).toEqual([tool]);
+    });
+  });
+
   describe("_reorderMessagesForToolCompat", () => {
     let ollama: Ollama;
 

--- a/core/llm/llms/Ollama.ts
+++ b/core/llm/llms/Ollama.ts
@@ -511,7 +511,7 @@ class Ollama extends BaseLLM implements ModelInstaller {
       stream: options.stream,
       // format: options.format, // Not currently in base completion options
     };
-    if (options.tools?.length && ollamaMessages.at(-1)?.role === "user") {
+    if (options.tools?.length) {
       chatOptions.tools = options.tools.map((tool) => ({
         type: "function",
         function: {


### PR DESCRIPTION
## Description

Fixes #13254.

Ollama chat requests only attached tool definitions when the last converted message had the `user` role. After Continue executed the first tool, the next Agent-mode request ended with a `tool` result, so `tools` disappeared from the request body and Ollama could not select the next tool.

Attach configured tools whenever `CompletionOptions.tools` is non-empty. This matches Ollama's current multi-turn agent-loop examples, which pass the available tools on every loop iteration, including after appending tool results.

## AI Code Review

- **Team members only**: AI review runs automatically when PR is opened or marked ready for review
- Team members can also trigger a review by commenting `@continue-review`

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created (not applicable: no user-facing API or configuration change)
- [x] The relevant tests, if any, have been updated or created

## Screen recording or screenshot

Not applicable; this is an outbound request-construction bug covered by a focused regression test.

## Tests

- Regression proof on unchanged source: the new test fails because `body.tools` is `undefined`, while the 10 existing Ollama tests pass
- `npm test --prefix core -- --runInBand llm/llms/Ollama.test.ts` (11/11 passed)
- `npm run tsc:check --prefix core`
- Prettier check for both changed files
- `git diff --check`
