### PR TITLE
fix(ollama): preserve tools across agent loop turns (#13254)

### DIFF
--- a/core/llm/llms/Ollama.test.ts
+++ b/core/llm/llms/Ollama.test.ts
@@ -223,4 +223,76 @@ describe("Ollama", () => {
       expect(result[1].role).toBe("tool");
     });
   });
+
+  describe("_streamChat tools preservation", () => {
+    let ollama: Ollama;
+
+    beforeEach(() => {
+      ollama = createOllama();
+      (ollama as any).ensureModelInfo = jest.fn().mockResolvedValue(undefined);
+      (ollama as any)._getModel = jest.fn().mockReturnValue("test-model");
+      (ollama as any)._getModelFileParams = jest.fn().mockReturnValue({});
+      (ollama as any).getEndpoint = jest.fn().mockReturnValue("http://localhost:11434/api/chat");
+    });
+
+    it("should include tools even when the last message role is 'tool'", async () => {
+      let capturedBody: any = null;
+      (ollama as any).fetch = jest.fn().mockImplementation((url: string, init: any) => {
+        capturedBody = JSON.parse(init.body);
+        return Promise.resolve({
+          ok: true,
+          body: {
+            getReader: () => ({
+              read: () => Promise.resolve({ done: true, value: undefined }),
+            }),
+          },
+        });
+      });
+
+      const messages: ChatMessage[] = [
+        { role: "user", content: "What is the weather?" },
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [
+            {
+              id: "1",
+              type: "function",
+              function: { name: "get_weather", arguments: "{}" },
+            },
+          ],
+        },
+        { role: "tool", content: "Sunny", toolCallId: "1" },
+      ];
+
+      const options = {
+        tools: [
+          {
+            type: "function" as const,
+            function: {
+              name: "get_weather",
+              description: "Get weather",
+              parameters: {},
+            },
+          },
+        ],
+      };
+
+      const generator = (ollama as any)._streamChat(
+        messages,
+        new AbortController().signal,
+        options,
+      );
+      try {
+        for await (const _ of generator) {
+        }
+      } catch {
+        // Stream reading may fail on dummy response, but request body was already captured
+      }
+
+      expect(capturedBody).not.toBeNull();
+      expect(capturedBody.tools).toHaveLength(1);
+      expect(capturedBody.tools[0].function.name).toBe("get_weather");
+    });
+  });
 });

--- a/core/llm/llms/Ollama.ts
+++ b/core/llm/llms/Ollama.ts
@@ -511,7 +511,7 @@ class Ollama extends BaseLLM implements ModelInstaller {
       stream: options.stream,
       // format: options.format, // Not currently in base completion options
     };
-    if (options.tools?.length && ollamaMessages.at(-1)?.role === "user") {
+    if (options.tools?.length) {
       chatOptions.tools = options.tools.map((tool) => ({
         type: "function",
         function: {


### PR DESCRIPTION
## Description

Fixes #13254. In core/llm/llms/Ollama.ts, options.tools was only forwarded if ollamaMessages.at(-1)?.role === 'user'. In multi-turn tool calling and agent loops, subsequent turns have assistant or tool message histories, causing Ollama to drop the tools definitions mid-loop.

This PR removes the unnecessary restriction, ensuring options.tools remains available throughout multi-turn tool interactions.

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

## Tests

- Added unit test in core/llm/llms/Ollama.test.ts verifying tools persistence when the last message is a tool response.
- Executed un test core/llm/llms/Ollama.test.ts (all 8 tests passing).